### PR TITLE
fix(pipelined): Add grpc error code for timeouts

### DIFF
--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -121,7 +121,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
     # General setup rpc
     # --------------------------
 
-    def SetupDefaultControllers(self, request, _) -> SetupFlowsResult:
+    def SetupDefaultControllers(self, request, context) -> SetupFlowsResult:
         """
         Setup default controllers, used on pipelined restarts
         """
@@ -136,6 +136,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             return fut.result(timeout=self._call_timeout)
         except concurrent.futures.TimeoutError:
             logging.error("SetupDefaultControllers processing timed out")
+            context.set_code(grpc.StatusCode.DEADLINE_EXCEEDED)
+            context.set_details('SetupDefaultControllers processing timed out')
             return SetupFlowsResult(result=SetupFlowsResult.FAILURE)
 
     def _setup_default_controllers(self, fut: 'Future(SetupFlowsResult)'):
@@ -172,6 +174,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             return fut.result(timeout=self._call_timeout)
         except concurrent.futures.TimeoutError:
             logging.error("SetupPolicyFlows processing timed out")
+            context.set_code(grpc.StatusCode.DEADLINE_EXCEEDED)
+            context.set_details('SetupPolicyFlows processing timed out')
             return SetupFlowsResult(result=SetupFlowsResult.FAILURE)
 
     def _setup_flows(
@@ -219,6 +223,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             return fut.result(timeout=self._call_timeout)
         except concurrent.futures.TimeoutError:
             logging.error("ActivateFlows request processing timed out")
+            context.set_code(grpc.StatusCode.DEADLINE_EXCEEDED)
+            context.set_details('ActivateFlows processing timed out')
             deactivate_req = get_deactivate_req(request)
             self._loop.call_soon_threadsafe(self._deactivate_flows,
                                             deactivate_req)
@@ -528,6 +534,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             return fut.result(timeout=self._call_timeout)
         except concurrent.futures.TimeoutError:
             logging.error("GetPolicyUsage processing timed out")
+            context.set_code(grpc.StatusCode.DEADLINE_EXCEEDED)
+            context.set_details('GetPolicyUsage processing timed out')
             return RuleRecordTable()
 
     # -------------------------
@@ -551,6 +559,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             return fut.result(timeout=self._call_timeout)
         except concurrent.futures.TimeoutError:
             logging.error("UpdateUEState processing timed out")
+            context.set_code(grpc.StatusCode.DEADLINE_EXCEEDED)
+            context.set_details('UpdateUEState processing timed out')
             return UESessionContextResponse(
                 operation_type=request.ue_session_state.ue_config_state,
                 cause_info=CauseIE(cause_ie=CauseIE.REQUEST_REJECTED_NO_REASON),
@@ -664,6 +674,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             return fut.result(timeout=self._call_timeout)
         except concurrent.futures.TimeoutError:
             logging.error("SetupUEMacFlows processing timed out")
+            context.set_code(grpc.StatusCode.DEADLINE_EXCEEDED)
+            context.set_details('SetupUEMacFlows processing timed out')
             return SetupFlowsResult(result=SetupFlowsResult.FAILURE)
 
     def _setup_ue_mac(
@@ -708,6 +720,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             return fut.result(timeout=self._call_timeout)
         except concurrent.futures.TimeoutError:
             logging.error("AddUEMacFlow processing timed out")
+            context.set_code(grpc.StatusCode.DEADLINE_EXCEEDED)
+            context.set_details('AddUEMacFlow processing timed out')
             return FlowResponse()
 
     def _add_ue_mac_flow(self, request, fut: 'Future(FlowResponse)'):
@@ -796,6 +810,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             return fut.result(timeout=self._call_timeout)
         except concurrent.futures.TimeoutError:
             logging.error("SetupQuotaFlows processing timed out")
+            context.set_code(grpc.StatusCode.DEADLINE_EXCEEDED)
+            context.set_details('SetupQuotaFlows processing timed out')
             return SetupFlowsResult(result=SetupFlowsResult.FAILURE)
 
     def _setup_quota(
@@ -894,6 +910,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             return fut.result(timeout=self._call_timeout)
         except concurrent.futures.TimeoutError:
             logging.error("SetSMFSessions processing timed out")
+            context.set_code(grpc.StatusCode.DEADLINE_EXCEEDED)
+            context.set_details('SetSMFSessions processing timed out')
             return UPFSessionContextState()
 
     def ng_update_session_flows(
@@ -944,7 +962,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         )
 
         return ret
-
 
 def _retrieve_failed_results(
     activate_flow_result: ActivateFlowsResult,


### PR DESCRIPTION

Signed-off-by: Nick Yurchenko <koolzz@fb.com>


backport of https://github.com/magma/magma/pull/10154
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Set proper return code for timeouts in pipelined rpc handling to handle errors on sessiond

## Test Plan

tested in spirient

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
