### PR TITLE
chore: fix bazel schedule job

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -12,8 +12,8 @@ on:  # yamllint disable-line rule:truthy
     paths:
       - .github/workflows/bazel.yml
   schedule:
-    # Run once a day to build bazel cache at 0200 hours
-    - cron: '0 2 * * *'
+    # Run four times a day to build bazel cache
+    - cron: '0 0,6,12,18 * * *'
 env:
   DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-007ddb9"
   BAZEL_CACHE: bazel-cache
@@ -30,9 +30,8 @@ jobs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
-        if: github.event_name == 'schedule' || github.event_name == 'push'
       - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
         id: changes
         with:
           filters: |
@@ -40,8 +39,7 @@ jobs:
               - [".github/workflows/bazel.yml", "lte/gateway/c/**", "orc8r/gateway/c/**", "orc8r/protos/**", "lte/protos/**", "src/go/**"]
 
   bazel_build_and_test:
-    needs:
-      - path_filter
+    needs: path_filter
     # Only run workflow if this is a scheduled run on master branch,
     # or a pull_request that skip-duplicate-action wants to run again.
     if: |


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Seeing this on master: 
<img width="1393" alt="Screen Shot 2021-11-04 at 8 25 21 AM" src="https://user-images.githubusercontent.com/37634144/140313052-d4c2477c-745f-4d10-aa58-a00fb00d1c17.png">

https://github.com/magma/magma/runs/4100451651?check_suite_focus=true

It looks like the job is incompatible with schedule triggers so changing it to only run the path action on pull_request trigger. (https://github.com/dorny/paths-filter/issues/100)
Also changing the cron frequency so that the cache stays more up-to-date. (The job takes around ~10-13min with occasional 20-30min run when the cache exceeds the size, so it shouldn't be a big deal.) 
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
