### PR TITLE
fix(agw): Compensate for eNB firmware param inversion

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
+++ b/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
@@ -809,6 +809,18 @@ class FreedomFiOneConfigurationInitializer(EnodebConfigurationPostProcessor):
         # Bump up the parameter key version
         self.acs.parameter_version_inc()
 
+        # Workaround a bug in Sercomm firmware in release 3920, 3921
+        # where the meaning of CellReservedForOperatorUse is wrong.
+        # Set to True to ensure the PLMN is not reserved
+        num_plmns = self.acs.data_model.get_num_plmns()
+        for i in range(1, num_plmns + 1):
+            object_name = ParameterName.PLMN_N % i
+            desired_cfg.set_parameter_for_object(
+                param_name=ParameterName.PLMN_N_CELL_RESERVED % i,
+                value=True,
+                object_name=object_name,
+            )
+
         if self.WEB_UI_ENABLE_LIST_KEY in service_cfg:
             serial_nos = service_cfg.get(self.WEB_UI_ENABLE_LIST_KEY)
             if self.acs.device_cfg.has_parameter(

--- a/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
@@ -595,8 +595,14 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             ),
             call.set_parameter('sas_location', 'indoor'),
             call.set_parameter('sas_height_type', 'AMSL'),
+            call.set_parameter_for_object(
+                param_name='PLMN 1 cell reserved',
+                value=True, object_name='PLMN 1',
+            ),
         ]
-        self.assertEqual(cfg_desired.mock_calls.sort(), expected.sort())
+        cfg_desired.mock_calls.sort()
+        expected.sort()
+        self.assertEqual(cfg_desired.mock_calls, expected)
 
         # Check without sas config
         service_cfg = {
@@ -627,8 +633,14 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             call.set_parameter('carrier_number', 2),
             call.set_parameter('contiguous_cc', 0),
             call.set_parameter('web_ui_enable', False),
+            call.set_parameter_for_object(
+                param_name='PLMN 1 cell reserved',
+                value=True, object_name='PLMN 1',
+            ),
         ]
-        self.assertEqual(cfg_desired.mock_calls.sort(), expected.sort())
+        cfg_desired.mock_calls.sort()
+        expected.sort()
+        self.assertEqual(cfg_desired.mock_calls, expected)
 
         service_cfg['web_ui_enable_list'] = ["2006CW5000023"]
 
@@ -646,15 +658,19 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             call.set_parameter('contiguous_cc', 0),
             call.set_parameter('web_ui_enable', False),
             call.set_parameter('web_ui_enable', True),
+            call.set_parameter_for_object(
+                param_name='PLMN 1 cell reserved',
+                value=True, object_name='PLMN 1',
+            ),
         ]
         cfg_desired = Mock()
         cfg_init.postprocess(
             EnodebConfigBuilder.get_mconfig(),
             service_cfg, cfg_desired,
         )
-        print(cfg_desired.mock_calls)
-        print(type(cfg_desired.mock_calls))
-        self.assertEqual(cfg_desired.mock_calls.sort(), expected.sort())
+        cfg_desired.mock_calls.sort()
+        expected.sort()
+        self.assertEqual(cfg_desired.mock_calls, expected)
 
     @patch('magma.configuration.service_configs.CONFIG_DIR', SRC_CONFIG_DIR)
     def test_service_cfg_parsing(self):


### PR DESCRIPTION
## Summary
A regression was introduced into the firmware build for Sercomm where
the flag for cell reserved was inverted. Compensate for that by
setting the cell reserved bit to be True on initial connect.
At a later point when we have a software version where the issue is fixed
we can add this as a conditional check.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

UE traffic was not working before fix, working after fix.
Unit test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
