### PR TITLE
feat(feg): base accounting heartbeat feature

### DIFF
--- a/feg/cloud/go/services/basic_acct/servicers/service.go
+++ b/feg/cloud/go/services/basic_acct/servicers/service.go
@@ -225,15 +225,17 @@ func ToAnAcctSession(session *protos.AcctSession) *anpb.Session {
 		SessionId:   session.GetSessionId(),
 		ProviderApn: session.GetServingApn(),
 	}
-	switch usr := session.GetUser().(type) {
-	case *protos.AcctSession_IMSI:
-		res.User = &anpb.Session_IMSI{IMSI: usr.IMSI}
-	case *protos.AcctSession_CertificateSerialNumber:
-		res.User = &anpb.Session_CertificateSerialNumber{CertificateSerialNumber: usr.CertificateSerialNumber}
-	case *protos.AcctSession_Name:
-		res.User = &anpb.Session_Name{Name: usr.Name}
-	case *protos.AcctSession_HardwareAddr:
-		res.User = &anpb.Session_HardwareAddr{HardwareAddr: usr.HardwareAddr}
+	if session.GetUser() != nil {
+		switch usr := session.GetUser().(type) {
+		case *protos.AcctSession_IMSI:
+			res.User = &anpb.Session_IMSI{IMSI: usr.IMSI}
+		case *protos.AcctSession_CertificateSerialNumber:
+			res.User = &anpb.Session_CertificateSerialNumber{CertificateSerialNumber: usr.CertificateSerialNumber}
+		case *protos.AcctSession_Name:
+			res.User = &anpb.Session_Name{Name: usr.Name}
+		case *protos.AcctSession_HardwareAddr:
+			res.User = &anpb.Session_HardwareAddr{HardwareAddr: usr.HardwareAddr}
+		}
 	}
 	res.AvailableQos = &anpb.QoS{
 		DownloadMbps: session.GetAvailableQos().GetDownloadMbps(),

--- a/feg/gateway/services/aaa/base_acct/client_api.go
+++ b/feg/gateway/services/aaa/base_acct/client_api.go
@@ -55,8 +55,11 @@ func Start(request *protos.AcctSession) (*protos.AcctSessionResp, error) {
 		return nil, err
 	}
 	resp, err := client.Start(context.Background(), request)
+	initApnFromSession(request)
 	if err != nil {
 		glog.Error(err)
+	} else {
+		resetHeartbeat()
 	}
 	return resp, err
 }
@@ -73,6 +76,8 @@ func Update(request *protos.AcctUpdateReq) (*protos.AcctSessionResp, error) {
 	resp, err := client.Update(context.Background(), request)
 	if err != nil {
 		glog.Error(err)
+	} else {
+		resetHeartbeat()
 	}
 	return resp, err
 }
@@ -87,6 +92,8 @@ func Stop(request *protos.AcctUpdateReq) (*protos.AcctStopResp, error) {
 	resp, err := client.Stop(context.Background(), request)
 	if err != nil {
 		glog.Error(err)
+	} else {
+		resetHeartbeat()
 	}
 	return resp, err
 }

--- a/feg/gateway/services/aaa/base_acct/heartbeat.go
+++ b/feg/gateway/services/aaa/base_acct/heartbeat.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package base_acct provides a client API for interacting with the
+// base_acct cloud service
+package base_acct
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+
+	"magma/feg/cloud/go/protos"
+)
+
+const HeartbeatDuration = time.Minute * 5 // TBD: make the duration configurable
+
+var (
+	initApn         sync.Once
+	apn             string
+	heartbeatTicker *time.Ticker
+)
+
+func StartBaseAccountingHeartbeat() {
+	heartbeatTicker = time.NewTicker(HeartbeatDuration)
+	go func() {
+		for range heartbeatTicker.C {
+			client, err := getBaseAcctClient()
+			if err != nil {
+				glog.Errorf("base acct heartbeat error: %v", err)
+			} else {
+				_, err := client.Update(
+					context.Background(),
+					&protos.AcctUpdateReq{Session: &protos.AcctSession{ServingApn: apn}})
+				if err != nil {
+					glog.Warningf("APN '%s' heartbeat failure: %v", apn, err)
+				}
+			}
+		}
+	}()
+}
+
+func initApnFromSession(session *protos.AcctSession) {
+	if session != nil {
+		apnStr := session.GetServingApn()
+		if len(apnStr) > 0 {
+			initApn.Do(func() { apn = apnStr })
+		}
+	}
+}

--- a/feg/gateway/services/aaa/base_acct/heartbeat_reset_go1_15.go
+++ b/feg/gateway/services/aaa/base_acct/heartbeat_reset_go1_15.go
@@ -1,0 +1,22 @@
+//
+// Copyright 2021 The Magma Authors.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//go:build go1.15
+// +build go1.15
+
+// Package base_acct provides a client API for interacting with the
+// base_acct cloud service
+package base_acct
+
+func resetHeartbeat() {
+	heartbeatTicker.Reset(HeartbeatDuration)
+}

--- a/feg/gateway/services/aaa/base_acct/heartbeat_reset_prego1_15.go
+++ b/feg/gateway/services/aaa/base_acct/heartbeat_reset_prego1_15.go
@@ -1,0 +1,21 @@
+//
+// Copyright 2021 The Magma Authors.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//go:build !go1.15
+// +build !go1.15
+
+// Package base_acct provides a client API for interacting with the
+// base_acct cloud service
+package base_acct
+
+func resetHeartbeat() { // there is no ticker reset in Go versions < 1.15
+}

--- a/feg/gateway/services/aaa/servicers/accounting.go
+++ b/feg/gateway/services/aaa/servicers/accounting.go
@@ -53,12 +53,16 @@ const (
 
 // NewEapAuthenticator returns a new instance of EAP Auth service
 func NewAccountingService(sessions aaa.SessionTable, cfg *mconfig.AAAConfig) (*accountingService, error) {
-	return &accountingService{
+	srv := &accountingService{
 		sessions:    sessions,
 		config:      cfg,
 		sessionTout: GetIdleSessionTimeout(cfg),
 		dae:         dae.NewDAEServicer(cfg.GetRadiusConfig()),
-	}, nil
+	}
+	if cfg != nil && cfg.GetAcctReportingEnabled() {
+		base_acct.StartBaseAccountingHeartbeat()
+	}
+	return srv, nil
 }
 
 // Start implements Radius Acct-Status-Type: Start endpoint

--- a/feg/gateway/services/aaa/servicers/accounting_test.go
+++ b/feg/gateway/services/aaa/servicers/accounting_test.go
@@ -100,7 +100,7 @@ func testAccountingTerminate(t *testing.T) {
 }
 
 // TestAccountingCreateWithRecycle to trigger the recycle of the session we need to authenticate
-// a ue and then try to create a session with the same imsi, but idfferent session id.
+// an ue and then try to create a session with the same IMSI, but a different session id.
 func TestAccountingCreateWithRecycle(t *testing.T) {
 	mockPipelined := mock_pipelined.NewRunningPipelined(t)
 	mock_sessiond.NewRunningSessionManager(t)


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add idle AP accounting heartbeat to update the smart contract accounting service when AP doesn't serve any clients, but up and ready.

## Test Plan
unit tests; test on a partner setup later

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
