### PR TITLE
feat(agw): harden access to agw local IP

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -49,6 +49,9 @@ default_rule_tag: 0x1
 
 # Pipeline application level configs
 access_control:
+  # Blocks access to all AGW local IPs from UEs.
+  block_agw_local_ips: true
+
   # Traffic to ip blocks in the specified direction in the blocklist will be
   # dropped. Each entry in the blocklist should consist of an ip and a
   # direction('inbound' or 'outbound'). If direction is not specified, then

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -46,6 +46,9 @@ default_rule_tag: 0x1
 
 # Pipeline application level configs
 access_control:
+  # Blocks access to all AGW local IPs from UEs.
+  block_agw_local_ips: true
+
   # Traffic to ip blocks in the specified direction in the blocklist will be
   # dropped. Each entry in the blocklist should consist of an ip and a
   # direction('inbound' or 'outbound'). If direction is not specified, then

--- a/lte/gateway/python/magma/pipelined/app/access_control.py
+++ b/lte/gateway/python/magma/pipelined/app/access_control.py
@@ -14,11 +14,13 @@ limitations under the License.
 import ipaddress
 from collections import namedtuple
 
+import netifaces
 from magma.pipelined.app.base import ControllerType, MagmaController
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.magma_match import MagmaMatch
 from magma.pipelined.openflow.registers import Direction
 from ryu.lib.packet import ether_types
+from ryu.lib.packet.in_proto import IPPROTO_ICMP
 
 
 class AccessControlController(MagmaController):
@@ -38,7 +40,10 @@ class AccessControlController(MagmaController):
 
     AccessControlConfig = namedtuple(
         'AccessControlConfig',
-        ['setup_type', 'ip_blocklist', 'allowed_gre_peers'],
+        [
+            'setup_type', 'ip_blocklist', 'allowed_gre_peers',
+            'block_agw_local_ips', 'mtr_interface',
+        ],
     )
 
     def __init__(self, *args, **kwargs):
@@ -52,10 +57,14 @@ class AccessControlController(MagmaController):
             self._service_manager.allocate_scratch_tables(self.APP_NAME, 1)[0]
 
     def _get_config(self, config_dict, mconfig):
+        block_agw_local_ips = config_dict['access_control'].get('block_agw_local_ips', True)
+        mtr_interface = config_dict.get('mtr_interface', None)
         return self.AccessControlConfig(
             setup_type=config_dict['setup_type'],
             ip_blocklist=config_dict['access_control']['ip_blocklist'],
             allowed_gre_peers=mconfig.allowed_gre_peers,
+            block_agw_local_ips=block_agw_local_ips,
+            mtr_interface=mtr_interface,
         )
 
     def initialize_on_connect(self, datapath):
@@ -68,6 +77,7 @@ class AccessControlController(MagmaController):
         self.delete_all_flows(datapath)
         self._install_default_flows(datapath)
         self._install_ip_blocklist_flow(datapath)
+        self._install_local_ip_blocking_flows(datapath)
         if self.config.setup_type == 'CWF':
             self._install_gre_allow_flows(datapath)
 
@@ -144,6 +154,30 @@ class AccessControlController(MagmaController):
             resubmit_table=self.next_table,
         )
 
+    def _install_local_ip_blocking_flows(self, datapath):
+        if self.config.setup_type != 'LTE':
+            return
+        if not self.config.block_agw_local_ips:
+            return
+        interfaces = netifaces.interfaces()
+        direction = self.CONFIG_INBOUND_DIRECTION
+        # block access to entire 127.* ip network
+        local_ipnet = ipaddress.ip_network('127.0.0.0/8')
+        self._install_ip_blocking_flow(datapath, local_ipnet, direction)
+
+        for iface in interfaces:
+            if_addrs = netifaces.ifaddresses(iface).get(netifaces.AF_INET, [])
+            for addr in if_addrs:
+                if ipaddress.ip_address(addr['addr']) in local_ipnet:
+                    continue
+                self.logger.info("Add blocking rule for: %s, iface %s", addr['addr'], iface)
+
+                ip_network = ipaddress.IPv4Network(addr['addr'])
+                self._install_ip_blocking_flow(datapath, ip_network, direction)
+                # Add flow to allow ICMP for monitoring flows.
+                if iface == self.config.mtr_interface:
+                    self._install_local_icmp_flows(datapath, ip_network)
+
     def _install_ip_blocklist_flow(self, datapath):
         """
         Install flows to drop any packets with ip address blocks matching the
@@ -152,41 +186,64 @@ class AccessControlController(MagmaController):
         for entry in self.config.ip_blocklist:
             ip_network = ipaddress.IPv4Network(entry['ip'])
             direction = entry.get('direction', None)
-            if direction is not None and \
-                    direction not in [
-                        self.CONFIG_INBOUND_DIRECTION,
-                        self.CONFIG_OUTBOUND_DIRECTION,
-                    ]:
-                self.logger.error(
-                    'Invalid direction found in ip blocklist: %s', direction,
-                )
-                continue
-            # If no direction is specified, both outbound and inbound traffic
-            # will be dropped.
-            if direction is None or direction == self.CONFIG_INBOUND_DIRECTION:
-                match = MagmaMatch(
-                    direction=Direction.OUT,
-                    eth_type=ether_types.ETH_TYPE_IP,
-                    ipv4_dst=(
-                        ip_network.network_address,
-                        ip_network.netmask,
-                    ),
-                )
-                flows.add_drop_flow(
-                    datapath, self.tbl_num, match, [],
-                    priority=flows.DEFAULT_PRIORITY,
-                )
-            if direction is None or \
-                    direction == self.CONFIG_OUTBOUND_DIRECTION:
-                match = MagmaMatch(
-                    direction=Direction.IN,
-                    eth_type=ether_types.ETH_TYPE_IP,
-                    ipv4_src=(
-                        ip_network.network_address,
-                        ip_network.netmask,
-                    ),
-                )
-                flows.add_drop_flow(
-                    datapath, self.tbl_num, match, [],
-                    priority=flows.DEFAULT_PRIORITY,
-                )
+            self._install_ip_blocking_flow(datapath, ip_network, direction)
+
+    def _install_local_icmp_flows(self, datapath, ip_network):
+        match = MagmaMatch(
+            direction=Direction.OUT,
+            eth_type=ether_types.ETH_TYPE_IP,
+            ipv4_dst=(
+                ip_network.network_address,
+                ip_network.netmask,
+            ),
+            ip_proto=IPPROTO_ICMP,
+        )
+        flows.add_resubmit_next_service_flow(
+            datapath, self.tbl_num,
+            match, [],
+            priority=flows.MEDIUM_PRIORITY,
+            resubmit_table=self.next_table,
+        )
+
+    def _install_ip_blocking_flow(self, datapath, ip_network, direction):
+        """
+        Install flows to drop any packets with ip address blocks matching the
+        blocklist.
+        """
+        if direction and direction not in [
+            self.CONFIG_INBOUND_DIRECTION,
+            self.CONFIG_OUTBOUND_DIRECTION,
+        ]:
+            self.logger.error(
+                'Invalid direction found in ip blocklist: %s', direction,
+            )
+            return
+        # If no direction is specified, both outbound and inbound traffic
+        # will be dropped.
+        if direction is None or direction == self.CONFIG_INBOUND_DIRECTION:
+            match = MagmaMatch(
+                direction=Direction.OUT,
+                eth_type=ether_types.ETH_TYPE_IP,
+                ipv4_dst=(
+                    ip_network.network_address,
+                    ip_network.netmask,
+                ),
+            )
+            flows.add_drop_flow(
+                datapath, self.tbl_num, match, [],
+                priority=flows.DEFAULT_PRIORITY,
+            )
+        if direction is None or \
+                direction == self.CONFIG_OUTBOUND_DIRECTION:
+            match = MagmaMatch(
+                direction=Direction.IN,
+                eth_type=ether_types.ETH_TYPE_IP,
+                ipv4_src=(
+                    ip_network.network_address,
+                    ip_network.netmask,
+                ),
+            )
+            flows.add_drop_flow(
+                datapath, self.tbl_num, match, [],
+                priority=flows.DEFAULT_PRIORITY,
+            )

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_access_control.AccessControlTestLocalIpBlockLTE.test_blocking_ip_match.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_access_control.AccessControlTestLocalIpBlockLTE.test_blocking_ip_match.snapshot
@@ -1,0 +1,12 @@
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=100,icmp,reg1=0x1,nw_dst=10.1.0.1 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=access_control(main_table), n_packets=2, n_bytes=68, priority=10,ip,reg1=0x1,nw_dst=127.0.0.0/8 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=10.0.2.15 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=192.168.60.142 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=192.168.129.1 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=192.168.128.1 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=10.1.0.1 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=172.17.0.1 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=192.168.1.1 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=0,reg1=0x1 actions=resubmit(,access_control(scratch_table_0)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=access_control(scratch_table_0), n_packets=1, n_bytes=34, priority=0 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3


### PR DESCRIPTION
In default config, UE can access AGW Ip address, following PR adds automated
methode to block the access to AGW IPs.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`
validation of ovs flows.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
