### PR TITLE
fix(orc8r): fixed fab command to connect gateway

### DIFF
--- a/orc8r/tools/fab/dev_utils.py
+++ b/orc8r/tools/fab/dev_utils.py
@@ -118,11 +118,14 @@ def get_next_available_gateway_id(
     Returns:
         Next available gateway ID in the form gwN
     """
-    # gateways is a dict mapping gw ID to full resource
-    gateways = cloud_get(
+    # res is a dict mapping gw ID to full resource
+    res = cloud_get(
         f'networks/{network_id}/gateways',
         admin_cert=admin_cert,
     )
+
+    # res could also return paginated gateways, so need to unwrap the mapping
+    gateways = res.get('gateways', res)
 
     n = len(gateways) + 1
     candidate = f'gw{n}'


### PR DESCRIPTION
## Summary
The API request `networks/{network_id}/gateways` now returns a paginated gateways rather than just a mapping of gw ID to full resource, so we need to unwrap the mapping. 

## Test Plan
Ran `fab -f dev_tools.py register_vm` 