### PR TITLE
feat(sessiond): Extended UT coverage for sessiond

### DIFF
--- a/lte/gateway/c/session_manager/test/BUILD.bazel
+++ b/lte/gateway/c/session_manager/test/BUILD.bazel
@@ -36,6 +36,11 @@ cc_library(
 )
 
 cc_library(
+    name = "session_state_tester_5g",
+    hdrs = ["SessionStateTester5g.h"],
+)
+
+cc_library(
     name = "protobuf_creators",
     srcs = ["ProtobufCreators.cpp"],
     hdrs = ["ProtobufCreators.h"],
@@ -207,6 +212,20 @@ cc_test(
 )
 
 cc_test(
+    name = "session_state_5g",
+    size = "small",
+    srcs = ["test_session_state_5g.cpp"],
+    deps = [
+        ":consts",
+        ":matchers",
+        ":protobuf_creators",
+        ":session_state_tester_5g",
+        ":sessiond_mocks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "store_client_test",
     size = "small",
     srcs = ["test_store_client.cpp"],
@@ -256,9 +275,9 @@ cc_test(
 )
 
 cc_test(
-    name = "upf_node_state_test",
+    name = "upf_msg_manage_handler",
     size = "small",
-    srcs = ["test_upf_node_state.cpp"],
+    srcs = ["test_upf_msg_manage_handler.cpp"],
     deps = [
         ":protobuf_creators",
         ":sessiond_mocks",

--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -35,7 +35,7 @@ foreach (session_test polling_pipelined session_credit local_enforcer cloud_repo
     session_manager_handler sessiond_integ session_state
     session_store store_client stored_state proxy_responder_handler
     metering_reporter local_enforcer_wallet_exhaust charging_grant
-    usage_monitor upf_node_state set_session_manager_handler session_state_5g)
+    usage_monitor upf_msg_manage_handler set_session_manager_handler session_state_5g)
   add_executable(${session_test}_test test_${session_test}.cpp)
   target_link_libraries(${session_test}_test SESSIOND_TEST_LIB)
   add_test(test_${session_test} ${session_test}_test)

--- a/lte/gateway/c/session_manager/test/Consts.h
+++ b/lte/gateway/c/session_manager/test/Consts.h
@@ -28,6 +28,7 @@
 #define IP3 "127.0.0.3"
 #define IP4 "127.0.0.4"
 #define APN1 "03-21-00-02-00-20:Magma"
+#define APN2 "example.com"
 #define IPv6_1 "2001:0db8:0a0b:12f0:0000:0000:0000:0001"
 #define IPv6_2 "2001:0db8:0a0b:12f0:0000:0000:0000:0002"
 #define IPv6_3 "2001:0db8:0a0b:12f0:0000:0000:0000:0003"
@@ -43,3 +44,8 @@
 #define BEARER_ID_1 0
 #define BEARER_ID_2 2
 #define BEARER_ID_3 3
+#define UE_IPV4 "192.168.128.11"
+#define AGW_IPV4 "192.168.60.142"
+#define REDIRECT_SERVER_IPV4_ADDRESS "10.20.30.40"
+#define PDU_ID 0x5
+#define SM_SESSION_VERSION 1

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -329,14 +329,18 @@ class MockSetInterfaceForUserPlane final
  public:
   MockSetInterfaceForUserPlane() : SetInterfaceForUserPlane::Service() {}
   MOCK_METHOD3(
-      SetUPFNodeState, Status(
+      SetUPFNodeState, void(
                            grpc::ServerContext*, const UPFNodeState*,
                            std::function<void(Status, SmContextVoid)>));
   MOCK_METHOD3(
       SetUPFSessionConfig,
-      Status(
+      void(
           grpc::ServerContext*, const UPFSessionConfigState*,
           std::function<void(Status, SmContextVoid)>));
+  MOCK_METHOD3(
+      SendPagingRequest, void(
+                             grpc::ServerContext*, const UPFPagingInfo*,
+                             std::function<void(Status, SmContextVoid)>));
 };
 
 class MockAmfServiceClient : public AmfServiceClient {

--- a/lte/gateway/c/session_manager/test/test_upf_msg_manage_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_upf_msg_manage_handler.cpp
@@ -11,7 +11,13 @@
  * limitations under the License.
  */
 
+#include <folly/io/async/EventBaseManager.h>
 #include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -29,16 +35,18 @@
 #include "magma_logging.h"
 #include "PipelinedClient.h"
 #include "AmfServiceClient.h"
+#include "Consts.h"
 
 #define SESSIOND_SERVICE "sessiond"
 #define SESSIOND_VERSION "1.0"
 #define session_max_rtx_count 3
 
+using grpc::Status;
 using ::testing::Test;
 
 namespace magma {
 
-class SetUPFNodeState : public ::testing::Test {
+class UpfMsgMessageHandlerTest : public ::testing::Test {
  public:
   virtual void SetUp() {
     rule_store    = std::make_shared<StaticRuleStore>();
@@ -59,11 +67,26 @@ class SetUPFNodeState : public ::testing::Test {
         mconfig, config["session_force_termination_timeout_ms"].as<int32_t>(),
         session_max_rtx_count);
 
+    evb = new folly::EventBase();
+    std::thread([&]() {
+      std::cout << "Started event loop thread\n";
+      folly::EventBaseManager::get()->setEventBase(evb, 0);
+    })
+        .detach();
+    session_enforcer->attachEventBase(evb);
+
     set_interface_for_up_mock =
         std::make_shared<MockSetInterfaceForUserPlane>();
-    sess_config = std::make_shared<UPFSessionConfigState>();
+
+    mobilityd_client = std::make_shared<AsyncMobilitydClient>();
+    node_request     = std::make_shared<UPFNodeState>();
+    sess_config      = std::make_shared<UPFSessionConfigState>();
+    page_request     = std::make_shared<UPFPagingInfo>();
+
+    upf_msg_handler = std::make_shared<magma::UpfMsgManageHandler>(
+        session_enforcer, mobilityd_client, *session_store);
   }
-  virtual void TearDown() {}
+  virtual void TearDown() { delete evb; }
 
  public:
   std::shared_ptr<SessionStore> session_store;
@@ -73,36 +96,130 @@ class SetUPFNodeState : public ::testing::Test {
   std::shared_ptr<AsyncAmfServiceClient> amf_srv_client;
   std::shared_ptr<MockSetInterfaceForUserPlane> set_interface_for_up_mock;
   std::shared_ptr<UPFSessionConfigState> sess_config;
+  std::shared_ptr<AsyncMobilitydClient> mobilityd_client;
+  std::shared_ptr<UPFPagingInfo> page_request;
+  std::shared_ptr<UpfMsgManageHandler> upf_msg_handler;
+  std::shared_ptr<UPFNodeState> node_request;
+  folly::EventBase* evb;
 };  // End of class
 
+// Testing the functionality of SendPagingRequest
+TEST_F(UpfMsgMessageHandlerTest, test_send_paging_request) {
+  // Validate SendPagingRequest
+  ON_CALL(*set_interface_for_up_mock, SendPagingRequest(_, _, _))
+      .WillByDefault(Return());
+
+  page_request->set_local_f_teid(11);
+  page_request->set_ue_ip_addr("192.168.128.11");
+  std::function<void(Status, SmContextVoid)> response_callback;
+
+  auto& page_req      = *page_request;
+  uint32_t fte_id     = page_req.local_f_teid();
+  std::string ip_addr = page_req.ue_ip_addr();
+  struct in_addr ue_ip;
+  IPAddress req = IPAddress();
+
+  inet_aton(ip_addr.c_str(), &ue_ip);
+  req.set_version(IPAddress::IPV4);
+  req.set_address(&ue_ip, sizeof(struct in_addr));
+
+  grpc::ServerContext server_context;
+  upf_msg_handler->SendPagingRequest(
+      &server_context, &page_req,
+      [this](grpc::Status status, SmContextVoid Void) {});
+  mobilityd_client->get_subscriberid_from_ipv4(
+      req, [this, fte_id, response_callback](
+               Status status, const SubscriberID& sid) {
+        // Validate the status
+        EXPECT_TRUE(status.ok());
+
+        const std::string& imsi = sid.id();
+        // Validate the imsi length
+        EXPECT_TRUE(imsi.length());
+        EXPECT_EQ(imsi, IMSI1);
+
+        auto session_map = session_store->read_sessions({imsi});
+        SessionSearchCriteria criteria(imsi, IMSI_AND_TEID, fte_id);
+        auto session_it = session_store->find_session(session_map, criteria);
+
+        // Validate if we found session from session_store
+        EXPECT_TRUE(session_it);
+
+        auto& session = **session_it;
+
+        EXPECT_EQ(fte_id, TEID_1_UL);
+
+        // Validate the session state if it is INACTIVE or not
+        EXPECT_TRUE(session->get_state() == INACTIVE);
+        // Update the paging request to AMF
+        session_enforcer->handle_state_update_to_amf(
+            *session, magma::lte::M5GSMCause::OPERATION_SUCCESS,
+            UE_PAGING_NOTIFY);
+
+        // After Paging session should be ACTIVE
+        EXPECT_TRUE(session->get_state() == ACTIVE);
+        EXPECT_TRUE(magma::lte::M5GSMCause::OPERATION_SUCCESS);
+      });
+}
+
 // Testing the functionality of SetUPFNodeState
-TEST_F(SetUPFNodeState, test_upf_node_state) {
+TEST_F(UpfMsgMessageHandlerTest, test_upf_node_state) {
   // Validate SetUPFNodeState
   ON_CALL(*set_interface_for_up_mock, SetUPFNodeState(_, _, _))
-      .WillByDefault(Return(Status::OK));
+      .WillByDefault(Return());
+
+  auto& req = *node_request;
+  node_request->set_upf_id("1");
+  std::function<void(Status, SmContextVoid)> response_callback;
 
   std::string upf_node_id = "192.168.200.1";
   std::string upf_n3_addr = "192.168.60.112";
 
+  grpc::ServerContext server_context;
+  upf_msg_handler->SetUPFNodeState(
+      &server_context, &req,
+      [this](grpc::Status status, SmContextVoid Void) {});
+
+  switch (req.upf_node_messages_case()) {
+    case UPFNodeState::kAssociatonState: {
+      UPFAssociationState Assostate = req.associaton_state();
+      auto recovery_time            = Assostate.recovery_time_stamp();
+      auto feature_set              = Assostate.feature_set();
+      std::string local_ipv4_addr =
+          Assostate.ip_resource_schema(0).ipv4_address();
+      break;
+    }
+    case UPFNodeState::kNodeReport: {
+      break;
+    }
+    case UPFNodeState::UPF_NODE_MESSAGES_NOT_SET: {
+      break;
+    }
+    default: { break; }
+  }
   session_enforcer->set_upf_node(upf_node_id, upf_n3_addr);
   std::string upf_id    = session_enforcer->get_upf_node_id();
   std::string ipv4_addr = session_enforcer->get_upf_n3_addr();
-
   // Validate the functionality of UPF Node ID
   EXPECT_TRUE(upf_node_id == upf_id);
 
   // Validate the functionality of UPF N3 interface address
   EXPECT_TRUE(upf_n3_addr == ipv4_addr);
+  EXPECT_EQ(req.upf_id(), "1");
 }
 
 // Testing the functionality of SetUPFSessionConfig
-TEST_F(SetUPFNodeState, test_upf_session_config) {
+TEST_F(UpfMsgMessageHandlerTest, test_upf_session_config) {
   // Validate SetUPFSessionConfig
   ON_CALL(*set_interface_for_up_mock, SetUPFSessionConfig(_, _, _))
-      .WillByDefault(Return(Status::OK));
+      .WillByDefault(Return());
 
   auto& ses_config = *sess_config;
   int32_t count    = 0;
+  grpc::ServerContext server_context;
+  upf_msg_handler->SetUPFSessionsConfig(
+      &server_context, &ses_config,
+      [this](grpc::Status status, SmContextVoid Void) {});
   for (auto& upf_session : ses_config.upf_session_state()) {
     // Deleting the IMSI prefix from imsi
     std::string imsi_upf = upf_session.subscriber_id();
@@ -128,7 +245,20 @@ TEST_F(SetUPFNodeState, test_upf_session_config) {
      * with SMF latest version
      */
     EXPECT_LE(version, cur_version);
+
+    EXPECT_TRUE(
+        session_enforcer->is_incremented_rtx_counter_within_max(session));
+
     RulesToProcess pending_activation, pending_deactivation;
+    const CreateSessionResponse& csr = session->get_create_session_response();
+    std::vector<StaticRuleInstall> static_rule_installs =
+        session_enforcer->to_vec(csr.static_rules());
+    std::vector<DynamicRuleInstall> dynamic_rule_installs =
+        session_enforcer->to_vec(csr.dynamic_rules());
+    session->process_get_5g_rule_installs(
+        static_rule_installs, dynamic_rule_installs, &pending_activation,
+        &pending_deactivation);
+
     // Sending the session request to UPF
     session_enforcer->m5g_send_session_request_to_upf(
         session, pending_activation, pending_deactivation);


### PR DESCRIPTION
feat(sessiond): Extended UT coverage for sessiond

## Summary
i. fixed the UT file name by renaming as listed below:
![image](https://user-images.githubusercontent.com/70899516/137778094-6bc3ee5f-6030-42bb-ae70-f3a4d88030be.png)
ii. modified few test cases and added EXPECT/ASSERTIONS for the UT file "test_set_session_manager_handler.cpp"  
iii. Corresponding github issue is #8713


## Test Plan
![image](https://user-images.githubusercontent.com/70899516/137778769-ddd9100b-9518-424b-918b-8e0fe7ce14c1.png)




## Additional Information
Signed-off-by: GANESH-WAVELABS <ganesh.irrinki@wavelabs.ai>
