### PR TITLE
fix(self-sign-cert): Add explicit list of altnames into controller cert

### DIFF
--- a/orc8r/cloud/deploy/scripts/self_sign_certs.sh
+++ b/orc8r/cloud/deploy/scripts/self_sign_certs.sh
@@ -55,6 +55,9 @@ subjectAltName = @alt_names
 [alt_names]
 DNS.1 = *.$domain
 DNS.2 = *.nms.$domain
+DNS.3 = api.$domain
+DNS.4 = bootstrapper-controller.$domain
+DNS.5 = controller.$domain
 EOF
 openssl x509 -req -in controller.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out controller.crt -days 825 -sha256 -extfile ${domain}.ext
 


### PR DESCRIPTION
Signed-off-by: Vitalii Kostenko <vitalii@freedomfi.com>

## Summary
Some of the libraries, specifically Java based, required to automate interactions with API are not happy to work with wildcard certificates. At least alt names are required, when specific Alt names are missing it's treated as security issue.
