### PR TITLE
chore(magmad): Expand magmad service restart error list

### DIFF
--- a/orc8r/gateway/python/magma/magmad/service_poller.py
+++ b/orc8r/gateway/python/magma/magmad/service_poller.py
@@ -183,5 +183,4 @@ class ServicePoller(Job):
                     err.code(),
                     err.details(),
                 )
-                if err.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
-                    self._service_info[service].continuous_timeouts += 1
+                self._service_info[service].continuous_timeouts += 1


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
- Connectiond fails to start on agw reboot due to recieved sigterm, this remediates it
- Sometimes the err code is different and I'm not quite sure why I specified the DEADLINE_EXCEEDED in the initial iteration. 
- This should remediate from critical issues such as service being down in all cases, not just DEADLINE_EXCEEDED.

## Test Plan

- Tested with connectiond

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
y I specified the DEADLINE_EXCEEDED in the initial iteration. 
- This should remediate from critical issues such as service being down in all cases, not just DEADLINE_EXCEEDED.

## Test Plan

- Tested with connectiond

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
