### PR TITLE
chore(state): enable selective opt-in logging to Sentry for state service

### DIFF
--- a/orc8r/gateway/python/magma/state/garbage_collector.py
+++ b/orc8r/gateway/python/magma/state/garbage_collector.py
@@ -16,6 +16,7 @@ import grpc
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.redis.containers import RedisFlatDict
 from magma.common.rpc_utils import grpc_async_wrapper, print_grpc
+from magma.common.sentry import SEND_TO_MONITORING
 from magma.common.service import MagmaService
 from magma.state.keys import make_scoped_device_id
 from magma.state.redis_dicts import get_json_redis_dicts, get_proto_redis_dicts
@@ -82,7 +83,11 @@ class GarbageCollector:
             print_grpc(response, self._print_grpc_payload)
 
         except grpc.RpcError as err:
-            logging.error("GRPC call failed for state deletion: %s", err)
+            logging.error(
+                "GRPC call failed for state deletion: %s",
+                err,
+                extra=SEND_TO_MONITORING,
+            )
         else:
             for redis_dict in self._redis_dicts:
                 for key in redis_dict.garbage_keys():

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -21,6 +21,7 @@ from google.protobuf.json_format import MessageToDict
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.rpc_utils import grpc_async_wrapper, print_grpc
 from magma.common.sdwatchdog import SDWatchdogTask
+from magma.common.sentry import SEND_TO_MONITORING
 from magma.common.service import MagmaService
 from magma.state.garbage_collector import GarbageCollector
 from magma.state.keys import make_mem_key, make_scoped_device_id
@@ -122,6 +123,7 @@ class StateReplicator(SDWatchdogTask):
                 logging.error(
                     "GRPC call failed for initial state re-sync: %s",
                     err,
+                    extra=SEND_TO_MONITORING,
                 )
                 return
         request = await self._collect_states_to_replicate()
@@ -259,7 +261,11 @@ class StateReplicator(SDWatchdogTask):
             print_grpc(response, self._print_grpc_payload)
 
         except grpc.RpcError as err:
-            logging.error("GRPC call failed for state replication: %s", err)
+            logging.error(
+                "GRPC call failed for state replication: %s",
+                err,
+                extra=SEND_TO_MONITORING,
+            )
         else:
             unreplicated_states = set()
             for idAndError in response.unreportedStates:


### PR DESCRIPTION
Merge after #9974

## Summary

In opt-in selected errors from GarbageCollector and StateReplicator are sent to Sentry.

## Context

In Sentry's opt-in mode only the most important errors should be sent to Sentry.