### PR TITLE
fix(ci): Further fix GCC warnings job errs

### DIFF
--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -61,7 +61,7 @@ jobs:
         id: changed_files
         uses: mmagician/get-changed-files@v2
         with:
-          format: 'json'
+          format: 'csv'
       - name: Load problem matcher
         # If needed https://github.com/microsoft/vscode-cpptools/issues/2266 for path fixups
         #
@@ -81,7 +81,7 @@ jobs:
           run: |
             cd /workspaces/magma/lte/gateway/
             CPPFLAGS="-Wextra -Wshadow -Wimplicit-fallthrough -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wjump-misses-init -Wformat=2 -Wstrict-overflow=4 -Wuninitialized -Wshift-overflow=2" make build_oai 2>&1 > /workspaces/magma/compile.log
-            echo "${{ steps.changed_files.outputs.all }}" | jq --raw-output '.[]' | while read f
+            echo "${{ steps.changed_files.outputs.all }}" | tr , '\n' | while read f
             do grep "$file" /workspaces/magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
             done;
       - name: Store build_logs_oai Artifact
@@ -124,7 +124,7 @@ jobs:
         id: changed_files
         uses: mmagician/get-changed-files@v2
         with:
-          format: 'json'
+          format: 'csv'
       - name: Load problem matcher
         # If needed https://github.com/microsoft/vscode-cpptools/issues/2266 for path fixups
         #
@@ -144,7 +144,7 @@ jobs:
           run: |
             cd /workspaces/magma/lte/gateway/
             CPPFLAGS="-Wextra -Wshadow -Wimplicit-fallthrough -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wjump-misses-init -Wformat=2 -Wstrict-overflow=4 -Wuninitialized -Wshift-overflow=2" make build_session_manager 2>&1 > /workspaces/magma/compile.log
-            echo "${{ steps.changed_files.outputs.all }}" | jq --raw-output '.[]' | while read f
+            echo "${{ steps.changed_files.outputs.all }}" | tr , '\n' | while read f
             do grep "$file" /workspaces/magma/compile.log | xo '/\/magma\/((.*):(\d+):(\d+):\s+(?:fatal\s)?(warning|error):\s+(.*))/$1/' || true;
             done;
       - name: Store build_logs_session_manager Artifact


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Previous PR made the check "pass", but actually still had some problems.

This PR resolves the issues with grabbing the list of changed files, but now we hit an issue with `sh: 6: xo: not found`. Will leave it for the next PR

<img width="1792" alt="Screen Shot 2021-11-03 at 1 46 53 AM" src="https://user-images.githubusercontent.com/8029544/140019327-53a60400-9645-401f-b4bd-fbdf6ded3059.png">


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->