### PR TITLE
test(mme): Add further s1ap mme handlers tests

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.h
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.h
@@ -204,6 +204,11 @@ status_code_e s1ap_mme_generate_ue_context_release_command(
     imsi64_t imsi64, sctp_assoc_id_t assoc_id, sctp_stream_id_t stream,
     mme_ue_s1ap_id_t mme_ue_s1ap_id, enb_ue_s1ap_id_t enb_ue_s1ap_id);
 
+status_code_e s1ap_mme_generate_ue_context_modification(
+    ue_description_t* ue_ref_p,
+    const itti_s1ap_ue_context_mod_req_t* const ue_context_mod_req_pP,
+    imsi64_t imsi64);
+
 status_code_e s1ap_mme_remove_stale_ue_context(
     enb_ue_s1ap_id_t enb_ue_s1ap_id, uint32_t enb_id);
 

--- a/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
@@ -12,6 +12,8 @@
  */
 #include "lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h"
 
+#include "lte/gateway/c/core/oai/include/mme_app_messages_types.h"
+
 task_zmq_ctx_t task_zmq_ctx_mme;
 static std::shared_ptr<MockMmeAppHandler> mme_app_handler_;
 
@@ -165,6 +167,8 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case MME_APP_DOWNLINK_DATA_REJ: {
+      mme_app_handler_->nas_proc_dl_transfer_rej();
+      bdestroy_wrapper(&MME_APP_DL_DATA_REJ(received_message_p).nas_msg);
     } break;
 
     case SGSAP_DOWNLINK_UNITDATA: {

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -56,6 +56,7 @@ class MockMmeAppHandler {
   MOCK_METHOD1(
       mme_app_handle_nw_init_bearer_deactv_req,
       bool(itti_s11_nw_init_deactv_bearer_request_t db_req));
+  MOCK_METHOD0(nas_proc_dl_transfer_rej, void());
 };
 
 class MockSctpHandler {

--- a/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.cpp
@@ -12,9 +12,17 @@
  */
 #include "lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.h"
 
+#include <cstdlib>
+
 extern "C" {
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_36.401.h"
+#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
+#include "lte/gateway/c/core/oai/common/common_types.h"
+#include "lte/gateway/c/core/oai/include/s1ap_messages_types.h"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
 }
+
+#include "lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.h"
 
 namespace magma {
 namespace lte {
@@ -61,6 +69,164 @@ void handle_mme_ue_id_notification(s1ap_state_t* s, sctp_assoc_id_t assoc_id) {
   notification_p->sctp_assoc_id  = assoc_id;
   s1ap_handle_mme_ue_id_notification(s, notification_p);
   free(message_p);
+}
+
+status_code_e send_s1ap_erab_rel_cmd(
+    mme_ue_s1ap_id_t ue_id, enb_ue_s1ap_id_t enb_ue_id) {
+  MessageDef* message_p;
+  message_p = itti_alloc_new_message(TASK_MME_APP, S1AP_E_RAB_REL_CMD);
+  itti_s1ap_e_rab_rel_cmd_t* s1ap_e_rab_rel_cmd =
+      &message_p->ittiMsg.s1ap_e_rab_rel_cmd;
+  s1ap_e_rab_rel_cmd->mme_ue_s1ap_id = ue_id;
+  s1ap_e_rab_rel_cmd->enb_ue_s1ap_id = enb_ue_id;
+
+  s1ap_e_rab_rel_cmd->e_rab_to_be_rel_list.no_of_items      = 1;
+  s1ap_e_rab_rel_cmd->e_rab_to_be_rel_list.item[0].e_rab_id = 5;
+
+  return send_msg_to_task(&task_zmq_ctx_main_s1ap, TASK_S1AP, message_p);
+}
+
+status_code_e send_conn_establishment_cnf(
+    mme_ue_s1ap_id_t ue_id, bool sec_capabilities_present,
+    bool ue_radio_capability) {
+  MessageDef* message_p;
+  message_p = itti_alloc_new_message(
+      TASK_MME_APP, MME_APP_CONNECTION_ESTABLISHMENT_CNF);
+  itti_mme_app_connection_establishment_cnf_t* establishment_cnf_p = NULL;
+  establishment_cnf_p =
+      &message_p->ittiMsg.mme_app_connection_establishment_cnf;
+  establishment_cnf_p->ue_id        = ue_id;
+  establishment_cnf_p->presencemask = 1;
+
+  establishment_cnf_p->no_of_e_rabs = 1;
+
+  establishment_cnf_p->e_rab_id[0] = 1;  //+ EPS_BEARER_IDENTITY_FIRST;
+  establishment_cnf_p->e_rab_level_qos_qci[0]            = 1;
+  establishment_cnf_p->e_rab_level_qos_priority_level[0] = 1;
+  establishment_cnf_p->transport_layer_address[0]        = bfromcstr("test");
+  establishment_cnf_p->gtp_teid[0]                       = 1;
+
+  establishment_cnf_p->ue_ambr.br_ul = 1000;
+  establishment_cnf_p->ue_ambr.br_dl = 1000;
+
+  apn_ambr_bitrate_unit_t br_unit                                     = BPS;
+  establishment_cnf_p->ue_ambr.br_unit                                = br_unit;
+  establishment_cnf_p->ue_security_capabilities_encryption_algorithms = 1;
+  establishment_cnf_p->ue_security_capabilities_integrity_algorithms  = 1;
+
+  establishment_cnf_p->nr_ue_security_capabilities_present =
+      sec_capabilities_present;
+  if (ue_radio_capability) {
+    establishment_cnf_p->ue_radio_capability = bfromcstr("test");
+  }
+
+  return send_msg_to_task(&task_zmq_ctx_main_s1ap, TASK_S1AP, message_p);
+}
+
+status_code_e send_s1ap_erab_setup_req(
+    mme_ue_s1ap_id_t ue_id, enb_ue_s1ap_id_t enb_ue_id, ebi_t ebi) {
+  MessageDef* message_p =
+      itti_alloc_new_message(TASK_MME_APP, S1AP_E_RAB_SETUP_REQ);
+  itti_s1ap_e_rab_setup_req_t* s1ap_e_rab_setup_req =
+      &message_p->ittiMsg.s1ap_e_rab_setup_req;
+
+  s1ap_e_rab_setup_req->mme_ue_s1ap_id = ue_id;
+  s1ap_e_rab_setup_req->enb_ue_s1ap_id = enb_ue_id;
+
+  // E-RAB to Be Setup List
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.no_of_items      = 1;
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0].e_rab_id = ebi;
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0]
+      .e_rab_level_qos_parameters.allocation_and_retention_priority
+      .pre_emption_capability =
+      (pre_emption_capability_t) PRE_EMPTION_CAPABILITY_ENABLED;
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0]
+      .e_rab_level_qos_parameters.allocation_and_retention_priority
+      .pre_emption_vulnerability =
+      (pre_emption_vulnerability_t) PRE_EMPTION_VULNERABILITY_ENABLED;
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0]
+      .e_rab_level_qos_parameters.allocation_and_retention_priority
+      .priority_level = 9;
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0]
+      .e_rab_level_qos_parameters.gbr_qos_information
+      .e_rab_maximum_bit_rate_downlink = 2000;
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0]
+      .e_rab_level_qos_parameters.gbr_qos_information
+      .e_rab_maximum_bit_rate_uplink = 2000;
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0]
+      .e_rab_level_qos_parameters.gbr_qos_information
+      .e_rab_guaranteed_bit_rate_downlink = 10000;
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0]
+      .e_rab_level_qos_parameters.gbr_qos_information
+      .e_rab_guaranteed_bit_rate_uplink = 10000;
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0]
+      .e_rab_level_qos_parameters.qci = 1;
+
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0].gtp_teid = 1;
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0].transport_layer_address =
+      bfromcstr("127.0.0.1");
+
+  s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0].nas_pdu =
+      bfromcstr("test");
+  return send_msg_to_task(&task_zmq_ctx_main_s1ap, TASK_S1AP, message_p);
+}
+
+status_code_e send_s1ap_erab_reset_req(
+    sctp_assoc_id_t assoc_id, sctp_stream_id_t stream_id,
+    enb_ue_s1ap_id_t enb_ue_id, mme_ue_s1ap_id_t ue_id) {
+  MessageDef* msg = DEPRECATEDitti_alloc_new_message_fatal(
+      TASK_MME_APP, S1AP_ENB_INITIATED_RESET_ACK);
+
+  itti_s1ap_enb_initiated_reset_ack_t* reset_ack =
+      &msg->ittiMsg.s1ap_enb_initiated_reset_ack;
+
+  s1_sig_conn_id_t* list =
+      (s1_sig_conn_id_t*) (calloc(1, sizeof(s1_sig_conn_id_t)));
+  list->enb_ue_s1ap_id = enb_ue_id;
+  list->mme_ue_s1ap_id = ue_id;
+  // ue_to_reset_list needs to be freed by S1AP module
+  reset_ack->ue_to_reset_list = list;
+  reset_ack->s1ap_reset_type  = RESET_PARTIAL;
+  reset_ack->sctp_assoc_id    = assoc_id;
+  reset_ack->sctp_stream_id   = stream_id;
+  reset_ack->num_ue           = 1;
+
+  // Send Reset Ack to S1AP module
+  return send_msg_to_task(&task_zmq_ctx_main_s1ap, TASK_S1AP, msg);
+}
+
+bool is_enb_state_valid(
+    s1ap_state_t* state, sctp_assoc_id_t assoc_id,
+    mme_s1_enb_state_s expected_state, uint32_t expected_num_ues) {
+  enb_description_t* enb_associated = nullptr;
+  hashtable_ts_get(
+      &state->enbs, (const hash_key_t) assoc_id,
+      reinterpret_cast<void**>(&enb_associated));
+  if (enb_associated->nb_ue_associated == expected_num_ues &&
+      enb_associated->s1_state == expected_state) {
+    return true;
+  }
+  return false;
+}
+
+bool is_num_enbs_valid(s1ap_state_t* state, uint32_t expected_num_enbs) {
+  hash_size_t num_enb_elements = state->enbs.num_elements;
+  if ((num_enb_elements == expected_num_enbs) &&
+      (state->num_enbs == expected_num_enbs)) {
+    return true;
+  }
+  return false;
+}
+
+bool is_ue_state_valid(
+    sctp_assoc_id_t assoc_id, enb_ue_s1ap_id_t enb_ue_id,
+    enum s1_ue_state_s expected_ue_state) {
+  ue_description_t* ue   = nullptr;
+  hash_table_ts_t* ue_ht = S1apStateManager::getInstance().get_ue_state_ht();
+  uint64_t comp_s1ap_id  = S1AP_GENERATE_COMP_S1AP_ID(assoc_id, enb_ue_id);
+  hashtable_ts_get(
+      ue_ht, (const hash_key_t) assoc_id, reinterpret_cast<void**>(&ue));
+  return ue->s1_ue_state == expected_ue_state ? true : false;
 }
 
 }  // namespace lte

--- a/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.h
+++ b/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.h
@@ -11,6 +11,7 @@
  * limitations under the License.
  */
 extern "C" {
+#include "lte/gateway/c/core/oai/include/s1ap_types.h"
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.h"
@@ -24,7 +25,32 @@ namespace lte {
 
 status_code_e setup_new_association(
     s1ap_state_t* state, sctp_assoc_id_t assoc_id);
+
 status_code_e generate_s1_setup_request_pdu(S1ap_S1AP_PDU_t* pdu_s1);
+
+status_code_e send_s1ap_erab_rel_cmd(
+    mme_ue_s1ap_id_t ue_id, enb_ue_s1ap_id_t enb_ue_id);
+
+status_code_e send_conn_establishment_cnf(
+    mme_ue_s1ap_id_t ue_id, bool sec_capabilities_present,
+    bool ue_radio_capability);
+
+status_code_e send_s1ap_erab_setup_req(
+    mme_ue_s1ap_id_t ue_id, enb_ue_s1ap_id_t enb_ue_id, ebi_t ebi);
+
+status_code_e send_s1ap_erab_reset_req(
+    sctp_assoc_id_t assoc_id, sctp_stream_id_t stream_id,
+    enb_ue_s1ap_id_t enb_ue_id, mme_ue_s1ap_id_t ue_id);
+
+bool is_enb_state_valid(
+    s1ap_state_t* state, sctp_assoc_id_t assoc_id,
+    mme_s1_enb_state_s expected_state, uint32_t expected_num_ues);
+
+bool is_num_enbs_valid(s1ap_state_t* state, uint32_t expected_num_enbs);
+
+bool is_ue_state_valid(
+    sctp_assoc_id_t assoc_id, enb_ue_s1ap_id_t enb_ue_id,
+    enum s1_ue_state_s expected_ue_state);
 
 void handle_mme_ue_id_notification(s1ap_state_t* s, sctp_assoc_id_t assoc_id);
 

--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers.cpp
@@ -72,6 +72,12 @@ class S1apMmeHandlersTest : public ::testing::Test {
     task_sctp.detach();
 
     s1ap_mme_init(&mme_config);
+
+    // Setup new association for testing
+    state     = S1apStateManager::getInstance().get_state(false);
+    assoc_id  = 1;
+    stream_id = 0;
+    setup_new_association(state, assoc_id);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
 
@@ -89,6 +95,9 @@ class S1apMmeHandlersTest : public ::testing::Test {
  protected:
   std::shared_ptr<MockMmeAppHandler> mme_app_handler;
   std::shared_ptr<MockSctpHandler> sctp_handler;
+  s1ap_state_t* state;
+  sctp_assoc_id_t assoc_id;
+  sctp_stream_id_t stream_id;
 };
 
 TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureHss) {
@@ -121,16 +130,11 @@ TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureHss) {
 }
 
 TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureReseting) {
-  // Setup new association for testing
-  s1ap_state_t* s          = S1apStateManager::getInstance().get_state(false);
-  sctp_assoc_id_t assoc_id = 1;
-  setup_new_association(s, assoc_id);
-
   EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(1);
 
   enb_description_t* enb_associated = NULL;
   hashtable_ts_get(
-      &s->enbs, (const hash_key_t) assoc_id,
+      &state->enbs, (const hash_key_t) assoc_id,
       reinterpret_cast<void**>(&enb_associated));
   enb_associated->s1_state = S1AP_RESETING;
 
@@ -140,11 +144,12 @@ TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureReseting) {
   ASSERT_EQ(pdu_rc, RETURNok);
 
   sctp_stream_id_t stream_id = 0;
-  status_code_e rc = s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1);
+  status_code_e rc =
+      s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_s1);
   ASSERT_EQ(rc, RETURNok);
 
   // State validation
-  ASSERT_EQ(s->num_enbs, 0);
+  ASSERT_EQ(state->num_enbs, 0);
 
   // Freeing pdu and payload data
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
@@ -156,22 +161,24 @@ TEST_F(S1apMmeHandlersTest, HandleS1SetupRequestFailureReseting) {
 TEST_F(S1apMmeHandlersTest, HandleICSResponseICSRelease) {
   ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
 
-  // Setup new association for testing
-  s1ap_state_t* s            = S1apStateManager::getInstance().get_state(false);
-  sctp_assoc_id_t assoc_id   = 1;
-  sctp_stream_id_t stream_id = 0;
-  bool is_state_same         = false;
-  setup_new_association(s, assoc_id);
+  bool is_state_same = false;
 
   EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(2);
   EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
   EXPECT_CALL(*mme_app_handler, mme_app_handle_s1ap_ue_context_release_req())
       .Times(1);
 
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_INIT, 0));
+
   S1ap_S1AP_PDU_t pdu_s1;
   memset(&pdu_s1, 0, sizeof(pdu_s1));
   ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
-  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_s1));
+
+  // State validation
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 0));
+  ASSERT_TRUE(is_num_enbs_valid(state, 1));
 
   uint8_t initial_ue_bytes[] = {
       0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
@@ -188,15 +195,16 @@ TEST_F(S1apMmeHandlersTest, HandleICSResponseICSRelease) {
   memset(&pdu, 0, sizeof(pdu));
 
   ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
-  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu));
 
-  handle_mme_ue_id_notification(s, assoc_id);
+  handle_mme_ue_id_notification(state, assoc_id);
 
   // Generate downlink nas transport with dummy payload
   bstring p;
   std::string test_str = "test";
   STRING_TO_BSTRING(test_str, p);
-  s1ap_generate_downlink_nas_transport(s, 1, 7, &p, 1, &is_state_same);
+  s1ap_generate_downlink_nas_transport(state, 1, 7, &p, 1, &is_state_same);
   bdestroy_wrapper(&p);
 
   // Authentication response proc packet bytes
@@ -215,7 +223,7 @@ TEST_F(S1apMmeHandlersTest, HandleICSResponseICSRelease) {
 
   ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_nas, payload_nas), RETURNok);
   ASSERT_EQ(
-      s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_nas), RETURNok);
+      s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_nas), RETURNok);
 
   uint8_t ics_bytes[] = {0x20, 0x09, 0x00, 0x22, 0x00, 0x00, 0x03, 0x00,
                          0x00, 0x40, 0x02, 0x00, 0x07, 0x00, 0x08, 0x40,
@@ -230,7 +238,7 @@ TEST_F(S1apMmeHandlersTest, HandleICSResponseICSRelease) {
 
   ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_ics, payload_ics), RETURNok);
   ASSERT_EQ(
-      s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_ics), RETURNok);
+      s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_ics), RETURNok);
 
   // Freeing pdu and payload data
   bdestroy_wrapper(&payload);
@@ -240,6 +248,10 @@ TEST_F(S1apMmeHandlersTest, HandleICSResponseICSRelease) {
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_nas);
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_ics);
+
+  // State validation
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 1));
+  ASSERT_TRUE(is_num_enbs_valid(state, 1));
 
   uint8_t ics_release_bytes[] = {0x00, 0x12, 0x40, 0x15, 0x00, 0x00, 0x03,
                                  0x00, 0x00, 0x00, 0x02, 0x00, 0x07, 0x00,
@@ -253,7 +265,11 @@ TEST_F(S1apMmeHandlersTest, HandleICSResponseICSRelease) {
 
   ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_ics_r, payload_ics_r), RETURNok);
   ASSERT_EQ(
-      s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_ics_r), RETURNok);
+      s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_ics_r),
+      RETURNok);
+
+  // State validation
+  ASSERT_TRUE(is_num_enbs_valid(state, 1));
 
   bdestroy_wrapper(&payload_ics_r);
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_ics_r);
@@ -265,19 +281,20 @@ TEST_F(S1apMmeHandlersTest, HandleICSResponseICSRelease) {
 TEST_F(S1apMmeHandlersTest, HandleUECapIndication) {
   ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
 
-  // Setup new association for testing
-  s1ap_state_t* s            = S1apStateManager::getInstance().get_state(false);
-  sctp_assoc_id_t assoc_id   = 1;
-  sctp_stream_id_t stream_id = 0;
-  setup_new_association(s, assoc_id);
-
   EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(1);
   EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_INIT, 0));
 
   S1ap_S1AP_PDU_t pdu_s1;
   memset(&pdu_s1, 0, sizeof(pdu_s1));
   ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
-  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_s1));
+
+  // State validation
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 0));
+  ASSERT_TRUE(is_num_enbs_valid(state, 1));
 
   uint8_t initial_ue_bytes[] = {
       0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
@@ -294,9 +311,10 @@ TEST_F(S1apMmeHandlersTest, HandleUECapIndication) {
   memset(&pdu, 0, sizeof(pdu));
 
   ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
-  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu));
 
-  handle_mme_ue_id_notification(s, assoc_id);
+  handle_mme_ue_id_notification(state, assoc_id);
 
   uint8_t ue_cap_bytes[] = {
       0x00, 0x16, 0x40, 0x53, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x02,
@@ -315,7 +333,11 @@ TEST_F(S1apMmeHandlersTest, HandleUECapIndication) {
 
   ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_cap, payload_ue_cap), RETURNok);
   ASSERT_EQ(
-      s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_cap), RETURNok);
+      s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_cap), RETURNok);
+
+  // State validation
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 1));
+  ASSERT_TRUE(is_num_enbs_valid(state, 1));
 
   // Freeing pdu and payload data
   bdestroy_wrapper(&payload);
@@ -329,23 +351,26 @@ TEST_F(S1apMmeHandlersTest, HandleUECapIndication) {
 }
 
 TEST_F(S1apMmeHandlersTest, GenerateUEContextReleaseCommand) {
-  // Setup new association for testing
-  s1ap_state_t* s            = S1apStateManager::getInstance().get_state(false);
-  sctp_assoc_id_t assoc_id   = 1;
-  sctp_stream_id_t stream_id = 0;
-  setup_new_association(s, assoc_id);
   ue_description_t ue_ref_p = {
       .enb_ue_s1ap_id = 1,
       .mme_ue_s1ap_id = 1,
       .sctp_assoc_id  = assoc_id,
       .comp_s1ap_id   = S1AP_GENERATE_COMP_S1AP_ID(assoc_id, 1)};
 
+  EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(2);
   EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_INIT, 0));
 
   S1ap_S1AP_PDU_t pdu_s1;
   memset(&pdu_s1, 0, sizeof(pdu_s1));
   ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
-  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu_s1));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_s1));
+
+  // State validation
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 0));
+  ASSERT_TRUE(is_num_enbs_valid(state, 1));
 
   uint8_t initial_ue_bytes[] = {
       0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
@@ -362,23 +387,416 @@ TEST_F(S1apMmeHandlersTest, GenerateUEContextReleaseCommand) {
   memset(&pdu, 0, sizeof(pdu));
 
   ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
-  ASSERT_EQ(RETURNok, s1ap_mme_handle_message(s, assoc_id, stream_id, &pdu));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu));
 
   // Invalid S1 Cause returns error
   ASSERT_EQ(
       RETURNerror, s1ap_mme_generate_ue_context_release_command(
-                       s, &ue_ref_p, S1AP_IMPLICIT_CONTEXT_RELEASE,
+                       state, &ue_ref_p, S1AP_IMPLICIT_CONTEXT_RELEASE,
                        INVALID_IMSI64, assoc_id, stream_id, 1, 1));
   // Valid S1 Causes passess successfully
   ASSERT_EQ(
       RETURNok, s1ap_mme_generate_ue_context_release_command(
-                    s, &ue_ref_p, S1AP_INITIAL_CONTEXT_SETUP_FAILED,
+                    state, &ue_ref_p, S1AP_INITIAL_CONTEXT_SETUP_FAILED,
                     INVALID_IMSI64, assoc_id, stream_id, 1, 1));
+
+  // State validation
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 0));
 
   // Freeing pdu and payload data
   bdestroy_wrapper(&payload);
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+TEST_F(S1apMmeHandlersTest, HandleUEContextReleaseCommand) {
+  ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
+
+  EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(1);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_INIT, 0));
+
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_s1));
+
+  uint8_t initial_ue_bytes[] = {
+      0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
+      0x00, 0x01, 0x00, 0x1a, 0x00, 0x20, 0x1f, 0x07, 0x41, 0x71, 0x08,
+      0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0, 0xe0,
+      0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
+      0x04, 0x00, 0x02, 0x1c, 0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00,
+      0xf1, 0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00, 0x00, 0xf1,
+      0x10, 0x00, 0x00, 0x00, 0xa0, 0x00, 0x86, 0x40, 0x01, 0x30};
+
+  bstring payload;
+  payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+  S1ap_S1AP_PDU_t pdu;
+  memset(&pdu, 0, sizeof(pdu));
+
+  ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu));
+
+  handle_mme_ue_id_notification(state, assoc_id);
+
+  // State validation
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 1));
+  ASSERT_TRUE(is_num_enbs_valid(state, 1));
+  ASSERT_EQ(state->mmeid2associd.num_elements, 1);
+
+  // Send UE context release command mimicing MME_APP
+  MessageDef* message_p;
+  message_p =
+      itti_alloc_new_message(TASK_MME_APP, S1AP_UE_CONTEXT_RELEASE_COMMAND);
+  S1AP_UE_CONTEXT_RELEASE_COMMAND(message_p).mme_ue_s1ap_id = 7;
+  S1AP_UE_CONTEXT_RELEASE_COMMAND(message_p).enb_ue_s1ap_id = 1;
+  S1AP_UE_CONTEXT_RELEASE_COMMAND(message_p).cause =
+      S1AP_SCTP_SHUTDOWN_OR_RESET;
+  ASSERT_EQ(
+      send_msg_to_task(&task_zmq_ctx_main_s1ap, TASK_S1AP, message_p),
+      RETURNok);
+
+  // Freeing pdu and payload data
+  bdestroy_wrapper(&payload);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+
+  ASSERT_TRUE(is_num_enbs_valid(state, 1));
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  ASSERT_EQ(state->mmeid2associd.num_elements, 0);
+}
+
+TEST_F(S1apMmeHandlersTest, HandleConnectionEstCnf) {
+  ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
+
+  EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(2);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_s1ap_ue_context_release_req())
+      .Times(0);
+  EXPECT_CALL(*mme_app_handler, nas_proc_dl_transfer_rej()).Times(0);
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_INIT, 0));
+
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_s1));
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 0));
+
+  uint8_t initial_ue_bytes[] = {
+      0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
+      0x00, 0x01, 0x00, 0x1a, 0x00, 0x20, 0x1f, 0x07, 0x41, 0x71, 0x08,
+      0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0, 0xe0,
+      0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
+      0x04, 0x00, 0x02, 0x1c, 0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00,
+      0xf1, 0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00, 0x00, 0xf1,
+      0x10, 0x00, 0x00, 0x00, 0xa0, 0x00, 0x86, 0x40, 0x01, 0x30};
+
+  bstring payload;
+  payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+  S1ap_S1AP_PDU_t pdu;
+  memset(&pdu, 0, sizeof(pdu));
+
+  ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu));
+
+  handle_mme_ue_id_notification(state, assoc_id);
+
+  ASSERT_EQ(state->mmeid2associd.num_elements, 1);
+
+  // Send UE connection establishment cnf mimicing MME_APP
+
+  ASSERT_EQ(send_conn_establishment_cnf(7, true, true), RETURNok);
+
+  // Freeing pdu and payload data
+  bdestroy_wrapper(&payload);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+TEST_F(S1apMmeHandlersTest, HandleS1apErabRelCmd) {
+  ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
+
+  EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(2);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_s1ap_ue_context_release_req())
+      .Times(0);
+  EXPECT_CALL(*mme_app_handler, nas_proc_dl_transfer_rej()).Times(0);
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_INIT, 0));
+
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_s1));
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 0));
+
+  uint8_t initial_ue_bytes[] = {
+      0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
+      0x00, 0x01, 0x00, 0x1a, 0x00, 0x20, 0x1f, 0x07, 0x41, 0x71, 0x08,
+      0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0, 0xe0,
+      0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
+      0x04, 0x00, 0x02, 0x1c, 0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00,
+      0xf1, 0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00, 0x00, 0xf1,
+      0x10, 0x00, 0x00, 0x00, 0xa0, 0x00, 0x86, 0x40, 0x01, 0x30};
+
+  bstring payload;
+  payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+  S1ap_S1AP_PDU_t pdu;
+  memset(&pdu, 0, sizeof(pdu));
+
+  ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu));
+
+  handle_mme_ue_id_notification(state, assoc_id);
+
+  ASSERT_EQ(state->mmeid2associd.num_elements, 1);
+
+  // Send S1AP_ERAB_REL_CMD mimicing MME_APP
+  ASSERT_EQ(send_s1ap_erab_rel_cmd(7, 1), RETURNok);
+
+  // Freeing pdu and payload data
+  bdestroy_wrapper(&payload);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+TEST_F(S1apMmeHandlersTest, HandleS1apErabSetupReq) {
+  ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
+
+  EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(2);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_INIT, 0));
+
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_s1));
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 0));
+
+  uint8_t initial_ue_bytes[] = {
+      0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
+      0x00, 0x01, 0x00, 0x1a, 0x00, 0x20, 0x1f, 0x07, 0x41, 0x71, 0x08,
+      0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0, 0xe0,
+      0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
+      0x04, 0x00, 0x02, 0x1c, 0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00,
+      0xf1, 0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00, 0x00, 0xf1,
+      0x10, 0x00, 0x00, 0x00, 0xa0, 0x00, 0x86, 0x40, 0x01, 0x30};
+
+  bstring payload;
+  payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+  S1ap_S1AP_PDU_t pdu;
+  memset(&pdu, 0, sizeof(pdu));
+
+  ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu));
+
+  handle_mme_ue_id_notification(state, assoc_id);
+
+  ASSERT_EQ(state->mmeid2associd.num_elements, 1);
+
+  // Send S1AP_ERAB_REL_CMD mimicing MME_APP
+  ASSERT_EQ(send_s1ap_erab_setup_req(7, 1, 1), RETURNok);
+
+  // Freeing pdu and payload data
+  bdestroy_wrapper(&payload);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+TEST_F(S1apMmeHandlersTest, HandleS1apErabResetReq) {
+  ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
+
+  EXPECT_CALL(*sctp_handler, sctpd_send_dl()).Times(2);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_s1ap_ue_context_release_req())
+      .Times(0);
+  EXPECT_CALL(*mme_app_handler, nas_proc_dl_transfer_rej()).Times(0);
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_INIT, 0));
+
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_s1));
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 0));
+
+  uint8_t initial_ue_bytes[] = {
+      0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
+      0x00, 0x01, 0x00, 0x1a, 0x00, 0x20, 0x1f, 0x07, 0x41, 0x71, 0x08,
+      0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0, 0xe0,
+      0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
+      0x04, 0x00, 0x02, 0x1c, 0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00,
+      0xf1, 0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00, 0x00, 0xf1,
+      0x10, 0x00, 0x00, 0x00, 0xa0, 0x00, 0x86, 0x40, 0x01, 0x30};
+
+  bstring payload;
+  payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+  S1ap_S1AP_PDU_t pdu;
+  memset(&pdu, 0, sizeof(pdu));
+
+  ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu));
+
+  handle_mme_ue_id_notification(state, assoc_id);
+
+  ASSERT_EQ(state->mmeid2associd.num_elements, 1);
+
+  // Send S1AP_ERAB_REL_CMD mimicing MME_APP
+  ASSERT_EQ(send_s1ap_erab_reset_req(assoc_id, stream_id, 1, 7), RETURNok);
+
+  // Freeing pdu and payload data
+  bdestroy_wrapper(&payload);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+TEST_F(S1apMmeHandlersTest, HandleS1apNasNonDeliveryFailure) {
+  ASSERT_EQ(task_zmq_ctx_main_s1ap.ready, true);
+
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_initial_ue_message()).Times(1);
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_s1ap_ue_context_release_req())
+      .Times(0);
+  EXPECT_CALL(*mme_app_handler, nas_proc_dl_transfer_rej()).Times(1);
+
+  bool is_state_same = false;
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_INIT, 0));
+
+  S1ap_S1AP_PDU_t pdu_s1;
+  memset(&pdu_s1, 0, sizeof(pdu_s1));
+  ASSERT_EQ(RETURNok, generate_s1_setup_request_pdu(&pdu_s1));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_s1));
+
+  ASSERT_TRUE(is_enb_state_valid(state, assoc_id, S1AP_READY, 0));
+
+  uint8_t initial_ue_bytes[] = {
+      0x00, 0x0c, 0x40, 0x48, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x02,
+      0x00, 0x01, 0x00, 0x1a, 0x00, 0x20, 0x1f, 0x07, 0x41, 0x71, 0x08,
+      0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10, 0x02, 0xe0, 0xe0,
+      0x00, 0x04, 0x02, 0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
+      0x04, 0x00, 0x02, 0x1c, 0x00, 0x00, 0x43, 0x00, 0x06, 0x00, 0x00,
+      0xf1, 0x10, 0x00, 0x01, 0x00, 0x64, 0x40, 0x08, 0x00, 0x00, 0xf1,
+      0x10, 0x00, 0x00, 0x00, 0xa0, 0x00, 0x86, 0x40, 0x01, 0x30};
+
+  bstring payload;
+  payload = blk2bstr(&initial_ue_bytes, sizeof(initial_ue_bytes));
+  S1ap_S1AP_PDU_t pdu;
+  memset(&pdu, 0, sizeof(pdu));
+
+  ASSERT_EQ(RETURNok, s1ap_mme_decode_pdu(&pdu, payload));
+  ASSERT_EQ(
+      RETURNok, s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu));
+
+  handle_mme_ue_id_notification(state, assoc_id);
+
+  // Generate downlink nas transport with dummy payload
+  bstring p;
+  std::string test_str = "test";
+  STRING_TO_BSTRING(test_str, p);
+  s1ap_generate_downlink_nas_transport(state, 1, 7, &p, 1, &is_state_same);
+  bdestroy_wrapper(&p);
+
+  // Authentication response proc packet bytes
+  uint8_t auth_bytes[] = {
+      0x00, 0x0d, 0x40, 0x3d, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x02,
+      0x00, 0x07, 0x00, 0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x1a, 0x00,
+      0x14, 0x13, 0x07, 0x53, 0x10, 0x1e, 0x63, 0x7e, 0x5c, 0x58, 0xec,
+      0x5a, 0xa8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x64, 0x40, 0x08, 0x00, 0x00, 0xf1, 0x10, 0x00, 0x00, 0x00, 0xa0,
+      0x00, 0x43, 0x40, 0x06, 0x00, 0x00, 0xf1, 0x10, 0x00, 0x01};
+
+  bstring payload_nas;
+  payload_nas = blk2bstr(&auth_bytes, sizeof(auth_bytes));
+  S1ap_S1AP_PDU_t pdu_nas;
+  memset(&pdu_nas, 0, sizeof(pdu_nas));
+
+  ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_nas, payload_nas), RETURNok);
+  ASSERT_EQ(
+      s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_nas), RETURNok);
+
+  uint8_t ics_bytes[] = {0x20, 0x09, 0x00, 0x22, 0x00, 0x00, 0x03, 0x00,
+                         0x00, 0x40, 0x02, 0x00, 0x07, 0x00, 0x08, 0x40,
+                         0x02, 0x00, 0x01, 0x00, 0x33, 0x40, 0x0f, 0x00,
+                         0x00, 0x32, 0x40, 0x0a, 0x0a, 0x1f, 0xc0, 0xa8,
+                         0x3c, 0x8d, 0x0a, 0x00, 0x01, 0x28};
+
+  bstring payload_ics;
+  payload_ics = blk2bstr(&ics_bytes, sizeof(ics_bytes));
+  S1ap_S1AP_PDU_t pdu_ics;
+  memset(&pdu_ics, 0, sizeof(pdu_ics));
+
+  ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_ics, payload_ics), RETURNok);
+  ASSERT_EQ(
+      s1ap_mme_handle_message(state, assoc_id, stream_id, &pdu_ics), RETURNok);
+
+  // Send NAS Non Delivery payload message
+  uint8_t nas_non_delivery_bytes[] = {
+      0x00, 0x10, 0x40, 0x28, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x02,
+      0x00, 0x07, 0x00, 0x08, 0x00, 0x02, 0x00, 0x01, 0x00, 0x1a, 0x00,
+      0x0f, 0x0e, 0x37, 0x2c, 0x71, 0xdc, 0xfa, 0x00, 0x07, 0x5d, 0x02,
+      0x00, 0x02, 0xe0, 0xe0, 0xc1, 0x00, 0x02, 0x40, 0x02, 0x00, 0x60};
+
+  bstring payload_nas_del;
+  payload_nas_del =
+      blk2bstr(&nas_non_delivery_bytes, sizeof(nas_non_delivery_bytes));
+  S1ap_S1AP_PDU_t pdu_nas_del;
+  memset(&pdu_nas_del, 0, sizeof(pdu_nas_del));
+
+  ASSERT_EQ(s1ap_mme_decode_pdu(&pdu_nas_del, payload_nas_del), RETURNok);
+  ASSERT_EQ(
+      s1ap_mme_handle_message(state, assoc_id, 1, &pdu_nas_del), RETURNok);
+
+  // Freeing pdu and payload data
+  bdestroy_wrapper(&payload);
+  bdestroy_wrapper(&payload_nas);
+  bdestroy_wrapper(&payload_ics);
+  bdestroy_wrapper(&payload_nas_del);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_s1);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_nas);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_ics);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_S1ap_S1AP_PDU, &pdu_nas_del);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
 }  // namespace lte


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Similar to #9398, this PR adds tests for uncovered S1AP handlers and procedures
- Refactors some of the repeated code into helper functions
- Adds missing declaration for some of the s1ap_mme_handlers functions

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- `make test_oai`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
