### PR TITLE
chore: address compiler error for asn1c generation

### DIFF
--- a/tools/build_defs/asn1c.bzl
+++ b/tools/build_defs/asn1c.bzl
@@ -14,9 +14,9 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 def _get_dir_name(name):
-    # we need to postfix the directory name with .cc to trick Bazel into thinking this is a valid input
+    # we need to postfix the directory name with .c to trick Bazel into thinking this is a valid input
     # Related GH issue: https://github.com/bazelbuild/bazel/issues/10552
-    return name + ".cc"
+    return name + ".c"
 
 def _contruct_substitution_commands(ctx, dir_path):
     """Returns a list of commands that replaces certain strings with another. 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Seen on master when compiling asn1c:

<img width="939" alt="Screen Shot 2021-11-04 at 2 40 11 PM" src="https://user-images.githubusercontent.com/37634144/140400196-f322dee5-2c01-4626-9747-d3760cdb1057.png">

This was because the directory postfix that I added (.cc) made Bazel think that this was a C++ file. Since asn1c generates c files, modifying the postfix to .c fixes the warnings.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Built locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
