### PR TITLE
chore(ci): Add lab instance for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ commands:
           org: lf-9c
       - sentry-upload:
           executable_name: << parameters.executable_name >>
-          project: lab-si-cpp
+          project: si-agw-native
           org: lf-9c
 
   sentry-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,6 +317,10 @@ commands:
           executable_name: << parameters.executable_name >>
           project: magma-staging-native
           org: lf-9c
+      - sentry-upload:
+          executable_name: << parameters.executable_name >>
+          project: lab-si-cpp
+          org: lf-9c
 
   sentry-release:
     steps:


### PR DESCRIPTION
Signed-off-by: Jared Mullane <jmullane@fb.com>

## Summary

Minor update to the CI to create a lab testing project for integration with the MCF-hosted Sentry site. 

## Test Plan

Minor change - copied previous template and changed name. 

