### PR TITLE
chore(mme): Remove unused function from SPGW context manager

### DIFF
--- a/lte/gateway/c/core/oai/include/sgw_context_manager.h
+++ b/lte/gateway/c/core/oai/include/sgw_context_manager.h
@@ -53,8 +53,6 @@ sgw_eps_bearer_ctxt_t* sgw_cm_insert_eps_bearer_ctxt_in_collection(
     sgw_eps_bearer_ctxt_t* const sgw_eps_bearer_ctxt);
 sgw_eps_bearer_ctxt_t* sgw_cm_get_eps_bearer_entry(
     sgw_pdn_connection_t* const sgw_pdn_connection, ebi_t ebi);
-int sgw_cm_remove_eps_bearer_entry(
-    sgw_pdn_connection_t* const sgw_pdn_connection, ebi_t eps_bearer_idP);
 // Returns SPGW state pointer for given UE indexed by IMSI
 s_plus_p_gw_eps_bearer_context_information_t* sgw_cm_get_spgw_context(
     teid_t teid);

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_context_manager.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_context_manager.c
@@ -315,22 +315,6 @@ sgw_eps_bearer_ctxt_t* sgw_cm_get_eps_bearer_entry(
   return sgw_pdn_connection->sgw_eps_bearers_array[EBI_TO_INDEX(ebi)];
 }
 
-//-----------------------------------------------------------------------------
-status_code_e sgw_cm_remove_eps_bearer_entry(
-    sgw_pdn_connection_t* const sgw_pdn_connection, ebi_t ebi)
-//-----------------------------------------------------------------------------
-{
-  if ((ebi < EPS_BEARER_IDENTITY_FIRST) || (ebi > EPS_BEARER_IDENTITY_LAST)) {
-    return RETURNerror;
-  }
-  /*sgw_eps_bearer_ctxt_t * sgw_eps_bearer_ctxt =
-  sgw_pdn_connection->sgw_eps_bearers_array[EBI_TO_INDEX(ebi)]; if
-  (sgw_eps_bearer_ctxt) { sgw_free_sgw_eps_bearer_context(&sgw_eps_bearer_ctxt);
-    return RETURNok;
-  }*/
-  return RETURNerror;
-}
-
 s_plus_p_gw_eps_bearer_context_information_t* sgw_cm_get_spgw_context(
     teid_t teid) {
   s_plus_p_gw_eps_bearer_context_information_t* spgw_bearer_context_info = NULL;

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -1179,10 +1179,6 @@ status_code_e sgw_handle_delete_session_request(
       /*
        * Remove eps bearer context, S11 bearer context and s11 tunnel
        */
-      sgw_cm_remove_eps_bearer_entry(
-          &ctx_p->sgw_eps_bearer_context_information.pdn_connection,
-          delete_session_req_pP->lbi);
-
       sgw_cm_remove_bearer_context_information(
           delete_session_req_pP->teid, imsi64);
       increment_counter("spgw_delete_session", 1, 1, "result", "success");
@@ -1435,10 +1431,6 @@ void handle_s5_create_session_response(
       "Deleted default bearer context with SGW C-plane TEID = %u "
       "as create session response failure is received\n",
       new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.mme_teid_S11);
-  sgw_cm_remove_eps_bearer_entry(
-      &new_bearer_ctxt_info_p->sgw_eps_bearer_context_information
-           .pdn_connection,
-      sgi_create_endpoint_resp.eps_bearer_id);
   sgw_cm_remove_bearer_context_information(
       session_resp.context_teid,
       new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.imsi64);
@@ -1779,9 +1771,6 @@ status_code_e sgw_handle_nw_initiated_deactv_bearer_rsp(
         sizeof(paa_t));
 
     sgw_handle_sgi_endpoint_deleted(&sgi_delete_end_point_request, imsi64);
-
-    sgw_cm_remove_eps_bearer_entry(
-        &spgw_ctxt->sgw_eps_bearer_context_information.pdn_connection, ebi);
 
     sgw_cm_remove_bearer_context_information(
         s11_pcrf_ded_bearer_deactv_rsp->s_gw_teid_s11_s4, imsi64);


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The function `sgw_cm_remove_eps_bearer_entry` is not doing anything. This change removes the function declaration, definition and references.

## Test Plan

make integ_test TESTS=s1aptests/test_attach_detach.py

