### PR TITLE
chore(pipelined): Add support for IPv6 IP solicitation over IPv6 GTP …

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/ipv6_solicitation.py
+++ b/lte/gateway/python/magma/pipelined/app/ipv6_solicitation.py
@@ -156,16 +156,13 @@ class IPV6SolicitationController(MagmaController):
 
     def _send_router_advertisement(
         self, ipv6_src: str, tun_id: int,
-        tun_ipv4_dst: str, output_port,
+        output_port,
     ):
         """
         Generates the Router Advertisement response packet
         """
         ofproto, parser = self._datapath.ofproto, self._datapath.ofproto_parser
 
-        if not tun_ipv4_dst:
-            self.logger.debug("Packet missing tunnel-dst information, can't reply")
-            return
         if not tun_id:
             self.logger.debug("Packet missing tunnel-id information, can't reply")
             return
@@ -213,7 +210,6 @@ class IPV6SolicitationController(MagmaController):
 
         actions_out = [
             parser.NXActionSetTunnel(tun_id=tun_id),
-            parser.NXActionRegLoad2(dst='tun_ipv4_dst', value=tun_ipv4_dst),
             parser.OFPActionOutput(port=output_port),
         ]
         out = parser.OFPPacketOut(
@@ -229,7 +225,7 @@ class IPV6SolicitationController(MagmaController):
 
     def _send_neighbor_advertisement(
         self, target_ipv6: str, tun_id: int,
-        tun_ipv4_dst: str, output_port, direction,
+        output_port, direction,
     ):
         """
         Generates the Neighbor Advertisement response packet
@@ -241,8 +237,6 @@ class IPV6SolicitationController(MagmaController):
             if not tun_id:
                 self.logger.error("NA: Packet missing tunnel-id information, can't reply")
                 return
-            if not tun_ipv4_dst:
-                self.logger.error("NA: Packet missing tunnel-dst information, can't reply")
             return
 
         prefix = self.get_custom_prefix(target_ipv6)
@@ -284,7 +278,6 @@ class IPV6SolicitationController(MagmaController):
         if direction == Direction.OUT:
             actions_out.extend([
                 parser.NXActionSetTunnel(tun_id=tun_id),
-                parser.NXActionRegLoad2(dst='tun_ipv4_dst', value=tun_ipv4_dst),
             ])
         actions_out.append(parser.OFPActionOutput(port=output_port))
         out = parser.OFPPacketOut(
@@ -311,7 +304,7 @@ class IPV6SolicitationController(MagmaController):
 
         in_port = ev.msg.match['in_port']
         tun_id = None
-        tun_ipv4_src = None
+
         tun_id_dst = None
         if DIRECTION_REG not in ev.msg.match:
             self.logger.error("Packet missing direction reg, can't reply")
@@ -324,11 +317,8 @@ class IPV6SolicitationController(MagmaController):
             if not tun_id_dst:
                 tun_id_dst = self._tunnel_id_mapper.get_tunnel(tun_id)
 
-            if 'tun_ipv4_src' in ev.msg.match:
-                tun_ipv4_src = ev.msg.match['tun_ipv4_src']
-
         pkt = packet.Packet(msg.data)
-        self.logger.debug("Received PKT ->")
+        self.logger.debug("Received PKT -> on port %d tun_id: %s tun_id_dst: %s", in_port, tun_id, tun_id_dst)
         for p in pkt.protocols:
             self.logger.debug(p)
 
@@ -339,13 +329,13 @@ class IPV6SolicitationController(MagmaController):
             self.logger.debug("Received router solicitation MSG")
             self._send_router_advertisement(
                 ipv6_header.src, tun_id_dst,
-                tun_ipv4_src, in_port,
+                in_port,
             )
         elif icmpv6_header.type_ == icmpv6.ND_NEIGHBOR_SOLICIT:
             self.logger.debug("Received neighbor solicitation MSG")
             self._send_neighbor_advertisement(
                 icmpv6_header.data.dst,
-                tun_id_dst, tun_ipv4_src,
+                tun_id_dst,
                 in_port, direction,
             )
 


### PR DESCRIPTION
…tunnels.

Get rid of IPv4 dst IP address and use in-port as egress port for reply.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`  and bare metal setup.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
