### PR TITLE
fix(agw): Enable opt-in based logging to Sentry

### DIFF
--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -17,7 +17,7 @@ from typing import Any, Optional
 from lte.protos.mconfig import mconfigs_pb2
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
 from magma.common.redis.client import get_default_client
-from magma.common.sentry import sentry_init
+from magma.common.sentry import SEND_TO_SENTRY, sentry_init
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
 from magma.mobilityd.ip_address_man import IPAddressManager
@@ -115,8 +115,9 @@ def main():
     service = MagmaService('mobilityd', mconfigs_pb2.MobilityD())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, requires_opt_in=True)
 
+    logging.error("Explicit logging test", extra=SEND_TO_SENTRY)
     # Load service configs and mconfig
     config = service.config
     mconfig = service.mconfig

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -32,7 +32,7 @@ from lte.protos.mobilityd_pb2_grpc import (
     add_MobilityServiceServicer_to_server,
 )
 from lte.protos.subscriberdb_pb2 import SubscriberID
-from magma.common.rpc_utils import return_void
+from magma.common.rpc_utils import log_error_sentry, return_void
 from magma.subscriberdb.sid import SIDUtils
 
 from .ip_address_man import (
@@ -89,6 +89,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._ip_address_man.add_ip_block(ip_block)
 
     @return_void
+    @log_error_sentry
     def AddIPBlock(self, request, context):
         """ Add a range of IP addresses into the free IP pool
 

--- a/orc8r/gateway/python/magma/common/rpc_utils.py
+++ b/orc8r/gateway/python/magma/common/rpc_utils.py
@@ -19,6 +19,7 @@ from enum import Enum
 import grpc
 from google.protobuf import message as proto_message
 from google.protobuf.json_format import MessageToJson
+from magma.common.sentry import SEND_TO_SENTRY
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos import common_pb2
 
@@ -39,6 +40,21 @@ def return_void(func):
     def wrapper(*args, **kwargs):
         func(*args, **kwargs)
         return common_pb2.Void()
+
+    return wrapper
+
+
+def log_error_sentry(func):
+    """
+    Reusable decorator for logging unexpected exceptions.
+    """
+
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as err:
+            logging.error("Uncaught error in gRPC request", exc_info=True, extra=SEND_TO_SENTRY)
+            raise err
 
     return wrapper
 

--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -10,8 +10,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
 import os
+from typing import Any, Dict, Optional
 
 import sentry_sdk
 import snowflake
@@ -24,10 +24,25 @@ SENTRY_SAMPLE_RATE = 'sentry_sample_rate'
 COMMIT_HASH = 'COMMIT_HASH'
 HWID = 'hwid'
 SERVICE_NAME = 'service_name'
+LOGGING_EXTRA = 'extra'
+SEND_TO_SENTRY_KEY = "send_to_sentry"
+SEND_TO_SENTRY = {SEND_TO_SENTRY_KEY: True}
 
 
-def sentry_init(service_name: str):
-    """Initialize connection and start piping errors to sentry.io."""
+def _ignore_if_not_marked(event: Dict[str, Any], hint: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if event.get(LOGGING_EXTRA) and event.get(LOGGING_EXTRA).get(SEND_TO_SENTRY_KEY):
+        return event
+    return None
+
+
+def sentry_init(service_name: str, requires_opt_in=False):
+    """ Initialize connection and start piping errors to sentry.io.
+
+    Args:
+        service_name: Name of the service that uses Sentry
+        requires_opt_in: If set to True, only errors that are explicitly
+        marked will be sent to Sentry. Otherwise all log errors will
+        be sent. To mark an error, set `extra=SEND_TO_SENTRY` in an error log."""
     sentry_enabled = get_service_config_value(
         service_name,
         SENTRY_ENABLED,
@@ -53,6 +68,7 @@ def sentry_init(service_name: str):
         dsn=sentry_url,
         release=os.getenv(COMMIT_HASH),
         traces_sample_rate=sentry_sample_rate,
+        before_send=_ignore_if_not_marked if requires_opt_in else None,
     )
     sentry_sdk.set_tag(HWID, snowflake.snowflake())
     sentry_sdk.set_tag(SERVICE_NAME, service_name)


### PR DESCRIPTION
Makes it possible to select only a subset of log messages to be
sent to Sentry instead of everything above a certain log level.

Includes example that use the feature in mobilityd. These should
be removed before merging.