### PR TITLE
fix(mme): Handle failed teid update by deactivating default bearer

### DIFF
--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -212,7 +212,8 @@ void pcef_update_teids(
               LOG_UTIL,
               "Received grpc::ABORTED for update_teids RPC for %s with error "
               "msg: %s. Deactivating bearer %u.",
-              imsi.c_str(), status.error_message().c_str(), request.bearer_id());
+              imsi.c_str(), status.error_message().c_str(),
+              request.bearer_id());
           // strip off "IMSI" prefix
           imsi                  = imsi.substr(4, std::string::npos);
           itti_msg->imsi_length = imsi.size();

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -201,7 +201,7 @@ void pcef_update_teids(
 
   magma::PCEFClient::update_teids(
       request,
-      [&](grpc::Status status, magma::UpdateTunnelIdsResponse response) {
+      [request](grpc::Status status, magma::UpdateTunnelIdsResponse response) {
         if (status.error_code() == grpc::ABORTED) {
           MessageDef* message_p = DEPRECATEDitti_alloc_new_message_fatal(
               TASK_GRPC_SERVICE, GX_NW_INITIATED_DEACTIVATE_BEARER_REQ);
@@ -211,8 +211,8 @@ void pcef_update_teids(
           OAILOG_INFO(
               LOG_UTIL,
               "Received grpc::ABORTED for update_teids RPC for %s with error "
-              "msg: %s. Deactivating bearer %u",
-              imsi.c_str(), status.error_message().c_str(), default_bearer_id);
+              "msg: %s. Deactivating bearer %u.",
+              imsi.c_str(), status.error_message().c_str(), request.bearer_id());
           // strip off "IMSI" prefix
           imsi                  = imsi.substr(4, std::string::npos);
           itti_msg->imsi_length = imsi.size();

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -200,8 +200,32 @@ void pcef_update_teids(
   request.set_agw_teid(agw_teid);
 
   magma::PCEFClient::update_teids(
-      request, [&](grpc::Status status,
-                   magma::UpdateTunnelIdsResponse response) { return; });
+      request,
+      [&](grpc::Status status, magma::UpdateTunnelIdsResponse response) {
+        if (status.error_code() == grpc::ABORTED) {
+          MessageDef* message_p = DEPRECATEDitti_alloc_new_message_fatal(
+              TASK_GRPC_SERVICE, GX_NW_INITIATED_DEACTIVATE_BEARER_REQ);
+          itti_gx_nw_init_deactv_bearer_request_t* itti_msg =
+              &message_p->ittiMsg.gx_nw_init_deactv_bearer_request;
+          std::string imsi = request.sid().id();
+          OAILOG_INFO(
+              LOG_UTIL,
+              "Received grpc::ABORTED for update_teids RPC for %s with error "
+              "msg: %s. Deactivating bearer %u",
+              imsi.c_str(), status.error_message().c_str(), default_bearer_id);
+          // strip off "IMSI" prefix
+          imsi                  = imsi.substr(4, std::string::npos);
+          itti_msg->imsi_length = imsi.size();
+          strcpy(itti_msg->imsi, imsi.c_str());
+          itti_msg->lbi           = request.bearer_id();
+          itti_msg->no_of_bearers = 1;
+          itti_msg->ebi[0]        = request.bearer_id();
+          send_msg_to_task(
+              &grpc_service_task_zmq_ctx, TASK_SPGW_APP, message_p);
+        }
+
+        return;
+      });
 }
 
 /*

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
@@ -245,7 +245,6 @@ status_code_e spgw_handle_nw_initiated_bearer_actv_req(
     if (hashtblP->nodes[i] != NULL) {
       node = hashtblP->nodes[i];
     }
-    pthread_mutex_unlock(&hashtblP->lock_nodes[i]);
     while (node) {
       num_elements++;
       hashtable_ts_get(
@@ -266,6 +265,7 @@ status_code_e spgw_handle_nw_initiated_bearer_actv_req(
       }
       node = node->next;
     }
+    pthread_mutex_unlock(&hashtblP->lock_nodes[i]);
     i++;
   }
 
@@ -359,10 +359,10 @@ int32_t spgw_handle_nw_initiated_bearer_deactv_req(
       spgw_ctxt_p = node->data;
       num_elements++;
       if (spgw_ctxt_p != NULL) {
-        if (!strcmp(
+        if (!strncmp(
                 (const char*)
                     spgw_ctxt_p->sgw_eps_bearer_context_information.imsi.digit,
-                (const char*) bearer_req_p->imsi)) {
+                (const char*) bearer_req_p->imsi, bearer_req_p->imsi_length)) {
           is_imsi_found = true;
           if ((bearer_req_p->lbi != 0) &&
               (bearer_req_p->lbi ==


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
When mme service updates sessiond with TEID, if sessiond cannot find an existing session, it returns abort response. MME was ignoring such cases. The PR treats such aborts the same as deletion of the default bearer (i.e., session termination) and mme triggers a network initiated detach procedure.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Modified s1ap test and hardcoded sessiond to return error. 
Tested on spirent where such events are observed when sessiond and mme diverges about the existence of a session.

Unit tests to be added once spgw test suit becomes ready.
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
