### PR TITLE
fix(mme): Using pair of mme_ue_id and timer_id and storing on set for timer validation

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_mme_ue_id_timer.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_mme_ue_id_timer.h
@@ -22,13 +22,16 @@ extern "C" {
 #include "common_types.h"
 #include "nas_timer.h"
 
-void initialize_mme_ue_id_timer_id_map(void);
+void initialize_mme_ue_id_timer_id_set(void);
+void clear_mme_ue_id_timer_id_set(void);
 
-void mme_app_upsert_mme_ue_id_timer_id(
+void mme_app_insert_mme_ue_id_timer_id(
     mme_ue_s1ap_id_t mme_ue_id, long timer_id);
-void mme_app_remove_mme_ue_id_timer_id(mme_ue_s1ap_id_t mme_ue_id);
+void mme_app_remove_mme_ue_id_timer_id(
+    mme_ue_s1ap_id_t mme_ue_id, long timer_id);
 
-long mme_app_get_timer_id_from_mme_ue_id(mme_ue_s1ap_id_t mme_ue_id);
+bool mme_app_is_mme_ue_id_timer_id_key_valid(
+    mme_ue_s1ap_id_t mme_ue_id, long timer_id);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state.cpp
@@ -29,7 +29,7 @@ using magma::lte::MmeNasStateManager;
  */
 int mme_nas_state_init(const mme_config_t* mme_config_p) {
   initialize_ipv4_map();
-  initialize_mme_ue_id_timer_id_map();
+  initialize_mme_ue_id_timer_id_set();
   return MmeNasStateManager::getInstance().initialize_state(mme_config_p);
 }
 
@@ -56,6 +56,7 @@ void put_mme_nas_state() {
  * state persisted in data store
  */
 void clear_mme_nas_state() {
+  clear_mme_ue_id_timer_id_set();
   MmeNasStateManager::getInstance().free_state();
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_data_context.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_data_context.c
@@ -93,8 +93,7 @@ void nas_stop_T3489(esm_context_t* const esm_ctx) {
     mme_ue_s1ap_id_t ue_id = ue_mm_context->mme_ue_s1ap_id;
     void* nas_timer_callback_args;
     esm_ctx->T3489.id = nas_timer_stop(
-        esm_ctx->T3489.id, (void**) &nas_timer_callback_args,
-        ue_id);
+        esm_ctx->T3489.id, (void**) &nas_timer_callback_args, ue_id);
     if (NAS_TIMER_INACTIVE_ID == esm_ctx->T3489.id) {
       OAILOG_INFO(
           LOG_NAS_EMM, "T3489 stopped UE " MME_UE_S1AP_ID_FMT "\n", ue_id);

--- a/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.c
+++ b/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.c
@@ -75,7 +75,7 @@ long int nas_timer_start(
     return NAS_TIMER_INACTIVE_ID;
   }
 
-  mme_app_upsert_mme_ue_id_timer_id(mme_ue_s1ap_id, timer_id);
+  mme_app_insert_mme_ue_id_timer_id(mme_ue_s1ap_id, timer_id);
 
   return timer_id;
 }
@@ -87,7 +87,7 @@ long int nas_timer_stop(
   nas_itti_timer_arg_t* nas_itti_timer_arg = NULL;
   timer_remove(timer_id, (void**) &nas_itti_timer_arg);
 
-  mme_app_remove_mme_ue_id_timer_id(mme_ue_s1ap_id);
+  mme_app_remove_mme_ue_id_timer_id(mme_ue_s1ap_id, timer_id);
 
   if (nas_itti_timer_arg) {
     *nas_timer_callback_arg = nas_itti_timer_arg->nas_timer_callback_arg;
@@ -104,9 +104,7 @@ void mme_app_nas_timer_handle_signal_expiry(
   OAILOG_FUNC_IN(LOG_NAS);
 
   bool is_timer_valid =
-      mme_app_get_timer_id_from_mme_ue_id(cb->ue_id) != NAS_TIMER_INACTIVE_ID ?
-          true :
-          false;
+      mme_app_is_mme_ue_id_timer_id_key_valid(cb->ue_id, timer_id);
 
   if ((!timer_exists(timer_id)) || !is_timer_valid ||
       (cb->nas_timer_callback == NULL)) {


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- #9593 introduced a regression on v1.6 for some of integ_tests, particularly `test_attach_detach_duplicate_nas_resp_messages` failed due to the timer updates between the procedures, this PR fixes this by updating the mme_ue_id to timer_id hashmap, to instead using a set of pairs using both values to ensure uniqueness of timer validations.


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- ran all integ tests 
- ensuring `test_attach_detach_duplicate_nas_resp_messages` passes after change
- Created https://github.com/magma/magma/issues/9647 to follow up and add S1AP tests for timer expiration handlers and max retransmission cases.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
