### PR TITLE
feat: add settings to run precommit.py on save

### DIFF
--- a/docs/readmes/contributing/contribute_vscode.md
+++ b/docs/readmes/contributing/contribute_vscode.md
@@ -34,6 +34,7 @@ Open VSCode and use **Command+Shift+P** to open the editor preferences and selec
         "ms-python.python",
         "njpwerner.autodocstring",
         "ms-python.vscode-pylance",
+        "pucelle.run-on-save",
     ],
 ```
 
@@ -90,14 +91,14 @@ We utilize [clangd](https://clangd.llvm.org) to enable smart code insights. Clan
 
 The compilation database can be gernated with both CMake and Bazel. The Bazel method will be described more in detail below. With CMake, it is not possible to generate a single compilation database for all C/C++ targets, so you will have generate one at a time and restart clangd.
 
-To generate the comilation database in the Remote SSH + Magma VM workspace, simply run `make build_oai`, or any other C/C++ target. Then run a task to symlink the root compilation database file to the newly generated one with the following steps.
+To generate the comilation database, simply run `make build_oai`, or any other C/C++ target. Then run a task to symlink the root compilation database file to the newly generated one with the following steps.
 
   1. Open the command palette (**Command+Shift+P**)
   2. Select **Tasks: Run Task** and choose **Set compile_commands.json for IntelliSense**
   3. Select a `compile_commands.json` to that was generated
   4. After the task completes, restart clangd
 
-In the devcontainer, follow the same steps but run `make build_oai_clang` instead to generate the database.
+The `compile_commands.json` at project root should contain a compilation instruction for each file in the target you specified. If you only see partial results, it might help to run the same make command a few more times.
 
 Once clangd is retarted, you should see some note about indexing in the bottom of your editor. Code completion and navigation should work after the indexing completes.
 

--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -97,7 +97,7 @@ def _run_docker_cmd(commands: List[str], use_local_image: bool):
         docker_image = IMAGE_NAME + ':latest'
     else:
         docker_image = GITHUB_IMAGE_NAME
-    cmd_prefix = 'docker run -it -u 0'.split(' ')
+    cmd_prefix = 'docker run -t -u 0'.split(' ')
     cmd = cmd_prefix + volume_cmd + [docker_image] + commands
     _run(cmd)
 

--- a/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
+++ b/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
@@ -15,6 +15,7 @@
 			"ms-python.python",
 			"njpwerner.autodocstring",
 			"ms-python.vscode-pylance",
+			"pucelle.run-on-save",
 		]
 	},
 	"settings": {
@@ -63,15 +64,16 @@
 		"python.linting.pylintPath": "pylint",
 		"python.testing.pytestEnabled": false,
 		"python.testing.unittestEnabled": false,
-		"editor.formatOnSave": true,
-		"python.formatting.autopep8Args": [
-			// This should be the same set of flags as ones specified in `lte/gateway/precommit.py`
-			"--select=W191,W291,W292,W293,W391,E131,E2,E3",
-		],
-		"[python]": {
-			"editor.codeActionsOnSave": {
-				"source.organizeImports": true
+		"runOnSave.shell": "bash",
+		"runOnSave.statusMessageTimeout": 3000,
+		"runOnSave.commands": [
+			{
+				"match": "\\.py$",
+				"command": "sudo ./lte/gateway/python/precommit.py -f -p ${fileRelative}",
+				"runIn": "backend",
+				"runningStatusMessage": "Running python formatting script on ${fileRelative}",
+				"finishStatusMessage": "${fileRelative} formatted"
 			}
-		},
+		]
 	},
 }


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Instead of configuring the python extension to run autopep8, configure a setting to just the python precommit.py script we have on save. This is better as we're guaranteed to get the same set of tools and its versions as CI.

TODO: this is not very useful unless the editor reloads the file from disk.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
