### PR TITLE
fix(mobilityd): ipv6 block size

### DIFF
--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -18,3 +18,4 @@ print_grpc_payload: false
 
 # [Experimental] Enable Sentry for this service
 sentry_enabled: true
+ipv6_prefixlen: 58

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -128,6 +128,7 @@ def main():
 
     dhcp_iface = config.get('dhcp_iface', 'dhcp0')
     dhcp_retry_limit = config.get('retry_limit', RETRY_LIMIT)
+    ipv6_prefixlen = config.get('ipv6_prefixlen', None)
 
     # TODO: consider adding gateway mconfig to decide whether to
     # persist to Redis
@@ -155,6 +156,7 @@ def main():
             mconfig.ipv6_prefix_allocation_type,
             DEFAULT_IPV6_PREFIX_ALLOC_MODE,
         ),
+        ipv6_prefixlen=ipv6_prefixlen,
     )
 
     # Load IPAddressManager


### PR DESCRIPTION
mobilityD expect operator to allocate '/48' or
bigger range. That is not practical or required for
many deployments. Following PR relaxes it to
'/60' and makes it configurable.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
