### PR TITLE
fix(amf): fix for the regression failure testcases

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -719,9 +719,6 @@ static int registration_accept_t3550_handler(
           registration_proc->retransmission_count);
       // To abort the registration procedure
       amf_proc_registration_abort(amf_ctx, ue_amf_context);
-      // Clean up all the sessions.
-      amf_smf_context_cleanup_pdu_session(ue_amf_context);
-      amf_free_ue_context(ue_amf_context);
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
@@ -1152,6 +1149,7 @@ int amf_proc_registration_abort(
     message_p->ittiMsgHeader.imsi = ue_amf_context->amf_context.imsi64;
     send_msg_to_task(&amf_app_task_zmq_ctx, TASK_NGAP, message_p);
     amf_delete_registration_proc(amf_ctx);
+    amf_free_ue_context(ue_amf_context);
     rc = RETURNok;
   }
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);

--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -1152,7 +1152,6 @@ int amf_proc_registration_abort(
     message_p->ittiMsgHeader.imsi = ue_amf_context->amf_context.imsi64;
     send_msg_to_task(&amf_app_task_zmq_ctx, TASK_NGAP, message_p);
     amf_delete_registration_proc(amf_ctx);
-    amf_free_ue_context(ue_amf_context);
     rc = RETURNok;
   }
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);


### PR DESCRIPTION
fix(amf): fix for the regression failure testcases


## Summary

1. Removed duplicate function calls to free the ue_context

## Test Plan
1. Verified on TVM

## Additional Information

