### PR TITLE
chore(mme): new unit tests for mme procedure procedure failures, idle mode, etc.

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -606,10 +606,6 @@ imsi64_t mme_app_handle_initial_ue_message(
   }
   // Check if there is any existing UE context using S-TMSI/GUTI
   if (initial_pP->is_s_tmsi_valid) {
-    printf(
-        "\n\nINITIAL UE Message: Valid mme_code %u and S-TMSI %u received from "
-        "eNB.\n\n",
-        initial_pP->opt_s_tmsi.mme_code, initial_pP->opt_s_tmsi.m_tmsi);
     OAILOG_DEBUG(
         LOG_MME_APP,
         "INITIAL UE Message: Valid mme_code %u and S-TMSI %u received from "
@@ -677,9 +673,6 @@ imsi64_t mme_app_handle_initial_ue_message(
           ue_context_p->paging_retx_count                  = 0;
         }
       } else {
-        printf(
-            "\n\nNo UE context found for MME code %u and S-TMSI %u\n\n",
-            initial_pP->opt_s_tmsi.mme_code, initial_pP->opt_s_tmsi.m_tmsi);
         OAILOG_DEBUG(
             LOG_MME_APP, "No UE context found for MME code %u and S-TMSI %u\n",
             initial_pP->opt_s_tmsi.mme_code, initial_pP->opt_s_tmsi.m_tmsi);
@@ -697,7 +690,6 @@ imsi64_t mme_app_handle_initial_ue_message(
   }
   // create a new ue context if nothing is found
   if (!(ue_context_p)) {
-    printf("\n\nUE context doesn't exist -> create one\n\n");
     OAILOG_DEBUG(LOG_MME_APP, "UE context doesn't exist -> create one\n");
     if (!(ue_context_p = mme_create_new_ue_context())) {
       /*
@@ -1704,7 +1696,6 @@ void mme_app_handle_release_access_bearers_resp(
   /*
    * Updating statistics
    */
-  printf("\n\n I AM HEREEEEE!!!!! \n\n");
   update_mme_app_stats_s1u_bearer_sub();
 
   // Send UE Context Release Command

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -606,6 +606,10 @@ imsi64_t mme_app_handle_initial_ue_message(
   }
   // Check if there is any existing UE context using S-TMSI/GUTI
   if (initial_pP->is_s_tmsi_valid) {
+    printf(
+        "\n\nINITIAL UE Message: Valid mme_code %u and S-TMSI %u received from "
+        "eNB.\n\n",
+        initial_pP->opt_s_tmsi.mme_code, initial_pP->opt_s_tmsi.m_tmsi);
     OAILOG_DEBUG(
         LOG_MME_APP,
         "INITIAL UE Message: Valid mme_code %u and S-TMSI %u received from "
@@ -673,6 +677,9 @@ imsi64_t mme_app_handle_initial_ue_message(
           ue_context_p->paging_retx_count                  = 0;
         }
       } else {
+        printf(
+            "\n\nNo UE context found for MME code %u and S-TMSI %u\n\n",
+            initial_pP->opt_s_tmsi.mme_code, initial_pP->opt_s_tmsi.m_tmsi);
         OAILOG_DEBUG(
             LOG_MME_APP, "No UE context found for MME code %u and S-TMSI %u\n",
             initial_pP->opt_s_tmsi.mme_code, initial_pP->opt_s_tmsi.m_tmsi);
@@ -690,6 +697,7 @@ imsi64_t mme_app_handle_initial_ue_message(
   }
   // create a new ue context if nothing is found
   if (!(ue_context_p)) {
+    printf("\n\nUE context doesn't exist -> create one\n\n");
     OAILOG_DEBUG(LOG_MME_APP, "UE context doesn't exist -> create one\n");
     if (!(ue_context_p = mme_create_new_ue_context())) {
       /*
@@ -1696,6 +1704,7 @@ void mme_app_handle_release_access_bearers_resp(
   /*
    * Updating statistics
    */
+  printf("\n\n I AM HEREEEEE!!!!! \n\n");
   update_mme_app_stats_s1u_bearer_sub();
 
   // Send UE Context Release Command

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -148,15 +148,11 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
             LOG_MME_APP,
             "S11 MODIFY BEARER RESPONSE local S11 teid = " TEID_FMT "\n",
             received_message_p->ittiMsg.s11_modify_bearer_response.teid);
-        printf(
-            "\n\nS11 MODIFY BEARER RESPONSE local S11 teid = " TEID_FMT "\n",
-            received_message_p->ittiMsg.s11_modify_bearer_response.teid);
         if ((!ue_context_p->path_switch_req) && (!ue_context_p->erab_mod_ind)) {
           /* Updating statistics */
           mme_app_handle_modify_bearer_rsp(
               &received_message_p->ittiMsg.s11_modify_bearer_response,
               ue_context_p);
-          printf("\n\nCalling update_mme_app_stats_s1u_bearer_add() \n\n");
           update_mme_app_stats_s1u_bearer_add();
         } else if (ue_context_p->path_switch_req) {
           mme_app_handle_path_switch_req_ack(
@@ -189,7 +185,6 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S11_RELEASE_ACCESS_BEARERS_RESPONSE: {
-      printf("\n\nAT mme_app_handle_release_access_bearers_resp(...)\n\n");
       mme_app_handle_release_access_bearers_resp(
           mme_app_desc_p,
           &received_message_p->ittiMsg.s11_release_access_bearers_response);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -148,12 +148,15 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
             LOG_MME_APP,
             "S11 MODIFY BEARER RESPONSE local S11 teid = " TEID_FMT "\n",
             received_message_p->ittiMsg.s11_modify_bearer_response.teid);
-
+        printf(
+            "\n\nS11 MODIFY BEARER RESPONSE local S11 teid = " TEID_FMT "\n",
+            received_message_p->ittiMsg.s11_modify_bearer_response.teid);
         if ((!ue_context_p->path_switch_req) && (!ue_context_p->erab_mod_ind)) {
           /* Updating statistics */
           mme_app_handle_modify_bearer_rsp(
               &received_message_p->ittiMsg.s11_modify_bearer_response,
               ue_context_p);
+          printf("\n\nCalling update_mme_app_stats_s1u_bearer_add() \n\n");
           update_mme_app_stats_s1u_bearer_add();
         } else if (ue_context_p->path_switch_req) {
           mme_app_handle_path_switch_req_ack(
@@ -186,6 +189,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S11_RELEASE_ACCESS_BEARERS_RESPONSE: {
+      printf("\n\nAT mme_app_handle_release_access_bearers_resp(...)\n\n");
       mme_app_handle_release_access_bearers_resp(
           mme_app_desc_p,
           &received_message_p->ittiMsg.s11_release_access_bearers_response);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgw_selection.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgw_selection.c
@@ -44,7 +44,6 @@ void mme_app_select_sgw(
       mme_config.e_dns_emulation.sgw_ip_addr[0].s_addr;
   ((struct sockaddr_in*) sgw_in_addr)->sin_family = AF_INET;
 
-  printf("Received SGW IP Address %p\n", (void*) sgw_in_addr);
   OAILOG_DEBUG(
       LOG_MME_APP, "SGW  returned %s\n",
       inet_ntoa(((struct sockaddr_in*) sgw_in_addr)->sin_addr));

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_statistics.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_statistics.c
@@ -79,6 +79,8 @@ void update_mme_app_stats_attached_ue_add(void) {
 void update_mme_app_stats_attached_ue_sub(void) {
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
   if (mme_app_desc_p->nb_ue_attached != 0) (mme_app_desc_p->nb_ue_attached)--;
+  mme_app_desc_p->nb_ue_idle = get_max(
+      mme_app_desc_p->nb_ue_attached - mme_app_desc_p->nb_ue_connected, 0);
   return;
 }
 /*****************************************************/

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_statistics.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_statistics.c
@@ -23,15 +23,22 @@
  * Statistics**************************************/
 
 /*****************************************************/
+static inline get_max(int num1, int num2) {
+  return (num1 > num2 ? num1 : num2);
+}
 // Number of Connected UEs
 void update_mme_app_stats_connected_ue_add(void) {
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
   (mme_app_desc_p->nb_ue_connected)++;
+  mme_app_desc_p->nb_ue_idle = get_max(
+      mme_app_desc_p->nb_ue_attached - mme_app_desc_p->nb_ue_connected, 0);
   return;
 }
 void update_mme_app_stats_connected_ue_sub(void) {
   mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
   if (mme_app_desc_p->nb_ue_connected != 0) (mme_app_desc_p->nb_ue_connected)--;
+  mme_app_desc_p->nb_ue_idle = get_max(
+      mme_app_desc_p->nb_ue_attached - mme_app_desc_p->nb_ue_connected, 0);
   return;
 }
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -244,5 +244,55 @@ void send_ue_capabilities_ind() {
   return;
 }
 
+void send_context_release_req(s1cause rel_cause, task_id_t TASK_ID) {
+  MessageDef* message_p =
+      itti_alloc_new_message(TASK_ID, S1AP_UE_CONTEXT_RELEASE_REQ);
+  S1AP_UE_CONTEXT_RELEASE_REQ(message_p).mme_ue_s1ap_id = 1;
+  S1AP_UE_CONTEXT_RELEASE_REQ(message_p).enb_ue_s1ap_id = 0;
+  S1AP_UE_CONTEXT_RELEASE_REQ(message_p).enb_id         = 0;
+  S1AP_UE_CONTEXT_RELEASE_REQ(message_p).relCause       = rel_cause;
+  send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
+  return;
+}
+
+void send_modify_bearer_resp(
+    std::vector<int>& bearer_to_modify, std::vector<int>& bearer_to_remove) {
+  MessageDef* message_p =
+      itti_alloc_new_message(TASK_SPGW_APP, S11_MODIFY_BEARER_RESPONSE);
+  itti_s11_modify_bearer_response_t* modify_response_p =
+      &message_p->ittiMsg.s11_modify_bearer_response;
+  modify_response_p->teid              = 1;
+  modify_response_p->cause.cause_value = REQUEST_ACCEPTED;
+  for (int i = 0; i < bearer_to_modify.size(); ++i) {
+    modify_response_p->bearer_contexts_modified.bearer_contexts[i]
+        .eps_bearer_id = bearer_to_modify[i];
+    modify_response_p->bearer_contexts_modified.bearer_contexts[i]
+        .cause.cause_value = REQUEST_ACCEPTED;
+  }
+  modify_response_p->bearer_contexts_modified.num_bearer_context =
+      bearer_to_modify.size();
+  for (int i = 0; i < bearer_to_modify.size(); ++i) {
+    modify_response_p->bearer_contexts_marked_for_removal.bearer_contexts[i]
+        .eps_bearer_id = bearer_to_modify[i];
+    modify_response_p->bearer_contexts_marked_for_removal.bearer_contexts[i]
+        .cause.cause_value = REQUEST_ACCEPTED;
+  }
+  modify_response_p->bearer_contexts_marked_for_removal.num_bearer_context =
+      bearer_to_modify.size();
+  send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
+  return;
+}
+
+void sgw_send_release_access_bearer_response(gtpv2c_cause_value_t cause) {
+  MessageDef* message_p = itti_alloc_new_message(
+      TASK_SPGW_APP, S11_RELEASE_ACCESS_BEARERS_RESPONSE);
+  itti_s11_release_access_bearers_response_t* release_access_bearers_resp_p =
+      &message_p->ittiMsg.s11_release_access_bearers_response;
+  release_access_bearers_resp_p->cause.cause_value = cause;
+  release_access_bearers_resp_p->teid              = 1;
+  send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
+  return;
+}
+
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -256,7 +256,8 @@ void send_context_release_req(s1cause rel_cause, task_id_t TASK_ID) {
 }
 
 void send_modify_bearer_resp(
-    std::vector<int>& bearer_to_modify, std::vector<int>& bearer_to_remove) {
+    const std::vector<int>& bearer_to_modify,
+    const std::vector<int>& bearer_to_remove) {
   MessageDef* message_p =
       itti_alloc_new_message(TASK_SPGW_APP, S11_MODIFY_BEARER_RESPONSE);
   itti_s11_modify_bearer_response_t* modify_response_p =
@@ -271,9 +272,9 @@ void send_modify_bearer_resp(
   }
   modify_response_p->bearer_contexts_modified.num_bearer_context =
       bearer_to_modify.size();
-  for (int i = 0; i < bearer_to_modify.size(); ++i) {
+  for (int i = 0; i < bearer_to_remove.size(); ++i) {
     modify_response_p->bearer_contexts_marked_for_removal.bearer_contexts[i]
-        .eps_bearer_id = bearer_to_modify[i];
+        .eps_bearer_id = bearer_to_remove[i];
     modify_response_p->bearer_contexts_marked_for_removal.bearer_contexts[i]
         .cause.cause_value = REQUEST_ACCEPTED;
   }

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -11,8 +11,13 @@
  * limitations under the License.
  */
 #include <string>
+#include <vector>
+
 extern "C" {
+#include "3gpp_29.274.h"
 #include "mme_config.h"
+#include "intertask_interface_types.h"
+#include "s1ap_messages_types.h"
 }
 
 namespace magma {
@@ -24,7 +29,8 @@ namespace lte {
 #define NAS_RETX_LIMIT 5
 
 #define MME_APP_EXPECT_CALLS(                                                  \
-    dlNas, connEstConf, ctxRel, air, ulr, purgeReq, csr, dsr, setAppHealth)    \
+    dlNas, connEstConf, ctxRel, air, ulr, purgeReq, csr, mbr, relBearer, dsr,  \
+    setAppHealth)                                                              \
   do {                                                                         \
     EXPECT_CALL(*s1ap_handler, s1ap_generate_downlink_nas_transport())         \
         .Times(dlNas)                                                          \
@@ -38,6 +44,9 @@ namespace lte {
     EXPECT_CALL(*s6a_handler, s6a_viface_purge_ue()).Times(purgeReq);          \
     EXPECT_CALL(*spgw_handler, sgw_handle_s11_create_session_request())        \
         .Times(csr);                                                           \
+    EXPECT_CALL(*spgw_handler, sgw_handle_modify_bearer_request()).Times(mbr); \
+    EXPECT_CALL(*spgw_handler, sgw_handle_release_access_bearers_request())    \
+        .Times(relBearer);                                                     \
     EXPECT_CALL(*spgw_handler, sgw_handle_delete_session_request())            \
         .Times(dsr)                                                            \
         .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
@@ -71,6 +80,13 @@ void send_ics_response();
 void send_ue_ctx_release_complete();
 
 void send_ue_capabilities_ind();
+
+void send_context_release_req(s1cause rel_cause, task_id_t TASK_ID);
+
+void send_modify_bearer_resp(
+    std::vector<int>& bearer_to_modify, std::vector<int>& bearer_to_remove);
+
+void sgw_send_release_access_bearer_response(gtpv2c_cause_value_t cause);
 
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -37,7 +37,8 @@ namespace lte {
         .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
     EXPECT_CALL(*s1ap_handler, s1ap_handle_conn_est_cnf()).Times(connEstConf); \
     EXPECT_CALL(*s1ap_handler, s1ap_handle_ue_context_release_command())       \
-        .Times(ctxRel);                                                        \
+        .Times(ctxRel)                                                         \
+        .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \
     EXPECT_CALL(*s6a_handler, s6a_viface_authentication_info_req())            \
         .Times(air);                                                           \
     EXPECT_CALL(*s6a_handler, s6a_viface_update_location_req()).Times(ulr);    \

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -85,7 +85,8 @@ void send_ue_capabilities_ind();
 void send_context_release_req(s1cause rel_cause, task_id_t TASK_ID);
 
 void send_modify_bearer_resp(
-    std::vector<int>& bearer_to_modify, std::vector<int>& bearer_to_remove);
+    const std::vector<int>& bearer_to_modify,
+    const std::vector<int>& bearer_to_remove);
 
 void sgw_send_release_access_bearer_response(gtpv2c_cause_value_t cause);
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -159,7 +159,7 @@ TEST_F(MmeAppProcedureTest, TestInitialUeMessageFaultyNasMsg) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  MME_APP_EXPECT_CALLS(1, 0, 0, 0, 0, 0, 0, 0, 1);
+  MME_APP_EXPECT_CALLS(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   // The following buffer just includes an attach request
@@ -192,7 +192,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyDetach) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  MME_APP_EXPECT_CALLS(3, 1, 1, 1, 1, 1, 1, 1, 2);
+  MME_APP_EXPECT_CALLS(3, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
@@ -231,7 +231,16 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyDetach) {
   send_mme_app_uplink_data_ind(
       nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
 
-  // Check MME state after attach complete
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
@@ -248,9 +257,6 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyDetach) {
   // mimicing SPGW task
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp();
-
-  // Wait for DL NAS Transport for once
-  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -275,7 +281,7 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachEpsOnlyDetach) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  MME_APP_EXPECT_CALLS(4, 1, 1, 1, 1, 1, 1, 1, 2);
+  MME_APP_EXPECT_CALLS(4, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
@@ -320,7 +326,16 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachEpsOnlyDetach) {
   send_mme_app_uplink_data_ind(
       nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
 
-  // Check MME state after attach complete
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
@@ -337,9 +352,6 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachEpsOnlyDetach) {
   // mimicing SPGW task
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp();
-
-  // Wait for DL NAS Transport for once
-  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -364,7 +376,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAirFailure) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  MME_APP_EXPECT_CALLS(1, 0, 1, 1, 0, 0, 0, 0, 2);
+  MME_APP_EXPECT_CALLS(1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 2);
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
@@ -408,7 +420,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAirTimeout) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  MME_APP_EXPECT_CALLS(1, 0, 1, 1, 0, 0, 0, 0, 2);
+  MME_APP_EXPECT_CALLS(1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 2);
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
@@ -449,7 +461,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyUlaFailure) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  MME_APP_EXPECT_CALLS(3, 0, 1, 1, 1, 0, 0, 0, 2);
+  MME_APP_EXPECT_CALLS(3, 0, 1, 1, 1, 0, 0, 0, 0, 0, 2);
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
@@ -508,7 +520,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachExpiredNasTimers) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  MME_APP_EXPECT_CALLS(15, 1, 1, 1, 1, 1, 1, 1, 2);
+  MME_APP_EXPECT_CALLS(15, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
@@ -556,7 +568,16 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachExpiredNasTimers) {
   send_mme_app_uplink_data_ind(
       nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
 
-  // Check MME state after attach complete
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
@@ -573,9 +594,6 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachExpiredNasTimers) {
   // mimicing SPGW task
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp();
-
-  // Wait for DL NAS Transport for once
-  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -600,7 +618,7 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachExpiredIdentity) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  MME_APP_EXPECT_CALLS(8, 1, 1, 1, 1, 1, 1, 1, 2);
+  MME_APP_EXPECT_CALLS(8, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
@@ -647,7 +665,16 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachExpiredIdentity) {
   send_mme_app_uplink_data_ind(
       nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
 
-  // Check MME state after attach complete
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
@@ -669,9 +696,6 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachExpiredIdentity) {
   // mimicing S1AP task
   send_ue_ctx_release_complete();
 
-  // Wait for DL NAS Transport for once
-  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-
   // Check MME state after detach complete
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
@@ -691,7 +715,7 @@ TEST_F(MmeAppProcedureTest, TestIcsRequestTimeout) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  MME_APP_EXPECT_CALLS(2, 1, 1, 1, 1, 1, 1, 1, 1);
+  MME_APP_EXPECT_CALLS(2, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1);
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
@@ -730,6 +754,116 @@ TEST_F(MmeAppProcedureTest, TestIcsRequestTimeout) {
   send_ue_ctx_release_complete();
 
   // Check MME state after delete session processing
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
+
+TEST_F(MmeAppProcedureTest, TestMobileOriginatedServiceReq) {
+  mme_app_desc_t* mme_state_p =
+      magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  std::condition_variable cv;
+  std::mutex mx;
+  std::unique_lock<std::mutex> lock(mx);
+
+  MME_APP_EXPECT_CALLS(3, 1, 2, 1, 1, 1, 1, 1, 1, 1, 3);
+
+  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  send_mme_app_initial_ue_msg(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp();
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
+  // Send context release request mimicing S1AP
+  send_context_release_req(S1AP_RADIO_EUTRAN_GENERATED_REASON, TASK_S1AP);
+
+  // Constructing and sending Release Access Bearer Response to mme_app
+  // mimicing SPGW
+  sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
+
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after context release request is processed
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 1);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+  // Constructing and sending Detach Request to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_detach_req, sizeof(nas_msg_detach_req), plmn);
+
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp();
+
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   EXPECT_EQ(mme_state_p->nb_ue_attached, 0);

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -639,7 +639,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectAuthRetxFailure) {
   // as well as context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  
+
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -765,7 +765,7 @@ TEST_F(MmeAppProcedureTest, TestIcsRequestTimeout) {
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
 }
 
-TEST_F(MmeAppProcedureTest, TestMobileOriginatedServiceReq) {
+TEST_F(MmeAppProcedureTest, TestAttachIdleDetach) {
   mme_app_desc_t* mme_state_p =
       magma::lte::MmeNasStateManager::getInstance().get_state(false);
   std::condition_variable cv;
@@ -870,6 +870,7 @@ TEST_F(MmeAppProcedureTest, TestMobileOriginatedServiceReq) {
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
   EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
 
   // Sleep to ensure that messages are received and contexts are released
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -621,7 +621,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectAuthRetxFailure) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  MME_APP_EXPECT_CALLS(6, 0, 2, 1, 0, 0, 0, 0, 0, 0, 1);
+  MME_APP_EXPECT_CALLS(6, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1);
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -67,6 +67,8 @@ class MockSpgwHandler {
  public:
   MOCK_METHOD0(sgw_handle_s11_create_session_request, void());
   MOCK_METHOD0(sgw_handle_delete_session_request, void());
+  MOCK_METHOD0(sgw_handle_modify_bearer_request, void());
+  MOCK_METHOD0(sgw_handle_release_access_bearers_request, void());
 };
 
 class MockService303Handler {

--- a/lte/gateway/c/core/oai/test/mock_tasks/spgw_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/spgw_mock.cpp
@@ -36,6 +36,14 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       spgw_handler_->sgw_handle_delete_session_request();
     } break;
 
+    case S11_MODIFY_BEARER_REQUEST: {
+      spgw_handler_->sgw_handle_modify_bearer_request();
+    } break;
+
+    case S11_RELEASE_ACCESS_BEARERS_REQUEST: {
+      spgw_handler_->sgw_handle_release_access_bearers_request();
+    } break;
+
     default: { } break; }
   itti_free_msg_content(received_message_p);
   free(received_message_p);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Added new unit tests for authentication request and SMC message transmission failures.
- Added unit test for attach-idle mode transition-detach sequence.
- Added modify bearer request stages where it is needed.
- Expanded expect call macro with additional fields and added new message types as boundary conditions that wakes up the main thread waiting on the conditional variable.
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run `make test_oai`.
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
