### PR TITLE
fix(ci): Fix secret name mismatch in Github testim-workflow

### DIFF
--- a/.github/workflows/testim-workflow.yml
+++ b/.github/workflows/testim-workflow.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Install Testim CLI
         run: npm install -g @testim/testim-cli
       - name: Run Daily NMS Tests
-        run: testim --token ${{ secrets.TESTIM_TOKEN }} --project ${{ secrets.TESTIM_PROJECT }} --test-plan "Daily Test Plan"
+        run: testim --token ${{ secrets.TESTIM_TOKEN }} --project ${{ secrets.TESTIM_PROJECT_ID }} --test-plan "Daily Test Plan"


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

`testim-workflow`, which is intended to trigger Testim integration tests on Magma's staging environment, has been failing, due to a secret name mismatch. See runs of the workflow [here](https://github.com/magma/magma/actions/workflows/testim-workflow.yml).

Should be fixed by updating `TESTIM_PROJECT` to `TESTIM_PROJECT_ID`.

## Test Plan

None

## Additional Information

- [ ] This change is backwards-breaking
