### PR TITLE
fix: Fix VSCode build all configuration

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,7 +21,6 @@
             "command": "bazel",
             "args": [
                 "build",
-                "--config=${env:VSCODE_BAZEL_BUILD_CONFIG}",
                 "-c",
                 "dbg",
                 "..."


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
`--config=X` value for build all is now pulled from /etc/bazelrc, so this does not have to be specified this way
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested with codespaces

<img width="1032" alt="Screen Shot 2021-10-19 at 10 19 43 AM" src="https://user-images.githubusercontent.com/37634144/137929415-b00a80e9-f873-41d4-bd20-8949956f5fd1.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
