### PR TITLE
fix: Fix VScode task to generate compile commands

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,7 @@
 		"coolchyni.beyond-debug",
 		"stackbuild.bazel-stack-vscode-cc",
 		"augustocdias.tasks-shell-input",
+		"ryuta46.multi-command",
 	],
 	"image": "ghcr.io/magma/devcontainer:sha-007ddb9",
 	"settings": {
@@ -48,6 +49,15 @@
 		// Update this field with any new targets that need compilation database generation
 		"bsv.cc.compdb.targets": [
 			"//lte/gateway/c/session_manager:sessiond"
+		],
+		"multiCommand.commands": [
+			{
+				"command": "multiCommand.sentry_generateCcWithBazelAndRestartClangderror",
+				"sequence": [
+					"bsv.cc.compdb.generate",
+					"clangd.restart",
+				],
+			}
 		]
 	},
 	"mounts": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,7 @@
             "command": "shellCommand.execute",
             "args": {
                 // Use bazel query to find all test targets. This will automatically pick up any new tests added.
-                "command": "bazel query 'tests(//lte/gateway/c/session_manager/test:all)' | cut -d ':' -f2",
+                "command": "bazel query 'tests(//lte/gateway/c/session_manager/test/...)' | cut -d ':' -f2",
             },
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,27 +2,11 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "(Bazel) Refresh Compilation Database And Restart Clangd",
-            "type": "shell",
-            "command": "echo 'Regenerated compilation database and restarted clangd!'",
-            "dependsOrder": "sequence",
-            "dependsOn": [
-                "bsv.cc.compdb.generate",
-                "clangd.restart"
-            ],
-            "runOptions": {
-                "runOn": "folderOpen"
-            },
-            "problemMatcher": []
-        },
-        {
             "label": "(Bazel) Build All",
             "type": "shell",
             "command": "bazel",
             "args": [
                 "build",
-                "-c",
-                "dbg",
                 "..."
             ],
             "group": {
@@ -36,12 +20,25 @@
             "command": "bazel",
             "args": [
                 "build",
-                "--config=${env:VSCODE_BAZEL_BUILD_CONFIG}",
-                "-c",
-                "dbg",
                 "//lte/gateway/c/session_manager/test:all"
             ],
             "group": "build"
+        },
+        {
+            "label": "Set compile_commands.json for IntelliSense",
+            "type": "shell",
+            "command": "rm compile_commands.json || true && ln -s ${input:pickCompileCommandsFile} ${workspaceFolder}/compile_commands.json",
+            "problemMatcher": []
+        }
+    ],
+    "inputs": [
+        {
+            "id": "pickCompileCommandsFile",
+            "type": "command",
+            "command": "shellCommand.execute",
+            "args": {
+                "command": "sudo find ${env:C_BUILD} -name 'compile_commands.json'",
+            },
         }
     ]
 }

--- a/experimental/bazel-base/VSCodeBazel.md
+++ b/experimental/bazel-base/VSCodeBazel.md
@@ -4,7 +4,7 @@
 
 ## Build and test all targets
 
-Run **Command+Shift+B** to trigger the default build configuration. In the Remote SSH workspace, it is set as `bazel build --config=vm ...`. In GitHub codespaces, it is set as `bazel build --config=devcontainer ...`.
+Run **Command+Shift+B** to trigger the default build configuration. Build tasks are defined in `.vscode/tasks.json`.
 
 ## Build specific targets and unit tests via codelens
 
@@ -19,13 +19,17 @@ At the top of each `BUILD.bazel` file, there is a codelens to build and test all
 
 ## Code jumping and navigation for C++ ([Intellisense](https://code.visualstudio.com/docs/editor/intellisense))
 
-In order to get code jumping and navigation working properly for C++, there are a few moving parts. We utilize [clangd](https://clangd.llvm.org) to enable smart code insights in VSCode. In order for [clangd](https://clangd.llvm.org) to work, we need to generate a `compile_commands.json` that serves as a compilation database for relevant targets.
+In order to get code jumping and navigation working properly for C++, there are a few moving parts. We utilize [clangd](https://clangd.llvm.org) to enable smart code insights in VSCode. [Clangd](https://clangd.llvm.org) searches for a `compile_commands.json` file that serves as a compilation database at $MAGMA_ROOT. Most often, clangd will need to be restarted when the compile_commands.json is modified.
 
-Note that since external libraries and generated source files are only pulled in after a build, you will have to build the relevant target at least once for code jumping and completion to work. See above section on how to build specific targets.
+Note that since external libraries and generated source files are only pulled in after a build, you will have to build the relevant target at least once for code jumping and completion to work. See above section on how to build specific targets with Bazel.
 
-As for compilation database generation, we have patched together a few commands into a task to make this easier. To generate the database, follow **Terminal->Run Task...->Refresh Compilation Database And Restart Clangd**. This is a wrapper command that runs `bsv.cc.compdb.generate` (**Bzl: Bazel/C++: Generate Compilation Database**) and then `clangd.restart` (**clangd: Restart language server**). If the wrapper command does not work, try running the indivdual commands opening up the command palette via **Command+Shift+P**.
+To generate the compilation database with Bazel, run **Command+Shift+P** to open the command palette and select **Multi command: Execute multi command**. Select the command **sentry_generateCcWithBazelAndRestartClangderror**. This is a wrapper command that runs two extension commands: `bsv.cc.compdb.generate` (**Bzl: Bazel/C++: Generate Compilation Database**) and then `clangd.restart` (**clangd: Restart language server**).
 
-If you get an error saying that `clangd` is not found, reinstall clangd with **clangd: Download language server** and try again.
+If you want to generate the compilation database another way, you will just need to symlink `$MAGMA_ROOT/compile_commands.json` to the file and restart clangd. We have a convenience task to choose and symlink the file. To use it, run  **Command+Shift+P** to open the command palette and select **Tasks: Run Task** and choose **Set compile_commands.json for IntelliSense**. This will prompt you to select a `compile_commands.json` to use. Once the task completes, restart clangd.
+
+If you see errors about clangd, try the following:
+1. For errors about `clangd` not being found, try running **clangd: Download language server** from the command palette
+2. For errors about the extension commands not being found, try running **clangd: Manually activate extension** to start the extension
 
 At this point, you should be able to jump to and have code completion for source files of generated and imported libraries.
 

--- a/experimental/bazel-base/VSCodeSetup.md
+++ b/experimental/bazel-base/VSCodeSetup.md
@@ -11,11 +11,11 @@ Open VSCode and use **Command+Shift+P** to open the editor preferences and selec
 ```
     "remote.SSH.defaultExtensions": [
         "llvm-vs-code-extensions.vscode-clangd",
-        "mitaki28.vscode-clang",
         "stackbuild.bazel-stack-vscode",
         "coolchyni.beyond-debug",
         "stackbuild.bazel-stack-vscode-cc",
         "augustocdias.tasks-shell-input",
+        "ryuta46.multi-command",
     ],
 ```
 

--- a/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
+++ b/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
@@ -7,11 +7,11 @@
 	"extensions": {
 		"recommendations": [
 			"llvm-vs-code-extensions.vscode-clangd",
-			"mitaki28.vscode-clang",
 			"stackbuild.bazel-stack-vscode",
 			"coolchyni.beyond-debug",
 			"stackbuild.bazel-stack-vscode-cc",
 			"augustocdias.tasks-shell-input",
+			"ryuta46.multi-command",
 		]
 	},
 	"settings": {
@@ -32,15 +32,22 @@
 		"bsv.bzl.lsp.enableCodelensRun": false,
 		"bsv.bzl.remoteCache.enabled": false,
 		"bsv.bzl.starlarkDebugger.enabled": false,
-		"clangd.path": "/usr/bin/clangd-12",
 		"clangd.arguments": [
 			"-log=verbose",
 			"-pretty",
 			"--background-index",
 		],
-		"clangd.onConfigChanged": "restart",
 		"bsv.cc.compdb.targets": [
 			"//lte/gateway/c/session_manager:sessiond",
+		],
+		"multiCommand.commands": [
+			{
+				"command": "multiCommand.generateCcWithBazelAndRestartClangd",
+				"sequence": [
+					"bsv.cc.compdb.generate",
+					"clangd.restart",
+				],
+			}
 		]
 	},
 }


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Use the multi command extension instead of relying on VSCode's 'dependsOn' key. (I've seen it work a few times, but it's not consistent and gives bad errors)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested on both Codespaces and Magma VM setup
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
