### PR TITLE
fix(mme): Fix memory leak in SGW config parsing

### DIFF
--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c
@@ -411,8 +411,9 @@ status_code_e sgw_config_parse_string(
 }
 
 int sgw_config_parse_file(sgw_config_t* config_pP) {
-  FILE* fp = NULL;
-  fp       = fopen(bdata(config_pP->config_file), "r");
+  FILE* fp     = NULL;
+  int ret_code = RETURNerror;
+  fp           = fopen(bdata(config_pP->config_file), "r");
   if (fp == NULL) {
     OAILOG_CRITICAL(
         LOG_CONFIG, "Failed to open SGW configuration file at path: %s\n",
@@ -432,7 +433,9 @@ int sgw_config_parse_file(sgw_config_t* config_pP) {
         "Failed to read SGW configuration file at path: %s:\n",
         bdata(config_pP->config_file));
   }
-  return sgw_config_parse_string(bdata(buff), config_pP);
+  ret_code = sgw_config_parse_string(bdata(buff), config_pP);
+  bdestroy_wrapper(&buff);
+  return ret_code;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This change fixes memory leak while parsing sgw config in MME

## Test Plan

Before the change, syslog was showing the following leaks whenever MME was restarted

```
Oct 21 02:54:49 magma-dev-focal mme[42548]: Cleaning up SPGW configs
Oct 21 02:54:49 magma-dev-focal mme[42548]: =================================================================
Oct 21 02:54:49 magma-dev-focal mme[42548]: ==42548==ERROR: LeakSanitizer: detected memory leaks
Oct 21 02:54:49 magma-dev-focal mme[42548]: Direct leak of 16 byte(s) in 1 object(s) allocated from:
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #0 0x7f25a38dfbc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #1 0x55b74cc44e50 in bfromcstr /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:188
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #2 0x55b74cc5f465 in bread /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:1464
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #3 0x55b74dfc75e0 in sgw_config_parse_file /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c:427
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #4 0x55b74dfb1ff8 in spgw_config_parse_file /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_config.c:99
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #5 0x55b74cfb9cc9 in mme_config_embedded_spgw_parse_opt_line /home/vagrant/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_embedded_spgw.c:>
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #6 0x55b74cc07d69 in main /home/vagrant/magma/lte/gateway/c/core/oai/oai_mme/oai_mme.c:106
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #7 0x7f25a17df0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
Oct 21 02:54:49 magma-dev-focal mme[42548]: Indirect leak of 8192 byte(s) in 1 object(s) allocated from:
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #0 0x7f25a38dfbc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #1 0x55b74cc4475c in balloc /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:148
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #2 0x55b74cc5f026 in breada /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:1444
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #3 0x55b74cc5f492 in bread /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:1464
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #4 0x55b74dfc75e0 in sgw_config_parse_file /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/sgw_config.c:427
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #5 0x55b74dfb1ff8 in spgw_config_parse_file /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_config.c:99
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #6 0x55b74cfb9cc9 in mme_config_embedded_spgw_parse_opt_line /home/vagrant/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_embedded_spgw.c:>
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #7 0x55b74cc07d69 in main /home/vagrant/magma/lte/gateway/c/core/oai/oai_mme/oai_mme.c:106
Oct 21 02:54:49 magma-dev-focal mme[42548]:     #8 0x7f25a17df0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
```

After the change, no such leak was reported

```
Oct 21 15:47:58 magma-dev-focal mme[304875]: Cleaning up SPGW configs
Oct 21 15:47:58 magma-dev-focal systemd[1]: magma@mme.service: Succeeded.
```

