### PR TITLE
fix(cloud): Adding staging domain SANs to self-signed certificates

### DIFF
--- a/orc8r/cloud/deploy/scripts/self_sign_certs.sh
+++ b/orc8r/cloud/deploy/scripts/self_sign_certs.sh
@@ -55,6 +55,8 @@ subjectAltName = @alt_names
 [alt_names]
 DNS.1 = *.$domain
 DNS.2 = *.nms.$domain
+DNS.3 = *.staging.$domain
+DNS.4 = *.nms.staging.$domain
 EOF
 openssl x509 -req -in controller.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out controller.crt -days 825 -sha256 -extfile ${domain}.ext
 


### PR DESCRIPTION
Signed-off-by: Arun Thulasi <arunt@fb.com>

fix(cloud): Adding staging domain SANs to self-signed certificates

## Summary

Enhancing the self-signed certificate script to add additional domains to support Orc8r Blue-Green upgrades. 

## Test Plan

After creating certificates, verify if they include the configured domain and staging domains as well.

openssl x509 -in controller.crt -noout -text | grep DNS

 DNS:*.bluegreen.failedwizard.dev, DNS:*.nms.bluegreen.failedwizard.dev, DNS:*.staging.bluegreen.failedwizard.dev, DNS:*.staging.nms.bluegreen.failedwizard.dev

## Additional Information

- [ ] This change is backwards-breaking

