### PR TITLE
fix: Fix continous deletion of default drop flow

### DIFF
--- a/lte/gateway/python/magma/pipelined/rule_mappers.py
+++ b/lte/gateway/python/magma/pipelined/rule_mappers.py
@@ -146,7 +146,7 @@ class SessionRuleToVersionMapper:
         with self._lock:
             version = self._version_by_imsi_and_rule.get(key)
             if version is None:
-                """Set to zero to allow proper cleanup of old flows"""
+                # Set to zero to allow proper cleanup of old flows
                 version = 0
         return version
 

--- a/lte/gateway/python/magma/pipelined/rule_mappers.py
+++ b/lte/gateway/python/magma/pipelined/rule_mappers.py
@@ -146,7 +146,8 @@ class SessionRuleToVersionMapper:
         with self._lock:
             version = self._version_by_imsi_and_rule.get(key)
             if version is None:
-                version = -1
+                """Set to zero to allow proper cleanup of old flows"""
+                version = 0
         return version
 
     def remove(self, imsi: str, ip_addr: IPAddress, rule_id: str, version: int):

--- a/lte/gateway/python/magma/pipelined/tests/test_rule_mappers.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_rule_mappers.py
@@ -75,13 +75,13 @@ class RuleMappersTest(unittest.TestCase):
             self._session_rule_version_mapper.get_version(
                 imsi, convert_ipv4_str_to_ip_proto(ip_addr), rule_ids[0],
             ),
-            -1,
+            0,
         )
         self.assertEqual(
             self._session_rule_version_mapper.get_version(
                 imsi, convert_ipv4_str_to_ip_proto(ip_addr), rule_ids[1],
             ),
-            -1,
+            0,
         )
 
     def test_session_rule_version_mapper_cwf(self):
@@ -124,13 +124,13 @@ class RuleMappersTest(unittest.TestCase):
             self._session_rule_version_mapper.get_version(
                 imsi, None, rule_ids[0],
             ),
-            -1,
+            0,
         )
         self.assertEqual(
             self._session_rule_version_mapper.get_version(
                 imsi, None, rule_ids[1],
             ),
-            -1,
+            0,
         )
 
 


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>


## Summary

Under high load, pipelined continuously sends FlowMod requests to ovs in order to delete the default drop rule.
This can reach as high as 3000 flow_mods requests per minute causing performance issues in control plane.

```
2021-11-03T22:18:49.038Z|02190|connmgr|INFO|cwag_br0<->tcp:127.0.0.1:6633: 2620 flow_mods in the 48 s starting 59 s ago (190 adds, 2430 deletes)
2021-11-03T22:20:46.771Z|02191|connmgr|INFO|cwag_br0<->tcp:127.0.0.1:6633: 2430 flow_mods in the 1 s starting 10 s ago (2430 deletes)
```

The reason behind this issue is that the rules store does not keep a rule version for the default drop flow,
Which means that curr_version will always be different from record.rule_version, triggering a delete request.
```
records {
  sid: "IMSI68248225537042"
  rule_id: "Facebook"
  rule_version: 1
}
records {
  sid: "IMSI68248225537042"
  rule_id: "Allow_All_Internet"
  rule_version: 1
}
records {
  sid: "IMSI68248225537042"
  rule_id: "internal_default_drop_flow_rule"
}
  ```

## Test Plan
Tested on a cwf setup