### PR TITLE
chore: add connectiond to bzl compile db generation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,8 @@
 		"clangd.onConfigChanged": "restart",
 		// Update this field with any new targets that need compilation database generation
 		"bsv.cc.compdb.targets": [
-			"//lte/gateway/c/session_manager:sessiond"
+			"//lte/gateway/c/session_manager:sessiond",
+			"//lte/gateway/c/connection_tracker/src:main",
 		],
 		"multiCommand.commands": [
 			{

--- a/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
+++ b/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
@@ -39,6 +39,7 @@
 		],
 		"bsv.cc.compdb.targets": [
 			"//lte/gateway/c/session_manager:sessiond",
+			"//lte/gateway/c/connection_tracker/src:main",
 		],
 		"multiCommand.commands": [
 			{


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
The bzl c plugin had a bug where it couldn't generate compile_commands.json for more than one target at a time, but that got fixed this morning. (https://github.com/stackb/bazel-stack-vscode-cc/issues/11) 

Adding connectiond to the gneration config so that the code editing experience is better for the directory :) 
<!-- Enumerate changes you made and why you made them -->

## Test Plan

https://user-images.githubusercontent.com/37634144/139439177-1f6a93d6-7aad-4c7b-a292-bde38584972d.mov


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
