### PR TITLE
fix(agw): Fixed memleak for s1 handover cancel 

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -2276,6 +2276,7 @@ int s1ap_mme_handle_handover_cancel(
   S1ap_HandoverCancelAcknowledge_t* out;
   S1ap_HandoverCancelAcknowledgeIEs_t* hca_ie = NULL;
   ue_description_t* ue_ref_p                  = NULL;
+  e_rab_admitted_list_t e_rab_admitted_list   = {0};
   mme_ue_s1ap_id_t mme_ue_s1ap_id             = INVALID_MME_UE_S1AP_ID;
   enb_ue_s1ap_id_t enb_ue_s1ap_id             = INVALID_ENB_UE_S1AP_ID;
   S1ap_Cause_PR cause_type;
@@ -2351,7 +2352,14 @@ int s1ap_mme_handle_handover_cancel(
     // this effectively cancels the HandoverPreparation proecedure as we
     // only send a HandoverCommand if the UE is in the S1AP_UE_HANDOVER
     // state.
-    ue_ref_p->s1_ue_state         = S1AP_UE_CONNECTED;
+    ue_ref_p->s1_ue_state = S1AP_UE_CONNECTED;
+    /* Free all the transport layer address pointers in ERAB admitted list
+     * before actually resetting the S1AP handover state
+     */
+    e_rab_admitted_list = ue_ref_p->s1ap_handover_state.e_rab_admitted_list;
+    for (int i = 0; i < e_rab_admitted_list.no_of_items; i++) {
+      bdestroy_wrapper(&e_rab_admitted_list.item[i].transport_layer_address);
+    }
     ue_ref_p->s1ap_handover_state = (struct s1ap_handover_state_s){0};
   } else {
     // Not a failure, but nothing for us to do.


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Backporting changes of #9938 into v1.6 branch

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- ran `make integ_test`
- used s1 handover individual cancel test case from https://github.com/magma/magma/pull/9523

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
