### PR TITLE
chore(mme): define macro for expected calls

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -18,6 +18,34 @@ extern "C" {
 namespace magma {
 namespace lte {
 
+#define MME_APP_TIMER_TO_MSEC 10
+#define END_OF_TEST_SLEEP_MS 500
+#define STATE_MAX_WAIT_MS 1000
+#define NAS_RETX_LIMIT 5
+
+#define MME_APP_EXPECT_CALLS(                                                  \
+    dlNas, connEstConf, ctxRel, air, ulr, purgeReq, csr, dsr, setAppHealth)    \
+  do {                                                                         \
+    EXPECT_CALL(*s1ap_handler, s1ap_generate_downlink_nas_transport())         \
+        .Times(dlNas)                                                          \
+        .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
+    EXPECT_CALL(*s1ap_handler, s1ap_handle_conn_est_cnf()).Times(connEstConf); \
+    EXPECT_CALL(*s1ap_handler, s1ap_handle_ue_context_release_command())       \
+        .Times(ctxRel);                                                        \
+    EXPECT_CALL(*s6a_handler, s6a_viface_authentication_info_req())            \
+        .Times(air);                                                           \
+    EXPECT_CALL(*s6a_handler, s6a_viface_update_location_req()).Times(ulr);    \
+    EXPECT_CALL(*s6a_handler, s6a_viface_purge_ue()).Times(purgeReq);          \
+    EXPECT_CALL(*spgw_handler, sgw_handle_s11_create_session_request())        \
+        .Times(csr);                                                           \
+    EXPECT_CALL(*spgw_handler, sgw_handle_delete_session_request())            \
+        .Times(dsr)                                                            \
+        .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
+    EXPECT_CALL(*service303_handler, service303_set_application_health())      \
+        .Times(setAppHealth)                                                   \
+        .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
+  } while (0)
+
 void nas_config_timer_reinit(nas_config_t* nas_conf, uint32_t timeout_msec);
 
 void send_sctp_mme_server_initialized();

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -55,7 +55,8 @@ task_zmq_ctx_t task_zmq_ctx_main;
     dlNas, connEstConf, ctxRel, air, ulr, purgeReq, csr, dsr, setAppHealth)    \
   do {                                                                         \
     EXPECT_CALL(*s1ap_handler, s1ap_generate_downlink_nas_transport())         \
-        .Times(dlNas).WillRepeatedly(ReturnFromAsyncTask(&cv));                                                         \
+        .Times(dlNas)                                                          \
+        .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
     EXPECT_CALL(*s1ap_handler, s1ap_handle_conn_est_cnf()).Times(connEstConf); \
     EXPECT_CALL(*s1ap_handler, s1ap_handle_ue_context_release_command())       \
         .Times(ctxRel);                                                        \
@@ -66,7 +67,8 @@ task_zmq_ctx_t task_zmq_ctx_main;
     EXPECT_CALL(*spgw_handler, sgw_handle_s11_create_session_request())        \
         .Times(csr);                                                           \
     EXPECT_CALL(*spgw_handler, sgw_handle_delete_session_request())            \
-        .Times(dsr).WillRepeatedly(ReturnFromAsyncTask(&cv));                  \
+        .Times(dsr)                                                            \
+        .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
     EXPECT_CALL(*service303_handler, service303_set_application_health())      \
         .Times(setAppHealth)                                                   \
         .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -46,34 +46,6 @@ ACTION_P(ReturnFromAsyncTask, cv) {
 
 task_zmq_ctx_t task_zmq_ctx_main;
 
-#define MME_APP_TIMER_TO_MSEC 10
-#define END_OF_TEST_SLEEP_MS 500
-#define STATE_MAX_WAIT_MS 1000
-#define NAS_RETX_LIMIT 5
-
-#define MME_APP_EXPECT_CALLS(                                                  \
-    dlNas, connEstConf, ctxRel, air, ulr, purgeReq, csr, dsr, setAppHealth)    \
-  do {                                                                         \
-    EXPECT_CALL(*s1ap_handler, s1ap_generate_downlink_nas_transport())         \
-        .Times(dlNas)                                                          \
-        .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
-    EXPECT_CALL(*s1ap_handler, s1ap_handle_conn_est_cnf()).Times(connEstConf); \
-    EXPECT_CALL(*s1ap_handler, s1ap_handle_ue_context_release_command())       \
-        .Times(ctxRel);                                                        \
-    EXPECT_CALL(*s6a_handler, s6a_viface_authentication_info_req())            \
-        .Times(air);                                                           \
-    EXPECT_CALL(*s6a_handler, s6a_viface_update_location_req()).Times(ulr);    \
-    EXPECT_CALL(*s6a_handler, s6a_viface_purge_ue()).Times(purgeReq);          \
-    EXPECT_CALL(*spgw_handler, sgw_handle_s11_create_session_request())        \
-        .Times(csr);                                                           \
-    EXPECT_CALL(*spgw_handler, sgw_handle_delete_session_request())            \
-        .Times(dsr)                                                            \
-        .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
-    EXPECT_CALL(*service303_handler, service303_set_application_health())      \
-        .Times(setAppHealth)                                                   \
-        .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
-  } while (0)
-
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
 


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Moved the repeatedly used expect calls to a separate macro.
- Eliminate open loop sleeps to handle messages triggered by timer expirations. This effectively eliminated flakiness and reduced unit testing time to minimum possible with message passing.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
`make test_oai`
See the test output for mme for 100 consecutive runs with no failures and test duration: https://gist.github.com/ulaskozat/b63b06f44b5d48fbcd245043ecc59eec

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
