### PR TITLE
chore: update the python precommit script to use an image hosted in G…

### DIFF
--- a/lte/gateway/docker/python-precommit/README.md
+++ b/lte/gateway/docker/python-precommit/README.md
@@ -17,10 +17,11 @@ docker run -it -u 0 -v $MAGMA_ROOT:/code magma/py-lint:latest flake8 <args>
 ## Recommended: Use `lte/gateway/python/precommit.py`
 We have a utility script that wraps all necessary Docker commands with Python.
 You should refer to the script for all available commands, but the main ones are as follows.
+
+The script by default uses an up-to-date Docker image hosted on [GitHub](https://github.com/magma/magma/pkgs/container/python-precommit).
+
 ```bash
 cd $MAGMA/lte/gateway/python
-# to build the base image
-./precommit.py --build
 
 # to run the flake8 linter by specifying paths
 ./precommit.py --lint -p PATH1 PATH2

--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -24,6 +24,7 @@ LINT_DOCKER_PATH = os.path.join(
 IMAGE_NAME = 'magma/py-lint'
 ORC8R_PYTHON_PATH = 'orc8r/gateway/python/magma'
 LTE_PYTHON_PATH = 'lte/gateway/python/magma'
+GITHUB_IMAGE_NAME = 'ghcr.io/magma/python-precommit:sha-38a9341'
 
 
 def main() -> None:
@@ -33,10 +34,14 @@ def main() -> None:
         return
     print("Magma root is " + MAGMA_ROOT)
     args = _parse_args()
+
+    if args.local:
+        print("If you are using the local Dockerfile, please make sure to run `precommit.py --build` to build the image!")
+
     if args.build_image:
         _build_docker_image()
-
         return
+
     # If no paths are specified, default to magma services
     if args.diff:
         args.paths = _get_diff_against_master()
@@ -44,9 +49,9 @@ def main() -> None:
         print("Please specify at least one path for format/lint!")
         return
     if args.format:
-        _format_diff(args.paths)
+        _format_diff(args.paths, args.local)
     if args.lint:
-        _run_flake8(args.paths)
+        _run_flake8(args.paths, args.local)
 
 
 def _build_docker_image():
@@ -59,34 +64,39 @@ def _build_docker_image():
     _run(cmd)
 
 
-def _format_diff(paths: List[str]):
+def _format_diff(paths: List[str], use_local_image: bool):
     for path in paths:
         # when changing any of these commands,
         # make sure to change the corresponding github action
-        _run_docker_cmd(['isort', path])
-        _run_add_trailing_comma(path)
+        _run_docker_cmd(['isort', path], use_local_image)
+        _run_add_trailing_comma(path, use_local_image)
         autopep8_checks = 'W191,W291,W292,W293,W391,E131,E2,E3'
-        _run_docker_cmd(['autopep8', '--select', autopep8_checks, '-r', '--in-place', path])
+        _run_docker_cmd(['autopep8', '--select', autopep8_checks, '-r', '--in-place', path], use_local_image)
 
 
-def _run_add_trailing_comma(path: str):
+def _run_add_trailing_comma(path: str, use_local_image: bool):
     abs_path = os.path.join(os.path.abspath(MAGMA_ROOT), path)
     if os.path.isfile(abs_path):
         # TODO upgrade to --py36-plus eventually
-        _run_docker_cmd([
-            'add-trailing-comma', '--py35-plus',
-            '--exit-zero-even-if-changed', path,
-        ])
+        _run_docker_cmd(
+            [
+                'add-trailing-comma', '--py35-plus',
+                '--exit-zero-even-if-changed', path,
+            ], use_local_image,
+        )
 
 
-def _run_flake8(paths: List[str]):
+def _run_flake8(paths: List[str], use_local_image: bool):
     for path in paths:
-        _run_docker_cmd(['flake8', '--exit-zero', path])
+        _run_docker_cmd(['flake8', '--exit-zero', path], use_local_image)
 
 
-def _run_docker_cmd(commands: List[str]):
+def _run_docker_cmd(commands: List[str], use_local_image: bool):
     volume_cmd = ['-v', os.path.abspath(MAGMA_ROOT) + ':/code']
-    docker_image = IMAGE_NAME + ':latest'
+    if use_local_image:
+        docker_image = IMAGE_NAME + ':latest'
+    else:
+        docker_image = GITHUB_IMAGE_NAME
     cmd_prefix = 'docker run -it -u 0'.split(' ')
     cmd = cmd_prefix + volume_cmd + [docker_image] + commands
     _run(cmd)
@@ -120,6 +130,11 @@ def _parse_args() -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser(description='Python lint/format tool')
 
+    parser.add_argument(
+        '--local',
+        action='store_true',
+        help='Build the base image from local Dockerfile and use it',
+    )
     parser.add_argument(
         '--build_image', '-b',
         action='store_true',


### PR DESCRIPTION
…itHub

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
1. modified the precommit script to use the docker image hosted on Github now. This image is updated whenever the python-precommit/Dockerfile file is updated. We have a GitHub action job that runs on master that builds and pushes the image.
2. Now that the precommit script by default uses the hosted image, added a new --local flag to use a locally built container. I anticipate not that many people will use this, but it will be useful whenever we want to update dependencies or edit the Dockerfile.

Images are hosted @ https://github.com/magma/magma/pkgs/container/python-precommit
GitHub action job that pushes docker image @ https://github.com/magma/magma/blob/master/.github/workflows/docker-push.yml
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
