### PR TITLE
chore: run agw-workflow for new devcontainer

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -85,3 +85,13 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  agw_test_devcontainer:
+    # DO NOT COMMIT:
+    # before merging, this needs to point to magma/magma/.github/workflows/agw-workflow.yml@master
+    # and https://github.com/magma/magma/pull/9787 needs to be merged
+    uses: maxhbr/magma/.github/workflows/agw-workflow.yml@maxhbr/makeAgwWorkflowCallable
+    needs: build_devcontainer_dockerfile
+    with:
+      devcontainer_image: ${{ needs.build_devcontainer_dockerfile.outputs.tags[0] }}
+      force_run: true

--- a/.github/workflows/dockerfile-health.yml
+++ b/.github/workflows/dockerfile-health.yml
@@ -83,3 +83,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=docker,dest=/tmp/mme_builder.tar
+
+  agw_test_devcontainer:
+    # DO NOT COMMIT:
+    # before merging, this needs to point to magma/magma/.github/workflows/agw-workflow.yml@master
+    # and https://github.com/magma/magma/pull/9787 needs to be merged
+    uses: maxhbr/magma/.github/workflows/agw-workflow.yml@maxhbr/makeAgwWorkflowCallable
+    needs: build_devcontainer_dockerfile
+    with:
+      devcontainer_image: ${{ needs.build_devcontainer_dockerfile.outputs.tags[0] }}
+      force_run: true


### PR DESCRIPTION
## Summary

try to use [reusing-workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) to run the agw-workflow on change of the devcontainer dockerfile.

This currently depends on https://github.com/magma/magma/pull/9787

## Test Plan

tbd.

