### PR TITLE
chore(mme): Update TEIDs on LTE calls only during session creation 

### DIFF
--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h
@@ -107,6 +107,8 @@ typedef struct sgw_eps_bearer_ctxt_s {
   char policy_rule_name[POLICY_RULE_NAME_MAXLEN + 1];
   uint32_t sgw_sequence_number;
   char* pgw_cp_ip_port;
+  bool update_teids;  // this is purely for optimization purposes and can be
+                      // safely initialized to true
 } sgw_eps_bearer_ctxt_t;
 
 typedef struct sgw_pdn_connection_s {

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
@@ -185,7 +185,7 @@ void spgw_handle_pcef_create_session_response(
 
   char* apn = (char*) bearer_ctxt_info_p->sgw_eps_bearer_context_information
                   .pdn_connection.apn_in_use;
-
+  eps_bearer_ctx_p->update_teids = true;
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
   IMSI64_TO_STRING(imsi64, imsi_str, IMSI_BCD_DIGITS_MAX);
 

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -550,10 +550,16 @@ static void sgw_add_gtp_tunnel(
           ue_ipv4, ue_ipv6, vlan, enb, enb_ipv6,
           eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
           eps_bearer_ctxt_p->enb_teid_S1u, imsi, NULL, DEFAULT_PRECEDENCE, apn);
+      // (@ulaskozat) We only need to update the TEIDs during session creation
+      // which triggers rule installments on sessiond. When pipelined needs to
+      // use eNB TEID for reporting we need to change this logic into something
+      // more meaningful.
+      bool update_teids               = eps_bearer_ctxt_p->update_teids;
+      eps_bearer_ctxt_p->update_teids = false;
       if (rv < 0) {
         OAILOG_ERROR_UE(
             LOG_SPGW_APP, imsi64, "ERROR in setting up TUNNEL err=%d\n", rv);
-      } else {
+      } else if (update_teids) {
         pcef_update_teids(
             (char*) imsi.digit, eps_bearer_ctxt_p->eps_bearer_id,
             eps_bearer_ctxt_p->enb_teid_S1u,

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp
@@ -536,6 +536,8 @@ void SpgwStateConverter::proto_to_sgw_eps_bearer(
   proto_to_traffic_flow_template(eps_bearer_proto.tft(), &eps_bearer->tft);
 
   eps_bearer->num_sdf = eps_bearer_proto.num_sdf();
+  eps_bearer->update_teids =
+      true;  // optimization purposes only, safe to set as true
 }
 
 void SpgwStateConverter::traffic_flow_template_to_proto(


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
MME service updates sessiond about TEID end points of a session during session creation, idle-active transitions and handovers. Since sessiond triggers activate flow rpcs to pipelined and if unsuccessful terminates the sessions, at scale tests we observed session undesired terminations for idle-active heavy workloads. This PR updates the TEIDs only as part of the session creation procedure and suppresses the other TEID updates to improve system performance. This has no side effects until pipelined or sessiond start utilizing eNB TEID for 4G (e.g., 4G-5G convergence, stats updates, etc.).

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- using s1ap integ test `test_attach_service.py"
Before PR:
```
Nov 01 21:20:45 magma-dev-focal sessiond[198199]: I1101 21:20:45.590132 198199 LocalSessionManagerHandler.cpp:688] Received a LocalCreateSessionRequest for IMSI001010000000001 with APN:magma.ipv4, default bearer ID:5, PLMN ID:00101, IMSI PLMN ID:00101, User location: 82 00 f1 10 00 01 00 f1 10 00 00 0a 0a
Nov 01 21:20:45 magma-dev-focal sessiond[198199]: I1101 21:20:45.590780 198199 LocalSessionManagerHandler.cpp:320] Initializing IMSI001010000000001-870644 in SessionStore before sending a CreateSessionRequest
Nov 01 21:20:45 magma-dev-focal sessiond[198199]: I1101 21:20:45.591526 198199 LocalSessionManagerHandler.cpp:338] Sending a CreateSessionRequest to fetch policies for IMSI001010000000001-870644
Nov 01 21:20:45 magma-dev-focal sessiond[198199]: I1101 21:20:45.593497 198199 LocalSessionManagerHandler.cpp:348] Processing CreateSessionResponse for IMSI001010000000001-870644
Nov 01 21:20:45 magma-dev-focal sessiond[198199]: I1101 21:20:45.595890 198199 LocalSessionManagerHandler.cpp:381] Successfully initialized IMSI001010000000001-870644 in SessionD after talking to PolicyDB/SessionProxy
Nov 01 21:20:45 magma-dev-focal sessiond[198199]: I1101 21:20:45.595947 198199 LocalSessionManagerHandler.cpp:506] Sending a request to DirectoryD to register sessiond ID: IMSI001010000000001-870644 msisdn:
Nov 01 21:20:45 magma-dev-focal sessiond[198199]: I1101 21:20:45.605326 198334 LocalSessionManagerHandler.cpp:615] Received a UpdateTunnelIds request for IMSI001010000000001 with default bearer id: 5 enb_teid= 167772456 agw_teid= 25
Nov 01 21:20:45 magma-dev-focal sessiond[198199]: I1101 21:20:45.606796 198199 LocalEnforcer.cpp:749] Activating untracked rule allowlist_sid-IMSI001010000000001-magma.ipv4
Nov 01 21:20:45 magma-dev-focal sessiond[198199]: I1101 21:20:45.611559 198253 SessionEvents.cpp:112] Could not log session_created event {"mac_addr":"","user_location":" 82 00 f1 10 00 01 00 f1 10 00 00 0a 0a","spgw_ip":"192.168.60.142","imei":"\u0004\b\u0006\u0004\u0005\u0000\b\u0003\u0001\u0003\u0001\u0001\u0002\u0003\u0001\u0007","pdp_start_time":1635801645,"session_id":"IMSI001010000000001-870644","apn":"magma.ipv4","msisdn":"","charging_characteristics":"","ipv6_addr":"","ip_addr":"192.168.128.12","imsi":"IMSI001010000000001"}, Error Message: Could not connect to FluentBit locally, Details: [Errno 111] Connection refused
Nov 01 21:20:46 magma-dev-focal sessiond[198199]: I1101 21:20:46.124203 198334 LocalSessionManagerHandler.cpp:615] Received a UpdateTunnelIds request for IMSI001010000000001 with default bearer id: 5 enb_teid= 167772456 agw_teid= 25
Nov 01 21:20:46 magma-dev-focal sessiond[198199]: I1101 21:20:46.127388 198253 SessionEvents.cpp:112] Could not log session_created event {"mac_addr":"","user_location":" 82 00 f1 10 00 01 00 f1 10 00 00 0a 0a","spgw_ip":"192.168.60.142","imei":"\u0004\b\u0006\u0004\u0005\u0000\b\u0003\u0001\u0003\u0001\u0001\u0002\u0003\u0001\u0007","pdp_start_time":1635801645,"session_id":"IMSI001010000000001-870644","apn":"magma.ipv4","msisdn":"","charging_characteristics":"","ipv6_addr":"","ip_addr":"192.168.128.12","imsi":"IMSI001010000000001"}, Error Message: Could not connect to FluentBit locally, Details: [Errno 111] Connection refused
Nov 01 21:20:46 magma-dev-focal sessiond[198199]: I1101 21:20:46.129915 198199 LocalSessionManagerHandler.cpp:540] Received a termination request from Access for IMSI001010000000001 apn magma.ipv4
Nov 01 21:20:46 magma-dev-focal sessiond[198199]: I1101 21:20:46.130230 198199 LocalEnforcer.cpp:535] Initiating session termination for IMSI001010000000001-870644
Nov 01 21:20:46 magma-dev-focal sessiond[198199]: I1101 21:20:46.275491 198199 SessionState.cpp:541] Reported rule (allowlist_sid-IMSI001010000000001-internet) not found in IMSI001010000000001-870644, ignoring
Nov 01 21:20:46 magma-dev-focal sessiond[198199]: I1101 21:20:46.275534 198199 LocalEnforcer.cpp:413] Received stats for 1 active sessions and 0 stale sessions
Nov 01 21:20:48 magma-dev-focal sessiond[198199]: I1101 21:20:48.275609 198199 LocalEnforcer.cpp:1281] IMSI001010000000001-870644 deleted from SessionMap
```

After PR:
```
-- Logs begin at Thu 2021-06-17 23:23:20 UTC. --
Nov 01 21:30:46 magma-dev-focal sessiond[220084]: I1101 21:30:46.125296 220108 sessiond_main.cpp:468] Started local service thread
Nov 01 21:30:46 magma-dev-focal sessiond[220084]: I1101 21:30:46.126163 220109 sessiond_main.cpp:473] Started proxy service thread
Nov 01 21:30:46 magma-dev-focal sessiond[220084]: I1101 21:30:46.130311 220110 sessiond_main.cpp:482] Started abort session service thread
Nov 01 21:32:19 magma-dev-focal sessiond[220084]: I1101 21:32:19.216573 220108 LocalSessionManagerHandler.cpp:77] Pipelined has been restarted, attempting to sync flows, old epoch = 0, new epoch = 1635802337
Nov 01 21:32:19 magma-dev-focal sessiond[220084]: I1101 21:32:19.218163 220084 LocalSessionManagerHandler.cpp:198] Sending a setup call to PipelineD with epoch: 1635802337
Nov 01 21:32:19 magma-dev-focal sessiond[220084]: I1101 21:32:19.226390 220084 LocalSessionManagerHandler.cpp:169] PipelineD setup failed, retrying PipelineD setup after delay, for epoch: 1635802337
Nov 01 21:32:19 magma-dev-focal sessiond[220084]: I1101 21:32:19.227306 220084 LocalSessionManagerHandler.cpp:169] PipelineD setup failed, retrying PipelineD setup after delay, for epoch: 1635802337
Nov 01 21:32:24 magma-dev-focal sessiond[220084]: I1101 21:32:24.231045 220084 LocalSessionManagerHandler.cpp:198] Sending a setup call to PipelineD with epoch: 1635802337
Nov 01 21:32:24 magma-dev-focal sessiond[220084]: I1101 21:32:24.236892 220084 LocalSessionManagerHandler.cpp:146] Successfully setup PipelineD with epoch: 1635802337
Nov 01 21:32:24 magma-dev-focal sessiond[220084]: I1101 21:32:24.238741 220084 LocalSessionManagerHandler.cpp:146] Successfully setup PipelineD with epoch: 1635802337
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.310616 220084 LocalSessionManagerHandler.cpp:688] Received a LocalCreateSessionRequest for IMSI001010000000001 with APN:magma.ipv4, default bearer ID:5, PLMN ID:00101, IMSI PLMN ID:00101, User location: 82 00 f1 10 00 01 00 f1 10 00 00 0a 0a
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.310918 220084 LocalSessionManagerHandler.cpp:320] Initializing IMSI001010000000001-794310 in SessionStore before sending a CreateSessionRequest
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.311750 220084 LocalSessionManagerHandler.cpp:338] Sending a CreateSessionRequest to fetch policies for IMSI001010000000001-794310
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.314100 220084 LocalSessionManagerHandler.cpp:348] Processing CreateSessionResponse for IMSI001010000000001-794310
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.315812 220084 LocalSessionManagerHandler.cpp:381] Successfully initialized IMSI001010000000001-794310 in SessionD after talking to PolicyDB/SessionProxy
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.315860 220084 LocalSessionManagerHandler.cpp:506] Sending a request to DirectoryD to register sessiond ID: IMSI001010000000001-794310 msisdn:
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.351184 220108 LocalSessionManagerHandler.cpp:615] Received a UpdateTunnelIds request for IMSI001010000000001 with default bearer id: 5 enb_teid= 167772456 agw_teid= 26
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.352159 220084 LocalEnforcer.cpp:749] Activating untracked rule allowlist_sid-IMSI001010000000001-magma.ipv4
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.354964 220098 SessionEvents.cpp:112] Could not log session_created event {"mac_addr":"","user_location":" 82 00 f1 10 00 01 00 f1 10 00 00 0a 0a","spgw_ip":"192.168.60.142","imei":"\u0004\b\u0006\u0004\u0005\u0000\b\u0003\u0001\u0003\u0001\u0001\u0002\u0003\u0001\u0007","pdp_start_time":1635804807,"session_id":"IMSI001010000000001-794310","apn":"magma.ipv4","msisdn":"","charging_characteristics":"","ipv6_addr":"","ip_addr":"192.168.128.12","imsi":"IMSI001010000000001"}, Error Message: Could not connect to FluentBit locally, Details: [Errno 111] Connection refused
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.852586 220084 LocalSessionManagerHandler.cpp:540] Received a termination request from Access for IMSI001010000000001 apn magma.ipv4
Nov 01 22:13:27 magma-dev-focal sessiond[220084]: I1101 22:13:27.852723 220084 LocalEnforcer.cpp:535] Initiating session termination for IMSI001010000000001-794310
Nov 01 22:13:28 magma-dev-focal sessiond[220084]: I1101 22:13:28.198678 220084 SessionState.cpp:541] Reported rule (allowlist_sid-IMSI001010000000001-internet) not found in IMSI001010000000001-794310, ignoring
Nov 01 22:13:28 magma-dev-focal sessiond[220084]: I1101 22:13:28.198961 220084 LocalEnforcer.cpp:413] Received stats for 1 active sessions and 0 stale sessions
Nov 01 22:13:30 magma-dev-focal sessiond[220084]: I1101 22:13:30.199365 220084 LocalEnforcer.cpp:1281] IMSI001010000000001-794310 deleted from SessionMap
```

- Integ tests.
- Spirent tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
