### PR TITLE
feat(mobilityd): add support for IPv6 default gw

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -454,7 +454,7 @@ class IPAddressManager:
     def set_gateway_info(self, info: GWInfo):
         ip = str(ipaddress.ip_address(info.ip.address))
         with self._lock:
-            self._store.dhcp_gw_info.update_mac(ip, info.mac, info.vlan)
+            self._store.dhcp_gw_info.update_mac(ip, info.mac, info.vlan, info.ip.version)
 
     def _recycle_reaped_ips(self):
         """ Periodically called to recycle the given IPs

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -183,6 +183,8 @@ def main():
             allocated_ipv6_block = ip_address_man.get_assigned_ipv6_block()
             if ipv6_block != allocated_ipv6_block:
                 ip_address_man.add_ip_block(ipv6_block)
+            # configure IPv6 default GW
+            store.dhcp_gw_info.read_default_gw_v6()
         except OverlappedIPBlocksError:
             logging.warning("Overlapped IPv6 block: %s", ipv6_block)
 

--- a/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
@@ -17,6 +17,7 @@ import unittest
 from collections import defaultdict
 
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
+from magma.mobilityd import uplink_gw
 from magma.mobilityd.uplink_gw import NO_VLAN, UplinkGatewayInfo
 
 LOG = logging.getLogger('mobilityd.def_gw.test')
@@ -156,7 +157,111 @@ class DefGwTest(unittest.TestCase):
         gw4 = _get_gw_info(ip4, mac4, vlan4)
         self.dhcp_gw_info.update_mac(ip4, mac4, vlan4)
 
+        ip5 = "2020::1"
+        vlan5 = "4"
+        mac5 = "11:22:33:44:55:66"
+        gw5 = _get_gw_info(ip5, mac5, vlan5)
+        self.dhcp_gw_info.update_mac(ip5, mac5, vlan5, IPAddress.IPV6)
+
         gw_list = self.dhcp_gw_info.get_all_router_ips()
 
-        expeected = gw_list_to_set([gw1, gw2, gw3, gw4])
-        self.assertEqual(gw_list_to_set(gw_list), expeected)
+        expected = gw_list_to_set([gw1, gw2, gw3, gw4, gw5])
+        self.assertEqual(gw_list_to_set(gw_list), expected)
+
+
+class MockedNetInterface:
+    AF_INET = 2
+    AF_INET6 = 10
+
+    def __init__(self):
+        pass
+
+    def gateways(self):
+        return {
+            'default': {
+                self.AF_INET: ('10.0.2.3', 'eth0'),
+                self.AF_INET6: ('2002::1', 'eth0'),
+            },
+
+            2: [('10.0.2.2', 'eth0', True)],
+        }
+
+
+class DefGwTestIpv6(unittest.TestCase):
+    """
+    Validate v6 router setting.
+    """
+
+    @classmethod
+    def setUpClass(cls, *_):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(DefGwTestIpv6, cls).setUpClass()
+        uplink_gw.netifaces = MockedNetInterface()
+
+    def setUp(self):
+        self.gw_store = defaultdict(str)
+        self.dhcp_gw_info = UplinkGatewayInfo(self.gw_store)
+
+    def test_gw_ip_for_DHCP(self):
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), None)
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), None)
+
+    def test_gw_ip_for_Ip_pool(self):
+        self.dhcp_gw_info.read_default_gw()
+        def_ip = '10.0.2.3'
+
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), '')
+        mac1 = "11:22:33:44:55:66"
+        self.dhcp_gw_info.update_mac(def_ip, mac1)
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), mac1)
+
+        # updating IP with same address shld keep mac
+        self.dhcp_gw_info.update_ip(def_ip)
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), mac1)
+
+        ip1 = "1.2.3.4"
+        self.dhcp_gw_info.update_ip(ip1)
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), '')
+
+    def test_gw_ip_for_Ip_pool_v6(self):
+        self.dhcp_gw_info.read_default_gw_v6()
+        def_ip_v6 = '2002::1'
+
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(version=IPAddress.IPV6), str(def_ip_v6))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(version=IPAddress.IPV6), '')
+        mac6 = "11:22:33:44:55:66"
+        self.dhcp_gw_info.update_mac(def_ip_v6, mac6, version=IPAddress.IPV6)
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(version=IPAddress.IPV6), str(def_ip_v6))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(version=IPAddress.IPV6), mac6)
+
+        self.dhcp_gw_info.read_default_gw()
+        def_ip = '10.0.2.3'
+
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), '')
+        mac4 = "11:22:33:44:55:44"
+        self.dhcp_gw_info.update_mac(def_ip, mac4)
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(), str(def_ip))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(), mac4)
+
+        ip4 = def_ip
+        mac4 = mac4
+        gw4 = _get_gw_info(ip4, mac4)
+
+        ip6 = def_ip_v6
+        mac6 = mac6
+        gw6 = _get_gw_info(ip6, mac6)
+
+        gw_list = self.dhcp_gw_info.get_all_router_ips()
+
+        expected = gw_list_to_set([gw4, gw6])
+        self.assertEqual(gw_list_to_set(gw_list), expected)

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -21,7 +21,7 @@ from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
 NO_VLAN = "NO_VLAN"
 
 
-def _get_vlan_key(vlan) -> str:
+def _get_vlan(vlan) -> str:
     # Validate vlan id is valid VLAN
     vlan_id_parsed = 0
     try:
@@ -34,8 +34,14 @@ def _get_vlan_key(vlan) -> str:
         return NO_VLAN
     if vlan_id_parsed < 0 or vlan_id_parsed > 4095:
         raise InvalidVlanId("invalid vlan: " + str(vlan))
-
     return str(vlan)
+
+
+def _get_vlan_key(vlan, version: int) -> str:
+    # Validate vlan id is valid VLAN
+    vlan = _get_vlan(vlan)
+
+    return vlan + "_" + str(version)
 
 
 # TODO: move helper class to separate directory.
@@ -50,15 +56,16 @@ class UplinkGatewayInfo:
         """
         self._backing_map = gw_info_map
         self._read_default_gw_timer = None
+        self._read_default_gw_v6_timer = None
         self._read_default_gw_interval_seconds = 20
 
-    def get_gw_ip(self, vlan_id: Optional[str] = "") -> Optional[str]:
+    def get_gw_ip(self, vlan_id: Optional[str] = "", version: int = IPAddress.IPV4) -> Optional[str]:
         """
         Retrieve gw IP address
         Args:
             vlan_id: vlan if of the GW.
         """
-        vlan_key = _get_vlan_key(vlan_id)
+        vlan_key = _get_vlan_key(vlan_id, version)
         if vlan_key in self._backing_map:
             gw_info = self._backing_map.get(vlan_key)
             ip = ipaddress.ip_address(gw_info.ip.address)
@@ -88,10 +95,38 @@ class UplinkGatewayInfo:
         self._read_default_gw_timer.start()
         logging.info("GW probe: timer started")
 
-    def update_ip(self, ip: Optional[str], vlan_id=None):
+    def read_default_gw_v6(self):
+        self._do_read_default_gw_v6()
+
+    def _do_read_default_gw_v6(self):
+        gws = netifaces.gateways()
+        logging.info("Using GW info: %s", gws)
+        if gws is not None:
+            default_gw = gws.get('default', None)
+            gw_ip_addr6 = None
+            if default_gw is not None:
+                gw_ip_addr6 = default_gw.get(netifaces.AF_INET6, None)
+            if gw_ip_addr6 is not None:
+                self.update_ip(gw_ip_addr6[0], version=IPAddress.IPV6)
+                logging.info("GW-v6 probe: timer stopped")
+                self._read_default_gw_timer6 = None
+                return
+
+        self._read_default_gw_timer6 = threading.Timer(
+            self._read_default_gw_interval_seconds,
+            self._do_read_default_gw_v6,
+        )
+        self._read_default_gw_timer6.start()
+        logging.info("GW-v6 probe: timer started")
+
+    def update_ip(
+        self, ip: Optional[str], vlan_id=None,
+        version: int = IPAddress.IPV4,
+    ):
         """
         Update IP address of the GW in mobilityD GW table.
         Args:
+            version: IPv4 or IPv6
             ip: gw ip address
             vlan_id: vlan of the GW, None in case of no vlan used.
         """
@@ -102,34 +137,37 @@ class UplinkGatewayInfo:
             return
 
         gw_ip = IPAddress(
-            version=IPAddress.IPV4,
+            version=version,
             address=ip_addr.packed,
         )
         # keep mac address same if its same GW IP
-        vlan_key = _get_vlan_key(vlan_id)
+        vlan_key = _get_vlan_key(vlan_id, version)
         if vlan_key in self._backing_map:
             gw_info = self._backing_map[vlan_key]
             if gw_info and gw_info.ip == gw_ip:
                 logging.debug("GW update: no change %s", ip)
                 return
 
-        updated_info = GWInfo(ip=gw_ip, mac="", vlan=vlan_key)
+        updated_info = GWInfo(ip=gw_ip, mac="", vlan=_get_vlan(vlan_id))
         self._backing_map[vlan_key] = updated_info
         logging.info("GW update: GW IP[%s]: %s" % (vlan_key, ip))
 
-    def get_gw_mac(self, vlan_id: Optional[str] = None) -> Optional[str]:
+    def get_gw_mac(self, vlan_id: Optional[str] = None, version: int = IPAddress.IPV4) -> Optional[str]:
         """
         Retrieve Mac address of default gw.
         Args:
             vlan_id: vlan of the gw, None if GW is not in a vlan.
         """
-        vlan_key = _get_vlan_key(vlan_id)
+        vlan_key = _get_vlan_key(vlan_id, version)
         if vlan_key in self._backing_map:
             return self._backing_map.get(vlan_key).mac
         else:
             return None
 
-    def update_mac(self, ip: Optional[str], mac: Optional[str], vlan_id=None):
+    def update_mac(
+        self, ip: Optional[str], mac: Optional[str], vlan_id=None,
+        version: int = IPAddress.IPV4,
+    ):
         """
         Update mac address of GW in mobilityD GW table
         Args:
@@ -142,7 +180,7 @@ class UplinkGatewayInfo:
         except ValueError:
             logging.debug("could not parse GW IP: %s", ip)
             return
-        vlan_key = _get_vlan_key(vlan_id)
+        vlan_key = _get_vlan_key(vlan_id, version)
 
         # TODO: enhance check for MAC address sanity.
         if mac is None or ':' not in mac:
@@ -152,10 +190,10 @@ class UplinkGatewayInfo:
             )
             return
         gw_ip = IPAddress(
-            version=IPAddress.IPV4,
+            version=version,
             address=ip_addr.packed,
         )
-        updated_info = GWInfo(ip=gw_ip, mac=mac, vlan=vlan_key)
+        updated_info = GWInfo(ip=gw_ip, mac=mac, vlan=_get_vlan(vlan_id))
         self._backing_map[vlan_key] = updated_info
         logging.info("GW update: GW IP[%s]: %s : mac %s" % (vlan_key, ip, mac))
 


### PR DESCRIPTION
This would allow Non-NAT IPV6 traffic over SGi.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
