### PR TITLE
test(mobilityd): add new makefile target to exectute specific unit tests

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -205,6 +205,12 @@ test_python: stop ## Run all Python-specific tests
 test_sudo_python: stop ## Run Python tests that require sudo (datapath, etc.)
 	make -C $(MAGMA_ROOT)/lte/gateway/python test_all SKIP_NON_SUDO_TESTS=1
 
+test_python_service: ## Run all Python-specific tests for a given service
+ifdef UT_PATH
+	$(eval ut_path?=$(shell realpath $(UT_PATH)))
+endif
+	make -C $(MAGMA_ROOT)/lte/gateway/python unit_tests MAGMA_SERVICE=$(MAGMA_SERVICE) UT_PATH=$(ut_path) DONT_BUILD_ENV=$(DONT_BUILD_ENV)
+
 test_oai: ## Run all OAI-specific tests
 	$(call run_ctest, $(C_BUILD)/core, $(C_BUILD)/core/oai, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(OAI_TEST_FLAGS))
 

--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -19,6 +19,45 @@ test_all: buildenv $(BIN)/nosetests $(BIN)/coverage $(TEST_LIST)
 $(TEST_LIST): %_test:
 	make -C $* .test
 
+define run_unit_tests
+    . $(PYTHON_BUILD)/bin/activate; cd $(2); $(PYTHON_BUILD)/bin/nosetests -s $(1) || exit 1
+endef
+define run_sudo_unit_tests
+    . $(PYTHON_BUILD)/bin/activate; cd $(2); sudo $(PYTHON_BUILD)/bin/nosetests -s $(1) || exit 1
+endef
+
+# unit_tests (UT_PATH=unit_test_path|MAGMA_SERVICE=service_name)[DONT_BUILD_ENV=1]
+unit_tests: $(TESTS) 
+ifndef MAGMA_SERVICE
+ifndef UT_PATH
+	@echo "usage: make unit_tests (UT_PATH=unit_test_path|MAGMA_SERVICE=service_name)[DONT_BUILD_ENV=1]"
+	@exit 1
+endif
+endif
+ifdef MAGMA_SERVICE 
+	$(eval TEST_PATH_LTE ?= $(shell grep -oP '[^\s]+(?=$(MAGMA_SERVICE))[^\s]+' $(MAGMA_ROOT)/lte/gateway/python/defs.mk))
+	$(eval TEST_PATH_ORC8R ?= $(shell grep -oP '[^\s]+(?=$(MAGMA_SERVICE))[^\s]+' $(MAGMA_ROOT)/orc8r/gateway/python/defs.mk))
+else ifdef UT_PATH
+	$(eval TEST_PATH_LTE ?= $(UT_PATH))
+endif
+	@if [ ! -d "$(MAGMA_ROOT)/lte/gateway/python/$(TEST_PATH)" ]; then if [ ! -d "$(MAGMA_ROOT)/orc8r/gateway/python/$(TEST_PATH_ORC8R)" ]; then echo "no tests found" && exit 1; fi; fi
+ifndef DONT_BUILD_ENV
+	@$(MAKE) buildenv $(BIN)/nosetests $(BIN)/coverage
+endif
+ifdef MAGMA_SERVICE
+	sudo service magma@$(MAGMA_SERVICE) stop
+endif
+	$(eval NON_SUDO_TESTS ?= $(patsubst %, \%%,$(TESTS)))
+	$(eval M_SUDO_TESTS ?= $(patsubst %, \%%,$(SUDO_TESTS)))
+	$(eval SELECTED_TESTS ?= $(patsubst %/, %\\/, $(TEST_PATH_LTE)))
+
+	$(if $(strip $(NON_SUDO_TESTS)),$(eval SEL_TEST_PATH_LTE ?= $(filter $(NON_SUDO_TESTS), $(SELECTED_TESTS))))
+	$(if $(strip $(M_SUDO_TESTS)),$(eval SEL_SUDO_TEST_PATH_LTE ?= $(filter $(M_SUDO_TESTS), $(SELECTED_TESTS))))
+	
+	$(if $(strip $(SEL_TEST_PATH_LTE)),$(call run_unit_tests,$(SEL_TEST_PATH_LTE), $(MAGMA_ROOT)/lte/gateway/python/))
+	$(if $(strip $(SEL_SUDO_TEST_PATH_LTE)),$(call run_sudo_unit_tests,$(SEL_SUDO_TEST_PATH_LTE), $(MAGMA_ROOT)/lte/gateway/python/))
+	$(if $(strip $(TEST_PATH_ORC8R)), $(call run_unit_tests, $(TEST_PATH_ORC8R), $(MAGMA_ROOT)/orc8r/gateway/python/))
+
 coverage: $(BIN)/coverage
 	$(BIN)/coverage report
 


### PR DESCRIPTION
## Summary

Instead of running all python unit tests, the execution of individual tests can speed up the workflow.
* a new target 'unit_tests' in the makefile enables individual unit test executions  
* executes unit tests of specific python services
* executes unit tests in specific directories
* prevents execution of environment build process if not necessary

## Test Plan
```
make unit_tests MAGMA_SERVICE=mobilityd DONT_BUILD_ENV=1
make unit_tests UT_PATH=magma/mobilityd/tests
```
