### PR TITLE
chore(orc8r): Refactor pylint test to run for all subdirectories

### DIFF
--- a/orc8r/gateway/python/magma/tests/pylint_tests.py
+++ b/orc8r/gateway/python/magma/tests/pylint_tests.py
@@ -42,17 +42,14 @@ class MagmaPyLintTest(unittest.TestCase):
             ],
             show_categories=["warning", "error", "fatal"],
         )
-        # TODO look up directories in magma/orc8r/gateway/python/magma
-        directories = [
-            'common',
-            'configuration',
-            'ctraced',
-            'directoryd',
-            'eventd',
-            'magmad',
-            'state',
-        ]
+
+        excluded_directories = []
+
         parent_path = os.path.dirname(os.path.dirname(__file__))
+        directories = [
+            d.name for d in os.scandir(parent_path)
+            if d.is_dir() and d.name not in excluded_directories
+        ]
         for directory in directories:
             path = os.path.join(parent_path, directory)
             py_wrap.assertNoLintErrors(path)


### PR DESCRIPTION
## Summary

Analogous to agw pylint test in #9751: Modifies the orc8r pylint test
such that it runs for all subfolders of orc8r/gateway/python/magma
automatically with the option of excluding directories from the loop
through a hardcoded list.

Closes #9811

## Test plan

Ran `make .test` in magma vm from magma/orc8r/gateway/python successfully.
Confirmed that lint tests still run for all directories
(now also including tests directory).