### PR TITLE
feat: build sentry statically with Bazel

### DIFF
--- a/orc8r/gateway/c/common/sentry/BUILD.bazel
+++ b/orc8r/gateway/c/common/sentry/BUILD.bazel
@@ -18,7 +18,10 @@ cc_library(
     srcs = ["SentryWrapper.cpp"],
     hdrs = ["includes/SentryWrapper.h"],
     # TODO(@themarwhal): Enable Sentry by default - GH9302
-    copts = ["-DSENTRY_ENABLED"],
+    copts = [
+        "-DSENTRY_ENABLED",
+        "-DSENTRY_BUILD_STATIC",
+    ],
     # TODO(@themarwhal): Migrate to using full path for includes - GH8299
     strip_include_prefix = "/orc8r/gateway/c/common/sentry",
     deps = [

--- a/third_party/sentry_native.BUILD
+++ b/third_party/sentry_native.BUILD
@@ -15,8 +15,8 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 # Source files generated with cmake.
 configure_out_srcs = [
-    # TODO(@themarwhal): Generate a static library - GH9323
-    "build/lib/libsentry.so",
+    "build/lib/libsentry.a",
+    "build/lib/libbreakpad_client.a",
 ]
 
 # Header files generated with cmake.
@@ -39,7 +39,7 @@ genrule(
         "cp -R $$(pwd)/external/sentry_native/* $$TMP_DIR",
         "cd $$TMP_DIR",
         # See sentry-native/src/CMakeLists.txt @ GitHub for how these values are used
-        "cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSENTRY_BUILD_TESTS=0 -DSENTRY_BUILD_EXAMPLES=0",
+        "cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF -DSENTRY_BUILD_TESTS=0 -DSENTRY_BUILD_EXAMPLES=0",
         "cmake --build build --parallel",
         "cmake --install build --prefix install --config RelWithDebInfo",
         # Copy out generated libraries into the path specified by outs
@@ -54,5 +54,6 @@ cc_library(
     srcs = configure_out_srcs,
     hdrs = configure_out_hdrs,
     includes = ["build/include"],
+    linkopts = ["-lcurl"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
For SessionD built with Bazel, use a static library for sentry. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested bazel sessiond with sentry enabled locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
