### PR TITLE
feat(mme): Update slice descriptor in ics message

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -683,15 +683,32 @@ void ngap_handle_conn_est_cnf(
   ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
 
   // list of NSSAI: later implement with loop
-  Ngap_AllowedNSSAI_Item_t* nssai_item;
+  amf_config_read_lock(&amf_config);
+  for (int i = 0; i < amf_config.plmn_support_list.plmn_support_count; i++) {
+    Ngap_AllowedNSSAI_Item_t* nssai_item = NULL;
+    Ngap_S_NSSAI_t* s_NSSAI              = NULL;
+    Ngap_SST_t* sST                      = NULL;
 
-  nssai_item =
-      (Ngap_AllowedNSSAI_Item_t*) calloc(1, sizeof(Ngap_AllowedNSSAI_Item_t));
-  nssai_item->s_NSSAI.sST.size   = 1;
-  nssai_item->s_NSSAI.sST.buf    = (uint8_t*) calloc(1, sizeof(uint8_t));
-  nssai_item->s_NSSAI.sST.buf[0] = 0x1;
+    nssai_item =
+        (Ngap_AllowedNSSAI_Item_t*) CALLOC(1, sizeof(Ngap_AllowedNSSAI_Item_t));
+    s_NSSAI = &nssai_item->s_NSSAI;
+    sST     = &s_NSSAI->sST;
 
-  ASN_SEQUENCE_ADD(&ie->value.choice.AllowedNSSAI.list, nssai_item);
+    INT8_TO_OCTET_STRING(
+        amf_config.plmn_support_list.plmn_support[i].s_nssai.sst, sST);
+
+    if (amf_config.plmn_support_list.plmn_support[i].s_nssai.sd.v !=
+        AMF_S_NSSAI_SD_INVALID_VALUE) {
+      // defaultSliceDifferentiator
+      s_NSSAI->sD = CALLOC(1, sizeof(Ngap_SD_t));
+      INT24_TO_OCTET_STRING(
+          amf_config.plmn_support_list.plmn_support[i].s_nssai.sd.v,
+          s_NSSAI->sD);
+    }
+
+    ASN_SEQUENCE_ADD(&ie->value.choice.AllowedNSSAI.list, nssai_item);
+  }
+  amf_config_unlock(&amf_config);
 
   // UESecurityCapabilities
   ie = (Ngap_InitialContextSetupRequestIEs_t*) calloc(

--- a/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
@@ -34,6 +34,9 @@ class NgapFlowTest : public testing::Test {
         NULL);
 
     amf_config_init(&amf_config);
+    amf_config.plmn_support_list.plmn_support_count          = 1;
+    amf_config.plmn_support_list.plmn_support[0].s_nssai.sst = 0x1;
+
     ngap_state_init(2, 2, false);
     state = get_ngap_state(false);
 
@@ -290,7 +293,17 @@ TEST_F(NgapFlowTest, initial_context_setup_request_sunny_day) {
   ue_ref->gnb_ue_ngap_id = gNB_UE_NGAP_ID;
   ue_ref->amf_ue_ngap_id = AMF_UE_NGAP_ID;
 
+  /* Without SSD */
   ngap_handle_conn_est_cnf(state, &NGAP_INITIAL_CONTEXT_SETUP_REQ(message_p));
+
+  /* With SSD */
+  amf_config.plmn_support_list.plmn_support[0].s_nssai.sd.v = 0x1;
+  ngap_handle_conn_est_cnf(state, &NGAP_INITIAL_CONTEXT_SETUP_REQ(message_p));
+
+  /* Reset the SSD */
+  amf_config.plmn_support_list.plmn_support[0].s_nssai.sd.v =
+      AMF_S_NSSAI_SD_INVALID_VALUE;
+
   itti_free_msg_content(message_p);
   free(message_p);
   bdestroy(buffer);


### PR DESCRIPTION
Fix:
         1. Adding slice descriptor support in ics packet
         2. Addressing #9939

Test:
          1. test_oai
          2. Simulator test call flow

Logs:
          6/18 Test  #6: test_ngap .........................   Passed    0.42 sec
          ST/SD : 02 01 00 00 01

Signed-off-by: Yogesh Pandey <yogesh@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
