### PR TITLE
fix(agw): Allow wider network range for host-only interfaces

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Build AGW
         run: |
           cd lte/gateway
+          echo '* 192.168.0.0/16' > /etc/vbox/networks.conf
           fab release package:vcs=git
           mkdir magma-packages
           vagrant ssh -c "cp -r magma-packages /vagrant"


### PR DESCRIPTION
## Summary

The agw-build step is currently failing. This PR attempts to fix that.



## Test Plan



## Additional Information

- [ ] This change is backwards-breaking

