### PR TITLE
chore(ci): bundle c cpp codecov into a single job

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -423,3 +423,41 @@ jobs:
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
+
+  session_manager_test:
+    needs: path_filter
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    name: session manager test job
+    runs-on: ubuntu-latest
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run session_manager tests
+        timeout-minutes: 10
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make test_session_manager
+      - name: Extract commit title
+        # yamllint enable
+        if: failure() && github.event_name == 'push'
+        id: commit
+        run: |
+            str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+            echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "Github action session_manager_test failed"
+          SLACK_USERNAME: "AGW workflow"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -124,7 +124,7 @@ jobs:
   c_cpp_unit_tests:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
-    name: Run C/C++ unit tests and upload coverage with Bazel
+    name: Run C/C++ unit tests with Bazel
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
@@ -144,6 +144,13 @@ jobs:
           key: ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-
+      - name: Setup Devcontainer Image
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the devontainer image!"
       - name: Build C / C++ code with Bazel
         uses: addnab/docker-run-action@v2
         with:
@@ -169,24 +176,6 @@ jobs:
             echo "created c-cpp-test-results/ directory, copying out test result XMLs"
             find bazel-out/k8-dbg/testlogs/ -name "*.xml" | while IFS= read -r f; do cp "$f" "c-cpp-test-results/${f//\//_}"; done
             exit $TEST_RESULT
-      - name: Run coverage with Bazel
-        if: always()
-        uses: addnab/docker-run-action@v2
-        with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
-          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
-          run: |
-            cd /workspaces/magma
-            # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178
-            bazel coverage //orc8r/gateway/c/...:* //lte/gateway/c/...:*
-            # copy out coverage information into magma so that it's accessible from the CI node
-            cp bazel-out/_coverage/_coverage_report.dat .
-      - name: Upload code coverage
-        if: always()
-        uses: codecov/codecov-action@v1
-        with:
-          flags: c_cpp_bazel
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -325,6 +314,49 @@ jobs:
       REVISION: "${{ github.sha }}"
     steps:
       - uses: actions/checkout@v2
+      - name: Bazel Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE }}
+          key: ${{ runner.os }}-${{ env.BAZEL_CACHE }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.BAZEL_CACHE }}-
+      - name: Bazel Cache Repo
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE_REPO }}
+          key: ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-
+      - name: Run codecov with CMake (MME / SCTPD / LIAGENT)
+        if: always()
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd $MAGMA_ROOT/lte/gateway
+            make coverage
+            cp $C_BUILD/coverage.info $MAGMA_ROOT
+      - name: Run coverage with Bazel (COMMON / SESSIOND)
+        if: always()
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd $MAGMA_ROOT
+            # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178
+            bazel coverage //orc8r/gateway/c/...:* //lte/gateway/c/...:*
+            # copy out coverage information into magma so that it's accessible from the CI node
+            cp bazel-out/_coverage/_coverage_report.dat $MAGMA_ROOT
+      - name: Upload code coverage
+        id: c-cpp-codecov-upload
+        uses: codecov/codecov-action@v1
+        with:
+          flags: c_cpp
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
       - name: Run mme-clang-tidy
@@ -343,16 +375,6 @@ jobs:
         run: |
             docker build --tag magma-mme-build --file ${{ env.MAGMA_ROOT }}/lte/gateway/docker/mme/Dockerfile.ubuntu20.04 .
             docker run --env BRANCH=${{ env.BRANCH }} --env REVISION=${{ env.REVISION }} --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma-mme-build:latest /bin/bash -c "cd /magma/lte/gateway;make clang_warning_oai_upload"
-      - name: Run codecov
-        # yamllint disable rule:line-length
-        run: |
-            docker build --tag magma/c_cpp_build --file ${{ env.MAGMA_ROOT }}/lte/gateway/docker/mme/Dockerfile.ubuntu20.04 .
-            ci_env=$(bash <(curl -s https://codecov.io/env))
-            docker run $ci_env --env CI=true --volume ${{ env.MAGMA_ROOT }}:/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma --interactive magma/c_cpp_build:latest /bin/bash -c "cd /magma/lte/gateway;make coverage;cp /build/c/coverage.info /magma/"
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v1
-        with:
-          flags: c_cpp
       - name: Extract commit title
         # yamllint enable
         if: failure() && github.event_name == 'push'
@@ -361,11 +383,11 @@ jobs:
             str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
             echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
-        if: steps.c-cpp-codecov.outcome=='failure' && github.event_name == 'push'
+        if: steps.c-cpp-codecov-upload.outcome=='failure' && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action c-cpp-codecov failed"
+          SLACK_TITLE: "Github action c-cpp-codecov-upload failed"
           SLACK_USERNAME: "AGW workflow"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
           SLACK_ICON_EMOJI: ":boom:"
@@ -439,7 +461,7 @@ jobs:
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma
           run: |
             cd /workspaces/magma/lte/gateway
             make test_session_manager

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,8 +25,3 @@ coverage:
         threshold: 0%
         flags:
           - c_cpp
-      c_cpp_bazel:
-        target: auto
-        threshold: 0%
-        flags:
-          - c_cpp_bazel


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I recently added (a job in the agw workflow to run unit tests and collect coverage with bazel). I am however noticing that the coverage job takes a lot longer than i would like. With best case scenario, the build and test takes minutes each, but the coverage job takes much, much longer. (I think we might be able to improve this time, but I currently do not have bandwidth to do that)

<img width="961" alt="Screen Shot 2021-11-09 at 9 58 02 AM" src="https://user-images.githubusercontent.com/37634144/140947899-2a98cffb-0a6f-40db-9e4f-21fb8c6f130a.png">

As I want to make the build/test aspect of the job mandatory soon, I want to move out the coverage portion of it to a non mandatory job. 

In this PR, I bundled the code coverage portion with the other non mandatory jobs, (mme clang tidy/warniing and the existing code coverage job). As all four of the items in that job is pretty long, we could split them into two jobs. One with mme clang tidy/warning and another with the two code coverage jobs. But I wasn't sure if number of GHA jobs were still an issue or not. (cc @quentinDERORY / @tmdzk I know we got an upgrade in our GHA plan, but do we still need to be conservative with the number of jobs? )

Also, I'm adding back the session manager test until the bazel c/c++ test is ready to be made mandatory. (The tests are stable, but I'm still lacking documentation)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
