### PR TITLE
fix(agw): adds cleanup of stray unix domain socket to agwd

### DIFF
--- a/src/go/agwd/server/BUILD.bazel
+++ b/src/go/agwd/server/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "server",
@@ -14,4 +14,86 @@ go_library(
         "@com_github_pkg_errors//:errors",
         "@org_golang_google_grpc//:go_default_library",
     ],
+)
+
+go_test(
+    name = "server_test",
+    srcs = [
+        "server_notwindows_test.go",
+        "server_windows_test.go",
+    ],
+    embed = [":server"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:aix": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:android": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:illumos": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:js": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "//src/go/internal/testutil",
+            "@com_github_golang_mock//gomock",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/src/go/agwd/server/server.go
+++ b/src/go/agwd/server/server.go
@@ -12,7 +12,11 @@
 package server
 
 import (
+	"fmt"
 	"net"
+	"os"
+	"runtime"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -41,10 +45,53 @@ func newServiceRouter(cfgr config.Configer) service.Router {
 	)
 }
 
+func cleanupUnixSocket(
+	logger log.Logger,
+	osStat func(string) (os.FileInfo, error),
+	osRemove func(string) error,
+	netDialTimeout func(network, address string, timeout time.Duration) (net.Conn, error),
+	path string) error {
+	_, err := osStat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "os.Stat(%s)", path)
+	}
+
+	// attempt to connect to see if someone is still bound to the socket.
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("cleanupUnixSocket(logger=_,path=%q) found pre-existing socket at path, but does not support cleanup in GOOS == windows", path)
+	}
+	_, err = netDialTimeout("unix", path, time.Second)
+	if err == nil {
+		return fmt.Errorf("os.Stat(%s): existing listener on socket file", path)
+	}
+	logger.Warning().Printf("Removing existing socket file; previous unclean shutdown?")
+	if err := osRemove(path); err != nil {
+		return errors.Wrapf(err, "os.Stat(%s)", path)
+	}
+
+	return nil
+}
+
+func cleanupUnixSocketOrDie(logger log.Logger, path string) {
+	if err := cleanupUnixSocket(logger, os.Stat, os.Remove, net.DialTimeout, path); err != nil {
+		panic(errors.Wrapf(
+			err,
+			"cleanupUnixSocket(logger=_, target.Endpoint=%s)",
+			path))
+	}
+}
+
 func startSctpdDownlinkServer(
 	cfgr config.Configer, logger log.Logger, sr service.Router,
 ) {
 	target := config.ParseTarget(cfgr.Config().GetMmeSctpdDownstreamServiceTarget())
+	if target.Scheme == "unix" {
+		cleanupUnixSocketOrDie(logger, target.Endpoint)
+	}
+
 	listener, err := net.Listen(
 		target.Scheme, target.Endpoint)
 	if err != nil {

--- a/src/go/agwd/server/server_notwindows_test.go
+++ b/src/go/agwd/server/server_notwindows_test.go
@@ -1,0 +1,75 @@
+// Copyright 2021 The Magma Authors.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build !windows
+
+package server
+
+import (
+	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/magma/magma/src/go/internal/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func removeNoError(string) error {
+	return nil
+}
+
+func osFileNoError(string) (os.FileInfo, error) {
+	return nil, nil
+}
+
+func netDialNoError(network, address string, timeout time.Duration) (net.Conn, error) {
+	return nil, nil
+}
+
+func netDialError(network, address string, timeout time.Duration) (net.Conn, error) {
+	return nil, errors.New("any error will do")
+}
+
+// TestCleanupExistingUnusedSock ensures that should an un-used existing socket exist, we clean it up
+// and log a warning.
+func TestCleanupExistingUnusedSock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger, logBuffer := testutil.NewTestLogger()
+
+	err := cleanupUnixSocket(logger, osFileNoError, removeNoError, netDialError, "arbitrary_file_path.sock")
+
+	assert.Nil(t, err)
+	assert.Equal(
+		t,
+		"WARN\tRemoving existing socket file; previous unclean shutdown?\n",
+		logBuffer.String())
+}
+
+// TestCleanupExistingConnectedSock validates that should an existing server be hosting on a unix
+// domain socket, we do not clean it up but instead log an error.
+func TestCleanupExistingConnectedSock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger, _ := testutil.NewTestLogger()
+
+	err := cleanupUnixSocket(logger, osFileNoError, removeNoError, netDialNoError, "arbitrary_file_path.sock")
+
+	assert.NotNil(t, err)
+	wantErrMsg := "existing listener on socket file"
+	assert.Containsf(t,
+		err.Error(), wantErrMsg, "expected error containing %q, got %s", wantErrMsg, err)
+}

--- a/src/go/agwd/server/server_windows_test.go
+++ b/src/go/agwd/server/server_windows_test.go
@@ -1,0 +1,74 @@
+// Copyright 2021 The Magma Authors.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build windows
+
+package server
+
+import (
+	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/magma/magma/src/go/internal/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func removeNoError(string) error {
+	return nil
+}
+
+func osFileNoError(string) (os.FileInfo, error) {
+	return nil, nil
+}
+
+func netDialNoError(network, address string, timeout time.Duration) (net.Conn, error) {
+	return nil, nil
+}
+
+func netDialError(network, address string, timeout time.Duration) (net.Conn, error) {
+	return nil, errors.New("any error will do")
+}
+
+// TestCleanupExistingUnusedSock ensures that should an un-used existing socket exist, we clean it up
+// and log a warning.
+func TestCleanupExistingUnusedSock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger, _ := testutil.NewTestLogger()
+
+	err := cleanupUnixSocket(logger, osFileNoError, removeNoError, netDialError, "arbitrary_file_path.sock")
+
+	assert.NotNil(t, err)
+	wantErrMsg := "found pre-existing socket at path, but does not support cleanup in GOOS == windows"
+	assert.Containsf(t,
+		err.Error(), wantErrMsg, "expected error containing %q, got %s", wantErrMsg, err)
+}
+
+// TestCleanupExistingConnectedSock validates that should an existing server be hosting on a unix
+// domain socket, we do not clean it up but instead log an error.
+func TestCleanupExistingConnectedSock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger, _ := testutil.NewTestLogger()
+
+	err := cleanupUnixSocket(logger, osFileNoError, removeNoError, netDialNoError, "arbitrary_file_path.sock")
+
+	assert.NotNil(t, err)
+	wantErrMsg := "found pre-existing socket at path, but does not support cleanup in GOOS == windows"
+	assert.Containsf(t,
+		err.Error(), wantErrMsg, "expected error containing %q, got %s", wantErrMsg, err)
+}


### PR DESCRIPTION
## Summary

This PR adds more graceful handling of dangling / leftover unix domain socket handling by the Golang `agwd` binary.

- If an existing socket exists at the specified path
  - But a Dial attempt indicates no Listener -> Log warning and delete old sock
  - But a Dial attempt indicates a Listener -> Return error (ultimately panic)

## Test Plan

Authored new unit tests to cover the majority of the code path for socket creation.

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>