### PR TITLE
chore: add bazel repository dependency for liblfds

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -123,3 +123,13 @@ def cpp_repositories():
         strip_prefix = "libtins-4.2",
         sha256 = "a9fed73e13f06b06a4857d342bb30815fa8c359d00bd69547e567eecbbb4c3a1",
     )
+
+    new_git_repository(
+        name = "liblfds",
+        build_file = "//bazel/external:liblfds.BUILD",
+        commit = "b813a0e546ed54e54b3873bdf180cf885c39bbca",
+        remote = "https://github.com/liblfds/liblfds.git",
+        shallow_since = "1464682027 +0300",
+        patches = ["//third_party/build/patches/liblfds:0001-arm64-support.patch"],
+        patch_args = ["--strip=1"],
+    )

--- a/bazel/external/liblfds.BUILD
+++ b/bazel/external/liblfds.BUILD
@@ -1,0 +1,20 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "lfds710",
+    srcs = glob(["liblfds/liblfds7.1.0/liblfds710/src/**"]),
+    hdrs = glob(["liblfds/liblfds7.1.0/liblfds710/inc/**"]),
+    includes = ["iblfds/liblfds7.1.0/liblfds710/inc"],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/build/patches/liblfds/BUILD.bazel
+++ b/third_party/build/patches/liblfds/BUILD.bazel
@@ -1,0 +1,10 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Build liblfds710 with Bazel. I used https://github.com/magma/magma/blob/master/third_party/build/bin/liblfds_build.sh as a guidance on what patches to apply.

```
bazel build @liblfds//:lfds710
...
Target @liblfds//:lfds710 up-to-date:
  bazel-bin/external/liblfds/liblfds710.a
  bazel-bin/external/liblfds/liblfds710.so
INFO: Elapsed time: 8.347s, Critical Path: 0.42s
INFO: 60 processes: 3 internal, 57 processwrapper-sandbox.
INFO: Build completed successfully, 60 total actions
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Since MME has not been bazelified yet, i ran the MME unit tests with the bazel built liblfds710.so to make sure the library is proabably good to go.

```bash
cd ~/magma
# build liblfds with bazel
bazel build @liblfds//:lfds710
# remove prebaked liblfds in the magma VM
sudo rm /usr/local/lib/liblfds710*
# place the .so file built with Bazel in /usr/local/lib
sudo cp ~/magma/bazel-bin/external/liblfds/liblfds710.so /usr/local/lib/liblfds710.so
make -C lte/gateway build_oai
make -C lte/gateway test_oai
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
