### PR TITLE
fix(mme): Change to gmtime for UTC Time in EMM Information

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.c
@@ -1663,9 +1663,9 @@ status_code_e emm_send_emm_information(
    * optional - Universal time and Local Time Zone
    */
   t   = time(NULL);
-  tmp = localtime_r(&t, &updateTime);
+  tmp = gmtime_r(&t, &updateTime);
   if (tmp == NULL) {
-    OAILOG_ERROR(LOG_NAS_EMM, "localtime() failed to get local timer info");
+    OAILOG_ERROR(LOG_NAS_EMM, "gmtime() failed to get local timer info");
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNerror);
   }
   size += TIME_ZONE_AND_TIME_MAX_LENGTH;


### PR DESCRIPTION
Signed-off-by: Saurabh Mehra <saurabhmehra@fb.com>


## Summary

Fixing the issue https://github.com/magma/magma/issues/8488
- Time Zone and Time - Universal Time and Local Time Zone IE in EMM Information message should contain UTC time and local timezone

## Test Plan

Tested on local vagrant machine. Time is sent at UTC time
![image](https://user-images.githubusercontent.com/26427970/137259657-288309f1-18ef-4cc6-98b6-6438eb849987.png)
