### PR TITLE
chore(smsd-relay): Don't log an error in happy path

### DIFF
--- a/lte/gateway/python/magma/smsd/relay.py
+++ b/lte/gateway/python/magma/smsd/relay.py
@@ -72,7 +72,7 @@ class SmsRelay(Job):
             return
 
         for msg in smsd_resp.messages:
-            logging.error('%s', msg)
+            logging.info('%s', msg)
             await self._send_sms(msg)
 
     async def _get_attached_imsis(self) -> List[str]:


### PR DESCRIPTION
## Context
Going through the error handling in some of the smaller services for #10027, we noticed that the smsd relay logs an error for each message that it tries to send. It looks to me like this should be on info (or even debug) level instead.

## Summary
Log message on info level instead of error for each sms that the relay tries to send.