### PR TITLE
fix(mme): Bug fix in nw initiated bearer deactivation

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.cpp
@@ -206,7 +206,7 @@ Status SpgwServiceImpl::DeleteBearer(
   itti_msg.no_of_bearers = 1;
   for (int i = 0; i < request->eps_bearer_ids_size() && i < BEARERS_PER_UE;
        i++) {
-    itti_msg.ebi[0] = request->eps_bearer_ids(i);
+    itti_msg.ebi[i] = request->eps_bearer_ids(i);
     send_deactivate_bearer_request_itti(&itti_msg);
   }
   return Status::OK;

--- a/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.cpp
@@ -203,7 +203,7 @@ Status SpgwServiceImpl::DeleteBearer(
   itti_msg.imsi_length = imsi.size();
   strcpy(itti_msg.imsi, imsi.c_str());
   itti_msg.lbi           = request->link_bearer_id();
-  itti_msg.no_of_bearers = 1;
+  itti_msg.no_of_bearers = request->eps_bearer_ids_size();
   for (int i = 0; i < request->eps_bearer_ids_size() && i < BEARERS_PER_UE;
        i++) {
     itti_msg.ebi[i] = request->eps_bearer_ids(i);

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
@@ -402,6 +402,7 @@ int32_t spgw_handle_nw_initiated_bearer_deactv_req(
                 no_of_bearers_rej++;
               }
             }
+            break; // while (node)
           }
         }
       }

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
@@ -402,7 +402,7 @@ int32_t spgw_handle_nw_initiated_bearer_deactv_req(
                 no_of_bearers_rej++;
               }
             }
-            break; // while (node)
+            break;  // while (node)
           }
         }
       }


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Iteration needs to be stopped as soon as the LBI match is found for given IMSI. This was leading to fetching the wrong TEID and detachment of wrong IMSI.
- Bearer list to be deleted was not passed correctly.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Spirent and integ tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
