### PR TITLE
fix(agw): Add IPv6 address for magma-dev VM.

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -39,6 +39,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # iperf3 trfserver routable IP.
     magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
 
+    # IPv6 interface
+    config.vm.provision :shell, inline: "ip -6 a add  2020::10/64 dev eth0 && ip -6 r add default via 2020::1", run: 'always'
+
     magma.vm.provider "virtualbox" do |vb|
       vb.name = "magma-dev"
       vb.linked_clone = true


### PR DESCRIPTION
Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`vagrant reload magma`
eth0 has IP address after reload.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
