### PR TITLE
fix(mme): Unsafe delete_wrapper

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -966,6 +966,8 @@ void amf_delete_registration_proc(amf_context_t* amf_ctx) {
   }
 
   amf_delete_child_procedures(amf_ctx, (nas5g_base_proc_t*) proc);
+  delete_wrapper(&proc);
+  amf_ctx->amf_procedures->amf_specific_proc = nullptr;
 }  // namespace magma5g
 
 /***********************************************************************
@@ -983,24 +985,26 @@ void amf_delete_registration_proc(amf_context_t* amf_ctx) {
  ***********************************************************************/
 void amf_delete_registration_ies(amf_registration_request_ies_t** ies) {
   if ((*ies)->imsi) {
-    delete_wrapper((void**) &(*ies)->imsi);
+    delete_wrapper(&(*ies)->imsi);
   }
 
   if ((*ies)->guti) {
-    delete_wrapper((void**) &(*ies)->guti);
+    delete_wrapper(&(*ies)->guti);
   }
 
   if ((*ies)->imei) {
-    delete_wrapper((void**) &(*ies)->imei);
+    delete_wrapper(&(*ies)->imei);
   }
 
   if ((*ies)->drx_parameter) {
-    delete_wrapper((void**) &(*ies)->drx_parameter);
+    delete_wrapper(&(*ies)->drx_parameter);
   }
 
   if ((*ies)->last_visited_registered_tai) {
-    delete_wrapper((void**) &(*ies)->last_visited_registered_tai);
+    delete_wrapper(&(*ies)->last_visited_registered_tai);
   }
+
+  delete_wrapper(ies);
 }
 
 /***********************************************************************
@@ -1027,7 +1031,9 @@ void amf_delete_child_procedures(
     while (p1) {
       p2 = LIST_NEXT(p1, entries);
       if (((nas5g_base_proc_t*) p1->proc)->parent == parent_proc) {
-        amf_delete_common_procedure(amf_ctx, &p1->proc);
+        LIST_REMOVE(p1, entries);
+        amf_delete_common_procedure(&p1->proc);
+        delete_wrapper(&p1);
       }
       p1 = p2;
     }
@@ -1040,8 +1046,7 @@ void amf_delete_child_procedures(
  ** Description: deletes the nas registration specific common         **
  **              procedures                                           **
  **                                                                   **
- ** Inputs:  amf_ctx:   The amf context                               **
- **          proc: nas amf common proc                                **
+ ** Inputs:  proc: nas amf common proc                                **
  **                                                                   **
  **                                                                   **
  ** Outputs:     None                                                 **
@@ -1049,62 +1054,22 @@ void amf_delete_child_procedures(
  **      Others:    None                                              **
  **                                                                   **
  ***********************************************************************/
-void amf_delete_common_procedure(
-    amf_context_t* amf_ctx, nas_amf_common_proc_t** proc) {
-  if (*proc) {
-    /* delete proc content */
+void amf_delete_common_procedure(nas_amf_common_proc_t** proc) {
+  if (proc && *proc) {
     switch ((*proc)->type) {
       case AMF_COMM_PROC_AUTH: {
+        delete_wrapper(reinterpret_cast<nas5g_amf_auth_proc_t**>(proc));
       } break;
       case AMF_COMM_PROC_SMC: {
+        delete_wrapper(reinterpret_cast<nas_amf_smc_proc_t**>(proc));
       } break;
       case AMF_COMM_PROC_IDENT: {
+        delete_wrapper(reinterpret_cast<nas_amf_ident_proc_t**>(proc));
       } break;
       default: {}
     }
-
-    // remove proc from list
-    if (amf_ctx->amf_procedures) {
-      nas_amf_common_procedure_t* p1 =
-          LIST_FIRST(&amf_ctx->amf_procedures->amf_common_procs);
-      nas_amf_common_procedure_t* p2 = NULL;
-      while (p1) {
-        p2 = LIST_NEXT(p1, entries);
-        if (p1->proc == (nas_amf_common_proc_t*) (*proc)) {
-          LIST_REMOVE(p1, entries);
-          delete_wrapper((void**) &p1->proc);
-          delete_wrapper((void**) &p1);
-          return;
-        }
-        p1 = p2;
-      }
-    }
   }
-
-  // if not found in list, free it anyway
-  if (*proc) {
-    delete_wrapper((void**) proc);
-  }
-}
-
-/***********************************************************************
- ** Name:    delete_wrapper()                                         **
- **                                                                   **
- ** Description: deletes the memory                                   **
- **                                                                   **
- ** Inputs: ptr:   pointer to be freed                                **
- **                                                                   **
- **                                                                   **
- ** Outputs:     None                                                 **
- **      Return:    void                                              **
- **      Others:    None                                              **
- **                                                                   **
- ***********************************************************************/
-void delete_wrapper(void** ptr) {
-  if (ptr && *ptr) {
-    delete (*ptr);
-    *ptr = NULL;
-  }
+  return;
 }
 /****************************************************************************
 **                                                                        **

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -41,6 +41,7 @@ extern "C" {
 #include "M5GRegistrationRequest.h"
 #include "ngap_messages_types.h"
 #include "amf_common.h"
+#include "assertions.h"
 
 // NAS messages
 #include "M5GDLNASTransport.h"
@@ -830,9 +831,7 @@ void amf_delete_registration_proc(amf_context_t* amf_txt);
 void amf_delete_registration_ies(amf_registration_request_ies_t** ies);
 void amf_delete_child_procedures(
     amf_context_t* amf_txt, struct nas5g_base_proc_t* const parent_proc);
-void amf_delete_common_procedure(
-    amf_context_t* amf_ctx, nas_amf_common_proc_t** proc);
-void delete_wrapper(void** ptr);
+void amf_delete_common_procedure(nas_amf_common_proc_t** proc);
 void format_plmn(amf_plmn_t* plmn);
 void amf_ue_context_on_new_guti(
     ue_m5gmm_context_t* ue_context_p, const guti_m5_t* const guti_p);
@@ -850,4 +849,29 @@ ue_m5gmm_context_s* ue_context_lookup_by_gnb_ue_id(
 
 int amf_idle_mode_procedure(amf_context_t* amf_ctx);
 void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p);
+
+/************************************************************************
+ ** Name:    delete_wrapper()                                         **
+ **                                                                   **
+ ** Description: deletes the memory                                   **
+ **                                                                   **
+ ** Inputs: ptr:   pointer to be freed                                **
+ **                                                                   **
+ **                                                                   **
+ ** Outputs:     None                                                 **
+ **      Return:    void                                              **
+ **      Others:    None                                              **
+ ***********************************************************************/
+template<typename T>
+void delete_wrapper(T** pObj) {
+  AssertFatal(
+      !(std::is_same<T, void>::value),
+      "delete_wrapper does not accept pointer of type void");
+  if (pObj && *pObj) {
+    T* obj = *pObj;
+    delete obj;
+    *pObj = nullptr;
+  }
+}
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.h
@@ -90,4 +90,15 @@ int amf_start_registration_proc_authentication(
     amf_context_t* amf_context, nas_amf_registration_proc_t* registration_proc);
 
 int amf_handle_s6a_update_location_ans(const s6a_update_location_ans_t* ula_pP);
+
+nas_amf_registration_proc_t* nas_new_registration_procedure(
+    ue_m5gmm_context_s* ue_ctxt);
+
+nas_amf_ident_proc_t* nas5g_new_identification_procedure(
+    amf_context_t* const amf_context);
+
+nas_amf_smc_proc_t* nas5g_new_smc_procedure(amf_context_t* const amf_context);
+nas5g_amf_auth_proc_t* nas5g_new_authentication_procedure(
+    amf_context_t* const amf_context);
+
 }  // namespace magma5g


### PR DESCRIPTION
Signed-off-by: shashidhar-patil <shashidhar.patil@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Earlier implementation: Pointer to be freed is cast to void** and passed to delete_wrapper. The delete wrapper calls delete on the void pointer.

Issue: Casting the pointers into void** and then calling delete on them may cause defects as the delete operator will not call the destructor for the object of type "Example_type" pointed to by 'example_ptr'. This will lead to undefined behavior and is unsafe.

Code Change: The delete wrapper is implemented as a template function and now takes into account the data type of the pointer while deleting it. This performs a safe delete.
 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Verified basic sanity with UERANSIM.
- Please find attached logs and pcap snap for basic registration.
- Verified UT cases.

Logs:
[mme.log](https://github.com/magma/magma/files/7364678/mme.log)

pcap snapshot:
![pcap_delete_wrapper](https://user-images.githubusercontent.com/89975652/137728401-b39ddd60-a522-4174-9ccb-e0eded86d9bf.png)

Unit test snapshot:
![UT_delete_wrapper](https://user-images.githubusercontent.com/89975652/137728520-57dc8ada-6253-4ef9-a94d-78699049630c.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
--

>
