### PR TITLE
fix(agw): vagrant init error on second magma vm provision.

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -40,7 +40,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
 
     # IPv6 interface
-    config.vm.provision :shell, inline: "ip -6 a add  2020::10/64 dev eth0 && ip -6 r add default via 2020::1", run: 'always'
+    config.vm.provision :shell, inline: "ip -6 r add  2020::10/64 dev eth0 && ip -6 r r default via 2020::1", run: 'always'
 
     magma.vm.provider "virtualbox" do |vb|
       vb.name = "magma-dev"


### PR DESCRIPTION
Rather than adding ip address replace it to avoid
-EEXIST error.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`vagrant provision magma`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
