### PR TITLE
chore(mme): New unit tests for mme_app and code clean up

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -1900,6 +1900,8 @@ void mme_ue_context_update_ue_emm_state(
 
     // Update Stats
     update_mme_app_stats_attached_ue_add();
+    printf(
+        "UE STATE - REGISTERED.");
     OAILOG_INFO_UE(
         LOG_MME_APP, ue_context_p->emm_context._imsi64,
         "UE STATE - REGISTERED.\n");

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -1900,8 +1900,6 @@ void mme_ue_context_update_ue_emm_state(
 
     // Update Stats
     update_mme_app_stats_attached_ue_add();
-    printf(
-        "UE STATE - REGISTERED.");
     OAILOG_INFO_UE(
         LOG_MME_APP, ue_context_p->emm_context._imsi64,
         "UE STATE - REGISTERED.\n");

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
@@ -231,50 +231,6 @@ void clear_emm_ctxt(emm_context_t* emm_context) {
    --------------------------------------------------------------------------
 */
 
-/*
-   --------------------------------------------------------------------------
-            Detach procedure executed by the MME
-   --------------------------------------------------------------------------
-*/
-/****************************************************************************
- **                                                                        **
- ** Name:    emm_proc_detach()                                         **
- **                                                                        **
- ** Description: Initiate the detach procedure to inform the UE that it is **
- **      detached for EPS services, or to re-attach to the network **
- **      and re-establish all PDN connections.                     **
- **                                                                        **
- **              3GPP TS 24.301, section 5.5.2.3.1                         **
- **      In state EMM-REGISTERED the network initiates the detach  **
- **      procedure by sending a DETACH REQUEST message to the UE,  **
- **      starting timer T3422 and entering state EMM-DEREGISTERED- **
- **      INITIATED.                                                **
- **                                                                        **
- ** Inputs:  ue_id:      UE lower layer identifier                  **
- **      type:      Type of the requested detach               **
- **      Others:    _emm_detach_type_str                       **
- **                                                                        **
- ** Outputs:     None                                                      **
- **      Return:    RETURNok, RETURNerror                      **
- **      Others:    T3422                                      **
- **                                                                        **
- ***************************************************************************/
-status_code_e emm_proc_detach(
-    mme_ue_s1ap_id_t ue_id, emm_proc_detach_type_t type) {
-  OAILOG_FUNC_IN(LOG_NAS_EMM);
-  int rc = RETURNerror;
-
-  OAILOG_INFO(
-      LOG_NAS_EMM,
-      "EMM-PROC  - Initiate detach type = %s (%d) for ue id " MME_UE_S1AP_ID_FMT
-      "\n",
-      emm_detach_type_str[type], type, ue_id);
-  /*
-   * TODO
-   */
-  OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
-}
-
 /****************************************************************************
  **                                                                        **
  ** Name:    emm_proc_sgs_detach_request                                   **

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_proc.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_proc.h
@@ -233,8 +233,6 @@ status_code_e emm_proc_extended_service_request(
  * --------------------------------------------------------------------------
  */
 
-status_code_e emm_proc_detach(
-    mme_ue_s1ap_id_t ue_id, emm_proc_detach_type_t type);
 status_code_e emm_proc_sgs_detach_request(
     mme_ue_s1ap_id_t ue_id, emm_proc_sgs_detach_type_t type);
 status_code_e emm_proc_nw_initiated_detach_request(

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -164,28 +164,35 @@ void send_s6a_ula(const std::string& imsi, bool success) {
   return;
 }
 
-void send_create_session_resp() {
+void send_create_session_resp(gtpv2c_cause_value_t cause_value) {
   MessageDef* message_p =
       itti_alloc_new_message(TASK_SPGW_APP, S11_CREATE_SESSION_RESPONSE);
   itti_s11_create_session_response_t* create_session_response_p =
       &message_p->ittiMsg.s11_create_session_response;
-  create_session_response_p->teid                    = 1;
-  create_session_response_p->cause.cause_value       = REQUEST_ACCEPTED;
-  create_session_response_p->paa.pdn_type            = IPv4;
-  create_session_response_p->paa.ipv4_address.s_addr = 1000;
+
+  create_session_response_p->teid              = 1;
+  create_session_response_p->cause.cause_value = cause_value;
   create_session_response_p->bearer_contexts_created.bearer_contexts[0]
-      .cause.cause_value = REQUEST_ACCEPTED;
-  create_session_response_p->bearer_contexts_created.bearer_contexts[0]
-      .s1u_sgw_fteid.teid = 1000;
-  create_session_response_p->bearer_contexts_created.bearer_contexts[0]
-      .s1u_sgw_fteid.interface_type = S1_U_SGW_GTP_U;
-  create_session_response_p->bearer_contexts_created.bearer_contexts[0]
-      .s1u_sgw_fteid.ipv4 = 1;
-  create_session_response_p->bearer_contexts_created.bearer_contexts[0]
-      .s1u_sgw_fteid.ipv4_address.s_addr = 100;
-  create_session_response_p->bearer_contexts_created.bearer_contexts[0]
-      .eps_bearer_id                                                    = 5;
+      .cause.cause_value = cause_value;
   create_session_response_p->bearer_contexts_created.num_bearer_context = 1;
+
+  if (cause_value == REQUEST_ACCEPTED) {
+    create_session_response_p->paa.pdn_type            = IPv4;
+    create_session_response_p->paa.ipv4_address.s_addr = 1000;
+    create_session_response_p->bearer_contexts_created.bearer_contexts[0]
+        .s1u_sgw_fteid.teid = 1000;
+    create_session_response_p->bearer_contexts_created.bearer_contexts[0]
+        .s1u_sgw_fteid.interface_type = S1_U_SGW_GTP_U;
+    create_session_response_p->bearer_contexts_created.bearer_contexts[0]
+        .s1u_sgw_fteid.ipv4 = 1;
+    create_session_response_p->bearer_contexts_created.bearer_contexts[0]
+        .s1u_sgw_fteid.ipv4_address.s_addr = 100;
+    create_session_response_p->bearer_contexts_created.bearer_contexts[0]
+        .eps_bearer_id = 5;
+    create_session_response_p->bearer_contexts_created.bearer_contexts[0]
+        .s1u_sgw_fteid.ipv6 = 1;
+  }
+
   send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
   return;
 }

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -302,5 +302,23 @@ void sgw_send_release_access_bearer_response(gtpv2c_cause_value_t cause) {
   return;
 }
 
+void send_s11_deactivate_bearer_req(
+    uint8_t no_of_bearers_to_be_deact, uint8_t* ebi_to_be_deactivated,
+    bool delete_default_bearer) {
+  MessageDef* message_p = itti_alloc_new_message(
+      TASK_SPGW_APP, S11_NW_INITIATED_DEACTIVATE_BEARER_REQUEST);
+  itti_s11_nw_init_deactv_bearer_request_t* s11_bearer_deactv_request =
+      &message_p->ittiMsg.s11_nw_init_deactv_bearer_request;
+
+  s11_bearer_deactv_request->s11_mme_teid          = 1;
+  s11_bearer_deactv_request->delete_default_bearer = delete_default_bearer;
+  s11_bearer_deactv_request->no_of_bearers         = no_of_bearers_to_be_deact;
+  memcpy(
+      s11_bearer_deactv_request->ebi, ebi_to_be_deactivated,
+      (sizeof(ebi_t) * no_of_bearers_to_be_deact));
+  send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
+  return;
+}
+
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -89,6 +89,9 @@ void send_modify_bearer_resp(
     const std::vector<int>& bearer_to_remove);
 
 void sgw_send_release_access_bearer_response(gtpv2c_cause_value_t cause);
+void send_s11_deactivate_bearer_req(
+    uint8_t no_of_bearers_to_be_deact, uint8_t* ebi_to_be_deactivated,
+    bool delete_default_bearer);
 
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -72,7 +72,7 @@ void send_authentication_info_resp(const std::string& imsi, bool success);
 
 void send_s6a_ula(const std::string& imsi, bool success);
 
-void send_create_session_resp();
+void send_create_session_resp(gtpv2c_cause_value_t cause_value);
 
 void send_delete_session_resp();
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -145,6 +145,9 @@ class MmeAppProcedureTest : public ::testing::Test {
   const uint8_t nas_msg_detach_req[21]  = {
       0x27, 0x8f, 0xf4, 0x06, 0xe5, 0x02, 0x07, 0x45, 0x09, 0x0b, 0xf6,
       0x00, 0xf1, 0x10, 0x00, 0x01, 0x01, 0x46, 0x93, 0xe8, 0xb8};
+  const uint8_t nas_msg_detach_accept[8] = {0x17, 0x88, 0x16, 0x67,
+                                            0xd3, 0x02, 0x07, 0x46};
+
   std::string imsi = "001010000000001";
   plmn_t plmn      = {.mcc_digit2 = 0,
                  .mcc_digit1 = 0,
@@ -952,6 +955,106 @@ TEST_F(MmeAppProcedureTest, TestCreateSessionFailure) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Check if the context is properly released
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
+
+TEST_F(MmeAppProcedureTest, TestNwInitiatedDetach) {
+  mme_app_desc_t* mme_state_p =
+      magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  std::condition_variable cv;
+  std::mutex mx;
+  std::unique_lock<std::mutex> lock(mx);
+
+  MME_APP_EXPECT_CALLS(4, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
+
+  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  send_mme_app_initial_ue_msg(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp(REQUEST_ACCEPTED);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+
+  uint8_t ebi_to_be_deactivated = 5;
+
+  // Constructing and sending deactivate bearer request
+  // for default bearer that should trigger session termination
+  send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, true);
+
+  // Wait for DL NAS Transport for Detach Request
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Detach Accept to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_detach_accept, sizeof(nas_msg_detach_accept), plmn);
+
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp();
+
+  // Wait for context release request
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   EXPECT_EQ(mme_state_p->nb_ue_attached, 0);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Unit test for failed session requests
- Unit test for network initiated session termination - single session
- Clean up unused procedure function

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
`make test_oai` in dev VM.
run s1ap integ tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
