### PR TITLE
fix(orc8r): Fix dev Orc8r API hang even after restart

### DIFF
--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -94,6 +94,8 @@ services:
       TEST_MODE: "1"
       RESOLVER: 127.0.0.11
       SERVICE_REGISTRY_MODE: yaml
+    depends_on:
+      - controller
     restart: always
 #    logging:
 #      driver: fluentd


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

All told, I think I spent at least 6 hours debugging this across multiple days -- for a one line fix 😄

Observed bug: sometimes, dev Orc8rs will get into a state where the REST API hangs -- but restarting the containers doesn't fix! And it's only 1 person's dev Orc8r that hits the issue, and going back to a known-good commit has no effect.

Attempted easy fixes

- `docker-compose down && docker-compose up`
- Reinstall Docker
- Restart computer

Debug process

- Determine IP addresses in Docker network: `docker network inspect -f '{{json .Containers}}' orc8r_default | jq '.[] | .Name + ":" + .IPv4Address'`
- [tcpdump of Docker network traffic](https://xxradar.medium.com/how-to-tcpdump-effectively-in-docker-2ed0a09b5406), while sending a curl request from the host `curl --insecure --key ${MAGMA_ROOT}/.cache/test_certs/admin_operator.key.pem --cert ${MAGMA_ROOT}/.cache/test_certs/admin_operator.pem 'https://localhost:9443/magma/v1/networks' -H 'accept: application/json'`
- Using Wireshark, notice the nginx container is forwarding the curl request to `http://23.202.231.169`, which is whack
- Learn about Docker DNS -- they have an embedded DNS that returns early if the local Docker network definition has an entry for the request, and if not, forward the request externally as a normal DNS request
- Check nginx.conf, looks like nginx should be forwarding to `http://controller:9081`
- `dig controller` gives local/private IP... not `23.202.231.169`...
- Learn about nginx DNS resolution -- they use an explicit IP address for the DNS resolver, which we hard-code to Docker's in-container DNS resolver's IP address
- So theoretically this should work fine, but something's still whack
- To sanity check, `dig controller` on my host, and it gives `23.202.231.169`. Hm...
- So why is Docker DNS not short-circuiting its resolution of `controller`? Is there a bug in Docker? Or nginx? Surely we wouldn't be the only ones experiencing this issue... Google search doesn't turn up much
- Beginning to get suspicious the issue may be non-determinism
- Restart *just* the nginx container -- everything magically starts working
- Add the `depends_on` line, then sanity-check it a couple times. Works every time now
- Assumed rc: if nginx doesn't start after controller, nginx will cache in the host's view of `controller` resolution, right before `controller` gets inserted into the local Docker DNS. Using `depends_on` ensures the local `controller` short-circuit is inserted before nginx starts up and resolves for the first time


## Test Plan

Manual

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->