### PR TITLE
chore: remove OAILOG_* from assertions.h

### DIFF
--- a/lte/gateway/c/core/oai/common/assertions.h
+++ b/lte/gateway/c/core/oai/common/assertions.h
@@ -32,7 +32,6 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <inttypes.h>
-#include "log.h"
 
 #include "backtrace.h"
 
@@ -68,8 +67,6 @@
 #define _Assert_(cOND, aCTION, fORMAT, aRGS...)                                \
   do {                                                                         \
     if (!(cOND)) {                                                             \
-      OAILOG_CRITICAL(                                                         \
-          LOG_ASSERT, "Assertion (" #cOND ") failed! " fORMAT "\n", ##aRGS);   \
       fprintf(                                                                 \
           stderr,                                                              \
           "\nAssertion (" #cOND                                                \
@@ -88,7 +85,6 @@
 
 #define Fatal(format, args...)                                                 \
   do {                                                                         \
-    OAILOG_CRITICAL(LOG_ASSERT, "Fatal! " format, ##args);                     \
     fprintf(                                                                   \
         stderr, "\nFatal!\n %s() %s:%d\n" format, __FUNCTION__, __FILE__,      \
         __LINE__, ##args);                                                     \
@@ -120,8 +116,6 @@
   do {                                                                         \
     int fct_ret;                                                               \
     if ((fct_ret = (fCT)) != 0) {                                              \
-      OAILOG_CRITICAL(                                                         \
-          LOG_ASSERT, "Function " #fCT " has failed returning %d\n", fct_ret); \
       fprintf(                                                                 \
           stderr,                                                              \
           "Function " #fCT                                                     \

--- a/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
+++ b/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
@@ -22,6 +22,7 @@
 #include "assertions.h"
 #include "intertask_interface.h"
 #include "itti_types.h"
+#include "log.h"
 
 int send_app_health_to_service303(
     task_zmq_ctx_t* task_zmq_ctx_p, task_id_t origin_id, bool healthy) {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
See discussion here: https://github.com/magma/magma/issues/9732#issuecomment-947055779

This PR removes OAI_LOG macros from assertions.h
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make test_oai
make integ_test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
