### PR TITLE
fix(pipelined): enforcement stats flow parsing

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -810,7 +810,12 @@ def _get_ipv4(flow):
         ip_register = 'ipv4_dst'
     if ip_register not in flow.match:
         return None
-    return flow.match[ip_register]
+    ipv4 = flow.match[ip_register]
+    # masked value returned as tuple
+    if type(ipv4) is tuple:
+        return ipv4[0]
+    else:
+        return ipv4
 
 
 def _get_ipv6(flow):
@@ -822,7 +827,12 @@ def _get_ipv6(flow):
         ip_register = 'ipv6_dst'
     if ip_register not in flow.match:
         return None
-    return flow.match[ip_register]
+    ipv6 = flow.match[ip_register]
+    # masked value returned as tuple
+    if type(ipv6) is tuple:
+        return ipv6[0]
+    else:
+        return ipv6
 
 
 def _get_version(flow):


### PR DESCRIPTION
In case of mask RYU returns tuple of IP address and mask. Following
patch handles it.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test` and on bare metal agw.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
