### PR TITLE
Revert "feat(mobilityd): add support for IPv6 default gw"

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -454,7 +454,7 @@ class IPAddressManager:
     def set_gateway_info(self, info: GWInfo):
         ip = str(ipaddress.ip_address(info.ip.address))
         with self._lock:
-            self._store.dhcp_gw_info.update_mac(ip, info.mac, info.vlan, info.ip.version)
+            self._store.dhcp_gw_info.update_mac(ip, info.mac, info.vlan)
 
     def _recycle_reaped_ips(self):
         """ Periodically called to recycle the given IPs

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -183,8 +183,6 @@ def main():
             allocated_ipv6_block = ip_address_man.get_assigned_ipv6_block()
             if ipv6_block != allocated_ipv6_block:
                 ip_address_man.add_ip_block(ipv6_block)
-            # configure IPv6 default GW
-            store.dhcp_gw_info.read_default_gw_v6()
         except OverlappedIPBlocksError:
             logging.warning("Overlapped IPv6 block: %s", ipv6_block)
 

--- a/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
@@ -17,7 +17,6 @@ import unittest
 from collections import defaultdict
 
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
-from magma.mobilityd import uplink_gw
 from magma.mobilityd.uplink_gw import NO_VLAN, UplinkGatewayInfo
 
 LOG = logging.getLogger('mobilityd.def_gw.test')
@@ -157,111 +156,7 @@ class DefGwTest(unittest.TestCase):
         gw4 = _get_gw_info(ip4, mac4, vlan4)
         self.dhcp_gw_info.update_mac(ip4, mac4, vlan4)
 
-        ip5 = "2020::1"
-        vlan5 = "4"
-        mac5 = "11:22:33:44:55:66"
-        gw5 = _get_gw_info(ip5, mac5, vlan5)
-        self.dhcp_gw_info.update_mac(ip5, mac5, vlan5, IPAddress.IPV6)
-
         gw_list = self.dhcp_gw_info.get_all_router_ips()
 
-        expected = gw_list_to_set([gw1, gw2, gw3, gw4, gw5])
-        self.assertEqual(gw_list_to_set(gw_list), expected)
-
-
-class MockedNetInterface:
-    AF_INET = 2
-    AF_INET6 = 10
-
-    def __init__(self):
-        pass
-
-    def gateways(self):
-        return {
-            'default': {
-                self.AF_INET: ('10.0.2.3', 'eth0'),
-                self.AF_INET6: ('2002::1', 'eth0'),
-            },
-
-            2: [('10.0.2.2', 'eth0', True)],
-        }
-
-
-class DefGwTestIpv6(unittest.TestCase):
-    """
-    Validate v6 router setting.
-    """
-
-    @classmethod
-    def setUpClass(cls, *_):
-        """
-        Starts the thread which launches ryu apps
-
-        Create a testing bridge, add a port, setup the port interfaces. Then
-        launch the ryu apps for testing pipelined. Gets the references
-        to apps launched by using futures.
-        """
-        super(DefGwTestIpv6, cls).setUpClass()
-        uplink_gw.netifaces = MockedNetInterface()
-
-    def setUp(self):
-        self.gw_store = defaultdict(str)
-        self.dhcp_gw_info = UplinkGatewayInfo(self.gw_store)
-
-    def test_gw_ip_for_DHCP(self):
-        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), None)
-        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), None)
-
-    def test_gw_ip_for_Ip_pool(self):
-        self.dhcp_gw_info.read_default_gw()
-        def_ip = '10.0.2.3'
-
-        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))
-        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), '')
-        mac1 = "11:22:33:44:55:66"
-        self.dhcp_gw_info.update_mac(def_ip, mac1)
-        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))
-        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), mac1)
-
-        # updating IP with same address shld keep mac
-        self.dhcp_gw_info.update_ip(def_ip)
-        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))
-        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), mac1)
-
-        ip1 = "1.2.3.4"
-        self.dhcp_gw_info.update_ip(ip1)
-        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), '')
-
-    def test_gw_ip_for_Ip_pool_v6(self):
-        self.dhcp_gw_info.read_default_gw_v6()
-        def_ip_v6 = '2002::1'
-
-        self.assertEqual(self.dhcp_gw_info.get_gw_ip(version=IPAddress.IPV6), str(def_ip_v6))
-        self.assertEqual(self.dhcp_gw_info.get_gw_mac(version=IPAddress.IPV6), '')
-        mac6 = "11:22:33:44:55:66"
-        self.dhcp_gw_info.update_mac(def_ip_v6, mac6, version=IPAddress.IPV6)
-        self.assertEqual(self.dhcp_gw_info.get_gw_ip(version=IPAddress.IPV6), str(def_ip_v6))
-        self.assertEqual(self.dhcp_gw_info.get_gw_mac(version=IPAddress.IPV6), mac6)
-
-        self.dhcp_gw_info.read_default_gw()
-        def_ip = '10.0.2.3'
-
-        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))
-        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), '')
-        mac4 = "11:22:33:44:55:44"
-        self.dhcp_gw_info.update_mac(def_ip, mac4)
-        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))
-        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), mac4)
-
-        ip4 = def_ip
-        mac4 = mac4
-        gw4 = _get_gw_info(ip4, mac4)
-
-        ip6 = def_ip_v6
-        mac6 = mac6
-        gw6 = _get_gw_info(ip6, mac6)
-
-        gw_list = self.dhcp_gw_info.get_all_router_ips()
-
-        expected = gw_list_to_set([gw4, gw6])
-        self.assertEqual(gw_list_to_set(gw_list), expected)
+        expeected = gw_list_to_set([gw1, gw2, gw3, gw4])
+        self.assertEqual(gw_list_to_set(gw_list), expeected)


### PR DESCRIPTION
This reverts commit a86ae7636b7e5efe6091e2d6749d5ce8110dfa47.

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
