### PR TITLE
fix: update vscode doc and clean up tasks/launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,16 +7,9 @@
             "name": "(Bazel) Run SessionD test with GDB",
             "program": "${workspaceFolder}/bazel-bin/lte/gateway/c/session_manager/test/${input:pickSessionDUnitTest}",
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "(Bazel) Build SessionD Unit Tests",
-            "commandsBeforeExec": ["enable pretty-printer"],
-        },
-        {
-            "type": "by-gdb",
-            "request": "launch",
-            "name": "(Bazel) Run SessionD test with GDB - Skip build",
-            "program": "${workspaceFolder}/bazel-bin/lte/gateway/c/session_manager/test/${input:pickSessionDUnitTest}",
-            "cwd": "${workspaceRoot}",
-            "commandsBeforeExec": ["enable pretty-printer"],
+            "commandsBeforeExec": [
+                "enable pretty-printer"
+            ],
         }
     ],
     "inputs": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,7 +22,7 @@
                 "build",
                 "//lte/gateway/c/session_manager/test:all"
             ],
-            "group": "build"
+            "group": "build",
         },
         {
             "label": "Set compile_commands.json for IntelliSense (make sure you have run `make build_X`!)",

--- a/docs/readmes/contributing/contribute_vscode.md
+++ b/docs/readmes/contributing/contribute_vscode.md
@@ -131,7 +131,8 @@ Additional features such as formatting on save is enabled for the Python source 
 #### Build specific targets and unit tests via codelens
 
 The **bazel-stack-vscode** extension adds [codelens](https://code.visualstudio.com/blogs/2017/02/12/code-lens-roundup) directly into `BUILD.bazel` files. Utilizing this makes building and testing as easy as clicking a button.
-For example, to run a single unit test for SessionD, open `lte/gateway/c/session_manager/test/BUILD.bazel` and click the `test` codelens. Similarly, click the `build` codelens to build only.
+
+For example, to run a single unit test for SessionD, open `lte/gateway/c/session_manager/test/BUILD.bazel` and click the `test` codelens. Similarly, click the `build` codelens to build only. If the codelens does not show up, try opening up a different `BUILD.bazel` file, or reloading the file (**Command+Shift+P** then **File: Revert File**).
 
 ![SessionD Unit Test Codelens](assets/contributing/sessiond-unit-test-codelens.png)
 
@@ -149,7 +150,11 @@ Refer to [Dealing with clangd extension errors](#dealing-with-clangd-extension-e
 
 > Currently only available for SessionD unit tests under `lte/gateway/c/session_manager/tests`, but it is easy to add configurations to enable it for any `cc_test`. Run `bazel query 'kind(cc_test,//...)'` in the terminal to get the full list of available targets. Modify `.vscode/tasks.json` and `.vscode/launch.json` to enable GDB debugging for other targets.
 
-Run **Command+Shift+D** to open the debug tab. In the drop down menu at the top of the tab, select **(Remote SSH) Run SessionD test with GDB** and press the gree arrow. This will open up a new drop down menu with all SessionD unit test targets. Once a test is selected, VSCode will build the target in debug mode and launch the test with GDB.
+First, build the test target that you wish to test. You can do this in the terminal by running Bazel directly, or through the codelens UI in the corresponding `BUILD.bazel` file.
+
+Run **Command+Shift+D** to open the debug tab. In the drop down menu at the top of the tab, select **(Remote SSH) Run SessionD test with GDB** and press the gree arrow. This will open up a new drop down menu with all SessionD unit test targets. Once a test is selected, VSCode will launch the test with GDB.
+
+The test output will be printed out in the terminal tab, and the debug console tab will contain a GDB interface.
 
 ![SessionD Start Debug](assets/contributing/sessiond-start-debug.png)
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
1. removing the gdb runner option with build as when it's building it looks like the task just hangs. (there's no good visibility into how far along the build is)
2. adding more documentation about the bazel codelens buttons not showing up some time and enhancing the gdb workflow doc
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
