### PR TITLE
feat(orc8r): Adding cloud configuration for PDN type

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -2733,6 +2733,7 @@ func TestListApns(t *testing.T) {
 					PreemptionVulnerability: swag.Bool(false),
 					PriorityLevel:           swag.Uint32(15),
 				},
+				PdnType: 0,
 			},
 		},
 		{
@@ -2748,6 +2749,7 @@ func TestListApns(t *testing.T) {
 					PreemptionVulnerability: swag.Bool(false),
 					PriorityLevel:           swag.Uint32(5),
 				},
+				PdnType: 1,
 			},
 		},
 	}, serdes.Entity)
@@ -2774,6 +2776,7 @@ func TestListApns(t *testing.T) {
 						PreemptionVulnerability: swag.Bool(false),
 						PriorityLevel:           swag.Uint32(15),
 					},
+					PdnType: 0,
 				},
 			},
 			"oai.ims": {
@@ -2789,6 +2792,7 @@ func TestListApns(t *testing.T) {
 						PreemptionVulnerability: swag.Bool(false),
 						PriorityLevel:           swag.Uint32(5),
 					},
+					PdnType: 1,
 				},
 			},
 		}),
@@ -2830,6 +2834,7 @@ func TestGetApn(t *testing.T) {
 				PreemptionVulnerability: swag.Bool(false),
 				PriorityLevel:           swag.Uint32(15),
 			},
+			PdnType: 0,
 		},
 	}, serdes.Entity)
 	assert.NoError(t, err)
@@ -2854,6 +2859,7 @@ func TestGetApn(t *testing.T) {
 					PreemptionVulnerability: swag.Bool(false),
 					PriorityLevel:           swag.Uint32(15),
 				},
+				PdnType: 0,
 			},
 		},
 	}

--- a/lte/cloud/go/services/lte/obsidian/models/apn_configuration_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/apn_configuration_swaggergen.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
+
 	strfmt "github.com/go-openapi/strfmt"
 
 	"github.com/go-openapi/errors"
@@ -21,6 +23,10 @@ type ApnConfiguration struct {
 	// Required: true
 	Ambr *AggregatedMaximumBitrate `json:"ambr"`
 
+	// Value identifier for PDN type (0=IPv4 1=IPv6 2=IPv4v6 3=IPv4orv6)
+	// Enum: [0 1 2 3]
+	PdnType uint32 `json:"pdn_type,omitempty"`
+
 	// qos profile
 	// Required: true
 	QosProfile *QosProfile `json:"qos_profile"`
@@ -31,6 +37,10 @@ func (m *ApnConfiguration) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateAmbr(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePdnType(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -57,6 +67,40 @@ func (m *ApnConfiguration) validateAmbr(formats strfmt.Registry) error {
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+var apnConfigurationTypePdnTypePropEnum []interface{}
+
+func init() {
+	var res []uint32
+	if err := json.Unmarshal([]byte(`[0,1,2,3]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		apnConfigurationTypePdnTypePropEnum = append(apnConfigurationTypePdnTypePropEnum, v)
+	}
+}
+
+// prop value enum
+func (m *ApnConfiguration) validatePdnTypeEnum(path, location string, value uint32) error {
+	if err := validate.Enum(path, location, value, apnConfigurationTypePdnTypePropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *ApnConfiguration) validatePdnType(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.PdnType) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validatePdnTypeEnum("pdn_type", "body", m.PdnType); err != nil {
+		return err
 	}
 
 	return nil

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -2439,6 +2439,15 @@ definitions:
         $ref: '#/definitions/aggregated_maximum_bitrate'
       qos_profile:
         $ref: '#/definitions/qos_profile'
+      pdn_type:
+        type: integer
+        format: uint32
+        enum:
+          - 0
+          - 1
+          - 2
+          - 3
+        description: Value identifier for PDN type (0=IPv4 1=IPv6 2=IPv4v6 3=IPv4orv6)
 
   apn_name:
     type: string

--- a/lte/cloud/go/services/subscriberdb/load.go
+++ b/lte/cloud/go/services/subscriberdb/load.go
@@ -207,6 +207,7 @@ func ConvertSubEntsToProtos(ent configurator.NetworkEntity, apnConfigs map[strin
 				PreemptionCapability:    swag.BoolValue(apnConfig.QosProfile.PreemptionCapability),
 				PreemptionVulnerability: swag.BoolValue(apnConfig.QosProfile.PreemptionVulnerability),
 			},
+			Pdn:      lte_protos.APNConfiguration_PDNType(apnConfig.PdnType),
 			Resource: apnResource,
 		}
 		if staticIP, found := cfg.StaticIps[assoc.Key]; found {

--- a/nms/packages/magmalte/generated/MagmaAPIBindings.js
+++ b/nms/packages/magmalte/generated/MagmaAPIBindings.js
@@ -101,6 +101,7 @@ export type apn = {
 };
 export type apn_configuration = {
     ambr: aggregated_maximum_bitrate,
+    pdn_type ? : 0 | 1 | 2 | 3,
     qos_profile: qos_profile,
 };
 export type apn_list = Array < string >

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -6544,6 +6544,15 @@ definitions:
     properties:
       ambr:
         $ref: '#/definitions/aggregated_maximum_bitrate'
+      pdn_type:
+        description: Value identifier for PDN type (0=IPv4 1=IPv6 2=IPv4v6 3=IPv4orv6)
+        enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        format: uint32
+        type: integer
       qos_profile:
         $ref: '#/definitions/qos_profile'
     required:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adds pdn_type to APN configuration on Orchestrator
- Also updated `subscriberdb/load.go` so value is streamed down to subscriberdb

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
```
(python) vagrant@magma-dev-focal:~/magma/lte/gateway$ subscriber_cli.py get IMSI208950000000013
sid {
  id: "208950000000013"
}
lte {
  state: ACTIVE
  auth_key: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
  auth_opc: "\000\001\002\003\004\005\006\007\010\t\n\013\014\r\016\017"
}
network_id {
  id: "test"
}
sub_profile: "default"
non_3gpp {
  apn_config {
    service_selection: "inet2"
    qos_profile {
      class_id: 9
      priority_level: 15
      preemption_capability: true
    }
    ambr {
      max_bandwidth_ul: 10000000
      max_bandwidth_dl: 20000000
    }
    pdn: IPV4V6
  }
}
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
