### PR TITLE
feat: Add support for L3 transport for PGW traffic

### DIFF
--- a/lte/gateway/c/core/oai/include/sgw_config.h
+++ b/lte/gateway/c/core/oai/include/sgw_config.h
@@ -60,6 +60,7 @@
 #define SGW_CONFIG_STRING_OVS_UPLINK_MAC "UPLINK_MAC"
 #define SGW_CONFIG_STRING_OVS_MULTI_TUNNEL "MULTI_TUNNEL"
 #define SGW_CONFIG_STRING_OVS_GTP_ECHO "GTP_ECHO"
+#define SGW_CONFIG_STRING_AGW_L3_TUNNEL "AGW_L3_TUNNEL"
 #define SGW_CONFIG_STRING_OVS_PIPELINED_CONFIG_ENABLED                         \
   "PIPELINED_CONFIG_ENABLED"
 
@@ -110,6 +111,7 @@ typedef struct sgw_config_s {
 
   bstring config_file;
   ovs_config_t ovs_config;
+  bool agw_l3_tunnel;
 } sgw_config_t;
 
 void sgw_config_init(sgw_config_t* config_pP);

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -152,9 +152,11 @@ static uint32_t get_gtp_port_no(char port_name[]) {
 /**
  * Create GTP tunnel using OVS tool
  */
-static uint32_t create_gtp_port(struct in_addr enb_addr, char port_name[]) {
+static uint32_t create_gtp_port(
+    struct in_addr enb_addr, char port_name[], bool is_pgw) {
   char gtp_port_create[512];
   char* gtp_echo;
+  char* l3_tunnel;
   int rc;
 
   if (spgw_config.sgw_config.ovs_config.gtp_echo) {
@@ -162,14 +164,16 @@ static uint32_t create_gtp_port(struct in_addr enb_addr, char port_name[]) {
   } else {
     gtp_echo = "false";
   }
+  if (is_pgw && spgw_config.sgw_config.agw_l3_tunnel) {
+     l3_tunnel = "true";
+  } else {
+     l3_tunnel = "false";
+  }
+
   rc = snprintf(
       gtp_port_create, sizeof(gtp_port_create),
-      "sudo ovs-vsctl --may-exist add-port gtp_br0 %s -- set Interface %s "
-      "type=%s "
-      "options:remote_ip=%s options:key=flow options:csum=true "
-      "bfd:enable=%s "
-      "bfd:min_tx=5000 bfd:min_rx=5000",
-      port_name, port_name, ovs_gtp_type, inet_ntoa(enb_addr), gtp_echo);
+      "sudo /usr/local/bin/magma-create-gtp-port.sh %s %s %s %s", port_name,
+      inet_ntoa(enb_addr), gtp_echo, l3_tunnel);
   if (rc < 0) {
     OAILOG_ERROR(LOG_GTPV1U, "gtp-port create: format error %d", rc);
     return rc;
@@ -181,7 +185,8 @@ static uint32_t create_gtp_port(struct in_addr enb_addr, char port_name[]) {
         LOG_GTPV1U, "gtp port create: [%s] failed: %d", gtp_port_create, rc);
   } else {
     OAILOG_DEBUG(
-        LOG_GTPV1U, "gtp port create done: for ENB: %s ", inet_ntoa(enb_addr));
+        LOG_GTPV1U, "gtp port create done[%s]: for ENB: %s ", gtp_port_create,
+        inet_ntoa(enb_addr));
   }
 
   return get_gtp_port_no(port_name);
@@ -191,7 +196,7 @@ static uint32_t create_gtp_port(struct in_addr enb_addr, char port_name[]) {
  * seach port in cached table. otherwise create tunnel and
  * retrieve port number from OVSDB.
  */
-static uint32_t find_gtp_port_no(struct in_addr enb_addr) {
+static uint32_t find_gtp_port_no(struct in_addr enb_addr, bool is_pgw) {
   if (!spgw_config.sgw_config.ovs_config.multi_tunnel) {
     return 0;
   }
@@ -207,7 +212,7 @@ static uint32_t find_gtp_port_no(struct in_addr enb_addr) {
     return portno;
   }
 
-  portno = create_gtp_port(enb_addr, port_name);
+  portno = create_gtp_port(enb_addr, port_name, is_pgw);
   add_portno_rec(port_name, portno);
   return portno;
 }
@@ -260,7 +265,7 @@ int openflow_add_tunnel(
     struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
     uint32_t i_tei, uint32_t o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
     uint32_t flow_precedence_dl, char* apn) {
-  uint32_t gtp_portno = find_gtp_port_no(enb);
+  uint32_t gtp_portno = find_gtp_port_no(enb, false);
 
   return openflow_controller_add_gtp_tunnel(
       ue, ue_ipv6, vlan, enb, i_tei, o_tei, (const char*) imsi.digit, flow_dl,
@@ -270,7 +275,7 @@ int openflow_add_tunnel(
 int openflow_del_tunnel(
     struct in_addr enb, struct in_addr ue, struct in6_addr* ue_ipv6,
     uint32_t i_tei, uint32_t o_tei, struct ip_flow_dl* flow_dl) {
-  uint32_t gtp_portno = find_gtp_port_no(enb);
+  uint32_t gtp_portno = find_gtp_port_no(enb, false);
 
   return openflow_controller_del_gtp_tunnel(
       ue, ue_ipv6, i_tei, flow_dl, gtp_portno);
@@ -282,8 +287,8 @@ int openflow_add_s8_tunnel(
     struct in_addr pgw, uint32_t i_tei, uint32_t o_tei, uint32_t pgw_i_tei,
     uint32_t pgw_o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
     uint32_t flow_precedence_dl) {
-  uint32_t enb_portno = find_gtp_port_no(enb);
-  uint32_t pgw_portno = find_gtp_port_no(pgw);
+  uint32_t enb_portno = find_gtp_port_no(enb, false);
+  uint32_t pgw_portno = find_gtp_port_no(pgw, true);
 
   return openflow_controller_add_gtp_s8_tunnel(
       ue, ue_ipv6, vlan, enb, pgw, i_tei, o_tei, pgw_i_tei, pgw_o_tei,
@@ -295,8 +300,8 @@ int openflow_del_s8_tunnel(
     struct in_addr enb, struct in_addr pgw, struct in_addr ue,
     struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
     struct ip_flow_dl* flow_dl) {
-  uint32_t enb_portno = find_gtp_port_no(enb);
-  uint32_t pgw_portno = find_gtp_port_no(pgw);
+  uint32_t enb_portno = find_gtp_port_no(enb, false);
+  uint32_t pgw_portno = find_gtp_port_no(pgw, true);
 
   return openflow_controller_del_gtp_s8_tunnel(
       ue, ue_ipv6, i_tei, flow_dl, enb_portno, pgw_portno);

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c
@@ -311,9 +311,11 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
     libconfig_int internal_sampling_fwd_tbl_num = 0;
     libconfig_int uplink_port_num               = 0;
     char* multi_tunnel                          = NULL;
+    char* agw_l3_tunnel                         = NULL;
     char* gtp_echo                              = NULL;
-    char* uplink_mac                            = NULL;
-    char* pipelined_managed_tbl0                = NULL;
+
+    char* uplink_mac             = NULL;
+    char* pipelined_managed_tbl0 = NULL;
     if (config_setting_lookup_string(
             ovs_settings, SGW_CONFIG_STRING_OVS_BRIDGE_NAME,
             (const char**) &ovs_bridge_name) &&
@@ -339,6 +341,9 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
         config_setting_lookup_string(
             ovs_settings, SGW_CONFIG_STRING_OVS_GTP_ECHO,
             (const char**) &gtp_echo) &&
+        config_setting_lookup_string(
+            ovs_settings, SGW_CONFIG_STRING_AGW_L3_TUNNEL,
+            (const char**) &agw_l3_tunnel) &&
         config_setting_lookup_string(
             ovs_settings, SGW_CONFIG_STRING_OVS_PIPELINED_CONFIG_ENABLED,
             (const char**) &pipelined_managed_tbl0)) {
@@ -373,6 +378,13 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
         config_pP->ovs_config.gtp_echo = false;
       }
       OAILOG_INFO(LOG_SPGW_APP, "GTP-U echo response enable: %s\n", gtp_echo);
+
+      if (strcasecmp(agw_l3_tunnel, "true") == 0) {
+        config_pP->agw_l3_tunnel = true;
+      } else {
+        config_pP->agw_l3_tunnel = false;
+      }
+      OAILOG_INFO(LOG_SPGW_APP, "AGW L3 tunneling enable: %s\n", agw_l3_tunnel);
     } else {
       Fatal("Couldn't find all ovs settings in spgw config\n");
     }

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -198,3 +198,11 @@ dp_irq:
  SGi_cpu: '2'
  SGi_queue_size: 256
 
+sgi_tunnel:
+ enabled: false
+ type: wg
+ enable_default_route: false
+ tunnels:
+ - wg_local_ip: 172.168.100.1/24
+   peer_pub_key: 'VQT+tLY6/xF+k1WqrXeQzlfb8hWMVLcPdtCPvwIUNU0='
+   peer_pub_ip: 1.2.3.4

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -174,3 +174,12 @@ dp_irq:
  S1_queue_size: 2048
  SGi_cpu: '2-3'
  SGi_queue_size: 1024
+
+sgi_tunnel:
+ enabled: false
+ type: wg
+ enable_default_route: false
+ tunnels:
+ - wg_local_ip: 172.168.100.1/24
+   peer_pub_key: 'VQT+tLY6/xF+k1WqrXeQzlfb8hWMVLcPdtCPvwIUNU0='
+   peer_pub_ip: 1.2.3.4

--- a/lte/gateway/configs/spgw.yml
+++ b/lte/gateway/configs/spgw.yml
@@ -48,3 +48,6 @@ pipelined_managed_tbl0: false
 
 # To enable GTP-U echo response on all GTP tunnels.
 ovs_gtpu_echo_resp: true
+
+# To enable PGW tunnel over wireguard tunneling
+agw_l3_tunnel: false

--- a/lte/gateway/configs/templates/spgw.conf.template
+++ b/lte/gateway/configs/templates/spgw.conf.template
@@ -47,6 +47,7 @@ S-GW :
       UPLINK_MAC                           = "{{ ovs_uplink_mac }}";
       MULTI_TUNNEL                         = "{{ ovs_multi_tunnel }}";
       GTP_ECHO                             = "{{ ovs_gtpu_echo_resp }}";
+      AGW_L3_TUNNEL                        = "{{ agw_l3_tunnel }}";
       PIPELINED_CONFIG_ENABLED             = "{{ pipelined_managed_tbl0 }}";
     };
 };

--- a/lte/gateway/deploy/roles/magma/files/magma-create-gtp-port.sh
+++ b/lte/gateway/deploy/roles/magma/files/magma-create-gtp-port.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+port_name=$1
+enb_addr=$2
+gtp_echo=$3
+enable_wg_tuneling=$4
+
+wg_setup_utility="/usr/local/bin/magma-setup-wg.sh"
+wg_key_dir="/var/opt/magma/sgi-tunnel"
+bfd_time=5000
+
+sudo ovs-vsctl --may-exist add-port gtp_br0 $port_name -- set Interface $port_name type=gtpu options:remote_ip=$enb_addr options:key=flow bfd:enable=$gtp_echo bfd:min_tx=$bfd_time bfd:min_rx=$bfd_time options:csum=true
+
+if [[ $enable_wg_tuneling == "true" ]]; then
+  $wg_setup_utility $wg_key_dir $enb_addr
+fi

--- a/lte/gateway/deploy/roles/magma/files/magma-setup-wg.sh
+++ b/lte/gateway/deploy/roles/magma/files/magma-setup-wg.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+key_dir=$1
+allowed_ips=$2
+
+#Optional ARGs
+local_ip=$3
+peer_pub_key=$4
+peer_ip=$5
+
+dev=magma_wg0
+portno=9333
+priv_key_file="$key_dir/wg_privatekey"
+
+mkdir -p "$key_dir"
+
+if [[ ! -s $priv_key_file ]]; then
+    wg genkey | tee "$key_dir"/wg_privatekey | wg pubkey > "$key_dir"/wg_publickey
+
+    chmod 600 "$key_dir"/wg_privatekey
+    chmod 600 "$key_dir"/wg_publickey
+fi
+
+if ! ip l sh $dev  &> /dev/null;
+then
+    echo "create $dev";
+    ip link add dev $dev type wireguard
+
+    ip address flush dev $dev
+    ip address replace dev $dev "$local_ip"
+
+    ip link set $dev up
+fi
+
+curren_allowed_ips=$(wg show $dev | grep allowed | cut -d: -f2 | xargs)
+if [[ -n $curren_allowed_ips ]]; then
+    allowed_ips="$allowed_ips,$curren_allowed_ips"
+fi
+if [[ -n $local_ip ]]; then
+  allowed_ips="$allowed_ips,$local_ip"
+fi
+
+if [[ -n $peer_ip ]]; then
+  end_point_arg="$peer_ip:$portno"
+else
+  end_point_arg="$(wg show magma_wg0 | grep endpoint | cut -d: -f2 | xargs):$portno"
+fi
+
+if [[ -z $peer_pub_key ]]; then
+  peer_pub_key=$(wg show |grep 'peer:' | cut -d: -f2 | xargs)
+fi
+
+wg set $dev listen-port $portno  private-key "$priv_key_file" peer "$peer_pub_key"  allowed-ips "$allowed_ips" endpoint "$end_point_arg"  persistent-keepalive 15
+
+cp /etc/wireguard/$dev.conf /etc/wireguard/$dev.conf.bk
+touch /etc/wireguard/$dev.conf
+wg-quick save $dev
+if ! diff -q /etc/wireguard/$dev.conf /etc/wireguard/$dev.conf.bk; then
+  ip link del $dev
+  wg-quick up $dev
+fi
+systemctl enable wg-quick@$dev

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -88,6 +88,10 @@
   copy: src=magma-setup-wg.sh dest=/usr/local/bin/magma-setup-wg.sh mode=751
   when: full_provision
 
+- name: Copy magma-create-gtp-port.sh
+  copy: src=magma-create-gtp-port.sh dest=/usr/local/bin/magma-create-gtp-port.sh mode=751
+  when: full_provision
+
 - name: Add the sysctl config from the step before
   become: yes
   command: 'sysctl -p /etc/sysctl.d/99-magma.conf'

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -84,6 +84,10 @@
   copy: src=magma-bridge-reset.sh dest=/usr/local/bin/magma-bridge-reset.sh mode=751
   when: full_provision
 
+- name: Copy magma-setup-wg.sh
+  copy: src=magma-setup-wg.sh dest=/usr/local/bin/magma-setup-wg.sh mode=751
+  when: full_provision
+
 - name: Add the sysctl config from the step before
   become: yes
   command: 'sysctl -p /etc/sysctl.d/99-magma.conf'

--- a/lte/gateway/python/magma/pipelined/datapath_setup.py
+++ b/lte/gateway/python/magma/pipelined/datapath_setup.py
@@ -10,12 +10,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from magma.common.misc_utils import call_process
+
 import subprocess
 import os
 import logging
 
 irq_utility = '/usr/local/bin/set_irq_affinity'
 ethtool_utility = '/usr/sbin/ethtool'
+
+wg_dev = 'magma_wg0'
+wg_setup_utility = '/usr/local/bin/magma-setup-wg.sh'
+wg_key_dir = '/var/opt/magma/sgi-tunnel'
 
 '''
 Following function sets various tuning parameters related
@@ -86,6 +92,50 @@ def tune_datapath(config_dict):
     except subprocess.CalledProcessError as ex:
         logging.debug('%s failed with: %s', set_sgi_queue_sz, ex)
 
+def setup_sgi_tunnel(config, loop):
+    def callback(returncode):
+        if returncode != 0:
+            logging.error(
+                "Failed to setup wg-dev: %d", returncode,
+            )
+    sgi_tunnel = config.get('sgi_tunnel', None)
+    if sgi_tunnel is None or sgi_tunnel.get('enabled', False) is False:
+        wg_del = 'wg-quick down %s || true' % wg_dev
+        logging.debug("sgi tunnel: del: %s", wg_del)
+        call_process(wg_del, callback, loop)
+        return
+
+    tun_type = sgi_tunnel.get('type', 'wg')
+    if tun_type != 'wg':
+        logging.error("sgi tunnel : %s not supported", tun_type)
+        return
+
+    enable_default_route = sgi_tunnel.get('enable_default_route', False)
+    tunnels = sgi_tunnel.get('tunnels', None)
+    if tunnels is None:
+        return
+
+    # TODO: handle multiple tunnels.
+    wg_local_ip = tunnels[0].get('wg_local_ip', None)
+    peer_pub_key = tunnels[0].get('peer_pub_key', None)
+    peer_pub_ip = tunnels[0].get('peer_pub_ip', None)
+
+    if wg_local_ip is None or peer_pub_ip is None or peer_pub_key is None:
+        logging.error("sgi tunnel: Missing config")
+        return
+
+    if enable_default_route:
+        allowed_ips = '0.0.0.0/0'
+    else:
+        allowed_ips = wg_local_ip
+
+    wg_add = "%s %s %s %s %s %s|| true" % \
+             (
+                 wg_setup_utility, wg_key_dir, allowed_ips,
+                 wg_local_ip, peer_pub_key, peer_pub_ip,
+             )
+    logging.info("sgi tunnel: add: %s", wg_add)
+    call_process(wg_add, callback, loop)
 
 def _check_util_failed(path: str):
     if not os.path.isfile(path) or not os.access(path, os.X_OK):

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -29,6 +29,10 @@ from magma.pipelined.app import of_rest_server
 from magma.pipelined.app.he import PROXY_PORT_NAME
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.check_quota_server import run_flask
+from magma.pipelined.datapath_setup import (
+    setup_sgi_tunnel,
+    tune_datapath,
+)
 from magma.pipelined.gtp_stats_collector import (
     MIN_OVSDB_DUMP_POLLING_INTERVAL,
     GTPStatsCollector,
@@ -40,7 +44,6 @@ from ryu import cfg
 from ryu.base.app_manager import AppManager
 from ryu.ofproto.ofproto_v1_4 import OFPP_LOCAL
 from scapy.arch import get_if_hwaddr
-from magma.pipelined.datapath_setup import tune_datapath
 
 
 def main():
@@ -120,6 +123,7 @@ def main():
     service.config['he_enabled'] = he_enabled
 
     # tune datapath according to config
+    setup_sgi_tunnel(service.config, service.loop)
     tune_datapath(service.config)
 
     # monitoring related configuration

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -424,6 +424,7 @@ ${ANSIBLE_FILES}/set_irq_affinity=/usr/local/bin/ \
 ${ANSIBLE_FILES}/ovs-kmod-upgrade.sh=/usr/local/bin/ \
 ${ANSIBLE_FILES}/magma-bridge-reset.sh=/usr/local/bin/ \
 ${ANSIBLE_FILES}/magma-setup-wg.sh=/usr/local/bin/ \
+${ANSIBLE_FILES}/magma-create-gtp-port.sh=/usr/local/bin/ \
 ${PY_PROTOS}=${PY_DEST} \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/${PKGNAME}*" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/*.egg-info" ${PY_DEST}) \

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -423,6 +423,7 @@ ${MAGMA_ROOT}/orc8r/tools/ansible/roles/fluent_bit/files/60-fluent-bit.conf=/etc
 ${ANSIBLE_FILES}/set_irq_affinity=/usr/local/bin/ \
 ${ANSIBLE_FILES}/ovs-kmod-upgrade.sh=/usr/local/bin/ \
 ${ANSIBLE_FILES}/magma-bridge-reset.sh=/usr/local/bin/ \
+${ANSIBLE_FILES}/magma-setup-wg.sh=/usr/local/bin/ \
 ${PY_PROTOS}=${PY_DEST} \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/${PKGNAME}*" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/*.egg-info" ${PY_DEST}) \


### PR DESCRIPTION
Following patch introduces SGi tunnel transport based on wireguard.
Design doc: #8723

Add config option for SGW to enable PGW packet routing
over WG tunnel. #8944

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`
manually tested WG tunnel for PGW on vagrant dev setup.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
This backport is for branch-1.6 for testing, it could be merged port 1.6.1 release.

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
