### PR TITLE
feat(ci): new ci for pre and post merge

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -5,10 +5,11 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - master
+      - v1.*
   pull_request:
     branches:
       - master
-      - 'v1.*'
+      - v1.*
     types: [opened, reopened, synchronize]
 
 env:
@@ -29,6 +30,17 @@ jobs:
           filters: |
             filesChanged:
               - [".github/workflows/agw-workflow.yml", "orc8r/**", "lte/**"]
+      # Need to save metadata for deploy from PR job
+      - name: Save PR number and trigger type
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          echo ${{ !steps.changes.outputs.filesChanged }} > ./pr/skipped
+      - name: upload metadata
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
   lte-test:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
@@ -97,13 +109,13 @@ jobs:
           files: /var/tmp/codecovs/cover_lte.xml,/var/tmp/codecovs/cover_orc8r.xml
           flags: lte-test
       - name: Extract commit title
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
             str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
             echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -144,13 +156,13 @@ jobs:
             make test_session_manager
       - name: Extract commit title
         # yamllint enable
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
             str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
             echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -191,13 +203,13 @@ jobs:
             make test_li_agent
       - name: Extract commit title
         # yamllint enable
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
             str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
             echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -239,13 +251,13 @@ jobs:
             make build_connection_tracker BUILD_TYPE=RelWithDebInfo
       - name: Extract commit title
         # yamllint enable
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
             str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
             echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -312,13 +324,13 @@ jobs:
             make test_oai BUILD_TYPE=RelWithDebInfo;
       - name: Extract commit title
         # yamllint enable
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
             str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
             echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -349,13 +361,13 @@ jobs:
             docker run --env BRANCH=${{ env.BRANCH}} --env REVISION=${{ env.REVISION }} --volume ${{ env.MAGMA_ROOT }}:/magma --interactive magma-mme-build:latest /bin/bash -c 'cd /magma/lte/gateway;make clang_tidy_oai_upload'
       - name: Extract commit title
         # yamllint enable
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
             str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
             echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -386,13 +398,13 @@ jobs:
             docker run --env BRANCH=${{ env.BRANCH }} --env REVISION=${{ env.REVISION }} --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma-mme-build:latest /bin/bash -c "cd /magma/lte/gateway;make clang_warning_oai_upload"
       - name: Extract commit title
         # yamllint enable
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
             str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
             echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -422,13 +434,13 @@ jobs:
             docker run $ci_env --env CI=true --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make coverage;ls -al /tmp/;bash <(curl -s https://codecov.io/bash) -f /build/c/coverage.info -F c_cpp"
       - name: Extract commit title
         # yamllint enable
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
             str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
             echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -438,3 +450,57 @@ jobs:
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
+  agw-build:
+    needs: path_filter
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' || github.event_name == 'push' }}
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup pyenv
+        uses: "gabrielfalcao/pyenv-action@v8"
+        with:
+          default: 3.8.5
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.5'
+      - name: Install pre requisites
+        run: |
+          pip3 install --upgrade pip
+          pip3 install ansible fabric3 jsonpickle requests PyYAML
+          vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-vbguest vagrant-mutate
+      - name: Build AGW
+        run: |
+          cd lte/gateway
+          fab release package:vcs=git
+          mkdir magma-packages
+          vagrant ssh -c "cp -r magma-packages /vagrant"
+      - name: Publish debian packages
+        if: github.event_name == 'push'
+        run: |
+          cd lte/gateway/magma-packages
+          for i in `ls -a1 *.deb`
+          do
+            echo "Pushing package $i to JFROG artifiactory: https://artifactory.magmacore.org/artifactory/debian-test/pool"
+            curl -uci-bot:${{ secrets.JFROG_CIBOT_APIKEYS }} -XPUT "https://artifactory.magmacore.org/artifactory/debian-test/pool/focal-ci/$i;deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64" -T $i
+          done
+      - uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: magma-packages
+          path: lte/gateway/magma-packages/*.deb
+      - name: Extract commit title
+        # yamllint enable
+        if: failure() && github.event_name == 'push'
+        id: commit
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: "Github action agw build failed"
+          SLACK_AVATAR: ":boom:"
+        uses: Ilshidur/action-slack@2.1.0
+        with:
+          args: "AGW  build failed on [${GITHUB_SHA:0:8}](${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}): ${{ steps.commit.outputs.title}}"

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -5,9 +5,11 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - master
+      - v1.*
   pull_request:
     branches:
       - master
+      - v1.*
     types: [opened, reopened, synchronize]
 
 jobs:
@@ -24,8 +26,18 @@ jobs:
         with:
           filters: |
             filesChanged:
-              - [".github/workflows/cloud-workflow.yml", "wifi/cloud/**", "cwf/cloud/**", "fbinternal/cloud/**", "feg/cloud/**", "lte/cloud/**", "orc8r/cloud/**", "orc8r/lib/**"]
-
+              - [".github/workflows/cloud-workflow.yml", "wifi/cloud/**", "lte/proto/**", "cwf/cloud/**", "fbinternal/cloud/**", "feg/cloud/**", "lte/cloud/**", "orc8r/cloud/**", "orc8r/lib/**"]
+      # Need to save metadata for deploy from PR job
+      - name: Save PR number and trigger type
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          echo ${{ !steps.changes.outputs.filesChanged }} > ./pr/skipped
+      - name: upload metadata
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
   # Fail if checked-in generated code doesn't match output from
   # generation command.
   insync-checkin:
@@ -50,13 +62,13 @@ jobs:
             git status
             git diff-index --quiet HEAD
       - name: Extract commit title
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -90,7 +102,7 @@ jobs:
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -128,12 +140,12 @@ jobs:
           flags: cloud_lint
       - name: Extract commit title
         id: commit
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -169,12 +181,12 @@ jobs:
           path: "${{ env.MAGMA_ROOT}}/orc8r/cloud/test-results/*"
       - name: Extract commit title
         id: commit
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -186,7 +198,7 @@ jobs:
           SLACK_FOOTER: ' '
   cloud-upload:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name == 'push'  }}
     name: cloud upload job
     runs-on: ubuntu-latest
     steps:
@@ -202,12 +214,12 @@ jobs:
           swaggerhub api:update MagmaCore/Magma/1.0.0 --file ${MAGMA_ROOT}/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml --published=publish --visibility=public --setdefault
       - name: Extract commit title
         id: commit
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -220,11 +232,7 @@ jobs:
   orc8r-build:
     needs:
       - path_filter
-      - insync-checkin
-      - deploy-sync-checkin
-      - cloud-lint
-      - cloud-test
-    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' || github.event_name == 'push' }}
     name: orc8r build job
     runs-on: ubuntu-latest
     env:
@@ -243,6 +251,18 @@ jobs:
         run: |
             cd ${MAGMA_ROOT}/orc8r/cloud/docker
             python3 build.py --all --nocache --parallel
+      - name: Export docker images to deploy them
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir images
+          cd images
+          docker save orc8r_nginx | gzip > nginx.tar.gz
+          docker save orc8r_controller  | gzip > controller.tar.gz
+      - uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: docker-images
+          path: images
       - name: Tag and push to Docker Registry
         if: github.ref == 'refs/heads/master'
         # yamllint disable rule:line-length
@@ -263,7 +283,7 @@ jobs:
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         # yamllint enable
         env:
@@ -276,7 +296,7 @@ jobs:
           SLACK_FOOTER: ' '
       # Notify ci channel when push succeeds
       - name: Notify success to Slack
-        if: success() && github.ref == 'refs/heads/master'
+        if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -11,6 +11,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   comment_pr:
+    name: Comment on PR for check ${{ github.event.workflow.name }}
     runs-on: ubuntu-latest
     env:
       CHECK_GUIDELINE: "[Guide to the different CI checks and resolution guidelines](https://docs.magmacore.org/docs/next/contributing/contribute_ci_checks)"

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -5,9 +5,11 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - master
+      - v1.*
   pull_request:
     branches:
       - master
+      - v1.*
     types: [opened, reopened, synchronize]
 
 jobs:
@@ -26,6 +28,17 @@ jobs:
           filters: |
             filesChanged:
               - [".github/workflows/cwag-workflow.yml", "orc8r/**", "lte/**", "feg/**", "cwf/**"]
+      # Need to save metadata for deploy from PR job
+      - name: Save PR number and trigger type
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          echo ${{ !steps.changes.outputs.filesChanged }} > ./pr/skipped
+      - name: upload metadata
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
   cwag-precommit:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
@@ -53,7 +66,7 @@ jobs:
             cd ${MAGMA_ROOT}/cwf/gateway
             make -C ${MAGMA_ROOT}/cwf/gateway/integ_tests precommit
       - name: Extract commit title
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
@@ -61,7 +74,7 @@ jobs:
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -73,7 +86,7 @@ jobs:
           SLACK_FOOTER: ' '
   cwag-build:
     needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' || github.event_name == 'push' }}
     name: cwag build job
     runs-on: ubuntu-latest
     env:
@@ -148,8 +161,47 @@ jobs:
              echo "Docker compose failed"
              exit 1
           fi
+      - name: Build xwf go radius
+        run: |
+          cd ${MAGMA_ROOT}/feg
+          docker build --build-arg BUILD_NUM=${GITHUB_SHA:0:8} --tag goradius -f radius/src/Dockerfile ./
+      - name: Load openvswitch kernel module for xwf integ test
+        # yamllint enable
+        run: sudo modprobe openvswitch
+      - name: Build xwfm-integ-tests
+        run: |
+          cd ${MAGMA_ROOT}
+          docker build --tag xwfm-integ-tests -f xwf/gateway/integ_tests/gw/Dockerfile ./
+      - name: Export docker images to deploy them on pull_request
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir images
+          cd images
+          docker save cwf_cwag_go | gzip > cwag_go.tar.gz
+          docker save cwf_gateway_go | gzip > gateway_go.tar.gz
+          docker save cwf_gateway_sessiond | gzip > gateway_sessiond.tar.gz
+          docker save cwf_gateway_python | gzip > gateway_python.tar.gz
+          docker save cwf_gateway_pipelined | gzip > gateway_pipelined.tar.gz
+          docker save goradius | gzip > goradius.tar.gz
+          docker save xwfm-integ-tests | gzip > xwfm-integ-tests.tar.gz
+      - name: Upload docker images as artifacts
+        uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: docker-images
+          path: images
+      # Need to save PR number as Github action does not propagate it with workflow_run event
+      # Used as version for PR builds
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
       - name: Tag and push to Docker Registry
-        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         env:
           DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY }}"
           DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"
@@ -157,16 +209,26 @@ jobs:
         run: |
             ./ci-scripts/tag-push-docker.sh --images 'cwag_go|gateway_go|gateway_python|gateway_sessiond|gateway_pipelined' --tag "${GITHUB_SHA:0:8}" --tag-latest true --project cwf
       - name: Tag and push to Jfrog Registry
-        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         env:
           DOCKER_REGISTRY: "cwf-test.artifactory.magmacore.org"
           DOCKER_USERNAME: "${{ secrets.JFROG_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.JFROG_PASSWORD }}"
         run: |
             ./ci-scripts/tag-push-docker.sh --images 'cwag_go|gateway_go|gateway_python|gateway_sessiond|gateway_pipelined' --tag "${GITHUB_SHA:0:8}" --tag-latest true --project cwf
+      - name: Tag and push to Docker Registry goradius
+        if: github.event_name == 'push'
+        # yamllint disable rule:line-length
+        run: |
+          ./ci-scripts/tag-push-docker.sh --images 'goradius' --tag "${GITHUB_SHA:0:8}" --tag-latest true
+      - name: Tag and push to Docker Registry xwfm-integ-tests
+        if: github.event_name == 'push'
+        # yamllint disable rule:line-length
+        run: |
+          ./ci-scripts/tag-push-docker.sh --images 'xwfm-integ-tests' --tag "${GITHUB_SHA:0:8}" --tag-latest true
       - name: Extract commit title
         id: commit
-        if: github.ref == 'refs/heads/master'
+        if: github.event_name == 'push'
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
@@ -174,11 +236,11 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       # yamllint enable
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "CWAG-deploy failed"
+          SLACK_TITLE: "CWAG/xwfm-deploy failed"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
           SLACK_USERNAME: "CWAG workflow"
           SLACK_ICON_EMOJI: ":boom:"
@@ -186,80 +248,12 @@ jobs:
           SLACK_FOOTER: ' '
       # Notify ci channel when push succeeds
       - name: Notify success to slack
-        if: success() && github.ref == 'refs/heads/master'
+        if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_TITLE: "*CWAG Artifact Has Been Published*"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: "CWAG workflow"
-          SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#00FF00"
-          SLACK_FOOTER: ' '
-  xwfm-deploy-latest:
-    needs:
-      - path_filter
-      - cwag-deploy
-    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
-    name: xwfm deploy job
-    runs-on: ubuntu-latest
-    env:
-      MAGMA_ROOT: "${{ github.workspace }}"
-      DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY }}"
-      DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"
-      DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build xwf go radius
-        run: |
-              cd ${MAGMA_ROOT}/feg
-              docker build --build-arg BUILD_NUM=${GITHUB_SHA:0:8} --tag goradius -f radius/src/Dockerfile ./
-      - name: Tag and push to Docker Registry
-        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-        # yamllint disable rule:line-length
-        run: |
-            ./ci-scripts/tag-push-docker.sh --images 'goradius' --tag "${GITHUB_SHA:0:8}" --tag-latest true
-      - name: Load openvswitch kernel module for xwf integ test
-        # yamllint enable
-        run: sudo modprobe openvswitch
-      - name: Build xwfm-integ-tests
-        run: |
-              cd ${MAGMA_ROOT}
-              docker build --tag xwfm-integ-tests -f xwf/gateway/integ_tests/gw/Dockerfile ./
-      - name: Tag and push to Docker Registry
-        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-        # yamllint disable rule:line-length
-        run: |
-            ./ci-scripts/tag-push-docker.sh --images 'xwfm-integ-tests' --tag "${GITHUB_SHA:0:8}" --tag-latest true
-      - name: Extract commit title
-        id: commit
-        if: github.ref == 'refs/heads/master'
-        run: |
-          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
-          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      # yamllint enable
-      - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action xwfm-deploy-latest failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: "CWAG workflow"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      # Notify ci channel when push succeeds
-      - name: Notify success to slack
-        if: success() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_TITLE: "*xwfm Artifact Has Been Published*"
+          SLACK_TITLE: "*CWAG/xwfm Artifact Has Been Published*"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
           SLACK_USERNAME: "CWAG workflow"
           SLACK_ICON_EMOJI: ":heavy_check_mark:"

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -1,0 +1,117 @@
+---
+
+name: CWF integ test
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run docker compose
+        run: |
+          cd cwf/gateway/docker
+          docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.nginx.yml -f docker-compose.integ-test.yml build --force-rm  --parallel
+      - name: Export docker images to deploy them
+        run: |
+          mkdir images
+          cd images
+          docker save cwf_gateway_sessiond:latest | gzip > cwf_gateway_sessiond.tar.gz
+          docker save cwf_nginx:latest  | gzip > cwf_nginx.tar.gz
+          docker save cwf_gateway_python:latest | gzip > cwf_gateway_python.tar.gz
+          docker save cwf_cwag_go:latest  | gzip > cwf_cwag_go.tar.gz
+          docker save cwf_gateway_go:latest | gzip > cwf_gateway_go.tar.gz
+          docker save cwf_gateway_pipelined:latest | gzip > cwf_gateway_pipelined.tar.gz
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docker-images
+          path: images
+      - name: Extract commit title
+        # yamllint enable
+        if: failure()
+        id: commit
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: "CWF integ test"
+          SLACK_AVATAR: ":boom:"
+        uses: Ilshidur/action-slack@2.1.0
+        with:
+          args: 'CWF integration test: docker build step failed on [${{github.sha}}](${{github.event.repository.owner.html_url}}/magma/commits/${{github.sha}}): ${{ steps.commit.outputs.title}}'
+  cwf-integ-test:
+    runs-on: macos-10.15
+    needs: docker-build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker-practice/actions-setup-docker@master
+        with:
+          docker_version: "20.10"
+      - name: setup pyenv
+        uses: "gabrielfalcao/pyenv-action@v8"
+        with:
+          default: 3.8.5
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.5'
+      - name: Install pre requisites
+        run: |
+          pip3 install --upgrade pip
+          pip3 install ansible fabric3 jsonpickle requests PyYAML
+          vagrant plugin install vagrant-vbguest vagrant-disksize
+      - uses: actions/download-artifact@v2
+        with:
+          name: docker-images
+      - uses: geekyeggo/delete-artifact@v1
+        with:
+          name: docker-images
+      - name: extract and load images
+        run: |
+          for IMAGES in `ls -a1 *.gz`
+          do
+            gzip -d $IMAGES
+          done
+          docker image load --input cwf_gateway_sessiond.tar
+          docker image load --input cwf_nginx.tar
+          docker image load --input cwf_gateway_python.tar
+          docker image load --input cwf_cwag_go.tar
+          docker image load --input cwf_gateway_go.tar
+          docker image load --input cwf_gateway_pipelined.tar
+      - name: Run the integ test
+        run: |
+          cd cwf/gateway
+          fab integ_test:destroy_vm=True,transfer_images=True,test_result_xml=tests.xml
+      - name: upload test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: cwf/gateway/tests.xml
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        with:
+          check_run_annotations: all tests
+          files: cwf/gateway/tests.xml
+      - name: Extract commit title
+        # yamllint enable
+        if: failure()
+        id: commit
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: "CWF integ test"
+          SLACK_AVATAR: ":boom:"
+        uses: Ilshidur/action-slack@2.1.0
+        with:
+          args: "CWF integration test test failed on [${GITHUB_SHA:0:8}](${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}): ${{ steps.commit.outputs.title}}"

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -5,6 +5,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - master
+      - v1.*
   pull_request:
     branches:
       - master
@@ -26,6 +27,17 @@ jobs:
           filters: |
             filesChanged:
               - [".github/workflows/cwf-operator.yml", "cwf/**", "k8s/**"]
+      # Need to save metadata for deploy from PR job
+      - name: Save PR number and trigger type
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          echo ${{ !steps.changes.outputs.filesChanged }} > ./pr/skipped
+      - name: upload metadata
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
   cwf-operator-precommit:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
@@ -71,8 +83,7 @@ jobs:
   cwf-operator-build:
     needs:
       - path_filter
-      - cwf-operator-precommit
-    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' || github.event_name == 'push' }}
     name: cwf operator build job
     runs-on: ubuntu-latest
     env:
@@ -85,6 +96,28 @@ jobs:
         run: |
              cd ${MAGMA_ROOT}/cwf/k8s/cwf_operator/docker
              DOCKER_REGISTRY=cwf_ docker-compose build --parallel
+      - name: Export docker images to deploy them on pull_request
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir images
+          cd images
+          docker save cwf_operator | gzip > operator.tar.gz
+      - name: Upload docker images as artifacts
+        uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: docker-images
+          path: images
+      # Need to save PR number as Github action does not propagate it with workflow_run event
+      # Used as version for PR builds
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
       - name: Tag and push to Docker Registry
         if: github.ref == 'refs/heads/master'
         # yamllint disable rule:line-length

--- a/.github/workflows/deploy-build-from-pr.yml
+++ b/.github/workflows/deploy-build-from-pr.yml
@@ -1,0 +1,222 @@
+---
+
+name: Deploy PR build
+on:  # yamllint disable-line rule:truthy
+  workflow_run:
+    workflows:
+      - agw-workflow
+      - nms-workflow
+      - cloud-workflow
+      - cwag-workflow
+      - cwf-operator
+      - feg-workflow
+      - Push Helm Charts to Artifactory
+    types:
+      - completed
+# Replace registries with new test registries reserved for PR builds
+jobs:
+  deploy:
+    if: github.event.workflow_run.event == 'pull_request'
+    name: Deploy artifacts from ${{ github.event.workflow.name }}
+    runs-on: ubuntu-latest
+    env:
+      WORKFLOW_NAME: "${{ github.event.workflow.name }}"
+      WORKFLOW_STATUS: "${{ github.event.workflow_run.conclusion }}"
+    steps:
+      - uses: hmarr/debug-action@v2
+      # Retrieve Generated artifacts and delete them to keep cache usage low
+      # Could handle case of no artifacts found in a better way (ie export trigger type in source workflow)
+      - name: Handle metadata from triggering workflow
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchMetadataArtifact = artifacts.data.artifacts.filter((artifact) => {
+                          return artifact.name == "pr"
+                        })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchMetadataArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+            github.actions.deleteArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchMetadataArtifact.id
+            });
+      - run: unzip pr.zip
+      - name: Save metadata
+        id: save_metadata
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./NR'));
+            var skipped = String(fs.readFileSync('./skipped')).trim();
+            console.log(String(issue_number))
+            console.log(String(skipped))
+            core.setOutput('issue_number',issue_number );
+            core.setOutput('skipped',skipped );
+      # Could be improved, only need the tag push docker and helm rotation script here
+      - name: checkout code
+        if: ${{  steps.save_metadata.outputs.skipped == 'false' }}
+        uses: actions/checkout@v2
+      # Retrieve Generated artifacts and delete them to keep cache usage low
+      # Could handle case of no artifacts found in a better way (ie export trigger type in source workflow)
+      - name: 'Download artifacts'
+        id: download_artifacts
+        if: steps.save_metadata.outputs.skipped == 'false'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return (artifact.name == "magma-packages" || artifact.name == "docker-images" || artifact.name == "helm-charts")
+            })[0];
+
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
+            github.actions.deleteArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id
+            });
+      - run: unzip artifacts.zip
+        if: steps.save_metadata.outputs.skipped == 'false'
+      - name: upload to artifactory
+        if: github.event.workflow.name == 'agw-workflow' &&  steps.save_metadata.outputs.skipped == 'false'
+        run: |
+          for i in `ls -a1 *.deb`
+          do
+            echo "Pushing package $i to JFROG artifiactory: https://artifactory.magmacore.org/artifactory/debian-test/pool"
+            curl -uci-bot:${{ secrets.JFROG_CIBOT_APIKEYS }} -XPUT "https://artifactory.magmacore.org/artifactory/debian-test/pool/focal-ci/$i;deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64" -T $i
+          done
+      - name: extract images
+        if: ${{ steps.save_metadata.outputs.skipped == 'false' &&  ( github.event.workflow.name == 'nms-workflow' || github.event.workflow.name == 'cloud-workflow' ||  github.event.workflow.name == 'feg-workflow'  ||  github.event.workflow.name == 'cwf-operator'   ||  github.event.workflow.name == 'cwag-workflow' )}}
+        run: |
+          for IMAGES in `ls -a1 *.gz`
+          do
+            gzip -d $IMAGES
+          done
+          ls -R
+      - name: Tag and push to Jfrog Registry
+        if: github.event.workflow.name == 'nms-workflow'
+        env:
+          DOCKER_REGISTRY: "orc8r-test.artifactory.magmacore.org"
+          DOCKER_USERNAME: "${{ secrets.JFROG_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.JFROG_PASSWORD }}"
+          ISSUE_NUMBER: "${{ steps.save_metadata.outputs.issue_number }}"
+        run: |
+          docker image load --input magmalte.tar
+          ./ci-scripts/tag-push-docker.sh --images 'magmalte' --tag "${ISSUE_NUMBER}" --tag-latest true
+      - name: Tag and push to Jfrog Registry
+        if: github.event.workflow.name == 'cloud-workflow' && steps.save_metadata.outputs.skipped == 'false'
+        env:
+          DOCKER_REGISTRY: "orc8r-test.artifactory.magmacore.org"
+          DOCKER_USERNAME: "${{ secrets.JFROG_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.JFROG_PASSWORD }}"
+          ISSUE_NUMBER: "${{ steps.save_metadata.outputs.issue_number }}"
+        run: |
+          docker image load --input nginx.tar
+          docker image load --input controller.tar
+          ./ci-scripts/tag-push-docker.sh --images 'nginx|controller' --tag "${ISSUE_NUMBER}" --tag-latest true
+      - name: Tag and push to Jfrog Registry
+        if: github.event.workflow.name == 'cwf-operator' && steps.save_metadata.outputs.skipped == 'false'
+        env:
+          DOCKER_REGISTRY: "orc8r-test.artifactory.magmacore.org"
+          DOCKER_USERNAME: "${{ secrets.JFROG_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.JFROG_PASSWORD }}"
+          ISSUE_NUMBER: "${{ steps.save_metadata.outputs.issue_number }}"
+        run: |
+          docker image load --input operator.tar
+          ./ci-scripts/tag-push-docker.sh --images 'operator' --tag "${ISSUE_NUMBER}" --tag-latest true
+      - name: Tag and push to Jfrog Registry
+        if: github.event.workflow.name == 'cwag-workflow' && steps.save_metadata.outputs.skipped == 'false'
+        env:
+          DOCKER_REGISTRY: "cwf-test.artifactory.magmacore.org"
+          DOCKER_USERNAME: "${{ secrets.JFROG_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.JFROG_PASSWORD }}"
+          ISSUE_NUMBER: "${{ steps.save_metadata.outputs.issue_number }}"
+        run: |
+          docker image load --input cwag_go.tar
+          docker image load --input gateway_go.tar
+          docker image load --input gateway_python.tar
+          docker image load --input gateway_sessiond.tar
+          docker image load --input gateway_pipelined.tar
+          ./ci-scripts/tag-push-docker.sh --images 'cwag_go|gateway_go|gateway_python|gateway_sessiond|gateway_pipelined' --tag "${ISSUE_NUMBER}" --tag-latest true
+      - name: Tag and push to Jfrog Registry
+        if: github.event.workflow.name == 'cwag-workflow' && steps.save_metadata.outputs.skipped == 'false'
+        env:
+          DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY }}"
+          DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+          ISSUE_NUMBER: "${{ steps.save_metadata.outputs.issue_number }}"
+        run: |
+          docker image load --input goradius.tar
+          docker image load --input xwfm-integ-tests.tar
+          ./ci-scripts/tag-push-docker.sh --images 'goradius|xwfm-integ-tests' --tag "${ISSUE_NUMBER}" --tag-latest true
+      - name: Tag and push to Jfrog Registry
+        if: github.event.workflow.name == 'feg-workflow' && steps.save_metadata.outputs.skipped == 'false' &&  steps.save_metadata.outputs.trigger_event != 'push'
+        env:
+          DOCKER_REGISTRY: "feg-test.artifactory.magmacore.org"
+          DOCKER_USERNAME: "${{ secrets.JFROG_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.JFROG_PASSWORD }}"
+          ISSUE_NUMBER: "${{ steps.save_metadata.outputs.issue_number }}"
+        run: |
+          docker image load --input gateway_go.tar
+          docker image load --input gateway_python.tar
+          ./ci-scripts/tag-push-docker.sh --images 'gateway_go|gateway_python' --tag "${ISSUE_NUMBER}" --tag-latest true
+      - name: Push Helm charts and verify the push
+        if: github.event.workflow.name == 'Push Helm Charts to Artifactory' && steps.save_metadata.outputs.skipped == 'false'
+        env:
+          HELM_CHART_MUSEUM_API_URL: "https://artifactory.magmacore.org:443/artifactory/api"
+          HELM_CHART_MUSEUM_URL: "https://artifactory.magmacore.org:443/artifactory/helm-test"
+          HELM_CHART_MUSEUM_REPO: helm-test
+          HELM_CHART_ARTIFACTORY_URL: "https://artifactory.magmacore.org:443/artifactory/"
+          HELM_CHART_MUSEUM_USERNAME: "${{ secrets.HELM_CHART_MUSEUM_USERNAME }}"
+          HELM_CHART_MUSEUM_TOKEN: "${{ secrets.HELM_CHART_MUSEUM_TOKEN }}"
+        run: |
+          for ARTIFACT_PATH in `ls -a1 *.tgz`
+          do
+            MD5_CHECKSUM="$(md5sum "$ARTIFACT_PATH" | awk '{print $1}')"
+            SHA1_CHECKSUM="$(shasum -a 1 "$ARTIFACT_PATH" | awk '{ print $1 }')"
+            SHA256_CHECKSUM="$(shasum -a 256 "$ARTIFACT_PATH" | awk '{ print $1 }')"
+            curl --user "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" --fail \
+            --header "X-Checksum-MD5:${MD5_CHECKSUM}" \
+            --header "X-Checksum-Sha1:${SHA1_CHECKSUM}" \
+            --header "X-Checksum-Sha256:${SHA256_CHECKSUM}" \
+            --upload-file "$ARTIFACT_PATH" "$HELM_CHART_MUSEUM_URL/$(basename "$ARTIFACT_PATH")"
+          done
+          curl --request POST --user "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" \
+                      "$HELM_CHART_MUSEUM_API_URL/helm/$HELM_CHART_MUSEUM_REPO/reindex"
+          # Ensure push was successful
+          helm repo add "$(basename "$HELM_CHART_MUSEUM_URL")" "$HELM_CHART_MUSEUM_URL" --username "$HELM_CHART_MUSEUM_USERNAME" --password "$HELM_CHART_MUSEUM_TOKEN"
+          helm repo update
+
+          # The Helm command returns 0 even when no results are found. Search for err str
+          # instead
+          HELM_SEARCH_RESULTS="$(helm search repo "$(basename "$HELM_CHART_MUSEUM_URL")")" # should list the uploaded charts
+          if [ "$HELM_SEARCH_RESULTS" == "No results found" ]; then
+            exitmsg "Error! Unable to find uploaded orc8r charts"
+          fi
+          # Only keep last 20 charts
+          pip install artifactory
+          python ci-scripts/helm_repo_rotation.py

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - master
+      - v1.*
   pull_request:
     branches:
       - master
+      - v1.*
     types: [opened, reopened, synchronize]
 
 jobs:
@@ -26,6 +28,17 @@ jobs:
           filters: |
             filesChanged:
               - [".github/workflows/feg-workflow.yml", "orc8r/**", "lte/**", "feg/**"]
+      # Need to save metadata for deploy from PR job
+      - name: Save PR number and trigger type
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          echo ${{ !steps.changes.outputs.filesChanged }} > ./pr/skipped
+      - name: upload metadata
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
   feg-lint:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
@@ -61,7 +74,7 @@ jobs:
           files: '${{ env.MAGMA_ROOT}}/feg/gateway/coverage/feg.gocov'
           flags: feg-lint
       - name: Extract commit title
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         id: commit
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
@@ -69,7 +82,7 @@ jobs:
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -113,14 +126,14 @@ jobs:
           path: "/tmp/test-results"
       - name: Extract commit title
         id: commit
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -131,10 +144,8 @@ jobs:
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
   feg-build:
-    needs:
-      - path_filter
-      - feg-precommit
-    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    needs: path_filter
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' || github.event_name == 'push' }}
     name: feg-build
     runs-on: ubuntu-latest
     env:
@@ -170,13 +181,26 @@ jobs:
         run: |
             cd ${MAGMA_ROOT}/feg/gateway/docker
             python3 build.py -e
+      - name: Export docker images to deploy them on pull_request
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir images
+          cd images
+          docker save feg_gateway_go | gzip > gateway_go.tar.gz
+          docker save feg_gateway_python | gzip > gateway_python.tar.gz
+      - name: Upload docker images as artifacts
+        uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: docker-images
+          path: images
       - name: Tag and push to Docker Registry
-        if: github.ref == 'refs/heads/master'
+        if: github.event_name == 'push'
         # yamllint disable rule:line-length
         run: |
             ./ci-scripts/tag-push-docker.sh --images 'gateway_go|gateway_python' --tag "${GITHUB_SHA:0:8}" --tag-latest true --project feg
       - name: Tag and push to Jfrog Registry
-        if: github.ref == 'refs/heads/master'
+        if: github.event_name == 'push'
         env:
           DOCKER_REGISTRY: "feg-test.artifactory.magmacore.org"
           DOCKER_USERNAME: "${{ secrets.JFROG_USERNAME }}"
@@ -184,7 +208,7 @@ jobs:
         run: |
             ./ci-scripts/tag-push-docker.sh --images 'gateway_go|gateway_python' --tag "${GITHUB_SHA:0:8}" --tag-latest true --project feg
       - name: Extract commit title
-        if: github.ref == 'refs/heads/master'
+        if: github.event_name == 'push'
         id: commit
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
@@ -193,7 +217,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       # yamllint enable
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -205,7 +229,7 @@ jobs:
           SLACK_FOOTER: ' '
       # Notify ci channel when push succeeds
       - name: Notify success to slack
-        if: success() && github.ref == 'refs/heads/master'
+        if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}

--- a/.github/workflows/fossa-workflow.yml
+++ b/.github/workflows/fossa-workflow.yml
@@ -5,9 +5,11 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - master
+      - v1.*
   pull_request:
     branches:
       - master
+      - v1.*
 jobs:
   fossa-analyze:
     env:
@@ -32,14 +34,14 @@ jobs:
             sudo ${MAGMA_ROOT}/circleci/fossa-analyze-go.sh
       - name: Extract commit title
         id: commit
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -9,7 +9,14 @@
 #######
 name: "GCC Warnings & Errors"
 on:
+  push:
+    branches:
+      - master
+      - v1.*
   pull_request:
+    branches:
+      - master
+      - v1.*
     types:
       - opened
       - reopened
@@ -78,6 +85,23 @@ jobs:
         with:
           name: build_logs_oai
           path: ${{ github.workspace }}/compile.log
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "build_oai failed"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_USERNAME: "Feg workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
 
   build_session_manager:
     needs:
@@ -124,3 +148,20 @@ jobs:
         with:
           name: build_logs_session_manager
           path: ${{ github.workspace }}/compile.log
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "build_session_manager failed"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_USERNAME: "Feg workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '

--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -1,7 +1,14 @@
 ---
 name: Golang Build & Test
 on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+      - v1.*
   pull_request:
+    branches:
+      - master
+      - v1.*
     types:
       - opened
       - reopened
@@ -42,6 +49,23 @@ jobs:
         run: |
           cd src/go/
           go build ./...
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "build_src_go tests failed"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_USERNAME: "Feg workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
 
   test_src_go:
     needs: pre_job_src_go_determinator
@@ -71,6 +95,23 @@ jobs:
         with:
           name: Unit Test Results
           path: "${{ github.workspace }}/src/go/test_src_go.xml"
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "test_src_go tests failed"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_USERNAME: "Feg workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
 
   test_src_go_qemu:
     needs: pre_job_src_go_determinator
@@ -99,11 +140,29 @@ jobs:
           gotestsum --format=testname --junitfile test_src_go.xml -- ./...
         env:
           GOARCH: ${{ matrix.arch }}
+        # TODO: Upload this test result as a comment on PR
       - name: Upload Test Results
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Results arm64
           path: "${{ github.workspace }}/src/go/test_src_go.xml"
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "test_src_go_qemu tests failed"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_USERNAME: "Feg workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
 
 
   codecov_src_go:
@@ -127,3 +186,20 @@ jobs:
           flags: src_go
           fail_ci_if_error: true
           verbose: true
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "codecov_src_go tests failed"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_USERNAME: "Feg workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -1,7 +1,20 @@
 ---
+
 name: "Check dependencies of helm charts"
 
-on: [pull_request]  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+      - v1.*
+  pull_request:
+    branches:
+      - master
+      - v1.*
+    types:
+      - opened
+      - reopened
+      - synchronize  # yamllint disable-line rule:truthy
 jobs:
   check_helm_chart_dependencies:
     env:
@@ -63,3 +76,20 @@ jobs:
           if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
             exit 1
           fi
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "check_helm_chart_dependencies tests failed"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_USERNAME: "Feg workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '

--- a/.github/workflows/lint-clang-format.yml
+++ b/.github/workflows/lint-clang-format.yml
@@ -1,7 +1,14 @@
 ---
 name: lint-clang-format
 on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+      - v1.*
   pull_request:
+    branches:
+      - master
+      - v1.*
     types:
       - opened
       - reopened
@@ -35,3 +42,20 @@ jobs:
           extensions: 'h,hpp,c,cpp'
           clangFormatVersion: 7
           style: file
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "check_helm_chart_dependencies tests failed"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_USERNAME: "Feg workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -3,6 +3,7 @@
 name: LTE integ test
 
 on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -29,5 +30,31 @@ jobs:
       - name: Run the integ test
         run: |
           cd lte/gateway
-          sed -i '' 's/1.1.20210928/1.1.20210618/' Vagrantfile
           fab integ_test
+      - name: Get test results
+        if: always()
+        run: |
+          cd lte/gateway
+          fab get_test_summaries:dst_path="test-results"
+          ls -R
+      - name: upload test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-results
+          path: lte/gateway/test-results/**/*.xml
+      - name: Publish Unit Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        with:
+          files: lte/gateway/test-results/**/*.xml
+          check_run_annotations: all tests
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: "LTE integ test"
+          SLACK_AVATAR: ":boom:"
+        uses: Ilshidur/action-slack@2.1.0
+        with:
+          args: "LTE integration test test failed on [${GITHUB_SHA:0:8}](${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}): ${{ steps.commit.outputs.title}}"

--- a/.github/workflows/nms-workflow.yml
+++ b/.github/workflows/nms-workflow.yml
@@ -5,9 +5,15 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - master
+      - v1.*
   pull_request:
     branches:
       - master
+      - v1.*
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   path_filter:
@@ -24,6 +30,17 @@ jobs:
           filters: |
             filesChanged:
               - [".github/workflows/nms-workflow.yml", "nms/**"]
+      # Need to save metadata for deploy from PR job
+      - name: Save PR number and trigger type
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          echo ${{ !steps.changes.outputs.filesChanged }} > ./pr/skipped
+      - name: upload metadata
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
   nms-flow-test:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
@@ -45,6 +62,12 @@ jobs:
         run: |
             cd ${MAGMA_ROOT}/nms
             yarn run flow
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
@@ -52,7 +75,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "NMS flow-test failed"
+          SLACK_TITLE: "NMS flow tests failed"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
           SLACK_USERNAME: "NMS workflow"
           SLACK_ICON_EMOJI: ":boom:"
@@ -86,6 +109,12 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/nms
           yarn run eslint ./
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
@@ -93,7 +122,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "NMS eslint failed"
+          SLACK_TITLE: "NMS eslint tests failed"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
           SLACK_USERNAME: "NMS workflow"
           SLACK_ICON_EMOJI: ":boom:"
@@ -116,6 +145,12 @@ jobs:
           cd ${MAGMA_ROOT}/nms
           yarn add jest@^26.4.2 -W --dev
           yarn test:ci
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
@@ -123,7 +158,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "NMS yarn test failed"
+          SLACK_TITLE: "NMS yarn tests failed"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
           SLACK_USERNAME: "NMS workflow"
           SLACK_ICON_EMOJI: ":boom:"
@@ -176,6 +211,12 @@ jobs:
         with:
           name: NMS Test Results
           path: "/tmp/nms_artifacts/*"
+      - name: Extract commit title
+        id: commit
+        if: failure() && github.event_name == 'push'
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
@@ -183,19 +224,15 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "NMS nms-e2e-test failed"
+          SLACK_TITLE: "NMS e2e tests failed"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
           SLACK_USERNAME: "NMS workflow"
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
   nms-build:
-    needs:
-      - path_filter
-      - nms-flow-test
-      - nms-eslint
-      - nms-yarn-test
-    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' || github.event_name == 'push'}}
+    needs: path_filter
     name: nms-build job
     runs-on: ubuntu-latest
     env:
@@ -217,8 +254,20 @@ jobs:
         # yamllint disable rule:line-length
         run: |
             ./ci-scripts/tag-push-docker.sh --images 'magmalte' --tag "${GITHUB_SHA:0:8}" --tag-latest false --project magmalte
+      - name: Export docker images to deploy them on pull_request
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir images
+          cd images
+          docker save magmalte_magmalte | gzip > magmalte.tar.gz
+      - name: Upload docker images as artifacts
+        uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: docker-images
+          path: images
       - name: Tag and push to Jfrog Registry
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        if: github.event_name == 'push'
         env:
           DOCKER_REGISTRY: "orc8r-test.artifactory.magmacore.org"
           DOCKER_USERNAME: "${{ secrets.JFROG_USERNAME }}"

--- a/.github/workflows/publish-helmcharts-to-artifactory.yml
+++ b/.github/workflows/publish-helmcharts-to-artifactory.yml
@@ -1,9 +1,20 @@
 ---
+# Need to refactor helm script to use versioning from charts themselves in release process
 name: "Push Helm Charts to Artifactory"
 
 on:  # yamllint disable-line rule:truthy
   push:
-    branches: [master, v1.*]  # Running on v1.* to tag official release
+    branches:
+      - master
+      - v1.*
+  pull_request:
+    branches:
+      - master
+      - v1.*
+    types:
+      - opened
+      - reopened
+      - synchronize
 jobs:
   build_publish_helm_charts:
     env:
@@ -12,6 +23,8 @@ jobs:
       HELM_CHART_MUSEUM_USERNAME: "${{ secrets.HELM_CHART_MUSEUM_USERNAME }}"
       HELM_CHART_MUSEUM_TOKEN: "${{ secrets.HELM_CHART_MUSEUM_TOKEN }}"
       MAGMA_ROOT: "${{ github.workspace }}"
+      EVENT_NAME: "${{ github.event_name }}"
+      ISSUE_NUMBER: "${{ github.event.number }}"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -21,24 +34,48 @@ jobs:
         run: |
           if [ "${GITHUB_REF##*/}" = "master" ] ;then
             echo "VERSION=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+          elif [ "${EVENT_NAME}" = "pull_request" ]; then
+            echo "test"
+            echo "VERSION=${ISSUE_NUMBER}" >> $GITHUB_ENV
+            echo ${ISSUE_NUMBER}
           fi
       - name: Launch build and publish script
         run: |
           if [ "${GITHUB_REF##*/}" = "master" ] ;then
             orc8r/tools/helm/package.sh --deployment-type all --version $VERSION
+          elif [ "${EVENT_NAME}" = "pull_request" ] ;then
+            mkdir charts
+            orc8r/tools/helm/package.sh --deployment-type all --version $VERSION --only-package
           else
             orc8r/tools/helm/package.sh --deployment-type all
           fi
+      - name: Upload charts as artifacts
+        uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: helm-charts
+          path: charts
+      # Need to save PR number as Github action does not propagate it with workflow_run event
+      # Used as version for PR builds
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          echo "false" > ./pr/skipped
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
       - name: Extract commit title
         id: commit
-        if: failure()
+        if: failure() && github.event_name == 'push'
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
-        if: failure()
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
@@ -49,6 +86,7 @@ jobs:
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
       - name: Only keep the last 20 uploaded versions
+        if: github.event_name == 'push'
         run: |
           pip install artifactory
           python ci-scripts/helm_repo_rotation.py

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -1,12 +1,18 @@
 ---
 name: Python Format Check
 on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+      - v1.*
   pull_request:
+    branches:
+      - master
+      - v1.*
     types:
       - opened
       - reopened
       - synchronize
-
 jobs:
   pre_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   unit-test-results:
-    name: Cloud Unit Test Results
+    name: Upload unit test for ${{ github.event.workflow.name }}
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.conclusion != 'skipped' &&

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -443,7 +443,18 @@
     dest: /etc/systemd/resolved.conf
 
 - name: Wait for APT Lock
-  shell:  while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do sleep 5; done;
+  shell: |
+    while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
+      sleep 1
+    done
+    while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 ; do
+      sleep 1
+    done
+    if [ -f /var/log/unattended-upgrades/unattended-upgrades.log ]; then
+      while sudo fuser /var/log/unattended-upgrades/unattended-upgrades.log >/dev/null 2>&1 ; do
+        sleep 1
+      done
+    fi
 
 - name: Remove unattended upgrades
   apt:

--- a/orc8r/tools/helm/package.sh
+++ b/orc8r/tools/helm/package.sh
@@ -29,18 +29,23 @@ update_and_send_to_artifactory () {
   # We want $VERSION to be split as this is an option to the helm command
   ARTIFACT_PATH="$(helm package "$CHART_PATH" $VERSION | awk '{print $8}')"
   helm repo index .
-  MD5_CHECKSUM="$(md5sum "$ARTIFACT_PATH" | awk '{print $1}')"
-  SHA1_CHECKSUM="$(shasum -a 1 "$ARTIFACT_PATH" | awk '{ print $1 }')"
-  SHA256_CHECKSUM="$(shasum -a 256 "$ARTIFACT_PATH" | awk '{ print $1 }')"
-  curl --user "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" --fail \
-              --header "X-Checksum-MD5:${MD5_CHECKSUM}" \
-              --header "X-Checksum-Sha1:${SHA1_CHECKSUM}" \
-              --header "X-Checksum-Sha256:${SHA256_CHECKSUM}" \
-              --upload-file "$ARTIFACT_PATH" "$HELM_CHART_MUSEUM_URL/$(basename "$ARTIFACT_PATH")"
+
+  if [[ $ONLY_PACKAGE = true ]]; then
+    mv "$ARTIFACT_PATH" "$MAGMA_ROOT/charts"
+  else
+    MD5_CHECKSUM="$(md5sum "$ARTIFACT_PATH" | awk '{print $1}')"
+    SHA1_CHECKSUM="$(shasum -a 1 "$ARTIFACT_PATH" | awk '{ print $1 }')"
+    SHA256_CHECKSUM="$(shasum -a 256 "$ARTIFACT_PATH" | awk '{ print $1 }')"
+    curl --user "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" --fail \
+                --header "X-Checksum-MD5:${MD5_CHECKSUM}" \
+                --header "X-Checksum-Sha1:${SHA1_CHECKSUM}" \
+                --header "X-Checksum-Sha256:${SHA256_CHECKSUM}" \
+                --upload-file "$ARTIFACT_PATH" "$HELM_CHART_MUSEUM_URL/$(basename "$ARTIFACT_PATH")"
+  fi
 }
 
 usage() {
-  echo "Usage: $0 [-v|--version V] [-d|--deployment-type $FWA|$FFWA|$ALL]"
+  echo "Usage: $0 [-v|--version V] [-d|--deployment-type $FWA|$FFWA|$ALL] [-p|--only-package]"
   exit 2
 }
 
@@ -49,6 +54,7 @@ exitmsg() {
   exit 1
 }
 
+ONLY_PACKAGE=false
 # Parse the args
 while [[ $# -gt 0 ]]
 do
@@ -61,6 +67,9 @@ case $key in
     -d|--deployment-type)
     DEPLOYMENT_TYPE="$2"
     shift
+    ;;
+    -p|--only-package)
+    ONLY_PACKAGE=true
     ;;
     -h|--help)
     usage
@@ -83,8 +92,7 @@ if [ "$DEPLOYMENT_TYPE" != "$FWA" ] && [ "$DEPLOYMENT_TYPE" != "$FFWA" ] && [ "$
 fi
 
 # Check for artifactory URL presence
-if [[ -z $HELM_CHART_ARTIFACTORY_URL ]]; then
-
+if [[ $ONLY_PACKAGE = false && -z $HELM_CHART_ARTIFACTORY_URL ]]; then
   if [[ -z $GITHUB_REPO ]]; then
     exitmsg "Environment variable GITHUB_REPO must be set"
   fi
@@ -170,35 +178,35 @@ if [[ -z $HELM_CHART_ARTIFACTORY_URL ]]; then
     exitmsg "Error! Unable to find uploaded orc8r charts"
   fi
 else
-  if [[ -z $HELM_CHART_MUSEUM_REPO ]]; then
-    exitmsg "Environment variable $HELM_CHART_MUSEUM_REPO must be set"
-  fi
-
-  if [[ -z $HELM_CHART_MUSEUM_USERNAME ]]; then
-    exitmsg "Environment variable HELM_CHART_MUSEUM_USERNAME must be set"
-  fi
-
-  if [[ -z $HELM_CHART_MUSEUM_TOKEN ]]; then
-    exitmsg "Environment variable HELM_CHART_MUSEUM_TOKEN must be set"
-  fi
-
   if [[ -z $MAGMA_ROOT ]]; then
     exitmsg "Environment variable MAGMA_ROOT must be set"
   fi
 
-  # Trim last backslash if exists
-  # shellcheck disable=SC2001
-  HELM_CHART_ARTIFACTORY_URL="$(echo "$HELM_CHART_ARTIFACTORY_URL" | sed 's:/$::')"
+  if [[ $ONLY_PACKAGE = false ]]; then
+      if [[ -z $HELM_CHART_MUSEUM_REPO ]]; then
+    exitmsg "Environment variable $HELM_CHART_MUSEUM_REPO must be set"
+    fi
 
-  # Verify existence of the helm repo
-  RESPONSE_CODE_REPO="$(curl --output /dev/null --stderr /dev/null --silent --write-out "%{http_code}"  "$HELM_CHART_ARTIFACTORY_URL/$HELM_CHART_MUSEUM_REPO/" || :)"
-  if [ "$RESPONSE_CODE_REPO" != "200" ]; then
-    exitmsg "There was an error connecting to the artifactory repository $HELM_CHART_MUSEUM_ORIGIN_REPO, the http error code was $RESPONSE_CODE_REPO"
+    if [[ -z $HELM_CHART_MUSEUM_USERNAME ]]; then
+      exitmsg "Environment variable HELM_CHART_MUSEUM_USERNAME must be set"
+    fi
+
+    if [[ -z $HELM_CHART_MUSEUM_TOKEN ]]; then
+      exitmsg "Environment variable HELM_CHART_MUSEUM_TOKEN must be set"
+    fi
+    # Trim last backslash if exists
+    # shellcheck disable=SC2001
+    HELM_CHART_ARTIFACTORY_URL="$(echo "$HELM_CHART_ARTIFACTORY_URL" | sed 's:/$::')"
+    # Verify existence of the helm repo
+    RESPONSE_CODE_REPO="$(curl --output /dev/null --stderr /dev/null --silent --write-out "%{http_code}"  "$HELM_CHART_ARTIFACTORY_URL/$HELM_CHART_MUSEUM_REPO/" || :)"
+    if [ $ONLY_PACKAGE != "True" ] && [ "$RESPONSE_CODE_REPO" != "200" ]; then
+      exitmsg "There was an error connecting to the artifactory repository $HELM_CHART_MUSEUM_ORIGIN_REPO, the http error code was $RESPONSE_CODE_REPO"
+    fi
+
+    HELM_CHART_MUSEUM_URL="$HELM_CHART_ARTIFACTORY_URL/$HELM_CHART_MUSEUM_REPO"
+    # Form API URL
+    HELM_CHART_MUSEUM_API_URL="$HELM_CHART_ARTIFACTORY_URL/api"
   fi
-
-  HELM_CHART_MUSEUM_URL="$HELM_CHART_ARTIFACTORY_URL/$HELM_CHART_MUSEUM_REPO"
-  # Form API URL
-  HELM_CHART_MUSEUM_API_URL="$HELM_CHART_ARTIFACTORY_URL/api"
 
   # Begin packaging necessary Helm charts
   update_and_send_to_artifactory "$MAGMA_ROOT/orc8r/cloud/helm/orc8r/"
@@ -220,19 +228,21 @@ else
     update_and_send_to_artifactory "$MAGMA_ROOT/wifi/cloud/helm/wifi-orc8r/"
   fi
 
-  # Refresh index.yaml
-  curl --request POST --user "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" \
-              "$HELM_CHART_MUSEUM_API_URL/helm/$HELM_CHART_MUSEUM_REPO/reindex"
+  if [[ $ONLY_PACKAGE = false ]]; then
+    # Refresh index.yaml
+    curl --request POST --user "$HELM_CHART_MUSEUM_USERNAME":"$HELM_CHART_MUSEUM_TOKEN" \
+                "$HELM_CHART_MUSEUM_API_URL/helm/$HELM_CHART_MUSEUM_REPO/reindex"
 
-  # Ensure push was successful
-  helm repo add "$(basename "$HELM_CHART_MUSEUM_URL")" "$HELM_CHART_MUSEUM_URL" --username "$HELM_CHART_MUSEUM_USERNAME" --password "$HELM_CHART_MUSEUM_TOKEN"
-  helm repo update
+    # Ensure push was successful
+    helm repo add "$(basename "$HELM_CHART_MUSEUM_URL")" "$HELM_CHART_MUSEUM_URL" --username "$HELM_CHART_MUSEUM_USERNAME" --password "$HELM_CHART_MUSEUM_TOKEN"
+    helm repo update
 
-  # The Helm command returns 0 even when no results are found. Search for err str
-  # instead
-  HELM_SEARCH_RESULTS="$(helm search repo "$(basename "$HELM_CHART_MUSEUM_URL")")" # should list the uploaded charts
-  if [ "$HELM_SEARCH_RESULTS" == "No results found" ]; then
-    exitmsg "Error! Unable to find uploaded orc8r charts"
+    # The Helm command returns 0 even when no results are found. Search for err str
+    # instead
+    HELM_SEARCH_RESULTS="$(helm search repo "$(basename "$HELM_CHART_MUSEUM_URL")")" # should list the uploaded charts
+    if [ "$HELM_SEARCH_RESULTS" == "No results found" ]; then
+      exitmsg "Error! Unable to find uploaded orc8r charts"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Pre merge pipeline:
- deploy build to test registries when there is a change (currently pointing to CI, will change when test registries are created) 
- Test executes in parallel of build
- Integ test (CWF & LTE) on demand

Post merge pipeline:
- Always deploy build to ci registries  (no path filtering as makes it harder to deploy latest of master to an environment if only one part of magma is on ci-registries)
- Test executes in parallel of build
- Integ test (CWF & LTE) always run

Build of agw has been migrated to github actions.
CWF integ tests run on two runners due to poor performance of docker-compose on MacOS.

Will later improve tests result display when building the full post build heavy testing pipeline with firebase.

## Test Plan

Tested on Forked repo

## Additional Information

Will later improve the way the workflows file hierarchy, but we will no be able to achieve one file per pre/post merge due to permissions in forked repo.
And current reusability of workflow is showing limitations.
