### PR TITLE
chore: apply IWYU to sessiond

### DIFF
--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -11,14 +11,24 @@
  * limitations under the License.
  */
 
+#include <glog/logging.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/impl/codegen/status.h>
 #include <memory>
+#include <ostream>
 #include <string>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "AAAClient.h"
-#include "magma_logging.h"
-#include "includes/ServiceRegistrySingleton.h"
 #include "SessionState.h"
+#include "Types.h"
+#include "feg/gateway/services/aaa/protos/accounting.grpc.pb.h"
+#include "feg/gateway/services/aaa/protos/accounting.pb.h"
+#include "includes/ServiceRegistrySingleton.h"
+#include "lte/protos/session_manager.pb.h"
+#include "magma_logging.h"
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/AAAClient.h
+++ b/lte/gateway/c/session_manager/AAAClient.h
@@ -13,13 +13,27 @@
 #pragma once
 
 #include <feg/gateway/services/aaa/protos/accounting.grpc.pb.h>
-
+#include <stdint.h>
+#include <functional>
 #include <memory>
 #include <string>
 
-#include "includes/GRPCReceiver.h"
 #include "SessionState.h"
 #include "SessionStore.h"
+#include "StoreClient.h"
+#include "includes/GRPCReceiver.h"
+
+namespace aaa {
+namespace protos {
+class acct_resp;
+class add_sessions_request;
+class terminate_session_request;
+}  // namespace protos
+}  // namespace aaa
+namespace grpc {
+class Channel;
+class Status;
+}  // namespace grpc
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/AmfServiceClient.cpp
+++ b/lte/gateway/c/session_manager/AmfServiceClient.cpp
@@ -1,5 +1,15 @@
 #include "AmfServiceClient.h"
+
+#include <glog/logging.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <functional>
+#include <ostream>
+#include <utility>
+
 #include "includes/ServiceRegistrySingleton.h"
+#include "lte/protos/session_manager.grpc.pb.h"
+#include "lte/protos/session_manager.pb.h"
 #include "magma_logging.h"
 
 using grpc::Status;

--- a/lte/gateway/c/session_manager/AmfServiceClient.h
+++ b/lte/gateway/c/session_manager/AmfServiceClient.h
@@ -12,13 +12,26 @@
  */
 #pragma once
 
+#include <grpc++/grpc++.h>
+#include <lte/protos/session_manager.grpc.pb.h>
+#include <lte/protos/session_manager.pb.h>
+#include <stdint.h>
+#include <memory>
 #include <mutex>
 
-#include <grpc++/grpc++.h>
-#include <lte/protos/session_manager.pb.h>
-#include <lte/protos/session_manager.grpc.pb.h>
-
 #include "includes/GRPCReceiver.h"
+#include "lte/protos/apn.pb.h"
+
+namespace grpc {
+class Channel;
+class Status;
+}  // namespace grpc
+namespace magma {
+namespace lte {
+class SetSMSessionContextAccess;
+class SetSmNotificationContext;
+}  // namespace lte
+}  // namespace magma
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -11,12 +11,17 @@
  * limitations under the License.
  */
 
+#include <glog/logging.h>
+#include <algorithm>
 #include <ctime>
 #include <limits>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "ChargingGrant.h"
+#include "CreditKey.h"
+#include "DiameterCodes.h"
 #include "EnumToString.h"
 #include "magma_logging.h"
 

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -12,10 +12,16 @@
  */
 #pragma once
 
+#include <stdint.h>
+#include <ctime>
+
 #include "DiameterCodes.h"
 #include "ServiceAction.h"
 #include "SessionCredit.h"
 #include "StoredState.h"
+#include "Types.h"
+#include "lte/protos/policydb.pb.h"
+#include "lte/protos/session_manager.pb.h"
 
 namespace magma {
 

--- a/lte/gateway/c/session_manager/DirectorydClient.cpp
+++ b/lte/gateway/c/session_manager/DirectorydClient.cpp
@@ -11,12 +11,19 @@
  * limitations under the License.
  */
 
+#include <grpcpp/channel.h>
 #include <memory>
 #include <utility>
 
 #include "DirectorydClient.h"
-#include "magma_logging.h"
 #include "includes/ServiceRegistrySingleton.h"
+#include "orc8r/protos/common.pb.h"
+#include "orc8r/protos/directoryd.grpc.pb.h"
+#include "orc8r/protos/directoryd.pb.h"
+
+namespace grpc {
+class Status;
+}  // namespace grpc
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/DirectorydClient.h
+++ b/lte/gateway/c/session_manager/DirectorydClient.h
@@ -15,15 +15,27 @@
 #include <orc8r/protos/common.pb.h>
 #include <orc8r/protos/directoryd.grpc.pb.h>
 #include <orc8r/protos/directoryd.pb.h>
-
+#include <stdint.h>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
 
-#include "includes/GRPCReceiver.h"
 #include "SessionState.h"
+#include "includes/GRPCReceiver.h"
+
+namespace grpc {
+class Channel;
+class Status;
+}  // namespace grpc
 
 namespace magma {
+namespace orc8r {
+class AllDirectoryRecords;
+class DeleteRecordRequest;
+class UpdateRecordRequest;
+}  // namespace orc8r
+
 using namespace orc8r;
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -14,7 +14,10 @@
 #include <sstream>
 #include <string>
 
+#include "ChargingGrant.h"
 #include "EnumToString.h"
+#include "lte/protos/abort_session.pb.h"
+#include "lte/protos/session_manager.pb.h"
 
 namespace magma {
 std::string reauth_state_to_str(ReAuthState state) {

--- a/lte/gateway/c/session_manager/EnumToString.h
+++ b/lte/gateway/c/session_manager/EnumToString.h
@@ -14,12 +14,13 @@
 
 #include <lte/protos/abort_session.pb.h>
 #include <lte/protos/session_manager.pb.h>
-
 #include <string>
 
 #include "ChargingGrant.h"
 #include "ServiceAction.h"
 #include "StoredState.h"
+#include "Types.h"
+#include "lte/protos/pipelined.pb.h"
 
 namespace magma {
 std::string reauth_state_to_str(ReAuthState state);

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -11,26 +11,49 @@
  * limitations under the License.
  */
 
-#include <google/protobuf/repeated_field.h>
-#include <google/protobuf/timestamp.pb.h>
-#include <google/protobuf/util/time_util.h>
-#include <grpcpp/channel.h>
+#include <ctype.h>
+#include <cxxabi.h>
+#include <folly/io/async/EventBase.h>
+#include <glog/logging.h>
+#include <grpcpp/impl/codegen/status.h>
 #include <lte/protos/session_manager.pb.h>
-#include <time.h>
-
+#include <algorithm>
+#include <cstdint>
+#include <experimental/optional>
+#include <iomanip>
 #include <memory>
+#include <ostream>
+#include <set>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 
+#include "AAAClient.h"
 #include "DiameterCodes.h"
 #include "EnumToString.h"
-#include "LocalEnforcer.h"
-#include "magma_logging.h"
-#include "includes/ServiceRegistrySingleton.h"
-#include "Utilities.h"
 #include "GrpcMagmaUtils.h"
+#include "LocalEnforcer.h"
+#include "PipelinedClient.h"
+#include "RuleStore.h"
+#include "ServiceAction.h"
+#include "SessionEvents.h"
+#include "SessionReporter.h"
+#include "ShardTracker.h"
+#include "SpgwServiceClient.h"
+#include "StoredState.h"
+#include "Utilities.h"
+#include "lte/protos/mconfig/mconfigs.pb.h"
+#include "lte/protos/policydb.pb.h"
+#include "lte/protos/spgw_service.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+#include "magma_logging.h"
+
+namespace google {
+namespace protobuf {
+class Message;
+class Timestamp;
+}  // namespace protobuf
+}  // namespace google
 
 namespace magma {
 bool LocalEnforcer::SEND_ACCESS_TIMEZONE   = false;

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -12,13 +12,19 @@
  */
 #pragma once
 
-#include <experimental/optional>
+#include <bits/exception.h>
+#include <folly/hash/Hash.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <lte/protos/mconfig/mconfigs.pb.h>
 #include <lte/protos/policydb.pb.h>
 #include <lte/protos/session_manager.grpc.pb.h>
-
+#include <stdint.h>
+#include <chrono>
+#include <ctime>
+#include <experimental/optional>
+#include <functional>
 #include <iomanip>
+#include <iosfwd>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -27,6 +33,7 @@
 #include <vector>
 
 #include "AAAClient.h"
+#include "CreditKey.h"
 #include "DirectorydClient.h"
 #include "PipelinedClient.h"
 #include "RuleStore.h"
@@ -34,10 +41,40 @@
 #include "SessionReporter.h"
 #include "SessionState.h"
 #include "SessionStore.h"
-#include "SpgwServiceClient.h"
 #include "ShardTracker.h"
+#include "SpgwServiceClient.h"
+#include "StoreClient.h"
+#include "Types.h"
+#include "lte/protos/pipelined.pb.h"
+#include "lte/protos/session_manager.pb.h"
+
+namespace aaa {
+class AAAClient;
+}  // namespace aaa
+namespace folly {
+class EventBase;
+}  // namespace folly
+namespace google {
+namespace protobuf {
+class Timestamp;
+}  // namespace protobuf
+}  // namespace google
+namespace grpc {
+class Status;
+}  // namespace grpc
 
 namespace magma {
+class PipelinedClient;
+class ServiceAction;
+class SessionReporter;
+class ShardTracker;
+class SpgwServiceClient;
+class StaticRuleStore;
+namespace lte {
+class EventsReporter;
+class SubscriberID;
+}  // namespace lte
+struct SessionStateUpdateCriteria;
 
 using ImsiAndSessionID = std::pair<std::string, std::string>;
 

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -10,20 +10,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <google/protobuf/util/time_util.h>
-
+#include <folly/io/async/EventBase.h>
+#include <glog/logging.h>
+#include <grpcpp/impl/codegen/status_code_enum.h>
 #include <chrono>
+#include <exception>
 #include <memory>
+#include <ostream>
 #include <string>
-#include <thread>
+#include <typeinfo>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
+#include "DirectorydClient.h"
 #include "GrpcMagmaUtils.h"
+#include "LocalEnforcer.h"
 #include "LocalSessionManagerHandler.h"
-#include "magma_logging.h"
-#include "includes/SentryWrapper.h"
+#include "ServiceAction.h"
+#include "SessionCredit.h"
+#include "SessionEvents.h"
+#include "SessionReporter.h"
+#include "SessionState.h"
+#include "StoredState.h"
+#include "Types.h"
 #include "Utilities.h"
+#include "includes/SentryWrapper.h"
+#include "lte/protos/pipelined.pb.h"
+#include "lte/protos/session_manager.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+#include "magma_logging.h"
+#include "orc8r/protos/directoryd.pb.h"
+
+namespace google {
+namespace protobuf {
+class Message;
+}  // namespace protobuf
+}  // namespace google
+namespace grpc {
+class ServerContext;
+}  // namespace grpc
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -13,8 +13,11 @@
 #pragma once
 
 #include <grpc++/grpc++.h>
+#include <grpcpp/impl/codegen/status.h>
 #include <lte/protos/session_manager.grpc.pb.h>
-
+#include <stdint.h>
+#include <chrono>
+#include <experimental/optional>
 #include <functional>
 #include <memory>
 #include <string>
@@ -23,6 +26,34 @@
 #include "SessionID.h"
 #include "SessionReporter.h"
 #include "SessionStore.h"
+#include "StoreClient.h"
+#include "orc8r/protos/common.pb.h"
+
+namespace grpc {
+class ServerContext;
+}  // namespace grpc
+namespace magma {
+class DirectorydClient;
+class LocalEnforcer;
+class SessionReporter;
+class SessionState;
+namespace lte {
+class EventsReporter;
+class LocalCreateSessionRequest;
+class LocalCreateSessionResponse;
+class LocalEndSessionRequest;
+class LocalEndSessionResponse;
+class PolicyBearerBindingRequest;
+class PolicyBearerBindingResponse;
+class RuleRecordTable;
+class SessionRules;
+class SetupFlowsResult;
+class SubscriberID;
+class UpdateTunnelIdsRequest;
+class UpdateTunnelIdsResponse;
+}  // namespace lte
+struct SessionConfig;
+}  // namespace magma
 
 using grpc::ServerContext;
 using grpc::Status;

--- a/lte/gateway/c/session_manager/MemoryStoreClient.cpp
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.cpp
@@ -11,16 +11,19 @@
  * limitations under the License.
  */
 
+#include <algorithm>
 #include <set>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "magma_logging.h"
 #include "MemoryStoreClient.h"
 #include "SessionState.h"
+#include "StoredState.h"
 
 namespace magma {
+class StaticRuleStore;
+
 namespace lte {
 
 MemoryStoreClient::MemoryStoreClient(

--- a/lte/gateway/c/session_manager/MemoryStoreClient.h
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.h
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <lte/protos/session_manager.grpc.pb.h>
-
 #include <memory>
 #include <set>
 #include <string>
@@ -24,6 +23,9 @@
 #include "StoredState.h"
 
 namespace magma {
+class StaticRuleStore;
+struct StoredSessionState;
+
 namespace lte {
 
 /**

--- a/lte/gateway/c/session_manager/MeteringReporter.cpp
+++ b/lte/gateway/c/session_manager/MeteringReporter.cpp
@@ -11,10 +11,15 @@
  * limitations under the License.
  */
 
+#include <stddef.h>
+#include <cstdint>
 #include <string>
+#include <unordered_map>
+#include <utility>
 
-#include "includes/MagmaService.h"
 #include "MeteringReporter.h"
+#include "StoredState.h"
+#include "Types.h"
 #include "includes/MetricsHelpers.h"
 
 namespace magma {

--- a/lte/gateway/c/session_manager/MeteringReporter.h
+++ b/lte/gateway/c/session_manager/MeteringReporter.h
@@ -14,10 +14,13 @@
 
 #include <string>
 
-#include "StoredState.h"
 #include "SessionCredit.h"
+#include "StoredState.h"
 
 namespace magma {
+struct SessionStateUpdateCriteria;
+struct TotalCreditUsage;
+
 namespace lte {
 
 class MeteringReporter {

--- a/lte/gateway/c/session_manager/MobilitydClient.cpp
+++ b/lte/gateway/c/session_manager/MobilitydClient.cpp
@@ -11,11 +11,23 @@
  * limitations under the License.
  */
 
+#include <grpcpp/channel.h>
 #include <memory>
 #include <utility>
+
 #include "MobilitydClient.h"
 #include "includes/ServiceRegistrySingleton.h"
-#include "magma_logging.h"
+#include "lte/protos/mobilityd.grpc.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+
+namespace grpc {
+class Status;
+}  // namespace grpc
+namespace magma {
+namespace lte {
+class IPAddress;
+}  // namespace lte
+}  // namespace magma
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/MobilitydClient.h
+++ b/lte/gateway/c/session_manager/MobilitydClient.h
@@ -12,13 +12,28 @@
  */
 #pragma once
 
+#include <lte/protos/mobilityd.grpc.pb.h>
+#include <stdint.h>
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
-#include <memory>
-#include <lte/protos/mobilityd.grpc.pb.h>
+
+#include "SessionState.h"
 #include "Types.h"
 #include "includes/GRPCReceiver.h"
-#include "SessionState.h"
+#include "lte/protos/apn.pb.h"
+
+namespace grpc {
+class Channel;
+class Status;
+}  // namespace grpc
+namespace magma {
+namespace lte {
+class IPAddress;
+class SubscriberID;
+}  // namespace lte
+}  // namespace magma
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
+++ b/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
@@ -12,17 +12,27 @@
  */
 #include <folly/dynamic.h>
 #include <folly/json.h>
+#include <glog/logging.h>
+#include <google/protobuf/stubs/status.h>
+#include <google/protobuf/stubs/stringpiece.h>
 #include <google/protobuf/util/json_util.h>
-
 #include <list>
 #include <map>
 #include <memory>
+#include <ostream>
 #include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "EnumToString.h"
-#include "magma_logging.h"
 #include "OperationalStatesHandler.h"
-#include "Utilities.h"
+#include "SessionState.h"
+#include "SessionStore.h"
+#include "Types.h"
+#include "lte/protos/policydb.pb.h"
+#include "lte/protos/session_manager.pb.h"
+#include "magma_logging.h"
 
 namespace magma {
 

--- a/lte/gateway/c/session_manager/OperationalStatesHandler.h
+++ b/lte/gateway/c/session_manager/OperationalStatesHandler.h
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <folly/dynamic.h>
-
 #include <list>
 #include <map>
 #include <memory>
@@ -22,6 +21,11 @@
 #include "SessionStore.h"
 
 namespace magma {
+class SessionState;
+namespace lte {
+class SessionStore;
+}  // namespace lte
+
 const std::string TYPE                   = "type";
 const std::string SUBSCRIBER_STATE_TYPE  = "subscriber_state";
 const std::string DEVICE_ID              = "device_id";

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -11,19 +11,36 @@
  * limitations under the License.
  */
 
-#include <google/protobuf/util/time_util.h>
-
+#include <glog/logging.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <algorithm>
+#include <cstdint>
 #include <memory>
+#include <ostream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "EnumToString.h"
 #include "GrpcMagmaUtils.h"
-#include "magma_logging.h"
 #include "PipelinedClient.h"
-#include "includes/ServiceRegistrySingleton.h"
 #include "Types.h"
+#include "includes/ServiceRegistrySingleton.h"
+#include "lte/protos/apn.pb.h"
+#include "lte/protos/pipelined.grpc.pb.h"
+#include "lte/protos/pipelined.pb.h"
+#include "lte/protos/policydb.pb.h"
+#include "lte/protos/session_manager.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+#include "magma_logging.h"
+
+namespace google {
+namespace protobuf {
+class Message;
+}  // namespace protobuf
+}  // namespace google
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -16,16 +16,32 @@
 #include <lte/protos/pipelined.pb.h>
 #include <lte/protos/policydb.pb.h>
 #include <lte/protos/subscriberdb.pb.h>
-
+#include <stdint.h>
+#include <experimental/optional>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include "includes/GRPCReceiver.h"
 #include "SessionState.h"
 #include "Types.h"
+#include "includes/GRPCReceiver.h"
+#include "lte/protos/abort_session.pb.h"
+
+namespace grpc {
+class Channel;
+class Status;
+}  // namespace grpc
+namespace magma {
+namespace lte {
+class AggregatedMaximumBitrate;
+class RuleRecordTable;
+class SubscriberID;
+class Teids;
+}  // namespace lte
+}  // namespace magma
 
 #define M5G_MIN_TEID (UINT32_MAX / 2)
 

--- a/lte/gateway/c/session_manager/PolicyLoader.cpp
+++ b/lte/gateway/c/session_manager/PolicyLoader.cpp
@@ -11,18 +11,21 @@
  * limitations under the License.
  */
 #include "PolicyLoader.h"
-#include <chrono>                     // for seconds
+
 #include <cpp_redis/core/client.hpp>  // for client, client::connect_state
 #include <cpp_redis/misc/error.hpp>   // for redis_error
-#include <yaml-cpp/yaml.h>            // IWYU pragma: keep
-#include <cstdint>                    // for uint32_t
-#include <memory>                     // for make_shared, __shared_ptr, ...
-#include <ostream>                    // for operator<<, basic_ostream, ...
-#include <string>                     // for string, char_traits, operator<<
-#include <thread>                     // for sleep_for
-#include "ObjectMap.h"                // for SUCCESS
-#include "RedisMap.hpp"               // for RedisMap
-#include "Serializers.h"              // for get_proto_deserializer, get_pro
+#include <glog/logging.h>
+#include <yaml-cpp/yaml.h>  // IWYU pragma: keep
+#include <algorithm>
+#include <chrono>   // for seconds
+#include <memory>   // for make_shared, __shared_ptr, ...
+#include <ostream>  // for operator<<, basic_ostream, ...
+#include <string>   // for string, char_traits, operator<<
+#include <thread>   // for sleep_for
+
+#include "ObjectMap.h"    // for SUCCESS
+#include "RedisMap.hpp"   // for RedisMap
+#include "Serializers.h"  // for get_proto_deserializer, get_pro
 #include "includes/ServiceConfigLoader.h"  // for ServiceConfigLoader
 #include "lte/protos/policydb.pb.h"        // for PolicyRule
 #include "magma_logging.h"                 // for MLOG, MERROR, MDEBUG, MINFO

--- a/lte/gateway/c/session_manager/PolicyLoader.h
+++ b/lte/gateway/c/session_manager/PolicyLoader.h
@@ -10,11 +10,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <stdint.h>                  // for uint32_t
-#include <atomic>                    // for atomic
-#include <functional>                // for function
-#include <vector>                    // for vector
+#include <stdint.h>    // for uint32_t
+#include <atomic>      // for atomic
+#include <functional>  // for function
+#include <vector>      // for vector
+
+#include "lte/protos/apn.pb.h"
 #include "lte/protos/policydb.pb.h"  // for lte
+
 namespace magma {
 namespace lte {
 class PolicyRule;

--- a/lte/gateway/c/session_manager/RedisStoreClient.cpp
+++ b/lte/gateway/c/session_manager/RedisStoreClient.cpp
@@ -12,27 +12,28 @@
  */
 
 #include "RedisStoreClient.h"
-#include <folly/Range.h>              // for operator<<, StringPiece
-#include <folly/dynamic-inl.h>        // for dynamic::dynamic, dynamic::~dyn...
-#include <folly/dynamic.h>            // for dynamic
-#include <folly/json.h>               // for parseJson, toJson
-#include <glog/logging.h>             // for COMPACT_GOOGLE_LOG_INFO, LogMes...
-#include <yaml-cpp/yaml.h>            // IWYU pragma: keep
-#include <stddef.h>                   // for size_t
-#include <stdint.h>                   // for uint32_t
-#include <algorithm>                  // for max
+
 #include <cpp_redis/core/client.hpp>  // for client, client::connect_state
 #include <cpp_redis/core/reply.hpp>   // for reply
 #include <cpp_redis/misc/error.hpp>   // for redis_error
+#include <folly/Range.h>              // for operator<<, StringPiece
+#include <folly/dynamic.h>            // for dynamic
+#include <folly/json.h>               // for parseJson, toJson
+#include <glog/logging.h>             // for COMPACT_GOOGLE_LOG_INFO, LogMes...
+#include <stddef.h>                   // for size_t
+#include <stdint.h>                   // for uint32_t
+#include <yaml-cpp/yaml.h>            // IWYU pragma: keep
 #include <future>                     // for future
 #include <ostream>                    // for operator<<, basic_ostream, size_t
 #include <unordered_map>              // for _Node_iterator, unordered_map
 #include <utility>                    // for move, pair
 #include <vector>                     // for vector
+
+#include "SessionState.h"  // for SessionState
+#include "StoredState.h"   // for deserialize_stored_session, ser...
 #include "includes/ServiceConfigLoader.h"  // for ServiceConfigLoader
-#include "SessionState.h"                  // for SessionState
-#include "StoredState.h"    // for deserialize_stored_session, ser...
-#include "magma_logging.h"  // for MERROR, MLOG
+#include "magma_logging.h"                 // for MERROR, MLOG
+
 namespace magma {
 class StaticRuleStore;
 }

--- a/lte/gateway/c/session_manager/RedisStoreClient.h
+++ b/lte/gateway/c/session_manager/RedisStoreClient.h
@@ -13,12 +13,16 @@
 
 #pragma once
 
+#include <bits/exception.h>
+#include <cpp_redis/core/client.hpp>
 #include <cpp_redis/cpp_redis>
-#include <exception>      // IWYU pragma: keep
-#include <memory>         // for shared_ptr
-#include <set>            // for set
-#include <string>         // for string
+#include <exception>  // IWYU pragma: keep
+#include <memory>     // for shared_ptr
+#include <set>        // for set
+#include <string>     // for string
+
 #include "StoreClient.h"  // for SessionMap, SessionVector, StoreClient
+
 namespace magma {
 class StaticRuleStore;
 }

--- a/lte/gateway/c/session_manager/RestartHandler.cpp
+++ b/lte/gateway/c/session_manager/RestartHandler.cpp
@@ -10,17 +10,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cxxabi.h>
+#include <glog/logging.h>
+#include <google/protobuf/stubs/common.h>
+#include <grpcpp/impl/codegen/status.h>
 #include <chrono>
 #include <future>
 #include <memory>
+#include <ostream>
 #include <string>
+#include <system_error>
+#include <thread>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
-#include "magma_logging.h"
+#include "AAAClient.h"
+#include "DirectorydClient.h"
 #include "RestartHandler.h"
+#include "SessionReporter.h"
+#include "SessionStore.h"
+#include "lte/protos/session_manager.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+#include "magma_logging.h"
+#include "orc8r/protos/directoryd.pb.h"
 
 namespace magma {
+class LocalEnforcer;
+namespace orc8r {
+class Void;
+}  // namespace orc8r
+
 namespace sessiond {
 
 const uint RestartHandler::max_cleanup_retries_  = 3;

--- a/lte/gateway/c/session_manager/RestartHandler.h
+++ b/lte/gateway/c/session_manager/RestartHandler.h
@@ -12,8 +12,10 @@
  */
 #pragma once
 
+#include <sys/types.h>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -22,7 +24,18 @@
 #include "LocalEnforcer.h"
 #include "SessionReporter.h"
 
+namespace aaa {
+class AsyncAAAClient;
+}  // namespace aaa
+
 namespace magma {
+class DirectorydClient;
+class LocalEnforcer;
+class SessionReporter;
+namespace lte {
+class SessionStore;
+}  // namespace lte
+
 namespace sessiond {
 
 /**

--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -10,14 +10,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <glog/logging.h>
-
+#include <stddef.h>
+#include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "RuleStore.h"
-#include "includes/ServiceRegistrySingleton.h"
+#include "lte/protos/pipelined.pb.h"
+#include "lte/protos/policydb.pb.h"
 
 namespace magma {
 

--- a/lte/gateway/c/session_manager/RuleStore.h
+++ b/lte/gateway/c/session_manager/RuleStore.h
@@ -14,7 +14,7 @@
 
 #include <lte/protos/pipelined.grpc.pb.h>
 #include <lte/protos/policydb.pb.h>
-
+#include <stdint.h>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -24,8 +24,15 @@
 
 #include "CreditKey.h"
 #include "includes/GRPCReceiver.h"
+#include "lte/protos/apn.pb.h"
 
 namespace magma {
+namespace lte {
+class PolicyRule;
+class SetGroupFAR;
+class SetGroupPDR;
+}  // namespace lte
+
 using namespace lte;
 /**
  * Template class for keeping track of a map of one key to many policy rules

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -11,15 +11,20 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <limits>
+#include <glog/logging.h>
+#include <stdlib.h>
+#include <cstdint>
+#include <ostream>
 #include <string>
+#include <unordered_map>
+#include <utility>
 
 #include "DiameterCodes.h"
 #include "EnumToString.h"
-#include "magma_logging_init.h"
 #include "SessionCredit.h"
 #include "Utilities.h"
+#include "magma_logging.h"
+#include "magma_logging_init.h"
 
 namespace magma {
 

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -12,11 +12,12 @@
  */
 #pragma once
 #include <lte/protos/session_manager.grpc.pb.h>
-
+#include <stdint.h>
 #include <string>
 
 #include "StoredState.h"
 #include "Types.h"
+#include "lte/protos/session_manager.pb.h"
 
 namespace magma {
 /**

--- a/lte/gateway/c/session_manager/SessionEvents.cpp
+++ b/lte/gateway/c/session_manager/SessionEvents.cpp
@@ -11,9 +11,28 @@
  * limitations under the License.
  */
 
+#include <folly/json.h>
+#include <glog/logging.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <stdint.h>
+#include <ostream>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "CreditKey.h"
 #include "EnumToString.h"
+#include "SessionCredit.h"
 #include "SessionEvents.h"
+#include "SessionState.h"
+#include "Types.h"
 #include "Utilities.h"
+#include "includes/EventdClient.h"
+#include "lte/protos/policydb.pb.h"
+#include "lte/protos/session_manager.pb.h"
+#include "magma_logging.h"
+#include "orc8r/protos/common.pb.h"
+#include "orc8r/protos/eventd.pb.h"
 
 using magma::orc8r::Event;
 using magma::orc8r::Void;

--- a/lte/gateway/c/session_manager/SessionEvents.h
+++ b/lte/gateway/c/session_manager/SessionEvents.h
@@ -10,21 +10,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
-#include <folly/dynamic.h>
 #include <folly/Format.h>
+#include <folly/dynamic.h>
 #include <folly/json.h>
 #include <orc8r/protos/eventd.pb.h>
-
 #include <memory>
 #include <string>
 #include <utility>
 
+#include "SessionState.h"
 #include "includes/EventdClient.h"
 #include "magma_logging.h"
-#include "SessionState.h"
 
 namespace magma {
+class EventdClient;
+class SessionState;
+struct SessionConfig;
+struct UpdateRequests;
+
 namespace lte {
 
 class EventsReporter {

--- a/lte/gateway/c/session_manager/SessionID.cpp
+++ b/lte/gateway/c/session_manager/SessionID.cpp
@@ -10,8 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <time.h>
-
 #include <sstream>
 #include <string>
 

--- a/lte/gateway/c/session_manager/SessionManagerServer.cpp
+++ b/lte/gateway/c/session_manager/SessionManagerServer.cpp
@@ -10,16 +10,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <grpc/impl/codegen/port_platform.h>
-#include <stdarg.h>
-#include <stdlib.h>
-
+#include <glog/logging.h>
+#include <grpc/impl/codegen/log.h>
+#include <grpcpp/impl/codegen/status.h>
 #include <chrono>
-#include <ctime>
 #include <memory>
+#include <ostream>
+#include <utility>
 
-#include "magma_logging.h"
 #include "SessionManagerServer.h"
+#include "magma_logging.h"
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/SessionManagerServer.h
+++ b/lte/gateway/c/session_manager/SessionManagerServer.h
@@ -12,9 +12,14 @@
  */
 #pragma once
 #include <grpc++/grpc++.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/impl/codegen/completion_queue.h>
+#include <grpcpp/impl/codegen/server_context.h>
 #include <lte/protos/abort_session.grpc.pb.h>
 #include <lte/protos/session_manager.grpc.pb.h>
-
+#include <atomic>
+#include <functional>
+#include <iosfwd>
 #include <memory>
 #include <utility>
 
@@ -22,6 +27,17 @@
 #include "SessionProxyResponderHandler.h"
 #include "SetMessageManagerHandler.h"
 #include "UpfMsgManageHandler.h"
+#include "lte/protos/abort_session.pb.h"
+#include "lte/protos/session_manager.pb.h"
+
+namespace grpc {
+class Status;
+}  // namespace grpc
+namespace magma {
+namespace orc8r {
+class Void;
+}  // namespace orc8r
+}  // namespace magma
 
 using grpc::ServerCompletionQueue;
 using grpc::ServerContext;

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
@@ -10,15 +10,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <chrono>
+#include <folly/io/async/EventBase.h>
+#include <glog/logging.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <grpcpp/impl/codegen/status_code_enum.h>
+#include <ostream>
 #include <string>
-#include <thread>
 
 #include "EnumToString.h"
 #include "GrpcMagmaUtils.h"
-#include "magma_logging.h"
-#include "includes/SentryWrapper.h"
+#include "LocalEnforcer.h"
 #include "SessionProxyResponderHandler.h"
+#include "SessionStore.h"
+#include "includes/SentryWrapper.h"
+#include "lte/protos/abort_session.pb.h"
+#include "lte/protos/session_manager.pb.h"
+#include "magma_logging.h"
+
+namespace google {
+namespace protobuf {
+class Message;
+}  // namespace protobuf
+}  // namespace google
+namespace grpc {
+class ServerContext;
+}  // namespace grpc
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.h
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.h
@@ -15,12 +15,28 @@
 #include <grpc++/grpc++.h>
 #include <lte/protos/abort_session.grpc.pb.h>
 #include <lte/protos/session_manager.grpc.pb.h>
-
 #include <functional>
 #include <memory>
 
 #include "LocalEnforcer.h"
 #include "SessionStore.h"
+
+namespace grpc {
+class ServerContext;
+class Status;
+}  // namespace grpc
+namespace magma {
+class LocalEnforcer;
+namespace lte {
+class AbortSessionRequest;
+class AbortSessionResult;
+class ChargingReAuthAnswer;
+class ChargingReAuthRequest;
+class PolicyReAuthAnswer;
+class PolicyReAuthRequest;
+class SessionStore;
+}  // namespace lte
+}  // namespace magma
 
 using grpc::ServerContext;
 using grpc::Status;

--- a/lte/gateway/c/session_manager/SessionReporter.cpp
+++ b/lte/gateway/c/session_manager/SessionReporter.cpp
@@ -11,14 +11,26 @@
  * limitations under the License.
  */
 #include <glog/logging.h>
-
+#include <grpcpp/channel.h>
+#include <grpcpp/impl/codegen/status.h>
 #include <iostream>
+#include <string>
 #include <utility>
 
 #include "GrpcMagmaUtils.h"
-#include "magma_logging.h"
-#include "includes/ServiceRegistrySingleton.h"
 #include "SessionReporter.h"
+#include "lte/protos/session_manager.grpc.pb.h"
+#include "lte/protos/session_manager.pb.h"
+#include "magma_logging.h"
+
+namespace folly {
+class EventBase;
+}  // namespace folly
+namespace google {
+namespace protobuf {
+class Message;
+}  // namespace protobuf
+}  // namespace google
 
 namespace magma {
 

--- a/lte/gateway/c/session_manager/SessionReporter.h
+++ b/lte/gateway/c/session_manager/SessionReporter.h
@@ -15,13 +15,31 @@
 #include <folly/io/async/EventBase.h>
 #include <grpc++/grpc++.h>
 #include <lte/protos/session_manager.grpc.pb.h>
-
+#include <stdint.h>
 #include <functional>
 #include <memory>
 
 #include "includes/GRPCReceiver.h"
+#include "lte/protos/apn.pb.h"
+
+namespace folly {
+class EventBase;
+}  // namespace folly
+namespace grpc {
+class Channel;
+class Status;
+}  // namespace grpc
 
 namespace magma {
+namespace lte {
+class CreateSessionRequest;
+class CreateSessionResponse;
+class SessionTerminateRequest;
+class SessionTerminateResponse;
+class UpdateSessionRequest;
+class UpdateSessionResponse;
+}  // namespace lte
+
 using namespace lte;
 
 /**

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -11,25 +11,27 @@
  * limitations under the License.
  */
 
+#include <ext/alloc_traits.h>
+#include <glog/logging.h>
+#include <google/protobuf/stubs/port.h>
 #include <google/protobuf/timestamp.pb.h>
-#include <google/protobuf/util/time_util.h>
-
+#include <algorithm>
+#include <ctime>
 #include <functional>
+#include <ostream>
 #include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "CreditKey.h"
-#include "DiameterCodes.h"
 #include "EnumToString.h"
-#include "magma_logging.h"
-#include "includes/MetricsHelpers.h"
 #include "RuleStore.h"
 #include "SessionState.h"
 #include "StoredState.h"
 #include "Utilities.h"
-#include "ShardTracker.h"
+#include "includes/MetricsHelpers.h"
+#include "magma_logging.h"
 
 namespace {
 const char* UE_TRAFFIC_COUNTER_NAME = "ue_traffic";

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -12,10 +12,12 @@
  */
 #pragma once
 
-#include <experimental/optional>
+#include <google/protobuf/timestamp.pb.h>
 #include <lte/protos/session_manager.grpc.pb.h>
 #include <lte/protos/spgw_service.grpc.pb.h>
-
+#include <stdint.h>
+#include <sys/types.h>
+#include <experimental/optional>
 #include <functional>
 #include <memory>
 #include <set>
@@ -29,10 +31,17 @@
 #include "CreditKey.h"
 #include "Monitor.h"
 #include "RuleStore.h"
+#include "ServiceAction.h"
 #include "SessionCredit.h"
 #include "SessionReporter.h"
 #include "StoredState.h"
 #include "Types.h"
+#include "lte/protos/apn.pb.h"
+#include "lte/protos/pipelined.pb.h"
+#include "lte/protos/policydb.pb.h"
+#include "lte/protos/session_manager.pb.h"
+#include "lte/protos/spgw_service.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
 
 namespace magma {
 using std::experimental::optional;

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -20,19 +20,29 @@
   Description 	Objects run in main thread context invoked by folly event
 *****************************************************************************/
 
+#include <folly/io/async/EventBase.h>
+#include <glog/logging.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <algorithm>
+#include <cstdint>
+#include <experimental/optional>
+#include <memory>
+#include <ostream>
 #include <string>
-#include <time.h>
 #include <utility>
 #include <vector>
-#include <memory>
 
-#include <google/protobuf/repeated_field.h>
-#include <google/protobuf/timestamp.pb.h>
-#include <google/protobuf/util/time_util.h>
-#include <grpcpp/channel.h>
-#include "magma_logging.h"
+#include "AmfServiceClient.h"
 #include "EnumToString.h"
+#include "PipelinedClient.h"
+#include "SessionState.h"
 #include "SessionStateEnforcer.h"
+#include "StoredState.h"
+#include "lte/protos/apn.pb.h"
+#include "lte/protos/mconfig/mconfigs.pb.h"
+#include "lte/protos/policydb.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+#include "magma_logging.h"
 
 #define DEFAULT_AMBR_UNITS (1024)
 #define DEFAULT_UP_LINK_PDR_ID 1

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.h
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.h
@@ -22,19 +22,37 @@ limitations under the License.
 
 #pragma once
 
-#include <unordered_map>
-#include <map>
-#include <unordered_set>
-#include <vector>
-
 #include <folly/io/async/EventBaseManager.h>
 #include <lte/protos/mconfig/mconfigs.pb.h>
 #include <lte/protos/policydb.pb.h>
+#include <stdint.h>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "AmfServiceClient.h"
 #include "PipelinedClient.h"
 #include "RuleStore.h"
 #include "SessionState.h"
 #include "SessionStore.h"
-#include "AmfServiceClient.h"
+#include "StoreClient.h"
+#include "Types.h"
+#include "lte/protos/pipelined.pb.h"
+#include "lte/protos/session_manager.pb.h"
+
+namespace folly {
+class EventBase;
+}  // namespace folly
+namespace magma {
+class AmfServiceClient;
+class PipelinedClient;
+class SessionState;
+struct SessionStateUpdateCriteria;
+}  // namespace magma
 
 #define M5G_MIN_TEID (UINT32_MAX / 2)
 #define DEFAULT_PDR_VERSION 1

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -11,15 +11,27 @@
  * limitations under the License.
  */
 
+#include <glog/logging.h>
+#include <ostream>
 #include <utility>
+#include <vector>
 
-#include "magma_logging.h"
+#include "CreditKey.h"
+#include "MemoryStoreClient.h"
+#include "MeteringReporter.h"
 #include "SessionState.h"
 #include "SessionStore.h"
 #include "StoredState.h"
+#include "Types.h"
+#include "lte/protos/session_manager.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+#include "magma_logging.h"
 
 namespace magma {
+class StaticRuleStore;
+
 namespace lte {
+class RedisStoreClient;
 
 SessionStore::SessionStore(
     std::shared_ptr<StaticRuleStore> rule_store,

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -12,9 +12,9 @@
  */
 #pragma once
 
-#include <experimental/optional>
 #include <lte/protos/session_manager.grpc.pb.h>
-
+#include <stdint.h>
+#include <experimental/optional>
 #include <memory>
 #include <set>
 #include <string>
@@ -25,10 +25,18 @@
 #include "RedisStoreClient.h"
 #include "RuleStore.h"
 #include "SessionState.h"
+#include "StoreClient.h"
 #include "StoredState.h"
 
 namespace magma {
+class StaticRuleStore;
+struct SessionStateUpdateCriteria;
+
 namespace lte {
+class MeteringReporter;
+class RedisStoreClient;
+class UpdateSessionRequest;
+
 using std::experimental::optional;
 
 // Value int represents the request numbers needed for requests to PCRF

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -17,15 +17,38 @@
   Author/Editor Sanjay Kumar Ojha
   Description 	Acts as 5G Landing object in SessionD & start 5G related flow
 *****************************************************************************/
-#include <chrono>
-#include <thread>
+#include <folly/io/async/EventBase.h>
+#include <glog/logging.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <grpcpp/impl/codegen/status_code_enum.h>
+#include <experimental/optional>
+#include <ostream>
 #include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
-#include <google/protobuf/util/time_util.h>
-
-#include "SetMessageManagerHandler.h"
-#include "magma_logging.h"
 #include "GrpcMagmaUtils.h"
+#include "SessionReporter.h"
+#include "SessionState.h"
+#include "SessionStateEnforcer.h"
+#include "SessionStore.h"
+#include "SetMessageManagerHandler.h"
+#include "lte/protos/session_manager.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+#include "magma_logging.h"
+
+namespace google {
+namespace protobuf {
+class Message;
+}  // namespace protobuf
+}  // namespace google
+namespace grpc {
+class ServerContext;
+}  // namespace grpc
+namespace magma {
+struct SessionStateUpdateCriteria;
+}  // namespace magma
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.h
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.h
@@ -18,17 +18,35 @@
   Description 	Defines Access and Mobility Management Messages
 *****************************************************************************/
 #pragma once
-#include <functional>
-#include <string>
-#include <memory>
-
 #include <grpc++/grpc++.h>
 #include <lte/protos/session_manager.grpc.pb.h>
+#include <stdint.h>
+#include <functional>
+#include <memory>
+#include <string>
 
-#include "SessionStateEnforcer.h"
 #include "SessionID.h"
 #include "SessionReporter.h"
+#include "SessionStateEnforcer.h"
 #include "SessionStore.h"
+#include "StoreClient.h"
+#include "Types.h"
+#include "orc8r/protos/common.pb.h"
+
+namespace grpc {
+class ServerContext;
+class Status;
+}  // namespace grpc
+namespace magma {
+class SessionReporter;
+class SessionStateEnforcer;
+namespace lte {
+class SessionStore;
+class SetSMSessionContext;
+class SetSmNotificationContext;
+class SmContextVoid;
+}  // namespace lte
+}  // namespace magma
 
 using grpc::ServerContext;
 using grpc::Status;

--- a/lte/gateway/c/session_manager/ShardTracker.cpp
+++ b/lte/gateway/c/session_manager/ShardTracker.cpp
@@ -11,9 +11,11 @@
  * limitations under the License.
  */
 
+#include <stddef.h>
+#include <memory>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
 
 #include "ShardTracker.h"
 

--- a/lte/gateway/c/session_manager/ShardTracker.h
+++ b/lte/gateway/c/session_manager/ShardTracker.h
@@ -11,9 +11,10 @@
  * limitations under the License.
  */
 #pragma once
+#include <stdint.h>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
 
 namespace magma {
 

--- a/lte/gateway/c/session_manager/SpgwServiceClient.cpp
+++ b/lte/gateway/c/session_manager/SpgwServiceClient.cpp
@@ -11,26 +11,20 @@
  * limitations under the License.
  */
 
-#include <glog/logging.h>                          // for COMPACT_GOOGLE_LOG...
-#include <grpcpp/channel.h>                        // for Channel
-#include <grpcpp/impl/codegen/async_unary_call.h>  // for default_delete
-#include <grpcpp/impl/codegen/status.h>            // for Status
+#include <glog/logging.h>                // for COMPACT_GOOGLE_LOG...
+#include <grpcpp/channel.h>              // for Channel
+#include <grpcpp/impl/codegen/status.h>  // for Status
+#include <cstdint>                       // for uint32_t
+#include <ostream>                       // for operator<<, basic_...
+#include <utility>                       // for move
 
-#include <algorithm>  // for copy
-#include <cstdint>    // for uint32_t
-#include <ostream>    // for operator<<, basic_...
-#include <utility>    // for move
-
+#include "SpgwServiceClient.h"
+#include "includes/ServiceRegistrySingleton.h"  // for ServiceRegistrySin...
 #include "lte/protos/policydb.pb.h"             // for RepeatedField, Rep...
 #include "lte/protos/spgw_service.grpc.pb.h"    // for SpgwService::Stub
 #include "lte/protos/spgw_service.pb.h"         // for DeleteBearerRequest
-#include "magma_logging.h"                      // for MLOG, MERROR, MINFO
-#include "includes/ServiceRegistrySingleton.h"  // for ServiceRegistrySin...
-#include "SpgwServiceClient.h"
-
-namespace grpc {
-class Channel;
-}
+#include "lte/protos/subscriberdb.pb.h"
+#include "magma_logging.h"  // for MLOG, MERROR, MINFO
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/SpgwServiceClient.h
+++ b/lte/gateway/c/session_manager/SpgwServiceClient.h
@@ -14,13 +14,13 @@
 
 #include <lte/protos/spgw_service.grpc.pb.h>  // for SpgwService::Stub, Spgw...
 #include <stdint.h>                           // for uint32_t
+#include <functional>                         // for function
+#include <memory>                             // for shared_ptr, unique_ptr
+#include <string>                             // for string
+#include <vector>                             // for vector
 
-#include <functional>  // for function
-#include <memory>      // for shared_ptr, unique_ptr
-#include <string>      // for string
-#include <vector>      // for vector
-
-#include "includes/GRPCReceiver.h"       // for GRPCReceiver
+#include "includes/GRPCReceiver.h"  // for GRPCReceiver
+#include "lte/protos/apn.pb.h"
 #include "lte/protos/subscriberdb.pb.h"  // for lte
 
 namespace grpc {

--- a/lte/gateway/c/session_manager/StatsPoller.cpp
+++ b/lte/gateway/c/session_manager/StatsPoller.cpp
@@ -11,9 +11,13 @@
  * limitations under the License.
  */
 #include <stdint.h>
-#include <atomic>
+#include <chrono>
 #include <memory>
+#include <thread>
+
+#include "LocalEnforcer.h"
 #include "StatsPoller.h"
+
 #define COOKIE 0
 #define COOKIE_MASK 0
 

--- a/lte/gateway/c/session_manager/StatsPoller.h
+++ b/lte/gateway/c/session_manager/StatsPoller.h
@@ -13,8 +13,11 @@
 #include <stdint.h>
 #include <atomic>
 #include <memory>
+
 #include "LocalEnforcer.h"
+
 namespace magma {
+class LocalEnforcer;
 
 class StatsPoller {
  public:

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -11,17 +11,23 @@
  * limitations under the License.
  */
 
+#include <folly/Range.h>
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <glog/logging.h>
 #include <google/protobuf/timestamp.pb.h>
 #include <google/protobuf/util/time_util.h>
-#include <lte/protos/pipelined.grpc.pb.h>
-#include <lte/protos/session_manager.grpc.pb.h>
-
+#include <algorithm>
+#include <ostream>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "CreditKey.h"
-#include "magma_logging.h"
 #include "StoredState.h"
+#include "lte/protos/apn.pb.h"
+#include "magma_logging.h"
 
 namespace magma {
 using google::protobuf::util::TimeUtil;

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -12,13 +12,15 @@
  */
 #pragma once
 
-#include <experimental/optional>
-#include <folly/dynamic.h>
 #include <folly/Format.h>
+#include <folly/dynamic.h>
 #include <folly/json.h>
+#include <google/protobuf/timestamp.pb.h>
 #include <lte/protos/pipelined.grpc.pb.h>
 #include <lte/protos/session_manager.grpc.pb.h>
-
+#include <sys/types.h>
+#include <cstdint>
+#include <experimental/optional>
 #include <functional>
 #include <set>
 #include <string>
@@ -27,6 +29,9 @@
 
 #include "CreditKey.h"
 #include "Types.h"
+#include "lte/protos/pipelined.pb.h"
+#include "lte/protos/policydb.pb.h"
+#include "lte/protos/session_manager.pb.h"
 
 namespace magma {
 using std::experimental::optional;

--- a/lte/gateway/c/session_manager/UpfMsgManageHandler.cpp
+++ b/lte/gateway/c/session_manager/UpfMsgManageHandler.cpp
@@ -9,18 +9,38 @@
  * limitations under the License.
  */
 #include "UpfMsgManageHandler.h"
-#include <google/protobuf/util/time_util.h>
-#include <chrono>
-#include <thread>
-#include <memory>
-#include <string>
-#include <sys/socket.h>
-#include <netinet/in.h>
+
 #include <arpa/inet.h>
-#include "magma_logging.h"
-#include "SessionStateEnforcer.h"
+#include <folly/io/async/EventBase.h>
+#include <glog/logging.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <grpcpp/impl/codegen/status_code_enum.h>
+#include <netinet/in.h>
+#include <experimental/optional>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
 #include "GrpcMagmaUtils.h"
+#include "MobilitydClient.h"
+#include "SessionState.h"
+#include "SessionStateEnforcer.h"
+#include "SessionStore.h"
+#include "Types.h"
+#include "lte/protos/mobilityd.pb.h"
 #include "lte/protos/session_manager.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+#include "magma_logging.h"
+
+namespace google {
+namespace protobuf {
+class Message;
+}  // namespace protobuf
+}  // namespace google
+namespace grpc {
+class ServerContext;
+}  // namespace grpc
 
 using grpc::Status;
 

--- a/lte/gateway/c/session_manager/UpfMsgManageHandler.h
+++ b/lte/gateway/c/session_manager/UpfMsgManageHandler.h
@@ -14,15 +14,34 @@
 
 #include <grpc++/grpc++.h>
 #include <lte/protos/session_manager.grpc.pb.h>
-
+#include <stdint.h>
 #include <functional>
 #include <memory>
+#include <string>
 
-#include "SessionStateEnforcer.h"
+#include "MobilitydClient.h"
 #include "SessionID.h"
 #include "SessionReporter.h"
+#include "SessionStateEnforcer.h"
 #include "SessionStore.h"
-#include "MobilitydClient.h"
+#include "orc8r/protos/common.pb.h"
+
+namespace grpc {
+class Server;
+class ServerContext;
+class Status;
+}  // namespace grpc
+namespace magma {
+class MobilitydClient;
+class SessionStateEnforcer;
+namespace lte {
+class SessionStore;
+class SmContextVoid;
+class UPFNodeState;
+class UPFPagingInfo;
+class UPFSessionConfigState;
+}  // namespace lte
+}  // namespace magma
 
 using grpc::Server;
 using grpc::ServerContext;

--- a/lte/gateway/c/session_manager/Utilities.cpp
+++ b/lte/gateway/c/session_manager/Utilities.cpp
@@ -11,13 +11,19 @@
  * limitations under the License.
  */
 #include <google/protobuf/util/time_util.h>
-
+#include <time.h>
 #include <algorithm>
 #include <chrono>
 #include <iomanip>
 #include <sstream>
 
 #include "Utilities.h"
+
+namespace google {
+namespace protobuf {
+class Timestamp;
+}  // namespace protobuf
+}  // namespace google
 
 namespace magma {
 

--- a/lte/gateway/c/session_manager/Utilities.h
+++ b/lte/gateway/c/session_manager/Utilities.h
@@ -14,8 +14,16 @@
 
 #include <google/protobuf/timestamp.pb.h>
 #include <google/protobuf/util/time_util.h>
-
+#include <stdint.h>
+#include <sys/types.h>
+#include <chrono>
 #include <string>
+
+namespace google {
+namespace protobuf {
+class Timestamp;
+}  // namespace protobuf
+}  // namespace google
 
 namespace magma {
 std::string bytes_to_hex(const std::string& s);

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -11,28 +11,67 @@
  * limitations under the License.
  */
 
+#include <cpp_redis/core/client.hpp>
+#include <folly/io/async/EventBase.h>
+#include <folly/io/async/EventBaseManager.h>
+#include <glog/logging.h>
+#include <grpcpp/impl/codegen/completion_queue.h>
 #include <lte/protos/mconfig/mconfigs.pb.h>
-
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+#include <yaml-cpp/yaml.h>
+#include <chrono>
 #include <cstdlib>
+#include <future>
 #include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
+#include "AAAClient.h"
+#include "AmfServiceClient.h"
+#include "DirectorydClient.h"
 #include "GrpcMagmaUtils.h"
-#include "UpfMsgManageHandler.h"
 #include "LocalEnforcer.h"
-#include "magma_logging_init.h"
-#include "includes/MagmaService.h"
-#include "includes/MConfigLoader.h"
+#include "LocalSessionManagerHandler.h"
+#include "MeteringReporter.h"
+#include "MobilitydClient.h"
 #include "OperationalStatesHandler.h"
+#include "PipelinedClient.h"
 #include "PolicyLoader.h"
 #include "RedisStoreClient.h"
 #include "RestartHandler.h"
-#include "includes/SentryWrapper.h"
-#include "includes/ServiceRegistrySingleton.h"
+#include "RuleStore.h"
 #include "SessionCredit.h"
+#include "SessionEvents.h"
 #include "SessionManagerServer.h"
+#include "SessionProxyResponderHandler.h"
 #include "SessionReporter.h"
+#include "SessionStateEnforcer.h"
 #include "SessionStore.h"
+#include "SetMessageManagerHandler.h"
+#include "ShardTracker.h"
+#include "SpgwServiceClient.h"
 #include "StatsPoller.h"
+#include "UpfMsgManageHandler.h"
+#include "includes/EventdClient.h"
+#include "includes/MConfigLoader.h"
+#include "includes/MagmaService.h"
+#include "includes/SentryWrapper.h"
+#include "includes/ServiceConfigLoader.h"
+#include "includes/ServiceRegistrySingleton.h"
+#include "lte/protos/policydb.pb.h"
+#include "magma_logging.h"
+#include "magma_logging_init.h"
+#include "orc8r/protos/common.pb.h"
+
+namespace grpc {
+class Channel;
+}  // namespace grpc
 
 #define SESSIOND_SERVICE "sessiond"
 #define SESSION_PROXY_SERVICE "session_proxy"

--- a/tools/iwyu.imp
+++ b/tools/iwyu.imp
@@ -15,4 +15,8 @@
     { include: ["<yaml-cpp/stlemitter.h>", "private", "<yaml-cpp/yaml.h>", "public"] },
     { include: ["<yaml-cpp/exceptions.h>", "private", "<yaml-cpp/yaml.h>", "public"] },
     { include: ["@<yaml-cpp/node/.*>", "private", "<yaml-cpp/yaml.h>", "public"] },
+
+    # folly
+    { include: ["<folly/dynamic-inl.h>", "private", "<folly/dynamic.h>", "public"] },
+    { include: ["<folly/lang/Assume-inl.h>", "private", "<folly/lang/Assume.h>", "public"] },
 ]


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
An automated (with several iteration) application of IWYU findings to lte/gateway/c/session_manager

IWYU doc @ https://github.com/include-what-you-use/include-what-you-use
<!-- Enumerate changes you made and why you made them -->

## Test Plan
In the devcontainer 
```bash
make build_session_manager
# copy the compile_commands.json file generated into magma root
iwyu_tool.py -p $MAGMA_ROOT/compile_commands.json lte/gateway/c/session_manager -- -Xiwyu --mapping_file=$MAGMA_ROOT/tools/iwyu.imp | tee sessiond-output.txt
fix_includes.py < sessiond-output.txt -b --reorder 
# build and resolve any issues. I was able to resolve issues by adding `// IWYU pragma: keep` to important includes that were removed by IWYU. If private headers were included that are not available, add a mapping to tools/iwyu.imp
```
^ repeat the steps above until you run the fix_includes.py tool and get this message
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
