### PR TITLE
fix(agw): Fixing service request metrics count on Grafana

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -14,7 +14,7 @@
                 "${workspaceFolder}/build/tasks/s1ap/r15",
                 "${workspaceFolder}/build/tasks/ngap/r16",
                 "${workspaceFolder}/orc8r/gateway/c/common/sentry",
-                "${workspaceFolder}",
+                "${workspaceFolder}"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -14,7 +14,7 @@
                 "${workspaceFolder}/build/tasks/s1ap/r15",
                 "${workspaceFolder}/build/tasks/ngap/r16",
                 "${workspaceFolder}/orc8r/gateway/c/common/sentry",
-                "${workspaceFolder}"
+                "${workspaceFolder}",
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
@@ -897,7 +897,6 @@ static int emm_as_establish_req(emm_as_establish_t* msg, int* emm_cause) {
 
     case SERVICE_REQUEST:
       // Requirement MME24.301R10_4.4.4.3_1
-      increment_counter("service_request", 1, NO_LABELS);
       OAILOG_INFO(
           LOG_NAS_EMM,
           "EMMAS-SAP - Message Type = SERVICE_REQUEST(0x%x) for (ue_id "

--- a/nms/packages/magmalte/generated/MagmaAPIBindings.js
+++ b/nms/packages/magmalte/generated/MagmaAPIBindings.js
@@ -16,11297 +16,10279 @@
  */
 
 export type aaa_server = {
-    accounting_enabled ? : boolean,
-    acct_reporting_enabled ? : boolean,
-    create_session_on_auth ? : boolean,
-    event_logging_enabled ? : boolean,
-    idle_session_timeout_ms ? : number,
-    radius_config ? : radius_config,
+  accounting_enabled?: boolean,
+  acct_reporting_enabled?: boolean,
+  create_session_on_auth?: boolean,
+  event_logging_enabled?: boolean,
+  idle_session_timeout_ms?: number,
+  radius_config?: radius_config,
 };
 export type aggregated_maximum_bitrate = {
-    max_bandwidth_dl: number,
-    max_bandwidth_ul: number,
+  max_bandwidth_dl: number,
+  max_bandwidth_ul: number,
 };
 export type aggregation_logging_configs = {
-    target_files_by_tag ? : {
-        [string]: string,
-    },
-    throttle_interval ? : string,
-    throttle_rate ? : number,
-    throttle_window ? : number,
+  target_files_by_tag?: {
+    [string]: string,
+  },
+  throttle_interval?: string,
+  throttle_rate?: number,
+  throttle_window?: number,
 };
 export type agw_test_config = {
-    package_repo: string,
-    release_channel: string,
-    slack_webhook: string,
-    target_gateway_id: string,
-    target_tier: string,
+  package_repo: string,
+  release_channel: string,
+  slack_webhook: string,
+  target_gateway_id: string,
+  target_tier: string,
 };
 export type alert_bulk_upload_response = {
-    errors: {
-        [string]: string,
-    },
-    statuses: {
-        [string]: string,
-    },
+  errors: {
+    [string]: string,
+  },
+  statuses: {
+    [string]: string,
+  },
 };
 export type alert_receiver_config = {
-    email_configs ? : Array < email_receiver >
-        ,
-    name: string,
-    slack_configs ? : Array < slack_receiver >
-        ,
-    webhook_configs ? : Array < webhook_receiver >
-        ,
+  email_configs?: Array<email_receiver>,
+  name: string,
+  slack_configs?: Array<slack_receiver>,
+  webhook_configs?: Array<webhook_receiver>,
 };
 export type alert_routing_tree = {
-    continue ?: boolean,
-    group_by ? : Array < string >
-        ,
-    group_interval ? : string,
-    group_wait ? : string,
-    match ? : {
-        label ? : string,
-        value ? : string,
-    },
-    match_re ? : {
-        label ? : string,
-        value ? : string,
-    },
-    receiver: string,
-    repeat_interval ? : string,
-    routes ? : Array < alert_routing_tree >
-        ,
+  continue?: boolean,
+  group_by?: Array<string>,
+  group_interval?: string,
+  group_wait?: string,
+  match?: {
+    label?: string,
+    value?: string,
+  },
+  match_re?: {
+    label?: string,
+    value?: string,
+  },
+  receiver: string,
+  repeat_interval?: string,
+  routes?: Array<alert_routing_tree>,
 };
 export type alert_silence_status = {
-    state: string,
+  state: string,
 };
 export type alert_silencer = {
-    comment: string,
-    createdBy: string,
-    endsAt: string,
-    matchers: Array < matcher >
-        ,
-    startsAt: string,
+  comment: string,
+  createdBy: string,
+  endsAt: string,
+  matchers: Array<matcher>,
+  startsAt: string,
 };
 export type allowed_gre_peer = {
-    ip: string,
-    key ? : number,
+  ip: string,
+  key?: number,
 };
-export type allowed_gre_peers = Array < allowed_gre_peer >
-;
+export type allowed_gre_peers = Array<allowed_gre_peer>;
 export type apn = {
-    apn_configuration: apn_configuration,
-    apn_name: apn_name,
+  apn_configuration: apn_configuration,
+  apn_name: apn_name,
 };
 export type apn_configuration = {
-    ambr: aggregated_maximum_bitrate,
-    pdn_type ? : 0 | 1 | 2 | 3,
-    qos_profile: qos_profile,
+  ambr: aggregated_maximum_bitrate,
+  pdn_type?: 0 | 1 | 2 | 3,
+  qos_profile: qos_profile,
 };
-export type apn_list = Array < string >
-;
+export type apn_list = Array<string>;
 export type apn_name = string;
 export type apn_resource = {
-    apn_name: apn_name,
-    gateway_ip ? : string,
-    gateway_mac ? : string,
-    id: string,
-    vlan_id ? : number,
+  apn_name: apn_name,
+  gateway_ip?: string,
+  gateway_mac?: string,
+  id: string,
+  vlan_id?: number,
 };
 export type apn_resources = {
-    [string]: apn_resource,
+  [string]: apn_resource,
 };
 export type arp = {
-    preemption_capability ? : boolean,
-    preemption_vulnerability ? : boolean,
-    priority_level ? : number,
+  preemption_capability?: boolean,
+  preemption_vulnerability?: boolean,
+  priority_level?: number,
 };
 export type base_name = string;
 export type base_name_record = {
-    assigned_subscribers ? : Array < subscriber_id >
-        ,
-    name: base_name,
-    rule_names: rule_names,
+  assigned_subscribers?: Array<subscriber_id>,
+  name: base_name,
+  rule_names: rule_names,
 };
-export type base_names = Array < base_name >
-;
+export type base_names = Array<base_name>;
 export type call_trace = {
-    config: call_trace_config,
-    state ? : call_trace_state,
+  config: call_trace_config,
+  state?: call_trace_state,
 };
 export type call_trace_config = {
-    capture_filters ? : string,
-    display_filters ? : string,
-    gateway_id ? : string,
-    timeout ? : number,
-    trace_id: string,
-    trace_type: "GATEWAY",
+  capture_filters?: string,
+  display_filters?: string,
+  gateway_id?: string,
+  timeout?: number,
+  trace_id: string,
+  trace_type: 'GATEWAY',
 };
 export type call_trace_state = {
-    call_trace_available ? : boolean,
-    call_trace_ending ? : boolean,
+  call_trace_available?: boolean,
+  call_trace_ending?: boolean,
 };
 export type carrier_wifi_gateway_health_status = {
-    description: string,
-    status: "HEALTHY" | "UNHEALTHY",
+  description: string,
+  status: 'HEALTHY' | 'UNHEALTHY',
 };
 export type carrier_wifi_ha_pair_state = {
-    gateway1_health ? : carrier_wifi_gateway_health_status,
-    gateway2_health ? : carrier_wifi_gateway_health_status,
-    ha_pair_status ? : carrier_wifi_ha_pair_status,
+  gateway1_health?: carrier_wifi_gateway_health_status,
+  gateway2_health?: carrier_wifi_gateway_health_status,
+  ha_pair_status?: carrier_wifi_ha_pair_status,
 };
 export type carrier_wifi_ha_pair_status = {
-    active_gateway: string,
+  active_gateway: string,
 };
 export type cellular_gateway_pool = {
-    config: cellular_gateway_pool_configs,
-    gateway_ids: Array < gateway_id >
-        ,
-    gateway_pool_id: gateway_pool_id,
-    gateway_pool_name ? : string,
+  config: cellular_gateway_pool_configs,
+  gateway_ids: Array<gateway_id>,
+  gateway_pool_id: gateway_pool_id,
+  gateway_pool_name?: string,
 };
 export type cellular_gateway_pool_configs = {
-    mme_group_id: number,
+  mme_group_id: number,
 };
 export type cellular_gateway_pool_record = {
-    gateway_pool_id: gateway_pool_id,
-    mme_code: number,
-    mme_relative_capacity: number,
+  gateway_pool_id: gateway_pool_id,
+  mme_code: number,
+  mme_relative_capacity: number,
 };
-export type cellular_gateway_pool_records = Array < cellular_gateway_pool_record >
-;
+export type cellular_gateway_pool_records = Array<cellular_gateway_pool_record>;
 export type challenge_key = {
-    key ? : string,
-    key_type: "ECHO" | "SOFTWARE_ECDSA_SHA256",
+  key?: string,
+  key_type: 'ECHO' | 'SOFTWARE_ECDSA_SHA256',
 };
 export type channel_id = string;
 export type ci_node = {
-    available: boolean,
-    id: string,
-    last_lease_time ? : string,
-    tag ? : string,
-    vpn_ip: string,
+  available: boolean,
+  id: string,
+  last_lease_time?: string,
+  tag?: string,
+  vpn_ip: string,
 };
 export type config_info = {
-    mconfig_created_at ? : number,
+  mconfig_created_at?: number,
 };
-export type core_network_types = Array < "EPC" | "5GC" >
-;
+export type core_network_types = Array<'EPC' | '5GC'>;
 export type csfb = {
-    client ? : sctp_client_configs,
+  client?: sctp_client_configs,
 };
 export type cwf_gateway = {
-    carrier_wifi: gateway_cwf_configs,
-    description: gateway_description,
-    device: gateway_device,
-    id: gateway_id,
-    magmad: magmad_gateway_configs,
-    name: gateway_name,
-    status ? : gateway_status,
-    tier: tier_id,
+  carrier_wifi: gateway_cwf_configs,
+  description: gateway_description,
+  device: gateway_device,
+  id: gateway_id,
+  magmad: magmad_gateway_configs,
+  name: gateway_name,
+  status?: gateway_status,
+  tier: tier_id,
 };
 export type cwf_ha_pair = {
-    config: cwf_ha_pair_configs,
-    gateway_id_1: string,
-    gateway_id_2: string,
-    ha_pair_id: string,
-    state ? : carrier_wifi_ha_pair_state,
+  config: cwf_ha_pair_configs,
+  gateway_id_1: string,
+  gateway_id_2: string,
+  ha_pair_id: string,
+  state?: carrier_wifi_ha_pair_state,
 };
 export type cwf_ha_pair_configs = {
-    transport_virtual_ip: string,
+  transport_virtual_ip: string,
 };
 export type cwf_network = {
-    carrier_wifi: network_carrier_wifi_configs,
-    description: network_description,
-    dns: network_dns_config,
-    features ? : network_features,
-    federation: federated_network_configs,
-    id: network_id,
-    name: network_name,
-    subscriber_config ? : network_subscriber_config,
+  carrier_wifi: network_carrier_wifi_configs,
+  description: network_description,
+  dns: network_dns_config,
+  features?: network_features,
+  federation: federated_network_configs,
+  id: network_id,
+  name: network_name,
+  subscriber_config?: network_subscriber_config,
 };
 export type cwf_subscriber_directory_record = {
-    ipv4_addr ? : string,
-    location_history: Array < string >
-        ,
-    mac_addr ? : string,
+  ipv4_addr?: string,
+  location_history: Array<string>,
+  mac_addr?: string,
 };
 export type diameter_client_configs = {
-    address ? : string,
-    dest_host ? : string,
-    dest_realm ? : string,
-    disable_dest_host ? : boolean,
-    host ? : string,
-    local_address ? : string,
-    overwrite_dest_host ? : boolean,
-    product_name ? : string,
-    protocol ? : "tcp" | "tcp4" | "tcp6" | "sctp" | "sctp4" | "sctp6",
-    realm ? : string,
-    retransmits ? : number,
-    retry_count ? : number,
-    watchdog_interval ? : number,
+  address?: string,
+  dest_host?: string,
+  dest_realm?: string,
+  disable_dest_host?: boolean,
+  host?: string,
+  local_address?: string,
+  overwrite_dest_host?: boolean,
+  product_name?: string,
+  protocol?: 'tcp' | 'tcp4' | 'tcp6' | 'sctp' | 'sctp4' | 'sctp6',
+  realm?: string,
+  retransmits?: number,
+  retry_count?: number,
+  watchdog_interval?: number,
 };
 export type diameter_server_configs = {
-    address ? : string,
-    dest_host ? : string,
-    dest_realm ? : string,
-    local_address ? : string,
-    protocol ? : "tcp" | "tcp4" | "tcp6" | "sctp" | "sctp4" | "sctp6",
+  address?: string,
+  dest_host?: string,
+  dest_realm?: string,
+  local_address?: string,
+  protocol?: 'tcp' | 'tcp4' | 'tcp6' | 'sctp' | 'sctp4' | 'sctp6',
 };
 export type disk_partition = {
-    device ? : string,
-    free ? : number,
-    mount_point ? : string,
-    total ? : number,
-    used ? : number,
+  device?: string,
+  free?: number,
+  mount_point?: string,
+  total?: number,
+  used?: number,
 };
 export type dns_config_record = {
-    a_record ? : Array < string >
-        ,
-    aaaa_record ? : Array < string >
-        ,
-    cname_record ? : Array < string >
-        ,
-    domain: string,
+  a_record?: Array<string>,
+  aaaa_record?: Array<string>,
+  cname_record?: Array<string>,
+  domain: string,
 };
 export type e2e_test_case = {
-    config: {},
-    pk: number,
-    state: e2e_test_case_state,
-    test_type: string,
+  config: {},
+  pk: number,
+  state: e2e_test_case_state,
+  test_type: string,
 };
 export type e2e_test_case_state = {
-    current_state ? : string,
-    error ? : string,
-    is_executing: boolean,
-    last_execution_time ? : string,
-    next_scheduled_time ? : string,
+  current_state?: string,
+  error?: string,
+  is_executing: boolean,
+  last_execution_time?: string,
+  next_scheduled_time?: string,
 };
 export type eap_aka = {
-    mnc_len ? : number,
-    plmn_ids ? : Array < string >
-        ,
-    timeout ? : eap_aka_timeouts,
-    use_s6a ? : boolean,
+  mnc_len?: number,
+  plmn_ids?: Array<string>,
+  timeout?: eap_aka_timeouts,
+  use_s6a?: boolean,
 };
 export type eap_aka_timeouts = {
-    challenge_ms ? : number,
-    error_notification_ms ? : number,
-    session_authenticated_ms ? : number,
-    session_ms ? : number,
+  challenge_ms?: number,
+  error_notification_ms?: number,
+  session_authenticated_ms?: number,
+  session_ms?: number,
 };
 export type eap_sim = {
-    mnc_len ? : number,
-    plmn_ids ? : Array < string >
-        ,
-    timeout ? : eap_sim_timeouts,
-    use_s6a ? : boolean,
+  mnc_len?: number,
+  plmn_ids?: Array<string>,
+  timeout?: eap_sim_timeouts,
+  use_s6a?: boolean,
 };
 export type eap_sim_timeouts = {
-    challenge_ms ? : number,
-    error_notification_ms ? : number,
-    session_authenticated_ms ? : number,
-    session_ms ? : number,
+  challenge_ms?: number,
+  error_notification_ms?: number,
+  session_authenticated_ms?: number,
+  session_ms?: number,
 };
 export type elastic_hit = {
-    _id: string,
-    _index: string,
-    _primary_term ? : string,
-    _score ? : number,
-    _seq_no ? : number,
-    _sort ? : Array < number >
-        ,
-    _source: {
-        [string]: string,
-    },
-    _type: string,
+  _id: string,
+  _index: string,
+  _primary_term?: string,
+  _score?: number,
+  _seq_no?: number,
+  _sort?: Array<number>,
+  _source: {
+    [string]: string,
+  },
+  _type: string,
 };
 export type elastic_hit_count = number;
 export type email_receiver = {
-    auth_identity ? : string,
-    auth_password ? : string,
-    auth_secret ? : string,
-    auth_username ? : string,
-    from: string,
-    headers ? : {
-        [string]: string,
-    },
-    hello ? : string,
-    html ? : string,
-    send_resolved ? : boolean,
-    smarthost: string,
-    text ? : string,
-    to: string,
+  auth_identity?: string,
+  auth_password?: string,
+  auth_secret?: string,
+  auth_username?: string,
+  from: string,
+  headers?: {
+    [string]: string,
+  },
+  hello?: string,
+  html?: string,
+  send_resolved?: boolean,
+  smarthost: string,
+  text?: string,
+  to: string,
 };
 export type enodeb = {
-    attached_gateway_id ? : string,
-    config: enodeb_configuration,
-    description ? : string,
-    enodeb_config ? : enodeb_config,
-    name: string,
-    serial: string,
+  attached_gateway_id?: string,
+  config: enodeb_configuration,
+  description?: string,
+  enodeb_config?: enodeb_config,
+  name: string,
+  serial: string,
 };
 export type enodeb_config = {
-    config_type: "MANAGED" | "UNMANAGED",
-    managed_config ? : enodeb_configuration,
-    unmanaged_config ? : unmanaged_enodeb_configuration,
+  config_type: 'MANAGED' | 'UNMANAGED',
+  managed_config?: enodeb_configuration,
+  unmanaged_config?: unmanaged_enodeb_configuration,
 };
 export type enodeb_configuration = {
-    bandwidth_mhz ? : 3 | 5 | 10 | 15 | 20,
-    cell_id: number,
-    device_class: "Baicells Nova-233 G2 OD FDD" | "Baicells Nova-243 OD TDD" | "Baicells Neutrino 224 ID FDD" | "Baicells ID TDD/FDD" | "NuRAN Cavium OC-LTE" | "FreedomFi One",
-    earfcndl ? : number,
-    pci ? : number,
-    special_subframe_pattern ? : number,
-    subframe_assignment ? : number,
-    tac ? : number,
-    transmit_enabled: boolean,
+  bandwidth_mhz?: 3 | 5 | 10 | 15 | 20,
+  cell_id: number,
+  device_class:
+    | 'Baicells Nova-233 G2 OD FDD'
+    | 'Baicells Nova-243 OD TDD'
+    | 'Baicells Neutrino 224 ID FDD'
+    | 'Baicells ID TDD/FDD'
+    | 'NuRAN Cavium OC-LTE'
+    | 'FreedomFi One',
+  earfcndl?: number,
+  pci?: number,
+  special_subframe_pattern?: number,
+  subframe_assignment?: number,
+  tac?: number,
+  transmit_enabled: boolean,
 };
-export type enodeb_serials = Array < string >
-;
+export type enodeb_serials = Array<string>;
 export type enodeb_state = {
-    enodeb_configured: boolean,
-    enodeb_connected: boolean,
-    fsm_state: string,
-    gps_connected: boolean,
-    gps_latitude: string,
-    gps_longitude: string,
-    ip_address ? : string,
-    mme_connected: boolean,
-    opstate_enabled: boolean,
-    ptp_connected: boolean,
-    reporting_gateway_id ? : string,
-    rf_tx_desired: boolean,
-    rf_tx_on: boolean,
-    time_reported ? : number,
-    ues_connected ? : number,
+  enodeb_configured: boolean,
+  enodeb_connected: boolean,
+  fsm_state: string,
+  gps_connected: boolean,
+  gps_latitude: string,
+  gps_longitude: string,
+  ip_address?: string,
+  mme_connected: boolean,
+  opstate_enabled: boolean,
+  ptp_connected: boolean,
+  reporting_gateway_id?: string,
+  rf_tx_desired: boolean,
+  rf_tx_on: boolean,
+  time_reported?: number,
+  ues_connected?: number,
 };
 export type enodebd_e2e_test = {
-    config: enodebd_test_config,
-    pk: number,
-    state: e2e_test_case_state,
+  config: enodebd_test_config,
+  pk: number,
+  state: e2e_test_case_state,
 };
 export type enodebd_test_config = {
-    agw_config: agw_test_config,
-    enodeb_SN: string,
-    enodeb_config: enodeb_config,
-    network_id: string,
-    run_traffic_tests: boolean,
-    ssid ? : string,
-    ssid_pw ? : string,
-    start_state ? : string,
-    subscriberID: string,
-    traffic_gwID: string,
+  agw_config: agw_test_config,
+  enodeb_SN: string,
+  enodeb_config: enodeb_config,
+  network_id: string,
+  run_traffic_tests: boolean,
+  ssid?: string,
+  ssid_pw?: string,
+  start_state?: string,
+  subscriberID: string,
+  traffic_gwID: string,
 };
 export type error = {
-    message: string,
+  message: string,
 };
 export type event = {
-    event_type: string,
-    hardware_id: string,
-    stream_name: string,
-    tag: string,
-    timestamp: string,
-    value: {},
+  event_type: string,
+  hardware_id: string,
+  stream_name: string,
+  tag: string,
+  timestamp: string,
+  value: {},
 };
 export type federated_mode_map = {
-    enabled ? : boolean,
-    mapping ? : Array < mode_map_item >
-        ,
+  enabled?: boolean,
+  mapping?: Array<mode_map_item>,
 };
 export type federated_network_configs = {
-    federated_modes_mapping ? : federated_mode_map,
-    feg_network_id: string,
+  federated_modes_mapping?: federated_mode_map,
+  feg_network_id: string,
 };
 export type federation_gateway = {
-    description: gateway_description,
-    device: gateway_device,
-    federation: gateway_federation_configs,
-    id: gateway_id,
-    magmad: magmad_gateway_configs,
-    name: gateway_name,
-    status ? : gateway_status,
-    tier: tier_id,
+  description: gateway_description,
+  device: gateway_device,
+  federation: gateway_federation_configs,
+  id: gateway_id,
+  magmad: magmad_gateway_configs,
+  name: gateway_name,
+  status?: gateway_status,
+  tier: tier_id,
 };
 export type federation_gateway_health_status = {
-    description: string,
-    service_status ? : {
-        [string]: service_status_health,
-    },
-    status: "HEALTHY" | "UNHEALTHY",
+  description: string,
+  service_status?: {
+    [string]: service_status_health,
+  },
+  status: 'HEALTHY' | 'UNHEALTHY',
 };
 export type federation_network_cluster_status = {
-    active_gateway: string,
+  active_gateway: string,
 };
 export type feg_lte_network = {
-    cellular: network_cellular_configs,
-    description: network_description,
-    dns: network_dns_config,
-    features ? : network_features,
-    federation: federated_network_configs,
-    id: network_id,
-    name: network_name,
+  cellular: network_cellular_configs,
+  description: network_description,
+  dns: network_dns_config,
+  features?: network_features,
+  federation: federated_network_configs,
+  id: network_id,
+  name: network_name,
 };
 export type feg_network = {
-    description: network_description,
-    dns: network_dns_config,
-    features ? : network_features,
-    federation: network_federation_configs,
-    id: network_id,
-    name: network_name,
-    subscriber_config ? : network_subscriber_config,
+  description: network_description,
+  dns: network_dns_config,
+  features?: network_features,
+  federation: network_federation_configs,
+  id: network_id,
+  name: network_name,
+  subscriber_config?: network_subscriber_config,
 };
 export type feg_network_id = string;
 export type flow_description = {
-    action: "PERMIT" | "DENY",
-    match: flow_match,
+  action: 'PERMIT' | 'DENY',
+  match: flow_match,
 };
 export type flow_match = {
-    direction: "UPLINK" | "DOWNLINK",
-    ip_dst ? : ip_address,
-    ip_proto: "IPPROTO_IP" | "IPPROTO_TCP" | "IPPROTO_UDP" | "IPPROTO_ICMP",
-    ip_src ? : ip_address,
-    ipv4_dst ? : string,
-    ipv4_src ? : string,
-    tcp_dst ? : number,
-    tcp_src ? : number,
-    udp_dst ? : number,
-    udp_src ? : number,
+  direction: 'UPLINK' | 'DOWNLINK',
+  ip_dst?: ip_address,
+  ip_proto: 'IPPROTO_IP' | 'IPPROTO_TCP' | 'IPPROTO_UDP' | 'IPPROTO_ICMP',
+  ip_src?: ip_address,
+  ipv4_dst?: string,
+  ipv4_src?: string,
+  tcp_dst?: number,
+  tcp_src?: number,
+  udp_dst?: number,
+  udp_src?: number,
 };
 export type flow_qos = {
-    max_req_bw_dl: number,
-    max_req_bw_ul: number,
+  max_req_bw_dl: number,
+  max_req_bw_ul: number,
 };
 export type gateway_cellular_configs = {
-    dns ? : gateway_dns_configs,
-    epc: gateway_epc_configs,
-    he_config ? : gateway_he_config,
-    non_eps_service ? : gateway_non_eps_configs,
-    pooling ? : cellular_gateway_pool_records,
-    ran: gateway_ran_configs,
+  dns?: gateway_dns_configs,
+  epc: gateway_epc_configs,
+  he_config?: gateway_he_config,
+  non_eps_service?: gateway_non_eps_configs,
+  pooling?: cellular_gateway_pool_records,
+  ran: gateway_ran_configs,
 };
 export type gateway_cwf_configs = {
-    allowed_gre_peers: allowed_gre_peers,
-    gateway_health_configs ? : gateway_health_configs,
-    ipdr_export_dst ? : ipdr_export_dst,
+  allowed_gre_peers: allowed_gre_peers,
+  gateway_health_configs?: gateway_health_configs,
+  ipdr_export_dst?: ipdr_export_dst,
 };
 export type gateway_description = string;
 export type gateway_device = {
-    hardware_id: string,
-    key: challenge_key,
+  hardware_id: string,
+  key: challenge_key,
 };
 export type gateway_dns_configs = {
-    dhcp_server_enabled: boolean,
-    enable_caching: boolean,
-    local_ttl: number,
-    records ? : gateway_dns_records,
+  dhcp_server_enabled: boolean,
+  enable_caching: boolean,
+  local_ttl: number,
+  records?: gateway_dns_records,
 };
-export type gateway_dns_records = Array < dns_config_record >
-;
+export type gateway_dns_records = Array<dns_config_record>;
 export type gateway_epc_configs = {
-    congestion_control_enabled ? : boolean,
-    dns_primary ? : string,
-    dns_secondary ? : string,
-    ip_block: string,
-    ipv4_p_cscf_addr ? : string,
-    ipv4_sgw_s1u_addr ? : string,
-    ipv6_block ? : string,
-    ipv6_dns_addr ? : string,
-    ipv6_p_cscf_addr ? : string,
-    ipv6_prefix_allocation_mode ? : "RANDOM" | "HASH",
-    nat_enabled: boolean,
-    sgi_management_iface_gw ? : string,
-    sgi_management_iface_ipv6_addr ? : string,
-    sgi_management_iface_ipv6_gw ? : string,
-    sgi_management_iface_static_ip ? : string,
-    sgi_management_iface_vlan ? : string,
-    subscriberdb_sync_interval ? : subscriberdb_sync_interval,
+  congestion_control_enabled?: boolean,
+  dns_primary?: string,
+  dns_secondary?: string,
+  ip_block: string,
+  ipv4_p_cscf_addr?: string,
+  ipv4_sgw_s1u_addr?: string,
+  ipv6_block?: string,
+  ipv6_dns_addr?: string,
+  ipv6_p_cscf_addr?: string,
+  ipv6_prefix_allocation_mode?: 'RANDOM' | 'HASH',
+  nat_enabled: boolean,
+  sgi_management_iface_gw?: string,
+  sgi_management_iface_ipv6_addr?: string,
+  sgi_management_iface_ipv6_gw?: string,
+  sgi_management_iface_static_ip?: string,
+  sgi_management_iface_vlan?: string,
+  subscriberdb_sync_interval?: subscriberdb_sync_interval,
 };
 export type gateway_federation_configs = {
-    aaa_server: aaa_server,
-    csfb ? : csfb,
-    eap_aka: eap_aka,
-    eap_sim ? : eap_sim,
-    gx: gx,
-    gy: gy,
-    health: health,
-    hss: hss,
-    nh_routes ? : nh_routes,
-    s6a: s6a,
-    s8 ? : s8,
-    served_network_ids: served_network_ids,
-    served_nh_ids ? : served_nh_ids,
-    swx: swx,
+  aaa_server: aaa_server,
+  csfb?: csfb,
+  eap_aka: eap_aka,
+  eap_sim?: eap_sim,
+  gx: gx,
+  gy: gy,
+  health: health,
+  hss: hss,
+  nh_routes?: nh_routes,
+  s6a: s6a,
+  s8?: s8,
+  served_network_ids: served_network_ids,
+  served_nh_ids?: served_nh_ids,
+  swx: swx,
 };
 export type gateway_he_config = {
-    enable_encryption: boolean,
-    enable_header_enrichment: boolean,
-    encryption_key ? : string,
-    he_encoding_type: "BASE64" | "HEX2BIN",
-    he_encryption_algorithm: "RC4" | "AES256_CBC_HMAC_MD5" | "AES256_ECB_HMAC_MD5" | "GZIPPED_AES256_ECB_SHA1",
-    he_hash_function: "MD5" | "HEX" | "SHA256",
-    hmac_key ? : string,
+  enable_encryption: boolean,
+  enable_header_enrichment: boolean,
+  encryption_key?: string,
+  he_encoding_type: 'BASE64' | 'HEX2BIN',
+  he_encryption_algorithm:
+    | 'RC4'
+    | 'AES256_CBC_HMAC_MD5'
+    | 'AES256_ECB_HMAC_MD5'
+    | 'GZIPPED_AES256_ECB_SHA1',
+  he_hash_function: 'MD5' | 'HEX' | 'SHA256',
+  hmac_key?: string,
 };
 export type gateway_health_configs = {
-    cpu_util_threshold_pct ? : number,
-    gre_probe_interval_secs ? : number,
-    icmp_probe_pkt_count ? : number,
-    mem_util_threshold_pct ? : number,
+  cpu_util_threshold_pct?: number,
+  gre_probe_interval_secs?: number,
+  icmp_probe_pkt_count?: number,
+  mem_util_threshold_pct?: number,
 };
 export type gateway_id = string;
 export type gateway_logging_configs = {
-    aggregation ? : aggregation_logging_configs,
-    event_verbosity ? : number,
-    log_level: "DEBUG" | "INFO" | "WARNING" | "ERROR" | "FATAL",
+  aggregation?: aggregation_logging_configs,
+  event_verbosity?: number,
+  log_level: 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR' | 'FATAL',
 };
 export type gateway_name = string;
 export type gateway_non_eps_configs = {
-    arfcn_2g ? : Array < number >
-        ,
-    csfb_mcc ? : string,
-    csfb_mnc ? : string,
-    csfb_rat ? : 0 | 1,
-    lac ? : number,
-    non_eps_service_control: 0 | 1 | 2 | 3,
+  arfcn_2g?: Array<number>,
+  csfb_mcc?: string,
+  csfb_mnc?: string,
+  csfb_rat?: 0 | 1,
+  lac?: number,
+  non_eps_service_control: 0 | 1 | 2 | 3,
 };
 export type gateway_pool_id = string;
 export type gateway_ran_configs = {
-    pci: number,
-    transmit_enabled: boolean,
+  pci: number,
+  transmit_enabled: boolean,
 };
 export type gateway_status = {
-    cert_expiration_time ? : number,
-    checkin_time ? : number,
-    hardware_id ? : string,
-    kernel_version ? : string,
-    kernel_versions_installed ? : Array < string >
-        ,
-    machine_info ? : machine_info,
-    meta ? : {
-        [string]: string,
-    },
-    platform_info ? : platform_info,
-    system_status ? : system_status,
-    version ? : string,
-    vpn_ip ? : string,
+  cert_expiration_time?: number,
+  checkin_time?: number,
+  hardware_id?: string,
+  kernel_version?: string,
+  kernel_versions_installed?: Array<string>,
+  machine_info?: machine_info,
+  meta?: {
+    [string]: string,
+  },
+  platform_info?: platform_info,
+  system_status?: system_status,
+  version?: string,
+  vpn_ip?: string,
 };
 export type gateway_vpn_configs = {
-    enable_shell: boolean,
+  enable_shell: boolean,
 };
 export type gateway_wifi_configs = {
-    additional_props ? : {
-        [string]: string,
-    },
-    client_channel ? : string,
-    info ? : string,
-    is_production ? : boolean,
-    latitude ? : number,
-    longitude ? : number,
-    mesh_id ? : mesh_id,
-    mesh_rssi_threshold ? : number,
-    override_password ? : string,
-    override_ssid ? : string,
-    override_xwf_config ? : string,
-    override_xwf_dhcp_dns1 ? : string,
-    override_xwf_dhcp_dns2 ? : string,
-    override_xwf_enabled ? : boolean,
-    override_xwf_partner_name ? : string,
-    override_xwf_radius_acct_port ? : number,
-    override_xwf_radius_auth_port ? : number,
-    override_xwf_radius_server ? : string,
-    override_xwf_radius_shared_secret ? : string,
-    override_xwf_uam_secret ? : string,
-    use_override_ssid ? : boolean,
-    use_override_xwf ? : boolean,
-    wifi_disabled ? : boolean,
+  additional_props?: {
+    [string]: string,
+  },
+  client_channel?: string,
+  info?: string,
+  is_production?: boolean,
+  latitude?: number,
+  longitude?: number,
+  mesh_id?: mesh_id,
+  mesh_rssi_threshold?: number,
+  override_password?: string,
+  override_ssid?: string,
+  override_xwf_config?: string,
+  override_xwf_dhcp_dns1?: string,
+  override_xwf_dhcp_dns2?: string,
+  override_xwf_enabled?: boolean,
+  override_xwf_partner_name?: string,
+  override_xwf_radius_acct_port?: number,
+  override_xwf_radius_auth_port?: number,
+  override_xwf_radius_server?: string,
+  override_xwf_radius_shared_secret?: string,
+  override_xwf_uam_secret?: string,
+  use_override_ssid?: boolean,
+  use_override_xwf?: boolean,
+  wifi_disabled?: boolean,
 };
 export type gbr = {
-    downlink: number,
-    uplink: number,
+  downlink: number,
+  uplink: number,
 };
 export type generic_command_params = {
-    command: string,
-    params ? : {
-        [string]: {},
-    },
+  command: string,
+  params?: {
+    [string]: {},
+  },
 };
 export type generic_command_response = {
-    response ? : {
-        [string]: {},
-    },
+  response?: {
+    [string]: {},
+  },
 };
 export type gettable_alert = {
-    name: string,
+  name: string,
 };
 export type gettable_alert_silencer = {
-    comment: string,
-    createdBy: string,
-    endsAt: string,
-    matchers: Array < matcher >
-        ,
-    startsAt: string,
-    id: string,
-    status: alert_silence_status,
-    updatedAt: string,
+  comment: string,
+  createdBy: string,
+  endsAt: string,
+  matchers: Array<matcher>,
+  startsAt: string,
+  id: string,
+  status: alert_silence_status,
+  updatedAt: string,
 };
 export type gx = {
-    disableGx ? : boolean,
-    overwrite_apn ? : string,
-    server ? : diameter_client_configs,
-    servers ? : Array < diameter_client_configs >
-        ,
-    virtual_apn_rules ? : Array < virtual_apn_rule >
-        ,
+  disableGx?: boolean,
+  overwrite_apn?: string,
+  server?: diameter_client_configs,
+  servers?: Array<diameter_client_configs>,
+  virtual_apn_rules?: Array<virtual_apn_rule>,
 };
 export type gy = {
-    disableGy ? : boolean,
-    init_method ? : 1 | 2,
-    overwrite_apn ? : string,
-    server ? : diameter_client_configs,
-    servers ? : Array < diameter_client_configs >
-        ,
-    virtual_apn_rules ? : Array < virtual_apn_rule >
-        ,
+  disableGy?: boolean,
+  init_method?: 1 | 2,
+  overwrite_apn?: string,
+  server?: diameter_client_configs,
+  servers?: Array<diameter_client_configs>,
+  virtual_apn_rules?: Array<virtual_apn_rule>,
 };
 export type health = {
-    cloud_disable_period_secs ? : number,
-    cpu_utilization_threshold ? : number,
-    health_services ? : Array < "S6A_PROXY" | "SESSION_PROXY" | "SWX_PROXY" >
-        ,
-    local_disable_period_secs ? : number,
-    memory_available_threshold ? : number,
-    minimum_request_threshold ? : number,
-    request_failure_threshold ? : number,
-    update_failure_threshold ? : number,
-    update_interval_secs ? : number,
+  cloud_disable_period_secs?: number,
+  cpu_utilization_threshold?: number,
+  health_services?: Array<'S6A_PROXY' | 'SESSION_PROXY' | 'SWX_PROXY'>,
+  local_disable_period_secs?: number,
+  memory_available_threshold?: number,
+  minimum_request_threshold?: number,
+  request_failure_threshold?: number,
+  update_failure_threshold?: number,
+  update_interval_secs?: number,
 };
 export type hss = {
-    default_sub_profile ? : subscription_profile,
-    lte_auth_amf ? : string,
-    lte_auth_op ? : string,
-    server ? : diameter_server_configs,
-    stream_subscribers ? : boolean,
-    sub_profiles ? : {
-        [string]: subscription_profile,
-    },
+  default_sub_profile?: subscription_profile,
+  lte_auth_amf?: string,
+  lte_auth_op?: string,
+  server?: diameter_server_configs,
+  stream_subscribers?: boolean,
+  sub_profiles?: {
+    [string]: subscription_profile,
+  },
 };
 export type http_config = {
-    basic_auth ? : http_config_basic_auth,
-    bearer_token ? : string,
-    proxy_url ? : string,
+  basic_auth?: http_config_basic_auth,
+  bearer_token?: string,
+  proxy_url?: string,
 };
 export type http_config_basic_auth = {
-    password: string,
-    username: string,
+  password: string,
+  username: string,
 };
 export type icmp_status = {
-    last_reported_time ? : number,
-    latency_ms: number,
+  last_reported_time?: number,
+  latency_ms: number,
 };
 export type imei = {
-    snr ? : string,
-    tac: string,
+  snr?: string,
+  tac: string,
 };
 export type ip_address = {
-    address ? : string,
-    version ? : "IPv4" | "IPv6",
+  address?: string,
+  version?: 'IPv4' | 'IPv6',
 };
 export type ipdr_export_dst = {
-    ip: string,
-    port: number,
+  ip: string,
+  port: number,
 };
 export type label_pair = {
-    name: string,
-    value: string,
+  name: string,
+  value: string,
 };
 export type latest_script_execution = {
-    timestamp: number,
-    version: string,
+  timestamp: number,
+  version: string,
 };
 export type li_ues = {
-    imsis: Array < string >
-        ,
-    ips: Array < string >
-        ,
-    macs: Array < string >
-        ,
-    msisdns: Array < string >
-        ,
+  imsis: Array<string>,
+  ips: Array<string>,
+  macs: Array<string>,
+  msisdns: Array<string>,
 };
 export type lte_gateway = {
-    apn_resources ? : apn_resources,
-    cellular: gateway_cellular_configs,
-    connected_enodeb_serials: enodeb_serials,
-    description: gateway_description,
-    device: gateway_device,
-    id: gateway_id,
-    magmad: magmad_gateway_configs,
-    name: gateway_name,
-    status ? : gateway_status,
-    tier: tier_id,
+  apn_resources?: apn_resources,
+  cellular: gateway_cellular_configs,
+  connected_enodeb_serials: enodeb_serials,
+  description: gateway_description,
+  device: gateway_device,
+  id: gateway_id,
+  magmad: magmad_gateway_configs,
+  name: gateway_name,
+  status?: gateway_status,
+  tier: tier_id,
 };
 export type lte_network = {
-    cellular: network_cellular_configs,
-    description: network_description,
-    dns: network_dns_config,
-    features ? : network_features,
-    id: network_id,
-    name: network_name,
-    subscriber_config ? : network_subscriber_config,
+  cellular: network_cellular_configs,
+  description: network_description,
+  dns: network_dns_config,
+  features?: network_features,
+  id: network_id,
+  name: network_name,
+  subscriber_config?: network_subscriber_config,
 };
 export type lte_subscription = {
-    auth_algo: "MILENAGE",
-    auth_key: string,
-    auth_opc ? : string,
-    state: "INACTIVE" | "ACTIVE",
-    sub_profile: sub_profile,
+  auth_algo: 'MILENAGE',
+  auth_key: string,
+  auth_opc?: string,
+  state: 'INACTIVE' | 'ACTIVE',
+  sub_profile: sub_profile,
 };
 export type machine_info = {
-    cpu_info ? : {
-        architecture ? : string,
-        core_count ? : number,
-        model_name ? : string,
-        threads_per_core ? : number,
-    },
-    network_info ? : {
-        network_interfaces ? : Array < network_interface >
-            ,
-        routing_table ? : Array < route >
-            ,
-    },
+  cpu_info?: {
+    architecture?: string,
+    core_count?: number,
+    model_name?: string,
+    threads_per_core?: number,
+  },
+  network_info?: {
+    network_interfaces?: Array<network_interface>,
+    routing_table?: Array<route>,
+  },
 };
 export type magmad_gateway = {
-    description: gateway_description,
-    device: gateway_device,
-    id: gateway_id,
-    magmad: magmad_gateway_configs,
-    name: gateway_name,
-    status ? : gateway_status,
-    tier: tier_id,
+  description: gateway_description,
+  device: gateway_device,
+  id: gateway_id,
+  magmad: magmad_gateway_configs,
+  name: gateway_name,
+  status?: gateway_status,
+  tier: tier_id,
 };
 export type magmad_gateway_configs = {
-    autoupgrade_enabled: boolean,
-    autoupgrade_poll_interval: number,
-    checkin_interval: number,
-    checkin_timeout: number,
-    dynamic_services ? : Array < string >
-        ,
-    feature_flags ? : {
-        [string]: boolean,
-    },
-    logging ? : gateway_logging_configs,
-    vpn ? : gateway_vpn_configs,
+  autoupgrade_enabled: boolean,
+  autoupgrade_poll_interval: number,
+  checkin_interval: number,
+  checkin_timeout: number,
+  dynamic_services?: Array<string>,
+  feature_flags?: {
+    [string]: boolean,
+  },
+  logging?: gateway_logging_configs,
+  vpn?: gateway_vpn_configs,
 };
 export type matcher = {
-    isRegex: boolean,
-    name: string,
-    value: string,
+  isRegex: boolean,
+  name: string,
+  value: string,
 };
 export type mesh_id = string;
 export type mesh_name = string;
 export type mesh_wifi_configs = {
-    additional_props ? : {
-        [string]: string,
-    },
-    mesh_channel_type ? : string,
-    mesh_frequency ? : number,
-    mesh_ssid ? : string,
-    password ? : string,
-    ssid ? : string,
-    vl_ssid ? : string,
-    xwf_enabled ? : boolean,
+  additional_props?: {
+    [string]: string,
+  },
+  mesh_channel_type?: string,
+  mesh_frequency?: number,
+  mesh_ssid?: string,
+  password?: string,
+  ssid?: string,
+  vl_ssid?: string,
+  xwf_enabled?: boolean,
 };
-export type metric_datapoint = Array < string >
-;
-export type metric_datapoints = Array < metric_datapoint >
-;
+export type metric_datapoint = Array<string>;
+export type metric_datapoints = Array<metric_datapoint>;
 export type mode_map_item = {
-    apn ? : string,
-    imsi_range ? : string,
-    mode ? : "local_subscriber" | "s8_subscriber",
-    plmn ? : string,
+  apn?: string,
+  imsi_range?: string,
+  mode?: 'local_subscriber' | 's8_subscriber',
+  plmn?: string,
 };
 export type msisdn = string;
 export type msisdn_assignment = {
-    id: subscriber_id,
-    msisdn: msisdn,
+  id: subscriber_id,
+  msisdn: msisdn,
 };
 export type mutable_call_trace = {
-    requested_end: boolean,
+  requested_end: boolean,
 };
 export type mutable_cellular_gateway_pool = {
-    config: cellular_gateway_pool_configs,
-    gateway_pool_id: gateway_pool_id,
-    gateway_pool_name ? : string,
+  config: cellular_gateway_pool_configs,
+  gateway_pool_id: gateway_pool_id,
+  gateway_pool_name?: string,
 };
 export type mutable_ci_node = {
-    id: string,
-    tag ? : string,
-    vpn_ip: string,
+  id: string,
+  tag?: string,
+  vpn_ip: string,
 };
 export type mutable_cwf_gateway = {
-    carrier_wifi: gateway_cwf_configs,
-    description: gateway_description,
-    device: gateway_device,
-    id: gateway_id,
-    magmad: magmad_gateway_configs,
-    name: gateway_name,
-    tier: tier_id,
+  carrier_wifi: gateway_cwf_configs,
+  description: gateway_description,
+  device: gateway_device,
+  id: gateway_id,
+  magmad: magmad_gateway_configs,
+  name: gateway_name,
+  tier: tier_id,
 };
 export type mutable_cwf_ha_pair = {
-    config: cwf_ha_pair_configs,
-    gateway_id_1: string,
-    gateway_id_2: string,
-    ha_pair_id: string,
+  config: cwf_ha_pair_configs,
+  gateway_id_1: string,
+  gateway_id_2: string,
+  ha_pair_id: string,
 };
 export type mutable_enodebd_e2e_test = {
-    config: enodebd_test_config,
-    pk: number,
+  config: enodebd_test_config,
+  pk: number,
 };
 export type mutable_federation_gateway = {
-    description: gateway_description,
-    device: gateway_device,
-    federation ? : gateway_federation_configs,
-    id: gateway_id,
-    magmad: magmad_gateway_configs,
-    name: gateway_name,
-    tier: tier_id,
+  description: gateway_description,
+  device: gateway_device,
+  federation?: gateway_federation_configs,
+  id: gateway_id,
+  magmad: magmad_gateway_configs,
+  name: gateway_name,
+  tier: tier_id,
 };
 export type mutable_lte_gateway = {
-    apn_resources ? : apn_resources,
-    cellular: gateway_cellular_configs,
-    connected_enodeb_serials: enodeb_serials,
-    description: gateway_description,
-    device: gateway_device,
-    id: gateway_id,
-    magmad: magmad_gateway_configs,
-    name: gateway_name,
-    tier: tier_id,
+  apn_resources?: apn_resources,
+  cellular: gateway_cellular_configs,
+  connected_enodeb_serials: enodeb_serials,
+  description: gateway_description,
+  device: gateway_device,
+  id: gateway_id,
+  magmad: magmad_gateway_configs,
+  name: gateway_name,
+  tier: tier_id,
 };
 export type mutable_rating_group = {
-    limit_type: "FINITE" | "INFINITE_UNMETERED" | "INFINITE_METERED",
+  limit_type: 'FINITE' | 'INFINITE_UNMETERED' | 'INFINITE_METERED',
 };
 export type mutable_sms_message = {
-    imsi: subscriber_id,
-    message: string,
-    source_msisdn: string,
+  imsi: subscriber_id,
+  message: string,
+  source_msisdn: string,
 };
 export type mutable_subscriber = {
-    active_apns ? : apn_list,
-    active_base_names ? : base_names,
-    active_policies ? : policy_ids,
-    active_policies_by_apn ? : policy_ids_by_apn,
-    forbidden_network_types ? : core_network_types,
-    id: subscriber_id,
-    lte: lte_subscription,
-    name ? : string,
-    static_ips ? : subscriber_static_ips,
+  active_apns?: apn_list,
+  active_base_names?: base_names,
+  active_policies?: policy_ids,
+  active_policies_by_apn?: policy_ids_by_apn,
+  forbidden_network_types?: core_network_types,
+  id: subscriber_id,
+  lte: lte_subscription,
+  name?: string,
+  static_ips?: subscriber_static_ips,
 };
-export type mutable_subscribers = Array < mutable_subscriber >
-;
+export type mutable_subscribers = Array<mutable_subscriber>;
 export type mutable_wifi_gateway = {
-    description: gateway_description,
-    device: gateway_device,
-    id: gateway_id,
-    magmad: magmad_gateway_configs,
-    name: gateway_name,
-    tier: tier_id,
-    wifi: gateway_wifi_configs,
+  description: gateway_description,
+  device: gateway_device,
+  id: gateway_id,
+  magmad: magmad_gateway_configs,
+  name: gateway_name,
+  tier: tier_id,
+  wifi: gateway_wifi_configs,
 };
 export type network = {
-    description: network_description,
-    dns: network_dns_config,
-    features ? : network_features,
-    id: network_id,
-    name: network_name,
-    sentry_config ? : network_sentry_config,
-    state_config ? : state_config,
-    type ? : network_type,
+  description: network_description,
+  dns: network_dns_config,
+  features?: network_features,
+  id: network_id,
+  name: network_name,
+  sentry_config?: network_sentry_config,
+  state_config?: state_config,
+  type?: network_type,
 };
 export type network_carrier_wifi_configs = {
-    aaa_server: aaa_server,
-    default_rule_id: string,
-    eap_aka: eap_aka,
-    eap_sim ? : eap_sim,
-    is_xwfm_variant ? : boolean,
-    li_ues ? : li_ues,
-    network_services: Array < "dpi" | "policy_enforcement" >
-        ,
+  aaa_server: aaa_server,
+  default_rule_id: string,
+  eap_aka: eap_aka,
+  eap_sim?: eap_sim,
+  is_xwfm_variant?: boolean,
+  li_ues?: li_ues,
+  network_services: Array<'dpi' | 'policy_enforcement'>,
 };
 export type network_cellular_configs = {
-    epc: network_epc_configs,
-    feg_network_id ? : feg_network_id,
-    ran: network_ran_configs,
+  epc: network_epc_configs,
+  feg_network_id?: feg_network_id,
+  ran: network_ran_configs,
 };
 export type network_description = string;
 export type network_dns_config = {
-    dhcp_server_enabled ? : boolean,
-    enable_caching: boolean,
-    local_ttl: number,
-    records ? : network_dns_records,
+  dhcp_server_enabled?: boolean,
+  enable_caching: boolean,
+  local_ttl: number,
+  records?: network_dns_records,
 };
-export type network_dns_records = Array < dns_config_record >
-;
+export type network_dns_records = Array<dns_config_record>;
 export type network_epc_configs = {
-    cloud_subscriberdb_enabled ? : boolean,
-    congestion_control_enabled ? : boolean,
-    default_rule_id ? : string,
-    enable5g_features ? : boolean,
-    gx_gy_relay_enabled: boolean,
-    hss_relay_enabled: boolean,
-    lte_auth_amf: string,
-    lte_auth_op: string,
-    mcc: string,
-    mnc: string,
-    mobility ? : {
-        enable_multi_apn_ip_allocation ? : boolean,
-        enable_static_ip_assignments ? : boolean,
-        ip_allocation_mode: "NAT" | "STATIC" | "DHCP_PASSTHROUGH" | "DHCP_BROADCAST",
-        nat ? : {
-            ip_blocks ? : Array < string >
-                ,
-        },
-        reserved_addresses ? : Array < string >
-            ,
-        static ? : {
-            ip_blocks_by_tac ? : {
-                [string]: Array < string >
-                    ,
-            },
-        },
+  cloud_subscriberdb_enabled?: boolean,
+  congestion_control_enabled?: boolean,
+  default_rule_id?: string,
+  enable5g_features?: boolean,
+  gx_gy_relay_enabled: boolean,
+  hss_relay_enabled: boolean,
+  lte_auth_amf: string,
+  lte_auth_op: string,
+  mcc: string,
+  mnc: string,
+  mobility?: {
+    enable_multi_apn_ip_allocation?: boolean,
+    enable_static_ip_assignments?: boolean,
+    ip_allocation_mode:
+      | 'NAT'
+      | 'STATIC'
+      | 'DHCP_PASSTHROUGH'
+      | 'DHCP_BROADCAST',
+    nat?: {
+      ip_blocks?: Array<string>,
     },
-    network_services ? : Array < "dpi" | "policy_enforcement" >
-        ,
-    node_identifier ? : string,
-    restricted_imeis ? : Array < imei >
-        ,
-    restricted_plmns ? : Array < plmn_config >
-        ,
-    service_area_maps ? : {
-        [string]: tac_list,
+    reserved_addresses?: Array<string>,
+    static?: {
+      ip_blocks_by_tac?: {
+        [string]: Array<string>,
+      },
     },
-    sub_profiles ? : {
-        [string]: {
-            max_dl_bit_rate: number,
-            max_ul_bit_rate: number,
-        },
+  },
+  network_services?: Array<'dpi' | 'policy_enforcement'>,
+  node_identifier?: string,
+  restricted_imeis?: Array<imei>,
+  restricted_plmns?: Array<plmn_config>,
+  service_area_maps?: {
+    [string]: tac_list,
+  },
+  sub_profiles?: {
+    [string]: {
+      max_dl_bit_rate: number,
+      max_ul_bit_rate: number,
     },
-    subscriberdb_sync_interval ? : subscriberdb_sync_interval,
-    tac: number,
+  },
+  subscriberdb_sync_interval?: subscriberdb_sync_interval,
+  tac: number,
 };
 export type network_features = {
-    features ? : {
-        [string]: string,
-    },
+  features?: {
+    [string]: string,
+  },
 };
 export type network_federation_configs = {
-    aaa_server: aaa_server,
-    csfb ? : csfb,
-    eap_aka: eap_aka,
-    eap_sim ? : eap_sim,
-    gx: gx,
-    gy: gy,
-    health: health,
-    hss: hss,
-    nh_routes ? : nh_routes,
-    s6a: s6a,
-    s8 ? : s8,
-    served_network_ids: served_network_ids,
-    served_nh_ids ? : served_nh_ids,
-    swx: swx,
+  aaa_server: aaa_server,
+  csfb?: csfb,
+  eap_aka: eap_aka,
+  eap_sim?: eap_sim,
+  gx: gx,
+  gy: gy,
+  health: health,
+  hss: hss,
+  nh_routes?: nh_routes,
+  s6a: s6a,
+  s8?: s8,
+  served_network_ids: served_network_ids,
+  served_nh_ids?: served_nh_ids,
+  swx: swx,
 };
 export type network_id = string;
 export type network_interface = {
-    ip_addresses ? : Array < string >
-        ,
-    ipv6_addresses ? : Array < string >
-        ,
-    mac_address ? : string,
-    network_interface_id ? : string,
-    status ? : "UP" | "DOWN" | "UNKNOWN",
+  ip_addresses?: Array<string>,
+  ipv6_addresses?: Array<string>,
+  mac_address?: string,
+  network_interface_id?: string,
+  status?: 'UP' | 'DOWN' | 'UNKNOWN',
 };
 export type network_name = string;
 export type network_probe_data = {
-    last_exported: string,
-    sequence_number: number,
-    target_id: string,
+  last_exported: string,
+  sequence_number: number,
+  target_id: string,
 };
 export type network_probe_destination = {
-    destination_details: network_probe_destination_details,
-    destination_id: network_probe_destination_id,
+  destination_details: network_probe_destination_details,
+  destination_id: network_probe_destination_id,
 };
 export type network_probe_destination_details = {
-    certificate: string,
-    delivery_address: string,
-    delivery_type: "all" | "events_only",
-    private_key: string,
-    skip_verify_server: boolean,
+  certificate: string,
+  delivery_address: string,
+  delivery_type: 'all' | 'events_only',
+  private_key: string,
+  skip_verify_server: boolean,
 };
 export type network_probe_destination_id = string;
 export type network_probe_task = {
-    task_details: network_probe_task_details,
-    task_id: network_probe_task_id,
+  task_details: network_probe_task_details,
+  task_id: network_probe_task_id,
 };
 export type network_probe_task_details = {
-    correlation_id ? : number,
-    delivery_type: "all" | "events_only",
-    domain_id ? : string,
-    duration ? : number,
-    operator_id ? : number,
-    target_id: string,
-    target_type: "imsi" | "imei" | "msisdn",
-    timestamp ? : string,
+  correlation_id?: number,
+  delivery_type: 'all' | 'events_only',
+  domain_id?: string,
+  duration?: number,
+  operator_id?: number,
+  target_id: string,
+  target_type: 'imsi' | 'imei' | 'msisdn',
+  timestamp?: string,
 };
 export type network_probe_task_id = string;
 export type network_ran_configs = {
-    bandwidth_mhz: 3 | 5 | 10 | 15 | 20,
-    fdd_config ? : {
-        earfcndl: number,
-        earfcnul: number,
-    },
-    tdd_config ? : {
-        earfcndl: number,
-        special_subframe_pattern: number,
-        subframe_assignment: number,
-    },
+  bandwidth_mhz: 3 | 5 | 10 | 15 | 20,
+  fdd_config?: {
+    earfcndl: number,
+    earfcnul: number,
+  },
+  tdd_config?: {
+    earfcndl: number,
+    special_subframe_pattern: number,
+    subframe_assignment: number,
+  },
 };
 export type network_sentry_config = {
-    sample_rate ? : number,
-    upload_mme_log ? : boolean,
-    url_native ? : string,
-    url_python ? : string,
+  sample_rate?: number,
+  upload_mme_log?: boolean,
+  url_native?: string,
+  url_python?: string,
 };
 export type network_subscriber_config = {
-    network_wide_base_names ? : base_names,
-    network_wide_rule_names ? : rule_names,
+  network_wide_base_names?: base_names,
+  network_wide_rule_names?: rule_names,
 };
 export type network_type = string;
 export type network_wifi_configs = {
-    additional_props ? : {
-        [string]: string,
-    },
-    mgmt_vpn_enabled ? : boolean,
-    mgmt_vpn_proto ? : string,
-    mgmt_vpn_remote ? : string,
-    openr_enabled ? : boolean,
-    ping_host_list ? : Array < string >
-        ,
-    ping_num_packets ? : number,
-    ping_timeout_secs ? : number,
-    vl_auth_server_addr ? : string,
-    vl_auth_server_port ? : number,
-    vl_auth_server_shared_secret ? : string,
-    xwf_config ? : string,
-    xwf_dhcp_dns1 ? : string,
-    xwf_dhcp_dns2 ? : string,
-    xwf_partner_name ? : string,
-    xwf_radius_acct_port ? : number,
-    xwf_radius_auth_port ? : number,
-    xwf_radius_server ? : string,
-    xwf_radius_shared_secret ? : string,
-    xwf_uam_secret ? : string,
+  additional_props?: {
+    [string]: string,
+  },
+  mgmt_vpn_enabled?: boolean,
+  mgmt_vpn_proto?: string,
+  mgmt_vpn_remote?: string,
+  openr_enabled?: boolean,
+  ping_host_list?: Array<string>,
+  ping_num_packets?: number,
+  ping_timeout_secs?: number,
+  vl_auth_server_addr?: string,
+  vl_auth_server_port?: number,
+  vl_auth_server_shared_secret?: string,
+  xwf_config?: string,
+  xwf_dhcp_dns1?: string,
+  xwf_dhcp_dns2?: string,
+  xwf_partner_name?: string,
+  xwf_radius_acct_port?: number,
+  xwf_radius_auth_port?: number,
+  xwf_radius_server?: string,
+  xwf_radius_shared_secret?: string,
+  xwf_uam_secret?: string,
 };
 export type nh_routes = {
-    [string]: string,
+  [string]: string,
 };
 export type node_lease = {
-    id: string,
-    lease_id: string,
-    vpn_ip: string,
+  id: string,
+  lease_id: string,
+  vpn_ip: string,
 };
 export type package_type = {
-    name ? : string,
-    version ? : string,
+  name?: string,
+  version?: string,
 };
 export type page_token = string;
 export type paginated_enodebs = {
-    enodebs: {
-        [string]: enodeb,
-    },
-    page_token: page_token,
-    total_count: number,
+  enodebs: {
+    [string]: enodeb,
+  },
+  page_token: page_token,
+  total_count: number,
 };
 export type paginated_gateways = {
-    gateways: {
-        [string]: magmad_gateway,
-    },
-    page_token: page_token,
-    total_count: number,
+  gateways: {
+    [string]: magmad_gateway,
+  },
+  page_token: page_token,
+  total_count: number,
 };
 export type paginated_subscribers = {
-    next_page_token: page_token,
-    subscribers: {
-        [string]: subscriber,
-    },
-    total_count: number,
+  next_page_token: page_token,
+  subscribers: {
+    [string]: subscriber,
+  },
+  total_count: number,
 };
 export type ping_request = {
-    hosts: Array < string >
-        ,
-    packets ? : number,
+  hosts: Array<string>,
+  packets?: number,
 };
 export type ping_response = {
-    pings: Array < ping_result >
-        ,
+  pings: Array<ping_result>,
 };
 export type ping_result = {
-    avg_response_ms ? : number,
-    error ? : string,
-    host_or_ip: string,
-    num_packets: number,
-    packets_received ? : number,
-    packets_transmitted ? : number,
+  avg_response_ms?: number,
+  error?: string,
+  host_or_ip: string,
+  num_packets: number,
+  packets_received?: number,
+  packets_transmitted?: number,
 };
 export type platform_info = {
-    config_info ? : config_info,
-    kernel_version ? : string,
-    kernel_versions_installed ? : Array < string >
-        ,
-    packages ? : Array < package_type >
-        ,
-    vpn_ip ? : string,
+  config_info?: config_info,
+  kernel_version?: string,
+  kernel_versions_installed?: Array<string>,
+  packages?: Array<package_type>,
+  vpn_ip?: string,
 };
 export type plmn_config = {
-    mcc: string,
-    mnc: string,
+  mcc: string,
+  mnc: string,
 };
 export type policy_id = string;
-export type policy_ids = Array < policy_id >
-;
+export type policy_ids = Array<policy_id>;
 export type policy_ids_by_apn = {
-    [string]: policy_ids,
+  [string]: policy_ids,
 };
 export type policy_qos_profile = {
-    arp ? : arp,
-    class_id: qos_class_id,
-    gbr ? : gbr,
-    id: string,
-    max_req_bw_dl: number,
-    max_req_bw_ul: number,
+  arp?: arp,
+  class_id: qos_class_id,
+  gbr?: gbr,
+  id: string,
+  max_req_bw_dl: number,
+  max_req_bw_ul: number,
 };
 export type policy_rule = {
-    app_name ? : "NO_APP_NAME" | "FACEBOOK" | "FACEBOOK_MESSENGER" | "INSTAGRAM" | "YOUTUBE" | "GOOGLE" | "GMAIL" | "GOOGLE_DOCS" | "NETFLIX" | "APPLE" | "MICROSOFT" | "REDDIT" | "WHATSAPP" | "GOOGLE_PLAY" | "APPSTORE" | "AMAZON" | "WECHAT" | "TIKTOK" | "TWITTER" | "WIKIPEDIA" | "GOOGLE_MAPS" | "YAHOO" | "IMO",
-    app_service_type ? : "NO_SERVICE_TYPE" | "CHAT" | "AUDIO" | "VIDEO",
-    assigned_subscribers ? : Array < subscriber_id >
-        ,
-    flow_list: Array < flow_description >
-        ,
-    header_enrichment_targets ? : Array < string >
-        ,
-    id: policy_id,
-    monitoring_key ? : string,
-    priority: number,
-    qos_profile ? : string,
-    rating_group ? : number,
-    redirect ? : redirect_information,
-    service_identifier ? : number,
-    tracking_type ? : "ONLY_OCS" | "ONLY_PCRF" | "OCS_AND_PCRF" | "NO_TRACKING",
+  app_name?:
+    | 'NO_APP_NAME'
+    | 'FACEBOOK'
+    | 'FACEBOOK_MESSENGER'
+    | 'INSTAGRAM'
+    | 'YOUTUBE'
+    | 'GOOGLE'
+    | 'GMAIL'
+    | 'GOOGLE_DOCS'
+    | 'NETFLIX'
+    | 'APPLE'
+    | 'MICROSOFT'
+    | 'REDDIT'
+    | 'WHATSAPP'
+    | 'GOOGLE_PLAY'
+    | 'APPSTORE'
+    | 'AMAZON'
+    | 'WECHAT'
+    | 'TIKTOK'
+    | 'TWITTER'
+    | 'WIKIPEDIA'
+    | 'GOOGLE_MAPS'
+    | 'YAHOO'
+    | 'IMO',
+  app_service_type?: 'NO_SERVICE_TYPE' | 'CHAT' | 'AUDIO' | 'VIDEO',
+  assigned_subscribers?: Array<subscriber_id>,
+  flow_list: Array<flow_description>,
+  header_enrichment_targets?: Array<string>,
+  id: policy_id,
+  monitoring_key?: string,
+  priority: number,
+  qos_profile?: string,
+  rating_group?: number,
+  redirect?: redirect_information,
+  service_identifier?: number,
+  tracking_type?: 'ONLY_OCS' | 'ONLY_PCRF' | 'OCS_AND_PCRF' | 'NO_TRACKING',
 };
 export type policy_rule_config = {
-    app_name ? : "NO_APP_NAME" | "FACEBOOK" | "FACEBOOK_MESSENGER" | "INSTAGRAM" | "YOUTUBE" | "GOOGLE" | "GMAIL" | "GOOGLE_DOCS" | "NETFLIX" | "APPLE" | "MICROSOFT" | "REDDIT" | "WHATSAPP" | "GOOGLE_PLAY" | "APPSTORE" | "AMAZON" | "WECHAT" | "TIKTOK" | "TWITTER" | "WIKIPEDIA" | "GOOGLE_MAPS" | "YAHOO" | "IMO",
-    app_service_type ? : "NO_SERVICE_TYPE" | "CHAT" | "AUDIO" | "VIDEO",
-    flow_list: Array < flow_description >
-        ,
-    header_enrichment_targets ? : Array < string >
-        ,
-    monitoring_key ? : string,
-    priority: number,
-    rating_group ? : number,
-    redirect ? : redirect_information,
-    service_identifier ? : number,
-    tracking_type ? : "ONLY_OCS" | "ONLY_PCRF" | "OCS_AND_PCRF" | "NO_TRACKING",
+  app_name?:
+    | 'NO_APP_NAME'
+    | 'FACEBOOK'
+    | 'FACEBOOK_MESSENGER'
+    | 'INSTAGRAM'
+    | 'YOUTUBE'
+    | 'GOOGLE'
+    | 'GMAIL'
+    | 'GOOGLE_DOCS'
+    | 'NETFLIX'
+    | 'APPLE'
+    | 'MICROSOFT'
+    | 'REDDIT'
+    | 'WHATSAPP'
+    | 'GOOGLE_PLAY'
+    | 'APPSTORE'
+    | 'AMAZON'
+    | 'WECHAT'
+    | 'TIKTOK'
+    | 'TWITTER'
+    | 'WIKIPEDIA'
+    | 'GOOGLE_MAPS'
+    | 'YAHOO'
+    | 'IMO',
+  app_service_type?: 'NO_SERVICE_TYPE' | 'CHAT' | 'AUDIO' | 'VIDEO',
+  flow_list: Array<flow_description>,
+  header_enrichment_targets?: Array<string>,
+  monitoring_key?: string,
+  priority: number,
+  rating_group?: number,
+  redirect?: redirect_information,
+  service_identifier?: number,
+  tracking_type?: 'ONLY_OCS' | 'ONLY_PCRF' | 'OCS_AND_PCRF' | 'NO_TRACKING',
 };
 export type prom_alert_config = {
-    alert: string,
-    annotations ? : prom_alert_labels,
-    expr: string,
-    for ? : string,
-    labels ? : prom_alert_labels,
+  alert: string,
+  annotations?: prom_alert_labels,
+  expr: string,
+  for?: string,
+  labels?: prom_alert_labels,
 };
-export type prom_alert_config_list = Array < prom_alert_config >
-;
+export type prom_alert_config_list = Array<prom_alert_config>;
 export type prom_alert_labels = {
-    [string]: string,
+  [string]: string,
 };
 export type prom_alert_status = {
-    inhibitedBy: Array < string >
-        ,
-    silencedBy: Array < string >
-        ,
-    state: string,
+  inhibitedBy: Array<string>,
+  silencedBy: Array<string>,
+  state: string,
 };
 export type prom_firing_alert = {
-    annotations: prom_alert_labels,
-    endsAt: string,
-    fingerprint: string,
-    generatorURL ? : string,
-    labels: prom_alert_labels,
-    receivers: gettable_alert,
-    startsAt: string,
-    status: prom_alert_status,
-    updatedAt: string,
+  annotations: prom_alert_labels,
+  endsAt: string,
+  fingerprint: string,
+  generatorURL?: string,
+  labels: prom_alert_labels,
+  receivers: gettable_alert,
+  startsAt: string,
+  status: prom_alert_status,
+  updatedAt: string,
 };
 export type prometheus_labelset = {
-    [string]: string,
+  [string]: string,
 };
 export type prometheus_target_metadata = {
-    instance: string,
-    job: string,
+  instance: string,
+  job: string,
 };
 export type prometheus_targets_metadata = {
-    help: string,
-    metric: string,
-    target: prometheus_target_metadata,
-    type: string,
-    unit: string,
+  help: string,
+  metric: string,
+  target: prometheus_target_metadata,
+  type: string,
+  unit: string,
 };
 export type promql_data = {
-    result: promql_result,
-    resultType: string,
+  result: promql_result,
+  resultType: string,
 };
 export type promql_metric = {
-    additionalProperties ? : string,
+  additionalProperties?: string,
 };
 export type promql_metric_value = {
-    metric: promql_metric,
-    value ? : metric_datapoint,
-    values ? : metric_datapoints,
+  metric: promql_metric,
+  value?: metric_datapoint,
+  values?: metric_datapoints,
 };
-export type promql_result = Array < promql_metric_value >
-;
+export type promql_result = Array<promql_metric_value>;
 export type promql_return_object = {
-    data: promql_data,
-    status: string,
+  data: promql_data,
+  status: string,
 };
 export type pushed_metric = {
-    labels ? : Array < label_pair >
-        ,
-    metricName: string,
-    timestamp ? : string,
-    value: number,
+  labels?: Array<label_pair>,
+  metricName: string,
+  timestamp?: string,
+  value: number,
 };
-export type qos_class_id = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 65 | 66 | 67 | 70 | 75 | 79;
+export type qos_class_id =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 65
+  | 66
+  | 67
+  | 70
+  | 75
+  | 79;
 export type qos_profile = {
-    class_id ? : number,
-    preemption_capability ? : boolean,
-    preemption_vulnerability ? : boolean,
-    priority_level ? : number,
+  class_id?: number,
+  preemption_capability?: boolean,
+  preemption_vulnerability?: boolean,
+  priority_level?: number,
 };
 export type radius_config = {
-    DAE_addr ? : string,
-    acct_addr ? : string,
-    auth_addr ? : string,
-    network ? : string,
-    secret ? : string,
+  DAE_addr?: string,
+  acct_addr?: string,
+  auth_addr?: string,
+  network?: string,
+  secret?: string,
 };
 export type rating_group = {
-    id: rating_group_id,
-    limit_type: "FINITE" | "INFINITE_UNMETERED" | "INFINITE_METERED",
+  id: rating_group_id,
+  limit_type: 'FINITE' | 'INFINITE_UNMETERED' | 'INFINITE_METERED',
 };
 export type rating_group_id = number;
 export type redirect_information = {
-    address_type: "IPv4" | "IPv6" | "URL" | "SIP_URI",
-    server_address: string,
-    support: "DISABLED" | "ENABLED",
+  address_type: 'IPv4' | 'IPv6' | 'URL' | 'SIP_URI',
+  server_address: string,
+  support: 'DISABLED' | 'ENABLED',
 };
 export type release_channel = {
-    id: channel_id,
-    name ? : string,
-    supported_versions: Array < string >
-        ,
+  id: channel_id,
+  name?: string,
+  supported_versions: Array<string>,
 };
 export type route = {
-    destination_ip ? : string,
-    gateway_ip ? : string,
-    genmask ? : string,
-    network_interface_id ? : string,
+  destination_ip?: string,
+  gateway_ip?: string,
+  genmask?: string,
+  network_interface_id?: string,
 };
 export type rule_id = string;
-export type rule_names = Array < string >
-;
+export type rule_names = Array<string>;
 export type s6a = {
-    plmn_ids ? : Array < string >
-        ,
-    server ? : diameter_client_configs,
+  plmn_ids?: Array<string>,
+  server?: diameter_client_configs,
 };
 export type s8 = {
-    apn_operator_suffix ? : string,
-    local_address ? : string,
-    pgw_address ? : string,
+  apn_operator_suffix?: string,
+  local_address?: string,
+  pgw_address?: string,
 };
 export type sctp_client_configs = {
-    local_address ? : string,
-    server_address ? : string,
+  local_address?: string,
+  server_address?: string,
 };
-export type served_network_ids = Array < string >
-;
-export type served_nh_ids = Array < string >
-;
+export type served_network_ids = Array<string>;
+export type served_nh_ids = Array<string>;
 export type service_status_health = {
-    health_status ? : "HEALTHY" | "UNHEALTHY",
-    service_state ? : "AVAILABLE" | "UNAVAILABLE",
+  health_status?: 'HEALTHY' | 'UNHEALTHY',
+  service_state?: 'AVAILABLE' | 'UNAVAILABLE',
 };
 export type slack_action = {
-    confirm ? : slack_confirm_field,
-    name ? : string,
-    style ? : string,
-    text: string,
-    type: string,
-    url: string,
-    value ? : string,
+  confirm?: slack_confirm_field,
+  name?: string,
+  style?: string,
+  text: string,
+  type: string,
+  url: string,
+  value?: string,
 };
 export type slack_confirm_field = {
-    dismiss_text: string,
-    ok_text: string,
-    text: string,
-    title: string,
+  dismiss_text: string,
+  ok_text: string,
+  text: string,
+  title: string,
 };
 export type slack_field = {
-    short ? : boolean,
-    title: string,
-    value: string,
+  short?: boolean,
+  title: string,
+  value: string,
 };
 export type slack_receiver = {
-    actions ? : Array < slack_action >
-        ,
-    api_url: string,
-    callback_id ? : string,
-    channel ? : string,
-    color ? : string,
-    fallback ? : string,
-    fields ? : Array < slack_field >
-        ,
-    footer ? : string,
-    icon_emoji ? : string,
-    icon_url ? : string,
-    image_url ? : string,
-    link_names ? : boolean,
-    pretext ? : string,
-    short_fields ? : boolean,
-    text ? : string,
-    thumb_url ? : string,
-    title ? : string,
-    username ? : string,
+  actions?: Array<slack_action>,
+  api_url: string,
+  callback_id?: string,
+  channel?: string,
+  color?: string,
+  fallback?: string,
+  fields?: Array<slack_field>,
+  footer?: string,
+  icon_emoji?: string,
+  icon_url?: string,
+  image_url?: string,
+  link_names?: boolean,
+  pretext?: string,
+  short_fields?: boolean,
+  text?: string,
+  thumb_url?: string,
+  title?: string,
+  username?: string,
 };
 export type sms_message = {
-    attempt_count: number,
-    error_status ? : string,
-    imsi: subscriber_id,
-    message: string,
-    pk: string,
-    source_msisdn: string,
-    status: "Waiting" | "Delivered" | "Failed",
-    time_created: string,
-    time_last_attempted ? : string,
+  attempt_count: number,
+  error_status?: string,
+  imsi: subscriber_id,
+  message: string,
+  pk: string,
+  source_msisdn: string,
+  status: 'Waiting' | 'Delivered' | 'Failed',
+  time_created: string,
+  time_last_attempted?: string,
 };
 export type state_config = {
-    sync_interval ? : number,
+  sync_interval?: number,
 };
 export type sub_profile = string;
 export type subscriber = {
-    active_apns ? : apn_list,
-    active_base_names ? : base_names,
-    active_policies ? : policy_ids,
-    active_policies_by_apn ? : policy_ids_by_apn,
-    config: subscriber_config,
-    forbidden_network_types ? : core_network_types,
-    id: subscriber_id,
-    lte: lte_subscription,
-    monitoring ? : subscriber_status,
-    msisdn ? : msisdn,
-    name ? : string,
-    state ? : subscriber_state,
+  active_apns?: apn_list,
+  active_base_names?: base_names,
+  active_policies?: policy_ids,
+  active_policies_by_apn?: policy_ids_by_apn,
+  config: subscriber_config,
+  forbidden_network_types?: core_network_types,
+  id: subscriber_id,
+  lte: lte_subscription,
+  monitoring?: subscriber_status,
+  msisdn?: msisdn,
+  name?: string,
+  state?: subscriber_state,
 };
 export type subscriber_config = {
-    forbidden_network_types ? : core_network_types,
-    lte: lte_subscription,
-    static_ips ? : subscriber_static_ips,
+  forbidden_network_types?: core_network_types,
+  lte: lte_subscription,
+  static_ips?: subscriber_static_ips,
 };
 export type subscriber_directory_record = {
-    location_history: Array < string >
-        ,
+  location_history: Array<string>,
 };
 export type subscriber_id = string;
 export type subscriber_ip_allocation = {
-    apn: string,
-    ip: string,
+  apn: string,
+  ip: string,
 };
 export type subscriber_state = {
-    directory ? : subscriber_directory_record,
-    mme ? : untyped_mme_state,
-    mobility ? : Array < subscriber_ip_allocation >
-        ,
-    s1ap ? : untyped_mme_state,
-    spgw ? : untyped_mme_state,
-    subscriber_state ? : untyped_subscriber_state,
+  directory?: subscriber_directory_record,
+  mme?: untyped_mme_state,
+  mobility?: Array<subscriber_ip_allocation>,
+  s1ap?: untyped_mme_state,
+  spgw?: untyped_mme_state,
+  subscriber_state?: untyped_subscriber_state,
 };
 export type subscriber_static_ips = {
-    [string]: string,
+  [string]: string,
 };
 export type subscriber_status = {
-    icmp ? : icmp_status,
+  icmp?: icmp_status,
 };
 export type subscriberdb_sync_interval = number;
 export type subscription_profile = {
-    max_dl_bit_rate ? : number,
-    max_ul_bit_rate ? : number,
+  max_dl_bit_rate?: number,
+  max_ul_bit_rate?: number,
 };
 export type swx = {
-    cache_TTL_seconds ? : number,
-    derive_unregister_realm ? : boolean,
-    hlr_plmn_ids ? : Array < string >
-        ,
-    register_on_auth ? : boolean,
-    server ? : diameter_client_configs,
-    servers ? : Array < diameter_client_configs >
-        ,
-    verify_authorization ? : boolean,
+  cache_TTL_seconds?: number,
+  derive_unregister_realm?: boolean,
+  hlr_plmn_ids?: Array<string>,
+  register_on_auth?: boolean,
+  server?: diameter_client_configs,
+  servers?: Array<diameter_client_configs>,
+  verify_authorization?: boolean,
 };
 export type system_status = {
-    cpu_idle ? : number,
-    cpu_system ? : number,
-    cpu_user ? : number,
-    disk_partitions ? : Array < disk_partition >
-        ,
-    mem_available ? : number,
-    mem_free ? : number,
-    mem_total ? : number,
-    mem_used ? : number,
-    swap_free ? : number,
-    swap_total ? : number,
-    swap_used ? : number,
-    time ? : number,
-    uptime_secs ? : number,
+  cpu_idle?: number,
+  cpu_system?: number,
+  cpu_user?: number,
+  disk_partitions?: Array<disk_partition>,
+  mem_available?: number,
+  mem_free?: number,
+  mem_total?: number,
+  mem_used?: number,
+  swap_free?: number,
+  swap_total?: number,
+  swap_used?: number,
+  time?: number,
+  uptime_secs?: number,
 };
 export type tac = number;
-export type tac_list = Array < tac >
-;
+export type tac_list = Array<tac>;
 export type tail_logs_request = {
-    service ? : string,
+  service?: string,
 };
 export type tenant = {
-    id: number,
-    name ? : string,
-    networks: Array < string >
-        ,
+  id: number,
+  name?: string,
+  networks: Array<string>,
 };
 export type tier = {
-    gateways: tier_gateways,
-    id: tier_id,
-    images: tier_images,
-    name ? : tier_name,
-    version: tier_version,
+  gateways: tier_gateways,
+  id: tier_id,
+  images: tier_images,
+  name?: tier_name,
+  version: tier_version,
 };
-export type tier_gateways = Array < gateway_id >
-;
+export type tier_gateways = Array<gateway_id>;
 export type tier_id = string;
 export type tier_image = {
-    name: string,
-    order: number,
+  name: string,
+  order: number,
 };
-export type tier_images = Array < tier_image >
-;
+export type tier_images = Array<tier_image>;
 export type tier_name = string;
 export type tier_version = string;
 export type unmanaged_enodeb_configuration = {
-    cell_id: number,
-    ip_address: string,
-    tac: number,
+  cell_id: number,
+  ip_address: string,
+  tac: number,
 };
 export type untyped_mme_state = {};
 export type untyped_subscriber_state = {};
 export type version_info = {
-    container_image_version ? : string,
-    helm_chart_version ? : string,
+  container_image_version?: string,
+  helm_chart_version?: string,
 };
 export type virtual_apn_rule = {
-    apn_filter ? : string,
-    apn_overwrite ? : string,
-    charging_characteristics_filter ? : string,
+  apn_filter?: string,
+  apn_overwrite?: string,
+  charging_characteristics_filter?: string,
 };
 export type webhook_receiver = {
-    http_config ? : http_config,
-    send_resolved ? : boolean,
-    url: string,
+  http_config?: http_config,
+  send_resolved?: boolean,
+  url: string,
 };
 export type wifi_gateway = {
-    description: gateway_description,
-    device: gateway_device,
-    id: gateway_id,
-    magmad: magmad_gateway_configs,
-    name: gateway_name,
-    status ? : gateway_status,
-    tier: tier_id,
-    wifi: gateway_wifi_configs,
+  description: gateway_description,
+  device: gateway_device,
+  id: gateway_id,
+  magmad: magmad_gateway_configs,
+  name: gateway_name,
+  status?: gateway_status,
+  tier: tier_id,
+  wifi: gateway_wifi_configs,
 };
 export type wifi_mesh = {
-    config: mesh_wifi_configs,
-    gateway_ids: Array < gateway_id >
-        ,
-    id: mesh_id,
-    name: mesh_name,
+  config: mesh_wifi_configs,
+  gateway_ids: Array<gateway_id>,
+  id: mesh_id,
+  name: mesh_name,
 };
 export type wifi_network = {
-    description: network_description,
-    features ? : network_features,
-    id: network_id,
-    name: network_name,
-    wifi: network_wifi_configs,
+  description: network_description,
+  features?: network_features,
+  id: network_id,
+  name: network_name,
+  wifi: network_wifi_configs,
 };
 
 export default class MagmaAPIBindings {
-    static request(
-        path: string,
-        method: 'POST' | 'GET' | 'PUT' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH',
-        query: {
-            [string]: mixed
-        },
-        body ? : {
-            [string]: any
-        } | string | Array < any > ,
-    ) {
-        throw new Error("Must be implemented");
-    }
-    static async getAboutVersion(): Promise < version_info >
-        {
-            let path = '/about/version';
-            let body;
-            let query = {};
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getChannels(): Promise < Array < channel_id >
-        >
-        {
-            let path = '/channels';
-            let body;
-            let query = {};
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postChannels(
-        parameters: {
-            'channel': release_channel,
-        }
-    ): Promise < "Success" > {
-        let path = '/channels';
-        let body;
-        let query = {};
-        if (parameters['channel'] === undefined) {
-            throw new Error('Missing required  parameter: channel');
-        }
+  static request(
+    path: string,
+    method: 'POST' | 'GET' | 'PUT' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH',
+    query: {
+      [string]: mixed,
+    },
+    body?:
+      | {
+          [string]: any,
+        }
+      | string
+      | Array<any>,
+  ) {
+    throw new Error('Must be implemented');
+  }
+  static async getAboutVersion(): Promise<version_info> {
+    const path = '/about/version';
+    let body;
+    const query = {};
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getChannels(): Promise<Array<channel_id>> {
+    const path = '/channels';
+    let body;
+    const query = {};
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postChannels(parameters: {
+    channel: release_channel,
+  }): Promise<'Success'> {
+    const path = '/channels';
+    let body;
+    const query = {};
+    if (parameters['channel'] === undefined) {
+      throw new Error('Missing required  parameter: channel');
+    }
+
+    if (parameters['channel'] !== undefined) {
+      body = parameters['channel'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteChannelsByChannelId(parameters: {
+    channelId: string,
+  }): Promise<'Success'> {
+    let path = '/channels/{channel_id}';
+    let body;
+    const query = {};
+    if (parameters['channelId'] === undefined) {
+      throw new Error('Missing required  parameter: channelId');
+    }
+
+    path = path.replace('{channel_id}', `${parameters['channelId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getChannelsByChannelId(parameters: {
+    channelId: string,
+  }): Promise<release_channel> {
+    let path = '/channels/{channel_id}';
+    let body;
+    const query = {};
+    if (parameters['channelId'] === undefined) {
+      throw new Error('Missing required  parameter: channelId');
+    }
+
+    path = path.replace('{channel_id}', `${parameters['channelId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putChannelsByChannelId(parameters: {
+    channelId: string,
+    releaseChannel: release_channel,
+  }): Promise<'Success'> {
+    let path = '/channels/{channel_id}';
+    let body;
+    const query = {};
+    if (parameters['channelId'] === undefined) {
+      throw new Error('Missing required  parameter: channelId');
+    }
+
+    path = path.replace('{channel_id}', `${parameters['channelId']}`);
+
+    if (parameters['releaseChannel'] === undefined) {
+      throw new Error('Missing required  parameter: releaseChannel');
+    }
+
+    if (parameters['releaseChannel'] !== undefined) {
+      body = parameters['releaseChannel'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCiNodes(parameters: {
+    tag?: string,
+    listUntagged?: string,
+  }): Promise<Array<ci_node>> {
+    const path = '/ci/nodes';
+    let body;
+    const query = {};
+
+    if (parameters['tag'] !== undefined) {
+      query['tag'] = parameters['tag'];
+    }
+
+    if (parameters['listUntagged'] !== undefined) {
+      query['list_untagged'] = parameters['listUntagged'];
+    }
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postCiNodes(parameters: {
+    ciNode: mutable_ci_node,
+  }): Promise<'Created'> {
+    const path = '/ci/nodes';
+    let body;
+    const query = {};
+    if (parameters['ciNode'] === undefined) {
+      throw new Error('Missing required  parameter: ciNode');
+    }
+
+    if (parameters['ciNode'] !== undefined) {
+      body = parameters['ciNode'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteCiNodesByNodeId(parameters: {
+    nodeId: string,
+  }): Promise<'Success'> {
+    let path = '/ci/nodes/{node_id}';
+    let body;
+    const query = {};
+    if (parameters['nodeId'] === undefined) {
+      throw new Error('Missing required  parameter: nodeId');
+    }
+
+    path = path.replace('{node_id}', `${parameters['nodeId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getCiNodesByNodeId(parameters: {
+    nodeId: string,
+  }): Promise<ci_node> {
+    let path = '/ci/nodes/{node_id}';
+    let body;
+    const query = {};
+    if (parameters['nodeId'] === undefined) {
+      throw new Error('Missing required  parameter: nodeId');
+    }
+
+    path = path.replace('{node_id}', `${parameters['nodeId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCiNodesByNodeId(parameters: {
+    nodeId: string,
+    ciNode: mutable_ci_node,
+  }): Promise<'Updated'> {
+    let path = '/ci/nodes/{node_id}';
+    let body;
+    const query = {};
+    if (parameters['nodeId'] === undefined) {
+      throw new Error('Missing required  parameter: nodeId');
+    }
+
+    path = path.replace('{node_id}', `${parameters['nodeId']}`);
+
+    if (parameters['ciNode'] === undefined) {
+      throw new Error('Missing required  parameter: ciNode');
+    }
+
+    if (parameters['ciNode'] !== undefined) {
+      body = parameters['ciNode'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async postCiNodesByNodeIdRelease(parameters: {
+    nodeId: string,
+  }): Promise<'Node released successfully'> {
+    let path = '/ci/nodes/{node_id}/release';
+    let body;
+    const query = {};
+    if (parameters['nodeId'] === undefined) {
+      throw new Error('Missing required  parameter: nodeId');
+    }
+
+    path = path.replace('{node_id}', `${parameters['nodeId']}`);
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async postCiNodesByNodeIdReleaseByLeaseId(parameters: {
+    nodeId: string,
+    leaseId: string,
+  }): Promise<'Node released successfully'> {
+    let path = '/ci/nodes/{node_id}/release/{lease_id}';
+    let body;
+    const query = {};
+    if (parameters['nodeId'] === undefined) {
+      throw new Error('Missing required  parameter: nodeId');
+    }
+
+    path = path.replace('{node_id}', `${parameters['nodeId']}`);
+
+    if (parameters['leaseId'] === undefined) {
+      throw new Error('Missing required  parameter: leaseId');
+    }
+
+    path = path.replace('{lease_id}', `${parameters['leaseId']}`);
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async postCiNodesByNodeIdReserve(parameters: {
+    nodeId: string,
+  }): Promise<node_lease> {
+    let path = '/ci/nodes/{node_id}/reserve';
+    let body;
+    const query = {};
+    if (parameters['nodeId'] === undefined) {
+      throw new Error('Missing required  parameter: nodeId');
+    }
+
+    path = path.replace('{node_id}', `${parameters['nodeId']}`);
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async postCiReserve(parameters: {tag?: string}): Promise<node_lease> {
+    const path = '/ci/reserve';
+    let body;
+    const query = {};
+
+    if (parameters['tag'] !== undefined) {
+      query['tag'] = parameters['tag'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getCwf(): Promise<Array<string>> {
+    const path = '/cwf';
+    let body;
+    const query = {};
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postCwf(parameters: {
+    cwfNetwork: cwf_network,
+  }): Promise<'Success'> {
+    const path = '/cwf';
+    let body;
+    const query = {};
+    if (parameters['cwfNetwork'] === undefined) {
+      throw new Error('Missing required  parameter: cwfNetwork');
+    }
+
+    if (parameters['cwfNetwork'] !== undefined) {
+      body = parameters['cwfNetwork'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteCwfByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getCwfByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<cwf_network> {
+    let path = '/cwf/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkId(parameters: {
+    networkId: string,
+    cwfNetwork: cwf_network,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['cwfNetwork'] === undefined) {
+      throw new Error('Missing required  parameter: cwfNetwork');
+    }
+
+    if (parameters['cwfNetwork'] !== undefined) {
+      body = parameters['cwfNetwork'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteCwfByNetworkIdCarrierWifi(parameters: {
+    networkId: string,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/carrier_wifi';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getCwfByNetworkIdCarrierWifi(parameters: {
+    networkId: string,
+  }): Promise<network_carrier_wifi_configs> {
+    let path = '/cwf/{network_id}/carrier_wifi';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdCarrierWifi(parameters: {
+    networkId: string,
+    config: network_carrier_wifi_configs,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/carrier_wifi';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdDescription(parameters: {
+    networkId: string,
+  }): Promise<network_description> {
+    let path = '/cwf/{network_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdDescription(parameters: {
+    networkId: string,
+    description: network_description,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['description'] === undefined) {
+      throw new Error('Missing required  parameter: description');
+    }
+
+    if (parameters['description'] !== undefined) {
+      body = parameters['description'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdGateways(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: cwf_gateway,
+  }> {
+    let path = '/cwf/{network_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postCwfByNetworkIdGateways(parameters: {
+    networkId: string,
+    gateway: mutable_cwf_gateway,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
+
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteCwfByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getCwfByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<cwf_gateway> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+    gateway: mutable_cwf_gateway,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
+
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdGatewaysByGatewayIdCarrierWifi(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_cwf_configs> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/carrier_wifi';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdGatewaysByGatewayIdCarrierWifi(parameters: {
+    networkId: string,
+    gatewayId: string,
+    config: gateway_cwf_configs,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/carrier_wifi';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdGatewaysByGatewayIdDescription(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_description> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdGatewaysByGatewayIdDescription(parameters: {
+    networkId: string,
+    gatewayId: string,
+    description: gateway_description,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    if (parameters['description'] === undefined) {
+      throw new Error('Missing required  parameter: description');
+    }
+
+    if (parameters['description'] !== undefined) {
+      body = parameters['description'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdGatewaysByGatewayIdDevice(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_device> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/device';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdGatewaysByGatewayIdDevice(parameters: {
+    networkId: string,
+    gatewayId: string,
+    device: gateway_device,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/device';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    if (parameters['device'] === undefined) {
+      throw new Error('Missing required  parameter: device');
+    }
+
+    if (parameters['device'] !== undefined) {
+      body = parameters['device'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdGatewaysByGatewayIdHealthStatus(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<carrier_wifi_gateway_health_status> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/health_status';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getCwfByNetworkIdGatewaysByGatewayIdMagmad(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<magmad_gateway_configs> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/magmad';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdGatewaysByGatewayIdMagmad(parameters: {
+    networkId: string,
+    gatewayId: string,
+    magmad: magmad_gateway_configs,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/magmad';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    if (parameters['magmad'] === undefined) {
+      throw new Error('Missing required  parameter: magmad');
+    }
+
+    if (parameters['magmad'] !== undefined) {
+      body = parameters['magmad'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdGatewaysByGatewayIdName(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_name> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdGatewaysByGatewayIdName(parameters: {
+    networkId: string,
+    gatewayId: string,
+    name: gateway_name,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    if (parameters['name'] === undefined) {
+      throw new Error('Missing required  parameter: name');
+    }
+
+    if (parameters['name'] !== undefined) {
+      body = parameters['name'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdGatewaysByGatewayIdStatus(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_status> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/status';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getCwfByNetworkIdGatewaysByGatewayIdTier(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<tier_id> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/tier';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdGatewaysByGatewayIdTier(parameters: {
+    networkId: string,
+    gatewayId: string,
+    tierId: tier_id,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/gateways/{gateway_id}/tier';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
+
+    if (parameters['tierId'] !== undefined) {
+      body = parameters['tierId'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdHaPairs(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: cwf_ha_pair,
+  }> {
+    let path = '/cwf/{network_id}/ha_pairs';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postCwfByNetworkIdHaPairs(parameters: {
+    networkId: string,
+    haPair: mutable_cwf_ha_pair,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/ha_pairs';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['haPair'] === undefined) {
+      throw new Error('Missing required  parameter: haPair');
+    }
+
+    if (parameters['haPair'] !== undefined) {
+      body = parameters['haPair'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteCwfByNetworkIdHaPairsByHaPairId(parameters: {
+    networkId: string,
+    haPairId: string,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/ha_pairs/{ha_pair_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['haPairId'] === undefined) {
+      throw new Error('Missing required  parameter: haPairId');
+    }
+
+    path = path.replace('{ha_pair_id}', `${parameters['haPairId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getCwfByNetworkIdHaPairsByHaPairId(parameters: {
+    networkId: string,
+    haPairId: string,
+  }): Promise<cwf_ha_pair> {
+    let path = '/cwf/{network_id}/ha_pairs/{ha_pair_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['haPairId'] === undefined) {
+      throw new Error('Missing required  parameter: haPairId');
+    }
+
+    path = path.replace('{ha_pair_id}', `${parameters['haPairId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdHaPairsByHaPairId(parameters: {
+    networkId: string,
+    haPairId: string,
+    haPair: mutable_cwf_ha_pair,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/ha_pairs/{ha_pair_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['haPairId'] === undefined) {
+      throw new Error('Missing required  parameter: haPairId');
+    }
+
+    path = path.replace('{ha_pair_id}', `${parameters['haPairId']}`);
+
+    if (parameters['haPair'] === undefined) {
+      throw new Error('Missing required  parameter: haPair');
+    }
+
+    if (parameters['haPair'] !== undefined) {
+      body = parameters['haPair'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdHaPairsByHaPairIdStatus(parameters: {
+    networkId: string,
+    haPairId: string,
+  }): Promise<carrier_wifi_ha_pair_status> {
+    let path = '/cwf/{network_id}/ha_pairs/{ha_pair_id}/status';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['haPairId'] === undefined) {
+      throw new Error('Missing required  parameter: haPairId');
+    }
+
+    path = path.replace('{ha_pair_id}', `${parameters['haPairId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getCwfByNetworkIdLiUes(parameters: {
+    networkId: string,
+  }): Promise<li_ues> {
+    let path = '/cwf/{network_id}/li_ues';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdLiUes(parameters: {
+    networkId: string,
+    description: li_ues,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/li_ues';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['description'] === undefined) {
+      throw new Error('Missing required  parameter: description');
+    }
+
+    if (parameters['description'] !== undefined) {
+      body = parameters['description'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdName(parameters: {
+    networkId: string,
+  }): Promise<network_name> {
+    let path = '/cwf/{network_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdName(parameters: {
+    networkId: string,
+    name: network_name,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['name'] === undefined) {
+      throw new Error('Missing required  parameter: name');
+    }
+
+    if (parameters['name'] !== undefined) {
+      body = parameters['name'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdSubscriberConfig(parameters: {
+    networkId: string,
+  }): Promise<network_subscriber_config> {
+    let path = '/cwf/{network_id}/subscriber_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdSubscriberConfig(parameters: {
+    networkId: string,
+    record: network_subscriber_config,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/subscriber_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getCwfByNetworkIdSubscriberConfigBaseNames(parameters: {
+    networkId: string,
+  }): Promise<base_names> {
+    let path = '/cwf/{network_id}/subscriber_config/base_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdSubscriberConfigBaseNames(parameters: {
+    networkId: string,
+    record: base_names,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/subscriber_config/base_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteCwfByNetworkIdSubscriberConfigBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/subscriber_config/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
+
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async postCwfByNetworkIdSubscriberConfigBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/subscriber_config/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
+
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getCwfByNetworkIdSubscriberConfigRuleNames(parameters: {
+    networkId: string,
+  }): Promise<rule_names> {
+    let path = '/cwf/{network_id}/subscriber_config/rule_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putCwfByNetworkIdSubscriberConfigRuleNames(parameters: {
+    networkId: string,
+    record: rule_names,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/subscriber_config/rule_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteCwfByNetworkIdSubscriberConfigRuleNamesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/subscriber_config/rule_names/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
+
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async postCwfByNetworkIdSubscriberConfigRuleNamesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+  }): Promise<'Success'> {
+    let path = '/cwf/{network_id}/subscriber_config/rule_names/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
+
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getCwfByNetworkIdSubscribersBySubscriberIdDirectoryRecord(parameters: {
+    networkId: string,
+    subscriberId: string,
+  }): Promise<cwf_subscriber_directory_record> {
+    let path = '/cwf/{network_id}/subscribers/{subscriber_id}/directory_record';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['subscriberId'] === undefined) {
+      throw new Error('Missing required  parameter: subscriberId');
+    }
+
+    path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getEventsByNetworkId(parameters: {
+    networkId: string,
+    streams?: string,
+    events?: string,
+    tags?: string,
+    hwIds?: string,
+    from?: string,
+    size?: string,
+    start?: string,
+    end?: string,
+  }): Promise<Array<{}>> {
+    let path = '/events/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['streams'] !== undefined) {
+      query['streams'] = parameters['streams'];
+    }
+
+    if (parameters['events'] !== undefined) {
+      query['events'] = parameters['events'];
+    }
+
+    if (parameters['tags'] !== undefined) {
+      query['tags'] = parameters['tags'];
+    }
+
+    if (parameters['hwIds'] !== undefined) {
+      query['hw_ids'] = parameters['hwIds'];
+    }
+
+    if (parameters['from'] !== undefined) {
+      query['from'] = parameters['from'];
+    }
+
+    if (parameters['size'] !== undefined) {
+      query['size'] = parameters['size'];
+    }
+
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
+    }
+
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getEventsByNetworkIdByStreamName(parameters: {
+    networkId: string,
+    streamName: string,
+    eventType?: string,
+    hardwareId?: string,
+    tag?: string,
+  }): Promise<Array<{}>> {
+    let path = '/events/{network_id}/{stream_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['streamName'] === undefined) {
+      throw new Error('Missing required  parameter: streamName');
+    }
+
+    path = path.replace('{stream_name}', `${parameters['streamName']}`);
+
+    if (parameters['eventType'] !== undefined) {
+      query['event_type'] = parameters['eventType'];
+    }
+
+    if (parameters['hardwareId'] !== undefined) {
+      query['hardware_id'] = parameters['hardwareId'];
+    }
+
+    if (parameters['tag'] !== undefined) {
+      query['tag'] = parameters['tag'];
+    }
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getEventsByNetworkIdAboutCount(parameters: {
+    networkId: string,
+    streams?: string,
+    events?: string,
+    tags?: string,
+    hwIds?: string,
+    start?: string,
+    end?: string,
+  }): Promise<number> {
+    let path = '/events/{network_id}/about/count';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['streams'] !== undefined) {
+      query['streams'] = parameters['streams'];
+    }
+
+    if (parameters['events'] !== undefined) {
+      query['events'] = parameters['events'];
+    }
+
+    if (parameters['tags'] !== undefined) {
+      query['tags'] = parameters['tags'];
+    }
+
+    if (parameters['hwIds'] !== undefined) {
+      query['hw_ids'] = parameters['hwIds'];
+    }
+
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
+    }
+
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getFeg(): Promise<Array<string>> {
+    const path = '/feg';
+    let body;
+    const query = {};
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postFeg(parameters: {
+    fegNetwork: feg_network,
+  }): Promise<'Success'> {
+    const path = '/feg';
+    let body;
+    const query = {};
+    if (parameters['fegNetwork'] === undefined) {
+      throw new Error('Missing required  parameter: fegNetwork');
+    }
+
+    if (parameters['fegNetwork'] !== undefined) {
+      body = parameters['fegNetwork'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteFegByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getFegByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<feg_network> {
+    let path = '/feg/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegByNetworkId(parameters: {
+    networkId: string,
+    fegNetwork: feg_network,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['fegNetwork'] === undefined) {
+      throw new Error('Missing required  parameter: fegNetwork');
+    }
+
+    if (parameters['fegNetwork'] !== undefined) {
+      body = parameters['fegNetwork'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getFegByNetworkIdClusterStatus(parameters: {
+    networkId: string,
+  }): Promise<federation_network_cluster_status> {
+    let path = '/feg/{network_id}/cluster_status';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async deleteFegByNetworkIdFederation(parameters: {
+    networkId: string,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/federation';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getFegByNetworkIdFederation(parameters: {
+    networkId: string,
+  }): Promise<network_federation_configs> {
+    let path = '/feg/{network_id}/federation';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegByNetworkIdFederation(parameters: {
+    networkId: string,
+    config: network_federation_configs,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/federation';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getFegByNetworkIdGateways(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: federation_gateway,
+  }> {
+    let path = '/feg/{network_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postFegByNetworkIdGateways(parameters: {
+    networkId: string,
+    gateway: mutable_federation_gateway,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
+
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteFegByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getFegByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<federation_gateway> {
+    let path = '/feg/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+    gateway: mutable_federation_gateway,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
+
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteFegByNetworkIdGatewaysByGatewayIdFederation(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/gateways/{gateway_id}/federation';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getFegByNetworkIdGatewaysByGatewayIdFederation(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_federation_configs> {
+    let path = '/feg/{network_id}/gateways/{gateway_id}/federation';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postFegByNetworkIdGatewaysByGatewayIdFederation(parameters: {
+    networkId: string,
+    gatewayId: string,
+    config: gateway_federation_configs,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/gateways/{gateway_id}/federation';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async putFegByNetworkIdGatewaysByGatewayIdFederation(parameters: {
+    networkId: string,
+    gatewayId: string,
+    config: gateway_federation_configs,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/gateways/{gateway_id}/federation';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getFegByNetworkIdGatewaysByGatewayIdHealthStatus(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<federation_gateway_health_status> {
+    let path = '/feg/{network_id}/gateways/{gateway_id}/health_status';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getFegByNetworkIdSubscriberConfig(parameters: {
+    networkId: string,
+  }): Promise<network_subscriber_config> {
+    let path = '/feg/{network_id}/subscriber_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegByNetworkIdSubscriberConfig(parameters: {
+    networkId: string,
+    record: network_subscriber_config,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/subscriber_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getFegByNetworkIdSubscriberConfigBaseNames(parameters: {
+    networkId: string,
+  }): Promise<base_names> {
+    let path = '/feg/{network_id}/subscriber_config/base_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegByNetworkIdSubscriberConfigBaseNames(parameters: {
+    networkId: string,
+    record: base_names,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/subscriber_config/base_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteFegByNetworkIdSubscriberConfigBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/subscriber_config/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
+
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async postFegByNetworkIdSubscriberConfigBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/subscriber_config/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
+
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getFegByNetworkIdSubscriberConfigRuleNames(parameters: {
+    networkId: string,
+  }): Promise<rule_names> {
+    let path = '/feg/{network_id}/subscriber_config/rule_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegByNetworkIdSubscriberConfigRuleNames(parameters: {
+    networkId: string,
+    record: rule_names,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/subscriber_config/rule_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteFegByNetworkIdSubscriberConfigRuleNamesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/subscriber_config/rule_names/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
+
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async postFegByNetworkIdSubscriberConfigRuleNamesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+  }): Promise<'Success'> {
+    let path = '/feg/{network_id}/subscriber_config/rule_names/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
+
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getFegLte(): Promise<Array<string>> {
+    const path = '/feg_lte';
+    let body;
+    const query = {};
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postFegLte(parameters: {
+    lteNetwork: feg_lte_network,
+  }): Promise<'Success'> {
+    const path = '/feg_lte';
+    let body;
+    const query = {};
+    if (parameters['lteNetwork'] === undefined) {
+      throw new Error('Missing required  parameter: lteNetwork');
+    }
+
+    if (parameters['lteNetwork'] !== undefined) {
+      body = parameters['lteNetwork'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteFegLteByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getFegLteByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<feg_lte_network> {
+    let path = '/feg_lte/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegLteByNetworkId(parameters: {
+    networkId: string,
+    lteNetwork: feg_lte_network,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['lteNetwork'] === undefined) {
+      throw new Error('Missing required  parameter: lteNetwork');
+    }
+
+    if (parameters['lteNetwork'] !== undefined) {
+      body = parameters['lteNetwork'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteFegLteByNetworkIdFederation(parameters: {
+    networkId: string,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}/federation';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getFegLteByNetworkIdFederation(parameters: {
+    networkId: string,
+  }): Promise<federated_network_configs> {
+    let path = '/feg_lte/{network_id}/federation';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegLteByNetworkIdFederation(parameters: {
+    networkId: string,
+    config: federated_network_configs,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}/federation';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getFegLteByNetworkIdSubscriberConfig(parameters: {
+    networkId: string,
+  }): Promise<network_subscriber_config> {
+    let path = '/feg_lte/{network_id}/subscriber_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegLteByNetworkIdSubscriberConfig(parameters: {
+    networkId: string,
+    record: network_subscriber_config,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}/subscriber_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getFegLteByNetworkIdSubscriberConfigBaseNames(parameters: {
+    networkId: string,
+  }): Promise<base_names> {
+    let path = '/feg_lte/{network_id}/subscriber_config/base_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegLteByNetworkIdSubscriberConfigBaseNames(parameters: {
+    networkId: string,
+    record: base_names,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}/subscriber_config/base_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteFegLteByNetworkIdSubscriberConfigBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}/subscriber_config/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
+
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async postFegLteByNetworkIdSubscriberConfigBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}/subscriber_config/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
+
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getFegLteByNetworkIdSubscriberConfigRuleNames(parameters: {
+    networkId: string,
+  }): Promise<rule_names> {
+    let path = '/feg_lte/{network_id}/subscriber_config/rule_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putFegLteByNetworkIdSubscriberConfigRuleNames(parameters: {
+    networkId: string,
+    record: rule_names,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}/subscriber_config/rule_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteFegLteByNetworkIdSubscriberConfigRuleNamesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}/subscriber_config/rule_names/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
+
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async postFegLteByNetworkIdSubscriberConfigRuleNamesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+  }): Promise<'Success'> {
+    let path = '/feg_lte/{network_id}/subscriber_config/rule_names/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
+
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getFoo(): Promise<number> {
+    const path = '/foo';
+    let body;
+    const query = {};
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getLte(): Promise<Array<string>> {
+    const path = '/lte';
+    let body;
+    const query = {};
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLte(parameters: {
+    lteNetwork: lte_network,
+  }): Promise<'Success'> {
+    const path = '/lte';
+    let body;
+    const query = {};
+    if (parameters['lteNetwork'] === undefined) {
+      throw new Error('Missing required  parameter: lteNetwork');
+    }
+
+    if (parameters['lteNetwork'] !== undefined) {
+      body = parameters['lteNetwork'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<lte_network> {
+    let path = '/lte/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['channel'] !== undefined) {
-            body = parameters['channel'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkId(parameters: {
+    networkId: string,
+    lteNetwork: lte_network,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteChannelsByChannelId(
-        parameters: {
-            'channelId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/channels/{channel_id}';
-        let body;
-        let query = {};
-        if (parameters['channelId'] === undefined) {
-            throw new Error('Missing required  parameter: channelId');
-        }
 
-        path = path.replace('{channel_id}', `${parameters['channelId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getChannelsByChannelId(
-            parameters: {
-                'channelId': string,
-            }
-        ): Promise < release_channel >
-        {
-            let path = '/channels/{channel_id}';
-            let body;
-            let query = {};
-            if (parameters['channelId'] === undefined) {
-                throw new Error('Missing required  parameter: channelId');
-            }
-
-            path = path.replace('{channel_id}', `${parameters['channelId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putChannelsByChannelId(
-        parameters: {
-            'channelId': string,
-            'releaseChannel': release_channel,
-        }
-    ): Promise < "Success" > {
-        let path = '/channels/{channel_id}';
-        let body;
-        let query = {};
-        if (parameters['channelId'] === undefined) {
-            throw new Error('Missing required  parameter: channelId');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        path = path.replace('{channel_id}', `${parameters['channelId']}`);
+    if (parameters['lteNetwork'] === undefined) {
+      throw new Error('Missing required  parameter: lteNetwork');
+    }
 
-        if (parameters['releaseChannel'] === undefined) {
-            throw new Error('Missing required  parameter: releaseChannel');
-        }
+    if (parameters['lteNetwork'] !== undefined) {
+      body = parameters['lteNetwork'];
+    }
 
-        if (parameters['releaseChannel'] !== undefined) {
-            body = parameters['releaseChannel'];
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdApns(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: apn,
+  }> {
+    let path = '/lte/{network_id}/apns';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCiNodes(
-            parameters: {
-                'tag' ? : string,
-                'listUntagged' ? : string,
-            }
-        ): Promise < Array < ci_node >
-        >
-        {
-            let path = '/ci/nodes';
-            let body;
-            let query = {};
-
-            if (parameters['tag'] !== undefined) {
-                query['tag'] = parameters['tag'];
-            }
-
-            if (parameters['listUntagged'] !== undefined) {
-                query['list_untagged'] = parameters['listUntagged'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postCiNodes(
-        parameters: {
-            'ciNode': mutable_ci_node,
-        }
-    ): Promise < "Created" > {
-        let path = '/ci/nodes';
-        let body;
-        let query = {};
-        if (parameters['ciNode'] === undefined) {
-            throw new Error('Missing required  parameter: ciNode');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['ciNode'] !== undefined) {
-            body = parameters['ciNode'];
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdApns(parameters: {
+    networkId: string,
+    apn: apn,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/apns';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['apn'] === undefined) {
+      throw new Error('Missing required  parameter: apn');
     }
-    static async deleteCiNodesByNodeId(
-        parameters: {
-            'nodeId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/ci/nodes/{node_id}';
-        let body;
-        let query = {};
-        if (parameters['nodeId'] === undefined) {
-            throw new Error('Missing required  parameter: nodeId');
-        }
 
-        path = path.replace('{node_id}', `${parameters['nodeId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getCiNodesByNodeId(
-            parameters: {
-                'nodeId': string,
-            }
-        ): Promise < ci_node >
-        {
-            let path = '/ci/nodes/{node_id}';
-            let body;
-            let query = {};
-            if (parameters['nodeId'] === undefined) {
-                throw new Error('Missing required  parameter: nodeId');
-            }
-
-            path = path.replace('{node_id}', `${parameters['nodeId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCiNodesByNodeId(
-        parameters: {
-            'nodeId': string,
-            'ciNode': mutable_ci_node,
-        }
-    ): Promise < "Updated" > {
-        let path = '/ci/nodes/{node_id}';
-        let body;
-        let query = {};
-        if (parameters['nodeId'] === undefined) {
-            throw new Error('Missing required  parameter: nodeId');
-        }
+    if (parameters['apn'] !== undefined) {
+      body = parameters['apn'];
+    }
 
-        path = path.replace('{node_id}', `${parameters['nodeId']}`);
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkIdApnsByApnName(parameters: {
+    networkId: string,
+    apnName: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/apns/{apn_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['ciNode'] === undefined) {
-            throw new Error('Missing required  parameter: ciNode');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['ciNode'] !== undefined) {
-            body = parameters['ciNode'];
-        }
+    if (parameters['apnName'] === undefined) {
+      throw new Error('Missing required  parameter: apnName');
+    }
 
-        return await this.request(path, 'PUT', query, body);
+    path = path.replace('{apn_name}', `${parameters['apnName']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdApnsByApnName(parameters: {
+    networkId: string,
+    apnName: string,
+  }): Promise<apn> {
+    let path = '/lte/{network_id}/apns/{apn_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async postCiNodesByNodeIdRelease(
-        parameters: {
-            'nodeId': string,
-        }
-    ): Promise < "Node released successfully" > {
-        let path = '/ci/nodes/{node_id}/release';
-        let body;
-        let query = {};
-        if (parameters['nodeId'] === undefined) {
-            throw new Error('Missing required  parameter: nodeId');
-        }
 
-        path = path.replace('{node_id}', `${parameters['nodeId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['apnName'] === undefined) {
+      throw new Error('Missing required  parameter: apnName');
     }
-    static async postCiNodesByNodeIdReleaseByLeaseId(
-        parameters: {
-            'nodeId': string,
-            'leaseId': string,
-        }
-    ): Promise < "Node released successfully" > {
-        let path = '/ci/nodes/{node_id}/release/{lease_id}';
-        let body;
-        let query = {};
-        if (parameters['nodeId'] === undefined) {
-            throw new Error('Missing required  parameter: nodeId');
-        }
 
-        path = path.replace('{node_id}', `${parameters['nodeId']}`);
+    path = path.replace('{apn_name}', `${parameters['apnName']}`);
 
-        if (parameters['leaseId'] === undefined) {
-            throw new Error('Missing required  parameter: leaseId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdApnsByApnName(parameters: {
+    networkId: string,
+    apnName: string,
+    apn: apn,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/apns/{apn_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{lease_id}', `${parameters['leaseId']}`);
-
-        return await this.request(path, 'POST', query, body);
-    }
-    static async postCiNodesByNodeIdReserve(
-            parameters: {
-                'nodeId': string,
-            }
-        ): Promise < node_lease >
-        {
-            let path = '/ci/nodes/{node_id}/reserve';
-            let body;
-            let query = {};
-            if (parameters['nodeId'] === undefined) {
-                throw new Error('Missing required  parameter: nodeId');
-            }
-
-            path = path.replace('{node_id}', `${parameters['nodeId']}`);
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async postCiReserve(
-            parameters: {
-                'tag' ? : string,
-            }
-        ): Promise < node_lease >
-        {
-            let path = '/ci/reserve';
-            let body;
-            let query = {};
-
-            if (parameters['tag'] !== undefined) {
-                query['tag'] = parameters['tag'];
-            }
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async getCwf(): Promise < Array < string >
-        >
-        {
-            let path = '/cwf';
-            let body;
-            let query = {};
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postCwf(
-        parameters: {
-            'cwfNetwork': cwf_network,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf';
-        let body;
-        let query = {};
-        if (parameters['cwfNetwork'] === undefined) {
-            throw new Error('Missing required  parameter: cwfNetwork');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['cwfNetwork'] !== undefined) {
-            body = parameters['cwfNetwork'];
-        }
+    if (parameters['apnName'] === undefined) {
+      throw new Error('Missing required  parameter: apnName');
+    }
 
-        return await this.request(path, 'POST', query, body);
+    path = path.replace('{apn_name}', `${parameters['apnName']}`);
+
+    if (parameters['apn'] === undefined) {
+      throw new Error('Missing required  parameter: apn');
     }
-    static async deleteCwfByNetworkId(
-        parameters: {
-            'networkId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+
+    if (parameters['apn'] !== undefined) {
+      body = parameters['apn'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdCellular(parameters: {
+    networkId: string,
+  }): Promise<network_cellular_configs> {
+    let path = '/lte/{network_id}/cellular';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdCellular(parameters: {
+    networkId: string,
+    config: network_cellular_configs,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/cellular';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdCellularEpc(parameters: {
+    networkId: string,
+  }): Promise<network_epc_configs> {
+    let path = '/lte/{network_id}/cellular/epc';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdCellularEpc(parameters: {
+    networkId: string,
+    config: network_epc_configs,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/cellular/epc';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdCellularFegNetworkId(parameters: {
+    networkId: string,
+  }): Promise<string> {
+    let path = '/lte/{network_id}/cellular/feg_network_id';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdCellularFegNetworkId(parameters: {
+    networkId: string,
+    fegNetworkId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/cellular/feg_network_id';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['fegNetworkId'] === undefined) {
+      throw new Error('Missing required  parameter: fegNetworkId');
+    }
+
+    if (parameters['fegNetworkId'] !== undefined) {
+      body = parameters['fegNetworkId'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdCellularRan(parameters: {
+    networkId: string,
+  }): Promise<network_ran_configs> {
+    let path = '/lte/{network_id}/cellular/ran';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdCellularRan(parameters: {
+    networkId: string,
+    config: network_ran_configs,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/cellular/ran';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdDescription(parameters: {
+    networkId: string,
+  }): Promise<network_description> {
+    let path = '/lte/{network_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdDescription(parameters: {
+    networkId: string,
+    description: network_description,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['description'] === undefined) {
+      throw new Error('Missing required  parameter: description');
+    }
+
+    if (parameters['description'] !== undefined) {
+      body = parameters['description'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdDns(parameters: {
+    networkId: string,
+  }): Promise<network_dns_config> {
+    let path = '/lte/{network_id}/dns';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdDns(parameters: {
+    networkId: string,
+    config: network_dns_config,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/dns';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdDnsRecords(parameters: {
+    networkId: string,
+  }): Promise<Array<dns_config_record>> {
+    let path = '/lte/{network_id}/dns/records';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdDnsRecords(parameters: {
+    networkId: string,
+    records: Array<dns_config_record>,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/dns/records';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['records'] === undefined) {
+      throw new Error('Missing required  parameter: records');
+    }
+
+    if (parameters['records'] !== undefined) {
+      body = parameters['records'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteLteByNetworkIdDnsRecordsByDomain(parameters: {
+    networkId: string,
+    domain: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/dns/records/{domain}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['domain'] === undefined) {
+      throw new Error('Missing required  parameter: domain');
+    }
+
+    path = path.replace('{domain}', `${parameters['domain']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdDnsRecordsByDomain(parameters: {
+    networkId: string,
+    domain: string,
+  }): Promise<dns_config_record> {
+    let path = '/lte/{network_id}/dns/records/{domain}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['domain'] === undefined) {
+      throw new Error('Missing required  parameter: domain');
+    }
+
+    path = path.replace('{domain}', `${parameters['domain']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdDnsRecordsByDomain(parameters: {
+    networkId: string,
+    domain: string,
+    record: dns_config_record,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/dns/records/{domain}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['domain'] === undefined) {
+      throw new Error('Missing required  parameter: domain');
+    }
+
+    path = path.replace('{domain}', `${parameters['domain']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async putLteByNetworkIdDnsRecordsByDomain(parameters: {
+    networkId: string,
+    domain: string,
+    record: dns_config_record,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/dns/records/{domain}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['domain'] === undefined) {
+      throw new Error('Missing required  parameter: domain');
+    }
+
+    path = path.replace('{domain}', `${parameters['domain']}`);
+
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
+
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdEnodebs(parameters: {
+    networkId: string,
+    pageSize?: number,
+    pageToken?: string,
+  }): Promise<paginated_enodebs> {
+    let path = '/lte/{network_id}/enodebs';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['pageSize'] !== undefined) {
+      query['page_size'] = parameters['pageSize'];
+    }
+
+    if (parameters['pageToken'] !== undefined) {
+      query['page_token'] = parameters['pageToken'];
+    }
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdEnodebs(parameters: {
+    networkId: string,
+    enodeb: enodeb,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/enodebs';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['enodeb'] === undefined) {
+      throw new Error('Missing required  parameter: enodeb');
+    }
+
+    if (parameters['enodeb'] !== undefined) {
+      body = parameters['enodeb'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkIdEnodebsByEnodebSerial(parameters: {
+    networkId: string,
+    enodebSerial: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/enodebs/{enodeb_serial}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['enodebSerial'] === undefined) {
+      throw new Error('Missing required  parameter: enodebSerial');
+    }
+
+    path = path.replace('{enodeb_serial}', `${parameters['enodebSerial']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdEnodebsByEnodebSerial(parameters: {
+    networkId: string,
+    enodebSerial: string,
+  }): Promise<enodeb> {
+    let path = '/lte/{network_id}/enodebs/{enodeb_serial}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['enodebSerial'] === undefined) {
+      throw new Error('Missing required  parameter: enodebSerial');
+    }
+
+    path = path.replace('{enodeb_serial}', `${parameters['enodebSerial']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdEnodebsByEnodebSerial(parameters: {
+    networkId: string,
+    enodebSerial: string,
+    enodeb: enodeb,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/enodebs/{enodeb_serial}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['enodebSerial'] === undefined) {
+      throw new Error('Missing required  parameter: enodebSerial');
+    }
+
+    path = path.replace('{enodeb_serial}', `${parameters['enodebSerial']}`);
+
+    if (parameters['enodeb'] === undefined) {
+      throw new Error('Missing required  parameter: enodeb');
+    }
+
+    if (parameters['enodeb'] !== undefined) {
+      body = parameters['enodeb'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdEnodebsByEnodebSerialState(parameters: {
+    networkId: string,
+    enodebSerial: string,
+  }): Promise<enodeb_state> {
+    let path = '/lte/{network_id}/enodebs/{enodeb_serial}/state';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['enodebSerial'] === undefined) {
+      throw new Error('Missing required  parameter: enodebSerial');
+    }
+
+    path = path.replace('{enodeb_serial}', `${parameters['enodebSerial']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getLteByNetworkIdFeatures(parameters: {
+    networkId: string,
+  }): Promise<network_features> {
+    let path = '/lte/{network_id}/features';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdFeatures(parameters: {
+    networkId: string,
+    config: network_features,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/features';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
+
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewayPools(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: cellular_gateway_pool,
+  }> {
+    let path = '/lte/{network_id}/gateway_pools';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdGatewayPools(parameters: {
+    networkId: string,
+    haGatewayPool: mutable_cellular_gateway_pool,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateway_pools';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['haGatewayPool'] === undefined) {
+      throw new Error('Missing required  parameter: haGatewayPool');
+    }
+
+    if (parameters['haGatewayPool'] !== undefined) {
+      body = parameters['haGatewayPool'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkIdGatewayPoolsByGatewayPoolId(parameters: {
+    networkId: string,
+    gatewayPoolId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateway_pools/{gateway_pool_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayPoolId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayPoolId');
+    }
+
+    path = path.replace('{gateway_pool_id}', `${parameters['gatewayPoolId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdGatewayPoolsByGatewayPoolId(parameters: {
+    networkId: string,
+    gatewayPoolId: string,
+  }): Promise<cellular_gateway_pool> {
+    let path = '/lte/{network_id}/gateway_pools/{gateway_pool_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayPoolId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayPoolId');
+    }
+
+    path = path.replace('{gateway_pool_id}', `${parameters['gatewayPoolId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewayPoolsByGatewayPoolId(parameters: {
+    networkId: string,
+    gatewayPoolId: string,
+    haGatewayPool: mutable_cellular_gateway_pool,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateway_pools/{gateway_pool_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayPoolId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayPoolId');
+    }
+
+    path = path.replace('{gateway_pool_id}', `${parameters['gatewayPoolId']}`);
+
+    if (parameters['haGatewayPool'] === undefined) {
+      throw new Error('Missing required  parameter: haGatewayPool');
+    }
+
+    if (parameters['haGatewayPool'] !== undefined) {
+      body = parameters['haGatewayPool'];
+    }
+
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGateways(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: lte_gateway,
+  }> {
+    let path = '/lte/{network_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdGateways(parameters: {
+    networkId: string,
+    gateway: mutable_lte_gateway,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
+
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<lte_gateway> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
+
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+    gateway: mutable_lte_gateway,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getCwfByNetworkId(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < cwf_network >
-        {
-            let path = '/cwf/{network_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkId(
-        parameters: {
-            'networkId': string,
-            'cwfNetwork': cwf_network,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['cwfNetwork'] === undefined) {
-            throw new Error('Missing required  parameter: cwfNetwork');
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['cwfNetwork'] !== undefined) {
-            body = parameters['cwfNetwork'];
-        }
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
 
-        return await this.request(path, 'PUT', query, body);
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
     }
-    static async deleteCwfByNetworkIdCarrierWifi(
-        parameters: {
-            'networkId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/carrier_wifi';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getCwfByNetworkIdCarrierWifi(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_carrier_wifi_configs >
-        {
-            let path = '/cwf/{network_id}/carrier_wifi';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdCarrierWifi(
-        parameters: {
-            'networkId': string,
-            'config': network_carrier_wifi_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/carrier_wifi';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdCellular(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_cellular_configs> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdDescription(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_description >
-        {
-            let path = '/cwf/{network_id}/description';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdDescription(
-        parameters: {
-            'networkId': string,
-            'description': network_description,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/description';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdCellular(parameters: {
+    networkId: string,
+    gatewayId: string,
+    config: gateway_cellular_configs,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['description'] === undefined) {
-            throw new Error('Missing required  parameter: description');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['description'] !== undefined) {
-            body = parameters['description'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdGateways(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: cwf_gateway,
-        } >
-        {
-            let path = '/cwf/{network_id}/gateways';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postCwfByNetworkIdGateways(
-        parameters: {
-            'networkId': string,
-            'gateway': mutable_cwf_gateway,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/gateways';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdCellularDns(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_dns_configs> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/dns';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
     }
-    static async deleteCwfByNetworkIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdCellularDns(parameters: {
+    networkId: string,
+    gatewayId: string,
+    config: gateway_dns_configs,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/dns';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
     }
-    static async getCwfByNetworkIdGatewaysByGatewayId(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < cwf_gateway >
-        {
-            let path = '/cwf/{network_id}/gateways/{gateway_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
 
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'gateway': mutable_cwf_gateway,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdCellularDnsRecords(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<Array<dns_config_record>> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/dns/records';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdCellularDnsRecords(parameters: {
+    networkId: string,
+    gatewayId: string,
+    records: Array<dns_config_record>,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/dns/records';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdGatewaysByGatewayIdCarrierWifi(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_cwf_configs >
-        {
-            let path = '/cwf/{network_id}/gateways/{gateway_id}/carrier_wifi';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdGatewaysByGatewayIdCarrierWifi(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'config': gateway_cwf_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/gateways/{gateway_id}/carrier_wifi';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['records'] === undefined) {
+      throw new Error('Missing required  parameter: records');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    if (parameters['records'] !== undefined) {
+      body = parameters['records'];
+    }
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdCellularEpc(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_epc_configs> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/epc';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdGatewaysByGatewayIdDescription(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_description >
-        {
-            let path = '/cwf/{network_id}/gateways/{gateway_id}/description';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdGatewaysByGatewayIdDescription(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'description': gateway_description,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/gateways/{gateway_id}/description';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdCellularEpc(parameters: {
+    networkId: string,
+    gatewayId: string,
+    config: gateway_epc_configs,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/epc';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['description'] === undefined) {
-            throw new Error('Missing required  parameter: description');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['description'] !== undefined) {
-            body = parameters['description'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdGatewaysByGatewayIdDevice(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_device >
-        {
-            let path = '/cwf/{network_id}/gateways/{gateway_id}/device';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdGatewaysByGatewayIdDevice(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'device': gateway_device,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/gateways/{gateway_id}/device';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdCellularNonEps(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_non_eps_configs> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/non_eps';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['device'] === undefined) {
-            throw new Error('Missing required  parameter: device');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['device'] !== undefined) {
-            body = parameters['device'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdGatewaysByGatewayIdHealthStatus(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < carrier_wifi_gateway_health_status >
-        {
-            let path = '/cwf/{network_id}/gateways/{gateway_id}/health_status';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getCwfByNetworkIdGatewaysByGatewayIdMagmad(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < magmad_gateway_configs >
-        {
-            let path = '/cwf/{network_id}/gateways/{gateway_id}/magmad';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdGatewaysByGatewayIdMagmad(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'magmad': magmad_gateway_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/gateways/{gateway_id}/magmad';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdCellularNonEps(parameters: {
+    networkId: string,
+    gatewayId: string,
+    config: gateway_non_eps_configs,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/non_eps';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['magmad'] === undefined) {
-            throw new Error('Missing required  parameter: magmad');
-        }
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
 
-        if (parameters['magmad'] !== undefined) {
-            body = parameters['magmad'];
-        }
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdGatewaysByGatewayIdName(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_name >
-        {
-            let path = '/cwf/{network_id}/gateways/{gateway_id}/name';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdGatewaysByGatewayIdName(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'name': gateway_name,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/gateways/{gateway_id}/name';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdCellularPooling(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<Array<cellular_gateway_pool_record>> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/pooling';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['name'] === undefined) {
-            throw new Error('Missing required  parameter: name');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdCellularPooling(parameters: {
+    networkId: string,
+    gatewayId: string,
+    resource: Array<cellular_gateway_pool_record>,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/pooling';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['name'] !== undefined) {
-            body = parameters['name'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdGatewaysByGatewayIdStatus(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_status >
-        {
-            let path = '/cwf/{network_id}/gateways/{gateway_id}/status';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getCwfByNetworkIdGatewaysByGatewayIdTier(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < tier_id >
-        {
-            let path = '/cwf/{network_id}/gateways/{gateway_id}/tier';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdGatewaysByGatewayIdTier(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'tierId': tier_id,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/gateways/{gateway_id}/tier';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['resource'] === undefined) {
+      throw new Error('Missing required  parameter: resource');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    if (parameters['resource'] !== undefined) {
+      body = parameters['resource'];
+    }
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdCellularRan(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_ran_configs> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/ran';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['tierId'] !== undefined) {
-            body = parameters['tierId'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdHaPairs(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: cwf_ha_pair,
-        } >
-        {
-            let path = '/cwf/{network_id}/ha_pairs';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postCwfByNetworkIdHaPairs(
-        parameters: {
-            'networkId': string,
-            'haPair': mutable_cwf_ha_pair,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/ha_pairs';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['haPair'] === undefined) {
-            throw new Error('Missing required  parameter: haPair');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdCellularRan(parameters: {
+    networkId: string,
+    gatewayId: string,
+    config: gateway_ran_configs,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/ran';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['haPair'] !== undefined) {
-            body = parameters['haPair'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
     }
-    static async deleteCwfByNetworkIdHaPairsByHaPairId(
-        parameters: {
-            'networkId': string,
-            'haPairId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/ha_pairs/{ha_pair_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['haPairId'] === undefined) {
-            throw new Error('Missing required  parameter: haPairId');
-        }
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
 
-        path = path.replace('{ha_pair_id}', `${parameters['haPairId']}`);
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteLteByNetworkIdGatewaysByGatewayIdConnectedEnodebSerials(parameters: {
+    networkId: string,
+    gatewayId: string,
+    serial: string,
+  }): Promise<'Success'> {
+    let path =
+      '/lte/{network_id}/gateways/{gateway_id}/connected_enodeb_serials';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getCwfByNetworkIdHaPairsByHaPairId(
-            parameters: {
-                'networkId': string,
-                'haPairId': string,
-            }
-        ): Promise < cwf_ha_pair >
-        {
-            let path = '/cwf/{network_id}/ha_pairs/{ha_pair_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['haPairId'] === undefined) {
-                throw new Error('Missing required  parameter: haPairId');
-            }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-            path = path.replace('{ha_pair_id}', `${parameters['haPairId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdHaPairsByHaPairId(
-        parameters: {
-            'networkId': string,
-            'haPairId': string,
-            'haPair': mutable_cwf_ha_pair,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/ha_pairs/{ha_pair_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['serial'] === undefined) {
+      throw new Error('Missing required  parameter: serial');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['serial'] !== undefined) {
+      body = parameters['serial'];
+    }
 
-        if (parameters['haPairId'] === undefined) {
-            throw new Error('Missing required  parameter: haPairId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdConnectedEnodebSerials(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<enodeb_serials> {
+    let path =
+      '/lte/{network_id}/gateways/{gateway_id}/connected_enodeb_serials';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{ha_pair_id}', `${parameters['haPairId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['haPair'] === undefined) {
-            throw new Error('Missing required  parameter: haPair');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['haPair'] !== undefined) {
-            body = parameters['haPair'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdHaPairsByHaPairIdStatus(
-            parameters: {
-                'networkId': string,
-                'haPairId': string,
-            }
-        ): Promise < carrier_wifi_ha_pair_status >
-        {
-            let path = '/cwf/{network_id}/ha_pairs/{ha_pair_id}/status';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['haPairId'] === undefined) {
-                throw new Error('Missing required  parameter: haPairId');
-            }
-
-            path = path.replace('{ha_pair_id}', `${parameters['haPairId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getCwfByNetworkIdLiUes(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < li_ues >
-        {
-            let path = '/cwf/{network_id}/li_ues';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdLiUes(
-        parameters: {
-            'networkId': string,
-            'description': li_ues,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/li_ues';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdGatewaysByGatewayIdConnectedEnodebSerials(parameters: {
+    networkId: string,
+    gatewayId: string,
+    serial: string,
+  }): Promise<'Success'> {
+    let path =
+      '/lte/{network_id}/gateways/{gateway_id}/connected_enodeb_serials';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['description'] === undefined) {
-            throw new Error('Missing required  parameter: description');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['description'] !== undefined) {
-            body = parameters['description'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdName(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_name >
-        {
-            let path = '/cwf/{network_id}/name';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdName(
-        parameters: {
-            'networkId': string,
-            'name': network_name,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/name';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['serial'] === undefined) {
+      throw new Error('Missing required  parameter: serial');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['serial'] !== undefined) {
+      body = parameters['serial'];
+    }
 
-        if (parameters['name'] === undefined) {
-            throw new Error('Missing required  parameter: name');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdConnectedEnodebSerials(parameters: {
+    networkId: string,
+    gatewayId: string,
+    serials: enodeb_serials,
+  }): Promise<'Success'> {
+    let path =
+      '/lte/{network_id}/gateways/{gateway_id}/connected_enodeb_serials';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['name'] !== undefined) {
-            body = parameters['name'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdSubscriberConfig(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_subscriber_config >
-        {
-            let path = '/cwf/{network_id}/subscriber_config';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdSubscriberConfig(
-        parameters: {
-            'networkId': string,
-            'record': network_subscriber_config,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/subscriber_config';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    if (parameters['serials'] === undefined) {
+      throw new Error('Missing required  parameter: serials');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    if (parameters['serials'] !== undefined) {
+      body = parameters['serials'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getCwfByNetworkIdSubscriberConfigBaseNames(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < base_names >
-        {
-            let path = '/cwf/{network_id}/subscriber_config/base_names';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdSubscriberConfigBaseNames(
-        parameters: {
-            'networkId': string,
-            'record': base_names,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/subscriber_config/base_names';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdDescription(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_description> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdDescription(parameters: {
+    networkId: string,
+    gatewayId: string,
+    description: gateway_description,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteCwfByNetworkIdSubscriberConfigBaseNamesByBaseName(
-        parameters: {
-            'networkId': string,
-            'baseName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/subscriber_config/base_names/{base_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['baseName'] === undefined) {
-            throw new Error('Missing required  parameter: baseName');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{base_name}', `${parameters['baseName']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['description'] === undefined) {
+      throw new Error('Missing required  parameter: description');
     }
-    static async postCwfByNetworkIdSubscriberConfigBaseNamesByBaseName(
-        parameters: {
-            'networkId': string,
-            'baseName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/subscriber_config/base_names/{base_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['description'] !== undefined) {
+      body = parameters['description'];
+    }
 
-        if (parameters['baseName'] === undefined) {
-            throw new Error('Missing required  parameter: baseName');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdDevice(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_device> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/device';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{base_name}', `${parameters['baseName']}`);
-
-        return await this.request(path, 'POST', query, body);
-    }
-    static async getCwfByNetworkIdSubscriberConfigRuleNames(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < rule_names >
-        {
-            let path = '/cwf/{network_id}/subscriber_config/rule_names';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putCwfByNetworkIdSubscriberConfigRuleNames(
-        parameters: {
-            'networkId': string,
-            'record': rule_names,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/subscriber_config/rule_names';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdDevice(parameters: {
+    networkId: string,
+    gatewayId: string,
+    device: gateway_device,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/device';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        return await this.request(path, 'PUT', query, body);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
     }
-    static async deleteCwfByNetworkIdSubscriberConfigRuleNamesByRuleId(
-        parameters: {
-            'networkId': string,
-            'ruleId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/subscriber_config/rule_names/{rule_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['ruleId'] === undefined) {
-            throw new Error('Missing required  parameter: ruleId');
-        }
+    if (parameters['device'] === undefined) {
+      throw new Error('Missing required  parameter: device');
+    }
 
-        path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+    if (parameters['device'] !== undefined) {
+      body = parameters['device'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdMagmad(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<magmad_gateway_configs> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/magmad';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async postCwfByNetworkIdSubscriberConfigRuleNamesByRuleId(
-        parameters: {
-            'networkId': string,
-            'ruleId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/cwf/{network_id}/subscriber_config/rule_names/{rule_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['ruleId'] === undefined) {
-            throw new Error('Missing required  parameter: ruleId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdMagmad(parameters: {
+    networkId: string,
+    gatewayId: string,
+    magmad: magmad_gateway_configs,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/magmad';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getCwfByNetworkIdSubscribersBySubscriberIdDirectoryRecord(
-            parameters: {
-                'networkId': string,
-                'subscriberId': string,
-            }
-        ): Promise < cwf_subscriber_directory_record >
-        {
-            let path = '/cwf/{network_id}/subscribers/{subscriber_id}/directory_record';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['subscriberId'] === undefined) {
-                throw new Error('Missing required  parameter: subscriberId');
-            }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-            path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getEventsByNetworkId(
-            parameters: {
-                'networkId': string,
-                'streams' ? : string,
-                'events' ? : string,
-                'tags' ? : string,
-                'hwIds' ? : string,
-                'from' ? : string,
-                'size' ? : string,
-                'start' ? : string,
-                'end' ? : string,
-            }
-        ): Promise < Array < {} >
-        >
-        {
-            let path = '/events/{network_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['streams'] !== undefined) {
-                query['streams'] = parameters['streams'];
-            }
-
-            if (parameters['events'] !== undefined) {
-                query['events'] = parameters['events'];
-            }
-
-            if (parameters['tags'] !== undefined) {
-                query['tags'] = parameters['tags'];
-            }
-
-            if (parameters['hwIds'] !== undefined) {
-                query['hw_ids'] = parameters['hwIds'];
-            }
-
-            if (parameters['from'] !== undefined) {
-                query['from'] = parameters['from'];
-            }
-
-            if (parameters['size'] !== undefined) {
-                query['size'] = parameters['size'];
-            }
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getEventsByNetworkIdByStreamName(
-            parameters: {
-                'networkId': string,
-                'streamName': string,
-                'eventType' ? : string,
-                'hardwareId' ? : string,
-                'tag' ? : string,
-            }
-        ): Promise < Array < {} >
-        >
-        {
-            let path = '/events/{network_id}/{stream_name}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['streamName'] === undefined) {
-                throw new Error('Missing required  parameter: streamName');
-            }
-
-            path = path.replace('{stream_name}', `${parameters['streamName']}`);
-
-            if (parameters['eventType'] !== undefined) {
-                query['event_type'] = parameters['eventType'];
-            }
-
-            if (parameters['hardwareId'] !== undefined) {
-                query['hardware_id'] = parameters['hardwareId'];
-            }
-
-            if (parameters['tag'] !== undefined) {
-                query['tag'] = parameters['tag'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getEventsByNetworkIdAboutCount(
-            parameters: {
-                'networkId': string,
-                'streams' ? : string,
-                'events' ? : string,
-                'tags' ? : string,
-                'hwIds' ? : string,
-                'start' ? : string,
-                'end' ? : string,
-            }
-        ): Promise < number >
-        {
-            let path = '/events/{network_id}/about/count';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['streams'] !== undefined) {
-                query['streams'] = parameters['streams'];
-            }
-
-            if (parameters['events'] !== undefined) {
-                query['events'] = parameters['events'];
-            }
-
-            if (parameters['tags'] !== undefined) {
-                query['tags'] = parameters['tags'];
-            }
-
-            if (parameters['hwIds'] !== undefined) {
-                query['hw_ids'] = parameters['hwIds'];
-            }
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getFeg(): Promise < Array < string >
-        >
-        {
-            let path = '/feg';
-            let body;
-            let query = {};
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postFeg(
-        parameters: {
-            'fegNetwork': feg_network,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg';
-        let body;
-        let query = {};
-        if (parameters['fegNetwork'] === undefined) {
-            throw new Error('Missing required  parameter: fegNetwork');
-        }
+    if (parameters['magmad'] === undefined) {
+      throw new Error('Missing required  parameter: magmad');
+    }
 
-        if (parameters['fegNetwork'] !== undefined) {
-            body = parameters['fegNetwork'];
-        }
+    if (parameters['magmad'] !== undefined) {
+      body = parameters['magmad'];
+    }
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdName(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_name> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteFegByNetworkId(
-        parameters: {
-            'networkId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getFegByNetworkId(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < feg_network >
-        {
-            let path = '/feg/{network_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegByNetworkId(
-        parameters: {
-            'networkId': string,
-            'fegNetwork': feg_network,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['fegNetwork'] === undefined) {
-            throw new Error('Missing required  parameter: fegNetwork');
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['fegNetwork'] !== undefined) {
-            body = parameters['fegNetwork'];
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdName(parameters: {
+    networkId: string,
+    gatewayId: string,
+    name: gateway_name,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getFegByNetworkIdClusterStatus(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < federation_network_cluster_status >
-        {
-            let path = '/feg/{network_id}/cluster_status';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async deleteFegByNetworkIdFederation(
-        parameters: {
-            'networkId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/federation';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getFegByNetworkIdFederation(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_federation_configs >
-        {
-            let path = '/feg/{network_id}/federation';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegByNetworkIdFederation(
-        parameters: {
-            'networkId': string,
-            'config': network_federation_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/federation';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    if (parameters['name'] === undefined) {
+      throw new Error('Missing required  parameter: name');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    if (parameters['name'] !== undefined) {
+      body = parameters['name'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getFegByNetworkIdGateways(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: federation_gateway,
-        } >
-        {
-            let path = '/feg/{network_id}/gateways';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postFegByNetworkIdGateways(
-        parameters: {
-            'networkId': string,
-            'gateway': mutable_federation_gateway,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/gateways';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdStatus(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_status> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/status';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdTier(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<tier_id> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/tier';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteFegByNetworkIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdTier(parameters: {
+    networkId: string,
+    gatewayId: string,
+    tierId: tier_id,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/tier';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getFegByNetworkIdGatewaysByGatewayId(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < federation_gateway >
-        {
-            let path = '/feg/{network_id}/gateways/{gateway_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegByNetworkIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'gateway': mutable_federation_gateway,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['tierId'] !== undefined) {
+      body = parameters['tierId'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdGatewaysByGatewayIdVpn(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_vpn_configs> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/vpn';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdGatewaysByGatewayIdVpn(parameters: {
+    networkId: string,
+    gatewayId: string,
+    config: gateway_vpn_configs,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/gateways/{gateway_id}/vpn';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteFegByNetworkIdGatewaysByGatewayIdFederation(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/gateways/{gateway_id}/federation';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
     }
-    static async getFegByNetworkIdGatewaysByGatewayIdFederation(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_federation_configs >
-        {
-            let path = '/feg/{network_id}/gateways/{gateway_id}/federation';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
 
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdMsisdns(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: subscriber_id,
+  }> {
+    let path = '/lte/{network_id}/msisdns';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postFegByNetworkIdGatewaysByGatewayIdFederation(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'config': gateway_federation_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/gateways/{gateway_id}/federation';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdMsisdns(parameters: {
+    networkId: string,
+    msisdnAssignment: msisdn_assignment,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/msisdns';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['msisdnAssignment'] === undefined) {
+      throw new Error('Missing required  parameter: msisdnAssignment');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    if (parameters['msisdnAssignment'] !== undefined) {
+      body = parameters['msisdnAssignment'];
+    }
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkIdMsisdnsByMsisdn(parameters: {
+    networkId: string,
+    msisdn: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/msisdns/{msisdn}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['msisdn'] === undefined) {
+      throw new Error('Missing required  parameter: msisdn');
     }
-    static async putFegByNetworkIdGatewaysByGatewayIdFederation(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'config': gateway_federation_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/gateways/{gateway_id}/federation';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{msisdn}', `${parameters['msisdn']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdMsisdnsByMsisdn(parameters: {
+    networkId: string,
+    msisdn: string,
+  }): Promise<subscriber_id> {
+    let path = '/lte/{network_id}/msisdns/{msisdn}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    if (parameters['msisdn'] === undefined) {
+      throw new Error('Missing required  parameter: msisdn');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{msisdn}', `${parameters['msisdn']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getFegByNetworkIdGatewaysByGatewayIdHealthStatus(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < federation_gateway_health_status >
-        {
-            let path = '/feg/{network_id}/gateways/{gateway_id}/health_status';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getFegByNetworkIdSubscriberConfig(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_subscriber_config >
-        {
-            let path = '/feg/{network_id}/subscriber_config';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegByNetworkIdSubscriberConfig(
-        parameters: {
-            'networkId': string,
-            'record': network_subscriber_config,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/subscriber_config';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getLteByNetworkIdName(parameters: {
+    networkId: string,
+  }): Promise<network_name> {
+    let path = '/lte/{network_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdName(parameters: {
+    networkId: string,
+    name: network_name,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getFegByNetworkIdSubscriberConfigBaseNames(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < base_names >
-        {
-            let path = '/feg/{network_id}/subscriber_config/base_names';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegByNetworkIdSubscriberConfigBaseNames(
-        parameters: {
-            'networkId': string,
-            'record': base_names,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/subscriber_config/base_names';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['name'] === undefined) {
+      throw new Error('Missing required  parameter: name');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['name'] !== undefined) {
+      body = parameters['name'];
+    }
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdNetworkProbeDestinations(parameters: {
+    networkId: string,
+  }): Promise<network_probe_destination> {
+    let path = '/lte/{network_id}/network_probe/destinations';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdNetworkProbeDestinations(parameters: {
+    networkId: string,
+    networkProbeDestination: network_probe_destination,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/network_probe/destinations';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteFegByNetworkIdSubscriberConfigBaseNamesByBaseName(
-        parameters: {
-            'networkId': string,
-            'baseName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/subscriber_config/base_names/{base_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['baseName'] === undefined) {
-            throw new Error('Missing required  parameter: baseName');
-        }
+    if (parameters['networkProbeDestination'] === undefined) {
+      throw new Error('Missing required  parameter: networkProbeDestination');
+    }
 
-        path = path.replace('{base_name}', `${parameters['baseName']}`);
+    if (parameters['networkProbeDestination'] !== undefined) {
+      body = parameters['networkProbeDestination'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkIdNetworkProbeDestinationsByDestinationId(parameters: {
+    networkId: string,
+    destinationId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/network_probe/destinations/{destination_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async postFegByNetworkIdSubscriberConfigBaseNamesByBaseName(
-        parameters: {
-            'networkId': string,
-            'baseName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/subscriber_config/base_names/{base_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['baseName'] === undefined) {
-            throw new Error('Missing required  parameter: baseName');
-        }
+    if (parameters['destinationId'] === undefined) {
+      throw new Error('Missing required  parameter: destinationId');
+    }
 
-        path = path.replace('{base_name}', `${parameters['baseName']}`);
-
-        return await this.request(path, 'POST', query, body);
-    }
-    static async getFegByNetworkIdSubscriberConfigRuleNames(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < rule_names >
-        {
-            let path = '/feg/{network_id}/subscriber_config/rule_names';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegByNetworkIdSubscriberConfigRuleNames(
-        parameters: {
-            'networkId': string,
-            'record': rule_names,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/subscriber_config/rule_names';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{destination_id}', `${parameters['destinationId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdNetworkProbeDestinationsByDestinationId(parameters: {
+    networkId: string,
+    destinationId: string,
+  }): Promise<network_probe_destination> {
+    let path = '/lte/{network_id}/network_probe/destinations/{destination_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    if (parameters['destinationId'] === undefined) {
+      throw new Error('Missing required  parameter: destinationId');
+    }
+
+    path = path.replace('{destination_id}', `${parameters['destinationId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdNetworkProbeDestinationsByDestinationId(parameters: {
+    networkId: string,
+    destinationId: string,
+    networkProbeDestination: network_probe_destination,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/network_probe/destinations/{destination_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteFegByNetworkIdSubscriberConfigRuleNamesByRuleId(
-        parameters: {
-            'networkId': string,
-            'ruleId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/subscriber_config/rule_names/{rule_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['ruleId'] === undefined) {
-            throw new Error('Missing required  parameter: ruleId');
-        }
+    if (parameters['destinationId'] === undefined) {
+      throw new Error('Missing required  parameter: destinationId');
+    }
 
-        path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+    path = path.replace('{destination_id}', `${parameters['destinationId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['networkProbeDestination'] === undefined) {
+      throw new Error('Missing required  parameter: networkProbeDestination');
     }
-    static async postFegByNetworkIdSubscriberConfigRuleNamesByRuleId(
-        parameters: {
-            'networkId': string,
-            'ruleId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg/{network_id}/subscriber_config/rule_names/{rule_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['networkProbeDestination'] !== undefined) {
+      body = parameters['networkProbeDestination'];
+    }
 
-        if (parameters['ruleId'] === undefined) {
-            throw new Error('Missing required  parameter: ruleId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdNetworkProbeTasks(parameters: {
+    networkId: string,
+  }): Promise<network_probe_task> {
+    let path = '/lte/{network_id}/network_probe/tasks';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdNetworkProbeTasks(parameters: {
+    networkId: string,
+    networkProbeTask: network_probe_task,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/network_probe/tasks';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getFegLte(): Promise < Array < string >
-        >
-        {
-            let path = '/feg_lte';
-            let body;
-            let query = {};
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postFegLte(
-        parameters: {
-            'lteNetwork': feg_lte_network,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte';
-        let body;
-        let query = {};
-        if (parameters['lteNetwork'] === undefined) {
-            throw new Error('Missing required  parameter: lteNetwork');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['lteNetwork'] !== undefined) {
-            body = parameters['lteNetwork'];
-        }
+    if (parameters['networkProbeTask'] === undefined) {
+      throw new Error('Missing required  parameter: networkProbeTask');
+    }
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['networkProbeTask'] !== undefined) {
+      body = parameters['networkProbeTask'];
     }
-    static async deleteFegLteByNetworkId(
-        parameters: {
-            'networkId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getFegLteByNetworkId(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < feg_lte_network >
-        {
-            let path = '/feg_lte/{network_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegLteByNetworkId(
-        parameters: {
-            'networkId': string,
-            'lteNetwork': feg_lte_network,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkIdNetworkProbeTasksByTaskId(parameters: {
+    networkId: string,
+    taskId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/network_probe/tasks/{task_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['lteNetwork'] === undefined) {
-            throw new Error('Missing required  parameter: lteNetwork');
-        }
+    if (parameters['taskId'] === undefined) {
+      throw new Error('Missing required  parameter: taskId');
+    }
 
-        if (parameters['lteNetwork'] !== undefined) {
-            body = parameters['lteNetwork'];
-        }
+    path = path.replace('{task_id}', `${parameters['taskId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdNetworkProbeTasksByTaskId(parameters: {
+    networkId: string,
+    taskId: string,
+  }): Promise<network_probe_task> {
+    let path = '/lte/{network_id}/network_probe/tasks/{task_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteFegLteByNetworkIdFederation(
-        parameters: {
-            'networkId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}/federation';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
-
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getFegLteByNetworkIdFederation(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < federated_network_configs >
-        {
-            let path = '/feg_lte/{network_id}/federation';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegLteByNetworkIdFederation(
-        parameters: {
-            'networkId': string,
-            'config': federated_network_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}/federation';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    if (parameters['taskId'] === undefined) {
+      throw new Error('Missing required  parameter: taskId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{task_id}', `${parameters['taskId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getFegLteByNetworkIdSubscriberConfig(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_subscriber_config >
-        {
-            let path = '/feg_lte/{network_id}/subscriber_config';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegLteByNetworkIdSubscriberConfig(
-        parameters: {
-            'networkId': string,
-            'record': network_subscriber_config,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}/subscriber_config';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdNetworkProbeTasksByTaskId(parameters: {
+    networkId: string,
+    taskId: string,
+    networkProbeTask: network_probe_task,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/network_probe/tasks/{task_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    if (parameters['taskId'] === undefined) {
+      throw new Error('Missing required  parameter: taskId');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    path = path.replace('{task_id}', `${parameters['taskId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getFegLteByNetworkIdSubscriberConfigBaseNames(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < base_names >
-        {
-            let path = '/feg_lte/{network_id}/subscriber_config/base_names';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegLteByNetworkIdSubscriberConfigBaseNames(
-        parameters: {
-            'networkId': string,
-            'record': base_names,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}/subscriber_config/base_names';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['networkProbeTask'] === undefined) {
+      throw new Error('Missing required  parameter: networkProbeTask');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['networkProbeTask'] !== undefined) {
+      body = parameters['networkProbeTask'];
+    }
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdPolicyQosProfiles(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: policy_qos_profile,
+  }> {
+    let path = '/lte/{network_id}/policy_qos_profiles';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdPolicyQosProfiles(parameters: {
+    networkId: string,
+    policy: policy_qos_profile,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/policy_qos_profiles';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteFegLteByNetworkIdSubscriberConfigBaseNamesByBaseName(
-        parameters: {
-            'networkId': string,
-            'baseName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}/subscriber_config/base_names/{base_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['baseName'] === undefined) {
-            throw new Error('Missing required  parameter: baseName');
-        }
+    if (parameters['policy'] === undefined) {
+      throw new Error('Missing required  parameter: policy');
+    }
 
-        path = path.replace('{base_name}', `${parameters['baseName']}`);
+    if (parameters['policy'] !== undefined) {
+      body = parameters['policy'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkIdPolicyQosProfilesByProfileId(parameters: {
+    networkId: string,
+    profileId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/policy_qos_profiles/{profile_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async postFegLteByNetworkIdSubscriberConfigBaseNamesByBaseName(
-        parameters: {
-            'networkId': string,
-            'baseName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}/subscriber_config/base_names/{base_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['baseName'] === undefined) {
-            throw new Error('Missing required  parameter: baseName');
-        }
+    if (parameters['profileId'] === undefined) {
+      throw new Error('Missing required  parameter: profileId');
+    }
 
-        path = path.replace('{base_name}', `${parameters['baseName']}`);
-
-        return await this.request(path, 'POST', query, body);
-    }
-    static async getFegLteByNetworkIdSubscriberConfigRuleNames(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < rule_names >
-        {
-            let path = '/feg_lte/{network_id}/subscriber_config/rule_names';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putFegLteByNetworkIdSubscriberConfigRuleNames(
-        parameters: {
-            'networkId': string,
-            'record': rule_names,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}/subscriber_config/rule_names';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{profile_id}', `${parameters['profileId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdPolicyQosProfilesByProfileId(parameters: {
+    networkId: string,
+    profileId: string,
+  }): Promise<policy_qos_profile> {
+    let path = '/lte/{network_id}/policy_qos_profiles/{profile_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    if (parameters['profileId'] === undefined) {
+      throw new Error('Missing required  parameter: profileId');
+    }
+
+    path = path.replace('{profile_id}', `${parameters['profileId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdPolicyQosProfilesByProfileId(parameters: {
+    networkId: string,
+    profileId: string,
+    profile: policy_qos_profile,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/policy_qos_profiles/{profile_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteFegLteByNetworkIdSubscriberConfigRuleNamesByRuleId(
-        parameters: {
-            'networkId': string,
-            'ruleId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}/subscriber_config/rule_names/{rule_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['ruleId'] === undefined) {
-            throw new Error('Missing required  parameter: ruleId');
-        }
+    if (parameters['profileId'] === undefined) {
+      throw new Error('Missing required  parameter: profileId');
+    }
 
-        path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+    path = path.replace('{profile_id}', `${parameters['profileId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['profile'] === undefined) {
+      throw new Error('Missing required  parameter: profile');
     }
-    static async postFegLteByNetworkIdSubscriberConfigRuleNamesByRuleId(
-        parameters: {
-            'networkId': string,
-            'ruleId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/feg_lte/{network_id}/subscriber_config/rule_names/{rule_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['profile'] !== undefined) {
+      body = parameters['profile'];
+    }
 
-        if (parameters['ruleId'] === undefined) {
-            throw new Error('Missing required  parameter: ruleId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdSms(parameters: {
+    networkId: string,
+  }): Promise<Array<sms_message>> {
+    let path = '/lte/{network_id}/sms';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdSms(parameters: {
+    networkId: string,
+    sms: mutable_sms_message,
+  }): Promise<string> {
+    let path = '/lte/{network_id}/sms';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getFoo(): Promise < number >
-        {
-            let path = '/foo';
-            let body;
-            let query = {};
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getLte(): Promise < Array < string >
-        >
-        {
-            let path = '/lte';
-            let body;
-            let query = {};
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLte(
-        parameters: {
-            'lteNetwork': lte_network,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte';
-        let body;
-        let query = {};
-        if (parameters['lteNetwork'] === undefined) {
-            throw new Error('Missing required  parameter: lteNetwork');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['lteNetwork'] !== undefined) {
-            body = parameters['lteNetwork'];
-        }
+    if (parameters['sms'] === undefined) {
+      throw new Error('Missing required  parameter: sms');
+    }
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['sms'] !== undefined) {
+      body = parameters['sms'];
     }
-    static async deleteLteByNetworkId(
-        parameters: {
-            'networkId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getLteByNetworkId(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < lte_network >
-        {
-            let path = '/lte/{network_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkId(
-        parameters: {
-            'networkId': string,
-            'lteNetwork': lte_network,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkIdSmsBySmsPk(parameters: {
+    networkId: string,
+    smsPk: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/sms/{sms_pk}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['lteNetwork'] === undefined) {
-            throw new Error('Missing required  parameter: lteNetwork');
-        }
+    if (parameters['smsPk'] === undefined) {
+      throw new Error('Missing required  parameter: smsPk');
+    }
 
-        if (parameters['lteNetwork'] !== undefined) {
-            body = parameters['lteNetwork'];
-        }
+    path = path.replace('{sms_pk}', `${parameters['smsPk']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdApns(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: apn,
-        } >
-        {
-            let path = '/lte/{network_id}/apns';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdApns(
-        parameters: {
-            'networkId': string,
-            'apn': apn,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/apns';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdSmsBySmsPk(parameters: {
+    networkId: string,
+    smsPk: string,
+  }): Promise<sms_message> {
+    let path = '/lte/{network_id}/sms/{sms_pk}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['apn'] === undefined) {
-            throw new Error('Missing required  parameter: apn');
-        }
+    if (parameters['smsPk'] === undefined) {
+      throw new Error('Missing required  parameter: smsPk');
+    }
 
-        if (parameters['apn'] !== undefined) {
-            body = parameters['apn'];
-        }
+    path = path.replace('{sms_pk}', `${parameters['smsPk']}`);
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getLteByNetworkIdSubscriberConfig(parameters: {
+    networkId: string,
+  }): Promise<network_subscriber_config> {
+    let path = '/lte/{network_id}/subscriber_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteLteByNetworkIdApnsByApnName(
-        parameters: {
-            'networkId': string,
-            'apnName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/apns/{apn_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['apnName'] === undefined) {
-            throw new Error('Missing required  parameter: apnName');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdSubscriberConfig(parameters: {
+    networkId: string,
+    record: network_subscriber_config,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscriber_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{apn_name}', `${parameters['apnName']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
     }
-    static async getLteByNetworkIdApnsByApnName(
-            parameters: {
-                'networkId': string,
-                'apnName': string,
-            }
-        ): Promise < apn >
-        {
-            let path = '/lte/{network_id}/apns/{apn_name}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
 
-            if (parameters['apnName'] === undefined) {
-                throw new Error('Missing required  parameter: apnName');
-            }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getLteByNetworkIdSubscriberConfigBaseNames(parameters: {
+    networkId: string,
+  }): Promise<base_names> {
+    let path = '/lte/{network_id}/subscriber_config/base_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            path = path.replace('{apn_name}', `${parameters['apnName']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdApnsByApnName(
-        parameters: {
-            'networkId': string,
-            'apnName': string,
-            'apn': apn,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/apns/{apn_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdSubscriberConfigBaseNames(parameters: {
+    networkId: string,
+    record: base_names,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscriber_config/base_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['apnName'] === undefined) {
-            throw new Error('Missing required  parameter: apnName');
-        }
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
 
-        path = path.replace('{apn_name}', `${parameters['apnName']}`);
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
 
-        if (parameters['apn'] === undefined) {
-            throw new Error('Missing required  parameter: apn');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteLteByNetworkIdSubscriberConfigBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscriber_config/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['apn'] !== undefined) {
-            body = parameters['apn'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdCellular(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_cellular_configs >
-        {
-            let path = '/lte/{network_id}/cellular';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdCellular(
-        parameters: {
-            'networkId': string,
-            'config': network_cellular_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/cellular';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async postLteByNetworkIdSubscriberConfigBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscriber_config/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdCellularEpc(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_epc_configs >
-        {
-            let path = '/lte/{network_id}/cellular/epc';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdCellularEpc(
-        parameters: {
-            'networkId': string,
-            'config': network_epc_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/cellular/epc';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getLteByNetworkIdSubscriberConfigRuleNames(parameters: {
+    networkId: string,
+  }): Promise<rule_names> {
+    let path = '/lte/{network_id}/subscriber_config/rule_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdCellularFegNetworkId(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < string >
-        {
-            let path = '/lte/{network_id}/cellular/feg_network_id';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdCellularFegNetworkId(
-        parameters: {
-            'networkId': string,
-            'fegNetworkId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/cellular/feg_network_id';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdSubscriberConfigRuleNames(parameters: {
+    networkId: string,
+    record: rule_names,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscriber_config/rule_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['fegNetworkId'] === undefined) {
-            throw new Error('Missing required  parameter: fegNetworkId');
-        }
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
 
-        if (parameters['fegNetworkId'] !== undefined) {
-            body = parameters['fegNetworkId'];
-        }
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdCellularRan(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_ran_configs >
-        {
-            let path = '/lte/{network_id}/cellular/ran';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdCellularRan(
-        parameters: {
-            'networkId': string,
-            'config': network_ran_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/cellular/ran';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteLteByNetworkIdSubscriberConfigRuleNamesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscriber_config/rule_names/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdDescription(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_description >
-        {
-            let path = '/lte/{network_id}/description';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdDescription(
-        parameters: {
-            'networkId': string,
-            'description': network_description,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/description';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async postLteByNetworkIdSubscriberConfigRuleNamesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscriber_config/rule_names/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['description'] === undefined) {
-            throw new Error('Missing required  parameter: description');
-        }
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
 
-        if (parameters['description'] !== undefined) {
-            body = parameters['description'];
-        }
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdDns(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_dns_config >
-        {
-            let path = '/lte/{network_id}/dns';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdDns(
-        parameters: {
-            'networkId': string,
-            'config': network_dns_config,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/dns';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getLteByNetworkIdSubscriberState(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: subscriber_state,
+  }> {
+    let path = '/lte/{network_id}/subscriber_state';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getLteByNetworkIdSubscriberStateBySubscriberId(parameters: {
+    networkId: string,
+    subscriberId: string,
+  }): Promise<subscriber_state> {
+    let path = '/lte/{network_id}/subscriber_state/{subscriber_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdDnsRecords(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < Array < dns_config_record >
-        >
-        {
-            let path = '/lte/{network_id}/dns/records';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdDnsRecords(
-        parameters: {
-            'networkId': string,
-            'records': Array < dns_config_record >
-                ,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/dns/records';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['subscriberId'] === undefined) {
+      throw new Error('Missing required  parameter: subscriberId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
 
-        if (parameters['records'] === undefined) {
-            throw new Error('Missing required  parameter: records');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getLteByNetworkIdSubscribers(parameters: {
+    networkId: string,
+    msisdn?: string,
+    ip?: string,
+    pageSize?: number,
+    pageToken?: string,
+  }): Promise<paginated_subscribers> {
+    let path = '/lte/{network_id}/subscribers';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['records'] !== undefined) {
-            body = parameters['records'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    if (parameters['msisdn'] !== undefined) {
+      query['msisdn'] = parameters['msisdn'];
     }
-    static async deleteLteByNetworkIdDnsRecordsByDomain(
-        parameters: {
-            'networkId': string,
-            'domain': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/dns/records/{domain}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['ip'] !== undefined) {
+      query['ip'] = parameters['ip'];
+    }
 
-        if (parameters['domain'] === undefined) {
-            throw new Error('Missing required  parameter: domain');
-        }
+    if (parameters['pageSize'] !== undefined) {
+      query['page_size'] = parameters['pageSize'];
+    }
 
-        path = path.replace('{domain}', `${parameters['domain']}`);
+    if (parameters['pageToken'] !== undefined) {
+      query['page_token'] = parameters['pageToken'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postLteByNetworkIdSubscribers(parameters: {
+    networkId: string,
+    subscribers: mutable_subscribers,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscribers';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getLteByNetworkIdDnsRecordsByDomain(
-            parameters: {
-                'networkId': string,
-                'domain': string,
-            }
-        ): Promise < dns_config_record >
-        {
-            let path = '/lte/{network_id}/dns/records/{domain}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['domain'] === undefined) {
-                throw new Error('Missing required  parameter: domain');
-            }
+    if (parameters['subscribers'] === undefined) {
+      throw new Error('Missing required  parameter: subscribers');
+    }
 
-            path = path.replace('{domain}', `${parameters['domain']}`);
+    if (parameters['subscribers'] !== undefined) {
+      body = parameters['subscribers'];
+    }
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdDnsRecordsByDomain(
-        parameters: {
-            'networkId': string,
-            'domain': string,
-            'record': dns_config_record,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/dns/records/{domain}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteLteByNetworkIdSubscribersBySubscriberId(parameters: {
+    networkId: string,
+    subscriberId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscribers/{subscriber_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['domain'] === undefined) {
-            throw new Error('Missing required  parameter: domain');
-        }
+    if (parameters['subscriberId'] === undefined) {
+      throw new Error('Missing required  parameter: subscriberId');
+    }
 
-        path = path.replace('{domain}', `${parameters['domain']}`);
+    path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getLteByNetworkIdSubscribersBySubscriberId(parameters: {
+    networkId: string,
+    subscriberId: string,
+  }): Promise<subscriber> {
+    let path = '/lte/{network_id}/subscribers/{subscriber_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['subscriberId'] === undefined) {
+      throw new Error('Missing required  parameter: subscriberId');
     }
-    static async putLteByNetworkIdDnsRecordsByDomain(
-        parameters: {
-            'networkId': string,
-            'domain': string,
-            'record': dns_config_record,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/dns/records/{domain}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
 
-        if (parameters['domain'] === undefined) {
-            throw new Error('Missing required  parameter: domain');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putLteByNetworkIdSubscribersBySubscriberId(parameters: {
+    networkId: string,
+    subscriberId: string,
+    subscriber: mutable_subscriber,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscribers/{subscriber_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{domain}', `${parameters['domain']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    if (parameters['subscriberId'] === undefined) {
+      throw new Error('Missing required  parameter: subscriberId');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdEnodebs(
-            parameters: {
-                'networkId': string,
-                'pageSize' ? : number,
-                'pageToken' ? : string,
-            }
-        ): Promise < paginated_enodebs >
-        {
-            let path = '/lte/{network_id}/enodebs';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['pageSize'] !== undefined) {
-                query['page_size'] = parameters['pageSize'];
-            }
-
-            if (parameters['pageToken'] !== undefined) {
-                query['page_token'] = parameters['pageToken'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdEnodebs(
-        parameters: {
-            'networkId': string,
-            'enodeb': enodeb,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/enodebs';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['subscriber'] === undefined) {
+      throw new Error('Missing required  parameter: subscriber');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['subscriber'] !== undefined) {
+      body = parameters['subscriber'];
+    }
 
-        if (parameters['enodeb'] === undefined) {
-            throw new Error('Missing required  parameter: enodeb');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async postLteByNetworkIdSubscribersBySubscriberIdActivate(parameters: {
+    networkId: string,
+    subscriberId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscribers/{subscriber_id}/activate';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['enodeb'] !== undefined) {
-            body = parameters['enodeb'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['subscriberId'] === undefined) {
+      throw new Error('Missing required  parameter: subscriberId');
     }
-    static async deleteLteByNetworkIdEnodebsByEnodebSerial(
-        parameters: {
-            'networkId': string,
-            'enodebSerial': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/enodebs/{enodeb_serial}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
 
-        if (parameters['enodebSerial'] === undefined) {
-            throw new Error('Missing required  parameter: enodebSerial');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async postLteByNetworkIdSubscribersBySubscriberIdDeactivate(parameters: {
+    networkId: string,
+    subscriberId: string,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscribers/{subscriber_id}/deactivate';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{enodeb_serial}', `${parameters['enodebSerial']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['subscriberId'] === undefined) {
+      throw new Error('Missing required  parameter: subscriberId');
     }
-    static async getLteByNetworkIdEnodebsByEnodebSerial(
-            parameters: {
-                'networkId': string,
-                'enodebSerial': string,
-            }
-        ): Promise < enodeb >
-        {
-            let path = '/lte/{network_id}/enodebs/{enodeb_serial}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
 
-            if (parameters['enodebSerial'] === undefined) {
-                throw new Error('Missing required  parameter: enodebSerial');
-            }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async putLteByNetworkIdSubscribersBySubscriberIdLteSubProfile(parameters: {
+    networkId: string,
+    subscriberId: string,
+    profileName: sub_profile,
+  }): Promise<'Success'> {
+    let path = '/lte/{network_id}/subscribers/{subscriber_id}/lte/sub_profile';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            path = path.replace('{enodeb_serial}', `${parameters['enodebSerial']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdEnodebsByEnodebSerial(
-        parameters: {
-            'networkId': string,
-            'enodebSerial': string,
-            'enodeb': enodeb,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/enodebs/{enodeb_serial}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['subscriberId'] === undefined) {
+      throw new Error('Missing required  parameter: subscriberId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
 
-        if (parameters['enodebSerial'] === undefined) {
-            throw new Error('Missing required  parameter: enodebSerial');
-        }
+    if (parameters['profileName'] === undefined) {
+      throw new Error('Missing required  parameter: profileName');
+    }
 
-        path = path.replace('{enodeb_serial}', `${parameters['enodebSerial']}`);
+    if (parameters['profileName'] !== undefined) {
+      body = parameters['profileName'];
+    }
 
-        if (parameters['enodeb'] === undefined) {
-            throw new Error('Missing required  parameter: enodeb');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworks(): Promise<Array<string>> {
+    const path = '/networks';
+    let body;
+    const query = {};
 
-        if (parameters['enodeb'] !== undefined) {
-            body = parameters['enodeb'];
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworks(parameters: {
+    network: network,
+  }): Promise<'Success'> {
+    const path = '/networks';
+    let body;
+    const query = {};
+    if (parameters['network'] === undefined) {
+      throw new Error('Missing required  parameter: network');
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdEnodebsByEnodebSerialState(
-            parameters: {
-                'networkId': string,
-                'enodebSerial': string,
-            }
-        ): Promise < enodeb_state >
-        {
-            let path = '/lte/{network_id}/enodebs/{enodeb_serial}/state';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['enodebSerial'] === undefined) {
-                throw new Error('Missing required  parameter: enodebSerial');
-            }
-
-            path = path.replace('{enodeb_serial}', `${parameters['enodebSerial']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getLteByNetworkIdFeatures(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_features >
-        {
-            let path = '/lte/{network_id}/features';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdFeatures(
-        parameters: {
-            'networkId': string,
-            'config': network_features,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/features';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['network'] !== undefined) {
+      body = parameters['network'];
+    }
+
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteNetworksByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<network> {
+    let path = '/networks/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkId(parameters: {
+    networkId: string,
+    network: network,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewayPools(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: cellular_gateway_pool,
-        } >
-        {
-            let path = '/lte/{network_id}/gateway_pools';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdGatewayPools(
-        parameters: {
-            'networkId': string,
-            'haGatewayPool': mutable_cellular_gateway_pool,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateway_pools';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['network'] === undefined) {
+      throw new Error('Missing required  parameter: network');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['network'] !== undefined) {
+      body = parameters['network'];
+    }
 
-        if (parameters['haGatewayPool'] === undefined) {
-            throw new Error('Missing required  parameter: haGatewayPool');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdAlerts(parameters: {
+    networkId: string,
+  }): Promise<Array<prom_firing_alert>> {
+    let path = '/networks/{network_id}/alerts';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['haGatewayPool'] !== undefined) {
-            body = parameters['haGatewayPool'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async deleteNetworksByNetworkIdAlertsSilence(parameters: {
+    networkId: string,
+    silenceId: string,
+  }): Promise<string> {
+    let path = '/networks/{network_id}/alerts/silence';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteLteByNetworkIdGatewayPoolsByGatewayPoolId(
-        parameters: {
-            'networkId': string,
-            'gatewayPoolId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateway_pools/{gateway_pool_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayPoolId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayPoolId');
-        }
+    if (parameters['silenceId'] === undefined) {
+      throw new Error('Missing required  parameter: silenceId');
+    }
 
-        path = path.replace('{gateway_pool_id}', `${parameters['gatewayPoolId']}`);
+    if (parameters['silenceId'] !== undefined) {
+      query['silence_id'] = parameters['silenceId'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdAlertsSilence(parameters: {
+    networkId: string,
+    active?: boolean,
+    pending?: boolean,
+    expired?: boolean,
+    filter?: string,
+  }): Promise<Array<gettable_alert_silencer>> {
+    let path = '/networks/{network_id}/alerts/silence';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getLteByNetworkIdGatewayPoolsByGatewayPoolId(
-            parameters: {
-                'networkId': string,
-                'gatewayPoolId': string,
-            }
-        ): Promise < cellular_gateway_pool >
-        {
-            let path = '/lte/{network_id}/gateway_pools/{gateway_pool_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['gatewayPoolId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayPoolId');
-            }
+    if (parameters['active'] !== undefined) {
+      query['active'] = parameters['active'];
+    }
 
-            path = path.replace('{gateway_pool_id}', `${parameters['gatewayPoolId']}`);
+    if (parameters['pending'] !== undefined) {
+      query['pending'] = parameters['pending'];
+    }
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewayPoolsByGatewayPoolId(
-        parameters: {
-            'networkId': string,
-            'gatewayPoolId': string,
-            'haGatewayPool': mutable_cellular_gateway_pool,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateway_pools/{gateway_pool_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['expired'] !== undefined) {
+      query['expired'] = parameters['expired'];
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['filter'] !== undefined) {
+      query['filter'] = parameters['filter'];
+    }
 
-        if (parameters['gatewayPoolId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayPoolId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdAlertsSilence(parameters: {
+    networkId: string,
+    silencer: alert_silencer,
+  }): Promise<string> {
+    let path = '/networks/{network_id}/alerts/silence';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_pool_id}', `${parameters['gatewayPoolId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['haGatewayPool'] === undefined) {
-            throw new Error('Missing required  parameter: haGatewayPool');
-        }
+    if (parameters['silencer'] === undefined) {
+      throw new Error('Missing required  parameter: silencer');
+    }
 
-        if (parameters['haGatewayPool'] !== undefined) {
-            body = parameters['haGatewayPool'];
-        }
+    if (parameters['silencer'] !== undefined) {
+      body = parameters['silencer'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGateways(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: lte_gateway,
-        } >
-        {
-            let path = '/lte/{network_id}/gateways';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdGateways(
-        parameters: {
-            'networkId': string,
-            'gateway': mutable_lte_gateway,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getNetworksByNetworkIdDescription(parameters: {
+    networkId: string,
+  }): Promise<network_description> {
+    let path = '/networks/{network_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdDescription(parameters: {
+    networkId: string,
+    description: network_description,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['description'] === undefined) {
+      throw new Error('Missing required  parameter: description');
     }
-    static async deleteLteByNetworkIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['description'] !== undefined) {
+      body = parameters['description'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdDns(parameters: {
+    networkId: string,
+  }): Promise<network_dns_config> {
+    let path = '/networks/{network_id}/dns';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdDns(parameters: {
+    networkId: string,
+    networkDns: network_dns_config,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/dns';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getLteByNetworkIdGatewaysByGatewayId(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < lte_gateway >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
+    if (parameters['networkDns'] === undefined) {
+      throw new Error('Missing required  parameter: networkDns');
+    }
 
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    if (parameters['networkDns'] !== undefined) {
+      body = parameters['networkDns'];
+    }
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'gateway': mutable_lte_gateway,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdDnsRecords(parameters: {
+    networkId: string,
+  }): Promise<network_dns_records> {
+    let path = '/networks/{network_id}/dns/records';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdDnsRecords(parameters: {
+    networkId: string,
+    records: network_dns_records,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/dns/records';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    if (parameters['records'] === undefined) {
+      throw new Error('Missing required  parameter: records');
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    if (parameters['records'] !== undefined) {
+      body = parameters['records'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdCellular(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_cellular_configs >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/cellular';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdCellular(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'config': gateway_cellular_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/cellular';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteNetworksByNetworkIdDnsRecordsByDomain(parameters: {
+    networkId: string,
+    domain: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/dns/records/{domain}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['domain'] === undefined) {
+      throw new Error('Missing required  parameter: domain');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{domain}', `${parameters['domain']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdDnsRecordsByDomain(parameters: {
+    networkId: string,
+    domain: string,
+  }): Promise<dns_config_record> {
+    let path = '/networks/{network_id}/dns/records/{domain}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdCellularDns(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_dns_configs >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/dns';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdCellularDns(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'config': gateway_dns_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/dns';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['domain'] === undefined) {
+      throw new Error('Missing required  parameter: domain');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{domain}', `${parameters['domain']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdDnsRecordsByDomain(parameters: {
+    networkId: string,
+    domain: string,
+    record: dns_config_record,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/dns/records/{domain}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    if (parameters['domain'] === undefined) {
+      throw new Error('Missing required  parameter: domain');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{domain}', `${parameters['domain']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdCellularDnsRecords(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < Array < dns_config_record >
-        >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/dns/records';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdCellularDnsRecords(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'records': Array < dns_config_record >
-                ,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/dns/records';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async putNetworksByNetworkIdDnsRecordsByDomain(parameters: {
+    networkId: string,
+    domain: string,
+    record: dns_config_record,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/dns/records/{domain}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['records'] === undefined) {
-            throw new Error('Missing required  parameter: records');
-        }
+    if (parameters['domain'] === undefined) {
+      throw new Error('Missing required  parameter: domain');
+    }
 
-        if (parameters['records'] !== undefined) {
-            body = parameters['records'];
-        }
+    path = path.replace('{domain}', `${parameters['domain']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdCellularEpc(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_epc_configs >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/epc';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdCellularEpc(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'config': gateway_epc_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/epc';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['record'] === undefined) {
+      throw new Error('Missing required  parameter: record');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['record'] !== undefined) {
+      body = parameters['record'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdFeatures(parameters: {
+    networkId: string,
+  }): Promise<network_features> {
+    let path = '/networks/{network_id}/features';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdFeatures(parameters: {
+    networkId: string,
+    networkFeatures: network_features,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/features';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdCellularNonEps(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_non_eps_configs >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/non_eps';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdCellularNonEps(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'config': gateway_non_eps_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/non_eps';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['networkFeatures'] === undefined) {
+      throw new Error('Missing required  parameter: networkFeatures');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['networkFeatures'] !== undefined) {
+      body = parameters['networkFeatures'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdGateways(parameters: {
+    networkId: string,
+    pageSize?: number,
+    pageToken?: string,
+  }): Promise<paginated_gateways> {
+    let path = '/networks/{network_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    if (parameters['pageSize'] !== undefined) {
+      query['page_size'] = parameters['pageSize'];
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    if (parameters['pageToken'] !== undefined) {
+      query['page_token'] = parameters['pageToken'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdCellularPooling(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < Array < cellular_gateway_pool_record >
-        >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/pooling';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdCellularPooling(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'resource': Array < cellular_gateway_pool_record >
-                ,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/pooling';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdGateways(parameters: {
+    networkId: string,
+    gateway: magmad_gateway,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
+    }
 
-        if (parameters['resource'] === undefined) {
-            throw new Error('Missing required  parameter: resource');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteNetworksByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['resource'] !== undefined) {
-            body = parameters['resource'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdCellularRan(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_ran_configs >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/ran';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdCellularRan(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'config': gateway_ran_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/cellular/ran';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<magmad_gateway> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+    gateway: magmad_gateway,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteLteByNetworkIdGatewaysByGatewayIdConnectedEnodebSerials(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'serial': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/connected_enodeb_serials';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['serial'] === undefined) {
-            throw new Error('Missing required  parameter: serial');
-        }
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
 
-        if (parameters['serial'] !== undefined) {
-            body = parameters['serial'];
-        }
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdConnectedEnodebSerials(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < enodeb_serials >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/connected_enodeb_serials';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdGatewaysByGatewayIdConnectedEnodebSerials(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'serial': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/connected_enodeb_serials';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async postNetworksByNetworkIdGatewaysByGatewayIdCommandGeneric(parameters: {
+    networkId: string,
+    gatewayId: string,
+    parameters: generic_command_params,
+  }): Promise<generic_command_response> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/command/generic';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['serial'] === undefined) {
-            throw new Error('Missing required  parameter: serial');
-        }
+    if (parameters['parameters'] === undefined) {
+      throw new Error('Missing required  parameter: parameters');
+    }
 
-        if (parameters['serial'] !== undefined) {
-            body = parameters['serial'];
-        }
+    if (parameters['parameters'] !== undefined) {
+      body = parameters['parameters'];
+    }
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'POST', query, body);
+  }
+  static async postNetworksByNetworkIdGatewaysByGatewayIdCommandPing(parameters: {
+    networkId: string,
+    gatewayId: string,
+    pingRequest: ping_request,
+  }): Promise<ping_response> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/command/ping';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async putLteByNetworkIdGatewaysByGatewayIdConnectedEnodebSerials(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'serials': enodeb_serials,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/connected_enodeb_serials';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['serials'] === undefined) {
-            throw new Error('Missing required  parameter: serials');
-        }
+    if (parameters['pingRequest'] === undefined) {
+      throw new Error('Missing required  parameter: pingRequest');
+    }
 
-        if (parameters['serials'] !== undefined) {
-            body = parameters['serials'];
-        }
+    if (parameters['pingRequest'] !== undefined) {
+      body = parameters['pingRequest'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdDescription(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_description >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/description';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdDescription(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'description': gateway_description,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/description';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async postNetworksByNetworkIdGatewaysByGatewayIdCommandReboot(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/command/reboot';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['description'] === undefined) {
-            throw new Error('Missing required  parameter: description');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async postNetworksByNetworkIdGatewaysByGatewayIdCommandRestartServices(parameters: {
+    networkId: string,
+    gatewayId: string,
+    services: Array<string>,
+  }): Promise<'Success'> {
+    let path =
+      '/networks/{network_id}/gateways/{gateway_id}/command/restart_services';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['description'] !== undefined) {
-            body = parameters['description'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdDevice(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_device >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/device';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdDevice(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'device': gateway_device,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/device';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['services'] === undefined) {
+      throw new Error('Missing required  parameter: services');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    if (parameters['services'] !== undefined) {
+      body = parameters['services'];
+    }
 
-        if (parameters['device'] === undefined) {
-            throw new Error('Missing required  parameter: device');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getNetworksByNetworkIdGatewaysByGatewayIdDescription(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_description> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['device'] !== undefined) {
-            body = parameters['device'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdMagmad(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < magmad_gateway_configs >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/magmad';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdMagmad(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'magmad': magmad_gateway_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/magmad';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdGatewaysByGatewayIdDescription(parameters: {
+    networkId: string,
+    gatewayId: string,
+    description: gateway_description,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['magmad'] === undefined) {
-            throw new Error('Missing required  parameter: magmad');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['magmad'] !== undefined) {
-            body = parameters['magmad'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdName(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_name >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/name';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdName(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'name': gateway_name,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/name';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['description'] === undefined) {
+      throw new Error('Missing required  parameter: description');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['description'] !== undefined) {
+      body = parameters['description'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdGatewaysByGatewayIdDevice(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_device> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/device';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['name'] === undefined) {
-            throw new Error('Missing required  parameter: name');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['name'] !== undefined) {
-            body = parameters['name'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdStatus(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_status >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/status';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getLteByNetworkIdGatewaysByGatewayIdTier(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < tier_id >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/tier';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdTier(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'tierId': tier_id,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/tier';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdGatewaysByGatewayIdDevice(parameters: {
+    networkId: string,
+    gatewayId: string,
+    device: gateway_device,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/device';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    if (parameters['device'] === undefined) {
+      throw new Error('Missing required  parameter: device');
+    }
 
-        if (parameters['tierId'] !== undefined) {
-            body = parameters['tierId'];
-        }
+    if (parameters['device'] !== undefined) {
+      body = parameters['device'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdGatewaysByGatewayIdVpn(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_vpn_configs >
-        {
-            let path = '/lte/{network_id}/gateways/{gateway_id}/vpn';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdGatewaysByGatewayIdVpn(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'config': gateway_vpn_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/gateways/{gateway_id}/vpn';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdGatewaysByGatewayIdMagmad(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<magmad_gateway_configs> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/magmad';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdGatewaysByGatewayIdMagmad(parameters: {
+    networkId: string,
+    gatewayId: string,
+    magmad: magmad_gateway_configs,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/magmad';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdMsisdns(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: subscriber_id,
-        } >
-        {
-            let path = '/lte/{network_id}/msisdns';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdMsisdns(
-        parameters: {
-            'networkId': string,
-            'msisdnAssignment': msisdn_assignment,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/msisdns';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['msisdnAssignment'] === undefined) {
-            throw new Error('Missing required  parameter: msisdnAssignment');
-        }
+    if (parameters['magmad'] === undefined) {
+      throw new Error('Missing required  parameter: magmad');
+    }
 
-        if (parameters['msisdnAssignment'] !== undefined) {
-            body = parameters['msisdnAssignment'];
-        }
+    if (parameters['magmad'] !== undefined) {
+      body = parameters['magmad'];
+    }
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdGatewaysByGatewayIdName(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_name> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteLteByNetworkIdMsisdnsByMsisdn(
-        parameters: {
-            'networkId': string,
-            'msisdn': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/msisdns/{msisdn}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['msisdn'] === undefined) {
-            throw new Error('Missing required  parameter: msisdn');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{msisdn}', `${parameters['msisdn']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdGatewaysByGatewayIdName(parameters: {
+    networkId: string,
+    gatewayId: string,
+    name: gateway_name,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getLteByNetworkIdMsisdnsByMsisdn(
-            parameters: {
-                'networkId': string,
-                'msisdn': string,
-            }
-        ): Promise < subscriber_id >
-        {
-            let path = '/lte/{network_id}/msisdns/{msisdn}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['msisdn'] === undefined) {
-                throw new Error('Missing required  parameter: msisdn');
-            }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-            path = path.replace('{msisdn}', `${parameters['msisdn']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getLteByNetworkIdName(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_name >
-        {
-            let path = '/lte/{network_id}/name';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdName(
-        parameters: {
-            'networkId': string,
-            'name': network_name,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/name';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['name'] === undefined) {
+      throw new Error('Missing required  parameter: name');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['name'] !== undefined) {
+      body = parameters['name'];
+    }
 
-        if (parameters['name'] === undefined) {
-            throw new Error('Missing required  parameter: name');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdGatewaysByGatewayIdStatus(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_status> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/status';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['name'] !== undefined) {
-            body = parameters['name'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdNetworkProbeDestinations(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_probe_destination >
-        {
-            let path = '/lte/{network_id}/network_probe/destinations';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdNetworkProbeDestinations(
-        parameters: {
-            'networkId': string,
-            'networkProbeDestination': network_probe_destination,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/network_probe/destinations';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['networkProbeDestination'] === undefined) {
-            throw new Error('Missing required  parameter: networkProbeDestination');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getNetworksByNetworkIdGatewaysByGatewayIdTier(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<tier_id> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/tier';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['networkProbeDestination'] !== undefined) {
-            body = parameters['networkProbeDestination'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
     }
-    static async deleteLteByNetworkIdNetworkProbeDestinationsByDestinationId(
-        parameters: {
-            'networkId': string,
-            'destinationId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/network_probe/destinations/{destination_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['destinationId'] === undefined) {
-            throw new Error('Missing required  parameter: destinationId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdGatewaysByGatewayIdTier(parameters: {
+    networkId: string,
+    gatewayId: string,
+    tierId: tier_id,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/gateways/{gateway_id}/tier';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{destination_id}', `${parameters['destinationId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
     }
-    static async getLteByNetworkIdNetworkProbeDestinationsByDestinationId(
-            parameters: {
-                'networkId': string,
-                'destinationId': string,
-            }
-        ): Promise < network_probe_destination >
-        {
-            let path = '/lte/{network_id}/network_probe/destinations/{destination_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-            if (parameters['destinationId'] === undefined) {
-                throw new Error('Missing required  parameter: destinationId');
-            }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-            path = path.replace('{destination_id}', `${parameters['destinationId']}`);
+    if (parameters['tierId'] !== undefined) {
+      body = parameters['tierId'];
+    }
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdNetworkProbeDestinationsByDestinationId(
-        parameters: {
-            'networkId': string,
-            'destinationId': string,
-            'networkProbeDestination': network_probe_destination,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/network_probe/destinations/{destination_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdLogsCount(parameters: {
+    networkId: string,
+    simpleQuery?: string,
+    fields?: string,
+    filters?: string,
+    start?: string,
+    end?: string,
+  }): Promise<elastic_hit_count> {
+    let path = '/networks/{network_id}/logs/count';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['destinationId'] === undefined) {
-            throw new Error('Missing required  parameter: destinationId');
-        }
+    if (parameters['simpleQuery'] !== undefined) {
+      query['simple_query'] = parameters['simpleQuery'];
+    }
 
-        path = path.replace('{destination_id}', `${parameters['destinationId']}`);
+    if (parameters['fields'] !== undefined) {
+      query['fields'] = parameters['fields'];
+    }
 
-        if (parameters['networkProbeDestination'] === undefined) {
-            throw new Error('Missing required  parameter: networkProbeDestination');
-        }
+    if (parameters['filters'] !== undefined) {
+      query['filters'] = parameters['filters'];
+    }
 
-        if (parameters['networkProbeDestination'] !== undefined) {
-            body = parameters['networkProbeDestination'];
-        }
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdNetworkProbeTasks(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_probe_task >
-        {
-            let path = '/lte/{network_id}/network_probe/tasks';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdNetworkProbeTasks(
-        parameters: {
-            'networkId': string,
-            'networkProbeTask': network_probe_task,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/network_probe/tasks';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getNetworksByNetworkIdLogsSearch(parameters: {
+    networkId: string,
+    simpleQuery?: string,
+    fields?: string,
+    filters?: string,
+    size?: string,
+    from?: string,
+    start?: string,
+    end?: string,
+  }): Promise<Array<elastic_hit>> {
+    let path = '/networks/{network_id}/logs/search';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['networkProbeTask'] === undefined) {
-            throw new Error('Missing required  parameter: networkProbeTask');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['networkProbeTask'] !== undefined) {
-            body = parameters['networkProbeTask'];
-        }
+    if (parameters['simpleQuery'] !== undefined) {
+      query['simple_query'] = parameters['simpleQuery'];
+    }
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['fields'] !== undefined) {
+      query['fields'] = parameters['fields'];
     }
-    static async deleteLteByNetworkIdNetworkProbeTasksByTaskId(
-        parameters: {
-            'networkId': string,
-            'taskId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/network_probe/tasks/{task_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['filters'] !== undefined) {
+      query['filters'] = parameters['filters'];
+    }
 
-        if (parameters['taskId'] === undefined) {
-            throw new Error('Missing required  parameter: taskId');
-        }
+    if (parameters['size'] !== undefined) {
+      query['size'] = parameters['size'];
+    }
 
-        path = path.replace('{task_id}', `${parameters['taskId']}`);
+    if (parameters['from'] !== undefined) {
+      query['from'] = parameters['from'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
     }
-    static async getLteByNetworkIdNetworkProbeTasksByTaskId(
-            parameters: {
-                'networkId': string,
-                'taskId': string,
-            }
-        ): Promise < network_probe_task >
-        {
-            let path = '/lte/{network_id}/network_probe/tasks/{task_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
 
-            if (parameters['taskId'] === undefined) {
-                throw new Error('Missing required  parameter: taskId');
-            }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdMetricsPush(parameters: {
+    networkId: string,
+    metrics: Array<pushed_metric>,
+  }): Promise<'Submitted'> {
+    let path = '/networks/{network_id}/metrics/push';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            path = path.replace('{task_id}', `${parameters['taskId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdNetworkProbeTasksByTaskId(
-        parameters: {
-            'networkId': string,
-            'taskId': string,
-            'networkProbeTask': network_probe_task,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/network_probe/tasks/{task_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['metrics'] === undefined) {
+      throw new Error('Missing required  parameter: metrics');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['metrics'] !== undefined) {
+      body = parameters['metrics'];
+    }
 
-        if (parameters['taskId'] === undefined) {
-            throw new Error('Missing required  parameter: taskId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getNetworksByNetworkIdName(parameters: {
+    networkId: string,
+  }): Promise<network_name> {
+    let path = '/networks/{network_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{task_id}', `${parameters['taskId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['networkProbeTask'] === undefined) {
-            throw new Error('Missing required  parameter: networkProbeTask');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdName(parameters: {
+    networkId: string,
+    name: network_name,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['networkProbeTask'] !== undefined) {
-            body = parameters['networkProbeTask'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdPolicyQosProfiles(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: policy_qos_profile,
-        } >
-        {
-            let path = '/lte/{network_id}/policy_qos_profiles';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdPolicyQosProfiles(
-        parameters: {
-            'networkId': string,
-            'policy': policy_qos_profile,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/policy_qos_profiles';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['name'] === undefined) {
+      throw new Error('Missing required  parameter: name');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['name'] !== undefined) {
+      body = parameters['name'];
+    }
 
-        if (parameters['policy'] === undefined) {
-            throw new Error('Missing required  parameter: policy');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdPoliciesBaseNames(parameters: {
+    networkId: string,
+  }): Promise<Array<base_name>> {
+    let path = '/networks/{network_id}/policies/base_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['policy'] !== undefined) {
-            body = parameters['policy'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdPoliciesBaseNames(parameters: {
+    networkId: string,
+    baseNameRecord: base_name_record,
+  }): Promise<base_name> {
+    let path = '/networks/{network_id}/policies/base_names';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteLteByNetworkIdPolicyQosProfilesByProfileId(
-        parameters: {
-            'networkId': string,
-            'profileId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/policy_qos_profiles/{profile_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['profileId'] === undefined) {
-            throw new Error('Missing required  parameter: profileId');
-        }
+    if (parameters['baseNameRecord'] === undefined) {
+      throw new Error('Missing required  parameter: baseNameRecord');
+    }
 
-        path = path.replace('{profile_id}', `${parameters['profileId']}`);
+    if (parameters['baseNameRecord'] !== undefined) {
+      body = parameters['baseNameRecord'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteNetworksByNetworkIdPoliciesBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/policies/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getLteByNetworkIdPolicyQosProfilesByProfileId(
-            parameters: {
-                'networkId': string,
-                'profileId': string,
-            }
-        ): Promise < policy_qos_profile >
-        {
-            let path = '/lte/{network_id}/policy_qos_profiles/{profile_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['profileId'] === undefined) {
-                throw new Error('Missing required  parameter: profileId');
-            }
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
 
-            path = path.replace('{profile_id}', `${parameters['profileId']}`);
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdPolicyQosProfilesByProfileId(
-        parameters: {
-            'networkId': string,
-            'profileId': string,
-            'profile': policy_qos_profile,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/policy_qos_profiles/{profile_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdPoliciesBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+  }): Promise<base_name_record> {
+    let path = '/networks/{network_id}/policies/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['profileId'] === undefined) {
-            throw new Error('Missing required  parameter: profileId');
-        }
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
 
-        path = path.replace('{profile_id}', `${parameters['profileId']}`);
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
 
-        if (parameters['profile'] === undefined) {
-            throw new Error('Missing required  parameter: profile');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdPoliciesBaseNamesByBaseName(parameters: {
+    networkId: string,
+    baseName: string,
+    baseNameRecord: base_name_record,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/policies/base_names/{base_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['profile'] !== undefined) {
-            body = parameters['profile'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdSms(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < Array < sms_message >
-        >
-        {
-            let path = '/lte/{network_id}/sms';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdSms(
-            parameters: {
-                'networkId': string,
-                'sms': mutable_sms_message,
-            }
-        ): Promise < string >
-        {
-            let path = '/lte/{network_id}/sms';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['sms'] === undefined) {
-                throw new Error('Missing required  parameter: sms');
-            }
-
-            if (parameters['sms'] !== undefined) {
-                body = parameters['sms'];
-            }
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async deleteLteByNetworkIdSmsBySmsPk(
-        parameters: {
-            'networkId': string,
-            'smsPk': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/sms/{sms_pk}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['baseName'] === undefined) {
+      throw new Error('Missing required  parameter: baseName');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{base_name}', `${parameters['baseName']}`);
 
-        if (parameters['smsPk'] === undefined) {
-            throw new Error('Missing required  parameter: smsPk');
-        }
+    if (parameters['baseNameRecord'] === undefined) {
+      throw new Error('Missing required  parameter: baseNameRecord');
+    }
 
-        path = path.replace('{sms_pk}', `${parameters['smsPk']}`);
+    if (parameters['baseNameRecord'] !== undefined) {
+      body = parameters['baseNameRecord'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdPoliciesBaseNamesViewFull(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: base_name_record,
+  }> {
+    let path = '/networks/{network_id}/policies/base_names?view=full';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getLteByNetworkIdSmsBySmsPk(
-            parameters: {
-                'networkId': string,
-                'smsPk': string,
-            }
-        ): Promise < sms_message >
-        {
-            let path = '/lte/{network_id}/sms/{sms_pk}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['smsPk'] === undefined) {
-                throw new Error('Missing required  parameter: smsPk');
-            }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getNetworksByNetworkIdPoliciesRules(parameters: {
+    networkId: string,
+  }): Promise<Array<rule_id>> {
+    let path = '/networks/{network_id}/policies/rules';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            path = path.replace('{sms_pk}', `${parameters['smsPk']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getLteByNetworkIdSubscriberConfig(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_subscriber_config >
-        {
-            let path = '/lte/{network_id}/subscriber_config';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdSubscriberConfig(
-        parameters: {
-            'networkId': string,
-            'record': network_subscriber_config,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscriber_config';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdPoliciesRules(parameters: {
+    networkId: string,
+    policyRule: policy_rule,
+  }): Promise<rule_id> {
+    let path = '/networks/{network_id}/policies/rules';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    if (parameters['policyRule'] === undefined) {
+      throw new Error('Missing required  parameter: policyRule');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    if (parameters['policyRule'] !== undefined) {
+      body = parameters['policyRule'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getLteByNetworkIdSubscriberConfigBaseNames(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < base_names >
-        {
-            let path = '/lte/{network_id}/subscriber_config/base_names';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdSubscriberConfigBaseNames(
-        parameters: {
-            'networkId': string,
-            'record': base_names,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscriber_config/base_names';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteNetworksByNetworkIdPoliciesRulesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/policies/rules/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdPoliciesRulesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+  }): Promise<policy_rule> {
+    let path = '/networks/{network_id}/policies/rules/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteLteByNetworkIdSubscriberConfigBaseNamesByBaseName(
-        parameters: {
-            'networkId': string,
-            'baseName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscriber_config/base_names/{base_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['baseName'] === undefined) {
-            throw new Error('Missing required  parameter: baseName');
-        }
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
 
-        path = path.replace('{base_name}', `${parameters['baseName']}`);
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdPoliciesRulesByRuleId(parameters: {
+    networkId: string,
+    ruleId: string,
+    policyRule: policy_rule,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/policies/rules/{rule_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async postLteByNetworkIdSubscriberConfigBaseNamesByBaseName(
-        parameters: {
-            'networkId': string,
-            'baseName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscriber_config/base_names/{base_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['baseName'] === undefined) {
-            throw new Error('Missing required  parameter: baseName');
-        }
+    if (parameters['ruleId'] === undefined) {
+      throw new Error('Missing required  parameter: ruleId');
+    }
 
-        path = path.replace('{base_name}', `${parameters['baseName']}`);
-
-        return await this.request(path, 'POST', query, body);
-    }
-    static async getLteByNetworkIdSubscriberConfigRuleNames(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < rule_names >
-        {
-            let path = '/lte/{network_id}/subscriber_config/rule_names';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdSubscriberConfigRuleNames(
-        parameters: {
-            'networkId': string,
-            'record': rule_names,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscriber_config/rule_names';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{rule_id}', `${parameters['ruleId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['policyRule'] === undefined) {
+      throw new Error('Missing required  parameter: policyRule');
+    }
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    if (parameters['policyRule'] !== undefined) {
+      body = parameters['policyRule'];
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdPoliciesRulesViewFull(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: policy_rule,
+  }> {
+    let path = '/networks/{network_id}/policies/rules?view=full';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
+
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async deleteNetworksByNetworkIdPrometheusAlertConfig(parameters: {
+    networkId: string,
+    alertName: string,
+  }): Promise<'Deleted'> {
+    let path = '/networks/{network_id}/prometheus/alert_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteLteByNetworkIdSubscriberConfigRuleNamesByRuleId(
-        parameters: {
-            'networkId': string,
-            'ruleId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscriber_config/rule_names/{rule_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['ruleId'] === undefined) {
-            throw new Error('Missing required  parameter: ruleId');
-        }
+    if (parameters['alertName'] === undefined) {
+      throw new Error('Missing required  parameter: alertName');
+    }
 
-        path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+    if (parameters['alertName'] !== undefined) {
+      query['alert_name'] = parameters['alertName'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdPrometheusAlertConfig(parameters: {
+    networkId: string,
+    alertName?: string,
+  }): Promise<prom_alert_config_list> {
+    let path = '/networks/{network_id}/prometheus/alert_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async postLteByNetworkIdSubscriberConfigRuleNamesByRuleId(
-        parameters: {
-            'networkId': string,
-            'ruleId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscriber_config/rule_names/{rule_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['ruleId'] === undefined) {
-            throw new Error('Missing required  parameter: ruleId');
-        }
+    if (parameters['alertName'] !== undefined) {
+      query['alert_name'] = parameters['alertName'];
+    }
 
-        path = path.replace('{rule_id}', `${parameters['ruleId']}`);
-
-        return await this.request(path, 'POST', query, body);
-    }
-    static async getLteByNetworkIdSubscriberState(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: subscriber_state,
-        } >
-        {
-            let path = '/lte/{network_id}/subscriber_state';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getLteByNetworkIdSubscriberStateBySubscriberId(
-            parameters: {
-                'networkId': string,
-                'subscriberId': string,
-            }
-        ): Promise < subscriber_state >
-        {
-            let path = '/lte/{network_id}/subscriber_state/{subscriber_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['subscriberId'] === undefined) {
-                throw new Error('Missing required  parameter: subscriberId');
-            }
-
-            path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getLteByNetworkIdSubscribers(
-            parameters: {
-                'networkId': string,
-                'msisdn' ? : string,
-                'ip' ? : string,
-                'pageSize' ? : number,
-                'pageToken' ? : string,
-            }
-        ): Promise < paginated_subscribers >
-        {
-            let path = '/lte/{network_id}/subscribers';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['msisdn'] !== undefined) {
-                query['msisdn'] = parameters['msisdn'];
-            }
-
-            if (parameters['ip'] !== undefined) {
-                query['ip'] = parameters['ip'];
-            }
-
-            if (parameters['pageSize'] !== undefined) {
-                query['page_size'] = parameters['pageSize'];
-            }
-
-            if (parameters['pageToken'] !== undefined) {
-                query['page_token'] = parameters['pageToken'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postLteByNetworkIdSubscribers(
-        parameters: {
-            'networkId': string,
-            'subscribers': mutable_subscribers,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscribers';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdPrometheusAlertConfig(parameters: {
+    networkId: string,
+    alertConfig: prom_alert_config,
+  }): Promise<'Created'> {
+    let path = '/networks/{network_id}/prometheus/alert_config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['subscribers'] === undefined) {
-            throw new Error('Missing required  parameter: subscribers');
-        }
+    if (parameters['alertConfig'] === undefined) {
+      throw new Error('Missing required  parameter: alertConfig');
+    }
 
-        if (parameters['subscribers'] !== undefined) {
-            body = parameters['subscribers'];
-        }
+    if (parameters['alertConfig'] !== undefined) {
+      body = parameters['alertConfig'];
+    }
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'POST', query, body);
+  }
+  static async putNetworksByNetworkIdPrometheusAlertConfigByAlertName(parameters: {
+    networkId: string,
+    alertName: string,
+    alertConfig: prom_alert_config,
+  }): Promise<'Updated'> {
+    let path = '/networks/{network_id}/prometheus/alert_config/{alert_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteLteByNetworkIdSubscribersBySubscriberId(
-        parameters: {
-            'networkId': string,
-            'subscriberId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscribers/{subscriber_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['subscriberId'] === undefined) {
-            throw new Error('Missing required  parameter: subscriberId');
-        }
+    if (parameters['alertName'] === undefined) {
+      throw new Error('Missing required  parameter: alertName');
+    }
 
-        path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
+    path = path.replace('{alert_name}', `${parameters['alertName']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['alertConfig'] === undefined) {
+      throw new Error('Missing required  parameter: alertConfig');
     }
-    static async getLteByNetworkIdSubscribersBySubscriberId(
-            parameters: {
-                'networkId': string,
-                'subscriberId': string,
-            }
-        ): Promise < subscriber >
-        {
-            let path = '/lte/{network_id}/subscribers/{subscriber_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['alertConfig'] !== undefined) {
+      body = parameters['alertConfig'];
+    }
 
-            if (parameters['subscriberId'] === undefined) {
-                throw new Error('Missing required  parameter: subscriberId');
-            }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async putNetworksByNetworkIdPrometheusAlertConfigBulk(parameters: {
+    networkId: string,
+    alertConfigs: prom_alert_config_list,
+  }): Promise<alert_bulk_upload_response> {
+    let path = '/networks/{network_id}/prometheus/alert_config/bulk';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putLteByNetworkIdSubscribersBySubscriberId(
-        parameters: {
-            'networkId': string,
-            'subscriberId': string,
-            'subscriber': mutable_subscriber,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscribers/{subscriber_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['alertConfigs'] === undefined) {
+      throw new Error('Missing required  parameter: alertConfigs');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['alertConfigs'] !== undefined) {
+      body = parameters['alertConfigs'];
+    }
 
-        if (parameters['subscriberId'] === undefined) {
-            throw new Error('Missing required  parameter: subscriberId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteNetworksByNetworkIdPrometheusAlertReceiver(parameters: {
+    networkId: string,
+    receiver: string,
+  }): Promise<'Deleted'> {
+    let path = '/networks/{network_id}/prometheus/alert_receiver';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['subscriber'] === undefined) {
-            throw new Error('Missing required  parameter: subscriber');
-        }
+    if (parameters['receiver'] === undefined) {
+      throw new Error('Missing required  parameter: receiver');
+    }
 
-        if (parameters['subscriber'] !== undefined) {
-            body = parameters['subscriber'];
-        }
+    if (parameters['receiver'] !== undefined) {
+      query['receiver'] = parameters['receiver'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdPrometheusAlertReceiver(parameters: {
+    networkId: string,
+  }): Promise<Array<alert_receiver_config>> {
+    let path = '/networks/{network_id}/prometheus/alert_receiver';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async postLteByNetworkIdSubscribersBySubscriberIdActivate(
-        parameters: {
-            'networkId': string,
-            'subscriberId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscribers/{subscriber_id}/activate';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['subscriberId'] === undefined) {
-            throw new Error('Missing required  parameter: subscriberId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdPrometheusAlertReceiver(parameters: {
+    networkId: string,
+    receiverConfig: alert_receiver_config,
+  }): Promise<'Created'> {
+    let path = '/networks/{network_id}/prometheus/alert_receiver';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['receiverConfig'] === undefined) {
+      throw new Error('Missing required  parameter: receiverConfig');
     }
-    static async postLteByNetworkIdSubscribersBySubscriberIdDeactivate(
-        parameters: {
-            'networkId': string,
-            'subscriberId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscribers/{subscriber_id}/deactivate';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['receiverConfig'] !== undefined) {
+      body = parameters['receiverConfig'];
+    }
 
-        if (parameters['subscriberId'] === undefined) {
-            throw new Error('Missing required  parameter: subscriberId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async putNetworksByNetworkIdPrometheusAlertReceiverByReceiver(parameters: {
+    networkId: string,
+    receiver: string,
+    receiverConfig: alert_receiver_config,
+  }): Promise<'Updated'> {
+    let path = '/networks/{network_id}/prometheus/alert_receiver/{receiver}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['receiver'] === undefined) {
+      throw new Error('Missing required  parameter: receiver');
     }
-    static async putLteByNetworkIdSubscribersBySubscriberIdLteSubProfile(
-        parameters: {
-            'networkId': string,
-            'subscriberId': string,
-            'profileName': sub_profile,
-        }
-    ): Promise < "Success" > {
-        let path = '/lte/{network_id}/subscribers/{subscriber_id}/lte/sub_profile';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{receiver}', `${parameters['receiver']}`);
 
-        if (parameters['subscriberId'] === undefined) {
-            throw new Error('Missing required  parameter: subscriberId');
-        }
+    if (parameters['receiverConfig'] === undefined) {
+      throw new Error('Missing required  parameter: receiverConfig');
+    }
 
-        path = path.replace('{subscriber_id}', `${parameters['subscriberId']}`);
+    if (parameters['receiverConfig'] !== undefined) {
+      body = parameters['receiverConfig'];
+    }
 
-        if (parameters['profileName'] === undefined) {
-            throw new Error('Missing required  parameter: profileName');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdPrometheusAlertReceiverRoute(parameters: {
+    networkId: string,
+  }): Promise<alert_routing_tree> {
+    let path = '/networks/{network_id}/prometheus/alert_receiver/route';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['profileName'] !== undefined) {
-            body = parameters['profileName'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdPrometheusAlertReceiverRoute(parameters: {
+    networkId: string,
+    route: alert_routing_tree,
+  }): Promise<'OK'> {
+    let path = '/networks/{network_id}/prometheus/alert_receiver/route';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getNetworks(): Promise < Array < string >
-        >
-        {
-            let path = '/networks';
-            let body;
-            let query = {};
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworks(
-        parameters: {
-            'network': network,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks';
-        let body;
-        let query = {};
-        if (parameters['network'] === undefined) {
-            throw new Error('Missing required  parameter: network');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['network'] !== undefined) {
-            body = parameters['network'];
-        }
+    if (parameters['route'] === undefined) {
+      throw new Error('Missing required  parameter: route');
+    }
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['route'] !== undefined) {
+      body = parameters['route'];
     }
-    static async deleteNetworksByNetworkId(
-        parameters: {
-            'networkId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getNetworksByNetworkId(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network >
-        {
-            let path = '/networks/{network_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkId(
-        parameters: {
-            'networkId': string,
-            'network': network,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async getNetworksByNetworkIdPrometheusQuery(parameters: {
+    networkId: string,
+    query: string,
+    time?: string,
+  }): Promise<promql_return_object> {
+    let path = '/networks/{network_id}/prometheus/query';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['network'] === undefined) {
-            throw new Error('Missing required  parameter: network');
-        }
+    if (parameters['query'] === undefined) {
+      throw new Error('Missing required  parameter: query');
+    }
 
-        if (parameters['network'] !== undefined) {
-            body = parameters['network'];
-        }
+    if (parameters['query'] !== undefined) {
+      query['query'] = parameters['query'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdAlerts(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < Array < prom_firing_alert >
-        >
-        {
-            let path = '/networks/{network_id}/alerts';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async deleteNetworksByNetworkIdAlertsSilence(
-            parameters: {
-                'networkId': string,
-                'silenceId': string,
-            }
-        ): Promise < string >
-        {
-            let path = '/networks/{network_id}/alerts/silence';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['silenceId'] === undefined) {
-                throw new Error('Missing required  parameter: silenceId');
-            }
-
-            if (parameters['silenceId'] !== undefined) {
-                query['silence_id'] = parameters['silenceId'];
-            }
-
-            return await this.request(path, 'DELETE', query, body);
-        }
-    static async getNetworksByNetworkIdAlertsSilence(
-            parameters: {
-                'networkId': string,
-                'active' ? : boolean,
-                'pending' ? : boolean,
-                'expired' ? : boolean,
-                'filter' ? : string,
-            }
-        ): Promise < Array < gettable_alert_silencer >
-        >
-        {
-            let path = '/networks/{network_id}/alerts/silence';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['active'] !== undefined) {
-                query['active'] = parameters['active'];
-            }
-
-            if (parameters['pending'] !== undefined) {
-                query['pending'] = parameters['pending'];
-            }
-
-            if (parameters['expired'] !== undefined) {
-                query['expired'] = parameters['expired'];
-            }
-
-            if (parameters['filter'] !== undefined) {
-                query['filter'] = parameters['filter'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdAlertsSilence(
-            parameters: {
-                'networkId': string,
-                'silencer': alert_silencer,
-            }
-        ): Promise < string >
-        {
-            let path = '/networks/{network_id}/alerts/silence';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['silencer'] === undefined) {
-                throw new Error('Missing required  parameter: silencer');
-            }
-
-            if (parameters['silencer'] !== undefined) {
-                body = parameters['silencer'];
-            }
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async getNetworksByNetworkIdDescription(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_description >
-        {
-            let path = '/networks/{network_id}/description';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdDescription(
-        parameters: {
-            'networkId': string,
-            'description': network_description,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/description';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['time'] !== undefined) {
+      query['time'] = parameters['time'];
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getNetworksByNetworkIdPrometheusQueryRange(parameters: {
+    networkId: string,
+    query: string,
+    start: string,
+    end?: string,
+    step?: string,
+  }): Promise<promql_return_object> {
+    let path = '/networks/{network_id}/prometheus/query_range';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['description'] === undefined) {
-            throw new Error('Missing required  parameter: description');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['description'] !== undefined) {
-            body = parameters['description'];
-        }
+    if (parameters['query'] === undefined) {
+      throw new Error('Missing required  parameter: query');
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdDns(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_dns_config >
-        {
-            let path = '/networks/{network_id}/dns';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdDns(
-        parameters: {
-            'networkId': string,
-            'networkDns': network_dns_config,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/dns';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['query'] !== undefined) {
+      query['query'] = parameters['query'];
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['start'] === undefined) {
+      throw new Error('Missing required  parameter: start');
+    }
 
-        if (parameters['networkDns'] === undefined) {
-            throw new Error('Missing required  parameter: networkDns');
-        }
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
+    }
 
-        if (parameters['networkDns'] !== undefined) {
-            body = parameters['networkDns'];
-        }
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdDnsRecords(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_dns_records >
-        {
-            let path = '/networks/{network_id}/dns/records';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdDnsRecords(
-        parameters: {
-            'networkId': string,
-            'records': network_dns_records,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/dns/records';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['step'] !== undefined) {
+      query['step'] = parameters['step'];
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getNetworksByNetworkIdPrometheusSeries(parameters: {
+    networkId: string,
+    match?: Array<string>,
+    start?: string,
+    end?: string,
+  }): Promise<Array<prometheus_labelset>> {
+    let path = '/networks/{network_id}/prometheus/series';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['records'] === undefined) {
-            throw new Error('Missing required  parameter: records');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['records'] !== undefined) {
-            body = parameters['records'];
-        }
+    if (parameters['match'] !== undefined) {
+      query['match'] = parameters['match'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
     }
-    static async deleteNetworksByNetworkIdDnsRecordsByDomain(
-        parameters: {
-            'networkId': string,
-            'domain': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/dns/records/{domain}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
 
-        if (parameters['domain'] === undefined) {
-            throw new Error('Missing required  parameter: domain');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getNetworksByNetworkIdRatingGroups(parameters: {
+    networkId: string,
+  }): Promise<Array<rating_group>> {
+    let path = '/networks/{network_id}/rating_groups';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{domain}', `${parameters['domain']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdRatingGroups(parameters: {
+    networkId: string,
+    ratingGroup: rating_group,
+  }): Promise<rating_group_id> {
+    let path = '/networks/{network_id}/rating_groups';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getNetworksByNetworkIdDnsRecordsByDomain(
-            parameters: {
-                'networkId': string,
-                'domain': string,
-            }
-        ): Promise < dns_config_record >
-        {
-            let path = '/networks/{network_id}/dns/records/{domain}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['domain'] === undefined) {
-                throw new Error('Missing required  parameter: domain');
-            }
+    if (parameters['ratingGroup'] === undefined) {
+      throw new Error('Missing required  parameter: ratingGroup');
+    }
 
-            path = path.replace('{domain}', `${parameters['domain']}`);
+    if (parameters['ratingGroup'] !== undefined) {
+      body = parameters['ratingGroup'];
+    }
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdDnsRecordsByDomain(
-        parameters: {
-            'networkId': string,
-            'domain': string,
-            'record': dns_config_record,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/dns/records/{domain}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteNetworksByNetworkIdRatingGroupsByRatingGroupId(parameters: {
+    networkId: string,
+    ratingGroupId: number,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/rating_groups/{rating_group_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['domain'] === undefined) {
-            throw new Error('Missing required  parameter: domain');
-        }
+    if (parameters['ratingGroupId'] === undefined) {
+      throw new Error('Missing required  parameter: ratingGroupId');
+    }
 
-        path = path.replace('{domain}', `${parameters['domain']}`);
+    path = path.replace('{rating_group_id}', `${parameters['ratingGroupId']}`);
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdRatingGroupsByRatingGroupId(parameters: {
+    networkId: string,
+    ratingGroupId: number,
+  }): Promise<rating_group> {
+    let path = '/networks/{network_id}/rating_groups/{rating_group_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['ratingGroupId'] === undefined) {
+      throw new Error('Missing required  parameter: ratingGroupId');
     }
-    static async putNetworksByNetworkIdDnsRecordsByDomain(
-        parameters: {
-            'networkId': string,
-            'domain': string,
-            'record': dns_config_record,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/dns/records/{domain}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{rating_group_id}', `${parameters['ratingGroupId']}`);
 
-        if (parameters['domain'] === undefined) {
-            throw new Error('Missing required  parameter: domain');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdRatingGroupsByRatingGroupId(parameters: {
+    networkId: string,
+    ratingGroupId: number,
+    ratingGroup: mutable_rating_group,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/rating_groups/{rating_group_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{domain}', `${parameters['domain']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['record'] === undefined) {
-            throw new Error('Missing required  parameter: record');
-        }
+    if (parameters['ratingGroupId'] === undefined) {
+      throw new Error('Missing required  parameter: ratingGroupId');
+    }
 
-        if (parameters['record'] !== undefined) {
-            body = parameters['record'];
-        }
+    path = path.replace('{rating_group_id}', `${parameters['ratingGroupId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdFeatures(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_features >
-        {
-            let path = '/networks/{network_id}/features';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdFeatures(
-        parameters: {
-            'networkId': string,
-            'networkFeatures': network_features,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/features';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['ratingGroup'] === undefined) {
+      throw new Error('Missing required  parameter: ratingGroup');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['ratingGroup'] !== undefined) {
+      body = parameters['ratingGroup'];
+    }
 
-        if (parameters['networkFeatures'] === undefined) {
-            throw new Error('Missing required  parameter: networkFeatures');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdSentry(parameters: {
+    networkId: string,
+  }): Promise<network_sentry_config> {
+    let path = '/networks/{network_id}/sentry';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['networkFeatures'] !== undefined) {
-            body = parameters['networkFeatures'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdGateways(
-            parameters: {
-                'networkId': string,
-                'pageSize' ? : number,
-                'pageToken' ? : string,
-            }
-        ): Promise < paginated_gateways >
-        {
-            let path = '/networks/{network_id}/gateways';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['pageSize'] !== undefined) {
-                query['page_size'] = parameters['pageSize'];
-            }
-
-            if (parameters['pageToken'] !== undefined) {
-                query['page_token'] = parameters['pageToken'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdGateways(
-        parameters: {
-            'networkId': string,
-            'gateway': magmad_gateway,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/gateways';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdSentry(parameters: {
+    networkId: string,
+    networkSentryConfig: network_sentry_config,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/sentry';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    if (parameters['networkSentryConfig'] === undefined) {
+      throw new Error('Missing required  parameter: networkSentryConfig');
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    if (parameters['networkSentryConfig'] !== undefined) {
+      body = parameters['networkSentryConfig'];
+    }
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdState(parameters: {
+    networkId: string,
+  }): Promise<state_config> {
+    let path = '/networks/{network_id}/state';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteNetworksByNetworkIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdState(parameters: {
+    networkId: string,
+    stateConfig: state_config,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/state';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['stateConfig'] === undefined) {
+      throw new Error('Missing required  parameter: stateConfig');
     }
-    static async getNetworksByNetworkIdGatewaysByGatewayId(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < magmad_gateway >
-        {
-            let path = '/networks/{network_id}/gateways/{gateway_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['stateConfig'] !== undefined) {
+      body = parameters['stateConfig'];
+    }
 
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdTiers(parameters: {
+    networkId: string,
+  }): Promise<Array<tier_id>> {
+    let path = '/networks/{network_id}/tiers';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'gateway': magmad_gateway,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdTiers(parameters: {
+    networkId: string,
+    tier: tier,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['tier'] === undefined) {
+      throw new Error('Missing required  parameter: tier');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    if (parameters['tier'] !== undefined) {
+      body = parameters['tier'];
+    }
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteNetworksByNetworkIdTiersByTierId(parameters: {
+    networkId: string,
+    tierId: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers/{tier_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async postNetworksByNetworkIdGatewaysByGatewayIdCommandGeneric(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-                'parameters': generic_command_params,
-            }
-        ): Promise < generic_command_response >
-        {
-            let path = '/networks/{network_id}/gateways/{gateway_id}/command/generic';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            if (parameters['parameters'] === undefined) {
-                throw new Error('Missing required  parameter: parameters');
-            }
-
-            if (parameters['parameters'] !== undefined) {
-                body = parameters['parameters'];
-            }
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async postNetworksByNetworkIdGatewaysByGatewayIdCommandPing(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-                'pingRequest': ping_request,
-            }
-        ): Promise < ping_response >
-        {
-            let path = '/networks/{network_id}/gateways/{gateway_id}/command/ping';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            if (parameters['pingRequest'] === undefined) {
-                throw new Error('Missing required  parameter: pingRequest');
-            }
-
-            if (parameters['pingRequest'] !== undefined) {
-                body = parameters['pingRequest'];
-            }
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async postNetworksByNetworkIdGatewaysByGatewayIdCommandReboot(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/gateways/{gateway_id}/command/reboot';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdTiersByTierId(parameters: {
+    networkId: string,
+    tierId: string,
+  }): Promise<tier> {
+    let path = '/networks/{network_id}/tiers/{tier_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
     }
-    static async postNetworksByNetworkIdGatewaysByGatewayIdCommandRestartServices(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'services': Array < string >
-                ,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/gateways/{gateway_id}/command/restart_services';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdTiersByTierId(parameters: {
+    networkId: string,
+    tierId: string,
+    tier: tier,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers/{tier_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['services'] === undefined) {
-            throw new Error('Missing required  parameter: services');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        if (parameters['services'] !== undefined) {
-            body = parameters['services'];
-        }
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        return await this.request(path, 'POST', query, body);
-    }
-    static async getNetworksByNetworkIdGatewaysByGatewayIdDescription(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_description >
-        {
-            let path = '/networks/{network_id}/gateways/{gateway_id}/description';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdGatewaysByGatewayIdDescription(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'description': gateway_description,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/gateways/{gateway_id}/description';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['tier'] === undefined) {
+      throw new Error('Missing required  parameter: tier');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['tier'] !== undefined) {
+      body = parameters['tier'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdTiersByTierIdGateways(parameters: {
+    networkId: string,
+    tierId: string,
+  }): Promise<tier_gateways> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['description'] === undefined) {
-            throw new Error('Missing required  parameter: description');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        if (parameters['description'] !== undefined) {
-            body = parameters['description'];
-        }
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdGatewaysByGatewayIdDevice(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_device >
-        {
-            let path = '/networks/{network_id}/gateways/{gateway_id}/device';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdGatewaysByGatewayIdDevice(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'device': gateway_device,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/gateways/{gateway_id}/device';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdTiersByTierIdGateways(parameters: {
+    networkId: string,
+    tierId: string,
+    gateway: gateway_id,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        if (parameters['device'] === undefined) {
-            throw new Error('Missing required  parameter: device');
-        }
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
 
-        if (parameters['device'] !== undefined) {
-            body = parameters['device'];
-        }
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdGatewaysByGatewayIdMagmad(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < magmad_gateway_configs >
-        {
-            let path = '/networks/{network_id}/gateways/{gateway_id}/magmad';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdGatewaysByGatewayIdMagmad(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'magmad': magmad_gateway_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/gateways/{gateway_id}/magmad';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async putNetworksByNetworkIdTiersByTierIdGateways(parameters: {
+    networkId: string,
+    tierId: string,
+    tier: tier_gateways,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        if (parameters['magmad'] === undefined) {
-            throw new Error('Missing required  parameter: magmad');
-        }
+    if (parameters['tier'] === undefined) {
+      throw new Error('Missing required  parameter: tier');
+    }
 
-        if (parameters['magmad'] !== undefined) {
-            body = parameters['magmad'];
-        }
+    if (parameters['tier'] !== undefined) {
+      body = parameters['tier'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdGatewaysByGatewayIdName(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_name >
-        {
-            let path = '/networks/{network_id}/gateways/{gateway_id}/name';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdGatewaysByGatewayIdName(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'name': gateway_name,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/gateways/{gateway_id}/name';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteNetworksByNetworkIdTiersByTierIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    tierId: string,
+    gatewayId: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        if (parameters['name'] === undefined) {
-            throw new Error('Missing required  parameter: name');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['name'] !== undefined) {
-            body = parameters['name'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdGatewaysByGatewayIdStatus(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_status >
-        {
-            let path = '/networks/{network_id}/gateways/{gateway_id}/status';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getNetworksByNetworkIdGatewaysByGatewayIdTier(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < tier_id >
-        {
-            let path = '/networks/{network_id}/gateways/{gateway_id}/tier';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdGatewaysByGatewayIdTier(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'tierId': tier_id,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/gateways/{gateway_id}/tier';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdTiersByTierIdImages(parameters: {
+    networkId: string,
+    tierId: string,
+  }): Promise<tier_images> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/images';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdTiersByTierIdImages(parameters: {
+    networkId: string,
+    tierId: string,
+    image: tier_image,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/images';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['tierId'] !== undefined) {
-            body = parameters['tierId'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdLogsCount(
-            parameters: {
-                'networkId': string,
-                'simpleQuery' ? : string,
-                'fields' ? : string,
-                'filters' ? : string,
-                'start' ? : string,
-                'end' ? : string,
-            }
-        ): Promise < elastic_hit_count >
-        {
-            let path = '/networks/{network_id}/logs/count';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['simpleQuery'] !== undefined) {
-                query['simple_query'] = parameters['simpleQuery'];
-            }
-
-            if (parameters['fields'] !== undefined) {
-                query['fields'] = parameters['fields'];
-            }
-
-            if (parameters['filters'] !== undefined) {
-                query['filters'] = parameters['filters'];
-            }
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getNetworksByNetworkIdLogsSearch(
-            parameters: {
-                'networkId': string,
-                'simpleQuery' ? : string,
-                'fields' ? : string,
-                'filters' ? : string,
-                'size' ? : string,
-                'from' ? : string,
-                'start' ? : string,
-                'end' ? : string,
-            }
-        ): Promise < Array < elastic_hit >
-        >
-        {
-            let path = '/networks/{network_id}/logs/search';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['simpleQuery'] !== undefined) {
-                query['simple_query'] = parameters['simpleQuery'];
-            }
-
-            if (parameters['fields'] !== undefined) {
-                query['fields'] = parameters['fields'];
-            }
-
-            if (parameters['filters'] !== undefined) {
-                query['filters'] = parameters['filters'];
-            }
-
-            if (parameters['size'] !== undefined) {
-                query['size'] = parameters['size'];
-            }
-
-            if (parameters['from'] !== undefined) {
-                query['from'] = parameters['from'];
-            }
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdMetricsPush(
-        parameters: {
-            'networkId': string,
-            'metrics': Array < pushed_metric >
-                ,
-        }
-    ): Promise < "Submitted" > {
-        let path = '/networks/{network_id}/metrics/push';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        if (parameters['metrics'] === undefined) {
-            throw new Error('Missing required  parameter: metrics');
-        }
+    if (parameters['image'] === undefined) {
+      throw new Error('Missing required  parameter: image');
+    }
 
-        if (parameters['metrics'] !== undefined) {
-            body = parameters['metrics'];
-        }
+    if (parameters['image'] !== undefined) {
+      body = parameters['image'];
+    }
 
-        return await this.request(path, 'POST', query, body);
-    }
-    static async getNetworksByNetworkIdName(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_name >
-        {
-            let path = '/networks/{network_id}/name';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdName(
-        parameters: {
-            'networkId': string,
-            'name': network_name,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/name';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async putNetworksByNetworkIdTiersByTierIdImages(parameters: {
+    networkId: string,
+    tierId: string,
+    tier: tier_images,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/images';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['name'] === undefined) {
-            throw new Error('Missing required  parameter: name');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        if (parameters['name'] !== undefined) {
-            body = parameters['name'];
-        }
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdPoliciesBaseNames(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < Array < base_name >
-        >
-        {
-            let path = '/networks/{network_id}/policies/base_names';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdPoliciesBaseNames(
-            parameters: {
-                'networkId': string,
-                'baseNameRecord': base_name_record,
-            }
-        ): Promise < base_name >
-        {
-            let path = '/networks/{network_id}/policies/base_names';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['baseNameRecord'] === undefined) {
-                throw new Error('Missing required  parameter: baseNameRecord');
-            }
-
-            if (parameters['baseNameRecord'] !== undefined) {
-                body = parameters['baseNameRecord'];
-            }
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async deleteNetworksByNetworkIdPoliciesBaseNamesByBaseName(
-        parameters: {
-            'networkId': string,
-            'baseName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/policies/base_names/{base_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['tier'] === undefined) {
+      throw new Error('Missing required  parameter: tier');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['tier'] !== undefined) {
+      body = parameters['tier'];
+    }
 
-        if (parameters['baseName'] === undefined) {
-            throw new Error('Missing required  parameter: baseName');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async deleteNetworksByNetworkIdTiersByTierIdImagesByImageName(parameters: {
+    networkId: string,
+    tierId: string,
+    imageName: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/images/{image_name}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{base_name}', `${parameters['baseName']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
     }
-    static async getNetworksByNetworkIdPoliciesBaseNamesByBaseName(
-            parameters: {
-                'networkId': string,
-                'baseName': string,
-            }
-        ): Promise < base_name_record >
-        {
-            let path = '/networks/{network_id}/policies/base_names/{base_name}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-            if (parameters['baseName'] === undefined) {
-                throw new Error('Missing required  parameter: baseName');
-            }
+    if (parameters['imageName'] === undefined) {
+      throw new Error('Missing required  parameter: imageName');
+    }
 
-            path = path.replace('{base_name}', `${parameters['baseName']}`);
+    path = path.replace('{image_name}', `${parameters['imageName']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdPoliciesBaseNamesByBaseName(
-        parameters: {
-            'networkId': string,
-            'baseName': string,
-            'baseNameRecord': base_name_record,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/policies/base_names/{base_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdTiersByTierIdName(parameters: {
+    networkId: string,
+    tierId: string,
+  }): Promise<tier_name> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['baseName'] === undefined) {
-            throw new Error('Missing required  parameter: baseName');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{base_name}', `${parameters['baseName']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        if (parameters['baseNameRecord'] === undefined) {
-            throw new Error('Missing required  parameter: baseNameRecord');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdTiersByTierIdName(parameters: {
+    networkId: string,
+    tierId: string,
+    name: tier_name,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['baseNameRecord'] !== undefined) {
-            body = parameters['baseNameRecord'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdPoliciesBaseNamesViewFull(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: base_name_record,
-        } >
-        {
-            let path = '/networks/{network_id}/policies/base_names?view=full';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getNetworksByNetworkIdPoliciesRules(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < Array < rule_id >
-        >
-        {
-            let path = '/networks/{network_id}/policies/rules';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdPoliciesRules(
-            parameters: {
-                'networkId': string,
-                'policyRule': policy_rule,
-            }
-        ): Promise < rule_id >
-        {
-            let path = '/networks/{network_id}/policies/rules';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['policyRule'] === undefined) {
-                throw new Error('Missing required  parameter: policyRule');
-            }
-
-            if (parameters['policyRule'] !== undefined) {
-                body = parameters['policyRule'];
-            }
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async deleteNetworksByNetworkIdPoliciesRulesByRuleId(
-        parameters: {
-            'networkId': string,
-            'ruleId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/policies/rules/{rule_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        if (parameters['ruleId'] === undefined) {
-            throw new Error('Missing required  parameter: ruleId');
-        }
+    if (parameters['name'] === undefined) {
+      throw new Error('Missing required  parameter: name');
+    }
 
-        path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+    if (parameters['name'] !== undefined) {
+      body = parameters['name'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdTiersByTierIdVersion(parameters: {
+    networkId: string,
+    tierId: string,
+  }): Promise<tier_version> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/version';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async getNetworksByNetworkIdPoliciesRulesByRuleId(
-            parameters: {
-                'networkId': string,
-                'ruleId': string,
-            }
-        ): Promise < policy_rule >
-        {
-            let path = '/networks/{network_id}/policies/rules/{rule_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['ruleId'] === undefined) {
-                throw new Error('Missing required  parameter: ruleId');
-            }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-            path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdPoliciesRulesByRuleId(
-        parameters: {
-            'networkId': string,
-            'ruleId': string,
-            'policyRule': policy_rule,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/policies/rules/{rule_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdTiersByTierIdVersion(parameters: {
+    networkId: string,
+    tierId: string,
+    version: tier_version,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tiers/{tier_id}/version';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['ruleId'] === undefined) {
-            throw new Error('Missing required  parameter: ruleId');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{rule_id}', `${parameters['ruleId']}`);
+    path = path.replace('{tier_id}', `${parameters['tierId']}`);
 
-        if (parameters['policyRule'] === undefined) {
-            throw new Error('Missing required  parameter: policyRule');
-        }
+    if (parameters['version'] === undefined) {
+      throw new Error('Missing required  parameter: version');
+    }
 
-        if (parameters['policyRule'] !== undefined) {
-            body = parameters['policyRule'];
-        }
+    if (parameters['version'] !== undefined) {
+      body = parameters['version'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdPoliciesRulesViewFull(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: policy_rule,
-        } >
-        {
-            let path = '/networks/{network_id}/policies/rules?view=full';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async deleteNetworksByNetworkIdPrometheusAlertConfig(
-        parameters: {
-            'networkId': string,
-            'alertName': string,
-        }
-    ): Promise < "Deleted" > {
-        let path = '/networks/{network_id}/prometheus/alert_config';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdTracing(parameters: {
+    networkId: string,
+  }): Promise<Array<{}>> {
+    let path = '/networks/{network_id}/tracing';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['alertName'] === undefined) {
-            throw new Error('Missing required  parameter: alertName');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postNetworksByNetworkIdTracing(parameters: {
+    networkId: string,
+    callTraceConfiguration: call_trace_config,
+  }): Promise<string> {
+    let path = '/networks/{network_id}/tracing';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['alertName'] !== undefined) {
-            query['alert_name'] = parameters['alertName'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getNetworksByNetworkIdPrometheusAlertConfig(
-            parameters: {
-                'networkId': string,
-                'alertName' ? : string,
-            }
-        ): Promise < prom_alert_config_list >
-        {
-            let path = '/networks/{network_id}/prometheus/alert_config';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['alertName'] !== undefined) {
-                query['alert_name'] = parameters['alertName'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdPrometheusAlertConfig(
-        parameters: {
-            'networkId': string,
-            'alertConfig': prom_alert_config,
-        }
-    ): Promise < "Created" > {
-        let path = '/networks/{network_id}/prometheus/alert_config';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['callTraceConfiguration'] === undefined) {
+      throw new Error('Missing required  parameter: callTraceConfiguration');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['callTraceConfiguration'] !== undefined) {
+      body = parameters['callTraceConfiguration'];
+    }
 
-        if (parameters['alertConfig'] === undefined) {
-            throw new Error('Missing required  parameter: alertConfig');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteNetworksByNetworkIdTracingByTraceId(parameters: {
+    networkId: string,
+    traceId: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tracing/{trace_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['alertConfig'] !== undefined) {
-            body = parameters['alertConfig'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['traceId'] === undefined) {
+      throw new Error('Missing required  parameter: traceId');
     }
-    static async putNetworksByNetworkIdPrometheusAlertConfigByAlertName(
-        parameters: {
-            'networkId': string,
-            'alertName': string,
-            'alertConfig': prom_alert_config,
-        }
-    ): Promise < "Updated" > {
-        let path = '/networks/{network_id}/prometheus/alert_config/{alert_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{trace_id}', `${parameters['traceId']}`);
 
-        if (parameters['alertName'] === undefined) {
-            throw new Error('Missing required  parameter: alertName');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getNetworksByNetworkIdTracingByTraceId(parameters: {
+    networkId: string,
+    traceId: string,
+  }): Promise<call_trace> {
+    let path = '/networks/{network_id}/tracing/{trace_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{alert_name}', `${parameters['alertName']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['alertConfig'] === undefined) {
-            throw new Error('Missing required  parameter: alertConfig');
-        }
+    if (parameters['traceId'] === undefined) {
+      throw new Error('Missing required  parameter: traceId');
+    }
 
-        if (parameters['alertConfig'] !== undefined) {
-            body = parameters['alertConfig'];
-        }
+    path = path.replace('{trace_id}', `${parameters['traceId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async putNetworksByNetworkIdPrometheusAlertConfigBulk(
-            parameters: {
-                'networkId': string,
-                'alertConfigs': prom_alert_config_list,
-            }
-        ): Promise < alert_bulk_upload_response >
-        {
-            let path = '/networks/{network_id}/prometheus/alert_config/bulk';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['alertConfigs'] === undefined) {
-                throw new Error('Missing required  parameter: alertConfigs');
-            }
-
-            if (parameters['alertConfigs'] !== undefined) {
-                body = parameters['alertConfigs'];
-            }
-
-            return await this.request(path, 'PUT', query, body);
-        }
-    static async deleteNetworksByNetworkIdPrometheusAlertReceiver(
-        parameters: {
-            'networkId': string,
-            'receiver': string,
-        }
-    ): Promise < "Deleted" > {
-        let path = '/networks/{network_id}/prometheus/alert_receiver';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdTracingByTraceId(parameters: {
+    networkId: string,
+    traceId: string,
+    callTraceConfiguration: mutable_call_trace,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/tracing/{trace_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['receiver'] === undefined) {
-            throw new Error('Missing required  parameter: receiver');
-        }
+    if (parameters['traceId'] === undefined) {
+      throw new Error('Missing required  parameter: traceId');
+    }
 
-        if (parameters['receiver'] !== undefined) {
-            query['receiver'] = parameters['receiver'];
-        }
+    path = path.replace('{trace_id}', `${parameters['traceId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getNetworksByNetworkIdPrometheusAlertReceiver(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < Array < alert_receiver_config >
-        >
-        {
-            let path = '/networks/{network_id}/prometheus/alert_receiver';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdPrometheusAlertReceiver(
-        parameters: {
-            'networkId': string,
-            'receiverConfig': alert_receiver_config,
-        }
-    ): Promise < "Created" > {
-        let path = '/networks/{network_id}/prometheus/alert_receiver';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['callTraceConfiguration'] === undefined) {
+      throw new Error('Missing required  parameter: callTraceConfiguration');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['callTraceConfiguration'] !== undefined) {
+      body = parameters['callTraceConfiguration'];
+    }
 
-        if (parameters['receiverConfig'] === undefined) {
-            throw new Error('Missing required  parameter: receiverConfig');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getNetworksByNetworkIdTracingByTraceIdDownload(parameters: {
+    networkId: string,
+    traceId: string,
+  }): Promise<{}> {
+    let path = '/networks/{network_id}/tracing/{trace_id}/download';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['receiverConfig'] !== undefined) {
-            body = parameters['receiverConfig'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['traceId'] === undefined) {
+      throw new Error('Missing required  parameter: traceId');
     }
-    static async putNetworksByNetworkIdPrometheusAlertReceiverByReceiver(
-        parameters: {
-            'networkId': string,
-            'receiver': string,
-            'receiverConfig': alert_receiver_config,
-        }
-    ): Promise < "Updated" > {
-        let path = '/networks/{network_id}/prometheus/alert_receiver/{receiver}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
-
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['receiver'] === undefined) {
-            throw new Error('Missing required  parameter: receiver');
-        }
+    path = path.replace('{trace_id}', `${parameters['traceId']}`);
 
-        path = path.replace('{receiver}', `${parameters['receiver']}`);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getNetworksByNetworkIdType(parameters: {
+    networkId: string,
+  }): Promise<string> {
+    let path = '/networks/{network_id}/type';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['receiverConfig'] === undefined) {
-            throw new Error('Missing required  parameter: receiverConfig');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['receiverConfig'] !== undefined) {
-            body = parameters['receiverConfig'];
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putNetworksByNetworkIdType(parameters: {
+    networkId: string,
+    type: string,
+  }): Promise<'Success'> {
+    let path = '/networks/{network_id}/type';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdPrometheusAlertReceiverRoute(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < alert_routing_tree >
-        {
-            let path = '/networks/{network_id}/prometheus/alert_receiver/route';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdPrometheusAlertReceiverRoute(
-        parameters: {
-            'networkId': string,
-            'route': alert_routing_tree,
-        }
-    ): Promise < "OK" > {
-        let path = '/networks/{network_id}/prometheus/alert_receiver/route';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['type'] === undefined) {
+      throw new Error('Missing required  parameter: type');
+    }
 
-        if (parameters['route'] === undefined) {
-            throw new Error('Missing required  parameter: route');
-        }
+    if (parameters['type'] !== undefined) {
+      body = parameters['type'];
+    }
 
-        if (parameters['route'] !== undefined) {
-            body = parameters['route'];
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getTenants(): Promise<Array<tenant>> {
+    const path = '/tenants';
+    let body;
+    const query = {};
 
-        return await this.request(path, 'POST', query, body);
-    }
-    static async getNetworksByNetworkIdPrometheusQuery(
-            parameters: {
-                'networkId': string,
-                'query': string,
-                'time' ? : string,
-            }
-        ): Promise < promql_return_object >
-        {
-            let path = '/networks/{network_id}/prometheus/query';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['query'] === undefined) {
-                throw new Error('Missing required  parameter: query');
-            }
-
-            if (parameters['query'] !== undefined) {
-                query['query'] = parameters['query'];
-            }
-
-            if (parameters['time'] !== undefined) {
-                query['time'] = parameters['time'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getNetworksByNetworkIdPrometheusQueryRange(
-            parameters: {
-                'networkId': string,
-                'query': string,
-                'start': string,
-                'end' ? : string,
-                'step' ? : string,
-            }
-        ): Promise < promql_return_object >
-        {
-            let path = '/networks/{network_id}/prometheus/query_range';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['query'] === undefined) {
-                throw new Error('Missing required  parameter: query');
-            }
-
-            if (parameters['query'] !== undefined) {
-                query['query'] = parameters['query'];
-            }
-
-            if (parameters['start'] === undefined) {
-                throw new Error('Missing required  parameter: start');
-            }
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            if (parameters['step'] !== undefined) {
-                query['step'] = parameters['step'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getNetworksByNetworkIdPrometheusSeries(
-            parameters: {
-                'networkId': string,
-                'match' ? : Array < string >
-                    ,
-                'start' ? : string,
-                'end' ? : string,
-            }
-        ): Promise < Array < prometheus_labelset >
-        >
-        {
-            let path = '/networks/{network_id}/prometheus/series';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['match'] !== undefined) {
-                query['match'] = parameters['match'];
-            }
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getNetworksByNetworkIdRatingGroups(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < Array < rating_group >
-        >
-        {
-            let path = '/networks/{network_id}/rating_groups';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdRatingGroups(
-            parameters: {
-                'networkId': string,
-                'ratingGroup': rating_group,
-            }
-        ): Promise < rating_group_id >
-        {
-            let path = '/networks/{network_id}/rating_groups';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['ratingGroup'] === undefined) {
-                throw new Error('Missing required  parameter: ratingGroup');
-            }
-
-            if (parameters['ratingGroup'] !== undefined) {
-                body = parameters['ratingGroup'];
-            }
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async deleteNetworksByNetworkIdRatingGroupsByRatingGroupId(
-        parameters: {
-            'networkId': string,
-            'ratingGroupId': number,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/rating_groups/{rating_group_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postTenants(parameters: {
+    tenant: tenant,
+  }): Promise<'Successfully created'> {
+    const path = '/tenants';
+    let body;
+    const query = {};
+    if (parameters['tenant'] === undefined) {
+      throw new Error('Missing required  parameter: tenant');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['tenant'] !== undefined) {
+      body = parameters['tenant'];
+    }
 
-        if (parameters['ratingGroupId'] === undefined) {
-            throw new Error('Missing required  parameter: ratingGroupId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteTenantsByTenantId(parameters: {
+    tenantId: number,
+  }): Promise<'Ok'> {
+    let path = '/tenants/{tenant_id}';
+    let body;
+    const query = {};
+    if (parameters['tenantId'] === undefined) {
+      throw new Error('Missing required  parameter: tenantId');
+    }
 
-        path = path.replace('{rating_group_id}', `${parameters['ratingGroupId']}`);
+    path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getTenantsByTenantId(parameters: {
+    tenantId: number,
+  }): Promise<tenant> {
+    let path = '/tenants/{tenant_id}';
+    let body;
+    const query = {};
+    if (parameters['tenantId'] === undefined) {
+      throw new Error('Missing required  parameter: tenantId');
     }
-    static async getNetworksByNetworkIdRatingGroupsByRatingGroupId(
-            parameters: {
-                'networkId': string,
-                'ratingGroupId': number,
-            }
-        ): Promise < rating_group >
-        {
-            let path = '/networks/{network_id}/rating_groups/{rating_group_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
 
-            if (parameters['ratingGroupId'] === undefined) {
-                throw new Error('Missing required  parameter: ratingGroupId');
-            }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putTenantsByTenantId(parameters: {
+    tenantId: number,
+    tenant: tenant,
+  }): Promise<'Ok'> {
+    let path = '/tenants/{tenant_id}';
+    let body;
+    const query = {};
+    if (parameters['tenantId'] === undefined) {
+      throw new Error('Missing required  parameter: tenantId');
+    }
 
-            path = path.replace('{rating_group_id}', `${parameters['ratingGroupId']}`);
+    path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdRatingGroupsByRatingGroupId(
-        parameters: {
-            'networkId': string,
-            'ratingGroupId': number,
-            'ratingGroup': mutable_rating_group,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/rating_groups/{rating_group_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['tenant'] === undefined) {
+      throw new Error('Missing required  parameter: tenant');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['tenant'] !== undefined) {
+      body = parameters['tenant'];
+    }
 
-        if (parameters['ratingGroupId'] === undefined) {
-            throw new Error('Missing required  parameter: ratingGroupId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getTenantsByTenantIdMetricsApiV1LabelByLabelNameValues(parameters: {
+    tenantId: number,
+    labelName: string,
+    start?: string,
+    end?: string,
+  }): Promise<{
+    data: Array<string>,
+    status: string,
+  }> {
+    let path = '/tenants/{tenant_id}/metrics/api/v1/label/{label_name}/values';
+    let body;
+    const query = {};
+    if (parameters['tenantId'] === undefined) {
+      throw new Error('Missing required  parameter: tenantId');
+    }
 
-        path = path.replace('{rating_group_id}', `${parameters['ratingGroupId']}`);
+    path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
 
-        if (parameters['ratingGroup'] === undefined) {
-            throw new Error('Missing required  parameter: ratingGroup');
-        }
+    if (parameters['labelName'] === undefined) {
+      throw new Error('Missing required  parameter: labelName');
+    }
 
-        if (parameters['ratingGroup'] !== undefined) {
-            body = parameters['ratingGroup'];
-        }
+    path = path.replace('{label_name}', `${parameters['labelName']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdSentry(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_sentry_config >
-        {
-            let path = '/networks/{network_id}/sentry';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdSentry(
-        parameters: {
-            'networkId': string,
-            'networkSentryConfig': network_sentry_config,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/sentry';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
 
-        if (parameters['networkSentryConfig'] === undefined) {
-            throw new Error('Missing required  parameter: networkSentryConfig');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getTenantsByTenantIdMetricsApiV1Query(parameters: {
+    tenantId: number,
+    query: string,
+    time?: string,
+  }): Promise<promql_return_object> {
+    let path = '/tenants/{tenant_id}/metrics/api/v1/query';
+    let body;
+    const query = {};
+    if (parameters['tenantId'] === undefined) {
+      throw new Error('Missing required  parameter: tenantId');
+    }
 
-        if (parameters['networkSentryConfig'] !== undefined) {
-            body = parameters['networkSentryConfig'];
-        }
+    path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdState(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < state_config >
-        {
-            let path = '/networks/{network_id}/state';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdState(
-        parameters: {
-            'networkId': string,
-            'stateConfig': state_config,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/state';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['query'] === undefined) {
+      throw new Error('Missing required  parameter: query');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['query'] !== undefined) {
+      query['query'] = parameters['query'];
+    }
 
-        if (parameters['stateConfig'] === undefined) {
-            throw new Error('Missing required  parameter: stateConfig');
-        }
+    if (parameters['time'] !== undefined) {
+      query['time'] = parameters['time'];
+    }
 
-        if (parameters['stateConfig'] !== undefined) {
-            body = parameters['stateConfig'];
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getTenantsByTenantIdMetricsApiV1QueryRange(parameters: {
+    tenantId: number,
+    query: string,
+    start: string,
+    end?: string,
+    step?: string,
+  }): Promise<promql_return_object> {
+    let path = '/tenants/{tenant_id}/metrics/api/v1/query_range';
+    let body;
+    const query = {};
+    if (parameters['tenantId'] === undefined) {
+      throw new Error('Missing required  parameter: tenantId');
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdTiers(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < Array < tier_id >
-        >
-        {
-            let path = '/networks/{network_id}/tiers';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdTiers(
-        parameters: {
-            'networkId': string,
-            'tier': tier,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['query'] === undefined) {
+      throw new Error('Missing required  parameter: query');
+    }
 
-        if (parameters['tier'] === undefined) {
-            throw new Error('Missing required  parameter: tier');
-        }
+    if (parameters['query'] !== undefined) {
+      query['query'] = parameters['query'];
+    }
 
-        if (parameters['tier'] !== undefined) {
-            body = parameters['tier'];
-        }
+    if (parameters['start'] === undefined) {
+      throw new Error('Missing required  parameter: start');
+    }
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
     }
-    static async deleteNetworksByNetworkIdTiersByTierId(
-        parameters: {
-            'networkId': string,
-            'tierId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers/{tier_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    if (parameters['step'] !== undefined) {
+      query['step'] = parameters['step'];
+    }
 
-        path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getTenantsByTenantIdMetricsApiV1Series(parameters: {
+    tenantId: number,
+    match?: Array<string>,
+    start?: string,
+    end?: string,
+  }): Promise<Array<prometheus_labelset>> {
+    let path = '/tenants/{tenant_id}/metrics/api/v1/series';
+    let body;
+    const query = {};
+    if (parameters['tenantId'] === undefined) {
+      throw new Error('Missing required  parameter: tenantId');
+    }
+
+    path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['match'] !== undefined) {
+      query['match[]'] = parameters['match'];
     }
-    static async getNetworksByNetworkIdTiersByTierId(
-            parameters: {
-                'networkId': string,
-                'tierId': string,
-            }
-        ): Promise < tier >
-        {
-            let path = '/networks/{network_id}/tiers/{tier_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
+    }
 
-            if (parameters['tierId'] === undefined) {
-                throw new Error('Missing required  parameter: tierId');
-            }
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
 
-            path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getTenantsByTenantIdMetricsQuery(parameters: {
+    tenantId: number,
+    query: string,
+    time?: string,
+  }): Promise<promql_return_object> {
+    let path = '/tenants/{tenant_id}/metrics/query';
+    let body;
+    const query = {};
+    if (parameters['tenantId'] === undefined) {
+      throw new Error('Missing required  parameter: tenantId');
+    }
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdTiersByTierId(
-        parameters: {
-            'networkId': string,
-            'tierId': string,
-            'tier': tier,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers/{tier_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['query'] === undefined) {
+      throw new Error('Missing required  parameter: query');
+    }
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    if (parameters['query'] !== undefined) {
+      query['query'] = parameters['query'];
+    }
 
-        path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    if (parameters['time'] !== undefined) {
+      query['time'] = parameters['time'];
+    }
 
-        if (parameters['tier'] === undefined) {
-            throw new Error('Missing required  parameter: tier');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getTenantsByTenantIdMetricsQueryRange(parameters: {
+    tenantId: number,
+    query: string,
+    start: string,
+    end?: string,
+    step?: string,
+  }): Promise<promql_return_object> {
+    let path = '/tenants/{tenant_id}/metrics/query_range';
+    let body;
+    const query = {};
+    if (parameters['tenantId'] === undefined) {
+      throw new Error('Missing required  parameter: tenantId');
+    }
 
-        if (parameters['tier'] !== undefined) {
-            body = parameters['tier'];
-        }
+    path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdTiersByTierIdGateways(
-            parameters: {
-                'networkId': string,
-                'tierId': string,
-            }
-        ): Promise < tier_gateways >
-        {
-            let path = '/networks/{network_id}/tiers/{tier_id}/gateways';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['tierId'] === undefined) {
-                throw new Error('Missing required  parameter: tierId');
-            }
-
-            path = path.replace('{tier_id}', `${parameters['tierId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdTiersByTierIdGateways(
-        parameters: {
-            'networkId': string,
-            'tierId': string,
-            'gateway': gateway_id,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers/{tier_id}/gateways';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['query'] === undefined) {
+      throw new Error('Missing required  parameter: query');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['query'] !== undefined) {
+      query['query'] = parameters['query'];
+    }
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    if (parameters['start'] === undefined) {
+      throw new Error('Missing required  parameter: start');
+    }
 
-        path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
+    }
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    if (parameters['step'] !== undefined) {
+      query['step'] = parameters['step'];
+    }
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getTenantsByTenantIdMetricsSeries(parameters: {
+    tenantId: number,
+    match?: Array<string>,
+    start?: string,
+    end?: string,
+  }): Promise<Array<prometheus_labelset>> {
+    let path = '/tenants/{tenant_id}/metrics/series';
+    let body;
+    const query = {};
+    if (parameters['tenantId'] === undefined) {
+      throw new Error('Missing required  parameter: tenantId');
     }
-    static async putNetworksByNetworkIdTiersByTierIdGateways(
-        parameters: {
-            'networkId': string,
-            'tierId': string,
-            'tier': tier_gateways,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers/{tier_id}/gateways';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    if (parameters['match'] !== undefined) {
+      query['match'] = parameters['match'];
+    }
 
-        path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    if (parameters['start'] !== undefined) {
+      query['start'] = parameters['start'];
+    }
 
-        if (parameters['tier'] === undefined) {
-            throw new Error('Missing required  parameter: tier');
-        }
+    if (parameters['end'] !== undefined) {
+      query['end'] = parameters['end'];
+    }
 
-        if (parameters['tier'] !== undefined) {
-            body = parameters['tier'];
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getTenantsTargetsMetadata(parameters: {
+    matchTarget?: string,
+    metric?: string,
+    limit?: string,
+  }): Promise<Array<prometheus_targets_metadata>> {
+    const path = '/tenants/targets_metadata';
+    let body;
+    const query = {};
 
-        return await this.request(path, 'PUT', query, body);
+    if (parameters['matchTarget'] !== undefined) {
+      query['match_target'] = parameters['matchTarget'];
     }
-    static async deleteNetworksByNetworkIdTiersByTierIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'tierId': string,
-            'gatewayId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers/{tier_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['metric'] !== undefined) {
+      query['metric'] = parameters['metric'];
+    }
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    if (parameters['limit'] !== undefined) {
+      query['limit'] = parameters['limit'];
+    }
 
-        path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getTestsE2E(): Promise<Array<e2e_test_case>> {
+    const path = '/tests/e2e';
+    let body;
+    const query = {};
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getTestsE2EEnodebd(): Promise<Array<enodebd_e2e_test>> {
+    const path = '/tests/e2e/enodebd';
+    let body;
+    const query = {};
+
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postTestsE2EEnodebd(parameters: {
+    test: mutable_enodebd_e2e_test,
+  }): Promise<'Created'> {
+    const path = '/tests/e2e/enodebd';
+    let body;
+    const query = {};
+    if (parameters['test'] === undefined) {
+      throw new Error('Missing required  parameter: test');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    if (parameters['test'] !== undefined) {
+      body = parameters['test'];
+    }
 
-        return await this.request(path, 'DELETE', query, body);
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteTestsE2EEnodebdByTestPk(parameters: {
+    testPk: number,
+  }): Promise<'Deleted'> {
+    let path = '/tests/e2e/enodebd/{test_pk}';
+    let body;
+    const query = {};
+    if (parameters['testPk'] === undefined) {
+      throw new Error('Missing required  parameter: testPk');
     }
-    static async getNetworksByNetworkIdTiersByTierIdImages(
-            parameters: {
-                'networkId': string,
-                'tierId': string,
-            }
-        ): Promise < tier_images >
-        {
-            let path = '/networks/{network_id}/tiers/{tier_id}/images';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{test_pk}', `${parameters['testPk']}`);
 
-            if (parameters['tierId'] === undefined) {
-                throw new Error('Missing required  parameter: tierId');
-            }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getTestsE2EEnodebdByTestPk(parameters: {
+    testPk: number,
+  }): Promise<enodebd_test_config> {
+    let path = '/tests/e2e/enodebd/{test_pk}';
+    let body;
+    const query = {};
+    if (parameters['testPk'] === undefined) {
+      throw new Error('Missing required  parameter: testPk');
+    }
 
-            path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    path = path.replace('{test_pk}', `${parameters['testPk']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdTiersByTierIdImages(
-        parameters: {
-            'networkId': string,
-            'tierId': string,
-            'image': tier_image,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers/{tier_id}/images';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putTestsE2EEnodebdByTestPk(parameters: {
+    testPk: number,
+    test: enodebd_test_config,
+  }): Promise<'Updated'> {
+    let path = '/tests/e2e/enodebd/{test_pk}';
+    let body;
+    const query = {};
+    if (parameters['testPk'] === undefined) {
+      throw new Error('Missing required  parameter: testPk');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{test_pk}', `${parameters['testPk']}`);
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    if (parameters['test'] === undefined) {
+      throw new Error('Missing required  parameter: test');
+    }
+
+    if (parameters['test'] !== undefined) {
+      body = parameters['test'];
+    }
 
-        path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifi(): Promise<Array<string>> {
+    const path = '/wifi';
+    let body;
+    const query = {};
 
-        if (parameters['image'] === undefined) {
-            throw new Error('Missing required  parameter: image');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postWifi(parameters: {
+    wifiNetwork: wifi_network,
+  }): Promise<'Success'> {
+    const path = '/wifi';
+    let body;
+    const query = {};
+    if (parameters['wifiNetwork'] === undefined) {
+      throw new Error('Missing required  parameter: wifiNetwork');
+    }
 
-        if (parameters['image'] !== undefined) {
-            body = parameters['image'];
-        }
+    if (parameters['wifiNetwork'] !== undefined) {
+      body = parameters['wifiNetwork'];
+    }
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteWifiByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async putNetworksByNetworkIdTiersByTierIdImages(
-        parameters: {
-            'networkId': string,
-            'tierId': string,
-            'tier': tier_images,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers/{tier_id}/images';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getWifiByNetworkId(parameters: {
+    networkId: string,
+  }): Promise<wifi_network> {
+    let path = '/wifi/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['tier'] === undefined) {
-            throw new Error('Missing required  parameter: tier');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkId(parameters: {
+    networkId: string,
+    wifiNetwork: wifi_network,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['tier'] !== undefined) {
-            body = parameters['tier'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    if (parameters['wifiNetwork'] === undefined) {
+      throw new Error('Missing required  parameter: wifiNetwork');
     }
-    static async deleteNetworksByNetworkIdTiersByTierIdImagesByImageName(
-        parameters: {
-            'networkId': string,
-            'tierId': string,
-            'imageName': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers/{tier_id}/images/{image_name}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['wifiNetwork'] !== undefined) {
+      body = parameters['wifiNetwork'];
+    }
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdDescription(parameters: {
+    networkId: string,
+  }): Promise<network_description> {
+    let path = '/wifi/{network_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['imageName'] === undefined) {
-            throw new Error('Missing required  parameter: imageName');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdDescription(parameters: {
+    networkId: string,
+    description: network_description,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{image_name}', `${parameters['imageName']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['description'] === undefined) {
+      throw new Error('Missing required  parameter: description');
     }
-    static async getNetworksByNetworkIdTiersByTierIdName(
-            parameters: {
-                'networkId': string,
-                'tierId': string,
-            }
-        ): Promise < tier_name >
-        {
-            let path = '/networks/{network_id}/tiers/{tier_id}/name';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['description'] !== undefined) {
+      body = parameters['description'];
+    }
 
-            if (parameters['tierId'] === undefined) {
-                throw new Error('Missing required  parameter: tierId');
-            }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdFeatures(parameters: {
+    networkId: string,
+  }): Promise<network_features> {
+    let path = '/wifi/{network_id}/features';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdTiersByTierIdName(
-        parameters: {
-            'networkId': string,
-            'tierId': string,
-            'name': tier_name,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers/{tier_id}/name';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdFeatures(parameters: {
+    networkId: string,
+    config: network_features,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/features';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
 
-        path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
 
-        if (parameters['name'] === undefined) {
-            throw new Error('Missing required  parameter: name');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdGateways(parameters: {
+    networkId: string,
+  }): Promise<{
+    [string]: wifi_gateway,
+  }> {
+    let path = '/wifi/{network_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['name'] !== undefined) {
-            body = parameters['name'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdTiersByTierIdVersion(
-            parameters: {
-                'networkId': string,
-                'tierId': string,
-            }
-        ): Promise < tier_version >
-        {
-            let path = '/networks/{network_id}/tiers/{tier_id}/version';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['tierId'] === undefined) {
-                throw new Error('Missing required  parameter: tierId');
-            }
-
-            path = path.replace('{tier_id}', `${parameters['tierId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdTiersByTierIdVersion(
-        parameters: {
-            'networkId': string,
-            'tierId': string,
-            'version': tier_version,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tiers/{tier_id}/version';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postWifiByNetworkIdGateways(parameters: {
+    networkId: string,
+    gateway: mutable_wifi_gateway,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/gateways';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
 
-        path = path.replace('{tier_id}', `${parameters['tierId']}`);
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
+    }
 
-        if (parameters['version'] === undefined) {
-            throw new Error('Missing required  parameter: version');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteWifiByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['version'] !== undefined) {
-            body = parameters['version'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdTracing(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < Array < {} >
-        >
-        {
-            let path = '/networks/{network_id}/tracing';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postNetworksByNetworkIdTracing(
-            parameters: {
-                'networkId': string,
-                'callTraceConfiguration': call_trace_config,
-            }
-        ): Promise < string >
-        {
-            let path = '/networks/{network_id}/tracing';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['callTraceConfiguration'] === undefined) {
-                throw new Error('Missing required  parameter: callTraceConfiguration');
-            }
-
-            if (parameters['callTraceConfiguration'] !== undefined) {
-                body = parameters['callTraceConfiguration'];
-            }
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async deleteNetworksByNetworkIdTracingByTraceId(
-        parameters: {
-            'networkId': string,
-            'traceId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tracing/{trace_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['traceId'] === undefined) {
-            throw new Error('Missing required  parameter: traceId');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getWifiByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<wifi_gateway> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{trace_id}', `${parameters['traceId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
     }
-    static async getNetworksByNetworkIdTracingByTraceId(
-            parameters: {
-                'networkId': string,
-                'traceId': string,
-            }
-        ): Promise < call_trace >
-        {
-            let path = '/networks/{network_id}/tracing/{trace_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-            if (parameters['traceId'] === undefined) {
-                throw new Error('Missing required  parameter: traceId');
-            }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdGatewaysByGatewayId(parameters: {
+    networkId: string,
+    gatewayId: string,
+    gateway: mutable_wifi_gateway,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            path = path.replace('{trace_id}', `${parameters['traceId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdTracingByTraceId(
-        parameters: {
-            'networkId': string,
-            'traceId': string,
-            'callTraceConfiguration': mutable_call_trace,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/tracing/{trace_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['traceId'] === undefined) {
-            throw new Error('Missing required  parameter: traceId');
-        }
+    if (parameters['gateway'] === undefined) {
+      throw new Error('Missing required  parameter: gateway');
+    }
 
-        path = path.replace('{trace_id}', `${parameters['traceId']}`);
+    if (parameters['gateway'] !== undefined) {
+      body = parameters['gateway'];
+    }
 
-        if (parameters['callTraceConfiguration'] === undefined) {
-            throw new Error('Missing required  parameter: callTraceConfiguration');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdGatewaysByGatewayIdDescription(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_description> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['callTraceConfiguration'] !== undefined) {
-            body = parameters['callTraceConfiguration'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getNetworksByNetworkIdTracingByTraceIdDownload(
-            parameters: {
-                'networkId': string,
-                'traceId': string,
-            }
-        ): Promise < {} >
-        {
-            let path = '/networks/{network_id}/tracing/{trace_id}/download';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['traceId'] === undefined) {
-                throw new Error('Missing required  parameter: traceId');
-            }
-
-            path = path.replace('{trace_id}', `${parameters['traceId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getNetworksByNetworkIdType(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < string >
-        {
-            let path = '/networks/{network_id}/type';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putNetworksByNetworkIdType(
-        parameters: {
-            'networkId': string,
-            'type': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/networks/{network_id}/type';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['type'] === undefined) {
-            throw new Error('Missing required  parameter: type');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdGatewaysByGatewayIdDescription(parameters: {
+    networkId: string,
+    gatewayId: string,
+    description: gateway_description,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/description';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['type'] !== undefined) {
-            body = parameters['type'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
     }
-    static async getTenants(): Promise < Array < tenant >
-        >
-        {
-            let path = '/tenants';
-            let body;
-            let query = {};
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postTenants(
-        parameters: {
-            'tenant': tenant,
-        }
-    ): Promise < "Successfully created" > {
-        let path = '/tenants';
-        let body;
-        let query = {};
-        if (parameters['tenant'] === undefined) {
-            throw new Error('Missing required  parameter: tenant');
-        }
 
-        if (parameters['tenant'] !== undefined) {
-            body = parameters['tenant'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['description'] === undefined) {
+      throw new Error('Missing required  parameter: description');
     }
-    static async deleteTenantsByTenantId(
-        parameters: {
-            'tenantId': number,
-        }
-    ): Promise < "Ok" > {
-        let path = '/tenants/{tenant_id}';
-        let body;
-        let query = {};
-        if (parameters['tenantId'] === undefined) {
-            throw new Error('Missing required  parameter: tenantId');
-        }
-
-        path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getTenantsByTenantId(
-            parameters: {
-                'tenantId': number,
-            }
-        ): Promise < tenant >
-        {
-            let path = '/tenants/{tenant_id}';
-            let body;
-            let query = {};
-            if (parameters['tenantId'] === undefined) {
-                throw new Error('Missing required  parameter: tenantId');
-            }
-
-            path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putTenantsByTenantId(
-        parameters: {
-            'tenantId': number,
-            'tenant': tenant,
-        }
-    ): Promise < "Ok" > {
-        let path = '/tenants/{tenant_id}';
-        let body;
-        let query = {};
-        if (parameters['tenantId'] === undefined) {
-            throw new Error('Missing required  parameter: tenantId');
-        }
 
-        path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
+    if (parameters['description'] !== undefined) {
+      body = parameters['description'];
+    }
 
-        if (parameters['tenant'] === undefined) {
-            throw new Error('Missing required  parameter: tenant');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdGatewaysByGatewayIdDevice(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_device> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/device';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['tenant'] !== undefined) {
-            body = parameters['tenant'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getTenantsByTenantIdMetricsApiV1LabelByLabelNameValues(
-            parameters: {
-                'tenantId': number,
-                'labelName': string,
-                'start' ? : string,
-                'end' ? : string,
-            }
-        ): Promise < {
-            data: Array < string >
-                ,
-            status: string,
-        } >
-        {
-            let path = '/tenants/{tenant_id}/metrics/api/v1/label/{label_name}/values';
-            let body;
-            let query = {};
-            if (parameters['tenantId'] === undefined) {
-                throw new Error('Missing required  parameter: tenantId');
-            }
-
-            path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
-
-            if (parameters['labelName'] === undefined) {
-                throw new Error('Missing required  parameter: labelName');
-            }
-
-            path = path.replace('{label_name}', `${parameters['labelName']}`);
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getTenantsByTenantIdMetricsApiV1Query(
-            parameters: {
-                'tenantId': number,
-                'query': string,
-                'time' ? : string,
-            }
-        ): Promise < promql_return_object >
-        {
-            let path = '/tenants/{tenant_id}/metrics/api/v1/query';
-            let body;
-            let query = {};
-            if (parameters['tenantId'] === undefined) {
-                throw new Error('Missing required  parameter: tenantId');
-            }
-
-            path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
-
-            if (parameters['query'] === undefined) {
-                throw new Error('Missing required  parameter: query');
-            }
-
-            if (parameters['query'] !== undefined) {
-                query['query'] = parameters['query'];
-            }
-
-            if (parameters['time'] !== undefined) {
-                query['time'] = parameters['time'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getTenantsByTenantIdMetricsApiV1QueryRange(
-            parameters: {
-                'tenantId': number,
-                'query': string,
-                'start': string,
-                'end' ? : string,
-                'step' ? : string,
-            }
-        ): Promise < promql_return_object >
-        {
-            let path = '/tenants/{tenant_id}/metrics/api/v1/query_range';
-            let body;
-            let query = {};
-            if (parameters['tenantId'] === undefined) {
-                throw new Error('Missing required  parameter: tenantId');
-            }
-
-            path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
-
-            if (parameters['query'] === undefined) {
-                throw new Error('Missing required  parameter: query');
-            }
-
-            if (parameters['query'] !== undefined) {
-                query['query'] = parameters['query'];
-            }
-
-            if (parameters['start'] === undefined) {
-                throw new Error('Missing required  parameter: start');
-            }
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            if (parameters['step'] !== undefined) {
-                query['step'] = parameters['step'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getTenantsByTenantIdMetricsApiV1Series(
-            parameters: {
-                'tenantId': number,
-                'match' ? : Array < string >
-                    ,
-                'start' ? : string,
-                'end' ? : string,
-            }
-        ): Promise < Array < prometheus_labelset >
-        >
-        {
-            let path = '/tenants/{tenant_id}/metrics/api/v1/series';
-            let body;
-            let query = {};
-            if (parameters['tenantId'] === undefined) {
-                throw new Error('Missing required  parameter: tenantId');
-            }
-
-            path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
-
-            if (parameters['match'] !== undefined) {
-                query['match[]'] = parameters['match'];
-            }
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getTenantsByTenantIdMetricsQuery(
-            parameters: {
-                'tenantId': number,
-                'query': string,
-                'time' ? : string,
-            }
-        ): Promise < promql_return_object >
-        {
-            let path = '/tenants/{tenant_id}/metrics/query';
-            let body;
-            let query = {};
-            if (parameters['tenantId'] === undefined) {
-                throw new Error('Missing required  parameter: tenantId');
-            }
-
-            path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
-
-            if (parameters['query'] === undefined) {
-                throw new Error('Missing required  parameter: query');
-            }
-
-            if (parameters['query'] !== undefined) {
-                query['query'] = parameters['query'];
-            }
-
-            if (parameters['time'] !== undefined) {
-                query['time'] = parameters['time'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getTenantsByTenantIdMetricsQueryRange(
-            parameters: {
-                'tenantId': number,
-                'query': string,
-                'start': string,
-                'end' ? : string,
-                'step' ? : string,
-            }
-        ): Promise < promql_return_object >
-        {
-            let path = '/tenants/{tenant_id}/metrics/query_range';
-            let body;
-            let query = {};
-            if (parameters['tenantId'] === undefined) {
-                throw new Error('Missing required  parameter: tenantId');
-            }
-
-            path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
-
-            if (parameters['query'] === undefined) {
-                throw new Error('Missing required  parameter: query');
-            }
-
-            if (parameters['query'] !== undefined) {
-                query['query'] = parameters['query'];
-            }
-
-            if (parameters['start'] === undefined) {
-                throw new Error('Missing required  parameter: start');
-            }
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            if (parameters['step'] !== undefined) {
-                query['step'] = parameters['step'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getTenantsByTenantIdMetricsSeries(
-            parameters: {
-                'tenantId': number,
-                'match' ? : Array < string >
-                    ,
-                'start' ? : string,
-                'end' ? : string,
-            }
-        ): Promise < Array < prometheus_labelset >
-        >
-        {
-            let path = '/tenants/{tenant_id}/metrics/series';
-            let body;
-            let query = {};
-            if (parameters['tenantId'] === undefined) {
-                throw new Error('Missing required  parameter: tenantId');
-            }
-
-            path = path.replace('{tenant_id}', `${parameters['tenantId']}`);
-
-            if (parameters['match'] !== undefined) {
-                query['match'] = parameters['match'];
-            }
-
-            if (parameters['start'] !== undefined) {
-                query['start'] = parameters['start'];
-            }
-
-            if (parameters['end'] !== undefined) {
-                query['end'] = parameters['end'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getTenantsTargetsMetadata(
-            parameters: {
-                'matchTarget' ? : string,
-                'metric' ? : string,
-                'limit' ? : string,
-            }
-        ): Promise < Array < prometheus_targets_metadata >
-        >
-        {
-            let path = '/tenants/targets_metadata';
-            let body;
-            let query = {};
-
-            if (parameters['matchTarget'] !== undefined) {
-                query['match_target'] = parameters['matchTarget'];
-            }
-
-            if (parameters['metric'] !== undefined) {
-                query['metric'] = parameters['metric'];
-            }
-
-            if (parameters['limit'] !== undefined) {
-                query['limit'] = parameters['limit'];
-            }
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getTestsE2E(): Promise < Array < e2e_test_case >
-        >
-        {
-            let path = '/tests/e2e';
-            let body;
-            let query = {};
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getTestsE2EEnodebd(): Promise < Array < enodebd_e2e_test >
-        >
-        {
-            let path = '/tests/e2e/enodebd';
-            let body;
-            let query = {};
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postTestsE2EEnodebd(
-        parameters: {
-            'test': mutable_enodebd_e2e_test,
-        }
-    ): Promise < "Created" > {
-        let path = '/tests/e2e/enodebd';
-        let body;
-        let query = {};
-        if (parameters['test'] === undefined) {
-            throw new Error('Missing required  parameter: test');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['test'] !== undefined) {
-            body = parameters['test'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdGatewaysByGatewayIdDevice(parameters: {
+    networkId: string,
+    gatewayId: string,
+    device: gateway_device,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/device';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
     }
-    static async deleteTestsE2EEnodebdByTestPk(
-        parameters: {
-            'testPk': number,
-        }
-    ): Promise < "Deleted" > {
-        let path = '/tests/e2e/enodebd/{test_pk}';
-        let body;
-        let query = {};
-        if (parameters['testPk'] === undefined) {
-            throw new Error('Missing required  parameter: testPk');
-        }
 
-        path = path.replace('{test_pk}', `${parameters['testPk']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getTestsE2EEnodebdByTestPk(
-            parameters: {
-                'testPk': number,
-            }
-        ): Promise < enodebd_test_config >
-        {
-            let path = '/tests/e2e/enodebd/{test_pk}';
-            let body;
-            let query = {};
-            if (parameters['testPk'] === undefined) {
-                throw new Error('Missing required  parameter: testPk');
-            }
-
-            path = path.replace('{test_pk}', `${parameters['testPk']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putTestsE2EEnodebdByTestPk(
-        parameters: {
-            'testPk': number,
-            'test': enodebd_test_config,
-        }
-    ): Promise < "Updated" > {
-        let path = '/tests/e2e/enodebd/{test_pk}';
-        let body;
-        let query = {};
-        if (parameters['testPk'] === undefined) {
-            throw new Error('Missing required  parameter: testPk');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        path = path.replace('{test_pk}', `${parameters['testPk']}`);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['test'] === undefined) {
-            throw new Error('Missing required  parameter: test');
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['test'] !== undefined) {
-            body = parameters['test'];
-        }
+    if (parameters['device'] === undefined) {
+      throw new Error('Missing required  parameter: device');
+    }
 
-        return await this.request(path, 'PUT', query, body);
+    if (parameters['device'] !== undefined) {
+      body = parameters['device'];
     }
-    static async getWifi(): Promise < Array < string >
-        >
-        {
-            let path = '/wifi';
-            let body;
-            let query = {};
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postWifi(
-        parameters: {
-            'wifiNetwork': wifi_network,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi';
-        let body;
-        let query = {};
-        if (parameters['wifiNetwork'] === undefined) {
-            throw new Error('Missing required  parameter: wifiNetwork');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdGatewaysByGatewayIdMagmad(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<magmad_gateway_configs> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/magmad';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['wifiNetwork'] !== undefined) {
-            body = parameters['wifiNetwork'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
     }
-    static async deleteWifiByNetworkId(
-        parameters: {
-            'networkId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
-
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-        return await this.request(path, 'DELETE', query, body);
-    }
-    static async getWifiByNetworkId(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < wifi_network >
-        {
-            let path = '/wifi/{network_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkId(
-        parameters: {
-            'networkId': string,
-            'wifiNetwork': wifi_network,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['wifiNetwork'] === undefined) {
-            throw new Error('Missing required  parameter: wifiNetwork');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdGatewaysByGatewayIdMagmad(parameters: {
+    networkId: string,
+    gatewayId: string,
+    magmad: magmad_gateway_configs,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/magmad';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['wifiNetwork'] !== undefined) {
-            body = parameters['wifiNetwork'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdDescription(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_description >
-        {
-            let path = '/wifi/{network_id}/description';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdDescription(
-        parameters: {
-            'networkId': string,
-            'description': network_description,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/description';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['description'] === undefined) {
-            throw new Error('Missing required  parameter: description');
-        }
+    if (parameters['magmad'] === undefined) {
+      throw new Error('Missing required  parameter: magmad');
+    }
 
-        if (parameters['description'] !== undefined) {
-            body = parameters['description'];
-        }
+    if (parameters['magmad'] !== undefined) {
+      body = parameters['magmad'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdFeatures(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_features >
-        {
-            let path = '/wifi/{network_id}/features';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdFeatures(
-        parameters: {
-            'networkId': string,
-            'config': network_features,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/features';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdGatewaysByGatewayIdName(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_name> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdGateways(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < {
-            [string]: wifi_gateway,
-        } >
-        {
-            let path = '/wifi/{network_id}/gateways';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postWifiByNetworkIdGateways(
-        parameters: {
-            'networkId': string,
-            'gateway': mutable_wifi_gateway,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/gateways';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdGatewaysByGatewayIdName(parameters: {
+    networkId: string,
+    gatewayId: string,
+    name: gateway_name,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'POST', query, body);
+    if (parameters['name'] === undefined) {
+      throw new Error('Missing required  parameter: name');
     }
-    static async deleteWifiByNetworkIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['name'] !== undefined) {
+      body = parameters['name'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdGatewaysByGatewayIdStatus(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_status> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/status';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
     }
-    static async getWifiByNetworkIdGatewaysByGatewayId(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < wifi_gateway >
-        {
-            let path = '/wifi/{network_id}/gateways/{gateway_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
 
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async getWifiByNetworkIdGatewaysByGatewayIdTier(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<tier_id> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/tier';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdGatewaysByGatewayId(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'gateway': mutable_wifi_gateway,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/gateways/{gateway_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdGatewaysByGatewayIdTier(parameters: {
+    networkId: string,
+    gatewayId: string,
+    tierId: tier_id,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/tier';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gateway'] === undefined) {
-            throw new Error('Missing required  parameter: gateway');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['gateway'] !== undefined) {
-            body = parameters['gateway'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdGatewaysByGatewayIdDescription(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_description >
-        {
-            let path = '/wifi/{network_id}/gateways/{gateway_id}/description';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdGatewaysByGatewayIdDescription(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'description': gateway_description,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/gateways/{gateway_id}/description';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['tierId'] === undefined) {
+      throw new Error('Missing required  parameter: tierId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['tierId'] !== undefined) {
+      body = parameters['tierId'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdGatewaysByGatewayIdWifi(parameters: {
+    networkId: string,
+    gatewayId: string,
+  }): Promise<gateway_wifi_configs> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/wifi';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['description'] === undefined) {
-            throw new Error('Missing required  parameter: description');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        if (parameters['description'] !== undefined) {
-            body = parameters['description'];
-        }
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdGatewaysByGatewayIdDevice(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_device >
-        {
-            let path = '/wifi/{network_id}/gateways/{gateway_id}/device';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdGatewaysByGatewayIdDevice(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'device': gateway_device,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/gateways/{gateway_id}/device';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdGatewaysByGatewayIdWifi(parameters: {
+    networkId: string,
+    gatewayId: string,
+    config: gateway_wifi_configs,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/gateways/{gateway_id}/wifi';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['gatewayId'] === undefined) {
+      throw new Error('Missing required  parameter: gatewayId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
 
-        if (parameters['device'] === undefined) {
-            throw new Error('Missing required  parameter: device');
-        }
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
 
-        if (parameters['device'] !== undefined) {
-            body = parameters['device'];
-        }
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdGatewaysByGatewayIdMagmad(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < magmad_gateway_configs >
-        {
-            let path = '/wifi/{network_id}/gateways/{gateway_id}/magmad';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdGatewaysByGatewayIdMagmad(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'magmad': magmad_gateway_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/gateways/{gateway_id}/magmad';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdMeshes(parameters: {
+    networkId: string,
+  }): Promise<Array<mesh_id>> {
+    let path = '/wifi/{network_id}/meshes';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async postWifiByNetworkIdMeshes(parameters: {
+    networkId: string,
+    wifiMesh: wifi_mesh,
+  }): Promise<mesh_id> {
+    let path = '/wifi/{network_id}/meshes';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['magmad'] === undefined) {
-            throw new Error('Missing required  parameter: magmad');
-        }
+    if (parameters['wifiMesh'] === undefined) {
+      throw new Error('Missing required  parameter: wifiMesh');
+    }
 
-        if (parameters['magmad'] !== undefined) {
-            body = parameters['magmad'];
-        }
+    if (parameters['wifiMesh'] !== undefined) {
+      body = parameters['wifiMesh'];
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdGatewaysByGatewayIdName(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_name >
-        {
-            let path = '/wifi/{network_id}/gateways/{gateway_id}/name';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdGatewaysByGatewayIdName(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'name': gateway_name,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/gateways/{gateway_id}/name';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'POST', query, body);
+  }
+  static async deleteWifiByNetworkIdMeshesByMeshId(parameters: {
+    networkId: string,
+    meshId: string,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/meshes/{mesh_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    if (parameters['meshId'] === undefined) {
+      throw new Error('Missing required  parameter: meshId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{mesh_id}', `${parameters['meshId']}`);
 
-        if (parameters['name'] === undefined) {
-            throw new Error('Missing required  parameter: name');
-        }
+    return await this.request(path, 'DELETE', query, body);
+  }
+  static async getWifiByNetworkIdMeshesByMeshId(parameters: {
+    networkId: string,
+    meshId: string,
+  }): Promise<wifi_mesh> {
+    let path = '/wifi/{network_id}/meshes/{mesh_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['name'] !== undefined) {
-            body = parameters['name'];
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdGatewaysByGatewayIdStatus(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_status >
-        {
-            let path = '/wifi/{network_id}/gateways/{gateway_id}/status';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async getWifiByNetworkIdGatewaysByGatewayIdTier(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < tier_id >
-        {
-            let path = '/wifi/{network_id}/gateways/{gateway_id}/tier';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdGatewaysByGatewayIdTier(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'tierId': tier_id,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/gateways/{gateway_id}/tier';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['meshId'] === undefined) {
+      throw new Error('Missing required  parameter: meshId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{mesh_id}', `${parameters['meshId']}`);
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdMeshesByMeshId(parameters: {
+    networkId: string,
+    meshId: string,
+    wifiMesh: wifi_mesh,
+  }): Promise<mesh_id> {
+    let path = '/wifi/{network_id}/meshes/{mesh_id}';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['tierId'] === undefined) {
-            throw new Error('Missing required  parameter: tierId');
-        }
+    if (parameters['meshId'] === undefined) {
+      throw new Error('Missing required  parameter: meshId');
+    }
 
-        if (parameters['tierId'] !== undefined) {
-            body = parameters['tierId'];
-        }
+    path = path.replace('{mesh_id}', `${parameters['meshId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdGatewaysByGatewayIdWifi(
-            parameters: {
-                'networkId': string,
-                'gatewayId': string,
-            }
-        ): Promise < gateway_wifi_configs >
-        {
-            let path = '/wifi/{network_id}/gateways/{gateway_id}/wifi';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['gatewayId'] === undefined) {
-                throw new Error('Missing required  parameter: gatewayId');
-            }
-
-            path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdGatewaysByGatewayIdWifi(
-        parameters: {
-            'networkId': string,
-            'gatewayId': string,
-            'config': gateway_wifi_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/gateways/{gateway_id}/wifi';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    if (parameters['wifiMesh'] === undefined) {
+      throw new Error('Missing required  parameter: wifiMesh');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['wifiMesh'] !== undefined) {
+      body = parameters['wifiMesh'];
+    }
 
-        if (parameters['gatewayId'] === undefined) {
-            throw new Error('Missing required  parameter: gatewayId');
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdMeshesByMeshIdConfig(parameters: {
+    networkId: string,
+    meshId: string,
+  }): Promise<mesh_wifi_configs> {
+    let path = '/wifi/{network_id}/meshes/{mesh_id}/config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{gateway_id}', `${parameters['gatewayId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    if (parameters['meshId'] === undefined) {
+      throw new Error('Missing required  parameter: meshId');
+    }
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    path = path.replace('{mesh_id}', `${parameters['meshId']}`);
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdMeshes(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < Array < mesh_id >
-        >
-        {
-            let path = '/wifi/{network_id}/meshes';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async postWifiByNetworkIdMeshes(
-            parameters: {
-                'networkId': string,
-                'wifiMesh': wifi_mesh,
-            }
-        ): Promise < mesh_id >
-        {
-            let path = '/wifi/{network_id}/meshes';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['wifiMesh'] === undefined) {
-                throw new Error('Missing required  parameter: wifiMesh');
-            }
-
-            if (parameters['wifiMesh'] !== undefined) {
-                body = parameters['wifiMesh'];
-            }
-
-            return await this.request(path, 'POST', query, body);
-        }
-    static async deleteWifiByNetworkIdMeshesByMeshId(
-        parameters: {
-            'networkId': string,
-            'meshId': string,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/meshes/{mesh_id}';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdMeshesByMeshIdConfig(parameters: {
+    networkId: string,
+    meshId: string,
+    meshWifiConfigs: mesh_wifi_configs,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/meshes/{mesh_id}/config';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['meshId'] === undefined) {
-            throw new Error('Missing required  parameter: meshId');
-        }
+    if (parameters['meshId'] === undefined) {
+      throw new Error('Missing required  parameter: meshId');
+    }
 
-        path = path.replace('{mesh_id}', `${parameters['meshId']}`);
+    path = path.replace('{mesh_id}', `${parameters['meshId']}`);
 
-        return await this.request(path, 'DELETE', query, body);
+    if (parameters['meshWifiConfigs'] === undefined) {
+      throw new Error('Missing required  parameter: meshWifiConfigs');
     }
-    static async getWifiByNetworkIdMeshesByMeshId(
-            parameters: {
-                'networkId': string,
-                'meshId': string,
-            }
-        ): Promise < wifi_mesh >
-        {
-            let path = '/wifi/{network_id}/meshes/{mesh_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-            if (parameters['meshId'] === undefined) {
-                throw new Error('Missing required  parameter: meshId');
-            }
+    if (parameters['meshWifiConfigs'] !== undefined) {
+      body = parameters['meshWifiConfigs'];
+    }
 
-            path = path.replace('{mesh_id}', `${parameters['meshId']}`);
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdMeshesByMeshIdName(parameters: {
+    networkId: string,
+    meshId: string,
+  }): Promise<mesh_name> {
+    let path = '/wifi/{network_id}/meshes/{mesh_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdMeshesByMeshId(
-            parameters: {
-                'networkId': string,
-                'meshId': string,
-                'wifiMesh': wifi_mesh,
-            }
-        ): Promise < mesh_id >
-        {
-            let path = '/wifi/{network_id}/meshes/{mesh_id}';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['meshId'] === undefined) {
-                throw new Error('Missing required  parameter: meshId');
-            }
-
-            path = path.replace('{mesh_id}', `${parameters['meshId']}`);
-
-            if (parameters['wifiMesh'] === undefined) {
-                throw new Error('Missing required  parameter: wifiMesh');
-            }
-
-            if (parameters['wifiMesh'] !== undefined) {
-                body = parameters['wifiMesh'];
-            }
-
-            return await this.request(path, 'PUT', query, body);
-        }
-    static async getWifiByNetworkIdMeshesByMeshIdConfig(
-            parameters: {
-                'networkId': string,
-                'meshId': string,
-            }
-        ): Promise < mesh_wifi_configs >
-        {
-            let path = '/wifi/{network_id}/meshes/{mesh_id}/config';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['meshId'] === undefined) {
-                throw new Error('Missing required  parameter: meshId');
-            }
-
-            path = path.replace('{mesh_id}', `${parameters['meshId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdMeshesByMeshIdConfig(
-        parameters: {
-            'networkId': string,
-            'meshId': string,
-            'meshWifiConfigs': mesh_wifi_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/meshes/{mesh_id}/config';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['meshId'] === undefined) {
+      throw new Error('Missing required  parameter: meshId');
+    }
 
-        if (parameters['meshId'] === undefined) {
-            throw new Error('Missing required  parameter: meshId');
-        }
+    path = path.replace('{mesh_id}', `${parameters['meshId']}`);
 
-        path = path.replace('{mesh_id}', `${parameters['meshId']}`);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdMeshesByMeshIdName(parameters: {
+    networkId: string,
+    meshId: string,
+    meshName: mesh_name,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/meshes/{mesh_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['meshWifiConfigs'] === undefined) {
-            throw new Error('Missing required  parameter: meshWifiConfigs');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['meshWifiConfigs'] !== undefined) {
-            body = parameters['meshWifiConfigs'];
-        }
+    if (parameters['meshId'] === undefined) {
+      throw new Error('Missing required  parameter: meshId');
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdMeshesByMeshIdName(
-            parameters: {
-                'networkId': string,
-                'meshId': string,
-            }
-        ): Promise < mesh_name >
-        {
-            let path = '/wifi/{network_id}/meshes/{mesh_id}/name';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            if (parameters['meshId'] === undefined) {
-                throw new Error('Missing required  parameter: meshId');
-            }
-
-            path = path.replace('{mesh_id}', `${parameters['meshId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdMeshesByMeshIdName(
-        parameters: {
-            'networkId': string,
-            'meshId': string,
-            'meshName': mesh_name,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/meshes/{mesh_id}/name';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{mesh_id}', `${parameters['meshId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['meshName'] === undefined) {
+      throw new Error('Missing required  parameter: meshName');
+    }
 
-        if (parameters['meshId'] === undefined) {
-            throw new Error('Missing required  parameter: meshId');
-        }
+    if (parameters['meshName'] !== undefined) {
+      body = parameters['meshName'];
+    }
 
-        path = path.replace('{mesh_id}', `${parameters['meshId']}`);
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdName(parameters: {
+    networkId: string,
+  }): Promise<network_name> {
+    let path = '/wifi/{network_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['meshName'] === undefined) {
-            throw new Error('Missing required  parameter: meshName');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['meshName'] !== undefined) {
-            body = parameters['meshName'];
-        }
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdName(parameters: {
+    networkId: string,
+    name: network_name,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/name';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdName(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_name >
-        {
-            let path = '/wifi/{network_id}/name';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdName(
-        parameters: {
-            'networkId': string,
-            'name': network_name,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/name';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    if (parameters['name'] === undefined) {
+      throw new Error('Missing required  parameter: name');
+    }
 
-        if (parameters['name'] === undefined) {
-            throw new Error('Missing required  parameter: name');
-        }
+    if (parameters['name'] !== undefined) {
+      body = parameters['name'];
+    }
 
-        if (parameters['name'] !== undefined) {
-            body = parameters['name'];
-        }
+    return await this.request(path, 'PUT', query, body);
+  }
+  static async getWifiByNetworkIdWifi(parameters: {
+    networkId: string,
+  }): Promise<network_wifi_configs> {
+    let path = '/wifi/{network_id}/wifi';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        return await this.request(path, 'PUT', query, body);
-    }
-    static async getWifiByNetworkIdWifi(
-            parameters: {
-                'networkId': string,
-            }
-        ): Promise < network_wifi_configs >
-        {
-            let path = '/wifi/{network_id}/wifi';
-            let body;
-            let query = {};
-            if (parameters['networkId'] === undefined) {
-                throw new Error('Missing required  parameter: networkId');
-            }
-
-            path = path.replace('{network_id}', `${parameters['networkId']}`);
-
-            return await this.request(path, 'GET', query, body);
-        }
-    static async putWifiByNetworkIdWifi(
-        parameters: {
-            'networkId': string,
-            'config': network_wifi_configs,
-        }
-    ): Promise < "Success" > {
-        let path = '/wifi/{network_id}/wifi';
-        let body;
-        let query = {};
-        if (parameters['networkId'] === undefined) {
-            throw new Error('Missing required  parameter: networkId');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        path = path.replace('{network_id}', `${parameters['networkId']}`);
+    return await this.request(path, 'GET', query, body);
+  }
+  static async putWifiByNetworkIdWifi(parameters: {
+    networkId: string,
+    config: network_wifi_configs,
+  }): Promise<'Success'> {
+    let path = '/wifi/{network_id}/wifi';
+    let body;
+    const query = {};
+    if (parameters['networkId'] === undefined) {
+      throw new Error('Missing required  parameter: networkId');
+    }
 
-        if (parameters['config'] === undefined) {
-            throw new Error('Missing required  parameter: config');
-        }
+    path = path.replace('{network_id}', `${parameters['networkId']}`);
 
-        if (parameters['config'] !== undefined) {
-            body = parameters['config'];
-        }
+    if (parameters['config'] === undefined) {
+      throw new Error('Missing required  parameter: config');
+    }
 
-        return await this.request(path, 'PUT', query, body);
+    if (parameters['config'] !== undefined) {
+      body = parameters['config'];
     }
+
+    return await this.request(path, 'PUT', query, body);
+  }
 }

--- a/nms/packages/magmalte/grafana/dashboards/Dashboards.js
+++ b/nms/packages/magmalte/grafana/dashboards/Dashboards.js
@@ -322,7 +322,7 @@ export const NetworkDBData = (networkIDs: Array<string>): GrafanaDBData => {
               },
               {
                 expr:
-                  'sum(rate(service_request{networkID=~"$networkID"}[5m])) by (networkID)-sum(rate(s1_setup{result="success",networkID=~"$networkID"}[5m])) by (networkID)',
+                  'sum(rate(service_request{networkID=~"$networkID",result="failure"}[5m])) by (networkID)',
                 legendFormat: 'Failure: {{networkID}}',
               },
             ],
@@ -342,7 +342,7 @@ export const NetworkDBData = (networkIDs: Array<string>): GrafanaDBData => {
               },
               {
                 expr:
-                  'sum(increase(service_request{networkID=~"$networkID"}[1h])) by (networkID)-sum(increase(s1_setup{result="success",networkID=~"$networkID"}[1h])) by (networkID)',
+                  'sum(increase(service_request{networkID=~"$networkID",result="failure"}[1h])) by (networkID)',
                 legendFormat: 'Failure: {{networkID}}',
               },
             ],
@@ -530,7 +530,7 @@ export const GatewayDBData = (networkIDs: Array<string>): GrafanaDBData => {
               },
               {
                 expr:
-                  'sum(rate(service_request{gatewayID=~"$gatewayID",networkID=~"$networkID"}[5m])) by (gatewayID,networkID)-sum(rate(s1_setup{gatewayID=~"$gatewayID",result="success",networkID=~"$networkID"}[5m])) by (gatewayID,networkID)',
+                  'sum(rate(service_request{gatewayID=~"$gatewayID",networkID=~"$networkID",result="failure"}[5m])) by (gatewayID,networkID)',
                 legendFormat: 'Failure: {{networkID}}',
               },
             ],
@@ -550,7 +550,7 @@ export const GatewayDBData = (networkIDs: Array<string>): GrafanaDBData => {
               },
               {
                 expr:
-                  'sum(increase(service_request{gatewayID=~"$gatewayID",networkID=~"$networkID"}[1h])) by (gatewayID,networkID)-sum(increase(s1_setup{gatewayID=~"$gatewayID",result="success",networkID=~"$networkID"}[1h])) by (gatewayID,networkID)',
+                  'sum(increase(service_request{gatewayID=~"$gatewayID",networkID=~"$networkID",result="failure"}[1h])) by (gatewayID,networkID)',
                 legendFormat: 'Failure: {{networkID}}',
               },
             ],


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- This PR fixes service request rate and count metrics on NMS (by counting success and failures separately and removing s1_setup from the metric calculation formula)
- Also removes plain service_request total counts from MME (success + failures should give the same count)

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- verified locally on NMS and generating service_requests counts with s1ap tester
<img width="1646" alt="Screen Shot 2021-11-03 at 11 28 01 PM" src="https://user-images.githubusercontent.com/6800940/140388451-1efe129d-88f8-417a-b596-6afcd920c69b.png">

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
