### PR TITLE
feat(orc8r): K8s Include labels and annotations based on the image/chart being deployed

### DIFF
--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/storeconfig-job.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/storeconfig-job.yaml
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+{{- if .Values.prometheus.create }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -50,3 +51,4 @@ spec:
             name: {{ template "metrics.fullname" . }}-defaultconfig
         - name: configs
 {{ toYaml .Values.metrics.volumes.prometheusConfig.volumeSpec | indent 10 }}
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/helpers/labels.tpl
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/helpers/labels.tpl
@@ -33,3 +33,8 @@ app.kubernetes.io/name: {{ $application }}
 app.kubernetes.io/component: {{ $component }}
 app.kubernetes.io/instance: {{ $envAll.Release.Name }}
 {{- end -}}
+
+{{/* Generate selector labels */}}
+{{- define "magmalte-image-version-label" -}}
+image-version: {{ .Values.magmalte.image.tag}}
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-deployment.yaml
@@ -22,7 +22,11 @@ kind: Deployment
 metadata:
   name: nms-magmalte
   labels:
+{{ include "default-labels" . | indent 4 }}
+{{ include "magmalte-image-version-label" . | indent 4 }}
 {{ tuple $envAll "nms" "magmalte" | include "nms.labels" | indent 4 }}
+  annotations:
+{{ include "release-name-annotation" . | indent 4 }}
 spec:
   replicas: {{ .Values.magmalte.replicas }}
   selector:

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-service.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-service.yaml
@@ -20,7 +20,11 @@ kind: Service
 metadata:
   name: magmalte
   labels:
+{{ include "default-labels" . | indent 4 }}
+{{ include "magmalte-image-version-label" . | indent 4 }}
 {{ tuple $envAll "nms" "magmalte" | include "nms.labels" | indent 4 }}
+  annotations:
+{{ include "release-name-annotation" . | indent 4 }}
 spec:
   selector:
 {{ tuple $envAll "nms" "magmalte" | include "nms.selector-labels" | indent 4 }}

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/nginx-proxy-deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/nginx-proxy-deployment.yaml
@@ -22,7 +22,12 @@ kind: Deployment
 metadata:
   name: nms-nginx-proxy
   labels:
+{{ include "default-labels" . | indent 4 }}
+{{ include "magmalte-image-version-label" . | indent 4 }}
 {{ tuple $envAll "nms" "nginx" | include "nms.labels" | indent 4 }}
+  annotations:
+{{ include "release-name-annotation" . | indent 4 }}
+
 spec:
   replicas: {{ .Values.nginx.replicas }}
   strategy:

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/nginx-proxy-service.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/nginx-proxy-service.yaml
@@ -20,9 +20,12 @@ kind: Service
 metadata:
   name: nginx-proxy
   labels:
-{{ tuple $envAll "nms" "nginx" | include "nms.labels" | indent 4 }}
-  {{- if .Values.nginx.service.annotations }}
+{{ include "default-labels" . | indent 4 }}
+{{ include "magmalte-image-version-label" . | indent 4 }}
+{{ tuple $envAll "nms" "magmalte" | include "nms.labels" | indent 4 }}
   annotations:
+{{ include "release-name-annotation" . | indent 4 }}
+  {{- if .Values.nginx.service.annotations }}
 {{ with .Values.nginx.service.annotations }}{{ toYaml . | indent 4 }}{{ end }}
   {{- end }}
 spec:

--- a/orc8r/cloud/helm/orc8r/templates/_helpers.tpl
+++ b/orc8r/cloud/helm/orc8r/templates/_helpers.tpl
@@ -33,3 +33,8 @@ app.kubernetes.io/part-of: orc8r-app
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/* Generate selector labels */}}
+{{- define "nginx-image-version-label" -}}
+image-version: {{ .Values.nginx.image.tag}}
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/accessd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/accessd.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "accessd.pdb") -}}
 {{- define "accessd.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: accessd
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/analytics.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/analytics.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "analytics.pdb") -}}
 {{- define "analytics.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: analytics
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/certifier.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/certifier.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "certifier.pdb") -}}
 {{- define "certifier.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: certifier
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/configurator.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/configurator.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "configurator.pdb") -}}
 {{- define "configurator.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: configurator
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/ctraced.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ctraced.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "ctraced.pdb") -}}
 {{- define "ctraced.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: ctraced
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/device.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/device.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "device.pdb") -}}
 {{- define "device.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: device
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/directoryd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/directoryd.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "directoryd.pdb") -}}
 {{- define "directoryd.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: directoryd
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/dispatcher.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dispatcher.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "dispatcher.pdb") -}}
 {{- define "dispatcher.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: dispatcher
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/eventd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/eventd.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "eventd.pdb") -}}
 {{- define "eventd.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: eventd
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/ingress.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ingress.service.yaml
@@ -21,12 +21,14 @@ metadata:
   labels:
     app.kubernetes.io/component: nginx-proxy
 {{ include "labels" . | indent 4 }}
+{{ include "nginx-image-version-label" . | indent 4 }}
 {{ include "orc8r-labels" . | indent 4 }}
     {{- with .Values.nginx.service.labels }}
 {{ toYaml . | indent 4 }}
     {{- end }}
-  {{- if or .Values.nginx.service.annotations .Values.nginx.service.extraAnnotations.clientcertLegacy }}
   annotations:
+{{ include "release-name-annotation" . | indent 4 }}
+  {{- if or .Values.nginx.service.annotations .Values.nginx.service.extraAnnotations.clientcertLegacy }}
 {{ with .Values.nginx.service.annotations }}{{ toYaml . | indent 4 }}{{ end }}
 {{ with .Values.nginx.service.extraAnnotations.clientcertLegacy }}{{ toYaml . | indent 4 }}{{ end }}
   {{- end }}
@@ -67,12 +69,14 @@ metadata:
   labels:
     app.kubernetes.io/component: nginx-proxy
 {{ include "labels" . | indent 4 }}
+{{ include "nginx-image-version-label" . | indent 4 }}
 {{ include "orc8r-labels" . | indent 4 }}
     {{- with .Values.nginx.service.labels }}
 {{ toYaml . | indent 4 }}
     {{- end }}
-  {{- if or .Values.nginx.service.annotations .Values.nginx.service.extraAnnotations.bootstrapLagacy }}
   annotations:
+{{ include "release-name-annotation" . | indent 4 }}
+  {{- if or .Values.nginx.service.annotations .Values.nginx.service.extraAnnotations.bootstrapLagacy }}
 {{ with .Values.nginx.service.annotations }}{{ toYaml . | indent 4 }}{{ end }}
 {{ with .Values.nginx.service.extraAnnotations.bootstrapLagacy }}{{ toYaml . | indent 4 }}{{ end }}
   {{- end }}
@@ -116,14 +120,16 @@ metadata:
   labels:
     app.kubernetes.io/component: nginx-proxy
 {{ include "labels" . | indent 4 }}
+{{ include "nginx-image-version-label" . | indent 4 }}
 {{ include "orc8r-labels" . | indent 4 }}
     {{- with .Values.nginx.service.labels }}
 {{ toYaml . | indent 4 }}
   {{- end }}
-  {{- if or .Values.nginx.service.annotations .Values.nginx.service.extraAnnotations.proxy }}
   annotations:
-  {{ with .Values.nginx.service.annotations }}{{ toYaml . | indent 4 }}{{ end }}
-  {{ with .Values.nginx.service.extraAnnotations.proxy }}{{ toYaml . | indent 4 }}{{ end }}
+{{ include "release-name-annotation" . | indent 4 }}
+  {{- if or .Values.nginx.service.annotations .Values.nginx.service.extraAnnotations.proxy }}
+{{ with .Values.nginx.service.annotations }}{{ toYaml . | indent 4 }}{{ end }}
+{{ with .Values.nginx.service.extraAnnotations.proxy }}{{ toYaml . | indent 4 }}{{ end }}
   {{- end }}
 spec:
   selector:

--- a/orc8r/cloud/helm/orc8r/templates/metricsd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/metricsd.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "metricsd.pdb") -}}
 {{- define "metricsd.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: metricsd
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/nginx.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/nginx.deployment.yaml
@@ -20,6 +20,9 @@ metadata:
     app.kubernetes.io/component: nginx-proxy
 {{ include "labels" . | indent 4 }}
 {{ include "orc8r-labels" . | indent 4 }}
+{{ include "nginx-image-version-label" . | indent 4 }}
+  annotations:
+{{ include "release-name-annotation" . | indent 4 }}
 spec:
   replicas: {{ .Values.nginx.replicas }}
   selector:

--- a/orc8r/cloud/helm/orc8r/templates/obsidian.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/obsidian.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "obsidian.pdb") -}}
 {{- define "obsidian.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: obsidian
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/orchestrator.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/orchestrator.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "orchestrator.pdb") -}}
 {{- define "orchestrator.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: orchestrator
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/service_registry.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/service_registry.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "service_registry.pdb") -}}
 {{- define "service_registry.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: service_registry
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/state.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/state.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "state.pdb") -}}
 {{- define "state.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: state
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/streamer.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/streamer.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "streamer.pdb") -}}
 {{- define "streamer.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: streamer
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/tenants.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/tenants.pdb.yaml
@@ -12,6 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "tenants.pdb") -}}
 {{- define "tenants.pdb" -}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -22,4 +23,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: tenants
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8rlib/templates/_deployment.yaml
+++ b/orc8r/cloud/helm/orc8rlib/templates/_deployment.yaml
@@ -18,6 +18,9 @@ metadata:
   labels:
     app.kubernetes.io/component: orc8r
 {{ include "default-labels" . | indent 4 }}
+{{ include "controller-image-version-label" . | indent 4 }}
+  annotations:
+{{ include "release-name-annotation" . | indent 4 }}
 spec:
   replicas: {{ .Values.controller.replicas }}
   selector:

--- a/orc8r/cloud/helm/orc8rlib/templates/_helpers.tpl
+++ b/orc8r/cloud/helm/orc8rlib/templates/_helpers.tpl
@@ -25,3 +25,13 @@ helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/* Generate selector labels */}}
+{{- define "controller-image-version-label" -}}
+image-version: {{ .Values.controller.image.tag}}
+{{- end -}}
+
+{{/* Generate image version tag labels */}}
+{{- define "release-name-annotation" -}}
+release-name: {{ .Release.Name }}
+{{- end -}}

--- a/orc8r/cloud/helm/orc8rlib/templates/_pdb.yaml
+++ b/orc8r/cloud/helm/orc8rlib/templates/_pdb.yaml
@@ -19,6 +19,9 @@ metadata:
   labels:
     app.kubernetes.io/component: orc8r
 {{ include "default-labels" . | indent 4 }}
+{{ include "controller-image-version-label" . | indent 4 }}
+  annotations:
+{{ include "release-name-annotation" . | indent 4 }}
 spec:
   {{- with .Values.controller.podDisruptionBudget.minAvailable }}
   minAvailable: {{ . }}

--- a/orc8r/cloud/helm/orc8rlib/templates/_service.yaml
+++ b/orc8r/cloud/helm/orc8rlib/templates/_service.yaml
@@ -18,6 +18,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
 {{ include "default-labels" . | indent 4 }}
+{{ include "controller-image-version-label" . | indent 4 }}
+  annotations:
+{{ include "release-name-annotation" . | indent 4 }}
 spec:
   selector:
 {{ include "default-selector-labels" . | indent 4 }}


### PR DESCRIPTION
## Summary

1. Include a label in the orc8r and lte-orc8r charts including the current version being deployed
    1. The label value comes directly from the docker image tag, which is the closes information the k8s have to the magma version
2. Include an annotation in the orc8r and lte-orc8r charts including the cluster release name being deploied (production/staging/green/blue)
    1. Annotation values comes from the helm chart name being deployed (configurable in terraform values)
3. OBS: For bot annotation and labels some K8s objects does not include this label since they’re independent of the magma version being run. Non exaustive list: Secrets/ConfigMaps/Certs/Roles/RoleBindings

Also fixed some bugs to allow testing:

1. Avoid to running metrics storeconfig job if prometheus is not enabled
2. Avoid creating PodDisruptionBudgets if not enabled



## Test Plan

Expected result is that all the k8s objects being deployed have an additional annotation and label as shown bellow. (Existing labels still remains)

```
metadata:
  annotations:
    release-name: lte-staging
  labels:
    image-version: 1.5.0-8952929
  name: orc8r-ha
```

Using the helm template it is possible to list which services have the target label and annocation:

```
helm template \
    {staging|lte-staging}\
    {orc8r|lte-orc8r} \
    --repo <REPO> (https://raw.githubusercontent.com/joary/helm-chart-labels-n-annotations/master/)
    --username <USER> \
    --password <PASS> \
    --version 1.5.23 \
    --timeout 600s \
    --values values.yml \
    --debug —dry-run | egrep "Source|release-name|image-version"
```

OBS: values.yml needs to be configured in a proper way to deploy a standard Orc8r, no new value is needed.

**Result for `orc8r` helm chart:**

```
# Source: orc8r/templates/accessd.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/analytics.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/bootstrapper.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/certifier.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/configurator.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/ctraced.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/device.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/directoryd.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/dispatcher.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/eventd.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/metricsd.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/obsidian.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/orchestrator.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/service_registry.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/state.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/streamer.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/tenants.pdb.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/service_reader.yaml
# Source: orc8r/charts/nms/templates/secrets-magmalte-mysql.yaml
# Source: orc8r/charts/secrets/templates/certs.secret.yaml
# Source: orc8r/charts/secrets/templates/configs-cwf.secret.yaml
# Source: orc8r/charts/secrets/templates/configs-orc8r.secret.yaml
# Source: orc8r/charts/secrets/templates/envdir.secret.yaml
# Source: orc8r/charts/secrets/templates/registry.secret.yaml
# Source: orc8r/charts/secrets/templates/registry.secret.yaml
# Source: orc8r/templates/controller.secret.yaml
# Source: orc8r/charts/nms/templates/configmap-nginx-etc.yaml
# Source: orc8r/templates/service_reader.yaml
# Source: orc8r/templates/service_reader.yaml
# Source: orc8r/charts/nms/templates/magmalte-service.yaml
    image-version: 1.5.0-8952929
    release-name: orc8r
# Source: orc8r/charts/nms/templates/nginx-proxy-service.yaml
    image-version: 1.5.0-8952929
    release-name: orc8r
# Source: orc8r/templates/accessd.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/analytics.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/bootstrapper.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/certifier.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/configurator.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/ctraced.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/device.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/directoryd.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/dispatcher.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/eventd.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/ingress.service.yaml
    image-version: 1.5.0-8952929
    release-name: orc8r
# Source: orc8r/templates/ingress.service.yaml
    image-version: 1.5.0-8952929
    release-name: orc8r
# Source: orc8r/templates/ingress.service.yaml
    image-version: 1.5.0-8952929
    release-name: orc8r
# Source: orc8r/templates/metricsd.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/obsidian.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/orchestrator.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/service_registry.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/state.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/streamer.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/tenants.service.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/charts/nms/templates/magmalte-deployment.yaml
    image-version: 1.5.0-8952929
    release-name: orc8r
# Source: orc8r/charts/nms/templates/nginx-proxy-deployment.yaml
    image-version: 1.5.0-8952929
    release-name: orc8r
# Source: orc8r/templates/accessd.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/analytics.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/bootstrapper.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/certifier.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/configurator.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/ctraced.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/device.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/directoryd.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/dispatcher.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/eventd.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/metricsd.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/nginx.deployment.yaml
    image-version: 1.5.0-8952929
    release-name: orc8r
# Source: orc8r/templates/obsidian.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/orchestrator.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/service_registry.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/state.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/streamer.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/templates/tenants.deployment.yaml
    release-name: orc8r
    image-version: 1.5.0-8952929
# Source: orc8r/charts/certs/templates/admin-operator-certificate.yaml
# Source: orc8r/charts/certs/templates/admin-operator-pkcs12-password.yaml
# Source: orc8r/charts/certs/templates/bootstrapper-certificate.yaml
# Source: orc8r/charts/certs/templates/certifier-certificate.yaml
# Source: orc8r/charts/certs/templates/certifier-issuer.yaml
# Source: orc8r/charts/certs/templates/controller-certificate.yaml
# Source: orc8r/charts/certs/templates/fluentd-certificate.yaml
# Source: orc8r/charts/certs/templates/nms-certificate.yaml
# Source: orc8r/charts/certs/templates/pre-install-checks.yaml
# Source: orc8r/charts/certs/templates/root-certificate.yaml
# Source: orc8r/charts/certs/templates/root-issuer.yaml
# Source: orc8r/charts/certs/templates/selfsigned-issuer.yaml
# Source: orc8r/charts/nms/templates/configmap-nginx-etc.yaml
# Source: orc8r/templates/cloudwatch-agent.yaml
# Source: orc8r/charts/metrics/templates/config-files.yaml
```

**Result for `lte-orc8r` helm chart:**

```
# Source: lte-orc8r/templates/ha.pdb.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/lte.pdb.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/nprobe.pdb.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/policydb.pdb.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/smsd.pdb.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/subscriberdb.pdb.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/subscriberdb_cache.pdb.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/ha.service.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/lte.service.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/nprobe.service.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/policydb.service.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/smsd.service.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/subscriberdb.service.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/subscriberdb_cache.service.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/ha.deployment.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/lte.deployment.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/nprobe.deployment.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/policydb.deployment.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/smsd.deployment.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/subscriberdb.deployment.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
# Source: lte-orc8r/templates/subscriberdb_cache.deployment.yaml
    release-name: lte-staging
    image-version: 1.5.0-8952929
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
