### PR TITLE
feat(orc8r): reindexer singleton getBatches on new getJobs to reindex

### DIFF
--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
@@ -69,10 +69,12 @@ const (
 	nid0 = "some_networkid_0"
 	nid1 = "some_networkid_1"
 	nid2 = "some_networkid_2"
+	nid3 = "some_networkid_3"
 
 	hwid0 = "some_hwid_0"
 	hwid1 = "some_hwid_1"
 	hwid2 = "some_hwid_2"
+	hwid3 = "some_hwid_3"
 
 	id0 = "some_indexerid_0"
 	id1 = "some_indexerid_1"

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
@@ -69,16 +69,19 @@ const (
 	nid0 = "some_networkid_0"
 	nid1 = "some_networkid_1"
 	nid2 = "some_networkid_2"
+	nid3 = "some_networkid_3"
 
 	hwid0 = "some_hwid_0"
 	hwid1 = "some_hwid_1"
 	hwid2 = "some_hwid_2"
+	hwid3 = "some_hwid_3"
 
 	id0 = "some_indexerid_0"
 	id1 = "some_indexerid_1"
 	id2 = "some_indexerid_2"
 	id3 = "some_indexerid_3"
 	id4 = "some_indexerid_4"
+	id5 = "some_indexerid_5"
 
 	zero      indexer.Version = 0
 	version0  indexer.Version = 10
@@ -91,6 +94,8 @@ const (
 	version3a indexer.Version = 400
 	version4  indexer.Version = 50
 	version4a indexer.Version = 500
+	version5  indexer.Version = 60
+	version5a indexer.Version = 600
 )
 
 var (

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
@@ -69,12 +69,10 @@ const (
 	nid0 = "some_networkid_0"
 	nid1 = "some_networkid_1"
 	nid2 = "some_networkid_2"
-	nid3 = "some_networkid_3"
 
 	hwid0 = "some_hwid_0"
 	hwid1 = "some_hwid_1"
 	hwid2 = "some_hwid_2"
-	hwid3 = "some_hwid_3"
 
 	id0 = "some_indexerid_0"
 	id1 = "some_indexerid_1"

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
@@ -64,7 +64,10 @@ const (
 	nStatesToReindexPerCall    = 100 // copied from reindex.go
 	directoryRecordsPerNetwork = 2 * nStatesToReindexPerCall
 	nNetworks                  = 3
-	nBatches                   = 9
+	// 3 networks and 3 batches per network = 3 * 3 = 9
+	nBatches = 9
+	// 4 networks and 3 batches per network = 4 * 3 = 12
+	newNBatches = 12
 
 	nid0 = "some_networkid_0"
 	nid1 = "some_networkid_1"
@@ -95,7 +98,6 @@ const (
 	version4  indexer.Version = 50
 	version4a indexer.Version = 500
 	version5  indexer.Version = 60
-	version5a indexer.Version = 600
 )
 
 var (
@@ -304,6 +306,9 @@ func TestRunUnsafe(t *testing.T) {
 	assertVersions(t, q, id4, version4, version4)
 }
 
+// initReindexTest reports enough directory records to cause 3 batches per network
+// (with the +1 gateway status per network). It creates 3 networks,
+// so numBatches following this method will be 3 * 3 = 9
 func initReindexTest(t *testing.T, dbName string) (reindex.Reindexer, reindex.JobQueue) {
 	indexer.DeregisterAllForTest(t)
 

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton.go
@@ -176,4 +176,3 @@ func (r *reindexerSingleton) getJobs(indexerID string) ([]*Job, error) {
 
 	return ret, nil
 }
-

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton.go
@@ -176,3 +176,4 @@ func (r *reindexerSingleton) getJobs(indexerID string) ([]*Job, error) {
 
 	return ret, nil
 }
+

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton.go
@@ -48,21 +48,33 @@ func (r *reindexerSingleton) Run(ctx context.Context) {
 	// TODO(reginawang3495) will support non-nil sendUpdate from Run after removing queue impl
 	var sendUpdate func(string) = nil
 
-	batches := r.getReindexBatches(ctx)
 	for {
 		if isCanceled(ctx) {
 			glog.Warning("State reindexing async job canceled")
 			return
 		}
 
-		r.reindexJobs(ctx, indexerID, batches, sendUpdate)
+		jobs, err := r.getJobs(indexerID)
+		if err == nil && jobs != nil {
+			batches := r.getReindexBatches(ctx)
+			r.reindexJobs(ctx, jobs, batches, sendUpdate)
+		}
+
 		clock.Sleep(reindexLoopInterval)
 	}
 }
 
 func (r *reindexerSingleton) RunUnsafe(ctx context.Context, indexerID string, sendUpdate func(string)) error {
+	jobs, err := r.getJobs(indexerID)
+	if err != nil {
+		return wrap(err, ErrDefault, indexerID)
+	}
+	if jobs == nil {
+		return nil
+	}
+
 	batches := r.getReindexBatches(ctx)
-	return r.reindexJobs(ctx, indexerID, batches, sendUpdate)
+	return r.reindexJobs(ctx, jobs, batches, sendUpdate)
 }
 
 // getReindexBatches gets network-segregated reindex batches with capped number of state IDs per batch.
@@ -96,15 +108,10 @@ func (r *reindexerSingleton) getReindexBatches(ctx context.Context) []reindexBat
 	return batches
 }
 
-func (r *reindexerSingleton) reindexJobs(ctx context.Context, indexerID string, batches []reindexBatch, sendUpdate func(string)) error {
-	jobs, err := r.getJobs(indexerID)
-	if err != nil {
-		return wrap(err, ErrDefault, indexerID)
-	}
-
+func (r *reindexerSingleton) reindexJobs(ctx context.Context, jobs []*Job, batches []reindexBatch, sendUpdate func(string)) error {
 	errs := &multierror.Error{}
 	for _, j := range jobs {
-		err = r.reindexJob(j, ctx, batches, sendUpdate)
+		err := r.reindexJob(j, ctx, batches, sendUpdate)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton_test.go
@@ -56,10 +56,10 @@ func TestSingletonRun(t *testing.T) {
 	clock.SkipSleeps(t)
 	defer clock.ResumeSleeps(t)
 
-	reindexer := initSingletonReindexTest(t)
+	r := initSingletonReindexTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go reindexer.Run(ctx)
+	go r.Run(ctx)
 
 	// Single indexer
 	idx0 := getIndexer(id0, zero, version0, true)
@@ -192,7 +192,7 @@ func initSingletonReindexTest(t *testing.T) reindex.Reindexer {
 }
 
 // reportMoreState reports enough directory records to cause 3 batches per network
-// (with the +1 gateway status per network). It adds an extra network from 3 -> 4),
+// (with the +1 gateway status per network). It adds an extra network from 3 -> 4,
 // so numBatches following this method will be 3 * 4 = 12
 func reportMoreState(t *testing.T) {
 	configurator_test.RegisterNetwork(t, nid3, "Network 3 for reindex test")

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton_test.go
@@ -159,7 +159,7 @@ func TestRunChangingReindexBatches(t *testing.T) {
 	// Check
 	recvCh(t, ch)
 
-	registerExtra
+	// registerExtra
 
 	recvCh(t, ch)
 

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -23,3 +23,19 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.27.1
 )
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.5.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/tools v0.1.1 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+)

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -23,19 +23,3 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.27.1
 )
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang/protobuf v1.5.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/mod v0.4.2 // indirect
-	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
-	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.1.1 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

`reindexer_singleton` `getBatches` on new jobs to reindex
- previously, we only got batches on initialization (or `Run`) of the `reindexer_singleton` service
## Test Plan

Added a regression tests and ran all `orc8r` tests

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
