### PR TITLE
test(mme): Initial framework for SPGW procedure unit tests

### DIFF
--- a/lte/gateway/c/core/oai/include/sgw_context_manager.h
+++ b/lte/gateway/c/core/oai/include/sgw_context_manager.h
@@ -58,6 +58,7 @@ int sgw_cm_remove_eps_bearer_entry(
 // Returns SPGW state pointer for given UE indexed by IMSI
 s_plus_p_gw_eps_bearer_context_information_t* sgw_cm_get_spgw_context(
     teid_t teid);
+spgw_ue_context_t* spgw_get_ue_context(imsi64_t imsi64);
 spgw_ue_context_t* spgw_create_or_get_ue_context(imsi64_t imsi64);
 
 int spgw_update_teid_in_ue_context(imsi64_t imsi64, teid_t teid);

--- a/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -68,6 +68,9 @@ int get_assigned_ipv4_block(
 int pgw_handle_allocate_ipv4_address(
     const char* subscriber_id, const char* apn, const char* pdn_type,
     teid_t context_teid, ebi_t eps_bearer_id) {
+#if MME_UNIT_TEST
+  return RETURNok;  // skip this call for unit testing
+#endif
   auto subscriber_id_str = std::string(subscriber_id);
   auto apn_str           = std::string(apn);
   auto pdn_type_str      = std::string(pdn_type);
@@ -86,6 +89,7 @@ int pgw_handle_allocate_ipv4_address(
             status, addr, vlan, subscriber_id_str.c_str(), apn_str.c_str(),
             pdn_type_str.c_str(), context_teid, eps_bearer_id);
       });
+
   return RETURNok;
 }
 
@@ -93,6 +97,9 @@ static void handle_allocate_ipv4_address_status(
     const Status& status, struct in_addr inaddr, int vlan, const char* imsi,
     const char* apn, const char* pdn_type, teid_t context_teid,
     ebi_t eps_bearer_id) {
+#if MME_UNIT_TEST
+  return;
+#endif
   MessageDef* message_p;
   message_p = itti_alloc_new_message(TASK_GRPC_SERVICE, IP_ALLOCATION_RESPONSE);
   if (!message_p) {
@@ -174,6 +181,9 @@ int get_subscriber_id_from_ipv4(
 int pgw_handle_allocate_ipv6_address(
     const char* subscriber_id, const char* apn, const char* pdn_type,
     teid_t context_teid, ebi_t eps_bearer_id) {
+#if MME_UNIT_TEST
+  return RETURNok;
+#endif
   auto subscriber_id_str = std::string(subscriber_id);
   auto apn_str           = std::string(apn);
   auto pdn_type_str      = std::string(pdn_type);
@@ -207,6 +217,9 @@ static void handle_allocate_ipv6_address_status(
     const Status& status, struct in6_addr addr, int vlan, const char* imsi,
     const char* apn, const char* pdn_type, teid_t context_teid,
     ebi_t eps_bearer_id) {
+#if MME_UNIT_TEST
+  return;
+#endif
   MessageDef* message_p;
   message_p = itti_alloc_new_message(TASK_GRPC_SERVICE, IP_ALLOCATION_RESPONSE);
   if (!message_p) {
@@ -264,6 +277,9 @@ static void handle_allocate_ipv6_address_status(
 int pgw_handle_allocate_ipv4v6_address(
     const char* subscriber_id, const char* apn, const char* pdn_type,
     teid_t context_teid, ebi_t eps_bearer_id) {
+#if MME_UNIT_TEST
+  return RETURNok;
+#endif
   auto subscriber_id_str = std::string(subscriber_id);
   auto apn_str           = std::string(apn);
   auto pdn_type_str      = std::string(pdn_type);
@@ -306,6 +322,9 @@ static void handle_allocate_ipv4v6_address_status(
     const Status& status, struct in_addr ip4_addr, struct in6_addr ip6_addr,
     int vlan, const char* imsi, const char* apn, const char* pdn_type,
     teid_t context_teid, ebi_t eps_bearer_id) {
+#if MME_UNIT_TEST
+  return;
+#endif
   MessageDef* message_p;
   message_p = itti_alloc_new_message(TASK_GRPC_SERVICE, IP_ALLOCATION_RESPONSE);
   if (!message_p) {

--- a/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -89,7 +89,6 @@ int pgw_handle_allocate_ipv4_address(
             status, addr, vlan, subscriber_id_str.c_str(), apn_str.c_str(),
             pdn_type_str.c_str(), context_teid, eps_bearer_id);
       });
-
   return RETURNok;
 }
 

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -101,6 +101,9 @@ static void pcef_fill_create_session_req(
 status_code_e send_itti_pcef_create_session_response(
     const std::string& imsi, s5_create_session_request_t session_request,
     const grpc::Status& status) {
+#if MME_UNIT_TEST
+  return RETURNok;
+#endif
   MessageDef* message_p = nullptr;
 
   message_p =

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -196,6 +196,9 @@ void pcef_send_policy2bearer_binding(
 void pcef_update_teids(
     const char* imsi, uint8_t default_bearer_id, uint32_t enb_teid,
     uint32_t agw_teid) {
+#if MME_UNIT_TEST
+  return;
+#endif
   magma::UpdateTunnelIdsRequest request;
   request.mutable_sid()->set_id("IMSI" + std::string(imsi));
   request.set_bearer_id(default_bearer_id);
@@ -206,6 +209,9 @@ void pcef_update_teids(
       request,
       [request](grpc::Status status, magma::UpdateTunnelIdsResponse response) {
         if (status.error_code() == grpc::ABORTED) {
+#if MME_UNIT_TEST
+          return;
+#endif
           MessageDef* message_p = DEPRECATEDitti_alloc_new_message_fatal(
               TASK_GRPC_SERVICE, GX_NW_INITIATED_DEACTIVATE_BEARER_REQ);
           itti_gx_nw_init_deactv_bearer_request_t* itti_msg =

--- a/lte/gateway/c/core/oai/lib/s8_proxy/s8_client_api.cpp
+++ b/lte/gateway/c/core/oai/lib/s8_proxy/s8_client_api.cpp
@@ -107,6 +107,9 @@ static void get_paa_from_proto_msg(
 static void recv_s8_delete_session_response(
     imsi64_t imsi64, teid_t context_teid, const grpc::Status& status,
     magma::feg::DeleteSessionResponsePgw& response) {
+#if MME_UNIT_TEST
+  return;
+#endif
   OAILOG_FUNC_IN(LOG_SGW_S8);
 
   s8_delete_session_response_t* s8_delete_session_rsp = NULL;
@@ -158,6 +161,9 @@ static void recv_s8_create_session_response(
     imsi64_t imsi64, teid_t context_teid, bearer_qos_t dflt_bearer_qos,
     const grpc::Status& status,
     magma::feg::CreateSessionResponsePgw& response) {
+#if MME_UNIT_TEST
+  return;
+#endif
   OAILOG_FUNC_IN(LOG_SGW_S8);
   s8_create_session_response_t* s5_response = NULL;
   MessageDef* message_p                     = NULL;

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_context_manager.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_context_manager.c
@@ -342,6 +342,15 @@ s_plus_p_gw_eps_bearer_context_information_t* sgw_cm_get_spgw_context(
   return spgw_bearer_context_info;
 }
 
+spgw_ue_context_t* spgw_get_ue_context(imsi64_t imsi64) {
+  OAILOG_FUNC_IN(LOG_SPGW_APP);
+  spgw_ue_context_t* ue_context_p = NULL;
+  hash_table_ts_t* state_ue_ht    = get_spgw_ue_state();
+  hashtable_ts_get(
+      state_ue_ht, (const hash_key_t) imsi64, (void**) &ue_context_p);
+  OAILOG_FUNC_RETURN(LOG_SPGW_APP, ue_context_p);
+}
+
 spgw_ue_context_t* spgw_create_or_get_ue_context(imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);
   spgw_ue_context_t* ue_context_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c
@@ -245,11 +245,12 @@ status_code_e spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state) {
     return RETURNerror;
   }
 
+/*
   if (RETURNerror ==
       pgw_pcef_emulation_init(spgw_state_p, &spgw_config_pP->pgw_config)) {
     return RETURNerror;
   }
-
+*/
   if (itti_create_task(TASK_SPGW_APP, &spgw_app_thread, NULL) < 0) {
     perror("pthread_create");
     OAILOG_ALERT(LOG_SPGW_APP, "Initializing SPGW-APP task interface: ERROR\n");

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c
@@ -240,17 +240,18 @@ status_code_e spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state) {
   // Read SPGW state for subscribers from db
   read_spgw_ue_state_db();
 
+#if !MME_UNIT_TEST  // No need to initialize OVS data path for unit tests
   if (gtpv1u_init(spgw_state_p, spgw_config_pP, persist_state) < 0) {
     OAILOG_ALERT(LOG_SPGW_APP, "Initializing GTPv1-U ERROR\n");
     return RETURNerror;
   }
+#endif
 
-/*
   if (RETURNerror ==
       pgw_pcef_emulation_init(spgw_state_p, &spgw_config_pP->pgw_config)) {
     return RETURNerror;
   }
-*/
+
   if (itti_create_task(TASK_SPGW_APP, &spgw_app_thread, NULL) < 0) {
     perror("pthread_create");
     OAILOG_ALERT(LOG_SPGW_APP, "Initializing SPGW-APP task interface: ERROR\n");
@@ -265,7 +266,9 @@ status_code_e spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state) {
 static void spgw_app_exit(void) {
   OAILOG_DEBUG(LOG_SPGW_APP, "Cleaning SGW\n");
   put_spgw_state();
+#if !MME_UNIT_TEST  // No need to initialize OVS data path for unit tests
   gtpv1u_exit();
+#endif
   spgw_state_exit();
   destroy_task_context(&spgw_app_task_zmq_ctx);
   OAILOG_DEBUG(LOG_SPGW_APP, "Finished cleaning up SGW\n");

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_config.c
@@ -215,4 +215,6 @@ void free_spgw_config(spgw_config_t* spgw_config_p) {
   free_sgw_config(&spgw_config_p->sgw_config);
   bdestroy_wrapper(&spgw_config_p->config_file);
   bdestroy_wrapper(&spgw_config_p->pgw_config.config_file);
+  bdestroy_wrapper(&spgw_config_p->service303_config.name);
+  bdestroy_wrapper(&spgw_config_p->service303_config.version);
 }

--- a/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
@@ -37,6 +37,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S11_CREATE_SESSION_RESPONSE: {
+      mme_app_handler_->mme_app_handle_create_sess_resp();
     } break;
 
     case S11_MODIFY_BEARER_RESPONSE: {
@@ -184,7 +185,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       stop_mock_mme_app_task();
     } break;
 
-    default: { } break; }
+    default: {} break; }
 
   itti_free_msg_content(received_message_p);
   free(received_message_p);

--- a/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
@@ -185,7 +185,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       stop_mock_mme_app_task();
     } break;
 
-    default: {} break; }
+    default: { } break; }
 
   itti_free_msg_content(received_message_p);
   free(received_message_p);

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -49,6 +49,7 @@ class MockMmeAppHandler {
  public:
   MOCK_METHOD0(mme_app_handle_initial_ue_message, void());
   MOCK_METHOD0(mme_app_handle_s1ap_ue_context_release_req, void());
+  MOCK_METHOD0(mme_app_handle_create_sess_resp, void());
 };
 
 class MockSctpHandler {

--- a/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(SPGW_TASK_TEST_LIB
     state_creators.cpp
     spgw_test_util.h
     spgw_test_util.cpp
+    spgw_test.cpp
     )
 
 link_directories(/usr/src/googletest/googlemock/lib/)

--- a/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
@@ -25,14 +25,14 @@ add_library(SPGW_TASK_TEST_LIB
 link_directories(/usr/src/googletest/googlemock/lib/)
 
 target_link_libraries(SPGW_TASK_TEST_LIB
-    TASK_SGW
+    TASK_SGW MOCK_TASKS
     gmock_main gtest gtest_main gmock
     pthread rt yaml-cpp
     )
 
 set_target_properties(SPGW_TASK_TEST_LIB PROPERTIES LINKER_LANGUAGE CXX)
 
-foreach (sgw_test spgw_state_converter)
+foreach (sgw_test spgw_state_converter spgw_procedures)
   add_executable(${sgw_test}_test test_${sgw_test}.cpp)
   target_link_libraries(${sgw_test}_test SPGW_TASK_TEST_LIB)
   add_test(test_${sgw_test} ${sgw_test}_test)

--- a/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
@@ -20,6 +20,8 @@ include_directories("/usr/src/googletest/googlemock/include/")
 add_library(SPGW_TASK_TEST_LIB
     state_creators.h
     state_creators.cpp
+    spgw_test_util.h
+    spgw_test_util.cpp
     )
 
 link_directories(/usr/src/googletest/googlemock/lib/)

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test.cpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "log.h"
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  OAILOG_INIT("SPGW", OAILOG_LEVEL_DEBUG, MAX_LOG_PROTOS);
+  return RUN_ALL_TESTS();
+}

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test.cpp
@@ -19,6 +19,6 @@ extern "C" {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  OAILOG_INIT("SPGW", OAILOG_LEVEL_DEBUG, MAX_LOG_PROTOS);
+  OAILOG_INIT("MME", OAILOG_LEVEL_DEBUG, MAX_LOG_PROTOS);
   return RUN_ALL_TESTS();
 }

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "spgw_test_util.h"
+
+extern "C" {
+#include "intertask_interface.h"
+#include "itti_free_defined_msg.h"
+}
+
+namespace magma {
+namespace lte {
+
+extern task_zmq_ctx_t task_zmq_ctx_main_spgw;
+
+void send_create_session_request(
+    const std::string& imsi_str, int bearer_id,
+    bearer_context_to_be_created_t sample_bearer_context, plmn_t sample_plmn) {
+  MessageDef* message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_MME_APP, S11_CREATE_SESSION_REQUEST);
+  itti_s11_create_session_request_t* session_request_p =
+      &message_p->ittiMsg.s11_create_session_request;
+
+  session_request_p->teid = 0;
+  strncpy(
+      (char*) session_request_p->imsi.digit, imsi_str.c_str(), imsi_str.size());
+  session_request_p->imsi.length = imsi_str.size();
+  session_request_p->sender_fteid_for_cp.teid == 1;
+  session_request_p->sender_fteid_for_cp.interface_type = S11_MME_GTP_C;
+
+  // Fill User Location Information
+  session_request_p->uli.present = 0;  // initialize the presencemask
+  session_request_p->rat_type    = RAT_EUTRAN;
+
+  session_request_p->bearer_contexts_to_be_created.bearer_contexts[bearer_id]
+      .eps_bearer_id = sample_bearer_context.eps_bearer_id;
+  session_request_p->bearer_contexts_to_be_created.bearer_contexts[bearer_id]
+      .bearer_level_qos.pci = sample_bearer_context.bearer_level_qos.pci;
+  session_request_p->bearer_contexts_to_be_created.bearer_contexts[bearer_id]
+      .bearer_level_qos.pl = sample_bearer_context.bearer_level_qos.pl;
+  session_request_p->bearer_contexts_to_be_created.bearer_contexts[bearer_id]
+      .bearer_level_qos.pvi = sample_bearer_context.bearer_level_qos.pvi;
+  session_request_p->bearer_contexts_to_be_created.bearer_contexts[bearer_id]
+      .bearer_level_qos.qci = sample_bearer_context.bearer_level_qos.qci;
+  session_request_p->bearer_contexts_to_be_created.bearer_contexts[bearer_id]
+      .bearer_level_qos.mbr.br_ul =
+      sample_bearer_context.bearer_level_qos.mbr.br_ul;
+  session_request_p->bearer_contexts_to_be_created.bearer_contexts[bearer_id]
+      .bearer_level_qos.mbr.br_dl =
+      sample_bearer_context.bearer_level_qos.mbr.br_dl;
+  session_request_p->bearer_contexts_to_be_created.num_bearer_context = 1;
+
+  session_request_p->sender_fteid_for_cp.teid           = (teid_t) 1;
+  session_request_p->sender_fteid_for_cp.interface_type = S11_MME_GTP_C;
+  session_request_p->sender_fteid_for_cp.ipv4_address.s_addr =
+      0xc0a83c8e;  // 192.168.60.142
+  session_request_p->sender_fteid_for_cp.ipv4 = 1;
+
+  const char default_apn[] = "magma.ipv4";
+  strncpy(session_request_p->apn, default_apn, 10);
+  session_request_p->ambr.br_dl = 100000000;
+  session_request_p->ambr.br_ul = 200000000;
+
+  session_request_p->pdn_type                = IPv4;
+  session_request_p->paa.pdn_type            = IPv4;
+  session_request_p->paa.ipv4_address.s_addr = INADDR_ANY;
+  session_request_p->paa.ipv6_address        = in6addr_any;
+
+  session_request_p->serving_network.mcc[0] = sample_plmn.mcc_digit1;
+  session_request_p->serving_network.mcc[1] = sample_plmn.mcc_digit2;
+  session_request_p->serving_network.mcc[2] = sample_plmn.mcc_digit3;
+  session_request_p->serving_network.mnc[0] = sample_plmn.mnc_digit1;
+  session_request_p->serving_network.mnc[1] = sample_plmn.mnc_digit2;
+  session_request_p->serving_network.mnc[2] = sample_plmn.mnc_digit3;
+
+  send_msg_to_task(&task_zmq_ctx_main_spgw, TASK_SPGW_APP, message_p);
+  // itti_free_msg_content(message_p);
+  // free(message_p);
+}
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
@@ -89,20 +89,15 @@ void fill_ip_allocation_response(
   ip_alloc_resp_p->paa.vlan                = vlan;
 }
 
-void send_create_session_request(
-    const std::string& imsi_str, int bearer_id,
-    bearer_context_to_be_created_t sample_bearer_context, plmn_t sample_plmn) {
-  MessageDef* message_p = DEPRECATEDitti_alloc_new_message_fatal(
-      TASK_MME_APP, S11_CREATE_SESSION_REQUEST);
-  itti_s11_create_session_request_t* session_request_p =
-      &message_p->ittiMsg.s11_create_session_request;
-
-  fill_create_session_request(
-      session_request_p, imsi_str, bearer_id, sample_bearer_context,
-      sample_plmn);
-  // send_msg_to_task(&task_zmq_ctx_main_spgw, TASK_SPGW_APP, message_p);
-  itti_free_msg_content(message_p);
-  free(message_p);
+void fill_pcef_create_session_response(
+    itti_pcef_create_session_response_t* pcef_csr_resp_p,
+    PcefRpcStatus_t rpc_status, teid_t context_teid, ebi_t eps_bearer_id,
+    SGIStatus_t sgi_status) {
+  pcef_csr_resp_p->rpc_status    = rpc_status;
+  pcef_csr_resp_p->teid          = context_teid;
+  pcef_csr_resp_p->eps_bearer_id = eps_bearer_id;
+  pcef_csr_resp_p->sgi_status    = sgi_status;
 }
+
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
@@ -14,7 +14,6 @@
 #include "spgw_test_util.h"
 
 extern "C" {
-#include "intertask_interface.h"
 #include "itti_free_defined_msg.h"
 }
 
@@ -23,14 +22,10 @@ namespace lte {
 
 extern task_zmq_ctx_t task_zmq_ctx_main_spgw;
 
-void send_create_session_request(
+void fill_create_session_request(
+    itti_s11_create_session_request_t* session_request_p,
     const std::string& imsi_str, int bearer_id,
     bearer_context_to_be_created_t sample_bearer_context, plmn_t sample_plmn) {
-  MessageDef* message_p = DEPRECATEDitti_alloc_new_message_fatal(
-      TASK_MME_APP, S11_CREATE_SESSION_REQUEST);
-  itti_s11_create_session_request_t* session_request_p =
-      &message_p->ittiMsg.s11_create_session_request;
-
   session_request_p->teid = 0;
   strncpy(
       (char*) session_request_p->imsi.digit, imsi_str.c_str(), imsi_str.size());
@@ -38,8 +33,7 @@ void send_create_session_request(
   session_request_p->sender_fteid_for_cp.teid == 1;
   session_request_p->sender_fteid_for_cp.interface_type = S11_MME_GTP_C;
 
-  // Fill User Location Information
-  session_request_p->uli.present = 0;  // initialize the presencemask
+  session_request_p->uli.present = 0;
   session_request_p->rat_type    = RAT_EUTRAN;
 
   session_request_p->bearer_contexts_to_be_created.bearer_contexts[bearer_id]
@@ -82,10 +76,33 @@ void send_create_session_request(
   session_request_p->serving_network.mnc[0] = sample_plmn.mnc_digit1;
   session_request_p->serving_network.mnc[1] = sample_plmn.mnc_digit2;
   session_request_p->serving_network.mnc[2] = sample_plmn.mnc_digit3;
+}
 
-  send_msg_to_task(&task_zmq_ctx_main_spgw, TASK_SPGW_APP, message_p);
-  // itti_free_msg_content(message_p);
-  // free(message_p);
+void fill_ip_allocation_response(
+    itti_ip_allocation_response_t* ip_alloc_resp_p, SGIStatus_t status,
+    teid_t context_teid, ebi_t eps_bearer_id, unsigned long ue_ip, int vlan) {
+  ip_alloc_resp_p->status                  = status;
+  ip_alloc_resp_p->context_teid            = context_teid;
+  ip_alloc_resp_p->eps_bearer_id           = eps_bearer_id;
+  ip_alloc_resp_p->paa.ipv4_address.s_addr = ue_ip;
+  ip_alloc_resp_p->paa.pdn_type            = IPv4;
+  ip_alloc_resp_p->paa.vlan                = vlan;
+}
+
+void send_create_session_request(
+    const std::string& imsi_str, int bearer_id,
+    bearer_context_to_be_created_t sample_bearer_context, plmn_t sample_plmn) {
+  MessageDef* message_p = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_MME_APP, S11_CREATE_SESSION_REQUEST);
+  itti_s11_create_session_request_t* session_request_p =
+      &message_p->ittiMsg.s11_create_session_request;
+
+  fill_create_session_request(
+      session_request_p, imsi_str, bearer_id, sample_bearer_context,
+      sample_plmn);
+  // send_msg_to_task(&task_zmq_ctx_main_spgw, TASK_SPGW_APP, message_p);
+  itti_free_msg_content(message_p);
+  free(message_p);
 }
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -25,6 +25,7 @@ namespace lte {
 
 #define DEFAULT_BEARER_INDEX 0
 #define DEFAULT_EPS_BEARER_ID 5
+#define UNASSIGNED_UE_IP 0
 #define DEFAULT_UE_IP 0xc0a8800a  // 192.168.128.10
 #define DEFAULT_VLAN 0
 
@@ -37,8 +38,9 @@ void fill_ip_allocation_response(
     itti_ip_allocation_response_t* ip_alloc_resp_p, SGIStatus_t status,
     teid_t context_teid, ebi_t eps_bearer_id, unsigned long ue_ip, int vlan);
 
-void send_create_session_request(
-    const std::string& imsi_str, int beareri_id,
-    bearer_context_to_be_created_t sample_bearer_context, plmn_t sample_plmn);
+void fill_pcef_create_session_response(
+    itti_pcef_create_session_response_t* pcef_csr_resp_p,
+    PcefRpcStatus_t csr_status, teid_t context_teid, ebi_t eps_bearer_id,
+    SGIStatus_t sgi_status);
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -13,6 +13,7 @@
 #include <string>
 
 extern "C" {
+#include "intertask_interface.h"
 #include "sgw_ie_defs.h"
 }
 
@@ -21,6 +22,20 @@ namespace lte {
 
 #define END_OF_TEST_SLEEP_MS 1000
 #define STATE_MAX_WAIT_MS 1000
+
+#define DEFAULT_BEARER_INDEX 0
+#define DEFAULT_EPS_BEARER_ID 5
+#define DEFAULT_UE_IP 0xc0a8800a  // 192.168.128.10
+#define DEFAULT_VLAN 0
+
+void fill_create_session_request(
+    itti_s11_create_session_request_t* session_request_p,
+    const std::string& imsi_str, int bearer_id,
+    bearer_context_to_be_created_t sample_bearer_context, plmn_t sample_plmn);
+
+void fill_ip_allocation_response(
+    itti_ip_allocation_response_t* ip_alloc_resp_p, SGIStatus_t status,
+    teid_t context_teid, ebi_t eps_bearer_id, unsigned long ue_ip, int vlan);
 
 void send_create_session_request(
     const std::string& imsi_str, int beareri_id,

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -12,11 +12,18 @@
  */
 #include <string>
 
+extern "C" {
+#include "sgw_ie_defs.h"
+}
+
 namespace magma {
 namespace lte {
 
-#define END_OF_TEST_SLEEP_MS 500
+#define END_OF_TEST_SLEEP_MS 1000
 #define STATE_MAX_WAIT_MS 1000
 
+void send_create_session_request(
+    const std::string& imsi_str, int beareri_id,
+    bearer_context_to_be_created_t sample_bearer_context, plmn_t sample_plmn);
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <string>
+
+namespace magma {
+namespace lte {
+
+#define END_OF_TEST_SLEEP_MS 500
+#define STATE_MAX_WAIT_MS 1000
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
@@ -21,6 +21,7 @@
 
 extern "C" {
 #include "mme_config.h"
+#include "pgw_handlers.h"
 #include "sgw_context_manager.h"
 #include "sgw_defs.h"
 #include "sgw_handlers.h"
@@ -38,9 +39,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
-    default: {
-    } break;
-  }
+    default: {} break; }
 
   itti_free_msg_content(received_message_p);
   free(received_message_p);
@@ -94,32 +93,30 @@ class SPGWAppProcedureTest : public ::testing::Test {
   std::shared_ptr<MockMmeAppHandler> mme_app_handler;
   std::string test_imsi_str          = "001010000000001";
   unsigned long long int test_imsi64 = 1010000000001;
-  plmn_t test_plmn                   = {
-                        .mcc_digit2 = 0,
-                        .mcc_digit1 = 0,
-                        .mnc_digit3 = 0x0f,
-                        .mcc_digit3 = 1,
-                        .mnc_digit2 = 1,
-                        .mnc_digit1 = 0};
+  plmn_t test_plmn                   = {.mcc_digit2 = 0,
+                      .mcc_digit1 = 0,
+                      .mnc_digit3 = 0x0f,
+                      .mcc_digit3 = 1,
+                      .mnc_digit2 = 1,
+                      .mnc_digit1 = 0};
   bearer_context_to_be_created_t sample_default_bearer_context = {
       .eps_bearer_id    = 5,
-      .bearer_level_qos = {
-          .pci = 1,
-          .pl  = 15,
-          .pvi = 0,
-          .qci = 9,
-          .gbr = {},
-          .mbr = {.br_ul = 200000000, .br_dl = 100000000}}};
+      .bearer_level_qos = {.pci = 1,
+                           .pl  = 15,
+                           .pvi = 0,
+                           .qci = 9,
+                           .gbr = {},
+                           .mbr = {.br_ul = 200000000, .br_dl = 100000000}}};
 };
 
-TEST_F(SPGWAppProcedureTest, TestIPAllocSuccess) {
-  // send a create session req to SPGW
+TEST_F(SPGWAppProcedureTest, TestIPAllocFailure) {
   spgw_state_t* spgw_state = get_spgw_state(false);
   itti_s11_create_session_request_t sample_session_req_p = {};
   fill_create_session_request(
       &sample_session_req_p, test_imsi_str, DEFAULT_BEARER_INDEX,
       sample_default_bearer_context, test_plmn);
 
+  // trigger create session req to SPGW
   status_code_e create_session_rc = sgw_handle_s11_create_session_request(
       spgw_state, &sample_session_req_p, test_imsi64);
 
@@ -143,9 +140,58 @@ TEST_F(SPGWAppProcedureTest, TestIPAllocSuccess) {
            .pdn_connection,
       DEFAULT_EPS_BEARER_ID);
 
-  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == 0);
+  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
 
-  // send an IP alloc response to SPGW
+  // send an IP alloc response to SPGW with status as failure
+  itti_ip_allocation_response_t test_ip_alloc_resp = {};
+  fill_ip_allocation_response(
+      &test_ip_alloc_resp, SGI_STATUS_ERROR_ALL_DYNAMIC_ADDRESSES_OCCUPIED,
+      ue_sgw_teid, DEFAULT_EPS_BEARER_ID, DEFAULT_UE_IP, DEFAULT_VLAN);
+  status_code_e ip_alloc_rc = sgw_handle_ip_allocation_rsp(
+      spgw_state, &test_ip_alloc_resp, test_imsi64);
+
+  // check that IP address is not allocated
+  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
+
+TEST_F(SPGWAppProcedureTest, TestCreateSessionRequestSuccess) {
+  spgw_state_t* spgw_state = get_spgw_state(false);
+  // expect call to MME create session response
+  itti_s11_create_session_request_t sample_session_req_p = {};
+  fill_create_session_request(
+      &sample_session_req_p, test_imsi_str, DEFAULT_BEARER_INDEX,
+      sample_default_bearer_context, test_plmn);
+
+  // trigger create session req to SPGW
+  status_code_e create_session_rc = sgw_handle_s11_create_session_request(
+      spgw_state, &sample_session_req_p, test_imsi64);
+
+  ASSERT_EQ(create_session_rc, RETURNok);
+
+  // Verify that a UE context exists in SPGW state after CSR is received
+  spgw_ue_context_t* ue_context_p = spgw_get_ue_context(test_imsi64);
+  ASSERT_TRUE(ue_context_p != nullptr);
+
+  // Verify that teid is created
+  ASSERT_FALSE(LIST_EMPTY(&ue_context_p->sgw_s11_teid_list));
+  teid_t ue_sgw_teid =
+      LIST_FIRST(&ue_context_p->sgw_s11_teid_list)->sgw_s11_teid;
+
+  // Verify that no IP address is allocated for this UE
+  s_plus_p_gw_eps_bearer_context_information_t* spgw_eps_bearer_ctxt_info_p =
+      sgw_cm_get_spgw_context(ue_sgw_teid);
+
+  sgw_eps_bearer_ctxt_t* eps_bearer_ctxt_p = sgw_cm_get_eps_bearer_entry(
+      &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information
+           .pdn_connection,
+      DEFAULT_EPS_BEARER_ID);
+
+  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
+
+  // send a IP alloc response to SPGW
   itti_ip_allocation_response_t test_ip_alloc_resp = {};
   fill_ip_allocation_response(
       &test_ip_alloc_resp, SGI_STATUS_OK, ue_sgw_teid, DEFAULT_EPS_BEARER_ID,
@@ -153,39 +199,20 @@ TEST_F(SPGWAppProcedureTest, TestIPAllocSuccess) {
   status_code_e ip_alloc_rc = sgw_handle_ip_allocation_rsp(
       spgw_state, &test_ip_alloc_resp, test_imsi64);
 
-  // check that IP address is allocated after this message is done
+  // check if IP address is allocated after this message is done
   ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == DEFAULT_UE_IP);
 
-  // Sleep to ensure that messages are received and contexts are released
-  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
-}
+  // send pcef create session response to SPGW
+  itti_pcef_create_session_response_t sample_pcef_csr_resp;
+  fill_pcef_create_session_response(
+      &sample_pcef_csr_resp, PCEF_STATUS_OK, ue_sgw_teid, DEFAULT_EPS_BEARER_ID,
+      SGI_STATUS_OK);
 
-TEST_F(SPGWAppProcedureTest, TestIPAllocFailure) {
-  // send a create session req to SPGW
-  spgw_state_t* spgw_state = get_spgw_state(false);
-  ASSERT_EQ(0, 0);
-  // Verify that a UE context exists in SPGW state after CSR is received
-
-  // Verify that no IP address is allocated for this UE
-
-  // send an IP alloc response to SPGW with status as failure
-  // check that IP address is not allocated after this message is done
-
-  // Sleep to ensure that messages are received and contexts are released
-  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
-}
-
-TEST_F(SPGWAppProcedureTest, TestCreateSessionRequest) {
-  // expect call to MME create session response
-
-  // send a create session req to SPGW
-  // send a IP alloc response to SPGW
-  // check if IP address is allocated after this message is done
-  // send s5 response to SPGW
-  // check if ambr has been returned
   // check if MME gets a create session response
-  ASSERT_EQ(0, 0);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_create_sess_resp()).Times(1);
 
+  spgw_handle_pcef_create_session_response(
+      spgw_state, &sample_pcef_csr_resp, test_imsi64);
   // Sleep to ensure that messages are received and contexts are released
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
 }

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
@@ -69,7 +69,7 @@ class SPGWAppProcedureTest : public ::testing::Test {
     std::cout << "Running setup" << std::endl;
     // initialize the SPGW task
     spgw_app_init(&spgw_config, mme_config.use_stateless);
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5000));
   }
 
   virtual void TearDown() {

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <string>
+#include <thread>
+
+#include "../mock_tasks/mock_tasks.h"
+#include "spgw_test_util.h"
+
+extern "C" {
+#include "mme_config.h"
+#include "spgw_config.h"
+#include "sgw_defs.h"
+}
+
+extern bool hss_associated;
+
+namespace magma {
+namespace lte {
+
+task_zmq_ctx_t task_zmq_ctx_main_spgw;
+
+static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
+  MessageDef* received_message_p = receive_msg(reader);
+
+  switch (ITTI_MSG_ID(received_message_p)) {
+    default: {
+    } break;
+  }
+
+  itti_free_msg_content(received_message_p);
+  free(received_message_p);
+  return 0;
+}
+
+class SPGWAppProcedureTest : public ::testing::Test {
+  virtual void SetUp() {
+    // setup mock MME app task
+    mme_app_handler = std::make_shared<MockMmeAppHandler>();
+    itti_init(
+        TASK_MAX, THREAD_MAX, MESSAGES_ID_MAX, tasks_info, messages_info, NULL,
+        NULL);
+
+    // initialize configs
+    mme_config_init(&mme_config);
+    spgw_config_init(&spgw_config);
+    create_partial_lists(&mme_config);
+    mme_config.use_stateless = false;
+    hss_associated           = true;
+
+    task_id_t task_id_list[2] = {TASK_MME_APP, TASK_SPGW_APP};
+    init_task_context(
+        TASK_MAIN, task_id_list, 2, handle_message, &task_zmq_ctx_main_spgw);
+
+    std::thread task_mme_app(start_mock_mme_app_task, mme_app_handler);
+    task_mme_app.detach();
+
+    std::cout << "Running setup" << std::endl;
+    // initialize the SPGW task
+    spgw_app_init(&spgw_config, mme_config.use_stateless);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  }
+
+  virtual void TearDown() {
+    send_terminate_message_fatal(&task_zmq_ctx_main_spgw);
+    destroy_task_context(&task_zmq_ctx_main_spgw);
+    itti_free_desc_threads();
+
+    free_mme_config(&mme_config);
+    free_spgw_config(&spgw_config);
+
+    // Sleep to ensure that messages are received and contexts are released
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  }
+
+ protected:
+  std::shared_ptr<MockMmeAppHandler> mme_app_handler;
+};
+
+TEST_F(SPGWAppProcedureTest, TestIPAllocFailure) {
+  // send a create session req to SPGW
+  // send a IP alloc response to SPGW
+  // check if IP address is not allocated after this message is done
+  EXPECT_EQ(0, 0);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
+
+TEST_F(SPGWAppProcedureTest, TestCreateSessionRequest) {
+  // expect call to MME create session response
+
+  // send a create session req to SPGW
+  // send a IP alloc response to SPGW
+  // check if IP address is allocated after this message is done
+  // send s5 response to SPGW
+  // check if ambr has been returned
+
+  EXPECT_EQ(0, 0);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
@@ -39,7 +39,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
-    default: {} break; }
+    default: { } break; }
 
   itti_free_msg_content(received_message_p);
   free(received_message_p);
@@ -191,7 +191,7 @@ TEST_F(SPGWAppProcedureTest, TestCreateSessionRequestSuccess) {
 
   ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
 
-  // send a IP alloc response to SPGW
+  // send an IP alloc response to SPGW
   itti_ip_allocation_response_t test_ip_alloc_resp = {};
   fill_ip_allocation_response(
       &test_ip_alloc_resp, SGI_STATUS_OK, ue_sgw_teid, DEFAULT_EPS_BEARER_ID,
@@ -213,6 +213,71 @@ TEST_F(SPGWAppProcedureTest, TestCreateSessionRequestSuccess) {
 
   spgw_handle_pcef_create_session_response(
       spgw_state, &sample_pcef_csr_resp, test_imsi64);
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
+
+TEST_F(SPGWAppProcedureTest, TestCreateSessionRequestFailure) {
+  spgw_state_t* spgw_state = get_spgw_state(false);
+  // expect call to MME create session response
+  itti_s11_create_session_request_t sample_session_req_p = {};
+  fill_create_session_request(
+      &sample_session_req_p, test_imsi_str, DEFAULT_BEARER_INDEX,
+      sample_default_bearer_context, test_plmn);
+
+  // trigger create session req to SPGW
+  status_code_e create_session_rc = sgw_handle_s11_create_session_request(
+      spgw_state, &sample_session_req_p, test_imsi64);
+
+  ASSERT_EQ(create_session_rc, RETURNok);
+
+  // Verify that a UE context exists in SPGW state after CSR is received
+  spgw_ue_context_t* ue_context_p = spgw_get_ue_context(test_imsi64);
+  ASSERT_TRUE(ue_context_p != nullptr);
+
+  // Verify that teid is created
+  ASSERT_FALSE(LIST_EMPTY(&ue_context_p->sgw_s11_teid_list));
+  teid_t ue_sgw_teid =
+      LIST_FIRST(&ue_context_p->sgw_s11_teid_list)->sgw_s11_teid;
+
+  // Verify that no IP address is allocated for this UE
+  s_plus_p_gw_eps_bearer_context_information_t* spgw_eps_bearer_ctxt_info_p =
+      sgw_cm_get_spgw_context(ue_sgw_teid);
+
+  sgw_eps_bearer_ctxt_t* eps_bearer_ctxt_p = sgw_cm_get_eps_bearer_entry(
+      &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information
+           .pdn_connection,
+      DEFAULT_EPS_BEARER_ID);
+
+  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
+
+  // send an IP alloc response to SPGW
+  itti_ip_allocation_response_t test_ip_alloc_resp = {};
+  fill_ip_allocation_response(
+      &test_ip_alloc_resp, SGI_STATUS_OK, ue_sgw_teid, DEFAULT_EPS_BEARER_ID,
+      DEFAULT_UE_IP, DEFAULT_VLAN);
+  status_code_e ip_alloc_rc = sgw_handle_ip_allocation_rsp(
+      spgw_state, &test_ip_alloc_resp, test_imsi64);
+
+  // check if IP address is allocated after this message is done
+  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == DEFAULT_UE_IP);
+
+  // send pcef create session response to SPGW
+  itti_pcef_create_session_response_t sample_pcef_csr_resp;
+  fill_pcef_create_session_response(
+      &sample_pcef_csr_resp, PCEF_STATUS_FAILED, ue_sgw_teid,
+      DEFAULT_EPS_BEARER_ID, SGI_STATUS_OK);
+
+  // check if MME gets a create session response
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_create_sess_resp()).Times(1);
+
+  spgw_handle_pcef_create_session_response(
+      spgw_state, &sample_pcef_csr_resp, test_imsi64);
+
+  // verify that spgw context for IMSI has been cleared
+  ue_context_p = spgw_get_ue_context(test_imsi64);
+  ASSERT_TRUE(ue_context_p == nullptr);
+
   // Sleep to ensure that messages are received and contexts are released
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
 }

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
@@ -17,6 +17,7 @@
 
 #include "../mock_tasks/mock_tasks.h"
 #include "spgw_test_util.h"
+#include "spgw_state.h"
 
 extern "C" {
 #include "mme_config.h"
@@ -86,16 +87,57 @@ class SPGWAppProcedureTest : public ::testing::Test {
 
  protected:
   std::shared_ptr<MockMmeAppHandler> mme_app_handler;
+  std::string test_imsi_str = "001010000000001";
+  plmn_t test_plmn          = {
+               .mcc_digit2 = 0,
+               .mcc_digit1 = 0,
+               .mnc_digit3 = 0x0f,
+               .mcc_digit3 = 1,
+               .mnc_digit2 = 1,
+               .mnc_digit1 = 0};
+  bearer_context_to_be_created_t sample_default_bearer_context = {
+      .eps_bearer_id    = 5,
+      .bearer_level_qos = {
+          .pci = 1,
+          .pl  = 15,
+          .pvi = 0,
+          .qci = 9,
+          .gbr = {},
+          .mbr = {.br_ul = 200000000, .br_dl = 100000000}}};
+}
+
+TEST_F(SPGWAppProcedureTest, TestIPAllocSuccess) {
+  // send a create session req to SPGW
+  spgw_state_t* spgw_state = get_spgw_state(false);
+  send_create_session_request(
+      test_imsi_str, 0, sample_default_bearer_context, test_plmn);
+  ASSERT_EQ(0, 0);
+  // Verify that a UE context exists in SPGW state after CSR is received
+
+  // Verify that no IP address is allocated for this UE
+
+  // send an IP alloc response to SPGW
+  // check that IP address is allocated after this message is done
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(10000));
 };
 
 TEST_F(SPGWAppProcedureTest, TestIPAllocFailure) {
   // send a create session req to SPGW
-  // send a IP alloc response to SPGW
-  // check if IP address is not allocated after this message is done
-  EXPECT_EQ(0, 0);
+  spgw_state_t* spgw_state = get_spgw_state(false);
+  // send_create_session_request( test_imsi_str, 0,
+  // sample_default_bearer_context, test_plmn);
+  ASSERT_EQ(0, 0);
+  // Verify that a UE context exists in SPGW state after CSR is received
+
+  // Verify that no IP address is allocated for this UE
+
+  // send an IP alloc response to SPGW with status as failure
+  // check that IP address is not allocated after this message is done
 
   // Sleep to ensure that messages are received and contexts are released
-  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+  std::this_thread::sleep_for(std::chrono::milliseconds(10000));
 }
 
 TEST_F(SPGWAppProcedureTest, TestCreateSessionRequest) {
@@ -107,7 +149,7 @@ TEST_F(SPGWAppProcedureTest, TestCreateSessionRequest) {
   // send s5 response to SPGW
   // check if ambr has been returned
 
-  EXPECT_EQ(0, 0);
+  ASSERT_EQ(0, 0);
 
   // Sleep to ensure that messages are received and contexts are released
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Initial framework to test SPGW procedures. This change adds:
- Functions to populate create session request, IP allocation response and pcef create session response
- Tests to check 
-- IP allocation failure 
-- create session request success
-- create session request failure

## Test Plan

make test_oai
