### PR TITLE
chore: apply IWYU result to MME - part 1

### DIFF
--- a/lte/gateway/c/core/oai/common/TLVDecoder.c
+++ b/lte/gateway/c/core/oai/common/TLVDecoder.c
@@ -21,11 +21,9 @@
   \company Eurecom
 */
 
-#include <stdio.h>
-#include <stdint.h>
-
-#include "bstrlib.h"
 #include "TLVDecoder.h"
+#include <stdint.h>   // for uint16_t, uint32_t, uint8_t
+#include "bstrlib.h"  // for bstring, bcatcstr, bformat, bformata, bfromcstr
 
 int errorCodeDecoder = 0;
 

--- a/lte/gateway/c/core/oai/common/async_system.c
+++ b/lte/gateway/c/core/oai/common/async_system.c
@@ -34,22 +34,21 @@
    \date 2017
    \email: lionel.gauthier@eurecom.fr
 */
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <stdarg.h>
 
-#include "bstrlib.h"
-#include "intertask_interface.h"
-#include "log.h"
 #include "async_system.h"
-#include "assertions.h"
-#include "dynamic_memory_check.h"
-#include "itti_free_defined_msg.h"
-#include "common_defs.h"
-#include "async_system_messages_types.h"
-#include "intertask_interface_types.h"
-#include "itti_types.h"
+#include <czmq_library.h>               // for zloop_t, zsock_t
+#include <pthread.h>                    // for pthread_exit
+#include <stdarg.h>                     // for va_end, va_list, va_start
+#include <stdbool.h>                    // for bool
+#include <stdio.h>                      // for NULL, perror
+#include <stdlib.h>                     // for free, exit, system
+#include "bstrlib.h"                    // for bdata, bfromcstralloc, btrunc
+#include "common_defs.h"                // for status_code_e, RETURNerror
+#include "dynamic_memory_check.h"       // for bdestroy_wrapper
+#include "intertask_interface.h"        // for DEPRECATEDitti_alloc_new_me...
+#include "intertask_interface_types.h"  // for TASK_ASYNC_SYSTEM, MessageDef
+#include "itti_free_defined_msg.h"      // for itti_free_msg_content
+#include "log.h"                        // for LOG_ASYNC_SYSTEM, OAI_FPRIN...
 
 static void async_system_exit(void);
 

--- a/lte/gateway/c/core/oai/common/backtrace.c
+++ b/lte/gateway/c/core/oai/common/backtrace.c
@@ -28,12 +28,10 @@
  * policies, either expressed or implied, of the FreeBSD Project.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <signal.h>
-#include <execinfo.h>
-
 #include "backtrace.h"
+#include <execinfo.h>  // for backtrace, backtrace_symbols
+#include <stdio.h>     // for printf, size_t
+#include <stdlib.h>    // for free
 
 /* Obtain a backtrace and print it to stdout. */
 void display_backtrace(void) {

--- a/lte/gateway/c/core/oai/common/backtrace.h
+++ b/lte/gateway/c/core/oai/common/backtrace.h
@@ -28,7 +28,7 @@
  * policies, either expressed or implied, of the FreeBSD Project.
  */
 
-#include <signal.h>
+#include <bits/types/siginfo_t.h>  // for siginfo_t
 
 #ifndef BACKTRACE_H_
 #define BACKTRACE_H_

--- a/lte/gateway/c/core/oai/common/common_utility_funs.cpp
+++ b/lte/gateway/c/core/oai/common/common_utility_funs.cpp
@@ -11,10 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <stdint.h>
-#include <iostream>
 #include "common_utility_funs.h"
-#include "lte/protos/mconfig/mconfigs.pb.h"
+#include <stddef.h>                          // for NULL
+#include <stdint.h>                          // for uint8_t
+#include "3gpp_23.003.h"                     // for plmn_t
+#include "amf_config.h"                      // for imsi64_t
+#include "common_defs.h"                     // for RETURNerror, RETURNok
+#include "conversions.h"                     // for IMSI_STRING_TO_IMSI64
+#include "hashtable.h"                       // for HASH_TABLE_OK, hashtable...
+#include "lte/protos/mconfig/mconfigs.pb.h"  // for ModeMapItem_FederatedMod...
+#include "mme_config.h"                      // for fed_mode_map_t, mme_config
+#include "obj_hashtable.h"                   // for obj_hashtable_get
 
 // Extract MCC and MNC from the imsi received and match with
 // configuration

--- a/lte/gateway/c/core/oai/common/common_utility_funs.h
+++ b/lte/gateway/c/core/oai/common/common_utility_funs.h
@@ -4,10 +4,11 @@
 extern "C" {
 #endif
 
-#include "mme_config.h"
-#include "log.h"
-#include "conversions.h"
-#include "common_defs.h"
+#include <stdint.h>                // for uint8_t
+#include "TrackingAreaIdentity.h"  // for tac_t
+#include "common_types.h"          // for regional_subscription_t
+#include "log.h"                   // for log_proto_t
+#include "obj_hashtable.h"         // IWYU pragma: keep
 
 int match_fed_mode_map(const char* imsi, log_proto_t module);
 int verify_service_area_restriction(

--- a/lte/gateway/c/core/oai/common/conversions.c
+++ b/lte/gateway/c/core/oai/common/conversions.c
@@ -34,11 +34,12 @@
   \company Eurecom
 */
 
-#include <stdint.h>
-#include <ctype.h>
-
 #include "conversions.h"
-#include "log.h"
+#include <ctype.h>        // for isspace
+#include <stdint.h>       // for uint8_t
+#include <string.h>       // for memcpy, memset
+#include "3gpp_29.274.h"  // for fteid_s
+#include "log.h"          // for LOG_COMMON, OAILOG_ERROR
 
 static const char hex_to_ascii_table[16] = {
     '0', '1', '2', '3', '4', '5', '6', '7',

--- a/lte/gateway/c/core/oai/common/conversions.h
+++ b/lte/gateway/c/core/oai/common/conversions.h
@@ -37,19 +37,16 @@
 
 #ifndef FILE_CONVERSIONS_SEEN
 #define FILE_CONVERSIONS_SEEN
-#include <stdio.h>
-#include <endian.h>
-#include <netinet/in.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <math.h>
 
-#include "bstrlib.h"
-#include "common_types.h"
-#include "3gpp_23.003.h"
-#include "3gpp_24.008.h"
-#include "3gpp_29.274.h"
-#include "EpsQualityOfService.h"
+#include <endian.h>        // for BYTE_ORDER, LITTLE_ENDIAN
+#include <netinet/in.h>    // for s6_addr
+#include <stdbool.h>       // for false, true
+#include <stdint.h>        // for uint8_t
+#include <stdio.h>         // for NULL, size_t
+#include "3gpp_23.003.h"   // for imsi_t, IMSI_BCD8_SIZE, IMSI_BCD_DIGITS_MAX
+#include "bstrlib.h"       // for bstring
+#include "common_types.h"  // for paa_t, ip_address_t, imsi64_t, IMEI_64_FMT
+struct fteid_s;
 
 /* Endianness conversions for 16 and 32 bits integers from host to network order
  */

--- a/lte/gateway/c/core/oai/common/digest.c
+++ b/lte/gateway/c/core/oai/common/digest.c
@@ -35,13 +35,11 @@
    \email: lionel.gauthier@eurecom.fr
 */
 
-#include <stdlib.h>
-#include <openssl/crypto.h>
-#include <openssl/evp.h>
-
-#include "log.h"
-#include "common_defs.h"
 #include "digest.h"
+#include <openssl/crypto.h>  // for OPENSSL_free, OPENSSL_malloc
+#include <openssl/evp.h>     // for EVP_DigestFinal_ex, EVP_DigestInit_ex
+#include "common_defs.h"     // for RETURNerror, RETURNok, status_code_e
+#include "log.h"             // for LOG_UTIL, OAILOG_ERROR
 
 //------------------------------------------------------------------------------
 // evp_x can be EVP_sha256, ...

--- a/lte/gateway/c/core/oai/common/digest.h
+++ b/lte/gateway/c/core/oai/common/digest.h
@@ -37,10 +37,10 @@
 
 #ifndef FILE_DIGEST_SEEN
 #define FILE_DIGEST_SEEN
-#include <openssl/evp.h>
-#include <openssl/ossl_typ.h>
-#include <stddef.h>
-#include "common_defs.h"
+
+#include <openssl/ossl_typ.h>  // for EVP_MD
+#include <stddef.h>            // for size_t
+#include "common_defs.h"       // for status_code_e
 
 status_code_e digest_buffer(
     const EVP_MD* (*evp_x)(void), const unsigned char* buffer,

--- a/lte/gateway/c/core/oai/common/glogwrapper/glog_logging.cpp
+++ b/lte/gateway/c/core/oai/common/glogwrapper/glog_logging.cpp
@@ -28,20 +28,19 @@
  * policies, either expressed or implied, of the FreeBSD Project.
  */
 
-#include <string>
-#include <vector>
-#include <regex>
-#include <algorithm>
-#include <fstream>
-#include <cstdio>
-#include <stdlib.h>
-#include <unistd.h>
 #include "glog_logging.h"
-#include <glog/logging.h>
-#include <glog/stl_logging.h>
-
-#include <sys/types.h>
-#include <dirent.h>
+#include <dirent.h>                 // for closedir, opendir, readdir, DIR
+#include <gflags/gflags_declare.h>  // for clstring
+#include <glog/logging.h>           // for FlushLogFiles, InitGoogleLogging
+#include <stdlib.h>                 // for free, realpath
+#include <unistd.h>                 // for symlink
+#include <algorithm>                // for max, sort
+#include <cstdio>                   // for remove, sprintf
+#include <fstream>                  // for operator<<
+#include <memory>                   // for allocator_traits<>::value_type
+#include <regex>                    // for match_results<>::_Base_type, rege...
+#include <string>                   // for string, operator<, swap, basic_st...
+#include <vector>                   // for vector
 
 std::vector<std::string> read_directory(const std::string& dir_path) {
   char* absolute_dir_path = realpath(dir_path.c_str(), nullptr);

--- a/lte/gateway/c/core/oai/common/glogwrapper/glog_logging.h
+++ b/lte/gateway/c/core/oai/common/glogwrapper/glog_logging.h
@@ -31,9 +31,8 @@
 #ifndef MAGMACORE_GLOG_LOGGING_H
 #define MAGMACORE_GLOG_LOGGING_H
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <linux/limits.h>
+#include <limits.h>  // for PATH_MAX
+#include <stdint.h>  // for int32_t, uint32_t
 
 #define MAX_FILE_NAME_LENGTH PATH_MAX
 

--- a/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
+++ b/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
@@ -22,18 +22,14 @@
   \email: lionel.gauthier@eurecom.fr
 */
 
-#include <stdlib.h>
-
-#include "dynamic_memory_check.h"
-#include "assertions.h"
-#include "3gpp_24.008.h"
-#include "3gpp_36.413.h"
-#include "intertask_interface.h"
 #include "itti_free_defined_msg.h"
-#include "async_system_messages_types.h"
-#include "ip_forward_messages_types.h"
-#include "s11_messages_types.h"
-#include "sctp_messages_types.h"
+#include <stdint.h>                // for uint8_t
+#include "3gpp_24.008.h"           // for clear_protocol_configuratio...
+#include "3gpp_36.413.h"           // for e_rab_to_be_setup_item_t
+#include "bstrlib.h"               // for bstring
+#include "common_types.h"          // for BEARERS_PER_UE
+#include "dynamic_memory_check.h"  // for bdestroy_wrapper, free_wrapper
+#include "intertask_interface.h"   // for ITTI_MSG_ID
 
 //------------------------------------------------------------------------------
 void itti_free_msg_content(MessageDef* const message_p) {

--- a/lte/gateway/c/core/oai/common/log.c
+++ b/lte/gateway/c/core/oai/common/log.c
@@ -34,35 +34,36 @@
    lionel.gauthier@eurecom.fr
 */
 
-#include <errno.h>
-#include <fcntl.h>
-#include <inttypes.h>
-#include <netdb.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdbool.h>
-#include <sys/time.h>
-#include <unistd.h>
-#include <stdarg.h>
-#include <pthread.h>
-#include <syslog.h>
-#include <assert.h>
-#include <netinet/in.h>
-#include <signal.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <time.h>
-
-#include "intertask_interface.h"
 #include "log.h"
-#include "shared_ts_log.h"
-#include "assertions.h"
-#include "dynamic_memory_check.h"
-#include "asn_system.h"
-#include "hashtable.h"
-#include "intertask_interface_types.h"
-#include "itti_types.h"
+#include <assert.h>                     // for assert
+#include <czmq_library.h>               // for zloop_t, zsock_t
+#include <errno.h>                      // for errno
+#include <fcntl.h>                      // for fcntl, F_GETFL, F_SETFL, O_NO...
+#include <inttypes.h>                   // for PRIu64
+#include <netdb.h>                      // for addrinfo, freeaddrinfo, gai_s...
+#include <netinet/in.h>                 // for IPPROTO_TCP
+#include <pthread.h>                    // for pthread_self, pthread_t, pthr...
+#include <signal.h>                     // for signal, SIGPIPE
+#include <stdarg.h>                     // for va_list, va_end, va_start
+#include <stdbool.h>                    // for bool, false, true
+#include <stdio.h>                      // for snprintf, NULL, size_t, fclose
+#include <stdlib.h>                     // for calloc, free, atoi
+#include <string.h>                     // for strlen, strerror, memset, strstr
+#include <strings.h>                    // for strcasecmp
+#include <sys/param.h>                  // for MIN
+#include <sys/socket.h>                 // for connect, socket, AF_UNSPEC
+#include <sys/time.h>                   // for timeval, gettimeofday
+#include <sys/types.h>                  // for time_t, uint
+#include <syslog.h>                     // for closelog, openlog, syslog
+#include <time.h>                       // for localtime, strftime, time
+#include <unistd.h>                     // for close
+#include "assertions.h"                 // for AssertFatal
+#include "dynamic_memory_check.h"       // for bdestroy_wrapper, free_wrapper
+#include "glogwrapper/glog_logging.h"   // for flush_log, log_string, init_l...
+#include "hashtable.h"                  // for hashtable_ts_get, hash_key_t
+#include "intertask_interface.h"        // for start_timer, TIMER_REPEAT_ONCE
+#include "intertask_interface_types.h"  // for TASK_LOG, MessageDef, task_id_t
+#include "shared_ts_log.h"              // for shared_log_queue_item_s, shar...
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/lte/gateway/c/core/oai/common/log.h
+++ b/lte/gateway/c/core/oai/common/log.h
@@ -37,25 +37,20 @@
 #ifndef FILE_LOG_SEEN
 #define FILE_LOG_SEEN
 
-#include <syslog.h>
-#include <stdio.h>
-
-#include "gcc_diag.h"
+#include <pthread.h>    // for pthread_t
+#include <stdarg.h>     // for va_list
+#include <stdbool.h>    // for bool, false, true
+#include <stdint.h>     // for uint64_t, int32_t, uint8_t
+#include <stdio.h>      // for fflush, fprintf, stderr, stdout, NULL, size_t
+#include <sys/types.h>  // for time_t
+#include "bstrlib.h"    // for bstring
+#include "gcc_diag.h"   // for OAI_GCC_DIAG_OFF, OAI_GCC_DIAG_ON
+struct shared_log_queue_item_s;  // lines 58-58
 
 /* asn1c debug */
 extern int asn_debug;
 extern int asn1_xer_print;
 extern int fd_g_debug_lvl;
-
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <pthread.h>
-
-#include "bstrlib.h"
-#include "glogwrapper/glog_logging.h"
-
-struct shared_log_queue_item_s;
 
 /* asn1c debug */
 extern int asn_debug;

--- a/lte/gateway/c/core/oai/common/redis_utils/redis_client.cpp
+++ b/lte/gateway/c/core/oai/common/redis_utils/redis_client.cpp
@@ -16,19 +16,17 @@
  */
 
 #include "redis_client.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <common_defs.h>
-
-#ifdef __cplusplus
-}
-#endif
-
-#include "includes/ServiceConfigLoader.h"
-#include <yaml-cpp/yaml.h>  // IWYU pragma: keep
+#include <google/protobuf/message.h>  // for Message
+#include <stddef.h>                   // for size_t
+#include <yaml-cpp/node/impl.h>       // for Node::operator[], Node::as
+#include <yaml-cpp/node/node.h>       // for Node
+#include <yaml-cpp/yaml.h>
+#include <stdexcept>
+#include <future>                          // for future
+#include <cpp_redis/core/reply.hpp>        // for reply
+#include "common_defs.h"                   // for RETURNok, RETURNerror, sta...
+#include "includes/ServiceConfigLoader.h"  // for ServiceConfigLoader
+#include "orc8r/protos/redis.pb.h"         // for RedisState
 
 using google::protobuf::Message;
 
@@ -167,7 +165,6 @@ std::vector<std::string> RedisClient::get_keys(const std::string& pattern) {
     }
 
     cursor = std::stoi(response[0].as_string());
-    ;
   } while (cursor != 0);
 
   return replies;

--- a/lte/gateway/c/core/oai/common/redis_utils/redis_client.h
+++ b/lte/gateway/c/core/oai/common/redis_utils/redis_client.h
@@ -17,13 +17,23 @@
 
 #pragma once
 
-#include <string>
+#include <stdint.h>                   // for uint64_t
+#include <memory>                     // for unique_ptr
+#include <string>                     // for string
+#include <vector>                     // for vector
+#include <cpp_redis/core/client.hpp>  // for client
+#include "common_defs.h"              // for status_code_e
 
-#include <cpp_redis/cpp_redis>
-#include <google/protobuf/message.h>
-
-#include <common_defs.h>
-#include "orc8r/protos/redis.pb.h"
+namespace google {
+namespace protobuf {
+class Message;
+}
+}  // namespace google
+namespace magma {
+namespace orc8r {
+class RedisState;
+}
+}  // namespace magma
 
 namespace magma {
 namespace lte {

--- a/lte/gateway/c/core/oai/common/shared_ts_log.c
+++ b/lte/gateway/c/core/oai/common/shared_ts_log.c
@@ -34,21 +34,22 @@
    \date 2016
    \email: lionel.gauthier@eurecom.fr
 */
+
+#include "shared_ts_log.h"
+#include <czmq_library.h>
+#include <liblfds710.h>  // for lfds710_stack_element
+#include <pthread.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <sys/time.h>
-#include <pthread.h>
-
+#include "assertions.h"
 #include "bstrlib.h"
+#include "dynamic_memory_check.h"
 #include "hashtable.h"
 #include "intertask_interface.h"
-#include "log.h"
-#include "shared_ts_log.h"
-#include "assertions.h"
-#include "dynamic_memory_check.h"
 #include "intertask_interface_types.h"
-#include "itti_types.h"
+#include "log.h"
 
 //-------------------------------
 #define LOG_MAX_QUEUE_ELEMENTS 2048

--- a/lte/gateway/c/core/oai/common/shared_ts_log.h
+++ b/lte/gateway/c/core/oai/common/shared_ts_log.h
@@ -38,13 +38,10 @@
 #ifndef FILE_SHARED_TS_LOG_SEEN
 #define FILE_SHARED_TS_LOG_SEEN
 
-#include <sys/time.h>
-#include <liblfds710.h>
-
+#include <liblfds710.h>  // for lfds710_stack_element
+#include "bstrlib.h"     // for bstring
 #include "log.h"
-#include "bstrlib.h"
-
-struct timeval;
+struct timeval;  // lines 47-47
 
 typedef enum {
   MIN_SH_TS_LOG_CLIENT = 0,

--- a/lte/gateway/c/core/oai/lib/bstr/bstrlib.h
+++ b/lte/gateway/c/core/oai/lib/bstr/bstrlib.h
@@ -18,10 +18,8 @@
 extern "C" {
 #endif
 
-#include <stdarg.h>
-#include <string.h>
-#include <limits.h>
-#include <ctype.h>
+#include <stdarg.h>  // for va_list
+#include <string.h>  // for size_t
 
 struct bStream;
 

--- a/lte/gateway/c/core/oai/lib/directoryd/directoryd.cpp
+++ b/lte/gateway/c/core/oai/lib/directoryd/directoryd.cpp
@@ -15,14 +15,12 @@
  *      contact@openairinterface.org
  */
 
-#include <grpcpp/impl/codegen/status.h>
-#include <string>
-#include <iostream>
-
-#include "GatewayDirectorydClient.h"
 #include "directoryd.h"
-#include "orc8r/protos/common.pb.h"
-#include "orc8r/protos/directoryd.pb.h"
+#include <grpcpp/impl/codegen/status.h>  // for Status
+#include <iostream>                      // for operator<<, basic_ostream
+#include <string>                        // for operator+, string, operator<<
+#include "GatewayDirectorydClient.h"     // for GatewayDirectoryServiceClient
+#include "orc8r/protos/common.pb.h"      // for Void
 
 static void directoryd_rpc_call_done(const grpc::Status& status);
 

--- a/lte/gateway/c/core/oai/lib/event_client/EventClientAPI.cpp
+++ b/lte/gateway/c/core/oai/lib/event_client/EventClientAPI.cpp
@@ -16,13 +16,14 @@
  */
 
 #include "EventClientAPI.h"
-
-#include <iostream>
-#include <thread>
-#include <grpcpp/support/status.h>
-#include <orc8r/protos/common.pb.h>
-
-#include "includes/EventdClient.h"
+#include <grpcpp/impl/codegen/status.h>            // for Status
+#include <grpcpp/impl/codegen/status_code_enum.h>  // for StatusCode, DEADLI...
+#include <orc8r/protos/common.pb.h>                // for Void
+#include <orc8r/protos/eventd.pb.h>                // for Event
+#include <iostream>                                // for operator<<, basic_...
+#include <string>                                  // for operator<<
+#include <thread>                                  // for thread
+#include "includes/EventdClient.h"                 // for AsyncEventdClient
 
 using grpc::Status;
 using grpc::StatusCode::DEADLINE_EXCEEDED;

--- a/lte/gateway/c/core/oai/lib/event_client/EventClientAPI.h
+++ b/lte/gateway/c/core/oai/lib/event_client/EventClientAPI.h
@@ -16,7 +16,11 @@
  */
 #pragma once
 
-#include "orc8r/protos/eventd.pb.h"
+namespace magma {
+namespace orc8r {
+class Event;
+}
+}  // namespace magma
 
 namespace magma {
 namespace lte {

--- a/lte/gateway/c/core/oai/lib/hashtable/hashtable.c
+++ b/lte/gateway/c/core/oai/lib/hashtable/hashtable.c
@@ -34,16 +34,15 @@
   \company Eurecom
   \email: lionel.gauthier@eurecom.fr
 */
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <inttypes.h>
-#include <pthread.h>
 
-#include "bstrlib.h"
-#include "dynamic_memory_check.h"
 #include "hashtable.h"
+#include <inttypes.h>              // for PRIx64
+#include <pthread.h>               // for pthread_mutex_unlock, pthread_mute...
+#include <stdbool.h>               // for true, false, bool
+#include <stdlib.h>                // for calloc, free, malloc
+#include <string.h>                // for memset
+#include "bstrlib.h"               // for bformat, bstring, bcatcstr, bconcat
+#include "dynamic_memory_check.h"  // for free_wrapper, bdestroy_wrapper
 
 #if TRACE_HASHTABLE
 #define PRINT_HASHTABLE(hTbLe, ...)                                            \

--- a/lte/gateway/c/core/oai/lib/hashtable/hashtable_uint64.c
+++ b/lte/gateway/c/core/oai/lib/hashtable/hashtable_uint64.c
@@ -33,15 +33,16 @@
   \company Eurecom
   \email: lionel.gauthier@eurecom.fr
 */
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <inttypes.h>
-#include <pthread.h>
 
-#include "bstrlib.h"
-#include "dynamic_memory_check.h"
-#include "hashtable.h"
+#include <inttypes.h>              // for PRIx64
+#include <pthread.h>               // for pthread_mutex_unlock, pthread_mutex_t
+#include <stdbool.h>               // for true, false, bool
+#include <stdint.h>                // for uint64_t
+#include <stdlib.h>                // for NULL, calloc, malloc
+#include <string.h>                // for memset
+#include "bstrlib.h"               // for bformat, bstring, bassign, bcatcstr
+#include "dynamic_memory_check.h"  // for free_wrapper, bdestroy_wrapper
+#include "hashtable.h"             // for hash_table_uint64_ts_t, hash_node_...
 
 #if TRACE_HASHTABLE
 #define PRINT_HASHTABLE(hTbLe, ...)                                            \

--- a/lte/gateway/c/core/oai/lib/hashtable/obj_hashtable_uint64.c
+++ b/lte/gateway/c/core/oai/lib/hashtable/obj_hashtable_uint64.c
@@ -35,18 +35,17 @@
   \email: lionel.gauthier@eurecom.fr
 */
 
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <inttypes.h>
-#include <stdbool.h>
-#include <pthread.h>
-
-#include "assertions.h"
-#include "bstrlib.h"
-#include "obj_hashtable.h"
-#include "dynamic_memory_check.h"
-#include "hashtable.h"
+#include <inttypes.h>              // for PRIx64
+#include <pthread.h>               // for pthread_mutex_unlock, pthread_mutex_t
+#include <stdbool.h>               // for true
+#include <stdint.h>                // for uint32_t, uint64_t, uint8_t
+#include <stdio.h>                 // for NULL, size_t
+#include <stdlib.h>                // for calloc
+#include <string.h>                // for memcmp, memcpy
+#include "bstrlib.h"               // for bstring, bassignformat, bcatcstr
+#include "dynamic_memory_check.h"  // for free_wrapper, bdestroy_wrapper
+#include "hashtable.h"             // for hash_size_t, HASH_TABLE_OK, hashta...
+#include "obj_hashtable.h"         // for obj_hash_table_uint64_t, obj_hash_...
 
 #if TRACE_HASHTABLE
 #define PRINT_HASHTABLE(hTbLe, ...)                                            \

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
@@ -29,30 +29,29 @@
  */
 
 #define _GNU_SOURCE
-#include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <unistd.h>
-#include <string.h>
-#include <malloc.h>
-#include <stdint.h>
-
-#include "assertions.h"
 #include "intertask_interface.h"
-#include "common_defs.h"
+#include <assert.h>                // for assert
+#include <pthread.h>               // for pthread_self, pthread_create
+#include <stdbool.h>               // for false, true, bool
+#include <stddef.h>                // for offsetof
+#include <stdint.h>                // for uint32_t, uint8_t
+#include <stdio.h>                 // for NULL, size_t
+#include <stdlib.h>                // for free, malloc, calloc
+#include <string.h>                // for memcpy, memset
+#include <time.h>                  // for clock_gettime, timespec, CLOCK...
+#include <unistd.h>                // for usleep, sleep
+#include "assertions.h"            // for AssertFatal, CHECK_INIT_RETURN
+#include "common_defs.h"           // for RETURNok, status_code_e
+#include "dynamic_memory_check.h"  // for free_wrapper
+#include "log.h"                   // for LOG_ITTI, OAILOG_DEBUG, OAILOG...
+#include "signals.h"               // for signal_handle, signal_mask
 
 /* Includes "intertask_interface_init.h" to check prototype coherence, but
    disable threads and messages information generation.
 */
 #define CHECK_PROTOTYPE_ONLY
 #include "intertask_interface_init.h"
-
 #undef CHECK_PROTOTYPE_ONLY
-
-#include "signals.h"
-#include "dynamic_memory_check.h"
-#include "log.h"
 
 /* ITTI DEBUG groups */
 #define ITTI_DEBUG_POLL (1 << 0)

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.h
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.h
@@ -37,16 +37,15 @@
 #ifndef INTERTASK_INTERFACE_H_
 #define INTERTASK_INTERFACE_H_
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <sys/types.h>
-#include <czmq.h>
-
-#include "intertask_interface_conf.h"
-#include "intertask_interface_types.h"
-#include "itti_types.h"
-#include "common_defs.h"
+#include <czmq_library.h>               // for zsock_t, zloop_t
+#include <pthread.h>                    // for pthread_mutex_t
+#include <stdbool.h>                    // for bool
+#include <stdint.h>                     // for uint8_t
+#include <stdio.h>                      // for size_t
+#include "common_defs.h"                // for status_code_e
+#include "common_types.h"               // for imsi64_t
+#include "intertask_interface_types.h"  // for task_id_t, MessageDef, Messag...
+struct timespec;
 
 #define ITTI_MSG_ID(mSGpTR) ((mSGpTR)->ittiMsgHeader.messageId)
 #define ITTI_MSG_ORIGIN_ID(mSGpTR) ((mSGpTR)->ittiMsgHeader.originTaskId)

--- a/lte/gateway/c/core/oai/lib/itti/signals.c
+++ b/lte/gateway/c/core/oai/lib/itti/signals.c
@@ -32,18 +32,17 @@
 #include "config.h"
 #endif
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-#include <signal.h>
-#include <ctype.h>
-
-#include "intertask_interface.h"
-#include "backtrace.h"
-#include "assertions.h"
 #include "signals.h"
-#include "intertask_interface_types.h"
+#include <bits/types/siginfo_t.h>  // for siginfo_t
+#include <ctype.h>                 // for isspace
+#include <signal.h>                // for sigaddset, sigemptyset, sigprocmask
+#include <stdio.h>                 // for fprintf, perror, stdout, fclose
+#include <stdlib.h>                // for atoi
+#include <string.h>                // for strlen, strncmp
+#include <unistd.h>                // for getpid, pid_t
+#include "assertions.h"            // for DevAssert
+#include "backtrace.h"             // for backtrace_handle_signal
+#include "intertask_interface.h"   // for send_terminate_message_fatal, task...
 
 #if defined(LOG_D) && defined(LOG_E)
 #define SIG_DEBUG(x, args...) OAILOG_D(EMU, x, ##args)

--- a/lte/gateway/c/core/oai/lib/itti/signals.h
+++ b/lte/gateway/c/core/oai/lib/itti/signals.h
@@ -31,6 +31,8 @@
 #ifndef SIGNALS_H_
 #define SIGNALS_H_
 
+#include "intertask_interface.h"  // for task_zmq_ctx_t
+
 int signal_mask(void);
 
 int signal_handle(int* end, task_zmq_ctx_t* task_ctx);

--- a/lte/gateway/c/core/oai/lib/message_utils/bytes_to_ie.h
+++ b/lte/gateway/c/core/oai/lib/message_utils/bytes_to_ie.h
@@ -31,14 +31,11 @@
 #ifndef FILE_BYTES_TO_IE_SEEN
 #define FILE_BYTES_TO_IE_SEEN
 
-#include <stdbool.h>
-#include <stdint.h>
-
-#include "common_ies.h"
-#include "common_types.h"
-#include "3gpp_23.003.h"
-#include "3gpp_24.008.h"
-#include "intertask_interface.h"
+#include <stdbool.h>      // for bool
+#include <stdint.h>       // for uint8_t
+#include "3gpp_23.003.h"  // for tmsi_t
+#include "3gpp_24.008.h"  // for lai_t
+#include "common_ies.h"   // for MobileIdentity_t
 
 void bytes_to_lai(const char* bytes, lai_t* lai);
 void bytes_to_tmsi(const char* bytes, tmsi_t* tmsi);

--- a/lte/gateway/c/core/oai/lib/message_utils/ie_to_bytes.h
+++ b/lte/gateway/c/core/oai/lib/message_utils/ie_to_bytes.h
@@ -31,13 +31,11 @@
 #ifndef FILE_IE_TO_BYTES_SEEN
 #define FILE_IE_TO_BYTES_SEEN
 
-#include <stdbool.h>
-
-#include "common_ies.h"
-#include "common_types.h"
-#include "3gpp_23.003.h"
-#include "3gpp_24.008.h"
-#include "TrackingAreaIdentity.h"
+#include <stdbool.h>               // for bool
+#include "3gpp_23.003.h"           // for ecgi_t, plmn_t
+#include "3gpp_24.008.h"           // for lai_t
+#include "TrackingAreaIdentity.h"  // for tai_t
+#include "common_ies.h"            // for MobileStationClassmark2_t
 
 // value field length of IEs (IEI and length indicator are excluded)
 #define IE_LENGTH_EPS_LOCATION_UPDATE_TYPE 1

--- a/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
+++ b/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
@@ -16,13 +16,10 @@
  */
 
 #include "service303_message_utils.h"
-
-#include <stddef.h>
-
-#include "assertions.h"
-#include "intertask_interface.h"
-#include "itti_types.h"
-#include "log.h"
+#include <stddef.h>               // for NULL
+#include "common_defs.h"          // for RETURNerror
+#include "intertask_interface.h"  // for send_msg_to_task, DEPRECATEDitt...
+#include "log.h"                  // for LOG_MME_APP, OAILOG_ERROR, OAIL...
 
 int send_app_health_to_service303(
     task_zmq_ctx_t* task_zmq_ctx_p, task_id_t origin_id, bool healthy) {

--- a/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.h
+++ b/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.h
@@ -18,10 +18,10 @@
 #ifndef FILE_SERVICE303_MESSAGE_UTILS
 #define FILE_SERVICE303_MESSAGE_UTILS
 
-#include <stdbool.h>
-
-#include "intertask_interface.h"
-#include "intertask_interface_types.h"
+#include <stdbool.h>                    // for bool
+#include "intertask_interface.h"        // for task_zmq_ctx_t
+#include "intertask_interface_types.h"  // for task_id_t
+#include "service303_messages_types.h"  // for application_mme_app_stats_msg_t
 
 int send_app_health_to_service303(
     task_zmq_ctx_t* task_zmq_ctx_p, task_id_t origin_id, bool healthy);

--- a/lte/gateway/c/core/oai/lib/openflow/controller/BaseApplication.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/BaseApplication.cpp
@@ -15,13 +15,21 @@
  *      contact@openairinterface.org
  */
 
-#include <stdio.h>
-
 #include "BaseApplication.h"
-#include "includes/MetricsHelpers.h"
+#include <fluid/of13/openflow-13.h>           // for OFPFC_ADD, OFPFC_DELETE
+#include <stdio.h>                            // for snprintf
+#include <fluid/of13/of13instruction.hh>      // for GoToTable
+#include <fluid/of13msg.hh>                   // for FlowMod
+#include <fluid/ofcommon/openflow-common.hh>  // for fluid_msg
+#include "ControllerEvents.h"                 // for ErrorEvent, ControllerE...
+#include "OpenflowMessenger.h"                // for OpenflowMessenger
+#include "includes/MetricsHelpers.h"          // for increment_counter
+namespace fluid_base {
+class OFConnection;
+}
 
 extern "C" {
-#include "log.h"
+#include "log.h"  // for LOG_GTPV1U, OAILOG_DEBUG
 }
 
 using namespace fluid_msg;

--- a/lte/gateway/c/core/oai/lib/openflow/controller/BaseApplication.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/BaseApplication.h
@@ -17,8 +17,20 @@
 
 #pragma once
 
-#include "OpenflowController.h"
-
+#include <stdint.h>              // for uint16_t, uint32_t
+#include "OpenflowController.h"  // for Application
+namespace fluid_base {
+class OFConnection;
+}
+namespace openflow {
+class ControllerEvent;
+}
+namespace openflow {
+class ErrorEvent;
+}
+namespace openflow {
+class OpenflowMessenger;
+}
 namespace openflow {
 
 /**

--- a/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -15,9 +15,12 @@
  *      contact@openairinterface.org
  */
 
-#include <netinet/in.h>
-#include <string.h>
 #include "ControllerEvents.h"
+#include <netinet/in.h>  // for in_addr, in6_addr, in6addr_any, ntohs
+#include <string.h>      // for size_t, memcmp, NULL
+// TODO: Once #5146 is resolved this can be included without <memory>
+#include <memory>                 // NOLINT
+#include <fluid/OFConnection.hh>  // NOLINT for OFConnection, OFConnection::E...
 
 using namespace fluid_msg;
 

--- a/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.h
@@ -17,10 +17,18 @@
 
 #pragma once
 
-#include <arpa/inet.h>
-#include <fluid/OFServer.hh>
-#include <fluid/ofcommon/openflow-common.hh>
-#include "gtpv1u.h"
+#include <netinet/in.h>                       // for in_addr, in6_addr
+#include <stddef.h>                           // for size_t
+#include <stdint.h>                           // for uint32_t, uint16_t, uin...
+#include <fluid/ofcommon/openflow-common.hh>  // for fluid_msg
+#include <string>                             // for string
+#include "gtpv1u.h"                           // for ip_flow_dl
+namespace fluid_base {
+class OFConnection;
+}
+namespace fluid_base {
+class OFHandler;
+}
 
 using namespace fluid_msg;
 

--- a/lte/gateway/c/core/oai/lib/openflow/controller/ControllerMain.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/ControllerMain.cpp
@@ -15,15 +15,24 @@
  *      contact@openairinterface.org
  */
 
-#include "OpenflowController.h"
-#include "PagingApplication.h"
-#include "BaseApplication.h"
 #include "ControllerMain.h"
-#include "GTPApplication.h"
+#include <netinet/in.h>          // for in_addr
+#include <stddef.h>              // for NULL
+#include <memory>                // for make_shared, static_pointer_cast
+#include <string>                // for string
+#include "BaseApplication.h"     // for BaseApplication
+#include "ControllerEvents.h"    // for HandleDataOnGTPTunnelEvent, AddGTPTu...
+#include "GTPApplication.h"      // for GTPApplication
+#include "OpenflowController.h"  // for OpenflowController
+#include "PagingApplication.h"   // for PagingApplication
+
 extern "C" {
-#include "log.h"
-#include "spgw_config.h"
-#include "common_defs.h"
+#include "bstrlib.h"      // for bdata
+#include "common_defs.h"  // for RETURNok
+#include "log.h"          // for OAILOG_FUNC_RETURN, LOG_GTPV1U, OAIL...
+#include "pgw_config.h"   // for pgw_config_t
+#include "sgw_config.h"   // for ovs_config_t, sgw_config_t
+#include "spgw_config.h"  // for spgw_config, spgw_config_t
 }
 
 static const int OFP_LOCAL   = 65534;

--- a/lte/gateway/c/core/oai/lib/openflow/controller/ControllerMain.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/ControllerMain.h
@@ -17,8 +17,7 @@
 
 #pragma once
 
-#include <stdbool.h>
-#include "gtpv1u.h"
+#include <stdint.h>  // for uint32_t
 
 #ifdef __cplusplus
 extern "C" {

--- a/lte/gateway/c/core/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/GTPApplication.cpp
@@ -15,17 +15,27 @@
  *      contact@openairinterface.org
  */
 
-#include <netinet/ip.h>
-#include <arpa/inet.h>
-#include <string>
-
 #include "GTPApplication.h"
-#include "IMSIEncoder.h"
-#include "gtpv1u.h"
+#include <fluid/of13/openflow-13.h>           // for OFPFC_ADD, OFPG_ANY
+#include <netinet/in.h>                       // for in_addr, in6_addr, INAD...
+#include <fluid/of13/of13action.hh>           // for SetFieldAction, PushVLA...
+#include <fluid/of13/of13instruction.hh>      // for ApplyActions, GoToTable
+#include <fluid/of13/of13match.hh>            // for InPort, EthType, NXMRegX
+#include <fluid/of13msg.hh>                   // for FlowMod
+#include <fluid/ofcommon/openflow-common.hh>  // for fluid_msg
+#include <fluid/util/ethaddr.hh>              // for EthAddress
+#include <fluid/util/ipaddr.hh>               // for IPAddress
+#include <string>                             // for string
+#include "ControllerEvents.h"                 // for AddGTPTunnelEvent, Dele...
+#include "IMSIEncoder.h"                      // for IMSIEncoder
+#include "OpenflowMessenger.h"                // for OpenflowMessenger
+#include "gtpv1u.h"                           // for ip_flow_dl, ip_flow_dl:...
+namespace fluid_base {
+class OFConnection;
+}
 
 extern "C" {
-#include "log.h"
-#include "bstrlib.h"
+#include "log.h"  // for LOG_GTPV1U, OAILOG_DEBU...
 }
 
 using namespace fluid_msg;

--- a/lte/gateway/c/core/oai/lib/openflow/controller/GTPApplication.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/GTPApplication.h
@@ -17,10 +17,32 @@
 
 #pragma once
 
-#include <gmp.h>  // gross but necessary to link spgw_config.h
-
-#include "OpenflowController.h"
-#include "gtpv1u.h"
+#include <stdint.h>              // for uint32_t, uint16_t, uint64_t
+#include <string>                // for string
+#include "OpenflowController.h"  // for Application
+namespace fluid_base {
+class OFConnection;
+}
+namespace fluid_msg {
+namespace of13 {
+class FlowMod;
+}
+}  // namespace fluid_msg
+namespace openflow {
+class AddGTPTunnelEvent;
+}
+namespace openflow {
+class ControllerEvent;
+}
+namespace openflow {
+class DeleteGTPTunnelEvent;
+}
+namespace openflow {
+class HandleDataOnGTPTunnelEvent;
+}
+namespace openflow {
+class OpenflowMessenger;
+}
 
 namespace openflow {
 

--- a/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.cpp
@@ -15,15 +15,19 @@
  *      contact@openairinterface.org
  */
 
-#include <thread>
-#include <mutex>
-#include <chrono>
-#include <condition_variable>
 #include "OpenflowController.h"
-#include "ControllerMain.h"
+#include <chrono>                             // for seconds
+#include <condition_variable>                 // for condition_variable, cv_...
+#include <cstdint>                            // for uint32_t, uint8_t
+#include <fluid/OFServerSettings.hh>          // NOLINT for OFServerSettings
+#include <fluid/base/EventLoop.hh>            // NOLINT for fluid_base
+#include <fluid/ofcommon/openflow-common.hh>  // NOLINT for fluid_msg
+#include <mutex>                              // NOLINT for mutex, lock_guard, uniq...
+#include <stdexcept>                          // NOLINT for runtime_error
+#include "OpenflowMessenger.h"                // NOLINT for DefaultMessenger, Openf...
 extern "C" {
-#include "log.h"
-#include "common_defs.h"
+#include "log.h"          // NOLINT for LOG_GTPV1U, OAILOG_INFO
+#include "common_defs.h"  // NOLINT for RETURNok, RETURNerror
 }
 
 using namespace fluid_base;

--- a/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowController.h
@@ -17,16 +17,20 @@
 
 #pragma once
 
-#include <unordered_map>
-#include <list>
+#include <stddef.h>  // for size_t
+#include <stdint.h>  // for uint8_t, uint32_t
+// TODO: Once #5146 is resolved this can be included without <memory>
 #include <memory>
-
-#include <fluid/OFServer.hh>
-
-#include "ControllerEvents.h"
-#include "OpenflowMessenger.h"
-#include "common_defs.h"
-
+#include <fluid/OFConnection.hh>  // NOLINT for OFConnection, OFConnection::Event
+#include <fluid/OFServer.hh>      // NOLINT for OFServer
+#include <memory>                 // NOLINT for shared_ptr
+#include <unordered_map>          // NOLINT for unordered_map
+#include <vector>                 // NOLINT for vector
+#include "ControllerEvents.h"     // NOLINT for ControllerEvent (ptr only), Control...
+#include "common_defs.h"          // NOLINT for status_code_e
+namespace openflow {
+class OpenflowMessenger;
+}
 namespace openflow {
 
 #define IP_ETH_TYPE 0x0800

--- a/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowMessenger.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowMessenger.cpp
@@ -16,7 +16,8 @@
  */
 
 #include "OpenflowMessenger.h"
-
+#include <fluid/OFConnection.hh>  // for OFConnection
+#include <fluid/ofcommon/msg.hh>  // for OFMsg
 namespace openflow {
 
 fluid_msg::of13::FlowMod DefaultMessenger::create_default_flow_mod(

--- a/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowMessenger.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/OpenflowMessenger.h
@@ -17,8 +17,18 @@
 
 #pragma once
 
-#include <fluid/of13msg.hh>
-#include <fluid/OFServer.hh>
+// TODO: Once #5146 is resolved this can be included without <memory>
+#include <memory>                    // NOLINT
+#include <fluid/of13/openflow-13.h>  // NOLINT for ofp_flow_mod_command
+#include <fluid/of13msg.hh>          // NOLINT for FlowMod
+#include <stdint.h>                  // NOLINT for uint16_t, uint8_t
+
+namespace fluid_base {
+class OFConnection;
+}
+namespace fluid_msg {
+class OFMsg;
+}
 
 namespace openflow {
 /**

--- a/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.cpp
@@ -15,15 +15,28 @@
  *      contact@openairinterface.org
  */
 
-#include <netinet/ip.h>
-#include <arpa/inet.h>
-#include "OpenflowController.h"
 #include "PagingApplication.h"
-#include "MobilityClientAPI.h"
+#include <arpa/inet.h>                        // for inet_ntoa, inet_ntop
+#include <fluid/of13/openflow-13.h>           // for OFPCML_NO_BUFFER, OFPFC...
+#include <netinet/in.h>                       // for htonl, in_addr, INET_AD...
+#include <netinet/ip.h>                       // for ip
+#include <string.h>                           // for memcpy
+#include <sys/socket.h>                       // for AF_INET
+#include <fluid/of13/of13action.hh>           // for OutputAction
+#include <fluid/of13/of13instruction.hh>      // for ApplyActions
+#include <fluid/of13/of13match.hh>            // for EthType, IPv4Dst
+#include <fluid/of13msg.hh>                   // for FlowMod, PacketIn
+#include <fluid/ofcommon/openflow-common.hh>  // for fluid_msg
+#include <fluid/util/ipaddr.hh>               // for IPAddress
+#include "OpenflowController.h"               // for IP_ETH_TYPE
+#include "OpenflowMessenger.h"                // for OpenflowMessenger
+namespace fluid_base {
+class OFConnection;
+}
 
 extern "C" {
-#include "log.h"
-#include "sgw_paging.h"
+#include "log.h"         // for LOG_GTPV1U, OAILOG_DEBUG
+#include "sgw_paging.h"  // for sgw_send_paging_request
 }
 
 using namespace fluid_msg;

--- a/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.h
@@ -17,8 +17,15 @@
 
 #pragma once
 
-#include "OpenflowController.h"
-
+#include <stdint.h>              // for uint8_t
+#include "ControllerEvents.h"    // for AddPagingRuleEvent, ControllerEvent ...
+#include "OpenflowController.h"  // for Application
+namespace fluid_base {
+class OFConnection;
+}
+namespace openflow {
+class OpenflowMessenger;
+}
 namespace openflow {
 #define ETH_HEADER_LENGTH 14
 

--- a/lte/gateway/c/core/oai/lib/pcef/PCEFClient.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/PCEFClient.cpp
@@ -15,17 +15,18 @@
  *      contact@openairinterface.org
  */
 
-#include <grpcpp/channel.h>
-#include <grpcpp/impl/codegen/async_unary_call.h>
-#include <thread>
-#include <iostream>
-#include <string>
-#include <utility>
-
-#include "orc8r/protos/mconfig/mconfigs.pb.h"
 #include "PCEFClient.h"
-#include "includes/ServiceRegistrySingleton.h"
-#include "lte/protos/session_manager.pb.h"
+#include <grpcpp/channel.h>                        // IWYU pragma: keep
+#include <grpcpp/impl/codegen/async_unary_call.h>  // for default_delete
+#include <includes/GRPCReceiver.h>                 // for AsyncLocalResponse
+#include <iostream>                                // for operator<<, basic_...
+#include <thread>                                  // for thread
+#include <utility>                                 // for move
+#include "includes/ServiceRegistrySingleton.h"     // for ServiceRegistrySin...
+#include "lte/protos/session_manager.pb.h"         // for LocalCreateSession...
+namespace grpc {
+class Channel;
+}
 
 namespace grpc {
 class Status;

--- a/lte/gateway/c/core/oai/lib/pcef/PCEFClient.h
+++ b/lte/gateway/c/core/oai/lib/pcef/PCEFClient.h
@@ -17,24 +17,54 @@
 
 #pragma once
 
-#include <grpc++/grpc++.h>
-#include <stdint.h>
-#include <functional>
-#include <memory>
-
-#include "lte/protos/session_manager.grpc.pb.h"
-#include "includes/GRPCReceiver.h"
-
+#include <stdint.h>                              // for uint32_t
+#include <functional>                            // for function
+#include <memory>                                // for unique_ptr
+#include "includes/GRPCReceiver.h"               // for GRPCReceiver
+#include "lte/protos/apn.pb.h"                   // for lte
+#include "lte/protos/session_manager.grpc.pb.h"  // for LocalSessionManager:...
 namespace grpc {
 class Status;
 }  // namespace grpc
 namespace magma {
 namespace lte {
 class LocalCreateSessionRequest;
+}
+}  // namespace magma
+namespace magma {
+namespace lte {
 class LocalCreateSessionResponse;
+}
+}  // namespace magma
+namespace magma {
+namespace lte {
+class LocalEndSessionRequest;
+}
+}  // namespace magma
+namespace magma {
+namespace lte {
 class LocalEndSessionResponse;
-class SubscriberID;
-}  // namespace lte
+}
+}  // namespace magma
+namespace magma {
+namespace lte {
+class PolicyBearerBindingRequest;
+}
+}  // namespace magma
+namespace magma {
+namespace lte {
+class PolicyBearerBindingResponse;
+}
+}  // namespace magma
+namespace magma {
+namespace lte {
+class UpdateTunnelIdsRequest;
+}
+}  // namespace magma
+namespace magma {
+namespace lte {
+class UpdateTunnelIdsResponse;
+}
 }  // namespace magma
 
 using grpc::Status;

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -15,29 +15,34 @@
  *      contact@openairinterface.org
  */
 
-#include <grpcpp/impl/codegen/status.h>
-#include <cstring>
-#include <string>
-#include <conversions.h>
-#include <common_defs.h>
+#include "pcef_handlers.h"
+#include <arpa/inet.h>                      // for inet_ntop
+#include <conversions.h>                    // for IMSI_STRING_TO_IMSI64
+#include <grpcpp/impl/codegen/status.h>     // for Status
+#include <sys/socket.h>                     // for AF_INET
+#include <cstring>                          // for memcpy
+#include <string>                           // for string, allocator, operator+
+#include "lte/protos/session_manager.pb.h"  // for LTESessionContext, QosInf...
+#include "lte/protos/subscriberdb.pb.h"     // for SubscriberID
+#include "PCEFClient.h"                     // for PCEFClient
+#include "TrackingAreaIdentity.h"           // for tai_t
+#include "3gpp_23.003.h"                    // for imeisv_s::(anonymous unio...
+#include "3gpp_24.007.h"                    // for ebi_t
+#include "3gpp_29.274.h"                    // for bearer_qos_t
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "common_defs.h"
-#include "log.h"
+#include "intertask_interface.h"        // for itti_alloc_new_message
+#include "intertask_interface_types.h"  // for MessageDef, MessageHeader
+#include "common_defs.h"                // for RETURNerror, status_code_e
+#include "log.h"                        // for LOG_SPGW_APP, OAILOG_DEBUG
+#include "spgw_types.h"                 // for s5_create_session_request_t
 
 #ifdef __cplusplus
 }
 #endif
-
-#include "pcef_handlers.h"
-#include "PCEFClient.h"
-#include "MobilityClientAPI.h"
-#include "itti_types.h"
-#include "lte/protos/session_manager.pb.h"
-#include "spgw_types.h"
 
 extern task_zmq_ctx_t grpc_service_task_zmq_ctx;
 

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.h
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.h
@@ -17,17 +17,15 @@
 
 #pragma once
 
-#include <gmp.h>
-#include <netinet/in.h>
-#include <stdint.h>
+#include <netinet/in.h>  // for INET_ADDRSTRLEN
+#include <stdint.h>      // for uint32_t, uint8_t
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "intertask_interface.h"
-#include "common_types.h"
-#include "ip_forward_messages_types.h"
-#include "spgw_types.h"
+#include "common_types.h"        // for APN_MAX_LENGTH, IMEISV_DIGITS_MAX
+#include "s11_messages_types.h"  // for itti_s11_create_session_request_t
+#include "spgw_types.h"          // for s5_create_session_request_t, spgw_st...
 
 struct pcef_create_session_data {
   char msisdn[MSISDN_LENGTH + 1];

--- a/lte/gateway/c/core/oai/lib/secu/kdf.c
+++ b/lte/gateway/c/core/oai/lib/secu/kdf.c
@@ -15,13 +15,13 @@
  *      contact@openairinterface.org
  */
 
-#include <stdlib.h>
-#include <stdint.h>
-#include <nettle/hmac.h>
-
-#include "security_types.h"
-#include "secu_defs.h"
-#include "dynamic_memory_check.h"
+#include <nettle/hmac.h>           // for hmac_sha256_ctx, hmac_sha256_digest
+#include <stdint.h>                // for uint8_t, uint32_t
+#include <stdlib.h>                // for calloc
+#include <string.h>                // for memcpy
+#include "dynamic_memory_check.h"  // for free_wrapper
+#include "secu_defs.h"             // for derive_NH, derive_keNB, kdf
+#include "security_types.h"        // for FC_KENB, FC_NH
 
 void kdf(
     const uint8_t* key, const unsigned key_len, uint8_t* s,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -11,6 +11,7 @@
  * limitations under the License.
  */
 #include <libconfig.h>
+#include <limits.h>
 #include "log.h"
 #include <errno.h>
 #include "3gpp_24.501.h"

--- a/lte/gateway/c/core/oai/test/openflow/openflow_mocks.h
+++ b/lte/gateway/c/core/oai/test/openflow/openflow_mocks.h
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 
 #include "OpenflowController.h"
+#include "OpenflowMessenger.h"  // for DefaultMessenger, Openf...
 
 using namespace openflow;
 using namespace fluid_base;


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I've been seeing inaccurate set of includes in MME, this causes confusion when trying to figure out the correct dependency to add for bazel. (For example, I thought intertask_interface.c depended on shared_ts_log.h, but it was just a misplaced #include https://github.com/magma/magma/issues/9819)

 I ran the Include-What-You-Use tool on MME (see result attched and repro steps here https://github.com/magma/magma/issues/9839), and this PR attempts to address the following directories

* `oai/common`
* `oai/lib/itti`
* `oai/lib/hashtable`
* `oai/lib/openflow`
* `oai/lib/pcef`

<!-- Enumerate changes you made and why you made them -->

## Test Plan
make test_oai
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
