### PR TITLE
chore(smsd): enable selective opt-in logging to Sentry for smsd

### DIFF
--- a/lte/gateway/python/magma/smsd/relay.py
+++ b/lte/gateway/python/magma/smsd/relay.py
@@ -20,6 +20,7 @@ import lte.protos.sms_orc8r_pb2_grpc as sms_orc8r_pb2_grpc
 from lte.protos.mconfig.mconfigs_pb2 import MME
 from magma.common.job import Job
 from magma.common.rpc_utils import grpc_async_wrapper, return_void
+from magma.common.sentry import SEND_TO_MONITORING
 from magma.configuration.mconfig_managers import load_service_mconfig
 from orc8r.protos.common_pb2 import Void
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
@@ -93,7 +94,7 @@ class SmsRelay(Job):
                 self._mme_sms.SMODownlink.future(dl, SMS_TIMEOUT_SECS),
             )
         except grpc.RpcError as err:
-            logging.error("RPC call to MME failed: %s", err)
+            logging.error("RPC call to MME failed: %s", err, extra=SEND_TO_MONITORING)
             return
 
     @return_void


### PR DESCRIPTION
Merge after #9974

## Summary

Send errors to Sentry if MME communication fails.  

## Context

In Sentry's opt-in mode only the most important errors should be sent to Sentry.