### PR TITLE
test(mme): Adding unit tests for S1AP state converter

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -62,8 +62,7 @@
 #endif
 
 bool s1ap_dump_ue_hash_cb(
-    const hash_key_t keyP, void* const ue_void, void* parameter,
-    void** unused_res);
+    hash_key_t keyP, void* ue_void, void* parameter, void** unused_res);
 static void start_stats_timer(void);
 static int handle_stats_timer(zloop_t* loop, int id, void* arg);
 static long epc_stats_timer_id;
@@ -447,7 +446,7 @@ void s1ap_dump_ue(const ue_description_t* const ue_ref) {
 }
 
 //------------------------------------------------------------------------------
-enb_description_t* s1ap_new_enb(s1ap_state_t* state) {
+enb_description_t* s1ap_new_enb(void) {
   enb_description_t* enb_ref = NULL;
 
   enb_ref = calloc(1, sizeof(enb_description_t));

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.h
@@ -51,17 +51,17 @@ void s1ap_mme_exit(void);
  * Calls dump_ue for each UE in list
  * \param enb_ref eNB structure reference to dump
  **/
-void s1ap_dump_enb(const enb_description_t* const enb_ref);
+void s1ap_dump_enb(const enb_description_t* enb_ref);
 
 /** \brief Dump UE related information.
  * \param ue_ref ue structure reference to dump
  **/
-void s1ap_dump_ue(const ue_description_t* const ue_ref);
+void s1ap_dump_ue(const ue_description_t* ue_ref);
 
 /** \brief Allocate and add to the list a new eNB descriptor
  * @returns Reference to the new eNB element in list
  **/
-enb_description_t* s1ap_new_enb(s1ap_state_t* state);
+enb_description_t* s1ap_new_enb(void);
 
 /** \brief Allocate and add to the right eNB list a new UE descriptor
  * \param sctp_assoc_id association ID over SCTP
@@ -69,7 +69,7 @@ enb_description_t* s1ap_new_enb(s1ap_state_t* state);
  * @returns Reference to the new UE element in list
  **/
 ue_description_t* s1ap_new_ue(
-    s1ap_state_t* state, const sctp_assoc_id_t sctp_assoc_id,
+    s1ap_state_t* state, sctp_assoc_id_t sctp_assoc_id,
     enb_ue_s1ap_id_t enb_ue_s1ap_id);
 
 /** \brief Remove target UE from the list

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -3720,7 +3720,7 @@ status_code_e s1ap_handle_new_association(
     /*
      * Create new context
      */
-    enb_association = s1ap_new_enb(state);
+    enb_association = s1ap_new_enb();
 
     if (enb_association == NULL) {
       /*

--- a/lte/gateway/c/core/oai/test/s1ap_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/s1ap_task/CMakeLists.txt
@@ -22,7 +22,8 @@ add_executable(s1ap_test
         s1ap_test.cpp
         test_s1ap_mme_handlers.cpp
         test_s1ap_handle_new_association.cpp
-        test_s1ap_state_manager.cpp)
+        test_s1ap_state_manager.cpp
+        test_s1ap_state_converter.cpp)
 
 target_link_libraries(s1ap_test
         TASK_S1AP MOCK_TASKS

--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_state_converter.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_state_converter.cpp
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "log.h"
+#include "S1ap_S1AP-PDU.h"
+#include "s1ap_mme_handlers.h"
+}
+
+#include "s1ap_state_converter.h"
+#include "s1ap_state_manager.h"
+
+using ::testing::Test;
+
+namespace magma {
+namespace lte {
+
+class S1APStateConverterTest : public ::testing::Test {
+  virtual void SetUp() {}
+
+  virtual void TearDown() {}
+};
+
+TEST_F(S1APStateConverterTest, S1apStateConversionSuccess) {
+  sctp_assoc_id_t assoc_id  = 1;
+  s1ap_state_t* init_state  = create_s1ap_state(2, 2);
+  s1ap_state_t* final_state = create_s1ap_state(2, 2);
+
+  enb_description_t* enb_association = s1ap_new_enb();
+  enb_association->sctp_assoc_id     = assoc_id;
+  enb_association->enb_id            = 0xFFFFFFFF;
+  enb_association->s1_state          = S1AP_READY;
+
+  // filling ue_id_coll
+  hashtable_uint64_ts_insert(
+      &enb_association->ue_id_coll, (const hash_key_t) 1, 17);
+  hashtable_uint64_ts_insert(
+      &enb_association->ue_id_coll, (const hash_key_t) 2, 25);
+
+  // filling supported_tai_items
+  supported_ta_list_t* enb_ta_list        = &enb_association->supported_ta_list;
+  enb_ta_list->list_count                 = 1;
+  enb_ta_list->supported_tai_items[0].tac = 1;
+  enb_ta_list->supported_tai_items[0].bplmnlist_count      = 1;
+  enb_ta_list->supported_tai_items[0].bplmns[0].mcc_digit1 = 1;
+  enb_ta_list->supported_tai_items[0].bplmns[0].mcc_digit2 = 1;
+  enb_ta_list->supported_tai_items[0].bplmns[0].mcc_digit3 = 1;
+  enb_ta_list->supported_tai_items[0].bplmns[0].mnc_digit1 = 1;
+  enb_ta_list->supported_tai_items[0].bplmns[0].mnc_digit2 = 1;
+  enb_ta_list->supported_tai_items[0].bplmns[0].mnc_digit3 = 1;
+
+  // Inserting 1 enb association
+  hashtable_ts_insert(
+      &init_state->enbs, (const hash_key_t) enb_association->sctp_assoc_id,
+      (void*) enb_association);
+  init_state->num_enbs = 1;
+
+  hashtable_ts_insert(
+      &init_state->mmeid2associd, (const hash_key_t) 1, (void**) &assoc_id);
+
+  oai::S1apState state_proto;
+  S1apStateConverter::state_to_proto(init_state, &state_proto);
+  S1apStateConverter::proto_to_state(state_proto, final_state);
+
+  EXPECT_EQ(init_state->num_enbs, final_state->num_enbs);
+  enb_description_t* enbd       = nullptr;
+  enb_description_t* enbd_final = nullptr;
+  EXPECT_EQ(
+      hashtable_ts_get(
+          &init_state->enbs, (const hash_key_t) assoc_id,
+          reinterpret_cast<void**>(&enbd)),
+      HASH_TABLE_OK);
+  EXPECT_EQ(
+      hashtable_ts_get(
+          &final_state->enbs, (const hash_key_t) assoc_id,
+          reinterpret_cast<void**>(&enbd_final)),
+      HASH_TABLE_OK);
+
+  EXPECT_EQ(enbd->sctp_assoc_id, enbd_final->sctp_assoc_id);
+  EXPECT_EQ(enbd->enb_id, enbd_final->enb_id);
+  EXPECT_EQ(enbd->s1_state, enbd_final->s1_state);
+
+  EXPECT_EQ(
+      enbd->supported_ta_list.list_count,
+      enbd_final->supported_ta_list.list_count);
+  EXPECT_EQ(
+      enbd->supported_ta_list.supported_tai_items[0].tac,
+      enbd_final->supported_ta_list.supported_tai_items[0].tac);
+
+  free_s1ap_state(init_state);
+  free_s1ap_state(final_state);
+}
+
+TEST_F(S1APStateConverterTest, S1apStateConversionExpectedEnbCount) {
+  sctp_assoc_id_t assoc_id  = 1;
+  s1ap_state_t* init_state  = create_s1ap_state(2, 2);
+  s1ap_state_t* final_state = create_s1ap_state(2, 2);
+
+  enb_description_t* enb_association = s1ap_new_enb();
+  enb_association->sctp_assoc_id     = assoc_id;
+  enb_association->enb_id            = 0xFFFFFFFF;
+  enb_association->s1_state          = S1AP_READY;
+  // Inserting 1 enb association
+  hashtable_ts_insert(
+      &init_state->enbs, (const hash_key_t) enb_association->sctp_assoc_id,
+      (void*) enb_association);
+  // state_to_proto should update num_enbs to match expected eNB count on the
+  // hashtable
+  init_state->num_enbs = 5;
+
+  oai::S1apState state_proto;
+  S1apStateConverter::state_to_proto(init_state, &state_proto);
+  EXPECT_EQ(init_state->num_enbs, 1);
+
+  S1apStateConverter::proto_to_state(state_proto, final_state);
+  EXPECT_EQ(final_state->num_enbs, 1);
+
+  free_s1ap_state(init_state);
+  free_s1ap_state(final_state);
+}
+
+TEST_F(S1APStateConverterTest, S1apStateConversionUeContext) {
+  ue_description_t* ue =
+      (ue_description_t*) calloc(1, sizeof(ue_description_t));
+  ue_description_t* final_ue =
+      (ue_description_t*) calloc(1, sizeof(ue_description_t));
+
+  // filling with test values
+  ue->mme_ue_s1ap_id                     = 1;
+  ue->enb_ue_s1ap_id                     = 1;
+  ue->sctp_assoc_id                      = 1;
+  ue->comp_s1ap_id                       = S1AP_GENERATE_COMP_S1AP_ID(1, 1);
+  ue->s1ap_handover_state.mme_ue_s1ap_id = 1;
+  ue->s1ap_handover_state.source_enb_id  = 1;
+  ue->s1ap_ue_context_rel_timer.id       = 1;
+  ue->s1ap_ue_context_rel_timer.msec     = 1000;
+
+  oai::UeDescription ue_proto;
+  S1apStateConverter::ue_to_proto(ue, &ue_proto);
+  S1apStateConverter::proto_to_ue(ue_proto, final_ue);
+
+  EXPECT_EQ(ue->comp_s1ap_id, final_ue->comp_s1ap_id);
+  EXPECT_EQ(ue->mme_ue_s1ap_id, final_ue->mme_ue_s1ap_id);
+  EXPECT_EQ(
+      ue->s1ap_ue_context_rel_timer.id, final_ue->s1ap_ue_context_rel_timer.id);
+
+  free_wrapper((void**) &ue);
+  free_wrapper((void**) &final_ue);
+}
+
+}  // namespace lte
+}  // namespace magma


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adds unit test coverage for the S1AP state converter
- Applied clang-tidy on s1ap state related code

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- `make test_oai`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
