### PR TITLE
chore(mme): Fix typo in Nas test CMakeLists

### DIFF
--- a/lte/gateway/c/core/oai/test/nas/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/nas/CMakeLists.txt
@@ -36,4 +36,4 @@ target_include_directories(test_nas_converter PUBLIC
     ${CHECK_INCLUDE_DIRS}
     )
 
-add_test(NAMES test_nas_converter COMMAND test_nas_converter)
+add_test(NAME test_nas_converter COMMAND test_nas_converter)


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fixed typo in CMakeLists.txt so that test name is set correctly

## Test Plan

Before this change, `make test_oai` showed:
```
      Start 11: test_s1ap
11/18 Test #11: test_s1ap .........................   Passed   11.64 sec
      Start 12: NAMES
12/18 Test #12: NAMES .............................   Passed    0.06 sec
      Start 13: test_openflow_controller
13/18 Test #13: test_openflow_controller ..........   Passed    0.02 sec
```

After this change, `make test_oai` shows:
```
      Start 11: test_s1ap
11/18 Test #11: test_s1ap .........................   Passed   11.74 sec
      Start 12: test_nas_converter
12/18 Test #12: test_nas_converter ................   Passed    0.06 sec
      Start 13: test_openflow_controller
13/18 Test #13: test_openflow_controller ..........   Passed    0.02 sec
```

