### PR TITLE
feat(pipelined): Scalability test for 5g call flow in UPF

### DIFF
--- a/lte/gateway/python/magma/pipelined/ng_set_session_msg.py
+++ b/lte/gateway/python/magma/pipelined/ng_set_session_msg.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 from collections import namedtuple
 
+from lte.protos.apn_pb2 import AggregatedMaximumBitrate
 from lte.protos.pipelined_pb2 import (
     PDI,
     Action,
@@ -59,7 +60,7 @@ class CreateSessionUtil:
     @staticmethod
     def CreateAddQERinPDR(
         qos_enforce_rule: QoSEnforceRuleEntry,
-        ue_ip_addr: str,
+        ue_ip_addr: str, apn_ambr: AggregatedMaximumBitrate,
     ) -> ActivateFlowsRequest:
 
         if qos_enforce_rule.allow == 'YES':
@@ -94,7 +95,6 @@ class CreateSessionUtil:
                     action=allow,
                 ),
             ]
-
         qos_enforce_rule = ActivateFlowsRequest(
                                   sid=SIDUtils.to_pb(qos_enforce_rule.imsi),
                                   ip_addr=ue_ip_addr,
@@ -107,7 +107,8 @@ class CreateSessionUtil:
                                             flow_list=flow_list,
                                           ), version=1,
                                       ), ],
-                                request_origin=RequestOriginType(type=RequestOriginType.N4),
+                                  request_origin=RequestOriginType(type=RequestOriginType.N4),
+                                  apn_ambr=apn_ambr,
         )
         return qos_enforce_rule
 
@@ -190,7 +191,7 @@ class CreateSessionUtil:
         self, imsi_val: str, pdr_state: str = "ADD", in_teid: int = 0,
         out_teid: int = 0, ue_ip_addr: str = "", gnb_ip_addr: str = "",
         del_rule_id: str = '', add_rule_id: str = '', ipv4_dst: str = None, allow: str = "YES",
-        priority: int = 10, hard_timeout: int = 0,
+        priority: int = 10, hard_timeout: int = 0, apn_ambr: AggregatedMaximumBitrate = None,
     ):
 
         pdr_id = 1
@@ -215,7 +216,7 @@ class CreateSessionUtil:
                 allow, priority, hard_timeout,
                 FlowMatch.UPLINK,
             )
-            uplink_qer_enforcer = CreateSessionUtil.CreateAddQERinPDR(uplink_qer_tuple, ue_ip_addr)
+            uplink_qer_enforcer = CreateSessionUtil.CreateAddQERinPDR(uplink_qer_tuple, ue_ip_addr, apn_ambr)
 
             downlink_qer_tuple = QoSEnforceRuleEntry(
                 imsi_val, add_rule_id, ipv4_dst,
@@ -223,7 +224,7 @@ class CreateSessionUtil:
                 FlowMatch.DOWNLINK,
             )
 
-            downlink_qer_enforcer = CreateSessionUtil.CreateAddQERinPDR(downlink_qer_tuple, ue_ip_addr)
+            downlink_qer_enforcer = CreateSessionUtil.CreateAddQERinPDR(downlink_qer_tuple, ue_ip_addr, apn_ambr)
 
         uplink_far = CreateSessionUtil.CreateFARinPDR(0, '')
         downlink_far = CreateSessionUtil.CreateFARinPDR(out_teid, gnb_ip_addr)


### PR DESCRIPTION
Signed-off-by: mehul jindal <mehul.jindal@wavelabs.ai>

## Summary

We have made the script for scalability test for 5G call flow in UPF only.
lte/gateway/python/scripts/pipelined_cli.py

## Test Plan
Disable Qos Test:
```
pipelined_cli.py stress_test5g set_smf_session5g --number_of_iterations 5000 --attaches_per_sec 50 --time_between_detach 10 --disable_qos

```
Enabled QoS Test:
```
pipelined_cli.py stress_test5g set_smf_session5g --number_of_iterations 5000 --attaches_per_sec 50 --time_between_detach 10

```
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Disable Qos Test Logs
[logsStressTest5GNoQOS.txt](https://github.com/magma/magma/files/7409648/logsStressTest5GNoQOS.txt)
[table0NoQOS.txt](https://github.com/magma/magma/files/7409649/table0NoQOS.txt)
[table13NoQOS.txt](https://github.com/magma/magma/files/7409650/table13NoQOS.txt)

Enable Qos Test Logs
[logsStressTest5GQOS.txt](https://github.com/magma/magma/files/7409675/logsStressTest5GQOS.txt)
[table0QOS.txt](https://github.com/magma/magma/files/7409676/table0QOS.txt)
[table13QOS.txt](https://github.com/magma/magma/files/7409677/table13QOS.txt)
