### PR TITLE
chore: create a separate volume for bazel-base docker container

### DIFF
--- a/experimental/bazel-base/docker-compose.yml
+++ b/experimental/bazel-base/docker-compose.yml
@@ -7,5 +7,7 @@ services:
         volumes:
             - ${MAGMA_ROOT}:/magma
             - ${MAGMA_ROOT}/lte/gateway/configs:/etc/magma
-            - /tmp/bazel:/tmp/bazel
+            - bazel-output:/tmp/bazel
         working_dir: /magma
+volumes:
+    bazel-output:


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
- it's much faster to just use a volume rather than mount it over /tmp/bazel. I don't have immediate plans to share /tmp/bazel for development yet, so opting for speed here.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
