### PR TITLE
fix(agw): magma-dev VM IPv6 config

### DIFF
--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -443,3 +443,7 @@
     state: latest
     pkg:
       - magma-libfluid
+
+- name: Set IPv6 address for magma dev
+  retries: 5
+  shell: ip -6 a add  2020::10/64 dev eth0 && ip -6 r add default via 2020::1


### PR DESCRIPTION
Setting the IPv6 address in Vagrantfile does not
work in all cases.
Try setting the IPv6 address in ansible role.

Signed-off-by: Pravin B Shelar <pravin.ovn@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
