### PR TITLE
fix(mme): Memory leak in SPGW state converter and cleanup

### DIFF
--- a/lte/gateway/c/core/oai/lib/pcef/PCEFClient.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/PCEFClient.cpp
@@ -55,7 +55,6 @@ PCEFClient::PCEFClient() {
   // Create stub for LocalSessionManager gRPC service
   stub_ = LocalSessionManager::NewStub(channel);
   std::thread resp_loop_thread([&]() { rpc_response_loop(); });
-  std::cout << "PCEF Client thread id " << resp_loop_thread.native_handle();
   resp_loop_thread.detach();
 }
 

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp
@@ -525,6 +525,7 @@ void SpgwStateConverter::proto_to_sgw_eps_bearer(
       bfromcstr(eps_bearer_proto.sgw_ip_address_s1u_s12_s4_up().c_str()),
   bstring_to_ip_address(
       ip_addr_bstr, &eps_bearer->s_gw_ip_address_S1u_S12_S4_up);
+  bdestroy_wrapper(&ip_addr_bstr);
 
   // if ipv6 addr is present it will overwrite, if not it will skip
   ip_addr_bstr =


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

All bstrings created while reading Redis state should be destroyed to prevent memory leaks. This change adds missing cleanup for s_gw_ip_address_S1u_S12_S4_up in EPS bearer.
This change also does a minor clean-up of PCEF thread logging, which is not needed any more.

## Test Plan

Before the change `test_paging_after_mme_restart.py` showed the following in syslog:

```
Nov  3 03:52:07 magma-dev-focal mme[288572]: =================================================================
Nov  3 03:52:07 magma-dev-focal mme[288572]: ==288572==ERROR: LeakSanitizer: detected memory leaks
Nov  3 03:52:07 magma-dev-focal mme[288572]: Direct leak of 48 byte(s) in 1 object(s) allocated from:
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #0 0x7f65f0a63dc6 in calloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10ddc6)
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #1 0x7f65efb94c0f in zlist_new (/lib/x86_64-linux-gnu/libczmq.so.4+0x24c0f)
Nov  3 03:52:07 magma-dev-focal mme[288572]: Direct leak of 16 byte(s) in 1 object(s) allocated from:
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #0 0x7f65f0a63bc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #1 0x55a49f4a76e7 in bfromcstr /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:188
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #2 0x55a4a0897b47 in magma::lte::SpgwStateConverter::proto_to_sgw_eps_bearer(magma::lte::oai::SgwEpsBearerContext const&, sgw_eps_bearer_ctxt_s*) /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp:525
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #3 0x55a4a089445e in magma::lte::SpgwStateConverter::proto_to_sgw_pdn_connection(magma::lte::oai::SgwPdnConnection const&, sgw_pdn_connection_s*) /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp:242
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #4 0x55a4a08936d3 in magma::lte::SpgwStateConverter::proto_to_spgw_bearer_context(magma::lte::oai::S11BearerContext const&, s_plus_p_gw_eps_bearer_context_information_s*) /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp:163
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #5 0x55a4a089b17b in magma::lte::SpgwStateConverter::proto_to_ue(magma::lte::oai::SpgwUeContext const&, spgw_ue_context_s*) /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp:1049
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #6 0x55a4a088fe8b in magma::lte::SpgwStateManager::read_ue_state_from_db() /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.cpp:134
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #7 0x55a4a088dd91 in read_spgw_ue_state_db /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_state.cpp:56
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #8 0x55a4a0842cca in spgw_app_init /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c:241
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #9 0x55a49f46f89c in main /home/vagrant/magma/lte/gateway/c/core/oai/oai_mme/oai_mme.c:143
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #10 0x7f65ee9630b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
Nov  3 03:52:07 magma-dev-focal mme[288572]: Indirect leak of 8 byte(s) in 1 object(s) allocated from:
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #0 0x7f65f0a63bc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #1 0x55a49f4a7876 in bfromcstr /home/vagrant/magma/lte/gateway/c/core/oai/lib/bstr/bstrlib.c:191
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #2 0x55a4a0897b47 in magma::lte::SpgwStateConverter::proto_to_sgw_eps_bearer(magma::lte::oai::SgwEpsBearerContext const&, sgw_eps_bearer_ctxt_s*) /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp:525
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #3 0x55a4a089445e in magma::lte::SpgwStateConverter::proto_to_sgw_pdn_connection(magma::lte::oai::SgwPdnConnection const&, sgw_pdn_connection_s*) /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp:242
Nov  3 03:52:07 magma-dev-focal mme[288572]:     #4 0x55a4a08936d3 in magma::lte::SpgwStateConverter::proto_to_spgw_bearer_context(magma::lte::oai::S11BearerContext const&, s_plus_p_gw_eps_bearer_context_information_s*) /home/vagrant/magma/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp:163
```

After the change, MME restarted without any leak report

