### PR TITLE
feat(orc8r): deIndex implementation

### DIFF
--- a/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
@@ -52,14 +52,12 @@ type directorydBlobstore struct {
 }
 
 func (d *directorydBlobstore) GetHostnameForHWID(hwid string) (string, error) {
-
 	res, err := d.getFromStore(placeholderNetworkID, DirectorydTypeHWIDToHostname, hwid)
 	printIfError(err, "Error GetHostnameForHWID: %+v", err)
 	return res, err
 }
 
 func (d *directorydBlobstore) GetIMSIForSessionID(networkID, sessionID string) (string, error) {
-
 	res, err := d.getFromStore(networkID, DirectorydTypeSessionIDToIMSI, sessionID)
 	printIfError(err, "Error GetIMSIForSessionID: %+v", err)
 	return res, err
@@ -146,13 +144,7 @@ func (d *directorydBlobstore) unmapFromStore(networkID, tkType string, keys []st
 	}
 	defer store.Rollback()
 
-	tks := storage.TKs{}
-	for _, key := range keys {
-		tks = append(tks, storage.TK{Type: tkType, Key: key})
-
-	}
-
-	err = store.Delete(networkID, tks)
+	err = store.Delete(networkID, storage.MakeTKs(tkType, keys))
 	if err != nil {
 		return errors.Wrapf(err, "failed to unmapFromStore with keys %s for tkKey %s", keys, tkType)
 	}

--- a/orc8r/cloud/go/services/orchestrator/servicers/indexer_servicer.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/indexer_servicer.go
@@ -69,7 +69,7 @@ func (i *indexerServicer) Index(ctx context.Context, req *protos.IndexRequest) (
 	if err != nil {
 		return nil, err
 	}
-	stErrs, err := indexImpl(ctx, req.NetworkId, states)
+	stErrs, err := setSecondaryStates(ctx, req.NetworkId, states)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,16 @@ func (i *indexerServicer) Index(ctx context.Context, req *protos.IndexRequest) (
 }
 
 func (i *indexerServicer) DeIndex(ctx context.Context, req *protos.DeIndexRequest) (*protos.DeIndexResponse, error) {
-	return &protos.DeIndexResponse{}, nil
+	states, err := state_types.MakeStatesByID(req.States, serdes.State)
+	if err != nil {
+		return &protos.DeIndexResponse{}, err
+	}
+	stErrs, err := unsetSecondaryStates(ctx, req.NetworkId, states)
+	if err != nil {
+		return nil, err
+	}
+	res := &protos.DeIndexResponse{StateErrors: state_types.MakeProtoStateErrors(stErrs)}
+	return res, nil
 }
 
 func (i *indexerServicer) PrepareReindex(ctx context.Context, req *protos.PrepareReindexRequest) (*protos.PrepareReindexResponse, error) {
@@ -92,16 +101,83 @@ func (i *indexerServicer) CompleteReindex(ctx context.Context, req *protos.Compl
 	return nil, status.Errorf(codes.InvalidArgument, "unsupported from/to for CompleteReindex: %v to %v", req.FromVersion, req.ToVersion)
 }
 
-func indexImpl(ctx context.Context, networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
-	return setSecondaryStates(ctx, networkID, states)
-}
-
-// setSecondaryState maps {sessionID -> IMSI} and {teid -> HwId}
+// setSecondaryStates maps {sessionID -> IMSI} and {TEID -> HWID}
 // Will attempt to update all secondary states, but will return error if any fails
 func setSecondaryStates(ctx context.Context, networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
-	sessionIDToIMSI := map[string]string{}
-	teidoHwId := map[string]string{}
-	stateErrors := state_types.StateErrors{}
+	sessionIDToIMSI, teidoHwId, stateErrors := getMappings(states)
+	if len(sessionIDToIMSI) == 0 && len(teidoHwId) == 0 {
+		return stateErrors, nil
+	}
+	multiError := multierrors.NewMulti()
+	if len(sessionIDToIMSI) != 0 {
+		err := directoryd.MapSessionIDsToIMSIs(ctx, networkID, sessionIDToIMSI)
+		multiError = multiError.AddFmt(err, "failed to update directoryd mapping of session IDs to IMSIs %+v", sessionIDToIMSI)
+	}
+	if len(teidoHwId) != 0 {
+		err := directoryd.MapSgwCTeidToHWID(ctx, networkID, teidoHwId)
+		multiError = multiError.AddFmt(err, "failed to update directoryd mapping of teid To HwID %+v", sessionIDToIMSI)
+	}
+	// multiError will only be nil if both updates succeeded
+	return stateErrors, multiError.AsError()
+}
+
+// unsetSecondaryStates removes {sessionID -> IMSI} and {TEID -> HWID} mappings
+func unsetSecondaryStates(ctx context.Context, networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
+	sessionIDToIMSI, teidoHwId, stateErrors := getMappings(states)
+	multiError := multierrors.NewMulti()
+
+	err := unsetTeids(ctx, networkID, teidoHwId)
+	multiError = multiError.Add(err)
+
+	err = unsetSessionIDs(ctx, networkID, sessionIDToIMSI)
+	multiError = multiError.Add(err)
+
+	return stateErrors, multiError.AsError()
+}
+
+// unsetTeids removes {TEID -> TEID} mappings
+func unsetTeids(ctx context.Context, networkID string, teidoHwId map[string]string) error {
+	var teids []string
+	for teid := range teidoHwId {
+		teids = append(teids, teid)
+	}
+	var err error
+	if len(teids) != 0 {
+		err = directoryd.UnmapSgwCTeidToHWID(ctx, networkID, teids)
+		if err != nil {
+			err = fmt.Errorf("UnmapSgwCTeidToHWID failed: %s", err)
+			glog.Error(err)
+		}
+	}
+	return err
+}
+
+// unsetSessionIDs removes {sessionID -> IMSI} mappings
+func unsetSessionIDs(ctx context.Context, networkID string, sessionIDToIMSI map[string]string) error {
+	var sessionIDs []string
+	for sessionID := range sessionIDToIMSI {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	var err error
+	if len(sessionIDs) != 0 {
+		err = directoryd.UnmapSessionIDsToIMSIs(ctx, networkID, sessionIDs)
+		if err != nil {
+			err = fmt.Errorf("UnmapSessionIDsToIMSIs failed: %s", err)
+			glog.Error(err)
+		}
+	}
+	return err
+}
+
+// getMappings builds SessionID to IMSI and TEIDs to HWID maps from state
+func getMappings(states state_types.StatesByID) (
+	sessionIDToIMSI map[string]string,
+	teidoHwId map[string]string,
+	stateErrors state_types.StateErrors,
+) {
+	sessionIDToIMSI = map[string]string{}
+	teidoHwId = map[string]string{}
+	stateErrors = state_types.StateErrors{}
 	for id, st := range states {
 		params, err := extractRecordParameters(id, st)
 		if err != nil {
@@ -116,26 +192,11 @@ func setSecondaryStates(ctx context.Context, networkID string, states state_type
 			teidoHwId[teid] = params.hwid
 		}
 	}
-
-	if len(sessionIDToIMSI) == 0 && len(teidoHwId) == 0 {
-		return stateErrors, nil
-	}
-
-	multiError := multierrors.NewMulti()
-	if len(sessionIDToIMSI) != 0 {
-		err := directoryd.MapSessionIDsToIMSIs(ctx, networkID, sessionIDToIMSI)
-		multiError = multiError.AddFmt(err, "failed to update directoryd mapping of session IDs to IMSIs %+v", sessionIDToIMSI)
-	}
-	if len(teidoHwId) != 0 {
-		err := directoryd.MapSgwCTeidToHWID(ctx, networkID, teidoHwId)
-		multiError = multiError.AddFmt(err, "failed to update directoryd mapping of teid To HwID %+v", sessionIDToIMSI)
-	}
-	// multiError will only be nil if both updates succeeded
-	return stateErrors, multiError.AsError()
+	return
 }
 
-// extractRecordParameters extracts IMSI, SessionID, TEID and HwID from directory record
-// Returns error any error is found. No partial updates are allowed.
+// extractRecordParameters extracts IMSI, SessionID, TEID and HWID from directory record
+// Returns error if any error is found. No partial updates are allowed.
 func extractRecordParameters(id state_types.ID, st state_types.State) (*directorydRecordParameters, error) {
 	imsi := id.DeviceID
 	record, ok := st.ReportedState.(*directoryd_types.DirectoryRecord)
@@ -153,9 +214,9 @@ func extractRecordParameters(id state_types.ID, st state_types.State) (*director
 	if err != nil {
 		return nil, err
 	}
-	// log an error in case blank sessionId and no teid
+	// log an error in case blank sessionId and no TEID
 	if sessionID == "" && len(teids) == 0 {
-		glog.V(2).Infof("Session ID not found for record from %s", imsi)
+		glog.V(2).Infof("Session ID not found for IMSI %s in record %v", imsi, record)
 	}
 
 	return &directorydRecordParameters{
@@ -166,7 +227,7 @@ func extractRecordParameters(id state_types.ID, st state_types.State) (*director
 	}, nil
 }
 
-// getTeidToHwIdPair will return all the TEIDs for that IMSI and its current location (HwID)
+// getTeidToHwIdPair will return all the TEIDs for that IMSI and its current location (HWID)
 func getTeidToHwIdPair(record *directoryd_types.DirectoryRecord) ([]string, string, error) {
 	teids, err := record.GetSgwCTeids()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add implementation of deIndex to remove TEID-HwID mapping and SessinId-IMSI mappings

## Test Plan

```
./build.py -g
./build.py -c
```


Done manual test with local setup

Created Index with

```
grpcurl -vv \
    -insecure \
    -key /tmp/magma_protos/gateway.key \
    -cert /tmp/magma_protos/gateway.crt \
    -authority state-controller.magma.test \
    -protoset /tmp/magma_protos/out.protoset \
    -d '{"states": [{"type": "directory_record",
"deviceID": "IMSI001020000000064",
"value":"eyJpZGVudGlmaWVycyI6IHsic2d3X2NfdGVpZCI6ICIxMTY2NDEzNDkwIn0sICJsb2NhdGlvbl9oaXN0b3J5IjogWyJlODhlZThjYy1hYThiLTQxODktOGYxNC00MWQ4M2RlOWNlNGUiXSwgInB5L29iamVjdCI6ICJtYWdtYS5kaXJlY3RvcnlkLnJwY19zZXJ2aWNlci5EaXJlY3RvcnlSZWNvcmQifQ==", "version":"3"}]}' \
    localhost:7443 \
    magma.orc8r.StateService/ReportStates
```


Observed index is created
```
magma_dev=# SELECT network_id, type, key FROM directoryd_blobstore;
  network_id  |       type       |    key
--------------+------------------+------------
 feg_lte_test | sgwCteid_to_hwid | 1166413490
(1 row)
```


Deleted index with

```
grpcurl -vv \
    -insecure \
    -key /tmp/magma_protos/gateway.key \
    -cert /tmp/magma_protos/gateway.crt \
    -authority state-controller.magma.test \
    -protoset /tmp/magma_protos/out.protoset \
    -d '{"ids": [{"type": "directory_record",
"deviceID": "IMSI001020000000064"}]}' \
    localhost:7443 \
    magma.orc8r.StateService/DeleteStates
```

Observed index is gone

```
magma_dev=# SELECT network_id, type, key FROM directoryd_blobstore;
 network_id | type | key
------------+------+-----
(0 rows)
```

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
