### PR TITLE
ci(nms): Publish Testim reports to Slack

### DIFF
--- a/.github/workflows/testim-workflow.yml
+++ b/.github/workflows/testim-workflow.yml
@@ -10,12 +10,37 @@ jobs:
   testim_check_job:
     runs-on: ubuntu-latest
     name: Testim Check
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
     steps:
+      - uses: actions/checkout@v2
       - name: Setup Node v12
         uses: actions/setup-node@v2
         with:
           node-version: '12'
       - name: Install Testim CLI
         run: npm install -g @testim/testim-cli
+      - name: Setup pyenv
+        uses: "gabrielfalcao/pyenv-action@v8"
+        with:
+          default: 3.8.5
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.5'
+      - name: Install Python Dependencies
+        run: |
+          python3 -m pip install junit2html requests xmltodict
       - name: Run Daily NMS Tests
-        run: testim --token ${{ secrets.TESTIM_TOKEN }} --project ${{ secrets.TESTIM_PROJECT_ID }} --test-plan "Daily Test Plan"
+        run: testim --token ${{ secrets.TESTIM_TOKEN }} --project ${{ secrets.TESTIM_PROJECT_ID }} --test-plan "Daily Test Plan" --report-file ./tests.xml
+      - name: Post Test Report
+        if: always()
+        run: |
+          ${{ env.MAGMA_ROOT }}/ci-scripts/post_testim_report.py tests.xml "${{ secrets.TESTIM_SLACK_TOKEN }}" C02EU9X4DNV
+      - name: Generate HTML Report
+        if: always()
+        run: |
+          python3 -m junit2htmlreport tests.xml tests.html
+      - name: Post HTML Report File
+        if: always()
+        run: |
+          curl -F file=@tests.html -F "initial_comment=Full Test Results" -F channels=C02EU9X4DNV -H "Authorization: ${{ secrets.TESTIM_SLACK_TOKEN }}" https://slack.com/api/files.upload

--- a/ci-scripts/post_testim_report.py
+++ b/ci-scripts/post_testim_report.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import json
+from collections import namedtuple
+
+import requests
+import xmltodict
+
+# API endpoint for posting a message to Slack
+MESSAGE_URL = url = "https://slack.com/api/chat.postMessage"
+
+TestFailure = namedtuple(
+    'TestFailure',
+    [
+        'test_name',
+        'failure_msg',
+    ],
+)
+
+
+def get_test_data(results_filename):
+    """
+    Returns dict of test results
+
+    Args:
+        results_filename: JUnit XML to be processed
+    Returns:
+        Dict JSON representation of passed in XML
+    """
+    file = open(results_filename)
+    data = file.read()
+    return xmltodict.parse(data)
+
+
+def get_test_count(test_data):
+    """
+    Args:
+        test_data: json of test data
+    Returns:
+        int: total test count
+    """
+    return test_data.get("testsuites").get("testsuite").get("@tests")
+
+
+def get_test_failures(test_data):
+    """
+    Args:
+        test_data: json of test data
+    Returns:
+        List[TestFailure]
+    """
+    test_cases = test_data.get("testsuites").get("testsuite").get("testcase")
+    failures = []
+    for result in test_cases:
+        if "failure" in result:
+            name = result.get("@name")
+            failure_msg = result.get("failure").get("@message")
+            failures.append(
+                TestFailure(test_name=name, failure_msg=failure_msg),
+            )
+    return failures
+
+
+def blockify(failure):
+    """
+    Args:
+        failure: TestFailure
+    Returns:
+        Dict - Block Kit representation for Slack posting
+    """
+    return {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f'*{failure.test_name}*\n```{failure.failure_msg}```',
+        },
+    }
+
+
+def header_blocks(test_count, failures):
+    """
+    Creates blocks for either success or failure
+
+    Args:
+        test_count: int - Total test count
+        failures: List[TestFailure]
+    Returns:
+        List[Dict] - Block Kit representation for Slack posting
+    """
+    blocks = []
+    if len(failures) > 0:
+        blocks.append({
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": f'Daily Tests - FAILED {len(failures)} TESTS',
+            },
+        })
+    else:
+        blocks.append({
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": 'Daily Tests - PASSED',
+            },
+        })
+    blocks.append({
+        "type": "context",
+        "elements": [
+            {
+                "type": "mrkdwn",
+                "text": f'Passed *{len(failures)}/{test_count}* tests',
+            },
+        ],
+    })
+    blocks.append({"type": "divider"})
+    return blocks
+
+
+def post_to_slack(test_count, failures, auth_token, channel_id):
+    """
+    Post success/failure message to Slack
+
+    Args:
+        test_count: int - Total test count
+        failures: List[TestFailure]
+        auth_token: str -  Slack authorization token
+        channel_id: str - Slack channel id
+    Returns:
+        None
+    """
+    headers = {
+        'content-type': 'application/json',
+        'Accept-Charset': 'UTF-8',
+        'Authorization': auth_token,
+    }
+    blocks = header_blocks(test_count, failures)\
+        + list(map(blockify, failures))
+    payload = {
+        "channel": channel_id,
+        "blocks": blocks,
+    }
+    r = requests.post(MESSAGE_URL, data=json.dumps(payload), headers=headers)
+    print(r.content)
+
+
+# Configuring how we parse arguments
+parser = argparse.ArgumentParser()
+parser.add_argument("file", help="JUnit XML filepath")
+parser.add_argument("token", help="Slack Auth token")
+parser.add_argument("channel", help="Slack channel id")
+
+# And actually parsing arguments here
+args = parser.parse_args()
+xml_file = args.file
+
+test_data = get_test_data(xml_file)
+test_count = get_test_count(test_data)
+failures = get_test_failures(test_data)
+
+post_to_slack(test_count, failures, args.token, args.channel)


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Publishes reports to Magma's Slack whenever the daily Testim test plan finishes running.

**Test example**:
![Screen Shot 2021-10-20 at 12 13 42 AM](https://user-images.githubusercontent.com/804385/138045427-d58a49ae-edc0-41c3-b969-72fcf7bcc034.png)

First, a header is posted to channel `testim-reports` showing whether the daily tests passed or failed, and shows a count of how many passed. Then, a breakdown of the failed tests is shown. Finally, and not shown in the screenshot, a generated `.html` test report of the results is posted for more detailed viewing if desired.

## Test Plan

Used [`nektos/act`](https://github.com/nektos/act) to test the modified `testim-workflow.yml` locally:
```
➜  magma git:(1-10-testim-ci2) ✗ act -j testim_check_job --secret-file .secrets --insecure-secrets
...
[Testim Check/Testim Check]   ✅  Success - Run Daily NMS Tests
[Testim Check/Testim Check] ⭐  Run Post Test Report
...
[Testim Check/Testim Check]   ✅  Success - Post Test Report
[Testim Check/Testim Check] ⭐  Run Generate HTML Report
[Testim Check/Testim Check]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /Users/andreilee/magma/workflow/8] user=
[Testim Check/Testim Check]   ✅  Success - Generate HTML Report
[Testim Check/Testim Check] ⭐  Run Post HTML Report File
...
```
- Secrets were copied to a local file, `.secrets`, to be able to run with `nektos/act`
- A simplified test plan from the one that will be used in production was chosen for local testing

## Additional Information

- [ ] This change is backwards-breaking
