### PR TITLE
feat(amf): DNN from subscriberdb being matched with the one requested by UE.

### DIFF
--- a/lte/gateway/c/core/oai/include/amf_config.h
+++ b/lte/gateway/c/core/oai/include/amf_config.h
@@ -40,6 +40,7 @@
 #define AMF_CONFIG_PLMN_SUPPORT_MNC "mnc"
 #define AMF_CONFIG_PLMN_SUPPORT_SST "DEFAULT_SLICE_SERVICE_TYPE"
 #define AMF_CONFIG_PLMN_SUPPORT_SD "DEFAULT_SLICE_DIFFERENTIATOR"
+#define CONFIG_DEFAULT_DNN "DEFAULT_DNN"
 #define AMF_CONFIG_AMF_PLMN_SUPPORT_LIST "PLMN_SUPPORT_LIST"
 #define AMF_CONFIG_AMF_NAME "AMF_NAME"
 
@@ -177,6 +178,7 @@ typedef struct amf_config_s {
     struct in_addr default_dns_sec;
   } ipv4;
   bstring amf_name;
+  bstring default_dnn;
 } amf_config_t;
 
 int amf_app_init(amf_config_t*);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -1323,6 +1323,13 @@ void amf_app_handle_initial_context_setup_rsp(
   // Handle smf_context
   ue_context = amf_ue_context_exists_amf_ue_ngap_id(initial_context_rsp->ue_id);
 
+  // s6a update location request
+  int rc = amf_send_n11_update_location_req(ue_context->amf_ue_ngap_id);
+
+  if (rc == RETURNerror) {
+    OAILOG_INFO(LOG_AMF_APP, "AMF_APP: n11_update_location_req failure\n");
+  }
+
   if (!ue_context) {
     OAILOG_ERROR(
         LOG_AMF_APP, " Ue context not found for the id " AMF_UE_NGAP_ID_FMT,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -329,6 +329,8 @@ typedef struct amf_context_s {
   tai_t originating_tai;
 
   ambr_t subscribed_ue_ambr;
+  /* apn_config_profile: set by S6A UPDATE LOCATION ANSWER */
+  apn_config_profile_t apn_config_profile;
 } amf_context_t;
 
 typedef struct amf_ue_context_s {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -148,9 +148,6 @@ static int start_authentication_information_procedure(
         RAND_LENGTH_OCTETS + AUTS_LENGTH, ue_id);
   }
 
-  // Calling GRPC call for default QoS
-  amf_send_n11_update_location_req(ue_id);
-
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
 }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -232,6 +232,12 @@ int amf_config_parse_file(
       config_pP->amf_name = bfromcstr(astring);
     }
 
+    // DEFAULT_DNN
+    if (config_setting_lookup_string(
+            setting_amf, CONFIG_DEFAULT_DNN, (const char**) &astring)) {
+      config_pP->default_dnn = bfromcstr(astring);
+    }
+
     // AMF_PLMN_SUPPORT SETTING
     setting = config_setting_get_member(
         setting_amf, AMF_CONFIG_AMF_PLMN_SUPPORT_LIST);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.h
@@ -49,6 +49,9 @@ int amf_handle_deregistration_ue_origin_req(
     amf_ue_ngap_id_t ue_id, DeRegistrationRequestUEInitMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status);
 int amf_smf_send(amf_ue_ngap_id_t ueid, ULNASTransportMsg* msg, int amf_cause);
+int amf_validate_dnn(
+    const amf_context_s* amf_ctxt_p, std::string dnn_string, int* index,
+    bool ue_sent_dnn);
 int amf_smf_notification_send(
     amf_ue_ngap_id_t ueid, ue_m5gmm_context_s* ue_context,
     notify_ue_event notify_event_type);
@@ -62,8 +65,6 @@ int amf_registration_success_security_cb(amf_context_t* amf_context);
 int amf_proc_registration_reject(
     const amf_ue_ngap_id_t ue_id, amf_cause_t amf_cause);
 
-void amf_app_handle_cm_idle_on_ue_context_release(
-    itti_ngap_ue_context_release_req_t cm_idle_req);
 // Handle UE CONTEXT RELEASE COMMAND in DL to NGAP
 void ue_context_release_command(
     amf_ue_ngap_id_t amf_ue_ngap_id, gnb_ue_ngap_id_t gnb_ue_ngap_id,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -20,6 +20,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/common/conversions.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_38.401.h"
 #include "lte/gateway/c/core/oai/include/s6a_messages_types.h"
+#include "lte/gateway/c/core/oai/include/amf_config.h"
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
 #ifdef __cplusplus
 }
@@ -39,12 +40,14 @@ extern "C" {
 using magma5g::AsyncM5GMobilityServiceClient;
 using magma5g::AsyncSmfServiceClient;
 
+extern amf_config_t amf_config;
 namespace magma5g {
 #define IMSI_LEN 15
 #define AMF_CAUSE_SUCCESS 1
 const uint32_t MAX_UE_PDU_SESSION_LIMIT = 15;
 
-int amf_max_pdu_session_reject(amf_ue_ngap_id_t ue_id, ULNASTransportMsg* msg);
+int handle_sm_message_routing_failure(
+    amf_ue_ngap_id_t ue_id, ULNASTransportMsg* msg, M5GMmCause m5gmmcause);
 
 static int pdu_session_resource_release_t3592_handler(
     zloop_t* loop, int timer_id, void* arg);
@@ -411,7 +414,8 @@ int amf_smf_send(
           "Max pdu session limit reached, Rejecting new session for the "
           "ue_id :" AMF_UE_NGAP_ID_FMT,
           ue_id);
-      rc = amf_max_pdu_session_reject(ue_id, msg);
+      M5GMmCause m5gmmCause = M5GMmCause::MAX_PDU_SESSIONS_REACHED;
+      rc = handle_sm_message_routing_failure(ue_id, msg, m5gmmCause);
 
       return rc;
     }
@@ -474,8 +478,44 @@ int amf_smf_send(
       amf_smf_msg.u.establish.gnb_gtp_teid =
           smf_ctx->gtp_tunnel_id.gnb_gtp_teid;
 
-      // Initialize default APN
-      memcpy(smf_ctx->apn, "internet", strlen("internet") + 1);
+      // Initialize DNN
+      char* default_dnn = bstr2cstr(amf_config.default_dnn, '?');
+
+      int index_dnn    = 0;
+      bool ue_sent_dnn = true;
+      std::string dnn_string;
+
+      if (msg->dnn.dnn.empty()) {
+        ue_sent_dnn = false;
+        dnn_string  = default_dnn;
+      } else {
+        dnn_string = msg->dnn.dnn;
+      }
+
+      int validate = amf_validate_dnn(
+          &ue_context->amf_context, dnn_string, &index_dnn, ue_sent_dnn);
+      free(default_dnn);
+
+      if (validate == RETURNok) {
+        memcpy(
+            smf_ctx->apn,
+            &ue_context->amf_context.apn_config_profile
+                 .apn_configuration[index_dnn]
+                 .service_selection,
+            strlen(ue_context->amf_context.apn_config_profile
+                       .apn_configuration[index_dnn]
+                       .service_selection) +
+                1);
+        OAILOG_INFO(LOG_AMF_APP, "dnn selected %s\n", smf_ctx->apn);
+      } else {
+        OAILOG_INFO(
+            LOG_AMF_APP,
+            "DNN mismatch or DNN missing, reject with a cause: 91 \n");
+        M5GMmCause cause_dnn_reject =
+            M5GMmCause::DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED;
+        rc = handle_sm_message_routing_failure(ue_id, msg, cause_dnn_reject);
+        return rc;
+      }
 
       smf_ctx->smf_proc_data.pti.pti =
           msg->payload_container.smf_msg.msg.pdu_session_estab_request.pti.pti;
@@ -524,6 +564,33 @@ int amf_smf_send(
   return rc;
 }
 
+/***************************************************************************
+**                                                                        **
+** Name:    amf_validate_dnn()                                            **
+**                                                                        **
+** Description:                                                           **
+** This function validates the DNN string received from UE or from        **
+** mme.yml againt apn stored in amf_context for a particular imsi.        **
+***************************************************************************/
+int amf_validate_dnn(
+    const amf_context_s* amf_ctxt_p, std::string dnn_string, int* index,
+    bool ue_sent_dnn) {
+  // Validating apn_configuration_s
+  if (dnn_string.empty()) {
+    return RETURNok;
+  }
+  for (int i = 0; i < MAX_APN_PER_UE; i++) {
+    if (strcmp(
+            amf_ctxt_p->apn_config_profile.apn_configuration[i]
+                .service_selection,
+            dnn_string.c_str()) == 0) {
+      *index = i;
+      return RETURNok;
+    }
+  }
+  *index = 0;
+  return ue_sent_dnn ? RETURNerror : RETURNok;
+}
 /***************************************************************************
 **                                                                        **
 ** Name:    amf_smf_notification_send()                                   **
@@ -708,7 +775,7 @@ int amf_send_n11_update_location_req(amf_ue_ngap_id_t ue_id) {
 
 /****************************************************************************
  **                                                                        **
- ** Name        :  amf_max_pdu_session_reject()                            **
+ ** Name        :  handle_sm_message_routing_failure() **
  **                                                                        **
  ** Description :  Send the Downlink Transport with 5GMM Cause to gnb      **
  **                                                                        **
@@ -718,8 +785,8 @@ int amf_send_n11_update_location_req(amf_ue_ngap_id_t ue_id) {
  **  Return     :  RETURNok, RETURNerror                                   **
  **                                                                        **
  ***************************************************************************/
-int amf_max_pdu_session_reject(
-    amf_ue_ngap_id_t ue_id, ULNASTransportMsg* ulmsg) {
+int handle_sm_message_routing_failure(
+    amf_ue_ngap_id_t ue_id, ULNASTransportMsg* ulmsg, M5GMmCause m5gmmcause) {
   nas5g_error_code_t rc    = M5G_AS_FAILURE;
   DLNASTransportMsg* dlmsg = nullptr;
   SmfMsg* smf_msg          = nullptr;
@@ -736,8 +803,7 @@ int amf_max_pdu_session_reject(
         a) include the PDU session ID in the PDU session ID IE;
         b) set the Payload container type IE to "N1 SM information";
         c) set the Payload container IE to the 5GSM message which was not
-     forwarded; and d) set the 5GMM cause IE to the 5GMM cause #65 "maximum
-     number of PDU sessions reached".
+     forwarded; and d) set the specific 5GMM cause IE.
   */
   ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
 
@@ -783,9 +849,8 @@ int amf_max_pdu_session_reject(
       ulmsg->payload_container.smf_msg.header.pdu_session_id;
   len++;
 
-  dlmsg->m5gmm_cause.iei = static_cast<uint8_t>(M5GIei::M5GMM_CAUSE);
-  dlmsg->m5gmm_cause.m5gmm_cause =
-      static_cast<uint8_t>(M5GMmCause::MAX_PDU_SESSIONS_REACHED);
+  dlmsg->m5gmm_cause.iei         = static_cast<uint8_t>(M5GIei::M5GMM_CAUSE);
+  dlmsg->m5gmm_cause.m5gmm_cause = static_cast<uint8_t>(m5gmmcause);
   len += 2;
 
   // Payload container IE from ulmsg

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -493,6 +493,12 @@ int amf_handle_s6a_update_location_ans(
 
   amf_ue_ngap_id_t amf_ue_ngap_id = ue_mm_context->amf_ue_ngap_id;
 
+  // Validating whether the apn_config sent from ue and saved in amf_ctx is
+  // present in s6a_update_location_ans_t received from subscriberdb.
+  memcpy(
+      &amf_ctxt_p->apn_config_profile,
+      &ula_pP->subscription_data.apn_config_profile,
+      sizeof(apn_config_profile_t));
   OAILOG_DEBUG(
       LOG_NAS_AMF,
       "Received update location Answer from Subscriberdb for"

--- a/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
@@ -147,6 +147,7 @@ int amf_smf_create_pdu_session(
   imsi64_t imsi64                   = INVALID_IMSI64;
   amf_context_t* amf_ctxt_p         = NULL;
   ue_m5gmm_context_s* ue_mm_context = NULL;
+  std::shared_ptr<smf_context_t> smf_ctx;
 
   OAILOG_INFO(
       LOG_AMF_APP, "Sending msg(grpc) to :[sessiond] for ue: [%s] session\n",
@@ -154,6 +155,8 @@ int amf_smf_create_pdu_session(
 
   IMSI_STRING_TO_IMSI64((char*) imsi, &imsi64);
   ue_mm_context = lookup_ue_ctxt_by_imsi(imsi64);
+  smf_ctx       = amf_get_smf_context_by_pdu_session_id(
+      ue_mm_context, message->pdu_session_id);
 
   if (ue_mm_context) {
     amf_ctxt_p = &ue_mm_context->amf_context;
@@ -168,9 +171,9 @@ int amf_smf_create_pdu_session(
       LOG_AMF_APP, "Sending msg(grpc) to :[mobilityd] for ue: [%s] ip-addr\n",
       imsi);
   AsyncM5GMobilityServiceClient::getInstance().allocate_ipv4_address(
-      imsi, "internet", message->pdu_session_id, message->pti, AF_INET,
-      message->gnb_gtp_teid, message->gnb_gtp_teid_ip_addr, 4,
-      amf_ctxt_p->subscribed_ue_ambr);
+      imsi, reinterpret_cast<char*>(smf_ctx->apn), message->pdu_session_id,
+      message->pti, AF_INET, message->gnb_gtp_teid,
+      message->gnb_gtp_teid_ip_addr, 4, amf_ctxt_p->subscribed_ue_ambr);
 
   return (RETURNok);
 }

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GULNASTransport.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GULNASTransport.h
@@ -18,6 +18,7 @@
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPayloadContainerType.h"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPayloadContainer.h"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GRequestType.h"
+#include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GDNN.h"
 
 namespace magma5g {
 // ULNASTransport Message Class
@@ -32,6 +33,7 @@ class ULNASTransportMsg {
   // optinal parameters
   RequestType request_type;
 #define UL_NAS_TRANSPORT_MINIMUM_LENGTH 7
+  DNNMsg dnn;
 
   ULNASTransportMsg();
   ~ULNASTransportMsg();

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GULNASTransport.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GULNASTransport.cpp
@@ -108,8 +108,16 @@ int ULNASTransportMsg::DecodeULNASTransportMsg(
         decoded_result += 1;
         decoded += decoded_result;
         break;
-      case M5GIei::S_NSSA:
       case M5GIei::DNN:
+        if ((decoded_result = ul_nas_transport->dnn.DecodeDNNMsg(
+                 &ul_nas_transport->dnn, static_cast<uint8_t>(M5GIei::DNN),
+                 buffer + decoded, len - decoded)) < 0) {
+          return decoded_result;
+        } else {
+          decoded += decoded_result;
+        }
+        break;
+      case M5GIei::S_NSSA:
       case M5GIei::ADDITIONAL_INFORMATION:
         // TLV Types. 1 byte for Type and 1 Byte for size
         type_len   = sizeof(uint8_t);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GDNN.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GDNN.cpp
@@ -27,14 +27,31 @@ int DNNMsg::DecodeDNNMsg(
   int decoded   = 0;
   uint8_t ielen = 0;
 
-  /*** Will be supported POST MVC ***/
   if (iei > 0) {
+    DECODE_U8(buffer + decoded, dnn_message->iei, decoded);
     CHECK_IEI_DECODER(iei, (unsigned char) *buffer);
-    IES_DECODE_U8(buffer, decoded, ielen);
+    MLOG(MDEBUG) << "iei : " << std::hex << static_cast<int>(dnn_message->iei);
   }
+  DECODE_U8(buffer + decoded, ielen, decoded);
   CHECK_LENGTH_DECODER(len - decoded, ielen);
+  dnn_message->len = ielen;
+  MLOG(MDEBUG) << "len : " << static_cast<int>(dnn_message->len);
+
+  uint8_t dnn_len = 0;
+  DECODE_U8(buffer + decoded, dnn_len, decoded);
+  MLOG(MDEBUG) << "dnn_len : " << static_cast<int>(dnn_len);
+
+  MLOG(MDEBUG) << std::string(
+      (const char*) (buffer + decoded), static_cast<int>(dnn_len));
+  dnn_message->dnn =
+      std::string((const char*) (buffer + decoded), static_cast<int>(dnn_len))
+          .c_str();
+
+  decoded = decoded + dnn_len;
+  MLOG(MDEBUG) << "dnn str : " << dnn_message->dnn;
+
   return decoded;
-};
+}
 
 // Encode DNN Message
 int DNNMsg::EncodeDNNMsg(
@@ -46,17 +63,22 @@ int DNNMsg::EncodeDNNMsg(
 
   if (iei > 0) {
     CHECK_IEI_ENCODER(iei, (unsigned char) dnn_message->iei);
-    *buffer = iei;
-    encoded++;
+    ENCODE_U8(buffer, iei, encoded);
+    MLOG(MDEBUG) << "iei : " << std::hex << static_cast<int>(dnn_message->iei);
   }
 
-  MLOG(MDEBUG) << "EncodeDNN : ";
-  IES_ENCODE_U8(buffer, encoded, dnn_message->len);
-  MLOG(MDEBUG) << "Length = " << std::hex << int(dnn_message->len);
+  ENCODE_U8(buffer + encoded, dnn_message->len, encoded);
+  MLOG(MDEBUG) << "len : " << static_cast<int>(dnn_message->len);
+
+  ENCODE_U8(buffer + encoded, dnn_message->dnn.length(), encoded);
+  MLOG(MDEBUG) << "dnn len : " << dnn_message->dnn.length();
+
   std::copy(dnn_message->dnn.begin(), dnn_message->dnn.end(), buffer + encoded);
   BUFFER_PRINT_LOG(buffer + encoded, dnn_message->dnn.length());
+  MLOG(MDEBUG) << "dnn str : " << dnn_message->dnn;
   encoded = encoded + dnn_message->dnn.length();
 
   return encoded;
 };
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
@@ -43,6 +43,8 @@ set(AMF_APP_TEST_SRC
     amf_app_test_util.cpp
     test_amf_procedures.cpp
     test_amf_algorithm_selection.cpp
+    util_s6a_update_location.cpp
+    util_s6a_update_location.h
     )
 
 add_executable(amf_app_test ${AMF_APP_TEST_SRC})

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -16,6 +16,10 @@
 #include "../../tasks/amf/amf_app_ue_context_and_proc.h"
 #include "lte/gateway/c/core/oai/include/mme_config.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_authentication.h"
+#include "util_s6a_update_location.h"
+#include "tasks/amf/amf_recv.h"
+#include "tasks/amf/amf_identity.h"
+#include "tasks/amf/amf_app_ue_context_and_proc.h"
 
 extern "C" {
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
@@ -40,6 +44,8 @@ task_zmq_ctx_t grpc_service_task_zmq_ctx;
 using ::testing::Test;
 
 namespace magma5g {
+extern std::unordered_map<imsi64_t, guti_and_amf_id_t> amf_supi_guti_map;
+extern std::unordered_map<amf_ue_ngap_id_t, ue_m5gmm_context_s*> ue_context_map;
 
 uint8_t NAS5GPktSnapShot::reg_req_buffer[38] = {
     0x7e, 0x00, 0x41, 0x79, 0x00, 0x0d, 0x01, 0x09, 0xf1, 0x07,
@@ -730,6 +736,115 @@ TEST(test_delete_registration_proc, test_delete_registration_proc) {
 
   delete_wrapper(&ue_ctxt->amf_context.amf_procedures);
   delete ue_ctxt;
+}
+
+TEST(test_optional_dnn_pdu, test_pdu_session_establish_optional) {
+  uint32_t bytes         = 0;
+  uint32_t container_len = 0;
+  bstring buffer;
+  amf_nas_message_t msg = {};
+
+  // build uplinknastransport //
+  // uplink nas transport(pdu session request)
+  uint8_t pdu[44] = {0x7e, 0x00, 0x67, 0x01, 0x00, 0x15, 0x2e, 0x01, 0x01,
+                     0xc1, 0xff, 0xff, 0x91, 0xa1, 0x28, 0x01, 0x00, 0x7b,
+                     0x00, 0x07, 0x80, 0x00, 0x0a, 0x00, 0x00, 0x0d, 0x00,
+                     0x12, 0x01, 0x81, 0x22, 0x01, 0x01, 0x25, 0x09, 0x08,
+                     0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74};
+  uint32_t len    = sizeof(pdu) / sizeof(uint8_t);
+
+  NAS5GPktSnapShot nas5g_pkt_snap;
+  ULNASTransportMsg pdu_sess_est_req;
+  bool decode_res = false;
+  memset(&pdu_sess_est_req, 0, sizeof(ULNASTransportMsg));
+
+  decode_res = decode_ul_nas_transport_msg(&pdu_sess_est_req, pdu, len);
+
+  EXPECT_EQ(decode_res, true);
+  // build uplinknastransport
+
+  std::string dnn("internet");
+  EXPECT_EQ(dnn, pdu_sess_est_req.dnn.dnn);
+
+  buffer = bfromcstralloc(len, "\0");
+  bytes  = pdu_sess_est_req.EncodeULNASTransportMsg(
+      &pdu_sess_est_req, buffer->data, len);
+  EXPECT_GT(bytes, 0);
+  ULNASTransportMsg decode_pdu_sess_est_req = {};
+  decode_res = decode_ul_nas_transport_msg(&decode_pdu_sess_est_req, pdu, len);
+  EXPECT_EQ(decode_res, true);
+  // build uplinknastransport
+  EXPECT_EQ(dnn, decode_pdu_sess_est_req.dnn.dnn);
+  bdestroy(buffer);
+}
+
+TEST(test_dnn, test_amf_handle_s6a_update_location_ans) {
+  // creating ue_context
+  ue_m5gmm_context_s* ue_context = amf_create_new_ue_context();
+
+  // Building s6a_update_location_ans_t
+  std::string imsi = "901700000000001";
+  s6a_update_location_ans_t ula_ans;
+  ula_ans = amf_send_s6a_ula(imsi);
+
+  // Building key value pair for amf_supi_guti_map and ue_context_map
+  uint64_t imsi_64 = 901700000000001;
+  guti_and_amf_id_t guti_amf;
+  guti_amf.amf_guti.m_tmsi = 0x2bfb815f;
+  guti_amf.amf_ue_ngap_id  = 0x01;
+
+  // Inserting into amf_supi_guti_map, ue_context_map
+  amf_supi_guti_map.insert(
+      std::pair<imsi64_t, guti_and_amf_id_t>(imsi_64, guti_amf));
+  ue_context_map.insert(std::pair<amf_ue_ngap_id_t, ue_m5gmm_context_s*>(
+      guti_amf.amf_ue_ngap_id, ue_context));
+
+  int rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
+  // Clearing the map and deleting ue_context
+  amf_supi_guti_map.clear();
+  ue_context_map.clear();
+  delete ue_context;
+}
+
+TEST(test_dnn, test_amf_validate_dnn) {
+  // uplink nas transport(pdu session request)
+  uint8_t pdu[44] = {0x7e, 0x00, 0x67, 0x01, 0x00, 0x15, 0x2e, 0x01, 0x01,
+                     0xc1, 0xff, 0xff, 0x91, 0xa1, 0x28, 0x01, 0x00, 0x7b,
+                     0x00, 0x07, 0x80, 0x00, 0x0a, 0x00, 0x00, 0x0d, 0x00,
+                     0x12, 0x01, 0x81, 0x22, 0x01, 0x01, 0x25, 0x09, 0x08,
+                     0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74};
+  uint32_t len    = sizeof(pdu) / sizeof(uint8_t);
+
+  ULNASTransportMsg msg;
+  bool decode_res = false;
+  memset(&msg, 0, sizeof(ULNASTransportMsg));
+  std::string dnn_string = msg.dnn.dnn;
+  int idx                = 0;
+  bool ue_sent_dnn       = true;
+  // decoding uplink uplink nas transport(pdu session request)
+  decode_res = decode_ul_nas_transport_msg(&msg, pdu, len);
+  EXPECT_EQ(decode_res, true);
+
+  amf_context_s amf_ctx = {};
+  std::string imsi      = "901700000000001";
+  s6a_update_location_ans_t ula_ans;
+
+  // mock handling ans received from s6a_update_location_request
+  ula_ans = amf_send_s6a_ula(imsi);
+  memcpy(
+      &amf_ctx.apn_config_profile,
+      &ula_ans.subscription_data.apn_config_profile,
+      sizeof(apn_config_profile_t));
+
+  // validating dnn against s6a update location ans
+  int rc = amf_validate_dnn(&amf_ctx, dnn_string, &idx, ue_sent_dnn);
+  EXPECT_TRUE(rc == RETURNok);
+}
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.cpp
+++ b/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.cpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include "util_nas5g_pkt.h"
+#include "include/s6a_messages_types.h"
+#include "util_s6a_update_location.h"
+
+namespace magma5g {
+// api to mock handling of s6a_update_location_ans
+
+s6a_update_location_ans_t amf_send_s6a_ula(const std::string& imsi) {
+  s6a_update_location_ans_t itti_msg = {};
+
+  // building s6a_update_location_ans_t
+  strncpy(itti_msg.imsi, imsi.c_str(), imsi.size());
+  itti_msg.imsi_length        = imsi.size();
+  itti_msg.result.present     = S6A_RESULT_BASE;
+  itti_msg.result.choice.base = DIAMETER_SUCCESS;
+
+  // ambr
+  memset(
+      &itti_msg.subscription_data.subscribed_ambr.br_unit, 0,
+      sizeof(apn_ambr_bitrate_unit_t));
+  memset(
+      &itti_msg.subscription_data.subscribed_ambr.br_ul, 100000000,
+      sizeof(bitrate_t));
+  memset(
+      &itti_msg.subscription_data.subscribed_ambr.br_dl, 200000000,
+      sizeof(bitrate_t));
+
+  // apnconfig
+  itti_msg.subscription_data.apn_config_profile.context_identifier = 0;
+  itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+      .context_identifier = 0;
+
+  memset(
+      &itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+           .ambr.br_unit,
+      0, sizeof(apn_ambr_bitrate_unit_t));
+  memset(
+      &itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+           .ambr.br_ul,
+      100000000, sizeof(bitrate_t));
+  memset(
+      &itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+           .ambr.br_dl,
+      200000000, sizeof(bitrate_t));
+
+  memcpy(
+      &itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+           .service_selection,
+      "internet", strlen("internet") + 1);
+  memset(
+      &itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+           .service_selection_length,
+      strlen("internet") + 1,
+      sizeof(itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+                 .service_selection_length));
+
+  return itti_msg;
+}
+
+}  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h
+++ b/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include "util_nas5g_pkt.h"
+#include "include/s6a_messages_types.h"
+
+namespace magma5g {
+// api to mock handling s6a_update_location_ans
+
+s6a_update_location_ans_t amf_send_s6a_ula(const std::string& imsi);
+
+}  // namespace magma5g

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -342,6 +342,7 @@ AMF :
     DEFAULT_DNS_IPV4_ADDRESS     = "{{ ipv4_dns }}";
     DEFAULT_DNS_SEC_IPV4_ADDRESS = "{{ ipv4_sec_dns }}";
     AMF_NAME = "{{ amf_name }}";
+    DEFAULT_DNN = "{{ default_dnn }}";
     PLMN_SUPPORT_LIST = (
        { MCC="{{ mcc }}" ; MNC="{{ mnc }}"; DEFAULT_SLICE_SERVICE_TYPE="{{ default_slice_service_type }}" ; DEFAULT_SLICE_DIFFERENTIATOR="{{ default_slice_differentiator }}"; }
     );

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -46,6 +46,7 @@ DEFAULT_NGAP_AMF_NAME = "MAGMAAMF1"
 DEFAULT_NGAP_AMF_REGION_ID = "1"
 DEFAULT_NGAP_SET_ID = "1"
 DEFAULT_NGAP_AMF_POINTER = "0"
+DEFAULT_DEFAULT_DNN = ""
 
 
 def _get_iface_ip(service, iface_config):
@@ -328,6 +329,25 @@ def _get_amf_name_config(service_mconfig: object) -> str:
     return service_mconfig.amf_name or DEFAULT_NGAP_AMF_NAME
 
 
+def _get_default_dnn_config(service_mconfig: object) -> str:
+    """Retrieve default_dnn config value. If it does not exist, it defaults to DEFAULT_DEFAULT_DNN.
+
+    Args:
+        service_mconfig: This is a configuration placeholder for mme.
+
+    Returns:
+        default dnn string.
+    """
+    enable_default_dnn_config = get_service_config_value(
+        'mme', 'default_dnn', None,
+    )
+
+    if enable_default_dnn_config is not None:
+        return enable_default_dnn_config
+
+    return DEFAULT_DEFAULT_DNN
+
+
 def _get_amf_region_id(service_mconfig: object) -> str:
     """Retrieve amf_region_id config value. If it does not exist it defaults to DEFAULT_NGAP_AMF_REGION_ID.
 
@@ -446,6 +466,7 @@ def _get_context():
         "amf_region_id": _get_amf_region_id(mme_service_config),
         "amf_set_id": _get_amf_set_id(mme_service_config),
         "amf_pointer": _get_amf_pointer(mme_service_config),
+        "default_dnn": _get_default_dnn_config(mme_service_config),
     }
 
     context["s1u_ip"] = mme_service_config.ipv4_sgw_s1u_addr or _get_iface_ip(


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
### NOTE: Due to multiple `push -f` CI tests are not running, hence a new PR is raised to run CI test: (#10164)
DNN from subscriberdb being matched with the one requested by UE.
 1. DNN from ue is decoded.
 2. `apn_config_profile` fetched from subscriberdb (stored in `s6a_update_location_ans_t`) is copied to `amf_ctx`.
 3. `apn_config_profile` from subscriberdb (stored in `amf_ctx`) will be matched against the one sent by UE. If a match is present, it will be saved in `smf_context`  otherwise default apn will be used.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

1. UERANSIM
 
2. Unit Testing

3. TeraVM

Unit Testing Successful:
![DNN_test](https://user-images.githubusercontent.com/52399057/138949610-86c68142-0388-4e0a-a9e3-3cd8e7ac0b1e.png)

## Test Scenario(UERANSIM)

### Subscriber dnn(apn) info:
![Subscriber_info](https://user-images.githubusercontent.com/52399057/139722927-c1a4d2a1-d8dd-4678-af26-14811cd8e8ec.png)


 
### Case 1: UE requested DNN is in the list returned from subscriberdb:
	   a. UE: apn_2, selected: apn_2, sbuscriberDB: apn_1, apn_2.
 
![Case_1_dnn_1](https://user-images.githubusercontent.com/52399057/139717402-c8cac5b9-de85-4fae-9526-584ef1c6b8a4.png)

selected dnn (mme.log):
![Case_1](https://user-images.githubusercontent.com/52399057/139722242-cad3177a-258e-4782-bcdd-7d72a6ff8806.png)

### Case 2: UE requested DNN is not in the list, reject with a proper cause (DNN is not supported) :
	  a. UE: apn_3, selected: NA, sbuscriberDB: apn_1, apn_2, (Reject with cause 91).
![Case_2_dnn_1](https://user-images.githubusercontent.com/52399057/139717519-12db1b8c-4e7e-47c6-95e9-092e57a5ff60.png)

### Case 3: UE did not request a particular DNN:
	  a. UE: None, selected: apn_1, sbuscriberDB: apn_1, apn_2, mme.yml: internet.
	  b. UE: None, selected: apn_2, sbuscriberDB: apn_1, apn_2, mme.yml: apn_2.
	  c. UE: None, selected: apn_1, sbuscriberDB: apn_1, apn_2, mme.yml: None.

#### UE DNN: None.
![Case_3_dnn_1](https://user-images.githubusercontent.com/52399057/139717582-451c153c-fbe6-4f5d-bec8-43de89a5f290.png)

##### a. UE: None, selected: apn_1, sbuscriberDB: apn_1, apn_2, mme.yml: internet.
mme.yml:
![mme_yml_1](https://user-images.githubusercontent.com/52399057/139720115-24a3f6aa-c406-436d-8510-bfefded34449.png)


selected dnn (mme.log):
![Case_3_a](https://user-images.githubusercontent.com/52399057/139717925-9b520b05-a3b0-491f-8bf6-c73449225f3c.png)

#####  b. UE: None, selected: apn_2, sbuscriberDB: apn_1, apn_2, mme.yml: apn_2.
mme.yml:
![mme_yml_2](https://user-images.githubusercontent.com/52399057/139720151-4d80ae43-c139-4c52-b960-a0e7fe0d9619.png)

selected dnn (mme.log):
![Case_3_b](https://user-images.githubusercontent.com/52399057/139717963-cb23f7a9-12a0-4189-b7eb-254584f07aab.png)

#####  c. UE: None, selected: apn_1, sbuscriberDB: apn_1, apn_2, mme.yml: None.
mme.yml
![mme_yml_3](https://user-images.githubusercontent.com/52399057/139720200-79cc3396-06bb-44f3-b4a6-0881624f8fc4.png)

selected dnn (mme.log):
![Case_3_c](https://user-images.githubusercontent.com/52399057/139717998-117f07bb-f1fb-42d2-a9a9-14486b89d463.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

Signed-off-by: LKishor123 <laawanya.kishor@wavelabs.ai>

