### PR TITLE
docs: Fix broken Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Magma's usage docs, and developer docs, are available at [https://docs.magmacore
 
 See the [Community](https://www.magmacore.org/community/) page for entry points.
 
-Start by joining the community on Slack: [magmacore workspace](https://join.slack.com/t/magmacore/shared_invite/zt-g76zkofr-g6~jYiS3KRzC9qhAISUC2A).
+Start by joining the community on Slack: [magmacore workspace](https://slack.magmacore.org/).
 
 Direct specific questions to the [GitHub Discussions page](https://github.com/magma/magma/discussions). Your question might already have an answer!
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Was previously only allowing people to join with certain email addresses. This change mirrors how we do it on the magmacore.org site

### Before


<img width="1792" alt="Screen Shot 2021-11-03 at 2 44 14 AM" src="https://user-images.githubusercontent.com/8029544/140024409-c8a8a6e1-3ec8-41e9-a920-dc0c222f4a01.png">

### After


<img width="1792" alt="Screen Shot 2021-11-03 at 2 46 30 AM" src="https://user-images.githubusercontent.com/8029544/140024495-748f5ea6-845a-4a25-995f-ed61ea5eff3c.png">


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->