### PR TITLE
chore: test out sessiond built with bazel in sessiond

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,3 +54,12 @@
 !protos/
 
 !xwf/gateway/
+
+# bazel files
+!*.bzl
+!*.bazel
+!.bazelrc
+!.bazelignore
+!.bazelversion
+!.bazel-cache
+!.bazel-cache-repo

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -134,3 +134,33 @@ new_local_repository(
     build_file = "//third_party:system_libraries.BUILD",
     path = "/",
 )
+
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "92779d3445e7bdc79b961030b996cb0c91820ade7ffa7edca69273f404b085d5",
+    strip_prefix = "rules_docker-0.20.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.20.0/rules_docker-v0.20.0.tar.gz"],
+)
+
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+
+container_repositories()
+
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
+
+container_deps()
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+)
+
+container_pull(
+    name = "ubuntu_bionic",
+    registry = "index.docker.io",
+    repository = "ubuntu",
+    tag = "bionic",
+)

--- a/cwf/gateway/docker/BUILD.bazel
+++ b/cwf/gateway/docker/BUILD.bazel
@@ -1,0 +1,34 @@
+cwf/gateway/docker/BUILD.bazel# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+
+load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
+
+
+# container_image(
+#     name = "cwf_sessiond_builder",
+#     base = "@ubuntu_bionic//image",
+#     cmd = [
+#         "cp ",
+#     ],
+#     files = [
+#         "//lte/gateway/c/session_manager:sessiond",
+#         "//lte/gateway/configs:configs",
+#         "//orc8r/gateway/configs:templates",
+#     ],
+# )
+
+cc_image(
+    name = "session_image",
+    base = "@ubuntu_bionic//image",
+    binary = "//lte/gateway/c/session_manager:sessiond",
+)

--- a/cwf/gateway/docker/c/Dockerfile
+++ b/cwf/gateway/docker/c/Dockerfile
@@ -15,94 +15,78 @@
 # Builder image for C binaries and Magma proto files
 # -----------------------------------------------------------------------------
 
-# debian stretch image
-# ARG OS_DIST=debian
-# ARG OS_RELEASE=stretch
-# ARG EXTRA_REPO=https://facebookconnectivity.jfrog.io/artifactory/list/dev/
-# ARG CLANG_VERSION=3.8
-
 # ubuntu bionic image
 ARG OS_DIST=ubuntu
 ARG OS_RELEASE=bionic
-ARG EXTRA_REPO=https://facebookconnectivity.jfrog.io/artifactory/cwf-prod
-ARG CLANG_VERSION=3.9
 
 # Stretch is required for c build
 FROM $OS_DIST:$OS_RELEASE AS builder
 ARG OS_DIST
 ARG OS_RELEASE
-ARG EXTRA_REPO
-ARG CLANG_VERSION
 
-# Add the magma apt repo
-RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg
-COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
+ENV TZ=America/New_York \
+    DEBIAN_FRONTEND=noninteractive
 
-RUN apt-key add /tmp/jfrog.pub && \
-    apt-add-repository "deb ${EXTRA_REPO} ${OS_RELEASE} main"
+RUN apt-get update && apt-get upgrade -y 
 
+RUN apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        apt-utils \
+        build-essential \
+        ca-certificates \
+        curl \
+        gcc \
+        git \
+        gnupg2 \
+        g++ \
+        wget
 
-# Install dependencies required for building
-RUN apt-get -y update && apt-get -y install \
-  sudo \
-  curl \
-  wget \
-  unzip \
-  cmake \
-  git \
-  build-essential \
-  autoconf \
-  libtool \
-  pkg-config \
-  libgflags-dev \
-  libgtest-dev \
-  clang-${CLANG_VERSION} \
-  libc++-dev \
-  protobuf-compiler \
-  grpc-dev \
-  ninja-build \
-  autogen \
-  ccache \
-  libprotoc-dev \
-  libxml2-dev \
-  libxslt-dev \
-  libyaml-cpp-dev \
-  nlohmann-json-dev \
-  magma-cpp-redis \
-  libgoogle-glog-dev \
-  prometheus-cpp-dev \
-  libfolly-dev \
-  magma-libfluid \
-  libdouble-conversion-dev \
-  libboost-chrono-dev \
-  libboost-context-dev \
-  libboost-program-options-dev \
-  libboost-filesystem-dev \
-  libboost-regex-dev
+# Install bazel
+WORKDIR /usr/sbin
+RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
+    chmod +x bazelisk-linux-amd64 && \
+    ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
+
+# Dependencies for rules_folly @ https://github.com/storypku/rules_folly
+RUN apt-get -y install --no-install-recommends \
+    autoconf \
+    automake \
+    libtool \
+    libssl-dev
+
+# Update shared library configuration
+RUN ldconfig -v
 
 ENV MAGMA_ROOT /magma
-ENV C_BUILD /build/c
-ENV OAI_BUILD $C_BUILD/oai
-
-ENV CCACHE_DIR $MAGMA_ROOT/.cache/gateway/ccache
-ENV MAGMA_DEV_MODE 1
-ENV XDG_CACHE_HOME $MAGMA_ROOT/.cache
 
 # Copy proto files
-COPY feg/protos $MAGMA_ROOT/feg/protos
-COPY feg/gateway/services/aaa/protos $MAGMA_ROOT/feg/gateway/services/aaa/protos
-COPY lte/protos $MAGMA_ROOT/lte/protos
-COPY orc8r/protos $MAGMA_ROOT/orc8r/protos
-COPY protos $MAGMA_ROOT/protos
+COPY feg/protos ${MAGMA_ROOT}/feg/protos
+COPY feg/gateway/services/aaa/protos ${MAGMA_ROOT}/feg/gateway/services/aaa/protos
+COPY lte/protos ${MAGMA_ROOT}/lte/protos
+COPY orc8r/protos ${MAGMA_ROOT}/orc8r/protos
+COPY protos ${MAGMA_ROOT}/protos
 
-# Build session_manager c code
-COPY lte/gateway/Makefile $MAGMA_ROOT/lte/gateway/Makefile
-COPY orc8r/gateway/c/common $MAGMA_ROOT/orc8r/gateway/c/common
-COPY lte/gateway/c $MAGMA_ROOT/lte/gateway/c
-ARG BUILD_TYPE=RelWithDebInfo
-ENV BUILD_TYPE=$BUILD_TYPE
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_session_manager BUILD_TYPE="${BUILD_TYPE}"
+# Copy bazel related files
+COPY WORKSPACE.bazel ${MAGMA_ROOT}/WORKSPACE.bazel
+COPY .bazelignore ${MAGMA_ROOT}/
+COPY .bazelrc ${MAGMA_ROOT}/
+COPY .bazelversion ${MAGMA_ROOT}/
+COPY *.bzl ${MAGMA_ROOT}/
+COPY *.bazel ${MAGMA_ROOT}/
+COPY third_party ${MAGMA_ROOT}/third_party
+
+# Mount bazel cache
+COPY .bazel-cache ${MAGMA_ROOT}/
+COPY .bazel-cache-repo ${MAGMA_ROOT}/
+
+# Copy session_manager source code
+COPY orc8r/gateway/c/common ${MAGMA_ROOT}/orc8r/gateway/c/common
+COPY lte/gateway/c ${MAGMA_ROOT}/lte/gateway/c
+
+# Build session_manager
+WORKDIR ${MAGMA_ROOT}
+# Sentry isn't supported on this base image (breakpad will not compile)
+RUN bazel build //lte/gateway/c/session_manager:sessiond --define=disable_sentry_native=1
 
 # -----------------------------------------------------------------------------
 # Dev/Production image
@@ -110,50 +94,9 @@ RUN make -C $MAGMA_ROOT/lte/gateway/ build_session_manager BUILD_TYPE="${BUILD_T
 FROM $OS_DIST:$OS_RELEASE AS gateway_c
 ARG OS_DIST
 ARG OS_RELEASE
-ARG EXTRA_REPO
-
-# Add the magma apt repo
-RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg
-COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
-
-RUN apt-key add /tmp/jfrog.pub && \
-    apt-add-repository "deb $EXTRA_REPO $OS_RELEASE main"
-
-
-# Install runtime dependencies
-RUN apt-get -y update && apt-get -y install \
-  curl \
-  sudo \
-  # install prometheus
-  prometheus-cpp-dev \
-  # install openvswitch
-  magma-libfluid \
-  # install lxml
-  python3-lxml \
-  bridge-utils \
-  # install yaml parser
-  libyaml-cpp-dev \
-  libgoogle-glog-dev \
-  # folly deps
-  libfolly-dev \
-  libdouble-conversion-dev \
-  libboost-chrono-dev \
-  libboost-context-dev \
-  libboost-program-options-dev \
-  libboost-filesystem-dev \
-  libboost-regex-dev \
-  nlohmann-json-dev \
-  redis-server \
-  python-redis \
-  magma-cpp-redis \
-  grpc-dev \
-  protobuf-compiler \
-  libprotoc-dev \
-  netcat
 
 # Copy the build artifacts.
-COPY --from=builder /build/c/session_manager/sessiond /usr/local/bin/sessiond
+COPY --from=builder /magma/bazel-bin/lte/gateway/c/session_manager/sessiond /usr/local/bin/sessiond
 
 # Copy the configs.
 COPY lte/gateway/configs /etc/magma

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -483,6 +483,7 @@ cc_binary(
     # From bazel doc: this flag makes it so all user libraries are linked statically (if a static version is available),
     #                 but where system libraries (excluding C/C++ runtime libraries) are linked dynamically
     linkstatic = True,
+    visibility = ["//visibility:public"],
     deps = [
         ":operational_states_handler",
         ":policy_loader",

--- a/lte/gateway/configs/BUILD.bazel
+++ b/lte/gateway/configs/BUILD.bazel
@@ -1,0 +1,19 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "configs",
+    srcs = glob([
+        "*.yml",
+    ]),
+)

--- a/orc8r/gateway/c/common/sentry/BUILD.bazel
+++ b/orc8r/gateway/c/common/sentry/BUILD.bazel
@@ -11,17 +11,29 @@
 
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "disable_sentry_native",
+    values = {"define": "disable_sentry_native=1"},
+)
+
+sentry_deps = [
+    "//orc8r/gateway/c/common/config:service_config_loader",
+    "@yaml-cpp//:yaml-cpp",
+]
+
 cc_library(
     name = "sentry_wrapper",
     srcs = ["SentryWrapper.cpp"],
     hdrs = ["includes/SentryWrapper.h"],
     # TODO(@themarwhal): Enable Sentry by default - GH9302
-    copts = ["-DSENTRY_ENABLED"],
+    copts = select({
+        ":disable_sentry_native": [],
+        "//conditions:default": ["-DSENTRY_ENABLED"],
+    }),
     # TODO(@themarwhal): Migrate to using full path for includes - GH8299
     strip_include_prefix = "/orc8r/gateway/c/common/sentry",
-    deps = [
-        "//orc8r/gateway/c/common/config:service_config_loader",
-        "@sentry_native//:sentry",
-        "@yaml-cpp//:yaml-cpp",
-    ],
+    deps = select({
+        ":disable_sentry_native": sentry_deps,
+        "//conditions:default": sentry_deps + ["@sentry_native//:sentry"],
+    }),
 )

--- a/orc8r/gateway/configs/BUILD.bazel
+++ b/orc8r/gateway/configs/BUILD.bazel
@@ -1,0 +1,19 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "templates",
+    srcs = glob([
+        "templates/*.template",
+    ]),
+)


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Experimental PR to build SessionD docker used for CWAG with bazel

Some stats
1. build time (for all of cwag) doubles unfortunately. This is because we are building fairly big libraries from scratch (folly, grpc, proto, etc.) (~20 minutes to ~40 mintues)
  -> we might be able to do better if we pull in cache from inside the dockerfile
2. 56% reduction in docker images size (945MB to 418MB). This is because we build most dependencies into the sessiond binary.


<!-- Enumerate changes you made and why you made them -->

## Test Plan
CWF integ test passes
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
