### PR TITLE
chore(ci): Add a check to make sure all buildifier lint warnings are …

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -27,7 +27,7 @@ jobs:
   path_filter:
     runs-on: ubuntu-latest
     outputs:
-      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
+      files_changed: ${{ steps.changes.outputs.files_changed }}
     steps:
       # Need to get git on push event
       - uses: dorny/paths-filter@v2
@@ -35,8 +35,17 @@ jobs:
         id: changes
         with:
           filters: |
-            filesChanged:
-              - [".github/workflows/bazel.yml", "lte/gateway/c/**", "orc8r/gateway/c/**", "orc8r/protos/**", "lte/protos/**", "src/go/**"]
+            files_changed:
+              - '.github/workflows/bazel.yml'
+              - 'orc8r/gateway/c/**'
+              - 'orc8r/protos/**'
+              - 'lte/gateway/c/**'
+              - 'lte/protos/**'
+              - 'src/go/**'
+              - '**/BUILD'
+              - '**/*.BUILD'
+              - '**/*.bazel'
+              - '**/*.bzl'
 
   bazel_build_and_test:
     needs: path_filter
@@ -44,7 +53,7 @@ jobs:
     # or a pull_request that skip-duplicate-action wants to run again.
     if: |
       (github.event_name == `schedule` && github.ref == 'refs/heads/master')
-        || ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+        || ${{ needs.path_filter.outputs.files_changed == 'true' }}
     name: Bazel Build and Test Job
     runs-on: ubuntu-latest
     steps:
@@ -89,23 +98,29 @@ jobs:
               echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
               rm -rf $EXPANDED_BAZEL_CACHE_PATH $EXPANDED_BAZEL_CACHE_REPO_PATH
             fi
-
-        - name: Bazel Build
+        - name: Setup Devcontainer Image
+          uses: addnab/docker-run-action@v2
+          with:
+            image: ${{ env.DEVCONTAINER_IMAGE }}
+            # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+            run: |
+              echo "Pulled the devontainer image!"
+        - name: Run `bazel build //...`
           uses: addnab/docker-run-action@v2
           with:
             image: ${{ env.DEVCONTAINER_IMAGE }}
             # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-            options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma -e ABC=123
+            options: -v ${{ github.workspace }}:/workspaces/magma/
             run: |
               cd /workspaces/magma
-              bazel build ...
-        - name: Bazel Test
+              bazel build //...
+        - name: Run `bazel test //...`
           if: github.event_name == 'pull_request'
           uses: addnab/docker-run-action@v2
           with:
             image: ${{ env.DEVCONTAINER_IMAGE }}
             # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-            options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma -e ABC=123
+            options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
             run: |
               cd /workspaces/magma
-              bazel test ... --test_output=errors --cache_test_results=no
+              bazel test //... --test_output=errors --cache_test_results=no

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,11 +9,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 buildifier(
     name = "buildifier",
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+buildifier_test(
+    name = "check_starlark_format",
+    size = "small",
+    timeout = "short",
+    srcs = ["//:starlark_files"],
+)
+
+filegroup(
+    name = "starlark_files",
+    srcs = glob(
+        include = [
+            "**/*.BUILD",
+            "**/*.bzl",
+            "**/*.sky",
+            "**/BUILD",
+            "**/BUILD.*.bazel",
+            "**/BUILD.*.oss",
+            "**/BUILD.bazel",
+            "**/WORKSPACE",
+            "**/WORKSPACE.*.bazel",
+            "**/WORKSPACE.*.oss",
+            "**/WORKSPACE.bazel",
+            "*.BUILD",
+            "*.bzl",
+            "*.sky",
+            "BUILD.*.bazel",
+            "BUILD.*.oss",
+            "WORKSPACE.*.bazel",
+            "WORKSPACE.*.oss",
+        ],
+        exclude = [
+            "bazel-*/**",
+            ".git/**",
+            "go_repositories.bzl",  # generated file
+        ],
+    ),
 )
 
 # gazelle:prefix github.com/magma/magma

--- a/cpp_repositories.bzl
+++ b/cpp_repositories.bzl
@@ -9,11 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""All external repositories used for C++/C dependencies"""
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 
 def cpp_repositories():
-    """All external repositories used for C++/C dependencies"""
+    """Entry point for all external repositories used for C++/C dependencies"""
     http_archive(
         name = "com_github_gflags_gflags",
         sha256 = "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf",

--- a/feg/gateway/services/aaa/protos/BUILD.bazel
+++ b/feg/gateway/services/aaa/protos/BUILD.bazel
@@ -10,8 +10,7 @@
 # limitations under the License.
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_proto_grpc//cpp:defs.bzl", "cpp_grpc_library")
-load("@rules_proto_grpc//cpp:defs.bzl", "cpp_proto_library")
+load("@rules_proto_grpc//cpp:defs.bzl", "cpp_grpc_library", "cpp_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/orc8r/protos/BUILD.bazel
+++ b/orc8r/protos/BUILD.bazel
@@ -10,8 +10,7 @@
 # limitations under the License.
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_proto_grpc//cpp:defs.bzl", "cpp_grpc_library")
-load("@rules_proto_grpc//cpp:defs.bzl", "cpp_proto_library")
+load("@rules_proto_grpc//cpp:defs.bzl", "cpp_grpc_library", "cpp_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/third_party_repositories.bzl
+++ b/third_party_repositories.bzl
@@ -9,8 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""All external repositories not specific to a language"""
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 
 def protobuf():
     http_archive(


### PR DESCRIPTION
…addressed

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
1. Add a bazel unit test that adds a formatting check. `bazel test //:check_starlark_format` will fail if there are formatting issues in starlark files.
2. Modifed the bazel job configuration to include more file triggers
<!-- Enumerate changes you made and why you made them -->

## Test Plan
This is what it looks like on failure:

<img width="954" alt="Screen Shot 2021-11-09 at 9 23 35 AM" src="https://user-images.githubusercontent.com/37634144/140941666-ae2557a8-efe5-4ab6-8137-23a619b02347.png">
<img width="938" alt="Screen Shot 2021-11-09 at 9 23 28 AM" src="https://user-images.githubusercontent.com/37634144/140941670-1adb7260-784c-4747-b9eb-fe42e0f448a7.png">



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
