### PR TITLE
fix(agw): fix expired root ca cert issue

### DIFF
--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -17,15 +17,29 @@
   tags:
     - agwc
 
-- name: Ensure ca-certificates is up to date
+- name: Update ca-certs
   become: true
   apt:
-    name: "{{ packages }}"
-    only_upgrade: true
-    state: latest
-  vars:
-    packages:
-      - ca-certificates
+    name: ca-certificates
+    update_cache: true
+  tags:
+    - agwc
+
+- name: Forbid usage of expired Let's Encrypt CA cert
+  ignore_errors: true
+  become: true
+  lineinfile:
+    path: /etc/ca-certificates.conf
+    regexp: 'mozilla/DST_Root_CA_X3.crt'
+    line: '!mozilla/DST_Root_CA_X3.crt'
+  tags:
+    - agwc
+
+
+- name: Trigger update of CA certs
+  ignore_errors: true
+  become: true
+  command: update-ca-certificates
   tags:
     - agwc
 


### PR DESCRIPTION

## Summary

Make sure that expired root CA is not in trusted ca certifcates.

AGW ami workflow is currently failing due to this certificate issue.


## Test Plan

on circle ci: https://app.circleci.com/pipelines/github/magma/magma/35599/workflows/aad16f73-6869-445e-b2a7-bd25a7d47c80/jobs/412636

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
