### PR TITLE
fix(pipelined): Re-enable and fix pipelined ipfix test

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/patches/ryu_ipfix_args.patch
+++ b/lte/gateway/deploy/roles/magma/files/patches/ryu_ipfix_args.patch
@@ -16,7 +16,7 @@
 -        # obs_point_id, sampling_port
 -        _fmt_str = '!HIIIH6x'
 +        # obs_point_id, msisdn, apn_mac_addr, apn_name, sampling_port
-+        _fmt_str = '!HIIIH16s6B24s8s6x'
++        _fmt_str = '!HIIIL16s6B24s8s6x'
 
          def __init__(self,
                       probability,

--- a/lte/gateway/python/magma/pipelined/tests/test_internal_pkt_ipfix_export.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_internal_pkt_ipfix_export.py
@@ -34,8 +34,6 @@ from magma.pipelined.tests.pipelined_test_util import (
 from nose.tools import nottest
 
 
-@unittest.skip("Skipping as it currently breaks debian...")
-@nottest
 class InternalPktIpfixExportTest(unittest.TestCase):
     BRIDGE = 'testing_br'
     IFACE = 'testing_br'


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The local ipfix patch was outdated, fix it
- Re-enable ipfix unit test

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
