### PR TITLE
feat: add error logging to sentry in OAI

### DIFF
--- a/lte/gateway/c/core/oai/common/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/common/CMakeLists.txt
@@ -60,6 +60,7 @@ set(COMMON_SRC
     pid_file.c
     shared_ts_log.c
     log.c
+    sentry_log.cpp
     state_converter.cpp
     common_utility_funs.cpp
     ${PROTO_SRCS}

--- a/lte/gateway/c/core/oai/common/sentry_log.cpp
+++ b/lte/gateway/c/core/oai/common/sentry_log.cpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "lte/gateway/c/core/oai/common/sentry_log.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "orc8r/gateway/c/common/sentry/includes/SentryWrapper.h"
+
+extern "C" void sentry_error(const char* fmt, ...) {
+  va_list args;
+  size_t len;
+  char* error_message;
+
+  va_start(args, fmt);
+  len = vsnprintf(nullptr, 0, fmt, args);
+  va_end(args);
+
+  error_message = reinterpret_cast<char*>(malloc(len + 1));
+  if (error_message != NULL) {
+    va_start(args, fmt);
+    vsnprintf(error_message, len + 1, fmt, args);
+    va_end(args);
+    sentry_log_error(error_message);
+    free(error_message);
+  }
+}

--- a/lte/gateway/c/core/oai/common/sentry_log.h
+++ b/lte/gateway/c/core/oai/common/sentry_log.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief format the given string and log it to Sentry
+ *
+ * @param format
+ * @param ... variable args to be formatated into format
+ */
+void sentry_error(const char* format, ...);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -35,6 +35,7 @@
 #include "lte/gateway/c/core/oai/common/log.h"
 #include "lte/gateway/c/core/oai/common/conversions.h"
 #include "lte/gateway/c/core/oai/common/common_types.h"
+#include "lte/gateway/c/core/oai/common/sentry_log.h"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
 #include "lte/gateway/c/core/oai/include/mme_config.h"
 #include "lte/gateway/c/core/oai/include/mme_app_ue_context.h"
@@ -2028,6 +2029,9 @@ status_code_e mme_app_handle_implicit_detach_timer_expiry(
     OAILOG_ERROR(
         LOG_MME_APP,
         "Invalid UE context received, MME UE S1AP Id: " MME_UE_S1AP_ID_FMT "\n",
+        mme_ue_s1ap_id);
+    sentry_error(
+        "Invalid UE context received, MME UE S1AP Id: " MME_UE_S1AP_ID_FMT,
         mme_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
   }

--- a/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
+++ b/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
@@ -165,6 +165,6 @@ void shutdown_sentry(void) {}
 
 void set_sentry_transaction(__attribute__((unused)) const char* name) {}
 
-void sentry_log_error(__attribute__((unused)) const char* message);
+void sentry_log_error(__attribute__((unused)) const char* message) {}
 
 #endif

--- a/orc8r/gateway/c/common/sentry/includes/SentryWrapper.h
+++ b/orc8r/gateway/c/common/sentry/includes/SentryWrapper.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Discussed with @ardzoht offline, but we are trying to start adding custom errors for types of logical surprises that we want to know about.

Adding `sentry_error` simply sends a error message to sentry with mme.log file at that point. If this proves useful, we can start adding breadcrumbs to help enrich the event. (Breadcrumbs are messages that don't get sent to sentry on its own, but is attached if there is an error).

Tested by adding a similar custom error in the state conversion code and running s1ap tests.

<img width="1792" alt="Screen Shot 2021-11-05 at 9 19 21 AM" src="https://user-images.githubusercontent.com/37634144/140518208-2dec5f44-a510-415e-a209-554a643eb5ff.png">

Note that the level field attached to the event is `errror` and not `fatal` as it is for crashes.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
