### PR TITLE
revert: bazel changes to use rules_folly as it breaks sentry

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,7 @@ common:docker --repository_cache=/magma/.bazel-cache-repo
 
 build:devcontainer --disk_cache=/workspaces/magma/.bazel-cache
 common:devcontainer --repository_cache=/workspaces/magma/.bazel-cache-repo
+build:devcontainer --define=folly_so=1
 
 build:specify_vm_cc --action_env=CC=/usr/bin/gcc
 build:specify_vm_cc --action_env=CXX=/usr/bin/g++
@@ -19,6 +20,7 @@ build:specify_vm_cc --action_env=CXX=/usr/bin/g++
 # For building with Bazel inside the Magma VM
 build:vm --disk_cache=/home/vagrant/magma/.bazel-cache
 common:vm --repository_cache=/home/vagrant/magma/.bazel-cache-repo
+build:vm --define=folly_so=1
 build:vm --config=specify_vm_cc
 
 build:asan --strip=never

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -119,10 +119,6 @@ load("//:cpp_repositories.bzl", "cpp_repositories")
 
 cpp_repositories()
 
-load("@com_github_storypku_rules_folly//bazel:folly_deps.bzl", "folly_deps")
-
-folly_deps()
-
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 
 boost_deps()

--- a/cpp_repositories.bzl
+++ b/cpp_repositories.bzl
@@ -28,8 +28,6 @@ def cpp_repositories():
         urls = ["https://github.com/google/glog/archive/v0.4.0.tar.gz"],
     )
 
-    # rules_folly requires a recent version (latest as of 08.04.2021)
-    # https://github.com/storypku/rules_folly/blob/89afec0807127f693e71ae49e3d0aa89b574279b/bazel/folly_deps.bzl#L116
     rules_boost_commit = "fb9f3c9a6011f966200027843d894923ebc9cd0b"
     http_archive(
         name = "com_github_nelhage_rules_boost",
@@ -37,16 +35,6 @@ def cpp_repositories():
         strip_prefix = "rules_boost-{}".format(rules_boost_commit),
         urls = [
             "https://github.com/nelhage/rules_boost/archive/{}.tar.gz".format(rules_boost_commit),
-        ],
-    )
-
-    rules_folly_version = "0.2.0"
-    http_archive(
-        name = "com_github_storypku_rules_folly",
-        sha256 = "16441df2d454a6d7ef4da38d4e5fada9913d1f9a3b2015b9fe792081082d2a65",
-        strip_prefix = "rules_folly-{}".format(rules_folly_version),
-        urls = [
-            "https://github.com/storypku/rules_folly/archive/v{}.tar.gz".format(rules_folly_version),
         ],
     )
 

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -6,21 +6,26 @@ FROM ubuntu:focal as bazel_builder
 ENV TZ=America/New_York \
     DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get upgrade -y 
-
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
         apt-transport-https \
         apt-utils \
         build-essential \
         ca-certificates \
         curl \
+        # dependency of @sentry_native//:sentry
+        libcurl4-openssl-dev \
         gcc \
         git \
         gnupg2 \
         g++ \
         python-dev \
+        zip \
+        unzip \
         vim \
-        wget
+        wget \
+        libssl-dev
 
 # Install bazel
 WORKDIR /usr/sbin
@@ -28,21 +33,49 @@ RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/dow
     chmod +x bazelisk-linux-amd64 && \
     ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
 
-# Dependencies for rules_folly @ https://github.com/storypku/rules_folly
-RUN apt-get -y install --no-install-recommends \
-    autoconf=2.69-11.1 \
-    automake=1:1.16.1-4ubuntu6 \
-    libtool=2.4.6-14 \
-    libssl-dev=1.1.1f-1ubuntu2.8
 
-# dependency of @sentry_native//:sentry
-RUN apt-get -y install --no-install-recommends libcurl4-openssl-dev
+# Install Folly as a static library in the container
+RUN apt-get install -y --no-install-recommends cmake
+
+## Install Fmt (Folly Dep)
+RUN git clone https://github.com/fmtlib/fmt.git && cd fmt && \
+    mkdir _build && cd _build && \
+    cmake .. -DFMT_TEST=0 && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd / && \
+    rm -rf fmt
+
+RUN apt-get install -y --no-install-recommends \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    libboost-all-dev \
+    libevent-dev \
+    libdouble-conversion-dev \
+    libiberty-dev
+
+# Facebook Folly C++ lib
+# Note: "Because folly does not provide any ABI compatibility guarantees from
+#        commit to commit, we generally recommend building folly as a static library."
+# Here we checkout the hash for v2021.02.22.00 (arbitrary recent version)
+RUN git clone https://github.com/facebook/folly && cd folly && \
+    git checkout tags/v2021.02.15.00 && \
+    mkdir _build && cd _build && \
+    cmake .. && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd / && \
+    rm -rf folly
 
 # libtins is required to build the connection_tracker
 RUN apt-get install -y --no-install-recommends \
     cmake=3.16.3-1ubuntu1 \
     libpcap-dev=1.9.1-3 \
     libmnl-dev=1.0.4-2
+
+# dependency of @sentry_native//:sentry
+RUN apt-get -y install --no-install-recommends \
+    libcurl4-openssl-dev=7.68.0-1ubuntu2.7
 
 # TODO(@themarwhal): this might not be hard to bazelify if we can generate the config
 RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
@@ -56,6 +89,9 @@ RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     rm -rf libtins && \
     # symlink to /usr/lib to match Magma VM
     ln -s /usr/local/lib/libtins.so /usr/lib/libtins.so
+
+RUN apt-get -y install --no-install-recommends \
+    libtool=2.4.6-14
 
 # TODO(GH9710): Generate asn1c with Bazel - also this repo is really old :o 
 RUN git clone https://gitlab.eurecom.fr/oai/asn1c.git && \

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -121,7 +121,7 @@ cc_library(
         "//orc8r/gateway/c/common/async_grpc:async_grpc_receiver",
         "//orc8r/gateway/c/common/service_registry",
         "@com_github_google_glog//:glog",
-        "@folly",
+        "@system_libraries//:folly",
     ],
 )
 
@@ -138,7 +138,7 @@ cc_library(
         "//lte/protos:session_manager_cpp_grpc",
         "//orc8r/gateway/c/common/logging",
         "@com_github_google_glog//:glog",
-        "@folly",
+        "@system_libraries//:folly",
     ],
 )
 

--- a/third_party/system_libraries.BUILD
+++ b/third_party/system_libraries.BUILD
@@ -13,6 +13,39 @@ load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+# This configuration is used for building inside the Magma VM
+# The default configuration applies for building inside the bazel build Docker container
+config_setting(
+    name = "use_folly_so",
+    values = {"define": "folly_so=1"},
+)
+
+cc_library(
+    name = "folly",
+    srcs = select({
+        ":use_folly_so": ["usr/local/lib/libfolly.so"],
+        "//conditions:default": [
+            "usr/local/lib/libfolly.a",
+            "usr/local/lib/libfmt.a",
+        ],
+    }),
+    linkopts = select({
+        ":use_folly_so": [
+            "-ldl",
+            "-levent",
+            "-ldouble-conversion",
+            "-lgflags",
+        ],
+        "//conditions:default": [
+            "-ldl",
+            "-levent",
+            "-ldouble-conversion",
+            "-lgflags",
+            "-liberty",
+        ],
+    }),
+)
+
 cc_library(
     name = "libtins",
     srcs = ["usr/lib/libtins.so"],


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Original PR: https://github.com/magma/magma/pull/9697

Sentry isn't enabled by default (it needs the DSN to be specified), so it took me a while to figure out that this regresses the sentry feature. (Somehow something about this rules_folly makes sentry crash on startup (see stack trace below)

Reverting the change for now as sentry breaking is not good :p 

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  __pthread_rwlock_wrlock_full (abstime=0x0, clockid=0, rwlock=0x0) at pthread_rwlock_common.c:604
604	pthread_rwlock_common.c: No such file or directory.
(gdb) bt
#0  __pthread_rwlock_wrlock_full (abstime=0x0, clockid=0, rwlock=0x0) at pthread_rwlock_common.c:604
#1  __GI___pthread_rwlock_wrlock (rwlock=0x0) at pthread_rwlock_wrlock.c:27
#2  0x00005646892be580 in CRYPTO_STATIC_MUTEX_lock_write (lock=0x0) at external/boringssl/src/crypto/thread_pthread.c:75
#3  0x000056468923c5ce in CRYPTO_get_ex_new_index (ex_data_class=0x0, out_index=0x0, argl=0, argp=0x0, free_func=0x0) at external/boringssl/src/crypto/ex_data.c:146
#4  0x00007f132c0e8d17 in ?? () from /lib/x86_64-linux-gnu/libcurl.so.4
#5  0x00007f132c0e9212 in ?? () from /lib/x86_64-linux-gnu/libcurl.so.4
#6  0x00007f132c0b3990 in ?? () from /lib/x86_64-linux-gnu/libcurl.so.4
#7  0x00007f132ca0eb28 in sentry__curl_transport_start (options=0x56468af84b70, transport_state=0x56468af5df60) at /var/tmp/sentry-native/src/transports/sentry_transport_curl.c:65
#8  0x00007f132ca07b37 in sentry__transport_startup (transport=transport@entry=0x56468af663c0, options=options@entry=0x56468af84b70) at /var/tmp/sentry-native/src/sentry_transport.c:82
#9  0x00007f132ca00164 in sentry_init (options=0x56468af84b70) at /var/tmp/sentry-native/src/sentry_core.c:121
#10 0x000056468983e82c in initialize_sentry (service_tag=0x56468986e33f "SessionD", sentry_config=0x7ffc24753ec0) at orc8r/gateway/c/common/sentry/SentryWrapper.cpp:115
#11 0x0000564688a4029b in main (argc=1, argv=0x7ffc247542f8) at lte/gateway/c/session_manager/sessiond_main.cpp:215
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
run bazel built sessiond with sentry and it no longer crashes.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
