### PR TITLE
chore(mobilityd): Add support to list IPv6 blocks

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -241,7 +241,7 @@ class IPAddressManager:
         :return: ip_network object for assigned block
         """
         with self._lock:
-            ip_block = self.ipv6_allocator.list_added_ip_blocks()[0]
+            ip_block = self.ipv6_allocator.list_added_ip_blocks()
         return ip_block
 
     def list_allocated_ips(self, ipblock: ip_network) -> List[ip_address]:

--- a/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import logging
 import random
+from copy import deepcopy
 from ipaddress import ip_address, ip_network
 from typing import List, Optional
 
@@ -236,7 +237,11 @@ class IPv6AllocatorPool(IPAllocator):
         """
         Returns: assigned IP blocks on the allocator
         """
-        return [self._assigned_ip_block]
+        ret = []
+        for ipblock in self._store.assigned_ip_blocks:
+            if ipblock.version == 6:
+                ret.append(ipblock)
+        return list(deepcopy(ret))
 
     def list_allocated_ips(self, ipblock: ip_network) -> List[ip_address]:
         raise NotImplementedError

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -133,6 +133,26 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
+    def ListAddedIPv6Blocks(self, request, context):
+        """ Return a list of IPv6 blocks assigned """
+        self._print_grpc(request)
+        resp = ListAddedIPBlocksResponse()
+
+        ip_blocks = self._ip_address_man.get_assigned_ipv6_block()
+
+        ip_block_msg_list = [
+            IPBlock(
+                version=IPAddress.IPV6,
+                net_address=block.network_address.packed,
+                prefix_len=block.prefixlen,
+            )
+            for block in ip_blocks
+        ]
+        resp.ip_block_list.extend(ip_block_msg_list)
+
+        self._print_grpc(resp)
+        return resp
+
     def ListAllocatedIPs(self, request, context):
         """ Return a list of IPs allocated from a IP block
 

--- a/lte/gateway/python/scripts/mobility_cli.py
+++ b/lte/gateway/python/scripts/mobility_cli.py
@@ -62,6 +62,16 @@ def list_ipv4_blocks_handler(client, args):
 
 
 @grpc_wrapper
+def list_ipv6_blocks_handler(client, args):
+    resp = client.ListAddedIPv6Blocks(Void())
+    print("IPv6 Blocks Assigned:")
+    for block_msg in resp.ip_block_list:
+        ip = ipaddress.ip_address(block_msg.net_address)
+        block = ipaddress.ip_network("%s/%d" % (ip, block_msg.prefix_len))
+        print("\t%s" % block)
+
+
+@grpc_wrapper
 def allocate_ip_handler(client, args):
     try:
         sid_msg = SIDUtils.to_pb(args.sid)
@@ -243,6 +253,12 @@ def main():
         'list_ipv4_blocks', help='List assigned IPv4 blocks',
     )
     subparser.set_defaults(func=list_ipv4_blocks_handler)
+
+    # list_ipv6_blocks
+    subparser = subparsers.add_parser(
+        'list_ipv6_blocks', help='List assigned IPv6 blocks',
+    )
+    subparser.set_defaults(func=list_ipv6_blocks_handler)
 
     # allocate_ip
     subparser = subparsers.add_parser(

--- a/lte/protos/mobilityd.proto
+++ b/lte/protos/mobilityd.proto
@@ -153,6 +153,10 @@ service MobilityService {
   //
   rpc ListAddedIPv4Blocks (magma.orc8r.Void) returns (ListAddedIPBlocksResponse);
 
+  // Return a list of assigned IPv6 blocks
+  //
+  rpc ListAddedIPv6Blocks (magma.orc8r.Void) returns (ListAddedIPBlocksResponse);
+
   // Return a list of allocated IPs inside a IP block
   // Throws INVALID_ARGUMENT if IPBlock is invalid
   // Throws FAILED_PRECONDITION if IPBlock is not previously assigned


### PR DESCRIPTION
This is useful for debugging purpose.

```
(python) vagrant@magma-dev-focal:~/magma/lte/gateway$ mobility_cli.py  list_ipv6_blocks
IPv6 Blocks Assigned:
	fdee:5:6c::/48
```
existing:
```
(python) vagrant@magma-dev-focal:~/magma/lte/gateway$ mobility_cli.py  list_ipv4_blocks
IPv4 Blocks Assigned:
	192.168.128.0/24
```

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
