### PR TITLE
feat: Migrate Bazel folly usage to https://github.com/storypku/rules_folly 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,6 @@ common:docker --repository_cache=/magma/.bazel-cache-repo
 
 build:devcontainer --disk_cache=/workspaces/magma/.bazel-cache
 common:devcontainer --repository_cache=/workspaces/magma/.bazel-cache-repo
-build:devcontainer --define=folly_so=1
 
 build:specify_vm_cc --action_env=CC=/usr/bin/gcc
 build:specify_vm_cc --action_env=CXX=/usr/bin/g++
@@ -20,7 +19,6 @@ build:specify_vm_cc --action_env=CXX=/usr/bin/g++
 # For building with Bazel inside the Magma VM
 build:vm --disk_cache=/home/vagrant/magma/.bazel-cache
 common:vm --repository_cache=/home/vagrant/magma/.bazel-cache-repo
-build:vm --define=folly_so=1
 build:vm --config=specify_vm_cc
 
 build:asan --strip=never

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -119,6 +119,10 @@ load("//:cpp_repositories.bzl", "cpp_repositories")
 
 cpp_repositories()
 
+load("@com_github_storypku_rules_folly//bazel:folly_deps.bzl", "folly_deps")
+
+folly_deps()
+
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 
 boost_deps()

--- a/cpp_repositories.bzl
+++ b/cpp_repositories.bzl
@@ -13,6 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 
 def cpp_repositories():
+    """All external repositories used for C++/C dependencies"""
     http_archive(
         name = "com_github_gflags_gflags",
         sha256 = "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf",
@@ -27,11 +28,26 @@ def cpp_repositories():
         urls = ["https://github.com/google/glog/archive/v0.4.0.tar.gz"],
     )
 
-    git_repository(
+    # rules_folly requires a recent version (latest as of 08.04.2021)
+    # https://github.com/storypku/rules_folly/blob/89afec0807127f693e71ae49e3d0aa89b574279b/bazel/folly_deps.bzl#L116
+    rules_boost_commit = "fb9f3c9a6011f966200027843d894923ebc9cd0b"
+    http_archive(
         name = "com_github_nelhage_rules_boost",
-        commit = "1e3a69bf2d5cd10c34b74f066054cd335d033d71",
-        remote = "https://github.com/nelhage/rules_boost",
-        shallow_since = "1591047380 -0700",
+        sha256 = "046f774b185436d506efeef8be6979f2c22f1971bfebd0979bafa28088bf28d0",
+        strip_prefix = "rules_boost-{}".format(rules_boost_commit),
+        urls = [
+            "https://github.com/nelhage/rules_boost/archive/{}.tar.gz".format(rules_boost_commit),
+        ],
+    )
+
+    rules_folly_version = "0.2.0"
+    http_archive(
+        name = "com_github_storypku_rules_folly",
+        sha256 = "16441df2d454a6d7ef4da38d4e5fada9913d1f9a3b2015b9fe792081082d2a65",
+        strip_prefix = "rules_folly-{}".format(rules_folly_version),
+        urls = [
+            "https://github.com/storypku/rules_folly/archive/v{}.tar.gz".format(rules_folly_version),
+        ],
     )
 
     http_archive(

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -6,26 +6,21 @@ FROM ubuntu:focal as bazel_builder
 ENV TZ=America/New_York \
     DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y 
+
+RUN apt-get install -y --no-install-recommends \
         apt-transport-https \
         apt-utils \
         build-essential \
         ca-certificates \
         curl \
-        # dependency of @sentry_native//:sentry
-        libcurl4-openssl-dev \
         gcc \
         git \
         gnupg2 \
         g++ \
         python-dev \
-        zip \
-        unzip \
         vim \
-        wget \
-        libssl-dev
+        wget
 
 # Install bazel
 WORKDIR /usr/sbin
@@ -33,43 +28,20 @@ RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/dow
     chmod +x bazelisk-linux-amd64 && \
     ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
 
-# Install Folly as a static library in the container
-RUN apt-get install -y --no-install-recommends cmake
+# Dependencies for rules_folly @ https://github.com/storypku/rules_folly
+RUN apt-get -y install --no-install-recommends \
+    autoconf=2.69-11.1 \
+    automake=1:1.16.1-4ubuntu6 \
+    libtool=2.4.6-14
 
-## Install Fmt (Folly Dep)
-RUN git clone https://github.com/fmtlib/fmt.git && cd fmt && \
-    mkdir _build && cd _build && \
-    cmake .. -DFMT_TEST=0 && \
-    make -j"$(nproc)" && \
-    make install && \
-    cd / && \
-    rm -rf fmt
+# dependency of @sentry_native//:sentry
+RUN apt-get -y install --no-install-recommends libcurl4-openssl-dev
 
+# libtins is required to build the connection_tracker
 RUN apt-get install -y --no-install-recommends \
-    libgoogle-glog-dev \
-    libgflags-dev \
-    libboost-all-dev \
-    libevent-dev \
-    libdouble-conversion-dev \
-    libiberty-dev
-
-##### Facebook Folly C++ lib
-# Note: "Because folly does not provide any ABI compatibility guarantees from
-#        commit to commit, we generally recommend building folly as a static library."
-# Here we checkout the hash for v2021.02.22.00 (arbitrary recent version)
-RUN git clone https://github.com/facebook/folly && cd folly && \
-    git checkout tags/v2021.02.15.00 && \
-    mkdir _build && cd _build && \
-    cmake .. && \
-    make -j"$(nproc)" && \
-    make install && \
-    cd / && \
-    rm -rf folly
-
-#### libtins is required to build the connection_tracker
-RUN apt-get install -y --no-install-recommends \
-    libpcap-dev \
-    libmnl-dev
+    cmake=3.16.3-1ubuntu1 \
+    libpcap-dev=1.9.1-3 \
+    libmnl-dev=1.0.4-2
 
 # TODO(@themarwhal): this might not be hard to bazelify if we can generate the config
 RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
@@ -84,7 +56,7 @@ RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     # symlink to /usr/lib to match Magma VM
     ln -s /usr/local/lib/libtins.so /usr/lib/libtins.so
 
-#### Update shared library configuration
+# Update shared library configuration
 RUN ldconfig -v
 
 RUN ln -s /magma/experimental/bazel-base/bazelrcs/docker.bazelrc /etc/bazelrc

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -121,7 +121,7 @@ cc_library(
         "//orc8r/gateway/c/common/async_grpc:async_grpc_receiver",
         "//orc8r/gateway/c/common/service_registry",
         "@com_github_google_glog//:glog",
-        "@system_libraries//:folly",
+        "@folly",
     ],
 )
 
@@ -138,7 +138,7 @@ cc_library(
         "//lte/protos:session_manager_cpp_grpc",
         "//orc8r/gateway/c/common/logging",
         "@com_github_google_glog//:glog",
-        "@system_libraries//:folly",
+        "@folly",
     ],
 )
 

--- a/third_party/system_libraries.BUILD
+++ b/third_party/system_libraries.BUILD
@@ -11,39 +11,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-# This configuration is used for building inside the Magma VM
-# The default configuration applies for building inside the bazel build Docker container
-config_setting(
-    name = "use_folly_so",
-    values = {"define": "folly_so=1"},
-)
-
-cc_library(
-    name = "folly",
-    srcs = select({
-        ":use_folly_so": ["usr/local/lib/libfolly.so"],
-        "//conditions:default": [
-            "usr/local/lib/libfolly.a",
-            "usr/local/lib/libfmt.a",
-        ],
-    }),
-    linkopts = select({
-        ":use_folly_so": [
-            "-ldl",
-            "-levent",
-            "-ldouble-conversion",
-            "-lgflags",
-        ],
-        "//conditions:default": [
-            "-ldl",
-            "-levent",
-            "-ldouble-conversion",
-            "-lgflags",
-            "-liberty",
-        ],
-    }),
-)
-
 cc_library(
     name = "libtins",
     srcs = ["usr/lib/libtins.so"],


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I was browsing the google discuss for bazel (https://groups.google.com/g/bazel-discuss) for an unrelated topic this morning and found that someone implemented a bazel library for folly!

It seems to work great and all unit tests pass. It does make building `bazel build ...`  from scratch (clean cache) longer as we now have to build folly instead of pulling it in from the system. (But this is OK, because we were cheating by building Folly in Docker anyways)

Additional work in this PR:
1. cleaning up the Dockerfile to remove unused `apt install ...`
2. pinning versions of `apt install ...`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Building `bazel build @folly//:folly` after `bazel clean --expunge`
<img width="540" alt="Screen Shot 2021-10-15 at 12 58 44 PM" src="https://user-images.githubusercontent.com/37634144/137525133-95357977-bad9-4e1d-b45b-0fa5874bbf78.png">

Running ` bazel test lte/gateway/c/...:*` after ^
<img width="777" alt="Screen Shot 2021-10-15 at 1 02 59 PM" src="https://user-images.githubusercontent.com/37634144/137525672-3ef12cf6-9425-40e0-af85-dc3490c5b0ec.png">



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
