### PR TITLE
chore(mobilityd): Get rid of persist_to_redis option. (#9700)

### DIFF
--- a/docs/readmes/lte/s1ap_tests.md
+++ b/docs/readmes/lte/s1ap_tests.md
@@ -139,8 +139,6 @@ service file `/etc/systemd/system/magma@mme.service` (you will need sudo privile
 
  `sudo systemctl daemon-reload`
 
-1. In `/etc/magma/mobilityd.yml`, set `persist_to_redis` to `true`
-
 1. Clean up all the state in redis: `redis-cli -p 6380 FLUSHALL`. This might
 throw a "Could not connect" error if magma@redis service is not running. Start
 the redis service with `sudo service magma@redis start` and then try again.

--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 # log_level is set in mconfig. it can be overridden here
-persist_to_redis: true
 redis_port: 6380
 print_grpc_payload: false
 

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -32,7 +32,6 @@ from magma.mobilityd.rpc_servicer import MobilityServiceRpcServicer
 
 DEFAULT_IPV6_PREFIX_ALLOC_MODE = 'RANDOM'
 RETRY_LIMIT = 300
-DEFAULT_REDIS_PORT = 6380
 
 
 def _get_ipv4_allocator(
@@ -134,8 +133,7 @@ def main():
     # persist to Redis
     client = get_default_client()
     store = MobilityStore(
-        client, config.get('persist_to_redis', False),
-        config.get('redis_port', DEFAULT_REDIS_PORT),
+        client,
     )
 
     chan = ServiceRegistry.get_rpc_channel(

--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -19,6 +19,7 @@ import threading
 import unittest.mock
 from ipaddress import ip_network
 
+import fakeredis
 from magma.common.redis.client import get_default_client
 from magma.mobilityd.ip_address_man import (
     IPAddressManager,
@@ -64,7 +65,7 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         ]
         subprocess.check_call(setup_uplink_br)
 
-        store = MobilityStore(get_default_client(), False, 3980)
+        store = MobilityStore(fakeredis.FakeStrictRedis())
         ipv4_allocator = IPAllocatorDHCP(
             store, iface='t0uplink_p0',
             retry_limit=50,

--- a/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
@@ -22,6 +22,7 @@ import ipaddress
 import time
 import unittest
 
+import fakeredis
 from magma.common.redis.client import get_default_client
 from magma.mobilityd.ip_address_man import (
     IPAddressManager,
@@ -51,7 +52,7 @@ class IPAllocatorTests(unittest.TestCase):
         """
         Creates and sets up an IPAllocator with the given recycling interval.
         """
-        store = MobilityStore(get_default_client(), False, 3980)
+        store = MobilityStore(fakeredis.FakeStrictRedis())
         store.dhcp_gw_info.read_default_gw()
         ip_allocator = IpAllocatorPool(store)
         ipv6_allocator = IPv6AllocatorPool(

--- a/lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py
@@ -17,6 +17,7 @@ import subprocess
 import unittest.mock
 from concurrent import futures
 
+import fakeredis
 import grpc
 from lte.protos.mobilityd_pb2 import (
     AllocateIPRequest,
@@ -53,7 +54,7 @@ class RpcTests(unittest.TestCase):
         self._rpc_server = grpc.server(thread_pool)
         port = self._rpc_server.add_insecure_port('0.0.0.0:0')
 
-        store = MobilityStore(get_default_client(), False, 3980)
+        store = MobilityStore(fakeredis.FakeStrictRedis())
         store.dhcp_gw_info.read_default_gw()
         ip_allocator = IpAllocatorPool(store)
         ipv6_allocator = IPv6AllocatorPool(

--- a/lte/gateway/python/magma/mobilityd/tests/test_ipv6_allocator.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ipv6_allocator.py
@@ -37,7 +37,7 @@ class TestIPV6Allocator(unittest.TestCase):
         """
         Creates and sets up an IPAllocator with the given IPv6 block.
         """
-        store = MobilityStore(fakeredis.FakeStrictRedis(), False, 3980)
+        store = MobilityStore(fakeredis.FakeStrictRedis())
         allocator = IPv6AllocatorPool(store, 'RANDOM')
         allocator.add_ip_block(block)
         return allocator

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -16,6 +16,7 @@ import logging
 import unittest
 from typing import Optional
 
+import fakeredis
 from lte.protos.apn_pb2 import APNConfiguration
 from lte.protos.subscriberdb_pb2 import (
     LTESubscription,
@@ -23,7 +24,6 @@ from lte.protos.subscriberdb_pb2 import (
     SubscriberData,
     SubscriberState,
 )
-from magma.common.redis.client import get_default_client
 from magma.mobilityd.ip_address_man import IPAddressManager
 from magma.mobilityd.ip_allocator_multi_apn import IPAllocatorMultiAPNWrapper
 from magma.mobilityd.ip_allocator_pool import IpAllocatorPool
@@ -110,7 +110,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         """
         Creates and sets up an IPAllocator with the given recycling interval.
         """
-        store = MobilityStore(get_default_client(), False, 3980)
+        store = MobilityStore(fakeredis.FakeStrictRedis())
         ip_allocator = IpAllocatorPool(store)
         ip_allocator_static = IPAllocatorStaticWrapper(
             store, MockedSubscriberDBStub(), ip_allocator,

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -42,7 +42,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         Creates and sets up an IPAllocator with the given recycling interval.
         """
 
-        store = MobilityStore(fakeredis.FakeStrictRedis(), False, 3980)
+        store = MobilityStore(fakeredis.FakeStrictRedis())
         ip_allocator = IpAllocatorPool(store)
         ipv4_allocator = IPAllocatorStaticWrapper(
             store,

--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -36,7 +36,6 @@ return_codes = Enum(
 )
 STATELESS_SERVICE_CONFIGS = [
     ("mme", "use_stateless", True),
-    ("mobilityd", "persist_to_redis", True),
     ("pipelined", "clean_restart", False),
     ("pipelined", "redis_enabled", True),
     ("sessiond", "support_stateless", True),

--- a/orc8r/gateway/python/magma/common/stateless_agw.py
+++ b/orc8r/gateway/python/magma/common/stateless_agw.py
@@ -23,7 +23,6 @@ from orc8r.protos import magmad_pb2
 
 STATELESS_SERVICE_CONFIGS = [
     ("mme", "use_stateless", True),
-    ("mobilityd", "persist_to_redis", True),
     ("pipelined", "clean_restart", False),
     ("pipelined", "redis_enabled", True),
     ("sessiond", "support_stateless", True),


### PR DESCRIPTION
## Summary

* Remove support for stateful mode and the persist_to_redis flag
* Remove DEFAULT_REDIS_PORT in main.py because the get_default_client method already provides the right port
* Replace implicit get_default_client by passing explicit client
* Fix all depending unit tests

fixes: #9700

## Test Plan

* Run python unit tests

