### PR TITLE
[NMS] fix(nms): Adjust alert rule for S1 setup failure

### DIFF
--- a/nms/packages/magmalte/alerts/lteAlerts.js
+++ b/nms/packages/magmalte/alerts/lteAlerts.js
@@ -97,7 +97,7 @@ export default function getLteAlerts(
     },
     'S1 Setup Failure': {
       alert: 'S1 Setup Failure',
-      expr: `increase(s1_setup{result="failure", networkID=~"${networkID}"}[5m]) > 0`,
+      expr: `increase(s1_setup{result="failure", networkID=~"${networkID}"}[1h]) > 0`,
       labels: {severity: 'major'},
       annotations: {
         description: 'Alerts when we have S1 setup failures',


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Altered alert rule for S1 Setup Failure detection - increasing the time window over which this is detected from 5m to 1h, as a temporary way to increase alert persistency.

## Test Plan

Sanity checked by checking that the query works in PromQL through Grafana:

<img width="1748" alt="Screen Shot 2021-10-26 at 3 01 39 PM" src="https://user-images.githubusercontent.com/804385/138947973-ac55b37d-ea85-4f88-b3b8-2ae6b7580aa5.png">

## Additional Information

- [ ] This change is backwards-breaking
