### PR TITLE
chore(pipelined): ipv6-solicitation: remove dependency on tun-id map.

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/ipv6_solicitation.py
+++ b/lte/gateway/python/magma/pipelined/app/ipv6_solicitation.py
@@ -16,7 +16,11 @@ from magma.pipelined.app.base import ControllerType, MagmaController
 from magma.pipelined.ipv6_prefix_store import get_ipv6_interface_id
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.magma_match import MagmaMatch
-from magma.pipelined.openflow.registers import DIRECTION_REG, Direction
+from magma.pipelined.openflow.registers import (
+    DIRECTION_REG,
+    TUN_PORT_REG,
+    Direction,
+)
 from ryu.controller import dpset, ofp_event
 from ryu.controller.handler import MAIN_DISPATCHER, set_ev_cls
 from ryu.lib.packet import ether_types, ethernet, icmpv6, in_proto, ipv6, packet
@@ -315,7 +319,10 @@ class IPV6SolicitationController(MagmaController):
         direction = ev.msg.match[DIRECTION_REG]
         if 'tunnel_id' in ev.msg.match:
             tun_id = ev.msg.match['tunnel_id']
-            tun_id_dst = self._tunnel_id_mapper.get_tunnel(tun_id)
+
+            tun_id_dst = ev.msg.match.get(TUN_PORT_REG, None)
+            if not tun_id_dst:
+                tun_id_dst = self._tunnel_id_mapper.get_tunnel(tun_id)
 
             if 'tun_ipv4_src' in ev.msg.match:
                 tun_ipv4_src = ev.msg.match['tun_ipv4_src']


### PR DESCRIPTION
Egress tun-id can be retrieved from ovs flow. Use it before checking
the tun-id map.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
