### PR TITLE
fix(mme): Fixing free_partial_tai_lists heap overflow

### DIFF
--- a/lte/gateway/c/core/oai/include/amf_config.h
+++ b/lte/gateway/c/core/oai/include/amf_config.h
@@ -98,6 +98,7 @@ typedef struct m5g_nas_config_s {
   bool enable_apn_correction;
   m5g_apn_map_config_t m5g_apn_map_config;
 } m5g_nas_config_t;
+
 typedef uint64_t imsi64_t;
 
 typedef struct ngap_config_s {
@@ -193,6 +194,7 @@ void amf_config_display(amf_config_t*);
 void clear_amf_config(amf_config_t*);
 void copy_amf_config_from_mme_config(
     amf_config_t* dest, const mme_config_t* src);
+void copy_served_tai_config_list(amf_config_t* dest, const mme_config_t* src);
 
 void amf_config_exit(void);
 void amf_config_free(amf_config_t* amf_config);

--- a/lte/gateway/c/core/oai/include/mme_config.h
+++ b/lte/gateway/c/core/oai/include/mme_config.h
@@ -460,7 +460,7 @@ void mme_config_exit(void);
 void free_mme_config(mme_config_t* mme_config);
 void clear_served_tai_config(served_tai_t* served_tai);
 
-void free_partial_lists(partial_list_t** partialList, uint8_t num_par_lists);
+void free_partial_lists(partial_list_t* partialList, uint8_t num_par_lists);
 
 #define mme_config_read_lock(mMEcONFIG)                                        \
   pthread_rwlock_rdlock(&(mMEcONFIG)->rw_lock)

--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -415,6 +415,7 @@ void amf_config_free(amf_config_t* amf_config) {
   free_wrapper((void**) &amf_config->served_tai.plmn_mnc_len);
   free_wrapper((void**) &amf_config->served_tai.tac);
 }
+
 /****************************************************************************
  **                                                                        **
  ** Name:    amf_config_exit()                                             **
@@ -428,6 +429,7 @@ void amf_config_exit(void) {
   pthread_rwlock_destroy(&amf_config.rw_lock);
   amf_config_free(&amf_config);
 }
+
 void clear_amf_config(amf_config_t* amf_config) {
   if (!amf_config) return;
 
@@ -440,8 +442,79 @@ void clear_amf_config(amf_config_t* amf_config) {
   bdestroy_wrapper(&amf_config->ip_capability);
   bdestroy_wrapper(&amf_config->amf_name);
   clear_served_tai_config(&amf_config->served_tai);
-  free_partial_lists(&amf_config->partial_list, amf_config->num_par_lists);
+  free_partial_lists(amf_config->partial_list, amf_config->num_par_lists);
   amf_config->num_par_lists = 0;
+}
+
+/***************************************************************************
+**                                                                        **
+** Name:   copy_served_tai_config_list()                                  **
+**                                                                        **
+** Description: copy tai list from mme_config to amf_config               **
+**                                                                        **
+**                                                                        **
+***************************************************************************/
+void copy_served_tai_config_list(amf_config_t* dest, const mme_config_t* src) {
+  if (!dest || !src) return;
+
+  // served_tai
+  if (dest->served_tai.nb_tai != src->served_tai.nb_tai) {
+    if (NULL != dest->served_tai.plmn_mcc)
+      free_wrapper((void**) &dest->served_tai.plmn_mcc);
+
+    if (NULL != dest->served_tai.plmn_mnc)
+      free_wrapper((void**) &dest->served_tai.plmn_mnc);
+
+    if (NULL != dest->served_tai.plmn_mnc_len)
+      free_wrapper((void**) &dest->served_tai.plmn_mnc_len);
+
+    if (NULL != dest->served_tai.tac)
+      free_wrapper((void**) &dest->served_tai.tac);
+
+    dest->served_tai.nb_tai = src->served_tai.nb_tai;
+    dest->served_tai.plmn_mcc =
+        calloc(dest->served_tai.nb_tai, sizeof(uint16_t));
+    dest->served_tai.plmn_mnc =
+        calloc(dest->served_tai.nb_tai, sizeof(uint16_t));
+    dest->served_tai.plmn_mnc_len =
+        calloc(dest->served_tai.nb_tai, sizeof(uint16_t));
+    dest->served_tai.tac = calloc(dest->served_tai.nb_tai, sizeof(uint16_t));
+  }
+  memcpy(
+      dest->served_tai.plmn_mcc, src->served_tai.plmn_mcc,
+      (dest->served_tai.nb_tai) * sizeof(uint16_t));
+  memcpy(
+      dest->served_tai.plmn_mnc, src->served_tai.plmn_mnc,
+      (dest->served_tai.nb_tai) * sizeof(uint16_t));
+  memcpy(
+      dest->served_tai.plmn_mnc_len, src->served_tai.plmn_mnc_len,
+      (dest->served_tai.nb_tai) * sizeof(uint16_t));
+  memcpy(
+      dest->served_tai.tac, src->served_tai.tac,
+      (dest->served_tai.nb_tai) * sizeof(uint16_t));
+
+  // num_par_lists
+  dest->num_par_lists = src->num_par_lists;
+
+  // partial_list
+  dest->partial_list = calloc(dest->num_par_lists, sizeof(partial_list_t));
+
+  for (uint8_t itr = 0; itr < src->num_par_lists && dest->partial_list; ++itr) {
+    dest->partial_list[itr].list_type = src->partial_list[itr].list_type;
+    dest->partial_list[itr].nb_elem   = src->partial_list[itr].nb_elem;
+
+    dest->partial_list[itr].plmn =
+        calloc(dest->partial_list[itr].nb_elem, sizeof(plmn_t));
+    memcpy(
+        dest->partial_list[itr].plmn, src->partial_list[itr].plmn,
+        (dest->partial_list[itr].nb_elem) * sizeof(plmn_t));
+
+    dest->partial_list[itr].tac =
+        calloc(dest->partial_list[itr].nb_elem, sizeof(tac_t));
+    memcpy(
+        dest->partial_list[itr].tac, src->partial_list[itr].tac,
+        (dest->partial_list[itr].nb_elem) * sizeof(tac_t));
+  }
 }
 
 void copy_amf_config_from_mme_config(

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -280,14 +280,14 @@ void mme_config_init(mme_config_t* config) {
   sac_to_tacs_map_config_init(&config->sac_to_tacs_map);
 }
 
-void free_partial_lists(partial_list_t** partial_list, uint8_t num_par_lists) {
+void free_partial_lists(partial_list_t* partial_list, uint8_t num_par_lists) {
   if ((!partial_list) || (!num_par_lists)) return;
 
   for (uint8_t itr = 0; itr < num_par_lists; itr++) {
-    free_wrapper((void**) &(partial_list[itr]->plmn));
-    free_wrapper((void**) &(partial_list[itr]->tac));
+    free_wrapper((void**) &(partial_list[itr].plmn));
+    free_wrapper((void**) &(partial_list[itr].tac));
   }
-  free_wrapper((void**) partial_list);
+  free_wrapper((void**) &partial_list);
 }
 
 void free_mme_config(mme_config_t* mme_config) {
@@ -314,7 +314,7 @@ void free_mme_config(mme_config_t* mme_config) {
   free_wrapper((void**) &mme_config->served_tai.tac);
 
   clear_served_tai_config(&mme_config->served_tai);
-  free_partial_lists(&mme_config->partial_list, mme_config->num_par_lists);
+  free_partial_lists(mme_config->partial_list, mme_config->num_par_lists);
   mme_config->num_par_lists = 0;
 
   bdestroy_wrapper(&mme_config->service303_config.name);
@@ -496,77 +496,6 @@ void create_partial_lists(mme_config_t* config_pP) {
     }
   }
   return;
-}
-
-/***************************************************************************
-**                                                                        **
-** Name:   copy_served_tai_config_list()                                  **
-**                                                                        **
-** Description: copy tai list from mme_config to amf_config               **
-**                                                                        **
-**                                                                        **
-***************************************************************************/
-void copy_served_tai_config_list(amf_config_t* dest, const mme_config_t* src) {
-  if (!dest || !src) return;
-
-  // served_tai
-  if (dest->served_tai.nb_tai != src->served_tai.nb_tai) {
-    if (NULL != dest->served_tai.plmn_mcc)
-      free_wrapper((void**) &dest->served_tai.plmn_mcc);
-
-    if (NULL != dest->served_tai.plmn_mnc)
-      free_wrapper((void**) &dest->served_tai.plmn_mnc);
-
-    if (NULL != dest->served_tai.plmn_mnc_len)
-      free_wrapper((void**) &dest->served_tai.plmn_mnc_len);
-
-    if (NULL != dest->served_tai.tac)
-      free_wrapper((void**) &dest->served_tai.tac);
-
-    dest->served_tai.nb_tai = src->served_tai.nb_tai;
-    dest->served_tai.plmn_mcc =
-        calloc(dest->served_tai.nb_tai, sizeof(uint16_t));
-    dest->served_tai.plmn_mnc =
-        calloc(dest->served_tai.nb_tai, sizeof(uint16_t));
-    dest->served_tai.plmn_mnc_len =
-        calloc(dest->served_tai.nb_tai, sizeof(uint16_t));
-    dest->served_tai.tac = calloc(dest->served_tai.nb_tai, sizeof(uint16_t));
-  }
-  memcpy(
-      dest->served_tai.plmn_mcc, src->served_tai.plmn_mcc,
-      (dest->served_tai.nb_tai) * sizeof(uint16_t));
-  memcpy(
-      dest->served_tai.plmn_mnc, src->served_tai.plmn_mnc,
-      (dest->served_tai.nb_tai) * sizeof(uint16_t));
-  memcpy(
-      dest->served_tai.plmn_mnc_len, src->served_tai.plmn_mnc_len,
-      (dest->served_tai.nb_tai) * sizeof(uint16_t));
-  memcpy(
-      dest->served_tai.tac, src->served_tai.tac,
-      (dest->served_tai.nb_tai) * sizeof(uint16_t));
-
-  // num_par_lists
-  dest->num_par_lists = src->num_par_lists;
-
-  // partial_list
-  dest->partial_list = calloc(dest->num_par_lists, sizeof(partial_list_t));
-
-  for (uint8_t itr = 0; itr < src->num_par_lists && dest->partial_list; ++itr) {
-    dest->partial_list[itr].list_type = src->partial_list[itr].list_type;
-    dest->partial_list[itr].nb_elem   = src->partial_list[itr].nb_elem;
-
-    dest->partial_list[itr].plmn =
-        calloc(dest->partial_list[itr].nb_elem, sizeof(plmn_t));
-    memcpy(
-        dest->partial_list[itr].plmn, src->partial_list[itr].plmn,
-        (dest->partial_list[itr].nb_elem) * sizeof(plmn_t));
-
-    dest->partial_list[itr].tac =
-        calloc(dest->partial_list[itr].nb_elem, sizeof(tac_t));
-    memcpy(
-        dest->partial_list[itr].tac, src->partial_list[itr].tac,
-        (dest->partial_list[itr].nb_elem) * sizeof(tac_t));
-  }
 }
 
 /****************************************************************************


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- During changes of mme_config on #9859, `free_partial_tai_lists` function resulted in `heap-buffer-overflow` which produced MME cores, this PR fixes it
- Multiple formatting changes on `amf_config` and `mme_config`

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Ran `make integ_test` to verify there's no overflow on mme restart

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
