### PR TITLE
chore(monitord): Enable selective opt-in logging to Sentry

### DIFF
--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -20,6 +20,7 @@ import grpc
 from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from magma.common.rpc_utils import grpc_async_wrapper
+from magma.common.sentry import SEND_TO_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from magma.magmad.check.network_check.ping import PingCommandResult
 from magma.monitord.icmp_state import ICMPMonitoringResponse
@@ -92,7 +93,10 @@ class CpeMonitoringModule:
                 ping_targets[sub.sid.id] = ip
         except grpc.RpcError as err:
             logging.error(
-                "GetSubscribers Error for %s! %s", err.code(), err.details(),
+                "GetSubscribers Error for %s! %s",
+                err.code(),
+                err.details(),
+                extra=SEND_TO_MONITORING,
             )
         return PingedTargets(ping_targets, ping_addresses)
 


### PR DESCRIPTION
Merge after #9974

## Summary

Send errors to Sentry if mobilityd communication fails.  

## Context

In Sentry's opt-in mode only the most important errors should be sent to Sentry. Monitord actually only has a single error log, so opt-in mode would send errors from this log to Sentry while other error logs that might be logged in third-party dependencies will be suppressed.