### PR TITLE
feat(sessiond): Send the DNN value requested by AMF in grpc response …

### DIFF
--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -667,6 +667,7 @@ void SessionStateEnforcer::prepare_response_to_access(
           .end_ipv4_addr());
 
   rsp_cmn->mutable_sid()->CopyFrom(config.common_context.sid());  // imsi
+  rsp_cmn->set_apn(config.common_context.apn());
   rsp_cmn->set_sm_session_state(config.common_context.sm_session_state());
   rsp_cmn->set_sm_session_version(config.common_context.sm_session_version());
   // Send message to AMF gRPC client handler.


### PR DESCRIPTION
…call

Signed-off-by: Pratibha Gavhade <pratibha.gavhade@wavelabs.ai>



## Summary
SMF will send the DNN value in CommonSessionContext requested by AMF in SetSMSessionContextAccess grpc response call.


## Test Plan
Tested PDUSession establishment and release with stub cli smf_upf_integration_cli.py
Please check comment section for more logs


## Additional Information




