### PR TITLE
ci(agw): Hil PoC

### DIFF
--- a/ci-scripts/test_agent/FirebaseClient.py
+++ b/ci-scripts/test_agent/FirebaseClient.py
@@ -31,10 +31,10 @@ class FirebaseClient:
         # Get a reference to the database service
         self.db = self.firebase.database()
 
-    def push_test_report(self, workload, valid, report):
+    def push_test_report(self, workload, verdict, report):
         data = {
             'timestamp': int(time.time()),
-            'valid': valid,
+            'verdict': verdict,
             'workload': workload.val(),
             'report': report,
         }
@@ -59,8 +59,8 @@ class FirebaseClient:
         for workload in workloads.each():
             print(workload.val())
             # skip if not valid
-            if workload.val().get('state') != "queued":
-                continue
+            #if workload.val().get('state') != "queued":
+            #    continue
 
             # check if first workload
             if bestWorkload is None:

--- a/ci-scripts/test_agent/FirebaseClient.py
+++ b/ci-scripts/test_agent/FirebaseClient.py
@@ -20,71 +20,100 @@ import pyrebase
 class FirebaseClient:
     def __init__(self):
         # Read db config
-        f = open('FirebaseConfig.json')
+        f = open("FirebaseConfig.json")
         self.config = json.load(f)
         # Initialize pyrebase app
         self.firebase = pyrebase.initialize_app(self.config)
         # Get a reference to the auth service
         self.auth = self.firebase.auth()
         # Log the user in
-        self.user = self.auth.sign_in_with_email_and_password(self.config['auth_email'], self.config['auth_password'])
+        self.user = self.auth.sign_in_with_email_and_password(
+            self.config["auth_email"], self.config["auth_password"]
+        )
         # Get a reference to the database service
         self.db = self.firebase.database()
 
     def push_test_report(self, workload, verdict, report):
         data = {
-            'timestamp': int(time.time()),
-            'verdict': verdict,
-            'workload': workload.val(),
-            'report': report,
+            "timestamp": int(time.time()),
+            "verdict": verdict,
+            "workload": workload.val(),
+            "report": report,
         }
-        self.db.child("workers").child(self.config['agent_id']).child("reports").push(data, self.user['idToken'])
+        self.db.child("workers").child(self.config["agent_id"]).child("reports").push(
+            data, self.user["idToken"]
+        )
 
     def update_worker_state(self, num_of_testers, testers_state):
         data = {
-            'timestamp': int(time.time()),
-            'num_of_testers': num_of_testers,
-            'testers_state': testers_state,
+            "timestamp": int(time.time()),
+            "num_of_testers": num_of_testers,
+            "testers_state": testers_state,
         }
-        self.db.child("workers").child(self.config['agent_id']).child("state").update(data, self.user['idToken'])
+        self.db.child("workers").child(self.config["agent_id"]).child("state").update(
+            data, self.user["idToken"]
+        )
 
     def read_workloads(self):
-        reports = self.db.child("workers").child(self.config['agent_id']).child("reports").get(self.user['idToken'])
+        reports = (
+            self.db.child("workers")
+            .child(self.config["agent_id"])
+            .child("reports")
+            .get(self.user["idToken"])
+        )
         for r in reports.each():
             print(r.val())
 
     def pop_next_workload(self):
-        workloads = self.db.child("workers").child(self.config['agent_id']).child("workloads").get(self.user['idToken'])
+        workloads = (
+            self.db.child("workers")
+            .child(self.config["agent_id"])
+            .child("workloads")
+            .get(self.user["idToken"])
+        )
         bestWorkload = None
         for workload in workloads.each():
             print(workload.val())
             # skip if not valid
-            #if workload.val().get('state') != "queued":
-            #    continue
+            if workload.val().get("state") != "queued":
+                continue
 
             # check if first workload
             if bestWorkload is None:
                 bestWorkload = workload
             # check if higher priority or newer
-            elif ((workload.val().get('priority') > bestWorkload.val().get('priority')) or
-                  ((workload.val().get('priority') == bestWorkload.val().get('priority')) and (workload.val().get('timestamp') > bestWorkload.val().get('timestamp')))):
+            elif (
+                workload.val().get("priority") > bestWorkload.val().get("priority")
+            ) or (
+                (workload.val().get("priority") == bestWorkload.val().get("priority"))
+                and (
+                    workload.val().get("timestamp")
+                    > bestWorkload.val().get("timestamp")
+                )
+            ):
                 bestWorkload = workload
 
         if bestWorkload:
             # remove from workloads
-            self.db.child("workers").child(self.config['agent_id']).child("workloads").child(bestWorkload.key()).update({"state": "in_progress"}, self.user['idToken'])
+            self.db.child("workers").child(self.config["agent_id"]).child(
+                "workloads"
+            ).child(bestWorkload.key()).update(
+                {"state": "in_progress"}, self.user["idToken"]
+            )
             print("Best workload: ", bestWorkload.key(), "==>", bestWorkload.val())
             return bestWorkload
         else:
             return None
 
     def get_build(self, workload):
-        build_id = workload.val().get('build_id')
-        build = self.db.child("builds").child(build_id).get(self.user['idToken'])
+        build_id = workload.val().get("build_id")
+        build = self.db.child("builds").child(build_id).get(self.user["idToken"])
         if build:
             return build
         else:
             return None
 
     def mark_workload_done(self, workload):
-        self.db.child("workers").child(self.config['agent_id']).child("workloads").child(workload.key()).update({"state": "done"}, self.user['idToken'])
+        self.db.child("workers").child(self.config["agent_id"]).child(
+            "workloads"
+        ).child(workload.key()).update({"state": "done"}, self.user["idToken"])

--- a/ci-scripts/test_agent/FirebaseClient.py
+++ b/ci-scripts/test_agent/FirebaseClient.py
@@ -54,7 +54,7 @@ class FirebaseClient:
             data, self.user["idToken"]
         )
 
-    def read_workloads(self):
+    def print_reports(self):
         reports = (
             self.db.child("workers")
             .child(self.config["agent_id"])

--- a/ci-scripts/test_agent/FirebaseClient.py
+++ b/ci-scripts/test_agent/FirebaseClient.py
@@ -48,6 +48,11 @@ class FirebaseClient:
         }
         self.db.child("workers").child(self.config['agent_id']).child("state").update(data, self.user['idToken'])
 
+    def read_workloads(self):
+        reports = self.db.child("workers").child(self.config['agent_id']).child("reports").get(self.user['idToken'])
+        for r in reports.each():
+            print(r.val())
+
     def pop_next_workload(self):
         workloads = self.db.child("workers").child(self.config['agent_id']).child("workloads").get(self.user['idToken'])
         bestWorkload = None

--- a/ci-scripts/test_agent/Tester.py
+++ b/ci-scripts/test_agent/Tester.py
@@ -14,10 +14,11 @@ import threading
 import subprocess
 import pickle
 
+
 class TesterState:
-    READY = 'READY'
-    BUSY = 'BUSY'
-    OFFLINE = 'OFFLINE'
+    READY = "READY"
+    BUSY = "BUSY"
+    OFFLINE = "OFFLINE"
 
 
 class Tester:
@@ -29,7 +30,7 @@ class Tester:
 
     def test_ended(self):
         # Get test results and prepare report
-        verdict, report = self.load_test_results(dbfile='/tmp/test_res_pickle')
+        verdict, report = self.load_test_results(dbfile="/tmp/test_res_pickle")
         # Callback
         self.callback(self.id, self.current_workload, verdict, report)
         self.current_workload = None
@@ -37,20 +38,20 @@ class Tester:
         self.state = TesterState.READY
 
     def load_test_results(self, dbfile):
-        """ test run can dump their results (dict) in pickle
+        """test run can dump their results (dict) in pickle
         which can be loaded here and used to push back to DB
         data format = {'verdict' = True/False, 'report': 'html file name with path'}
         """
         try:
-            with open(dbfile, 'rb') as dbfile:
+            with open(dbfile, "rb") as dbfile:
                 db = pickle.load(dbfile)
         except (IOError, OSError, pickle.PickleError, pickle.UnpicklingError):
             print("Not a valid returning null")
             return False, None
         else:
-            with open(db['report'], "r") as rfile:
+            with open(db["report"], "r") as rfile:
                 report = rfile.read()
-            verdict = 'pass' if db['verdict'] else "fail"
+            verdict = "pass" if db["verdict"] else "fail"
             return verdict, report
 
     def start_test(self, workload, build, test_done_callback):
@@ -59,7 +60,7 @@ class Tester:
         self.callback = test_done_callback
 
         # start test on current_workload
-        print('Tester {} Starting test on workload'.format(self.id))
+        print("Tester {} Starting test on workload".format(self.id))
         print(workload.key(), "==>", workload.val())
 
         # register callback to call_ended()
@@ -70,11 +71,14 @@ class Tester:
             proc.wait()
             call_ended()
             return
-        thread = threading.Thread(target=run_hil_thread, args=(self.test_ended, ['./run_test.sh']))
+
+        thread = threading.Thread(
+            target=run_hil_thread, args=(self.test_ended, ["./run_test.sh"])
+        )
         thread.start()
 
         self.state = TesterState.BUSY
-        print('test started on workload'.format(self.id))
+        print("test started on workload".format(self.id))
         return
 
     def is_ready(self):

--- a/ci-scripts/test_agent/Tester.py
+++ b/ci-scripts/test_agent/Tester.py
@@ -84,6 +84,9 @@ class Tester:
     def is_ready(self):
         return self.state == TesterState.READY
 
+    def get_id(self):
+        return self.id
+
     def get_state(self):
         return self.state
 

--- a/ci-scripts/test_agent/Tester.py
+++ b/ci-scripts/test_agent/Tester.py
@@ -29,9 +29,9 @@ class Tester:
 
     def test_ended(self):
         # Get test results and prepare report
-        valid, report = self.load_test_results(dbfile='/tmp/test_res_pickle')
+        verdict, report = self.load_test_results(dbfile='/tmp/test_res_pickle')
         # Callback
-        self.callback(self.id, self.current_workload, valid, report)
+        self.callback(self.id, self.current_workload, verdict, report)
         self.current_workload = None
         self.current_build = None
         self.state = TesterState.READY
@@ -39,19 +39,19 @@ class Tester:
     def load_test_results(self, dbfile):
         """ test run can dump their results (dict) in pickle
         which can be loaded here and used to push back to DB
-        data format = {'valid' = True/False, 'report': 'html file name with path'}
+        data format = {'verdict' = True/False, 'report': 'html file name with path'}
         """
         try:
             with open(dbfile, 'rb') as dbfile:
                 db = pickle.load(dbfile)
         except (IOError, OSError, pickle.PickleError, pickle.UnpicklingError):
             print("Not a valid returning null")
-            return {'valid': False, 'report': None}
+            return False, None
         else:
             with open(db['report'], "r") as rfile:
                 report = rfile.read()
-            valid = 'pass' if db['valid'] else "fail"
-            return valid, report
+            verdict = 'pass' if db['verdict'] else "fail"
+            return verdict, report
 
     def start_test(self, workload, build, test_done_callback):
         self.current_workload = workload

--- a/ci-scripts/test_agent/main.py
+++ b/ci-scripts/test_agent/main.py
@@ -27,9 +27,9 @@ num_of_testers = 1
 db_client = FirebaseClient()
 
 
-def test_done_callback(tester_id, workload, valid, report):
+def test_done_callback(tester_id, workload, verdict, report):
     db_client.mark_workload_done(workload)
-    db_client.push_test_report(workload, valid, report)
+    db_client.push_test_report(workload, verdict, report)
     return
 
 
@@ -51,10 +51,13 @@ def main():
                         tester.start_test(new_workload, build, test_done_callback)
                 else:
                     print("Waiting for new workload")
-            testers_state.append({'state': tester.get_state(), 'current_workload': tester.get_current_workload().val()})
+            current_workload = tester.get_current_workload()
+            if current_workload:
+                testers_state.append({'state': tester.get_state(), 'current_workload': current_workload.val()})
+            else:
+                testers_state.append({'state': tester.get_state(), 'current_workload': None})
 
         db_client.update_worker_state(num_of_testers, testers_state)
-        print("Waiting for Available tester")
         time.sleep(15)
 
 

--- a/ci-scripts/test_agent/main.py
+++ b/ci-scripts/test_agent/main.py
@@ -42,7 +42,7 @@ def main():
         testers_state = []
         for tester in testers:
             if tester.is_ready():
-                print("tester is ready")
+                print("tester {} is ready".format(tester.get_id()))
                 new_workload = db_client.pop_next_workload()
                 print("new workload is", new_workload)
                 if new_workload:

--- a/ci-scripts/test_agent/main.py
+++ b/ci-scripts/test_agent/main.py
@@ -53,9 +53,16 @@ def main():
                     print("Waiting for new workload")
             current_workload = tester.get_current_workload()
             if current_workload:
-                testers_state.append({'state': tester.get_state(), 'current_workload': current_workload.val()})
+                testers_state.append(
+                    {
+                        "state": tester.get_state(),
+                        "current_workload": current_workload.val(),
+                    }
+                )
             else:
-                testers_state.append({'state': tester.get_state(), 'current_workload': None})
+                testers_state.append(
+                    {"state": tester.get_state(), "current_workload": None}
+                )
 
         db_client.update_worker_state(num_of_testers, testers_state)
         time.sleep(15)


### PR DESCRIPTION


## Summary

- Added way to trigger test suite from CI agent in thread
- Added way to get output back from test execution

## Test Plan

executed for both pass and fail case

```
{'report': '<!DOCTYPE html>\n<html>\n\n<head>\n  <style>\n    table {\n      font-family: arial, sans-serif;\n      border-collapse: collapse;\n      width: 70%;\n    }\n\n    td,\n    th {\n      border: 1px solid #dddddd;\n      text-align: left;\n      padding: 8px;\n    }\n\n    tr:nth-child(even) {\n      background-color: #dddddd;\n    }\n  </style>\n</head>\n\n<body>\n\n  <h2>Test Cases Run Summary</h2>\n  <h3>Magma build 1.7.0-1636043527-e1683af7</h3>\n  <h3>Test Run SUT Log <a href="https://ens-spirent-test-summary.com.s3.amazonaws.com/logs/2021-11-04 12:11:49_sanity_magma.log"\n      download="Magma_log">Magma_log</a>\n  </h3>\n  <h4>Test Run SUT Cores <a\n      href="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/index.html?prefix=cores/">Check cores</a>\n    </h3>\n    <table>\n      <tr>\n        <th> Test Case Name </th>\n        <th> Test Run Results </th>\n        <th> Test Results Analytics </th>\n        <th> Grafana link </th>\n      </tr>\n      \n      <tr>\n        <td> TC001_SANITY_control_50UE_3rate </td>\n        <td> PASS </td>\n        <td> [\'td-agent-bit\', \'mobilityd\', \'state\', \'directoryd\', \'health\', \'enodebd\', \'sessiond\', \'envoy_controller\', \'mme\', \'dnsd\', \'magmad\', \'eventd\', \'control_proxy\', \'pipelined\', \'ctraced\', \'redis\', \'policydb\', \'subscriberdb\', \'smsd\'] </td>\n        <td><a\n            href="https://grafana.spirent.fbmagma.ninja/d/9PzxTuPMz/spirent-landslide-results?orgId=3&var-agw=hil-1&var-run_id=968&from=1636053132466&to=1636053588756">grafana</a>\n        </td>\n      </tr>\n      \n      <tr>\n        <td> TC002_SANITY_data_30UE_5rate_active_idle </td>\n        <td> FAIL </td>\n        <td> [\'Failed Procedure -> \', \'PDN_Con_Procedure\', \'Attach_Procedure\', \'connectiond\', \'subscriberdb\'] </td>\n        <td><a\n            href="https://grafana.spirent.fbmagma.ninja/d/9PzxTuPMz/spirent-landslide-results?orgId=3&var-agw=hil-1&var-run_id=969&from=1636053588756&to=1636054118437">grafana</a>\n        </td>\n      </tr>\n      \n      <tr>\n        <td> TC003_SANITY_data_50UE_3rate_25M_attach_detach </td>\n        <td> FAIL </td>\n        <td> [\'Failed Procedure -> \', \'PDN_Con_Procedure\', \'Attach_Procedure\', \'L3_Data_Traffic\', \'subscriberdb\'] </td>\n        <td><a\n            href="https://grafana.spirent.fbmagma.ninja/d/9PzxTuPMz/spirent-landslide-results?orgId=3&var-agw=hil-1&var-run_id=970&from=1636054118437&to=1636054487067">grafana</a>\n        </td>\n      </tr>\n      \n      <tr>\n        <td> TC004_SANITY_control_200UE_3rate </td>\n        <td> FAIL </td>\n        <td> [\'Failed Procedure -> \', \'PDN_Con_Procedure\', \'Attach_Procedure\'] </td>\n        <td><a\n            href="https://grafana.spirent.fbmagma.ninja/d/9PzxTuPMz/spirent-landslide-results?orgId=3&var-agw=hil-1&var-run_id=971&from=1636054487067&to=1636054725321">grafana</a>\n        </td>\n      </tr>\n      \n      <tr>\n        <td> TC005_SANITY_data_200UE_3rate_100M_attach_detach </td>\n        <td> FAIL </td>\n        <td> [\'Failed Procedure -> \', \'PDN_Con_Procedure\', \'Attach_Procedure\', \'L3_Data_Traffic\'] </td>\n        <td><a\n            href="https://grafana.spirent.fbmagma.ninja/d/9PzxTuPMz/spirent-landslide-results?orgId=3&var-agw=hil-1&var-run_id=973&from=1636054725322&to=1636055024279">grafana</a>\n        </td>\n      </tr>\n      \n    </table>', 'timestamp': 1636055067, 'verdict': 'fail', 'workload': {'build_id': '644a913aaebde7993caaca03c79be39654d7fba1', 'priority': 2, 'state': 'done', 'timestamp': 1635677984}}

```
{'report': '<!DOCTYPE html>\n<html>\n\n<head>\n  <style>\n    table {\n      font-family: arial, sans-serif;\n      border-collapse: collapse;\n      width: 70%;\n    }\n\n    td,\n    th {\n      border: 1px solid #dddddd;\n      text-align: left;\n      padding: 8px;\n    }\n\n    tr:nth-child(even) {\n      background-color: #dddddd;\n    }\n  </style>\n</head>\n\n<body>\n\n  <h2>Test Cases Run Summary</h2>\n  <h3>Magma build 1.7.0-1635975844-6f239000</h3>\n  <h3>Test Run SUT Log <a href="https://ens-spirent-test-summary.com.s3.amazonaws.com/logs/2021-11-03 15:57:38_sanity_magma.log"\n      download="Magma_log">Magma_log</a>\n  </h3>\n  <h4>Test Run SUT Cores <a\n      href="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/index.html?prefix=cores/">Check cores</a>\n    </h3>\n    <table>\n      <tr>\n        <th> Test Case Name </th>\n        <th> Test Run Results </th>\n        <th> Test Results Analytics </th>\n        <th> Grafana link </th>\n      </tr>\n      \n      <tr>\n        <td> TC001_SANITY_control_50UE_3rate </td>\n        <td> PASS </td>\n        <td> [\'subscriberdb\'] </td>\n        <td><a\n            href="https://grafana.spirent.fbmagma.ninja/d/9PzxTuPMz/spirent-landslide-results?orgId=3&var-agw=hil-1&var-run_id=909&from=1635980280510&to=1635980409157">grafana</a>\n        </td>\n      </tr>\n      \n    </table>', 'timestamp': 1635980425, 'valid': 'pass', 'workload': {'build_id': '644a913aaebde7993caaca03c79be39654d7fba1', 'priority': 2, 'state': 'done', 'timestamp': 1635677984}}
```

## Additional Information


