### PR TITLE
chore: remove unused include in intertask_interface.c

### DIFF
--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
@@ -52,7 +52,6 @@
 
 #include "signals.h"
 #include "dynamic_memory_check.h"
-#include "shared_ts_log.h"
 #include "log.h"
 
 /* ITTI DEBUG groups */


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
funny story, I thought there was an awful dependency cycle with intertask_interface.c/h and shared_ts_log.c/h. (See https://github.com/magma/magma/issues/9819) 

turns out it was just an unused include. :D 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make build_oai
make test_oai
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
