### PR TITLE
fix(mme): remove memory leaks in attach rejects

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
@@ -208,7 +208,7 @@ status_code_e emm_recv_attach_request(
     rc         = emm_proc_attach_reject(ue_id, *emm_cause);
     *emm_cause = EMM_CAUSE_SUCCESS;
     // Free the ESM container
-    bdestroy(msg->esmmessagecontainer);
+    bdestroy_wrapper(&(msg->esmmessagecontainer));
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
   }
 
@@ -228,6 +228,8 @@ status_code_e emm_recv_attach_request(
         ue_id, mme_app_last_msg_latency, pre_mme_task_msg_latency);
     rc         = emm_proc_attach_reject(ue_id, EMM_CAUSE_CONGESTION);
     *emm_cause = EMM_CAUSE_SUCCESS;
+    // Free the ESM container
+    bdestroy_wrapper(&(msg->esmmessagecontainer));
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
   }
 
@@ -317,7 +319,7 @@ status_code_e emm_recv_attach_request(
       free_emm_attach_request_ies(
           (emm_attach_request_ies_t * * const) & params);
       // Free the ESM container
-      bdestroy(msg->esmmessagecontainer);
+      bdestroy_wrapper(&(msg->esmmessagecontainer));
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
     }
 


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Fixes memory leaks in attach rejects and replaces bdestroy with the safer bdestroy_wrapper calls. Earlier attempt #9653 that just added bdestroy was leading to service aborts during state serialization.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
integ tests. spirent tests.
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
