### PR TITLE
chore: fix broken bazel-base dockerfile

### DIFF
--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -32,7 +32,8 @@ RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/dow
 RUN apt-get -y install --no-install-recommends \
     autoconf=2.69-11.1 \
     automake=1:1.16.1-4ubuntu6 \
-    libtool=2.4.6-14
+    libtool=2.4.6-14 \
+    libssl-dev=1.1.1f-1ubuntu2.8
 
 # dependency of @sentry_native//:sentry
 RUN apt-get -y install --no-install-recommends libcurl4-openssl-dev


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I removed a dependency in https://github.com/magma/magma/pull/9697/ thinking that it was not used. But turns out it was :(. I think maybe when I removed the dependency it was still in the cache? It is hard to tell. (More reasons to have all dependencies managed Bazel, I suppose). 

Quick fix to add it back in.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
