### PR TITLE
ci: update devcontainer to contain xo binary

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -151,6 +151,9 @@ RUN wget --progress=dot:giga https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz &&
     rm -rf nettle* && \
     rm -rf gnutls*
 
+##### Useful for logfile modification e.g. pruning all /magma/... prefix from GCC warning logs
+RUN GOBIN="/usr/bin/" go get github.com/ezekg/xo
+
 ##### GRPC and it's dependencies
 RUN git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc && \
     cd grpc && \


### PR DESCRIPTION
This go binary `xo` is used to fixup paths in our gcc-warnings workflow, which now uses the devcontainer.  It appears since migrating gcc warnings to use devcontainer, I have broken the workflow due to lack of the `xo` binary.

Note I did not build and test this to ensure it is the *only* breakage of the gcc-warnings workflow, but it is certain one of the breakages so lets start here.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>