### PR TITLE
chore(ci): Set signoff help URL to jump straight to answer

### DIFF
--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -46,7 +46,7 @@ jobs:
           ### Howto
           - [Magma guidelines on signing commits](https://magma.github.io/magma/docs/next/contributing/contribute_workflow#guidelines)
           - [About the \`signoff\` feature](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)
-          - [Howto: sign-off most-recent commit](https://stackoverflow.com/questions/13043357/git-sign-off-previous-commits)
+          - [Howto: sign-off most-recent commit](https://stackoverflow.com/questions/13043357#answer-15667644)
           - [Howto: sign-off multiple past commits](https://gist.github.com/kwk/d70f20d17b18c4f3296d)
           - $CHECK_GUIDELINE" >> $GITHUB_WORKSPACE/msg
       - name: Python format comment message


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

For some reason the helpful answer isn't at the top, so this fix forces the browser to jump straight to the helpful answer

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->