### PR TITLE
chore: add clangd-12 to magma vm and activate extension on startup

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,11 +25,18 @@
             "group": "build"
         },
         {
-            "label": "Set compile_commands.json for IntelliSense",
+            "label": "Set compile_commands.json for IntelliSense (make sure you have run `make build_X`!)",
             "type": "shell",
             "command": "rm compile_commands.json || true && ln -s ${input:pickCompileCommandsFile} ${workspaceFolder}/compile_commands.json",
             "problemMatcher": []
-        }
+        },
+        {
+            "label": "Activate clangd extension on workspace startup",
+            "command": "${command:clangd.activate}",
+            "runOptions": {
+                "runOn": "folderOpen"
+            }
+        },
     ],
     "inputs": [
         {
@@ -37,6 +44,7 @@
             "type": "command",
             "command": "shellCommand.execute",
             "args": {
+                "description": "Pick a compile_commands.json",
                 "command": "sudo find ${env:C_BUILD} -name 'compile_commands.json'",
             },
         }

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -420,14 +420,13 @@
     src: patches/aioeventlet_fd_exception.patch
     dest: /usr/local/lib/python3.8/dist-packages/aioeventlet.py
 
+# TODO: preburn this
 - name: Install requirements for VSCode <-> Bazel integration
-  when: preburn
+  retries: 5
   apt:
-    state: present
-    update_cache: yes 
+    state: latest
     pkg:
       - clangd-12
-  retries: 5
 
 - name: Symlink system wide bazelrc into the VM
   file:

--- a/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
+++ b/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
@@ -33,6 +33,7 @@
 		"bsv.bzl.lsp.enableCodelensRun": false,
 		"bsv.bzl.remoteCache.enabled": false,
 		"bsv.bzl.starlarkDebugger.enabled": false,
+		"clangd.path": "clangd-12",
 		"clangd.arguments": [
 			"-log=verbose",
 			"-pretty",


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
1. install clangd-12 on provision (I added it as a preburn, but the script to update the VM is broken according to @quentinDERORY)
2. add a vscode task to activate clangd extension on startup
3. add a vscode config to point to the clangd installed with step 1
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
