### PR TITLE
feat: Add Python settings and extensions for the remote SSH Vscode setup

### DIFF
--- a/experimental/bazel-base/VSCodeSetup.md
+++ b/experimental/bazel-base/VSCodeSetup.md
@@ -16,6 +16,9 @@ Open VSCode and use **Command+Shift+P** to open the editor preferences and selec
         "stackbuild.bazel-stack-vscode-cc",
         "augustocdias.tasks-shell-input",
         "ryuta46.multi-command",
+        "ms-python.python",
+        "njpwerner.autodocstring",
+        "ms-python.vscode-pylance",
     ],
 ```
 

--- a/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
+++ b/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
@@ -12,17 +12,18 @@
 			"stackbuild.bazel-stack-vscode-cc",
 			"augustocdias.tasks-shell-input",
 			"ryuta46.multi-command",
+			"ms-python.python",
+			"njpwerner.autodocstring",
+			"ms-python.vscode-pylance",
 		]
 	},
 	"settings": {
 		"files.watcherExclude": {
 			"**/.bazel-cache/**": true,
 			"**/.bazel-cache-repo/**": true,
-		},		
-		"bsv.bazel.buildFlags": [
-		],
-		"bsv.bazel.testFlags": [
-		],
+		},
+		"bsv.bazel.buildFlags": [],
+		"bsv.bazel.testFlags": [],
 		"bsv.bes.enabled": false,
 		"bsv.bzl.codesearch.enabled": false,
 		"bsv.bzl.invocation.buildEventPublishAllActions": false,
@@ -48,6 +49,28 @@
 					"clangd.restart",
 				],
 			}
-		]
+		],
+		"python.analysis.extraPaths": [
+			"/home/vagrant/magma/orc8r/gateway/python/",
+			"/home/vagrant/magma/lte/gateway/python/",
+			"/home/vagrant/build/python/gen/",
+			"/home/vagrant/build/python/gen/orc8r/",
+			"/home/vagrant/build/python/gen/lte/",
+		],
+		"python.defaultInterpreterPath": "/home/vagrant/build/python/bin/python",
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "pylint",
+		"python.testing.pytestEnabled": false,
+		"python.testing.unittestEnabled": false,
+		"editor.formatOnSave": true,
+		"python.formatting.autopep8Args": [
+			// This should be the same set of flags as ones specified in `lte/gateway/precommit.py`
+			"--select=W191,W291,W292,W293,W391,E131,E2,E3",
+		],
+		"[python]": {
+			"editor.codeActionsOnSave": {
+				"source.organizeImports": true
+			}
+		},
 	},
 }


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Working on a separate PR on VSCode setup guide + usage guide in docusaurus so will add doc on how to use the Python plugins there.

But essentially here are the things enabled in this PR:
1. Python code jumping / code completion (or suggestion)
2. run autopep8 and sort imports on save.
3. auto complete python doc generation

<!-- Enumerate changes you made and why you made them -->

## Test Plan
tested locally on my vscode
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
