### PR TITLE
refactor: move getindexerversion to more discoverable area

### DIFF
--- a/orc8r/cloud/go/services/state/indexer/reindex/queue.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue.go
@@ -84,6 +84,10 @@ type Versioner interface {
 	// Intended for use when automatic reindexing is disabled.
 	GetIndexerVersions() ([]*indexer.Versions, error)
 
+	// GetIndexerVersion gets the tracked indexer versions for an indexer ID.
+	// Returns nil if not found.
+	GetIndexerVersion(indexerID string) (*indexer.Versions, error)
+
 	// SetIndexerActualVersion sets the actual version of an indexer, post-reindex.
 	// Intended for use when automatic reindexing is disabled.
 	SetIndexerActualVersion(indexerID string, actual indexer.Version) error
@@ -143,21 +147,6 @@ func GetStatuses(queue JobQueue) (map[string]Status, error) {
 		statuses[id] = info.Status
 	}
 	return statuses, nil
-}
-
-// GetIndexerVersion gets the tracked indexer versions for an indexer ID.
-// Returns nil if not found.
-func GetIndexerVersion(versioner Versioner, indexerID string) (*indexer.Versions, error) {
-	versions, err := versioner.GetIndexerVersions()
-	if err != nil {
-		return nil, err
-	}
-	for _, v := range versions {
-		if v.IndexerID == indexerID {
-			return v, nil
-		}
-	}
-	return nil, nil
 }
 
 func (j *Job) String() string {

--- a/orc8r/cloud/go/services/state/indexer/reindex/queue_sql_integ_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue_sql_integ_test.go
@@ -356,7 +356,7 @@ func TestSQLJobQueue_Integration_IndexerVersions(t *testing.T) {
 	// Update one actual version
 	err = q.SetIndexerActualVersion(id2, version2)
 	assert.NoError(t, err)
-	gotv, err := reindex.GetIndexerVersion(q, id2)
+	gotv, err := q.GetIndexerVersion(id2)
 	assert.NoError(t, err)
 	assert.Equal(t, version2, gotv.Actual)
 

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
@@ -184,7 +184,7 @@ func (r *reindexerImpl) getJobs(indexerID string) ([]*Job, error) {
 
 	var ret []*Job
 	for _, x := range idxs {
-		v, err := GetIndexerVersion(r.queue, x.GetID())
+		v, err := r.queue.GetIndexerVersion(x.GetID())
 		if err != nil {
 			return nil, err
 		}

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_test.go
@@ -444,7 +444,7 @@ func assertErrored(t *testing.T, q reindex.JobQueue, indexerID string, sentinel 
 }
 
 func assertVersions(t *testing.T, queue reindex.JobQueue, indexerID string, actual, desired indexer.Version) {
-	v, err := reindex.GetIndexerVersion(queue, indexerID)
+	v, err := queue.GetIndexerVersion(indexerID)
 	assert.NoError(t, err)
 	assert.Equal(t, actual, v.Actual)
 	assert.Equal(t, desired, v.Desired)

--- a/orc8r/cloud/go/services/state/indexer/reindex/versioner.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/versioner.go
@@ -61,6 +61,19 @@ func (v *versioner) GetIndexerVersions() ([]*indexer.Versions, error) {
 	return ret, nil
 }
 
+func (v *versioner) GetIndexerVersion(indexerID string) (*indexer.Versions, error) {
+	versions, err := v.GetIndexerVersions()
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range versions {
+		if v.IndexerID == indexerID {
+			return v, nil
+		}
+	}
+	return nil, nil
+}
+
 func (v *versioner) SetIndexerActualVersion(indexerID string, version indexer.Version) error {
 	txFn := func(tx *sql.Tx) (interface{}, error) {
 		return nil, setIndexerActualVersion(v.builder, tx, indexerID, version)

--- a/orc8r/cloud/go/services/state/indexer/reindex/versioner_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/versioner_test.go
@@ -52,7 +52,7 @@ func TestVersioner(t *testing.T) {
 	// Update one actual version
 	err = versioner.SetIndexerActualVersion(id2, version2)
 	assert.NoError(t, err)
-	gotv, err := reindex.GetIndexerVersion(versioner, id2)
+	gotv, err := versioner.GetIndexerVersion(id2)
 	assert.NoError(t, err)
 	assert.Equal(t, version2, gotv.Actual)
 


### PR DESCRIPTION

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Moved `versioner.GetIndexerVersion` to a more discoverable place

## Test Plan
Ran orc8r tests + CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
