### PR TITLE
fix(agw): prevent crash.Wrap from swallowing panics

### DIFF
--- a/src/go/crash/crash.go
+++ b/src/go/crash/crash.go
@@ -58,6 +58,7 @@ func Wrap(crash Crash, fn func()) {
 		if err := recover(); err != nil {
 			crash.Recover(err)
 			crash.Flush(time.Second * 5)
+			panic(err)
 		}
 	}()
 	fn()


### PR DESCRIPTION
## Summary
crash.Wrap's current behavior is to call Recover and Flush, but then do nothing with the panic. This means that panics inside a go routine will not halt execution of the running executable. This breaks common expectations around control flow in Go.

## Test Plan

Added unit test to confirm behavior.

## Additional Information
None