### PR TITLE
chore(sessiond): reorder includes, self-generate all protos

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -52,14 +52,14 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function")
 endif ()
 
-include_directories("${OUTPUT_DIR}")
 include_directories("${MAGMA_ROOT}/orc8r/gateway/c/common/logging")
-
-include_directories(${MAGMA_LIB_DIR}/service303)
-include_directories(${MAGMA_LIB_DIR}/service_registry)
-include_directories(${MAGMA_LIB_DIR}/async_grpc)
-include_directories(${MAGMA_LIB_DIR}/config)
-include_directories(${MAGMA_LIB_DIR}/eventd)
+include_directories(${MAGMA_ROOT}/orc8r/gateway/c/common/service303)
+include_directories(${MAGMA_ROOT}/orc8r/gateway/c/common/service_registry)
+include_directories(${MAGMA_ROOT}/orc8r/gateway/c/common/async_grpc)
+include_directories(${MAGMA_ROOT}/orc8r/gateway/c/common/async_grpc/includes)
+include_directories(${MAGMA_ROOT}/orc8r/gateway/c/common/config)
+include_directories(${MAGMA_ROOT}/orc8r/gateway/c/common/eventd)
+include_directories("${OUTPUT_DIR}")
 
 # TODO: Temp workaround until packages are imported by these cmakefile
 # Will be removed in subsequent patch
@@ -76,7 +76,7 @@ create_proto_dir("feg/gateway/services/aaa" CWF_CPP_OUT_DIR)
 list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
 
-set(SMGR_ORC8R_CPP_PROTOS digest directoryd redis)
+set(SMGR_ORC8R_CPP_PROTOS common digest directoryd eventd metricsd redis service303)
 generate_cpp_protos("${SMGR_ORC8R_CPP_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${ORC8R_CPP_OUT_DIR})
 
@@ -89,7 +89,7 @@ set(SMGR_CWF_CPP_PROTOS accounting context)
 generate_cwf_cpp_protos("${SMGR_CWF_CPP_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${CWF_PROTO_DIR} ${CWF_CPP_OUT_DIR})
 
-set(SMGR_ORC8R_GRPC_PROTOS directoryd)
+set(SMGR_ORC8R_GRPC_PROTOS directoryd eventd service303)
 generate_grpc_protos("${SMGR_ORC8R_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${ORC8R_CPP_OUT_DIR})
 


### PR DESCRIPTION
## Summary

This PR was authored in order to enable #9926 to land without fully-pathifying `sessiond` build (PR #9924 blocked awaiting end of CLion support).

The existing PR #9926 highlighted / discovered errors in the CMakeLists.txt for `session_manager`. Specifically, the include paths prioritized `/build/` path discovery over repo discovery (which technically worked due to various copy operations, but was not best practice and with our full path fixups, resulted in mixed include re-import for some header files - redefinition errors in compilation).

Re-arranging the include priorities also highlighted that we were not generating all protos that `session_manager` needed, but were relying on other build artifacts in the `/build/` directory (generated by e.g. Common lib).  This may be WAI but caused problems so this PR moves to generate all protos for `session_manager`.

Note that when we apply full path fixups to `session_manager` in e.g. PR #9924 we can drop all of the per-directory include paths for `session_manager`'s top level `CMakeLists.txt`

Signed-off-by: Scott Moeller <electronjoe@gmail.com>