### PR TITLE
fix(ci): Remove nms-e2e-test circleci workflow as req

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1444,7 +1444,7 @@ workflows:
   #     - schedule:
   #         cron: "0 * * * *"
   #         <<: *only_master
-        
+
   #   jobs:
   #     - xwfm-test:
   #         notify_magma_ci: false
@@ -1474,7 +1474,6 @@ workflows:
             - nms-flow-test
             - eslint
             - nms-yarn-test
-            - nms-e2e-test
 
   github:
     jobs:

--- a/.github/workflows/nms-workflow.yml
+++ b/.github/workflows/nms-workflow.yml
@@ -195,7 +195,6 @@ jobs:
       - nms-flow-test
       - nms-eslint
       - nms-yarn-test
-      - nms-e2e-test
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-build job
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Removing `nms-e2e-test` as a requirement for `nms-build` circleci workflow to run.

While circleci workflow `nms-e2e-test` is not marked as required, it's a dependency for `nms-build`, which *is* marked as required, making `nms-e2e-test` implied required. This isn't ideal, especially as the e2e tests are superseded by our Testim tests, and the e2e tests are flaky right now.

## Test Plan

None whatsoever. Does this change affect the CI checks on this pull request?

## Additional Information

- [ ] This change is backwards-breaking
