### PR TITLE
fix(orc8r): change sgi_management_iface_ipv6_addr type of CIDR

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/models/gateway_epc_configs_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/gateway_epc_configs_swaggergen.go
@@ -72,8 +72,7 @@ type GatewayEpcConfigs struct {
 	SgiManagementIfaceGw string `json:"sgi_management_iface_gw,omitempty"`
 
 	// IPv6 address for management interface on the AGW in CIDR format
-	// Format: ipv6
-	SgiManagementIfaceIPV6Addr strfmt.IPv6 `json:"sgi_management_iface_ipv6_addr,omitempty"`
+	SgiManagementIfaceIPV6Addr string `json:"sgi_management_iface_ipv6_addr,omitempty"`
 
 	// IPv6 address of gateway for management interface on the AGW
 	// Format: ipv6
@@ -134,10 +133,6 @@ func (m *GatewayEpcConfigs) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateSgiManagementIfaceGw(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSgiManagementIfaceIPV6Addr(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -333,19 +328,6 @@ func (m *GatewayEpcConfigs) validateSgiManagementIfaceGw(formats strfmt.Registry
 	}
 
 	if err := validate.MaxLength("sgi_management_iface_gw", "body", string(m.SgiManagementIfaceGw), 49); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *GatewayEpcConfigs) validateSgiManagementIfaceIPV6Addr(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.SgiManagementIfaceIPV6Addr) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("sgi_management_iface_ipv6_addr", "body", "ipv6", m.SgiManagementIfaceIPV6Addr.String(), formats); err != nil {
 		return err
 	}
 

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -2031,7 +2031,7 @@ definitions:
       sgi_management_iface_ipv6_addr:
         description: IPv6 address for management interface on the AGW in CIDR format
         type: string
-        format: ipv6
+        format: cidr
         example: '2001:4860:4860:0:0:0:0:8888/64'
       sgi_management_iface_ipv6_gw:
         description: IPv6 address of gateway for management interface on the AGW

--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -193,7 +193,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 			SgiManagementIfaceVlan:     gwEpc.SgiManagementIfaceVlan,
 			SgiManagementIfaceIpAddr:   gwEpc.SgiManagementIfaceStaticIP,
 			SgiManagementIfaceGw:       gwEpc.SgiManagementIfaceGw,
-			SgiManagementIfaceIpv6Addr: string(gwEpc.SgiManagementIfaceIPV6Addr),
+			SgiManagementIfaceIpv6Addr: gwEpc.SgiManagementIfaceIPV6Addr,
 			SgiManagementIfaceIpv6Gw:   string(gwEpc.SgiManagementIfaceIPV6Gw),
 			HeConfig:                   heConfig,
 			LiUes:                      liUes,

--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -1652,7 +1652,7 @@ func newGatewayConfigNonNat(vlan string, sgi_ip string, sgi_gw string, sgi_ipv6 
 			SgiManagementIfaceVlan:     vlan,
 			SgiManagementIfaceStaticIP: sgi_ip,
 			SgiManagementIfaceGw:       sgi_gw,
-			SgiManagementIfaceIPV6Addr: strfmt.IPv6(sgi_ipv6),
+			SgiManagementIfaceIPV6Addr: sgi_ipv6,
 			SgiManagementIfaceIPV6Gw:   strfmt.IPv6(sgi_ipv6_gw),
 		},
 		NonEpsService: &lte_models.GatewayNonEpsConfigs{

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -8617,7 +8617,7 @@ definitions:
       sgi_management_iface_ipv6_addr:
         description: IPv6 address for management interface on the AGW in CIDR format
         example: 2001:4860:4860:0:0:0:0:8888/64
-        format: ipv6
+        format: cidr
         type: string
       sgi_management_iface_ipv6_gw:
         description: IPv6 address of gateway for management interface on the AGW


### PR DESCRIPTION
This option needs subnet of SGi interface, so it needs type change.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
