### PR TITLE
ci: migrate CI devcontainer hash forward

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 		"augustocdias.tasks-shell-input",
 		"ryuta46.multi-command",
 	],
-	"image": "ghcr.io/magma/devcontainer:sha-007ddb9",
+	"image": "ghcr.io/magma/devcontainer:sha-3c02c72",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"files.watcherExclude": {

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-007ddb9"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-3c02c72"
 
 jobs:
   path_filter:

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -21,7 +21,7 @@ env:
   
   S3_BUCKET_PATH: s3://magma-bazel-cache
 
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-007ddb9"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-3c02c72"
 
 jobs:
   bazel-build-magma-vm-and-push-cache:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
     # Run once a day to build bazel cache at 0200 hours
     - cron: '0 2 * * *'
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-007ddb9"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-3c02c72"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -22,7 +22,7 @@ on:
       - reopened
       - synchronize
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-007ddb9"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-3c02c72"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
This should be done regularly - but this particular instance is triggered by my need for `xo` binary in devconatiner (see #10068).

Signed-off-by: Scott Moeller <electronjoe@gmail.com>