### PR TITLE
fix(agw): Fixed memleak for s1 handover cancel

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -2271,6 +2271,7 @@ status_code_e s1ap_mme_handle_handover_cancel(
   S1ap_HandoverCancelAcknowledge_t* out;
   S1ap_HandoverCancelAcknowledgeIEs_t* hca_ie = NULL;
   ue_description_t* ue_ref_p                  = NULL;
+  e_rab_admitted_list_t e_rab_admitted_list   = {0};
   mme_ue_s1ap_id_t mme_ue_s1ap_id             = INVALID_MME_UE_S1AP_ID;
   enb_ue_s1ap_id_t enb_ue_s1ap_id             = INVALID_ENB_UE_S1AP_ID;
   S1ap_Cause_PR cause_type;
@@ -2346,7 +2347,14 @@ status_code_e s1ap_mme_handle_handover_cancel(
     // this effectively cancels the HandoverPreparation proecedure as we
     // only send a HandoverCommand if the UE is in the S1AP_UE_HANDOVER
     // state.
-    ue_ref_p->s1_ue_state         = S1AP_UE_CONNECTED;
+    ue_ref_p->s1_ue_state = S1AP_UE_CONNECTED;
+    /* Free all the transport layer address pointers in ERAB admitted list
+     * before actually resetting the S1AP handover state
+     */
+    e_rab_admitted_list = ue_ref_p->s1ap_handover_state.e_rab_admitted_list;
+    for (int i = 0; i < e_rab_admitted_list.no_of_items; i++) {
+      bdestroy_wrapper(&e_rab_admitted_list.item[i].transport_layer_address);
+    }
     ue_ref_p->s1ap_handover_state = (struct s1ap_handover_state_s){0};
   } else {
     // Not a failure, but nothing for us to do.


### PR DESCRIPTION
## Title
Fixed memleak for s1 handover cancel

## Summary
A memory leak was observed during the s1ap handover cancel scenario. The memory was allocated for the transport layer addresses in erab admitted list of s1ap handover state during the s1ap handover request acknowledge handling while it was getting freed only during handover notify and was missing in the unsuccessful scenario of handover cancel. This PR fixes the issue.

The memory leak from the syslog can be seen below:
```
=================================================================
==442575==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 32 byte(s) in 2 object(s) allocated from:
    #0 0x7f9156640bc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
    #1 0x5648a3c14318 in blk2bstr /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:286
    #2 0x5648a3cef835 in s1ap_mme_handle_handover_request_ack /home/vagrant/magma/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c:2039
    #3 0x5648a3ccdaef in s1ap_mme_handle_message /home/vagrant/magma/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c:221
    #4 0x5648a3c365f2 in handle_message /home/vagrant/magma/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c:150
    #5 0x7f91557765c6 in zloop_start (/lib/x86_64-linux-gnu/libczmq.so.4+0x295c6)
Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7f9156640bc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
    #1 0x5648a3c1450a in blk2bstr /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:295
    #2 0x5648a3cef835 in s1ap_mme_handle_handover_request_ack /home/vagrant/magma/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c:2039
    #3 0x5648a3ccdaef in s1ap_mme_handle_message /home/vagrant/magma/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c:221
    #4 0x5648a3c365f2 in handle_message /home/vagrant/magma/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c:150
    #5 0x7f91557765c6 in zloop_start (/lib/x86_64-linux-gnu/libczmq.so.4+0x295c6)
SUMMARY: AddressSanitizer: 48 byte(s) leaked in 4 allocation(s).

```

## Test plan
Verified with s1 handover test cases individually and as part of sanity/non-sanity

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>