### PR TITLE
fix(pipelined): Adding support for read enable5g_features flag from available config file

### DIFF
--- a/lte/gateway/c/core/oai/include/pgw_config.h
+++ b/lte/gateway/c/core/oai/include/pgw_config.h
@@ -80,6 +80,8 @@
 #define PGW_CONFIG_DNS_SERVER_IPV6_ADDRESS "DNS_SERVER_IPV6_ADDRESS"
 
 #define PGW_CONFIG_STRING_NAT_ENABLED "ENABLE_NAT"
+#define PGW_CONFIG_STRING_ENABLE5G_FEATURES "ENABLE5G_FEATURES"
+#define PGW_CONFIG_STRING_UPF_NODE_IDENTIFIER "UPF_NODE_IDENTIFIER"
 
 // may be more
 #define PGW_MAX_ALLOCATED_PDN_ADDRESSES 1024
@@ -116,6 +118,8 @@ typedef struct pgw_config_s {
   bool force_push_pco;
   uint16_t ue_mtu;
   bool enable_nat;
+  bool enable5g_features;
+  struct in_addr upf_node_identifier;
 
   struct {
     bool enabled;

--- a/lte/gateway/configs/spgw.yml
+++ b/lte/gateway/configs/spgw.yml
@@ -20,6 +20,7 @@ ipv4_dns: "8.8.8.8" # will be replaced by dnsd if caching is enabled
 ipv4_sec_dns: "8.8.4.4"
 ovs_bridge_name: "gtp_br0"
 ovs_uplink_mac: "ff:ff:ff:ff:ff:ff"
+upf_node_identifier: "192.168.200.1"
 
 # Interface used for determing MTU
 pgw_uplink: "gtp_br0"

--- a/lte/gateway/configs/templates/spgw.conf.template
+++ b/lte/gateway/configs/templates/spgw.conf.template
@@ -90,5 +90,7 @@ P-GW =
     FORCE_PUSH_PROTOCOL_CONFIGURATION_OPTIONS = "no";                           # STRING, {"yes", "no"}.
     UE_MTU                                    = 1400         # MTU - (extended GTPv1 hdr(16 Bytes) + UDP hdr(8) -IPv4(20) hdr + additonal bytes(56)) INTEGER
     RELAY_ENABLED                             = "{{ relay_enabled }}";
-    ENABLE_NAT                                = "{{ enable_nat }}"
+    ENABLE_NAT                                = "{{ enable_nat }}";
+    ENABLE5G_FEATURES                         = "{{ enable5g_features }}";
+    UPF_NODE_IDENTIFIER                       = "{{ upf_node_identifier }}";
 };


### PR DESCRIPTION

fix(pipelined): Adding support for read enable5g_features flag from available config file

## Summary

Existing Problem : In teravm setup always TC2 & TC9 are getting failed in daily jenkins. The reason was in teravm setup `enable5g_features` flag is reading from /var/opt/magma/configs/pipelined.yml file, but current pipelined code is reading from /etc/magma/pipelined.yml file. Also `periodic_stats_reporting` flag was set to `true` by default due to this traffic was failing.

Solution :
1) Added support for reading `enable5g_features` flag based on the available config file /var/opt/magma/configs/pipelined.yml or /etc/magma/pipelined.yml and set the default value of `enable5g_features` flag to `true` in /etc/magma/pipelined.yml
2) Also `periodic_stats_reporting` flag set to `false` by default in /etc/magma/pipelined.yml
3) In sessiond `enable5g_features` flag set to `true` by default in /etc/magma/sessiond.yml

## Test Plan
Tested the PDU session establishment & release with stubbed CLI magma/lte/gateway/python/scripts/smf_upf_integration_cli.py
For test logs and screen shots please refer below comment.

## Additional Information
Corresponding git hub issue IDs are #9638 #9012 

