### PR TITLE
bug(agw): V1.6 check if UE context exists when timer expires

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.c
+++ b/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.c
@@ -121,6 +121,7 @@ void mme_app_nas_timer_handle_signal_expiry(
         "Timer id %ld fired for ue_id " MME_UE_S1AP_ID_FMT
         " which does not have any UE context\n",
         timer_id, cb->ue_id);
+    mme_app_remove_mme_ue_id_timer_id(cb->ue_id, timer_id);
     OAILOG_FUNC_OUT(LOG_NAS);
   }
 

--- a/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.c
+++ b/lte/gateway/c/core/oai/tasks/nas/util/nas_timer.c
@@ -41,6 +41,7 @@
 #include "dynamic_memory_check.h"
 #include "intertask_interface_types.h"
 #include "mme_app_mme_ue_id_timer.h"
+#include "mme_app_ue_context.h"
 #include "itti_types.h"
 #include "log.h"
 
@@ -111,6 +112,18 @@ void mme_app_nas_timer_handle_signal_expiry(
     OAILOG_ERROR(LOG_NAS, "Invalid timer id %ld \n", timer_id);
     OAILOG_FUNC_OUT(LOG_NAS);
   }
+
+  // check if a UE context still exists for this UE
+  ue_mm_context_t* ue_context = mme_ue_context_exists_mme_ue_s1ap_id(cb->ue_id);
+  if (!ue_context) {
+    OAILOG_ERROR(
+        LOG_NAS,
+        "Timer id %ld fired for ue_id " MME_UE_S1AP_ID_FMT
+        " which does not have any UE context\n",
+        timer_id, cb->ue_id);
+    OAILOG_FUNC_OUT(LOG_NAS);
+  }
+
   cb->nas_timer_callback(cb->nas_timer_callback_arg, imsi64);
   OAILOG_FUNC_OUT(LOG_NAS);
 }


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

MME can experience a race condition, where a timer fires for a UE, just as its context has been removed. This can lead to invalid memory access for UE context. HIL sanity test failed with one such occurrence in https://github.com/magma/magma/issues/9662. This change adds a guard to check whether UE context exists even when the timer id is valid.

This issue does not exist in v1.7 which uses LibZMQ timers that are maintained by each task in its own context.

## Test Plan

- Regression testing: S1ap integration tests
- Functional testing: Multiple runs of sanity tests in HIL setup

