### PR TITLE
fix(sessiond): Default qos value needs to send to amf

### DIFF
--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -619,10 +619,18 @@ void SessionStateEnforcer::prepare_response_to_access(
    * values and sent to AMF.
    */
   // For now its default QOS, AMBR has default values
-  rsp->mutable_session_ambr()->set_br_unit(AggregatedMaximumBitrate::KBPS);
-  rsp->mutable_session_ambr()->set_max_bandwidth_ul(DEFAULT_AMBR_UNITS);
-  rsp->mutable_session_ambr()->set_max_bandwidth_dl(DEFAULT_AMBR_UNITS);
-
+  rsp->mutable_session_ambr()->set_br_unit(
+      config.rat_specific_context.m5gsm_session_context()
+          .default_ambr()
+          .br_unit());
+  rsp->mutable_session_ambr()->set_max_bandwidth_ul(
+      config.rat_specific_context.m5gsm_session_context()
+          .default_ambr()
+          .max_bandwidth_ul());
+  rsp->mutable_session_ambr()->set_max_bandwidth_dl(
+      config.rat_specific_context.m5gsm_session_context()
+          .default_ambr()
+          .max_bandwidth_ul());
   /* This flag is used for sending defult qos value or getting from policy
    *  value to AMF.
    */

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -633,6 +633,17 @@ TEST_F(SessionManagerHandlerTest, test_SetAmfSessionAmbr) {
   cfg.rat_specific_context.mutable_m5gsm_session_context()->set_ssc_mode(
       SSC_MODE_3);
 
+  cfg.rat_specific_context.mutable_m5gsm_session_context()
+      ->mutable_default_ambr()
+      ->set_br_unit(AggregatedMaximumBitrate::KBPS);
+
+  cfg.rat_specific_context.mutable_m5gsm_session_context()
+      ->mutable_default_ambr()
+      ->set_max_bandwidth_ul(1024);
+  cfg.rat_specific_context.mutable_m5gsm_session_context()
+      ->mutable_default_ambr()
+      ->set_max_bandwidth_dl(1024);
+
   SessionUpdate session_update =
       SessionStore::get_default_session_update(session_map);
   uint32_t pdu_id = 5;
@@ -643,6 +654,7 @@ TEST_F(SessionManagerHandlerTest, test_SetAmfSessionAmbr) {
   SessionStateUpdateCriteria& session_uc = session_update[IMSI2][session_id];
   SetSmNotificationContext notif;
   std::string imsi;
+  session->set_config(cfg, &session_uc);
 
   magma::SetSMSessionContextAccess expected_response;
 

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -636,7 +636,6 @@ TEST_F(SessionManagerHandlerTest, test_SetAmfSessionAmbr) {
   cfg.rat_specific_context.mutable_m5gsm_session_context()
       ->mutable_default_ambr()
       ->set_br_unit(AggregatedMaximumBitrate::KBPS);
-
   cfg.rat_specific_context.mutable_m5gsm_session_context()
       ->mutable_default_ambr()
       ->set_max_bandwidth_ul(1024);


### PR DESCRIPTION
Signed-off-by: prabina pattnaik <prabinak@wavelabs.ai>

## Summary

Fix the integration issue with AMF and Sessiond for default qos support.
If no qos profile has configured in policydb then amf will send the default qos value to UE.

## Test Plan
Verified with UERAMSIM
UT test case (test_SetAmfSessionAmbr)

## Additional Information
Logs:

```
Request received from AMF
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:   magma.lte.SetSMSessionContext {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:       common_context {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:         sid {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           id: "901700000000001"
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:         }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:         apn: "internet"
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:         rat_type: TGPP_NR
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:       }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:       rat_specific_context {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:         m5gsm_session_context {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           pdu_session_id: 1
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           pdu_address {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             redirect_server_address: "0.201.37.32"
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           gnode_endpoint {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             end_ipv4_addr: "46.127.0.0"
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           procedure_trans_identity: "\001\350\230\340"
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           default_ambr {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             max_bandwidth_ul: 100000000
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             max_bandwidth_dl: 200000000
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:         }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:       }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:   }

Response to AMF:
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:   magma.lte.SetSMSessionContextAccess {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:       common_context {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:         sid {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           id: "901700000000001"
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:         }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:       }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:       rat_specific_context {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:         m5g_session_context_rsp {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           pdu_session_id: 1
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           selected_ssc_mode: SSC_MODE_3
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           session_ambr {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             max_bandwidth_ul: 100000000
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             max_bandwidth_dl: 100000000
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           M5gsm_cause: OPERATION_SUCCESS
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           allowed_ssc_mode: SSC_MODE_3
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           M5G_sm_congestion_reattempt_indicator: true
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           pdu_address {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             redirect_server_address: "0.201.37.32"
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           upf_endpoint {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             teid: 2147483647
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             end_ipv4_addr: "192.168.60.37"
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           procedure_trans_identity: "\001\350\230\340"
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           qos {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             qci: QCI_9
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             arp {
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:               priority_level: 1
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:             }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:           }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:         }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:       }
Oct 13 10:31:14 magma-dev-focal sessiond[5206]:   }
