### PR TITLE
fix(orc8r): remove min/max from  opc lte key swagger definition

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/models/network_epc_configs_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/network_epc_configs_swaggergen.go
@@ -47,8 +47,6 @@ type NetworkEpcConfigs struct {
 
 	// lte auth op
 	// Required: true
-	// Max Length: 16
-	// Min Length: 15
 	// Format: byte
 	LteAuthOp strfmt.Base64 `json:"lte_auth_op"`
 
@@ -196,14 +194,6 @@ func (m *NetworkEpcConfigs) validateLteAuthAmf(formats strfmt.Registry) error {
 func (m *NetworkEpcConfigs) validateLteAuthOp(formats strfmt.Registry) error {
 
 	if err := validate.Required("lte_auth_op", "body", strfmt.Base64(m.LteAuthOp)); err != nil {
-		return err
-	}
-
-	if err := validate.MinLength("lte_auth_op", "body", string(m.LteAuthOp), 15); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("lte_auth_op", "body", string(m.LteAuthOp), 16); err != nil {
 		return err
 	}
 

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -1710,8 +1710,6 @@ definitions:
         type: string
         format: byte
         example: EREREREREREREREREREREQ==
-        minLength: 15
-        maxLength: 16
         x-nullable: false
       lte_auth_amf:
         type: string

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -9977,8 +9977,6 @@ definitions:
       lte_auth_op:
         example: EREREREREREREREREREREQ==
         format: byte
-        maxLength: 16
-        minLength: 15
         type: string
         x-nullable: false
       mcc:


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

It looks like previous swagger-ui was not checking the min/max length defined on swagger properly. Since we updated swagger ui lte federated network post method was failing. It looks like the new ui version does check the length. 

Length of the `lte_auth_op` is not properly defined there. Removing it from the definition same we have in the rest of `lte_auth_op` fields on swagger (like in [HSS](https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Amagma%2Fmagma.git&branch=master&file=orc8r%2Fcloud%2Fswagger%2Fspecs%2Fpartial%2Ffeg.swagger.v1.yml&editor=JetBrains&version=v1.2.1&utm_product_name=IntelliJ+IDEA&utm_product_version=2021.2.2&start_row=848&start_col=17&end_row=848&end_col=17))

## Test Plan
The request was taken properly
![image](https://user-images.githubusercontent.com/16157139/138575277-2b97088e-0e01-45b5-b024-484b01c32c2c.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
