### PR TITLE
feat: add cc_asn1_library rule to generate .asn1 changes

### DIFF
--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -57,6 +57,15 @@ RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     # symlink to /usr/lib to match Magma VM
     ln -s /usr/local/lib/libtins.so /usr/lib/libtins.so
 
+# TODO(GH9710): Generate asn1c with Bazel - also this repo is really old :o 
+RUN git clone https://gitlab.eurecom.fr/oai/asn1c.git && \
+    cd asn1c && \
+    git checkout f12568d617dbf48497588f8e227d70388fa217c9 && \
+    autoreconf -iv && \
+    ./configure && \
+    make -j"$(nproc)" && \
+    make install
+
 # Update shared library configuration
 RUN ldconfig -v
 

--- a/lte/gateway/c/core/oai/tasks/ngap/BUILD.bazel
+++ b/lte/gateway/c/core/oai/tasks/ngap/BUILD.bazel
@@ -9,25 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("//tools/build_defs:asn1c.bzl", "cc_asn1_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
-cc_library(
-    name = "libtins",
-    srcs = ["usr/lib/libtins.so"],
-    linkopts = ["-ltins"],
-)
-
-cc_library(
-    name = "libmnl",
-    srcs = ["usr/lib/x86_64-linux-gnu/libmnl.so"],
-    linkopts = ["-lmnl"],
-)
-
-# TODO(GH9710): Generate asn1c with Bazel
-native_binary(
-    name = "asn1c",
-    src = "usr/local/bin/asn1c",
-    out = "asn1c",
+cc_asn1_library(
+    name = "asn1_r16",
+    asn1_file = "messages/asn1/r16/r16.asn1",
+    prefix = "Ngap_",
 )

--- a/lte/gateway/c/core/oai/tasks/s1ap/BUILD.bazel
+++ b/lte/gateway/c/core/oai/tasks/s1ap/BUILD.bazel
@@ -9,25 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("//tools/build_defs:asn1c.bzl", "cc_asn1_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
-cc_library(
-    name = "libtins",
-    srcs = ["usr/lib/libtins.so"],
-    linkopts = ["-ltins"],
-)
-
-cc_library(
-    name = "libmnl",
-    srcs = ["usr/lib/x86_64-linux-gnu/libmnl.so"],
-    linkopts = ["-lmnl"],
-)
-
-# TODO(GH9710): Generate asn1c with Bazel
-native_binary(
-    name = "asn1c",
-    src = "usr/local/bin/asn1c",
-    out = "asn1c",
+cc_asn1_library(
+    name = "asn1_r15",
+    asn1_file = "messages/asn1/r15/s1ap-15.6.0.asn1",
+    prefix = "S1ap_",
 )

--- a/tools/build_defs/BUILD.bazel
+++ b/tools/build_defs/BUILD.bazel
@@ -9,25 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
-
-package(default_visibility = ["//visibility:public"])
-
-cc_library(
-    name = "libtins",
-    srcs = ["usr/lib/libtins.so"],
-    linkopts = ["-ltins"],
-)
-
-cc_library(
-    name = "libmnl",
-    srcs = ["usr/lib/x86_64-linux-gnu/libmnl.so"],
-    linkopts = ["-lmnl"],
-)
-
-# TODO(GH9710): Generate asn1c with Bazel
-native_binary(
-    name = "asn1c",
-    src = "usr/local/bin/asn1c",
-    out = "asn1c",
-)
+# empty build file to make tools/build_defs into a package

--- a/tools/build_defs/asn1c.bzl
+++ b/tools/build_defs/asn1c.bzl
@@ -1,0 +1,185 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom library and macros to generate files with asn1c"""
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+def _get_dir_name(name):
+    # we need to postfix the directory name with .cc to trick Bazel into thinking this is a valid input
+    # Related GH issue: https://github.com/bazelbuild/bazel/issues/10552
+    return name + ".cc"
+
+def _contruct_substitution_commands(ctx, dir_path):
+    """Returns a list of commands that replaces certain strings with another. 
+
+    The replacement configuration is taken from ctx.attr.substitutions.
+    """
+    substitution_commands = []
+    substitution_template = "egrep -lRZ \'{before}\' {dir} | xargs --no-run-if-empty -0 -l sed -i -e \'s/{before}/{after}/g\'"
+    for before in ctx.attr.substitutions:
+        after = ctx.attr.substitutions[before]
+        substitution_commands.append(
+            substitution_template.format(
+                dir = dir_path,
+                before = before,
+                after = after,
+            ),
+        )
+    return substitution_commands
+
+def _constructor_file_filter_commands(ctx, dir_path):
+    """Returns a list of commands that removes any files that fit the condition described below.
+
+    1. any file that does not end with .c or .h
+    2. any file that is specified in ctx.attr.files_to_remove
+    """
+    filter_commands = []
+
+    # cc_library will complain if there are files that are not one of (.c, .cc, .cpp, .h, ...)
+    filter_files_template = "ls -d {dir}/* | grep --invert-match --extended-regexp \'{choose}\' | xargs  --no-run-if-empty rm "
+    choose = "**.[.][ch]$"
+    filter_commands.append(filter_files_template.format(dir = dir_path, choose = choose))
+
+    # remove any files specified in ctx.attr
+    for file_name in ctx.attr.files_to_remove:
+        filter_commands.append("rm {dir}/{file} || true".format(dir = dir_path, file = file_name))
+    return filter_commands
+
+def _construct_asn1c_commands(ctx, dir_path):
+    """Returns a string of command that runs asn1c"""
+    prefix = ctx.attr.prefix
+    flags = ctx.attr.flags
+    asn1_file = ctx.attr.asn1_file.files.to_list()[0].path
+    asn1c_command_template = "{asn1c} {flags} -D {dir} {input}"
+    return [
+        asn1c_command_template.format(
+            asn1c = ctx.executable._asn1c.path,
+            prefix = prefix,
+            flags = flags,
+            dir = dir_path,
+            input = asn1_file,
+        ),
+    ]
+
+def _gen_with_asn1c_impl(ctx):
+    """generate files by running asn1c
+
+    Args:
+        ctx: passed through Bazel
+    """
+    name = ctx.attr.name
+    gen_tree = ctx.actions.declare_directory(_get_dir_name(name))
+    gen_path = gen_tree.path
+
+    # Run asn1c to generate files and apply some modifications
+    commands = _construct_asn1c_commands(ctx, gen_path) + _constructor_file_filter_commands(ctx, gen_path) + _contruct_substitution_commands(ctx, gen_path)
+    ctx.actions.run_shell(
+        inputs = ctx.attr.asn1_file.files.to_list() + [ctx.executable._asn1c],
+        outputs = [gen_tree],
+        command = " && ".join(commands),
+        progress_message = "Generating ASN1 files into: {dir}".format(dir = gen_path),
+        env = {
+            "ASN1C_PREFIX": ctx.attr.prefix,
+        },
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([gen_tree]),
+        ),
+        # Include additional information so the cc_library can understand where to look for headers/includes
+        CcInfo(
+            compilation_context = cc_common.create_compilation_context(
+                headers = depset([gen_tree]),
+                system_includes = depset([gen_path]),
+            ),
+        ),
+    ]
+
+def _get_attrs():
+    return {
+        # This makes it so that the executable asn1c is treated as an input to this rule
+        "_asn1c": attr.label(
+            executable = True,
+            default = Label("@system_libraries//:asn1c"),
+            cfg = "host",
+        ),
+        "asn1_file": attr.label(
+            mandatory = True,
+            allow_single_file = [".asn1"],
+            doc = """The asn file asn1c should use to generate files""",
+        ),
+        "prefix": attr.string(
+            mandatory = True,
+            doc = """Value that is set to ASN1C_PREFIX""",
+        ),
+        "flags": attr.string(
+            doc = """Command line flags passed to asn1c""",
+        ),
+        "substitutions": attr.string_dict(
+            doc = """A string map of any substitions to be made""",
+        ),
+        "files_to_remove": attr.string_list(
+            doc = """A list of file names to remove after code generation""",
+        ),
+    }
+
+gen_with_asn1c = rule(
+    implementation = _gen_with_asn1c_impl,
+    attrs = _get_attrs(),
+    output_to_genfiles = True,
+)
+
+def cc_asn1_library(
+        name,
+        asn1_file,
+        prefix):
+    """Create a CC library of generated asn1 files.
+
+    This library wraps up generated files from these 4 actions:
+      1. generate .c/.h files by running asn1c with the given input: asn1_file
+      2. remove all non .c/.h files
+      3. remove converter-example.c
+      4. apply string substitutions
+
+    Args:
+        name: the name of rule
+        asn1_file: relative path to the .asn1 file that will be passed to asn1c
+        prefix: value that is set to ASN1C_PREFIX
+    """
+    gen_name = name + "_genrule"
+
+    flags = "-pdu=all -fcompound-names -fno-include-deps -gen-PER"
+
+    # Taken from https://github.com/magma/magma/blob/14c1cf643a61d576b3d24642e17ed3911d19210d/lte/gateway/c/core/oai/tasks/s1ap/CMakeLists.txt#L35
+    # The original PR (PR2707) doesn't give an explanation on why this is necessary.
+    # I'm guessing it is to avoid the following GCC error: To avoid the following GCC warning: integer constant is so large that it is unsigned
+    substitutions = {
+        "18446744073709551615": "18446744073709551615u",
+    }
+
+    gen_with_asn1c(
+        name = gen_name,
+        asn1_file = asn1_file,
+        flags = flags,
+        prefix = prefix,
+        substitutions = substitutions,
+        # We want to remove converter-example.c as it does not compile
+        files_to_remove = ["converter-example.c"],
+    )
+
+    cc_library(
+        name = name,
+        srcs = [gen_name],
+        # This is needed so that the CCInfo (header/include info) can be used
+        deps = [gen_name],
+    )


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This PR adds a custom logic for Magma to generate ASN1 files and make a library out of it. 
All flags were copied from https://github.com/magma/magma/blob/4ad87780c543b05baaf6511e987a225e4b5e1a97/lte/gateway/c/core/oai/tasks/ngap/CMakeLists.txt

Some notes on how I ended up with this solution.

### Why genrule doesn't work
using genrule to run asn1c does not work as genrule requires an explicit list of output files. As ASN1C generates ~ 100 files, I did not want to go this route. (which would involve listing out every single output file)

### Why I chose to write a custom rule
I found two main ways that people seem to get around this. The first is zipping up the generated files and declaring that as an output. Wasn't exactly sure how those files ended up being used though. The other option is to create a custom rule that uses `ctx.actions.declare_directory`. (See https://github.com/envoyproxy/envoy/blob/main/bazel/envoy_build_system.bzl#L74) I ended up going with the second approach as I could find more examples on sourcegraph that used `ctx.actions.declare_directory`.

This thread helped me figure out how to use CCInfo - https://groups.google.com/g/bazel-discuss/c/iH_Id2sCTe4/m/BvuHW7PVBAAJ

## How to use the new library definition
```
# in any BUILD file
cc_asn1_library(
     name = "asn1_r16",
     asn1_file = "messages/asn1/r16/r16.asn1",
     prefix = "Ngap_",
 )

cc_library(
   name = "...",
   srcs = [...],
   hdrs = [...],
   deps = [":asn1_r16"],
}
```

## Pending
1. figure out if compiling asn1c with bazel is an option, in order to increase determinism of asn1c use and reduce environmental dependencies by Bazel.



<!-- Enumerate changes you made and why you made them -->

## Test Plan
After running `bazel clean` (not the full clean with --expunge)
<img width="468" alt="Screen Shot 2021-10-14 at 3 19 52 PM" src="https://user-images.githubusercontent.com/37634144/137381936-6fa0a6d0-b8f7-4ced-9357-a973bd8bc943.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
