### PR TITLE
feat(mobilityd): Add support for static IPv6 address

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -396,7 +396,6 @@ class IPAddressManager:
 
     def release_ip_address(
         self, sid: str, ip: ip_address,
-        version: int = IPAddress.IPV4,
     ):
         """ Release an IP address.
 
@@ -435,10 +434,10 @@ class IPAddressManager:
 
             IP_RELEASED_TOTAL.inc()
 
-            if version == IPAddress.IPV4:
+            if ip.version == 4:
                 self._store.ip_state_map.mark_ip_state(ip, IPState.RELEASED)
                 self._try_set_recycle_timer()  # start the timer to recycle
-            elif version == IPAddress.IPV6:
+            elif ip.version == 6:
                 # For IPv6, no recycling logic
                 ip_desc = self._store.ipv6_state_map.mark_ip_state(
                     ip,

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
@@ -175,7 +175,11 @@ class IpAllocatorPool(IPAllocator):
         Return:
              copy of the list of assigned IP blocks
         """
-        return list(deepcopy(self._store.assigned_ip_blocks))
+        ret = []
+        for ipblock in self._store.assigned_ip_blocks:
+            if ipblock.version == 4:
+                ret.append(ipblock)
+        return list(deepcopy(ret))
 
     def list_allocated_ips(self, ipblock: ip_network) -> List[ip_address]:
         """ List IP addresses allocated from a given IP block

--- a/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
@@ -62,6 +62,7 @@ class IPv6AllocatorPool(IPAllocator):
 
         # For now only one IPv6 network is supported
         self._assigned_ip_block = ipblock
+        self._store.assigned_ip_blocks.add(ipblock)
 
     def remove_ip_blocks(
         self, ipblocks: List[ip_network],
@@ -113,6 +114,8 @@ class IPv6AllocatorPool(IPAllocator):
             self._assigned_ip_block,
         )
         self._assigned_ip_block = None
+        self._store.assigned_ip_blocks -= removed_blocks
+
         return removed_blocks
 
     def alloc_ip_address(self, sid: str, _) -> IPDesc:

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -233,7 +233,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         try:
             self._ip_address_man.release_ip_address(
                 composite_sid, ip,
-                request.ip.version,
             )
             logging.info(
                 "Released IP %s for sid %s",

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ipv6_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ipv6_alloc.py
@@ -1,0 +1,540 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import ipaddress
+import time
+import unittest
+from typing import Optional
+
+import fakeredis
+from lte.protos.mobilityd_pb2 import IPAddress
+from magma.mobilityd.ip_address_man import (
+    DuplicateIPAssignmentError,
+    IPAddressManager,
+)
+from magma.mobilityd.ip_allocator_pool import IpAllocatorPool
+from magma.mobilityd.ip_allocator_static import IPAllocatorStaticWrapper
+from magma.mobilityd.ip_descriptor import IPType
+from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
+from magma.mobilityd.mobility_store import MobilityStore
+from magma.mobilityd.subscriberdb_client import SubscriberDBStaticIPValueError
+from magma.mobilityd.tests.test_multi_apn_ip_alloc import MockedSubscriberDBStub
+from magma.mobilityd.uplink_gw import InvalidVlanId
+
+
+class StaticIPAllocationTests(unittest.TestCase):
+    """
+    Test class for the Mobilityd Static IP Allocator
+    """
+    RECYCLING_INTERVAL_SECONDS = 0.01
+
+    def _new_ip_allocator(self, recycling_interval):
+        """
+        Creates and sets up an IPAllocator with the given recycling interval.
+        """
+
+        store = MobilityStore(fakeredis.FakeStrictRedis())
+        ipv4_allocator = IpAllocatorPool(store)
+        ipv6_allocator = IPv6AllocatorPool(
+            store,
+            session_prefix_alloc_mode='RANDOM',
+        )
+        ipv6_allocator = IPAllocatorStaticWrapper(
+            store,
+            subscriberdb_rpc_stub=MockedSubscriberDBStub(),
+            ip_allocator=ipv6_allocator,
+            ipv6=True,
+        )
+        self._allocator = IPAddressManager(
+            ipv4_allocator,
+            ipv6_allocator,
+            store,
+            recycling_interval,
+        )
+        self._allocator.add_ip_block(self._block)
+
+    def setUp(self):
+        self._block = ipaddress.ip_network('2021::0/54')
+        self._new_ip_allocator(self.RECYCLING_INTERVAL_SECONDS)
+
+    def tearDown(self):
+        MockedSubscriberDBStub.clear_subs()
+
+    def check_type(self, sid: str, type: IPType):
+        ip_desc = self._allocator._store.sid_ips_map[sid]
+        self.assertEqual(ip_desc.type, type)
+        if type == IPType.IP_POOL:
+            ip_block = self._block
+        else:
+            ip_block = ipaddress.ip_network(ip_desc.ip)
+        self.assertEqual(ip_desc.ip_block, ip_block)
+
+    def check_gw_info(
+        self, vlan: Optional[int], gw_ip: str,
+        gw_mac: Optional[str],
+    ):
+        gw_info_ip = self._allocator._store.dhcp_gw_info.get_gw_ip(vlan)
+        self.assertEqual(gw_info_ip, gw_ip)
+        gw_info_mac = self._allocator._store.dhcp_gw_info.get_gw_mac(vlan)
+        self.assertEqual(gw_info_mac, gw_mac)
+
+    def test_get_ipv6_for_subscriber(self):
+        """ test get_ip_for_sid without any assignment """
+        sid = 'IMSI11'
+        with self.assertRaises(SubscriberDBStaticIPValueError):
+            ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+
+    def test_get_ipv6_for_subscriber_with_apn(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        ip0_ipaddr = ipaddress.ip_address(assigned_ip)
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ip0_ipaddr)
+        self.check_type(sid, IPType.STATIC)
+        ip_block = ipaddress.ip_network(ip0_ipaddr)
+        self.assertIn(ip_block, self._allocator._store.assigned_ip_blocks)
+
+        self._allocator.release_ip_address(sid, ip0_ipaddr)
+        time.sleep(2)
+        self.assertNotIn(ip_block, self._allocator._store.assigned_ip_blocks)
+
+    def test_get_ipv6_for_subscriber_with_different_apn(self):
+        """ test get_ip_for_sid with different APN assigned ip"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="xyz", ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertNotEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.IP_POOL)
+
+    def test_get_ipv6_for_subscriber_with_wildcard_apn(self):
+        """ test wildcard apn"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ipv6_for_subscriber_with_wildcard_and_exact_apn(self):
+        """ test IP assignement from multiple  APNs"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        assigned_ip_wild = '2022::22:22'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip_wild)
+        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ipv6_for_subscriber_with_invalid_ip(self):
+        """ test invalid data from DB """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::hh'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertNotEqual(str(ip0), assigned_ip)
+        self.check_type(sid, IPType.IP_POOL)
+
+    def test_get_ipv6_for_subscriber_with_multi_apn_but_no_match(self):
+        """ test IP assignment from multiple  APNs"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        assigned_ip_wild = '2022::22:22'
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="abc",
+            ip=assigned_ip_wild,
+        )
+        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="xyz", ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertNotEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.IP_POOL)
+
+    def test_get_ipv6_for_subscriber_with_incomplete_sub(self):
+        """ test IP assignment from subscriber without non_3gpp config"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        MockedSubscriberDBStub.add_incomplete_sub(sid=imsi)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.check_type(sid, IPType.IP_POOL)
+
+    def test_get_ipv6_for_subscriber_with_wildcard_no_apn(self):
+        """ test wildcard apn"""
+        imsi = 'IMSI110'
+        sid = imsi + ",ipv6"
+        assigned_ip = '2022::1'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ipv6_for_subscriber_with_apn_dot(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma.ipv6'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ipv6_for_subscriber_with_wildcard_and_no_exact_apn(self):
+        """ test IP assignement from multiple  APNs"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        assigned_ip_wild = '2022::22:22'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip_wild)
+        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="xyz", ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip_wild))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ipv6_for_subscriber_with_wildcard_and_exact_apn_no_ip(self):
+        """ test IP assignement from multiple  APNs"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip_wild = '2022::22:22'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip_wild)
+        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=None)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertNotEqual(ip0, ipaddress.ip_address(assigned_ip_wild))
+        self.check_type(sid, IPType.IP_POOL)
+
+    def test_get_ipv6_for_subscriber_with_apn_with_gw(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        gw_ip = "2022::1:1:1"
+        gw_mac = "11:22:33:11:77:28"
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac,
+        )
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(None, gw_ip, gw_mac)
+
+    def test_get_ipv6_for_subscriber_with_only_wildcard_apn_gw(self):
+        """ test wildcard apn"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        gw_ip = "2022::1:1:1"
+        gw_mac = "11:22:33:11:77:81"
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn="*", ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac,
+        )
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ipv6_for_subscriber_with_apn_with_gw_vlan(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        gw_ip = "2022::1:1:1"
+        gw_mac = "11:22:33:11:77:44"
+        vlan = "200"
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(vlan, gw_ip, gw_mac)
+
+    def test_get_ipv6_for_subscriber_with_apn_with_gw_invalid_ip(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        gw_ip = "2022::1:1:1g"
+        gw_mac = "11:22:33:11:77:76"
+        vlan = "200"
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(vlan, None, None)
+
+    def test_get_ipv6_for_subscriber_with_apn_with_gw_nul_ip(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        gw_ip = ""
+        gw_mac = "11:22:33:11:77:45"
+        vlan = "200"
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(vlan, None, None)
+
+    def test_get_ipv6_for_subscriber_with_apn_with_gw_nul_mac(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        gw_ip = "2022::1:1:1"
+        gw_mac = None
+        vlan = "200"
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(vlan, gw_ip, "")
+
+    def test_get_ipv6_for_subscriber_with_wildcard_apn_gw(self):
+        """ test wildcard apn"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        gw_ip = "2022::1:1:1"
+        gw_mac = "11:22:33:11:77:81"
+        vlan = "300"
+
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
+
+        wildcard_assigned_ip = "20.20.20.20"
+        wildcard_gw_ip = "2022::3:3:3"
+        wildcard_gw_mac = "11:22:33:88:77:99"
+        wildcard_vlan = "400"
+
+        MockedSubscriberDBStub.add_sub_ip(
+            sid=imsi, apn="*",
+            ip=wildcard_assigned_ip,
+            gw_ip=wildcard_gw_ip,
+            gw_mac=wildcard_gw_mac,
+            vlan=wildcard_vlan,
+        )
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(vlan, gw_ip, gw_mac)
+        self.check_gw_info(wildcard_vlan, None, None)
+
+    def test_get_ipv6_for_subscriber_with_apn_with_gw_invalid_vlan(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        gw_ip = "2022::1:1:1"
+        gw_mac = "11:22:33:11:77:44"
+        vlan = "20000"
+        MockedSubscriberDBStub.add_sub(
+            sid=imsi, apn=apn, ip=assigned_ip,
+            gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan,
+        )
+
+        with self.assertRaises(InvalidVlanId):
+            ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+
+    def test_get_ipv6_for_subscriber_with_apn_dup_assignment(self):
+        """ test duplicate static IPs """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+        apn = 'magma'
+        imsi = 'IMSI999'
+        sid = imsi + '.' + apn + ",ipv6"
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+        with self.assertRaises(DuplicateIPAssignmentError):
+            ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+
+    def test_get_ipv6_for_2_subscribers_with_apn(self):
+        """ test duplicate static IPs """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2022::1'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+        apn1 = 'magma'
+        imsi1 = 'IMSI999'
+        assigned_ip1 = '2022::1:1'
+        sid1 = imsi1 + '.' + apn1 + ",ipv6"
+        MockedSubscriberDBStub.add_sub(sid=imsi1, apn=apn1, ip=assigned_ip1)
+
+        ip1, _ = self._allocator.alloc_ip_address(sid1, version=IPAddress.IPV6)
+        ip1_returned = self._allocator.get_ip_for_sid(sid1)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip1, ip1_returned)
+        self.assertEqual(ip1, ipaddress.ip_address(assigned_ip1))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ipv6_for_subscriber_with_apn_overlap_ip_pool(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn + ",ipv6"
+        assigned_ip = '2021::2022:1'
+
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        with self.assertRaises(DuplicateIPAssignmentError):
+            ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)


### PR DESCRIPTION
Enable static IP allocator to allocate statically
assigned IPv6 address.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test` and integ tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
