### PR TITLE
chore: add sentry logging functionality

### DIFF
--- a/lte/gateway/c/core/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/core/oai/oai_mme/oai_mme.c
@@ -108,8 +108,7 @@ int main(int argc, char* argv[]) {
 #else
   CHECK_INIT_RETURN(mme_config_parse_opt_line(argc, argv, &mme_config));
 #endif
-  // Initialize Sentry error collection (Currently only supported on
-  // Ubuntu 20.04)
+  // Initialize Sentry error collection
   // We have to initialize here for now since itti_init asserts on there being
   // only 1 thread
   initialize_sentry(SENTRY_TAG_MME, &mme_config.sentry_config);

--- a/orc8r/gateway/c/common/sentry/includes/SentryWrapper.h
+++ b/orc8r/gateway/c/common/sentry/includes/SentryWrapper.h
@@ -21,6 +21,8 @@ extern "C" {
 #define SENTRY_TAG_MME "MME"
 #define SENTRY_TAG_SESSIOND "SessionD"
 #define SENTRY_TAG_LEN 16
+#define SENTRY_DB_PREFIX ".sentry-native-"
+#define SENTRY_DB_PREFIX_LEN 16
 
 /**
  * @brief Struct to contain Sentry configuration relevant for C/C++ services
@@ -29,6 +31,8 @@ typedef struct sentry_config {
   float sample_rate;
   bool upload_mme_log;
   char url_native[MAX_URL_LENGTH];
+  // Add debug logging for sentry, useful for debugging connection issues
+  bool add_debug_logging;
 } sentry_config_t;
 
 /**
@@ -49,6 +53,13 @@ void shutdown_sentry(void);
  * @param name
  */
 void set_sentry_transaction(const char* name);
+
+/**
+ * @brief Log a message to sentry at ERROR level
+ *
+ * @param message
+ */
+void sentry_log_error(const char* message);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Add a method in SentryWrapper to send events with error messages to Sentry. This will allow us to catch any issues that does not crash the service, but we still want to track.

The event will add the same set of tags as a crash (hostname, servicename, hwid, etc.) and include a stacktrace. For MME, if the config to attach /var/log/mme.log is enabled, that will be attached as well.

Usage
```c
#include "SentryWrapper.h"
sentry_log_error("we should not be here!");
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested locally with a test sentry account

<img width="1070" alt="Screen Shot 2021-10-27 at 12 14 17 PM" src="https://user-images.githubusercontent.com/37634144/139105387-0e862d4b-c3e4-4d88-ab34-319f2c6fd015.png">

<img width="873" alt="Screen Shot 2021-10-27 at 12 14 38 PM" src="https://user-images.githubusercontent.com/37634144/139105454-970af523-8f17-41d0-b973-40de03c14851.png">


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
