### PR TITLE
fix(mme): Fix for handling NAS authentication failure

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -1133,12 +1133,6 @@ status_code_e mme_app_handle_auth_t3460_expiry(
       // abort ANY ongoing EMM procedure (R10_5_4_2_7_b)
       nas_delete_all_emm_procedures(emm_ctx);
 
-      // Clean up MME APP UE context
-      memset((void*) &emm_sap, 0, sizeof(emm_sap));
-      emm_sap.primitive = EMMCN_IMPLICIT_DETACH_UE;
-      emm_sap.u.emm_cn.u.emm_cn_implicit_detach.ue_id = ue_id;
-      emm_sap_send(&emm_sap);
-      increment_counter("ue_attach", 1, 1, "action", "attach_abort");
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -1132,7 +1132,6 @@ status_code_e mme_app_handle_auth_t3460_expiry(
 
       // abort ANY ongoing EMM procedure (R10_5_4_2_7_b)
       nas_delete_all_emm_procedures(emm_ctx);
-
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response.py
@@ -44,7 +44,7 @@ class TestNoAuthResponse(unittest.TestCase):
             service="mme",
             name=str(metricsd.ue_detach),
             labels={str(metricsd.cause): "implicit_detach"},
-            value=1,
+            value=0,
         ),
         MetricValue(
             service="mme",


### PR DESCRIPTION
Signed-off-by: Pruthvi Hebbani <pruthvi.hebbani@radisys.com>

fix(mme): Fix for handling NAS authentication failure

## Summary

In case of NAS authentication failure, MME was triggering UE context release command twice. Once as part of handling attach failure and then during implicit detach. This PR fixes the issue.

## Test Plan

- Verified test_no_auth_response.py TC to ensure that MME sends UE context release command only once as part of handling attach failure
- Verified s1ap tester sanity


