### PR TITLE
fix(agw): Enable opt-in based logging to Sentry

### DIFF
--- a/lte/gateway/configs/ctraced.yml
+++ b/lte/gateway/configs/ctraced.yml
@@ -25,4 +25,5 @@ trace_interfaces:
 trace_tool: tshark
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/directoryd.yml
+++ b/lte/gateway/configs/directoryd.yml
@@ -17,4 +17,5 @@ print_grpc_payload: false
 log_level: INFO
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/enodebd.yml
+++ b/lte/gateway/configs/enodebd.yml
@@ -48,4 +48,5 @@ web_ui_enable_list: []
 s1_interface: eth1
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -62,4 +62,5 @@ event_registry:
     filename: mme_events.v1.yml
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/health.yml
+++ b/lte/gateway/configs/health.yml
@@ -27,4 +27,5 @@ state_recovery:
   snapshots_dir: /tmp/redis_snapshots
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/kernsnoopd.yml
+++ b/lte/gateway/configs/kernsnoopd.yml
@@ -22,4 +22,5 @@ ebpf_programs:
 #  - byte_count
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -174,4 +174,5 @@ services_to_restart:
 restart_timeout_threshold: 15
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -15,6 +15,8 @@
 redis_port: 6380
 print_grpc_payload: false
 
-# [Experimental] Enable Sentry for this service
-sentry_enabled: true
 ipv6_prefixlen: 58
+
+# [Experimental] Enable Sentry for this service
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: send_all_errors

--- a/lte/gateway/configs/monitord.yml
+++ b/lte/gateway/configs/monitord.yml
@@ -15,4 +15,5 @@
 mtr_interface: mtr0
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -220,4 +220,5 @@ sgi_tunnel:
 #
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -196,4 +196,5 @@ sgi_tunnel:
 #
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/policydb.yml
+++ b/lte/gateway/configs/policydb.yml
@@ -36,4 +36,5 @@ bridge_interface: gtp_br0
 redirect_rule_name:
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/redirectd.yml
+++ b/lte/gateway/configs/redirectd.yml
@@ -16,4 +16,5 @@
 http_port: 8080
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/smsd.yml
+++ b/lte/gateway/configs/smsd.yml
@@ -13,4 +13,5 @@
 log_level: INFO
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/state.yml
+++ b/lte/gateway/configs/state.yml
@@ -50,4 +50,5 @@ json_state:
     state_scope: "network"
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -57,4 +57,5 @@ s6a_over_grpc: True
 grpc_workers: 10
 
 # [Experimental] Enable Sentry for this service
-sentry_enabled: false
+# Allowed values: send_all_errors, send_selected_errors, disabled
+sentry: disabled

--- a/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
@@ -420,7 +420,7 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
                 "sas_location": "indoor",
                 "sas_height_type": "AMSL",
             },
-            "sentry_enabled": False,
+            "sentry": "disabled",
         }
 
     def build_freedomfi_one_acs_state_machine(self):

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -33,6 +33,11 @@ from lte.protos.mobilityd_pb2_grpc import (
 )
 from lte.protos.subscriberdb_pb2 import SubscriberID
 from magma.common.rpc_utils import return_void
+from magma.common.sentry import (
+    SentryStatus,
+    get_sentry_status,
+    send_uncaught_errors_to_monitoring,
+)
 from magma.subscriberdb.sid import SIDUtils
 
 from .ip_address_man import (
@@ -53,6 +58,8 @@ from .subscriberdb_client import (
     SubscriberDBMultiAPNValueError,
     SubscriberDBStaticIPValueError,
 )
+
+enable_sentry_wrapper = get_sentry_status("mobilityd") == SentryStatus.SEND_SELECTED_ERRORS
 
 
 class MobilityServiceRpcServicer(MobilityServiceServicer):
@@ -89,6 +96,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._ip_address_man.add_ip_block(ip_block)
 
     @return_void
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def AddIPBlock(self, request, context):
         """ Add a range of IP addresses into the free IP pool
 
@@ -113,6 +121,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         except IPVersionNotSupportedError:
             self._unimplemented_ip_version_error(context)
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ListAddedIPv4Blocks(self, request, context):
         """ Return a list of IPv4 blocks assigned """
         logging.debug("Received ListAddedIPv4Blocks")
@@ -133,6 +142,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ListAddedIPv6Blocks(self, request, context):
         """ Return a list of IPv6 blocks assigned """
         self._print_grpc(request)
@@ -153,6 +163,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ListAllocatedIPs(self, request, context):
         """ Return a list of IPs allocated from a IP block
 
@@ -192,6 +203,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def AllocateIPAddress(self, request, context):
         """ Allocate an IP address from the free IP pool """
         logging.debug("Received AllocateIPAddress")
@@ -235,6 +247,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         return resp
 
     @return_void
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ReleaseIPAddress(self, request, context):
         """ Release an allocated IP address """
         logging.debug("Received ReleaseIPAddress")
@@ -269,6 +282,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
             )
             context.set_code(grpc.StatusCode.NOT_FOUND)
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def RemoveIPBlock(self, request, context):
         """ Attempt to remove IP blocks and return the removed blocks """
         logging.debug("Received RemoveIPBlock")
@@ -306,6 +320,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetIPForSubscriber(self, request, context):
         logging.debug("Received GetIPForSubscriber")
         self._print_grpc(request)
@@ -333,6 +348,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetSubscriberIDFromIP(self, request, context):
         logging.debug("Received GetSubscriberIDFromIP")
         ip_addr = request
@@ -352,6 +368,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetSubscriberIPTable(self, request, context):
         """ Get the full subscriber table """
         logging.debug("Received GetSubscriberIPTable")
@@ -371,6 +388,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ListGatewayInfo(self, request, context):
         logging.debug("Received ListGatewayInfo")
         self._print_grpc(request)
@@ -383,6 +401,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         return resp
 
     @return_void
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def SetGatewayInfo(self, request, context):
         logging.debug("Received SetGatewayInfo")
         info = request

--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -10,30 +10,82 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+import logging
 import os
+from enum import Enum
+from functools import wraps
+from typing import Any, Dict, Optional
 
 import sentry_sdk
 import snowflake
 from magma.configuration.service_configs import get_service_config_value
 
 CONTROL_PROXY = 'control_proxy'
-SENTRY_ENABLED = 'sentry_enabled'
+SENTRY_CONFIG = 'sentry'
 SENTRY_URL = 'sentry_url_python'
 SENTRY_SAMPLE_RATE = 'sentry_sample_rate'
 COMMIT_HASH = 'COMMIT_HASH'
 HWID = 'hwid'
 SERVICE_NAME = 'service_name'
+LOGGING_EXTRA = 'extra'
+SEND_TO_MONITORING_KEY = "send_to_monitoring"
+SEND_TO_MONITORING = {SEND_TO_MONITORING_KEY: True}
+
+
+class SentryStatus(Enum):
+    SEND_ALL_ERRORS = 'send_all_errors'
+    SEND_SELECTED_ERRORS = 'send_selected_errors'
+    DISABLED = 'disabled'
+
+
+def send_uncaught_errors_to_monitoring(enabled: bool):
+    """Reusable decorator for logging unexpected exceptions."""
+    def error_logging_wrapper(func):
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as err:
+                logging.error("Uncaught error", exc_info=True, extra=SEND_TO_MONITORING)
+                raise err
+
+        if enabled:
+            return wrapper
+        return func
+
+    return error_logging_wrapper
+
+
+def _ignore_if_not_marked(
+        event: Dict[str, Any],
+        hint: Dict[str, Any],  # pylint: disable=unused-argument
+) -> Optional[Dict[str, Any]]:
+    if event.get(LOGGING_EXTRA) and event.get(LOGGING_EXTRA).get(SEND_TO_MONITORING_KEY):
+        del event[LOGGING_EXTRA][SEND_TO_MONITORING_KEY]
+        return event
+    return None
+
+
+def get_sentry_status(service_name: str) -> SentryStatus:
+    """Get Sentry status from service config value"""
+    try:
+        return SentryStatus(
+            get_service_config_value(
+                service_name,
+                SENTRY_CONFIG,
+                default=SentryStatus.DISABLED.value,
+            ),
+        )
+    except ValueError:
+        return SentryStatus.DISABLED
 
 
 def sentry_init(service_name: str):
     """Initialize connection and start piping errors to sentry.io."""
-    sentry_enabled = get_service_config_value(
-        service_name,
-        SENTRY_ENABLED,
-        default=False,
-    )
-    if not sentry_enabled:
+
+    sentry_status = get_sentry_status(service_name)
+    if sentry_status == SentryStatus.DISABLED:
         return
 
     sentry_url = get_service_config_value(
@@ -53,6 +105,7 @@ def sentry_init(service_name: str):
         dsn=sentry_url,
         release=os.getenv(COMMIT_HASH),
         traces_sample_rate=sentry_sample_rate,
+        before_send=_ignore_if_not_marked if sentry_status == SentryStatus.SEND_SELECTED_ERRORS else None,
     )
     sentry_sdk.set_tag(HWID, snowflake.snowflake())
     sentry_sdk.set_tag(SERVICE_NAME, service_name)

--- a/orc8r/gateway/python/magma/common/tests/sentry_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/sentry_tests.py
@@ -1,0 +1,52 @@
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import unittest
+
+from magma.common.sentry import (
+    _ignore_if_not_marked,
+    send_uncaught_errors_to_monitoring,
+)
+
+
+class SentryTests(unittest.TestCase):
+    """
+    Tests for Sentry monitoring
+    """
+
+    def test_ignore_if_not_marked(self):
+        """Test ignored events that are not sent to Sentry"""
+        self.assertIsNone(_ignore_if_not_marked({"key": "value", "extra": {"something_else": 3}}, {}))
+
+    def test_do_not_ignore_and_remove_tag_if_marked(self):
+        """Test marked events that are sent to Sentry"""
+        returned_event = _ignore_if_not_marked({"key": "value", "extra": {"send_to_monitoring": True}}, {})
+        self.assertEqual(returned_event, {"key": "value", "extra": {}})
+
+    def test_uncaught_error_wrapper(self):
+        """Test enabled wrapper logs an error"""
+        @send_uncaught_errors_to_monitoring(True)
+        def raise_error():
+            raise ValueError("Something went wrong")
+
+        with self.assertLogs() as captured:
+            try:
+                raise_error()
+            except ValueError:
+                pass
+
+        self.assertEqual(len(captured.records), 1)
+        log_record = captured.records[0]
+        self.assertEqual(log_record.message, "Uncaught error")
+        self.assertEqual(log_record.levelno, logging.ERROR)


### PR DESCRIPTION
## Summary

Makes it possible to select only a subset of log messages to be sent to Sentry instead of everything above a certain log level. In Python services there are now three possible configuration settings for Sentry:
* send all errors
* send only selected errors (opt-in)
* disabled

Also adds a configurable decorator to send all uncaught errors to Sentry, which is useful in the opt-in case. It is used for all gRPC endpoints of mobilityd.