### PR TITLE
fix(mme): PDUSessionResourceSetupReq and PDUSessionEstablishmentAccept clubbed into Single NGAP Message

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -676,16 +676,6 @@ void amf_app_handle_pdu_session_response(
         "Sending message to gNB for PDUSessionResourceSetupRequest "
         "**n_active_pdus=%d **\n",
         smf_ctx->n_active_pdus);
-    amf_rc = pdu_session_resource_setup_request(ue_context, ue_id, smf_ctx);
-    if (amf_rc != RETURNok) {
-      OAILOG_DEBUG(
-          LOG_AMF_APP,
-          "Failure in sending message to gNB for "
-          "PDUSessionResourceSetupRequest\n");
-      /* TODO: in future add negative case handling, send pdu reject
-       * command to UE and release message to SMF
-       */
-    }
 
     amf_smf_msg.pdu_session_id = pdu_session_resp->pdu_session_id;
     /*Execute PDU establishement accept from AMF to gnodeb */
@@ -872,7 +862,7 @@ int amf_app_handle_pdu_session_accept(
       buffer->data, &msg, len, &ue_context->amf_context._security);
   if (bytes > 0) {
     buffer->slen = bytes;
-    amf_app_handle_nas_dl_req(ue_id, buffer, rc);
+    pdu_session_resource_setup_request(ue_context, ue_id, smf_ctx, buffer);
 
   } else {
     OAILOG_WARNING(LOG_AMF_APP, "NAS encode failed \n");

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
@@ -85,7 +85,7 @@ void ambr_calculation_pdu_session(
  */
 int pdu_session_resource_setup_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
-    std::shared_ptr<smf_context_t> smf_context) {
+    std::shared_ptr<smf_context_t> smf_context, bstring nas_msg) {
   pdu_session_resource_setup_request_transfer_t amf_pdu_ses_setup_transfer_req;
   itti_ngap_pdusession_resource_setup_req_t* ngap_pdu_ses_setup_req = nullptr;
   MessageDef* message_p                                             = nullptr;
@@ -147,6 +147,8 @@ int pdu_session_resource_setup_request(
   ngap_pdu_ses_setup_req->pduSessionResource_setup_list.item[0]
       .PDU_Session_Resource_Setup_Request_Transfer =
       amf_pdu_ses_setup_transfer_req;
+
+  ngap_pdu_ses_setup_req->nas_pdu = nas_msg;
 
   // Send message to NGAP task
   amf_send_msg_to_task(&amf_app_task_zmq_ctx, TASK_NGAP, message_p);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -788,7 +788,7 @@ void amf_smf_context_cleanup_pdu_session(ue_m5gmm_context_s* ue_context);
 // PDU session related communication to gNB
 int pdu_session_resource_setup_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
-    std::shared_ptr<smf_context_t>);
+    std::shared_ptr<smf_context_t>, bstring);
 void amf_app_handle_resource_setup_response(
     itti_ngap_pdusessionresource_setup_rsp_t session_seup_resp);
 int pdu_session_resource_release_request(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -788,7 +788,7 @@ void amf_smf_context_cleanup_pdu_session(ue_m5gmm_context_s* ue_context);
 // PDU session related communication to gNB
 int pdu_session_resource_setup_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
-    std::shared_ptr<smf_context_t>, bstring);
+    std::shared_ptr<smf_context_t> smf_context, bstring nas_msg);
 void amf_app_handle_resource_setup_response(
     itti_ngap_pdusessionresource_setup_rsp_t session_seup_resp);
 int pdu_session_resource_release_request(

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -1201,6 +1201,19 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
 
     ngap_pdusession_setup_item_ies->pDUSessionID = session_item->Pdu_Session_ID;
 
+    ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU =
+        calloc(1, sizeof(Ngap_NAS_PDU_t));
+    ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->size =
+        blength(pdusession_resource_setup_req->nas_pdu);
+
+    ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->buf = calloc(
+        blength(pdusession_resource_setup_req->nas_pdu), sizeof(uint8_t));
+
+    memcpy(
+        ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->buf,
+        bdata(pdusession_resource_setup_req->nas_pdu),
+        ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->size);
+
     /*NSSAI*/
     ngap_pdusession_setup_item_ies->s_NSSAI.sST.size = 1;
     ngap_pdusession_setup_item_ies->s_NSSAI.sST.buf =


### PR DESCRIPTION


Test Cases:
  - verified PDUSession setup with UERANSIM

Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

   AMF clubs both PDUSessionResourceSetupReq and PDUSessionEstablishmentAccept into Single NGAP Message and sends to gNB during PDU Session setup.

## Test Plan

- verified PDU Session setup with UERANSIM
![image](https://user-images.githubusercontent.com/83060027/138907205-e2300cac-9db2-4b82-96a4-75cb1b959c7e.png)

[mme_pdu_accept_resource_setup.log](https://github.com/magma/magma/files/7419274/mme_pdu_accept_resource_setup.log)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
