### PR TITLE
fix(agw): Persistent IPv6 config

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -39,9 +39,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # iperf3 trfserver routable IP.
     magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
 
-    # IPv6 interface
-    config.vm.provision :shell, inline: "ip -6 r add  2020::10/64 dev eth0 && ip -6 r r default via 2020::1", run: 'always'
-
     magma.vm.provider "virtualbox" do |vb|
       vb.name = "magma-dev"
       vb.linked_clone = true

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -293,6 +293,16 @@
     dest: /etc/network/interfaces.d/gtp
   when: full_provision
 
+- name: Configure IPv6 address on eth0 interface
+  blockinfile:
+    block: |
+        iface eth0 inet6 static
+              address 2020::10/64
+              gateway 2020::1
+    insertafter: "iface eth0 inet dhcp"
+    path: "/etc/network/interfaces"
+  when: full_provision
+
 - name: Delete the OVS bridge on system initialization
   lineinfile: dest=/etc/default/openvswitch-switch regexp='.*OVS_CTL_OPTS=.*' line='OVS_CTL_OPTS=\'--delete-bridges\'' state=present
   when: full_provision
@@ -442,7 +452,3 @@
     state: latest
     pkg:
       - magma-libfluid
-
-- name: Set IPv6 address for magma dev
-  retries: 5
-  shell: ip -6 a add  2020::10/64 dev eth0 && ip -6 r add default via 2020::1


### PR DESCRIPTION
## Summary

fixes #10096 

Issue #10096 was caused by trying to add a route that was already added before. These changes persist the IPv6 address and default route in /etc/network/interfaces and thereby delegate their creation to the OS.

## Test Plan

```
cd $MAGMA_ROOT/lte/gateway
vagrant destroy magma
vagrant up magma
vagrant halt magma
vagrant up --provision magma
```

Assert that the second provision works. Assert that after the first provisioning, `eth0` has the IPv6 address `2020::10/64` and there is a default route via `2020::1` (by looking at the output of `ip -6 addr` and `ip -6 route`)

## Additional Information

- [ ] This change is backwards-breaking