### PR TITLE
fix: GHA error on scheduled bazel build runs

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -6,6 +6,11 @@ on:  # yamllint disable-line rule:truthy
       - opened
       - reopened
       - synchronize
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/bazel.yml
   schedule:
     # Run once a day to build bazel cache at 0200 hours
     - cron: '0 2 * * *'
@@ -26,7 +31,7 @@ jobs:
     steps:
       # Need to get git on push event
       - uses: actions/checkout@v2
-        if: github.event_name == 'push'
+        if: github.event_name == 'schedule' || github.event_name == 'push'
       - uses: dorny/paths-filter@v2
         id: changes
         with:


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Noticed that scheduled runs have been failing for this job: https://github.com/magma/magma/actions/runs/1414973164

I think this will fix it.

(also modifying the job to run on push as well  - when this file is changed)
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
