### PR TITLE
chore(agw): Updating Python Sentry SDK to v1.5.0

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -102,7 +102,7 @@ setup(
         'spyne>=2.13.15',
         'scapy==2.4.4',
         'flask>=1.0.2',
-        'sentry_sdk>=1.0.0',
+        'sentry_sdk>=1.5.0',
         'aiodns>=1.1.1',
         'pymemoize>=1.0.2',
         'wsgiserver>=1.3',

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -77,7 +77,7 @@ setup(
         'PyYAML>=3.12',
         'pytz>=2014.4',
         'prometheus_client==0.3.1',
-        'sentry_sdk>=1.0.0',
+        'sentry_sdk>=1.5.0',
         'snowflake>=0.0.3',
         'psutil==5.8.0',
         'cryptography>=1.9',


### PR DESCRIPTION
## Summary

Updated Sentry SDK version in setup.py of lte/gateway and orc8r/gateway.

## Test Plan

`make run` in lte/gateway. And tested connection to Sentry locally.

Screenshot of the relevant section from event report:
<img width="1251" alt="Screenshot 2021-11-18 at 15 58 13" src="https://user-images.githubusercontent.com/82914459/142447183-4c84c888-1c82-406d-ab6f-e939e7d4fe46.png">

