### PR TITLE
feat(ci): Add firebase integration to build workflow

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -89,6 +89,9 @@ jobs:
           python ci-scripts/helm_repo_rotation.py
   agw-build:
     runs-on: macos-10.15
+    outputs:
+      artifacts: ${{ steps.publish_packages.outputs.artifact }}
+      valid: ${{ steps.publish_packages.outputs.valid }}
     steps:
       - uses: actions/checkout@v2
       - name: setup pyenv
@@ -115,13 +118,28 @@ jobs:
           mkdir magma-packages
           vagrant ssh -c "cp -r magma-packages /vagrant"
       - name: Publish debian packages
+        id: publish_packages
         if: github.event_name == 'push'
         run: |
           cd lte/gateway/magma-packages
           for i in `ls -a1 *.deb`
           do
             echo "Pushing package $i to JFROG artifiactory: https://artifactory.magmacore.org/artifactory/debian-test/pool"
-            curl -uci-bot:${{ secrets.JFROG_CIBOT_APIKEYS }} -XPUT "https://artifactory.magmacore.org/artifactory/debian-test/pool/focal-ci/$i;deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64" -T $i
+            HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -uci-bot:${{ secrets.JFROG_CIBOT_APIKEYS }} -XPUT "https://artifactory.magmacore.org/artifactory/debian-test/pool/focal-ci/$i;deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64" -T $i)
+            echo "$HTTP_RESPONSE"
+            # capture server response for magma package
+            if [[ "$i" == "magma_"*"_amd64.deb" ]]; then
+              # extract the body
+              HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
+              # extract the status
+              HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+              if [[ "$HTTP_STATUS" != "2"* ]]; then
+                echo "::set-output name=valid::false"
+              else
+                echo "::set-output name=artifact::$(echo $HTTP_BODY)"
+                echo "::set-output name=valid::true"
+              fi
+            fi
           done
       - uses: actions/upload-artifact@v2
         if: github.event_name == 'pull_request'
@@ -144,7 +162,6 @@ jobs:
         uses: Ilshidur/action-slack@2.1.0
         with:
           args: "AGW  build failed on [${{github.sha}}](${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}): ${{ steps.commit.outputs.title}}"
-
   orc8r-build:
     name: orc8r build job
     runs-on: ubuntu-latest
@@ -647,3 +664,25 @@ jobs:
           SLACK_ICON_EMOJI: ":heavy_check_mark:"
           SLACK_COLOR: "#00FF00"
           SLACK_FOOTER: ' '
+  Publish_to_firebase:
+    name: Publish to firebase
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: [agw-build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Publish to
+        env:
+          FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
+          WORKERS: "playground,fb_lab_spirent,fb_lab_tvm"  # all workers for post-merge pipeline. Comma separated
+          BUILD_ID: "${{ github.sha }}"
+          BUILD_METADATA: '{"github:workflow": "${{ github.workflow }}", "github:run_id": "${{ github.run_id }}", "github:actor": "${{ github.actor }}", "github:repository": "${{ github.repository }}", "github:event_name": "${{ github.event_name }}", "github:sha": "${{ github.sha }}", "github:sha:url": "${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}", "github:ref": "${{ github.ref }}"}'
+          AGW_ARTIFACTS: ${{ needs.agw-build.outputs.artifacts }}
+          AGW_VALID: ${{ needs.agw-build.outputs.valid }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install Pyrebase
+          python ci-scripts/firebase_publish.py

--- a/ci-scripts/firebase_publish.py
+++ b/ci-scripts/firebase_publish.py
@@ -1,0 +1,97 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import os
+import time
+
+import pyrebase
+
+
+def main():
+    """Publish builds and workloads to Firebase realtime database"""
+    # Read db config
+    firebase_config = os.environ["FIREBASE_CONFIG"]
+    config = json.loads(firebase_config)
+
+    # Initialize pyrebase app
+    firebase = pyrebase.initialize_app(config)
+
+    # Get a reference to the auth service
+    auth = firebase.auth()
+
+    # Log the user in
+    user = auth.sign_in_with_email_and_password(
+        config["auth_email"], config["auth_password"],
+    )
+
+    # Get a reference to the database service
+    db = firebase.database()
+
+    # Grab environment variables
+    workers_env = os.environ["WORKERS"]
+    build_id = os.environ["BUILD_ID"]
+    build_metadata_env = os.environ["BUILD_METADATA"]
+    agw_artifacts_env = os.environ["AGW_ARTIFACTS"]
+    agw_valid_env = os.environ["AGW_VALID"]
+
+    # Prepare list of registered test workers
+    workers = [x.strip() for x in workers_env.split(",")]
+
+    # Prepare build metadata
+    build_metadata = {}
+    try:
+        build_metadata = json.loads(build_metadata_env)
+        build_metadata["timestamp"] = int(time.time())
+    except ValueError:
+        print("Decoding build_metadata_env JSON failed: ", build_metadata_env)
+    build_info = {"metadata": build_metadata}
+
+    # Add agw arifacts
+    agw_artifacts = {}
+    agw_valid = False
+    if agw_valid_env == "true":
+        try:
+            agw_artifacts = json.loads(agw_artifacts_env)
+            agw_valid = True
+        except ValueError:
+            print("Decoding agw artifacts JSON has failed: ", agw_artifacts_env)
+    build_info["agw"] = {
+        "valid": agw_valid,
+        "artifacts": agw_artifacts,
+    }
+
+    # Prepare workload
+    workload = {
+        "build_id": build_id,
+        "priority": 2,
+        "state": "queued",
+        "timestamp": int(time.time()),
+    }
+
+    # Publish build to Firebase realtime database
+    print("Publishing build to database: builds/", build_id)
+    print(build_info)
+    db.child("builds").child(build_id).set(build_info, user["idToken"])
+
+    # Publish workloads to Firebase realtime database
+    print("Pushing the following workload to workers: ", workers)
+    print(workload)
+    for worker in workers:
+        db.child("workers").child(worker).child("workloads").push(
+            workload, user["idToken"],
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib talkhasib@fb.com

## Summary

Add code to publish build information and test workloads to firestore realtime database
This only covers the AGW build for now. This should be enough to start testing with Spirent lab setup

## Test Plan
Tested on ci-firebase branch. Build and workloads get published to firebase database