### PR TITLE
chore(agw): Enable pylint test on mobilityd

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -233,7 +233,7 @@ class DHCPClient:
 
             # default in wait is 30 sec
             wait_time = max(wait_time, self._lease_renew_wait_min)
-            logging.debug("lease renewal check after: %s sec" % wait_time)
+            logging.debug("lease renewal check after: %s sec", wait_time)
             self._monitor_thread_event.wait(wait_time)
             if self._monitor_thread_event.is_set():
                 break
@@ -314,7 +314,7 @@ class DHCPClient:
                         mac_addr, vlan, DHCPState.REQUEST, dhcp_state,
                     )
             else:
-                LOG.debug("Unknown MAC: %s " % packet.summary())
+                LOG.debug("Unknown MAC: %s ", packet.summary())
                 return
 
     # ref: https://fossies.org/linux/scapy/scapy/layers/dhcp.py

--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -424,14 +424,14 @@ class IPAddressManager:
                     sid, ip, sid, self._store.sid_ips_map.get(sid),
                 )
                 raise MappingNotFoundError(
-                    "(%s, %s) pair is not found", sid, str(ip),
+                    "(%s, %s) pair is not found" % (sid, ip),
                 )
             if not self.is_ip_in_state(ip, IPState.ALLOCATED):
                 logging.error(
                     "IP not found in used list, check if IP is "
                     "already released: <%s, %s>", sid, ip,
                 )
-                raise IPNotInUseError("IP not found in used list: %s", str(ip))
+                raise IPNotInUseError("IP not found in used list: %s" % ip)
 
             IP_RELEASED_TOTAL.inc()
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
@@ -35,8 +35,9 @@ class IPAllocator(ABC):
 
     @abstractmethod
     def remove_ip_blocks(
-        self, *ipblocks: List[ip_network],
-        force: bool
+        self,
+        ipblocks: List[ip_network],
+        force: bool,
     ) -> List[ip_network]:
         ...
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -76,8 +76,9 @@ class IPAllocatorDHCP(IPAllocator):
         )
 
     def remove_ip_blocks(
-        self, *ipblocks: List[ip_network],
-        force: bool = False
+        self,
+        ipblocks: List[ip_network],
+        force: bool = False,
     ) -> List[ip_network]:
         logging.warning(
             "Trying to delete ipblock from DHCP allocator: %s",
@@ -105,13 +106,13 @@ class IPAllocatorDHCP(IPAllocator):
             if ip in ipblock
         ]
 
-    def alloc_ip_address(self, sid: str, vlan: int) -> IPDesc:
+    def alloc_ip_address(self, sid: str, vlan_id: int) -> IPDesc:
         """
         Assumption: one-to-one mappings between SID and IP.
 
         Args:
             sid (string): universal subscriber id
-            vlan: vlan of the APN
+            vlan_id: vlan of the APN
 
         Returns:
             ipaddress.ip_address: IP address allocated
@@ -121,14 +122,14 @@ class IPAllocatorDHCP(IPAllocator):
         """
         mac = create_mac_from_sid(sid)
 
-        dhcp_desc = self._dhcp_client.get_dhcp_desc(mac, vlan)
+        dhcp_desc = self._dhcp_client.get_dhcp_desc(mac, str(vlan_id))
         LOG.debug(
             "allocate IP for %s mac %s dhcp_desc %s", sid, mac,
             dhcp_desc,
         )
 
         if dhcp_allocated_ip(dhcp_desc) is not True:
-            dhcp_desc = self._alloc_ip_address_from_dhcp(mac, vlan)
+            dhcp_desc = self._alloc_ip_address_from_dhcp(mac, vlan_id)
 
         if dhcp_allocated_ip(dhcp_desc):
             ip_block = ip_network(dhcp_desc.subnet)
@@ -138,7 +139,7 @@ class IPAllocatorDHCP(IPAllocator):
                 sid=sid,
                 ip_block=ip_block,
                 ip_type=IPType.DHCP,
-                vlan_id=vlan,
+                vlan_id=vlan_id,
             )
             self._store.assigned_ip_blocks.add(ip_block)
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
@@ -201,13 +201,14 @@ class IpAllocatorPool(IPAllocator):
         ]
         return res
 
-    def alloc_ip_address(self, sid: str, vlan: int) -> IPDesc:
+    def alloc_ip_address(self, sid: str, vlan_id: int) -> IPDesc:
         """ Allocate an IP address from the free list
 
         Assumption: one-to-one mappings between SID and IP.
 
         Args:
             sid (string): universal subscriber id
+            vlan_id (int): unused
 
         Returns:
             ipaddress.ip_address: IP address allocated

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -79,13 +79,13 @@ class IPAllocatorStaticWrapper(IPAllocator):
         """
         return self._ip_allocator.list_allocated_ips(ipblock)
 
-    def alloc_ip_address(self, sid: str, vlan: int) -> IPDesc:
+    def alloc_ip_address(self, sid: str, vlan_id: int) -> IPDesc:
         """ Check if subscriber has static IP assigned.
         If it is not allocated use IP allocator to assign an IP.
         """
         ip_desc = self._allocate_static_ip(sid)
         if ip_desc is None:
-            ip_desc = self._ip_allocator.alloc_ip_address(sid, vlan)
+            ip_desc = self._ip_allocator.alloc_ip_address(sid, vlan_id)
         return ip_desc
 
     def release_ip(self, ip_desc: IPDesc):

--- a/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
@@ -137,7 +137,7 @@ class IPv6AllocatorPool(IPAllocator):
         if not session_prefix_part:
             logging.error('Could not get IPv6 session prefix for sid: %s', sid)
             raise MaxCalculationError(
-                'Could not get IPv6 session prefix for sid: %s', sid,
+                'Could not get IPv6 session prefix for sid: %s' % sid,
             )
 
         # Get interface identifier from 64 bits fixed length
@@ -145,7 +145,7 @@ class IPv6AllocatorPool(IPAllocator):
         if not iid_part:
             logging.error('Could not get IPv6 IID for sid: %s', sid)
             raise MaxCalculationError(
-                'Could not get IPv6 IID for sid: %s', sid,
+                'Could not get IPv6 IID for sid: %s' % sid,
             )
 
         ipv6_addr = ipv6_addr_part + (session_prefix_part * iid_part)
@@ -171,7 +171,7 @@ class IPv6AllocatorPool(IPAllocator):
 
         session_prefix = self._store.sid_session_prefix_allocated.get(sid)
         if not session_prefix:
-            raise IPNotInUseError('IP %s not allocated', ip_addr)
+            raise IPNotInUseError('IP %s not allocated' % ip_addr)
 
         if ip_addr in self._assigned_ip_block and session_prefix:
             # Extract IID part of the given IPv6 prefix and session prefix
@@ -183,7 +183,7 @@ class IPv6AllocatorPool(IPAllocator):
                 del self._store.sid_session_prefix_allocated[sid]
                 del self._store.allocated_iid[sid]
             else:
-                raise IPNotInUseError('IP %s not allocated', ip_addr)
+                raise IPNotInUseError('IP %s not allocated' % ip_addr)
 
     def _get_ipv6_iid_part(self, sid: str, length: int = 64) -> Optional[int]:
         """
@@ -196,7 +196,7 @@ class IPv6AllocatorPool(IPAllocator):
 
         Returns: IID N bits
         """
-        for i in range(MAX_CALC_TRIES):
+        for _ in range(MAX_CALC_TRIES):
             rand_iid_bits = random.getrandbits(length)
             if rand_iid_bits not in self._store.allocated_iid.values():
                 self._store.allocated_iid[sid] = float(rand_iid_bits)
@@ -220,7 +220,7 @@ class IPv6AllocatorPool(IPAllocator):
         # TODO: Support multiple alloc modes
         # TODO: Improve performance of iP allocation for smaller ipv6-blocks
         if self._ipv6_session_prefix_alloc_mode == IPv6SessionAllocType.RANDOM:
-            for i in range(MAX_CALC_TRIES):
+            for _ in range(MAX_CALC_TRIES):
                 session_prefix_part = random.getrandbits(session_prefix_len)
                 if session_prefix_part != session_prefix_allocated:
                     self._store.sid_session_prefix_allocated[

--- a/lte/gateway/python/magma/mobilityd/mobility_store.py
+++ b/lte/gateway/python/magma/mobilityd/mobility_store.py
@@ -114,7 +114,7 @@ class defaultdict_key(defaultdict):
         # Follow defaultdict pattern in raising KeyError
         if self.default_factory is None:
             raise KeyError(key)
-        self[key] = self.default_factory(key)
+        self[key] = self.default_factory(key)  # pylint: disable=E1102
         return self[key]
 
 

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -89,16 +89,17 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._ip_address_man.add_ip_block(ip_block)
 
     @return_void
-    def AddIPBlock(self, ipblock_msg, context):
+    def AddIPBlock(self, request, context):
         """ Add a range of IP addresses into the free IP pool
 
         Args:
-            ipblock_msg (IPBlock): ip block to add. ipblock_msg has the
+            request (IPBlock): ip block to add. The request has the
             type IPBlock, a protobuf message type for the gRPC interface.
             Internal representation of ip blocks uses the ipaddress.ip_network
             type and is named as ipblock.
         """
         logging.debug("Received AddIPBlock")
+        ipblock_msg = request
         self._print_grpc(ipblock_msg)
         ipblock = self._ipblock_msg_to_ipblock(ipblock_msg, context)
         if ipblock is None:
@@ -112,10 +113,10 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         except IPVersionNotSupportedError:
             self._unimplemented_ip_version_error(context)
 
-    def ListAddedIPv4Blocks(self, void, context):
+    def ListAddedIPv4Blocks(self, request, context):
         """ Return a list of IPv4 blocks assigned """
         logging.debug("Received ListAddedIPv4Blocks")
-        self._print_grpc(void)
+        self._print_grpc(request)
         resp = ListAddedIPBlocksResponse()
 
         ip_blocks = self._ip_address_man.list_added_ip_blocks()
@@ -132,16 +133,17 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
-    def ListAllocatedIPs(self, ipblock_msg, context):
+    def ListAllocatedIPs(self, request, context):
         """ Return a list of IPs allocated from a IP block
 
         Args:
-            ipblock_msg (IPBlock): ip block to add. ipblock_msg has the
+            request (IPBlock): ip block to add. The request has the
             type IPBlock, a protobuf message type for the gRPC interface.
             Internal representation of ip blocks uses the ipaddress.ip_network
             type and is named as ipblock.
         """
         logging.debug("Received ListAllocatedIPs")
+        ipblock_msg = request
         self._print_grpc(ipblock_msg)
         resp = ListAllocatedIPsResponse()
 
@@ -234,8 +236,9 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
                 request.ip.version,
             )
             logging.info(
-                "Released IP %s for sid %s"
-                % (ip, SIDUtils.to_str(request.sid)),
+                "Released IP %s for sid %s",
+                ip,
+                SIDUtils.to_str(request.sid),
             )
         except IPNotInUseError:
             context.set_details('IP %s not in use' % ip)
@@ -311,8 +314,9 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
-    def GetSubscriberIDFromIP(self, ip_addr, context):
+    def GetSubscriberIDFromIP(self, request, context):
         logging.debug("Received GetSubscriberIDFromIP")
+        ip_addr = request
         self._print_grpc(ip_addr)
 
         sent_ip = ipaddress.ip_address(ip_addr.address)
@@ -324,15 +328,15 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
             resp = SubscriberID()
         else:
             # handle composite key case
-            sid, *rest = sid.partition('.')
+            sid, *_ = sid.partition('.')
             resp = SIDUtils.to_pb(sid)
         self._print_grpc(resp)
         return resp
 
-    def GetSubscriberIPTable(self, void, context):
+    def GetSubscriberIPTable(self, request, context):
         """ Get the full subscriber table """
         logging.debug("Received GetSubscriberIPTable")
-        self._print_grpc(void)
+        self._print_grpc(request)
 
         resp = SubscriberIPTable()
 
@@ -348,9 +352,9 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
-    def ListGatewayInfo(self, void, context):
+    def ListGatewayInfo(self, request, context):
         logging.debug("Received ListGatewayInfo")
-        self._print_grpc(void)
+        self._print_grpc(request)
 
         resp = ListGWInfoResponse()
         gw_info_list = self._ip_address_man.list_gateway_info()
@@ -360,8 +364,9 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         return resp
 
     @return_void
-    def SetGatewayInfo(self, info, context):
+    def SetGatewayInfo(self, request, context):
         logging.debug("Received SetGatewayInfo")
+        info = request
         self._print_grpc(info)
         self._ip_address_man.set_gateway_info(info)
 
@@ -375,8 +380,10 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
                 version,
             )
             logging.info(
-                "Allocated IP %s for sid %s for apn %s"
-                % (ip, SIDUtils.to_str(request.sid), request.apn),
+                "Allocated IP %s for sid %s for apn %s",
+                ip,
+                SIDUtils.to_str(request.sid),
+                request.apn,
             )
             ip_addr = IPAddress(address=ip.packed, version=version)
             return AllocateIPAddressResponse(

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -56,7 +56,7 @@ class UplinkGatewayInfo:
         """
         self._backing_map = gw_info_map
         self._read_default_gw_timer = None
-        self._read_default_gw_v6_timer = None
+        self._read_default_gw_timer6 = None
         self._read_default_gw_interval_seconds = 20
 
     def get_gw_ip(self, vlan_id: Optional[str] = "", version: int = IPAddress.IPV4) -> Optional[str]:
@@ -150,7 +150,7 @@ class UplinkGatewayInfo:
 
         updated_info = GWInfo(ip=gw_ip, mac="", vlan=_get_vlan(vlan_id))
         self._backing_map[vlan_key] = updated_info
-        logging.info("GW update: GW IP[%s]: %s" % (vlan_key, ip))
+        logging.info("GW update: GW IP[%s]: %s", vlan_key, ip)
 
     def get_gw_mac(self, vlan_id: Optional[str] = None, version: int = IPAddress.IPV4) -> Optional[str]:
         """
@@ -195,7 +195,7 @@ class UplinkGatewayInfo:
         )
         updated_info = GWInfo(ip=gw_ip, mac=mac, vlan=_get_vlan(vlan_id))
         self._backing_map[vlan_key] = updated_info
-        logging.info("GW update: GW IP[%s]: %s : mac %s" % (vlan_key, ip, mac))
+        logging.info("GW update: GW IP[%s]: %s : mac %s", vlan_key, ip, mac)
 
     def get_all_router_ips(self) -> List[GWInfo]:
         return list(self._backing_map.values())

--- a/lte/gateway/python/magma/tests/pylint_tests.py
+++ b/lte/gateway/python/magma/tests/pylint_tests.py
@@ -42,20 +42,15 @@ class MagmaPyLintTest(unittest.TestCase):
             ],
             show_categories=["warning", "error", "fatal"],
         )
-        # TODO look up directories in magma/lte/gateway/python/magma
-        directories = [
-            'enodebd',
-            'health',
-            # 'mobilityd',
-            'monitord',
-            'pipelined',
-            'pkt_tester',
-            'policydb',
-            'redirectd',
-            'smsd',
-            'subscriberdb',
+        excluded_directories = [
+            'kernsnoopd',
+            'tests',
         ]
         parent_path = os.path.dirname(os.path.dirname(__file__))
+        directories = [
+            d.name for d in os.scandir(parent_path)
+            if d.is_dir() and d.name not in excluded_directories
+        ]
         for directory in directories:
             path = os.path.join(parent_path, directory)
             py_wrap.assertNoLintErrors(path)


### PR DESCRIPTION
## Summary

Address pylint issues in mobilityd and enable automatic pylint runs. Most of the issues were related to string formatting in log messages and exceptions, or to differences in parameters between abstract base class methods and their implementations.

Fixes #6099.

## Test Plan

Executed unit tests in magma vm (`make test_python`).