### PR TITLE
fix(amf): Handling of SUPI Registration

### DIFF
--- a/lte/gateway/c/core/oai/include/amf_app_messages_def.h
+++ b/lte/gateway/c/core/oai/include/amf_app_messages_def.h
@@ -41,3 +41,6 @@ MESSAGE_DEF(
 MESSAGE_DEF(
     AMF_IP_ALLOCATION_RESPONSE, itti_amf_ip_allocation_response_t,
     amf_ip_allocation_response)
+MESSAGE_DEF(
+    AMF_APP_DECRYPT_IMSI_INFO_RESP, itti_amf_decrypted_imsi_info_ans_t,
+    amf_app_decrypt_info_resp)

--- a/lte/gateway/c/core/oai/include/amf_app_messages_types.h
+++ b/lte/gateway/c/core/oai/include/amf_app_messages_types.h
@@ -38,6 +38,8 @@
 #define AMF_APP_DL_DATA_REJ(mSGpTR) (mSGpTR)->ittiMsg.amf_app_dl_data_rej
 #define AMF_APP_AUTH_RESPONSE_DATA(mSGpTR)                                     \
   (mSGpTR)->ittiMsg.amf_app_subs_auth_info_resp
+#define AMF_APP_DECRYPT_IMSI_RESPONSE_DATA(mSGpTR)                             \
+  (mSGpTR)->ittiMsg.amf_app_decrypt_info_resp
 
 typedef struct itti_amf_app_connection_establishment_cnf_s {
   Ngap_initial_context_setup_request_t contextSetupRequest;
@@ -103,6 +105,20 @@ typedef struct itti_amf_subs_auth_info_ans_s {
   m5g_authentication_info_t auth_info;
 
 } itti_amf_subs_auth_info_ans_t;
+
+typedef struct itti_amf_decrypted_imsi_info_ans_s {
+  /* IMSI of the subscriber */
+  char imsi[IMSI_BCD_DIGITS_MAX + 1];
+
+  /* Length of the Imsi. Mostly 15 */
+  uint8_t imsi_length;
+
+  /* Authentication is success or failure with code */
+  int result;
+
+  /* UE identifier */
+  amf_ue_ngap_id_t ue_id;
+} itti_amf_decrypted_imsi_info_ans_t;
 
 typedef struct itti_amf_ip_allocation_response_s {
   /* IMSI of the subscriber */

--- a/lte/gateway/c/core/oai/lib/n11/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/lib/n11/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(LIB_N11
     amf_client_proto_msg_to_itti_msg.cpp
     M5GAuthenticationServiceClient.cpp
     M5GMobilityServiceClient.cpp
+    M5GSUCIRegistrationServiceClient.cpp
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     )

--- a/lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.cpp
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.h"
+
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <cassert>
+
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_38.413.h"
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.501.h"
+#include "lte/gateway/c/core/oai/common/log.h"
+
+#include <google/protobuf/util/time_util.h>
+#include <grpcpp/impl/codegen/client_context.h>
+#include <grpcpp/impl/codegen/status.h>
+
+#include "lte/protos/subscriberdb.grpc.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+#include "orc8r/gateway/c/common/service_registry/includes/ServiceRegistrySingleton.h"
+#include "lte/gateway/c/core/oai/lib/n11/amf_client_proto_msg_to_itti_msg.h"
+#include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GCommonDefs.h"
+#include "lte/gateway/c/core/oai/tasks/amf/amf_recv.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::InsecureChannelCredentials;
+using grpc::Status;
+using magma::AsyncLocalResponse;
+using magma::ServiceRegistrySingleton;
+using magma::lte::M5GSUCIRegistrationAnswer;
+using magma::lte::M5GSUCIRegistrationRequest;
+using magma5g::amf_proc_registration_reject;
+
+extern task_zmq_ctx_t grpc_service_task_zmq_ctx;
+
+static void handle_decrypted_imsi_info_ans(
+    grpc::Status status, magma::lte::M5GSUCIRegistrationAnswer response,
+    amf_ue_ngap_id_t ue_id) {
+  MessageDef* message_p;
+
+  if (!status.ok() || (response.ue_msin_recv().length() == 0)) {
+    std::cout << "get_decrypt_imsi_info fails with code " << status.error_code()
+              << ", msg: " << status.error_message() << std::endl;
+    MLOG(MERROR)
+        << "   Error : Deconcealing IMSI Failed, sending Registration Reject";
+    int amf_cause = AMF_UE_ILLEGAL;
+    amf_proc_registration_reject(ue_id, amf_cause);
+    return;
+  }
+
+  message_p =
+      itti_alloc_new_message(TASK_GRPC_SERVICE, AMF_APP_DECRYPT_IMSI_INFO_RESP);
+
+  itti_amf_decrypted_imsi_info_ans_t* amf_app_decrypted_imsi_info_resp;
+  amf_app_decrypted_imsi_info_resp =
+      &message_p->ittiMsg.amf_app_decrypt_info_resp;
+  memset(
+      amf_app_decrypted_imsi_info_resp, 0,
+      sizeof(itti_amf_decrypted_imsi_info_ans_t));
+
+  magma5g::convert_proto_msg_to_itti_amf_decrypted_imsi_info_ans(
+      response, amf_app_decrypted_imsi_info_resp);
+
+  amf_app_decrypted_imsi_info_resp->ue_id = ue_id;
+
+  send_msg_to_task(&grpc_service_task_zmq_ctx, TASK_AMF_APP, message_p);
+}
+
+namespace magma5g {
+
+AsyncM5GSUCIRegistrationServiceClient::AsyncM5GSUCIRegistrationServiceClient() {
+  auto channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
+      "subscriberdb", ServiceRegistrySingleton::LOCAL);
+  stub_ = M5GSUCIRegistration::NewStub(channel);
+  std::thread resp_loop_thread([&]() { rpc_response_loop(); });
+  resp_loop_thread.detach();
+}
+
+AsyncM5GSUCIRegistrationServiceClient&
+AsyncM5GSUCIRegistrationServiceClient::getInstance() {
+  static AsyncM5GSUCIRegistrationServiceClient instance;
+  return instance;
+}
+
+M5GSUCIRegistrationRequest create_decrypt_imsi_request(
+    const uint8_t ue_pubkey_identifier, const std::string& ue_pubkey,
+    const std::string& ciphertext, const std::string& mac_tag) {
+  M5GSUCIRegistrationRequest request;
+
+  request.Clear();
+  request.set_ue_pubkey_identifier(ue_pubkey_identifier);
+  request.set_ue_pubkey(ue_pubkey);
+  request.set_ue_ciphertext(ciphertext);
+  request.set_ue_encrypted_mac(mac_tag);
+
+  return request;
+}
+
+bool AsyncM5GSUCIRegistrationServiceClient::get_decrypt_imsi_info(
+    const uint8_t ue_pubkey_identifier, const std::string& ue_pubkey,
+    const std::string& ciphertext, const std::string& mac_tag,
+    amf_ue_ngap_id_t ue_id) {
+  M5GSUCIRegistrationRequest request = create_decrypt_imsi_request(
+      ue_pubkey_identifier, ue_pubkey, ciphertext, mac_tag);
+
+  GetSuciInfoRPC(
+      request,
+      [ue_id](const Status& status, const M5GSUCIRegistrationAnswer& response) {
+        handle_decrypted_imsi_info_ans(status, response, ue_id);
+      });
+  return true;
+}
+
+void AsyncM5GSUCIRegistrationServiceClient::GetSuciInfoRPC(
+    const M5GSUCIRegistrationRequest& request,
+    const std::function<void(Status, M5GSUCIRegistrationAnswer)>& callback) {
+  auto localResp = new AsyncLocalResponse<M5GSUCIRegistrationAnswer>(
+      std::move(callback), RESPONSE_TIMEOUT);
+  localResp->set_response_reader(
+      std::move(stub_->AsyncM5GDecryptImsiSUCIRegistration(
+          localResp->get_context(), request, &queue_)));
+}
+
+}  // namespace magma5g

--- a/lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.h
+++ b/lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.h
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <functional>
+#include <memory>
+
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_38.413.h"
+
+#include <grpc++/grpc++.h>
+#include "lte/protos/subscriberdb.grpc.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
+#include "orc8r/gateway/c/common/async_grpc/includes/GRPCReceiver.h"
+
+using grpc::Status;
+using magma::GRPCReceiver;
+using magma::lte::M5GSUCIRegistration;
+using magma::lte::M5GSUCIRegistrationAnswer;
+using magma::lte::M5GSUCIRegistrationRequest;
+
+namespace magma5g {
+M5GSUCIRegistrationRequest create_decrypt_imsi_request(
+    const uint8_t ue_pubkey_identifier, const std::string& ue_pubkey,
+    const std::string& ciphertext, const std::string& mac_tag);
+
+class M5GSUCIRegistrationServiceClient {
+ public:
+  virtual ~M5GSUCIRegistrationServiceClient() {}
+  virtual bool get_decrypt_imsi_info(
+      const uint8_t ue_pubkey_identifier, const std::string& ue_pubkey,
+      const std::string& ciphertext, const std::string& mac_tag,
+      amf_ue_ngap_id_t ue_id) = 0;
+};
+
+class AsyncM5GSUCIRegistrationServiceClient
+    : public GRPCReceiver,
+      public M5GSUCIRegistrationServiceClient {
+ public:
+  bool get_decrypt_imsi_info(
+      const uint8_t ue_pubkey_identifier, const std::string& ue_pubkey,
+      const std::string& ciphertext, const std::string& mac_tag,
+      amf_ue_ngap_id_t ue_id);
+
+  static AsyncM5GSUCIRegistrationServiceClient& getInstance();
+
+  AsyncM5GSUCIRegistrationServiceClient(
+      AsyncM5GSUCIRegistrationServiceClient const&) = delete;
+  void operator=(AsyncM5GSUCIRegistrationServiceClient const&) = delete;
+
+ private:
+  AsyncM5GSUCIRegistrationServiceClient();
+  static const uint32_t RESPONSE_TIMEOUT = 10;  // seconds
+  std::unique_ptr<M5GSUCIRegistration::Stub> stub_{};
+
+  void GetSuciInfoRPC(
+      const M5GSUCIRegistrationRequest& request,
+      const std::function<void(Status, M5GSUCIRegistrationAnswer)>& callback);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/core/oai/lib/n11/amf_client_proto_msg_to_itti_msg.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/amf_client_proto_msg_to_itti_msg.cpp
@@ -85,4 +85,19 @@ void convert_proto_msg_to_itti_m5g_auth_info_ans(
   return;
 }
 
+void convert_proto_msg_to_itti_amf_decrypted_imsi_info_ans(
+    M5GSUCIRegistrationAnswer response,
+    itti_amf_decrypted_imsi_info_ans_t* amf_app_decrypted_imsi_info_resp) {
+  if (response.ue_msin_recv().length() <= 0) {
+    std::cout << "[ERROR] Decrypted IMSI response is invalid:"
+              << response.ue_msin_recv().length() << std::endl;
+    return;
+  }
+  amf_app_decrypted_imsi_info_resp->imsi_length =
+      response.ue_msin_recv().length();
+  memcpy(
+      amf_app_decrypted_imsi_info_resp->imsi, response.ue_msin_recv().c_str(),
+      amf_app_decrypted_imsi_info_resp->imsi_length);
+}
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/lib/n11/amf_client_proto_msg_to_itti_msg.h
+++ b/lte/gateway/c/core/oai/lib/n11/amf_client_proto_msg_to_itti_msg.h
@@ -22,13 +22,19 @@ extern "C" {
 #endif
 #include "lte/gateway/c/core/oai/include/amf_app_messages_types.h"
 #include "lte/protos/subscriberauth.pb.h"
+#include "lte/protos/subscriberdb.pb.h"
 
 using magma::lte::M5GAuthenticationInformationAnswer;
+using magma::lte::M5GSUCIRegistrationAnswer;
 
 namespace magma5g {
 
 void convert_proto_msg_to_itti_m5g_auth_info_ans(
     M5GAuthenticationInformationAnswer msg,
     itti_amf_subs_auth_info_ans_t* itti_msg);
+
+void convert_proto_msg_to_itti_amf_decrypted_imsi_info_ans(
+    M5GSUCIRegistrationAnswer response,
+    itti_amf_decrypted_imsi_info_ans_t* amf_app_decrypted_imsi_info_resp);
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -33,6 +33,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.h"
 #include "orc8r/gateway/c/common/service303/includes/MetricsHelpers.h"
+#include "include/amf_client_servicer.h"
 
 #define M5GS_REGISTRATION_RESULT_MAXIMUM_LENGTH 1
 #define INVALID_IMSI64 (imsi64_t) 0
@@ -1160,6 +1161,37 @@ int amf_proc_registration_abort(
     rc = RETURNok;
   }
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
+}
+/***************************************************************************
+**                                                                        **
+** Name:    get_decrypt_imsi_suci_extension()                             **
+**                                                                        **
+** Description: Invokes .get_decrypt_imsi_info                            **
+**              to fetch decrypted imsi                                   **
+**                                                                        **
+**                                                                        **
+***************************************************************************/
+int get_decrypt_imsi_suci_extension(
+    amf_context_t* amf_context, uint8_t ue_pubkey_identifier,
+    const std::string& ue_pubkey, const std::string& ciphertext,
+    const std::string& mac_tag) {
+  OAILOG_FUNC_IN(LOG_NAS_AMF);
+
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t ue_id =
+      PARENT_STRUCT(amf_context, ue_m5gmm_context_s, amf_context)
+          ->amf_ue_ngap_id;
+
+  OAILOG_INFO(
+      LOG_AMF_APP,
+      "Sending msg(grpc) to :[subscriberdb] for ue: [" AMF_UE_NGAP_ID_FMT
+      "] decrypt-imsi\n",
+      ue_id);
+
+  AMFClientServicer::getInstance().get_decrypt_imsi_info(
+      ue_pubkey_identifier, ue_pubkey, ciphertext, mac_tag, ue_id);
+
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
 }
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_main.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_main.cpp
@@ -92,6 +92,11 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           &AMF_APP_AUTH_RESPONSE_DATA(received_message_p));
       break;
 
+    case AMF_APP_DECRYPT_IMSI_INFO_RESP:
+      amf_decrypt_imsi_info_answer(
+          &AMF_APP_DECRYPT_IMSI_RESPONSE_DATA(received_message_p));
+      break;
+
     case AMF_IP_ALLOCATION_RESPONSE:
       itti_amf_ip_allocation_response_t* response_p;
       response_p = &(received_message_p->ittiMsg.amf_ip_allocation_response);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -286,6 +286,15 @@ typedef struct paging_context_s {
   uint8_t paging_retx_count;
 } paging_context_t;
 
+// NAS decode and validaion of IE
+typedef struct amf_nas_message_decode_status_s {
+  uint8_t integrity_protected_message : 1;
+  uint8_t ciphered_message : 1;
+  uint8_t mac_matched : 1;
+  uint8_t security_context_available : 1;
+  int amf_cause;
+} amf_nas_message_decode_status_t;
+
 /*
  * Structure of the AMF context established by core for a particular UE
  * --------------------------------------------------------------------
@@ -336,6 +345,8 @@ typedef struct amf_context_s {
   ambr_t subscribed_ue_ambr;
   /* apn_config_profile: set by S6A UPDATE LOCATION ANSWER */
   apn_config_profile_t apn_config_profile;
+
+  amf_nas_message_decode_status_t decode_status;
 } amf_context_t;
 
 // Amf-Map Declarations:
@@ -457,15 +468,6 @@ typedef struct amf_msg_header_t {
 // Release Request routine.
 void amf_app_ue_context_release(
     ue_m5gmm_context_s* ue_context_p, ngap_Cause_t cause);
-
-// NAS decode and validaion of IE
-typedef struct amf_nas_message_decode_status_s {
-  uint8_t integrity_protected_message : 1;
-  uint8_t ciphered_message : 1;
-  uint8_t mac_matched : 1;
-  uint8_t security_context_available : 1;
-  int amf_cause;
-} amf_nas_message_decode_status_t;
 
 // 5G Mobility Management Messages
 union mobility_msg_u {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -1030,4 +1030,5 @@ static int authenthication_t3560_handler(
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
 }
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.h
@@ -101,4 +101,6 @@ nas_amf_smc_proc_t* nas5g_new_smc_procedure(amf_context_t* const amf_context);
 nas5g_amf_auth_proc_t* nas5g_new_authentication_procedure(
     amf_context_t* const amf_context);
 
+int amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia);
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -13,12 +13,14 @@
 
 #include "include/amf_client_servicer.h"
 #include "M5GAuthenticationServiceClient.h"
+#include "M5GSUCIRegistrationServiceClient.h"
 #include "amf_common.h"
 #include <memory>
 #include "lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.h"
 #include "lte/gateway/c/core/oai/lib/n11/SmfServiceClient.h"
 
 using magma5g::AsyncM5GAuthenticationServiceClient;
+using magma5g::AsyncM5GSUCIRegistrationServiceClient;
 
 namespace magma5g {
 
@@ -75,6 +77,15 @@ int AMFClientServicerBase::amf_smf_create_pdu_session_ipv4(
 
 bool AMFClientServicerBase::set_smf_session(SetSMSessionContext& request) {
   return AsyncSmfServiceClient::getInstance().set_smf_session(request);
+}
+
+bool AMFClientServicerBase::get_decrypt_imsi_info(
+    const uint8_t ue_pubkey_identifier, const std::string& ue_pubkey,
+    const std::string& ciphertext, const std::string& mac_tag,
+    amf_ue_ngap_id_t ue_id) {
+  return (AsyncM5GSUCIRegistrationServiceClient::getInstance()
+              .get_decrypt_imsi_info(
+                  ue_pubkey_identifier, ue_pubkey, ciphertext, mac_tag, ue_id));
 }
 
 AMFClientServicer& AMFClientServicer::getInstance() {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -206,6 +206,33 @@ int amf_handle_service_request(
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 
+void amf_copy_plmn_to_supi(
+    const ImsiM5GSMobileIdentity& imsi, supi_as_imsi_t& supi_imsi) {
+  supi_imsi.plmn.mcc_digit1 = imsi.mcc_digit1;
+  supi_imsi.plmn.mcc_digit2 = imsi.mcc_digit2;
+  supi_imsi.plmn.mcc_digit3 = imsi.mcc_digit3;
+
+  supi_imsi.plmn.mnc_digit1 = imsi.mnc_digit1;
+  supi_imsi.plmn.mnc_digit2 = imsi.mnc_digit2;
+  supi_imsi.plmn.mnc_digit3 = imsi.mnc_digit3;
+}
+
+int amf_copy_plmn_to_context(
+    const ImsiM5GSMobileIdentity& imsi, ue_m5gmm_context_s* ue_context) {
+  if (ue_context == NULL) {
+    OAILOG_ERROR(LOG_AMF_APP, "UE context is null");
+    return RETURNerror;
+  }
+
+  ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit1 = imsi.mcc_digit1;
+  ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit2 = imsi.mcc_digit2;
+  ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit3 = imsi.mcc_digit3;
+  ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit1 = imsi.mnc_digit1;
+  ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit2 = imsi.mnc_digit2;
+  ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit3 = imsi.mnc_digit3;
+  return RETURNok;
+}
+
 /* Identifies 5GS Registration type and processes the Message accordingly */
 int amf_handle_registration_request(
     amf_ue_ngap_id_t ue_id, tai_t* originating_tai, ecgi_t* originating_ecgi,
@@ -265,6 +292,8 @@ int amf_handle_registration_request(
       &(ue_context->amf_context.originating_tai), (const void*) originating_tai,
       sizeof(tai_t));
 
+  ue_context->amf_context.decode_status = decode_status;
+
   if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_INITIAL) {
     OAILOG_DEBUG(LOG_NAS_AMF, "New REGISTRATION_REQUEST processing\n");
     // Check integrity and ciphering algorithm bits
@@ -320,18 +349,8 @@ int amf_handle_registration_request(
          */
         params->imsi = new imsi_t();
         /* Copying PLMN to local supi which is imsi*/
-        supi_imsi.plmn.mcc_digit1 =
-            msg->m5gs_mobile_identity.mobile_identity.imsi.mcc_digit1;
-        supi_imsi.plmn.mcc_digit2 =
-            msg->m5gs_mobile_identity.mobile_identity.imsi.mcc_digit2;
-        supi_imsi.plmn.mcc_digit3 =
-            msg->m5gs_mobile_identity.mobile_identity.imsi.mcc_digit3;
-        supi_imsi.plmn.mnc_digit1 =
-            msg->m5gs_mobile_identity.mobile_identity.imsi.mnc_digit1;
-        supi_imsi.plmn.mnc_digit2 =
-            msg->m5gs_mobile_identity.mobile_identity.imsi.mnc_digit2;
-        supi_imsi.plmn.mnc_digit3 =
-            msg->m5gs_mobile_identity.mobile_identity.imsi.mnc_digit3;
+        amf_copy_plmn_to_supi(
+            msg->m5gs_mobile_identity.mobile_identity.imsi, supi_imsi);
         // copy 5 octet scheme_output to msin of supi_imsi
         memcpy(
             &supi_imsi.msin,
@@ -356,18 +375,8 @@ int amf_handle_registration_request(
             params->imsi->u.value[4], params->imsi->u.value[5],
             params->imsi->u.value[6], params->imsi->u.value[7]);
 
-        ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit1 =
-            supi_imsi.plmn.mcc_digit1;
-        ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit2 =
-            supi_imsi.plmn.mcc_digit2;
-        ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit3 =
-            supi_imsi.plmn.mcc_digit3;
-        ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit1 =
-            supi_imsi.plmn.mnc_digit1;
-        ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit2 =
-            supi_imsi.plmn.mnc_digit2;
-        ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit3 =
-            supi_imsi.plmn.mnc_digit3;
+        amf_copy_plmn_to_context(
+            msg->m5gs_mobile_identity.mobile_identity.imsi, ue_context);
 
         ue_context->amf_context.reg_id_type = M5GSMobileIdentityMsg_SUCI_IMSI;
 
@@ -399,6 +408,29 @@ int amf_handle_registration_request(
             found_imsi->second = guti_and_amf_id;
           }
         }
+      } else {
+        /*
+         * Call subscriberdb to decode the SUPI or IMSI from SUCI as scheme
+         * output is encrypted
+         */
+        delete params;
+        amf_copy_plmn_to_context(
+            msg->m5gs_mobile_identity.mobile_identity.imsi, ue_context);
+
+        ue_context->amf_context.reg_id_type = M5GSMobileIdentityMsg_SUCI_IMSI;
+
+        std::string empheral_public_key = reinterpret_cast<char*>(
+            msg->m5gs_mobile_identity.mobile_identity.imsi.empheral_public_key);
+        std::string ciphertext = reinterpret_cast<char*>(
+            msg->m5gs_mobile_identity.mobile_identity.imsi.ciphertext);
+        std::string mac_tag = reinterpret_cast<char*>(
+            msg->m5gs_mobile_identity.mobile_identity.imsi.mac_tag);
+
+        get_decrypt_imsi_suci_extension(
+            &ue_context->amf_context,
+            msg->m5gs_mobile_identity.mobile_identity.imsi.home_nw_id,
+            empheral_public_key, ciphertext, mac_tag);
+        OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
       }
     } else if (
         msg->m5gs_mobile_identity.mobile_identity.guti.type_of_identity ==

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.h
@@ -16,6 +16,7 @@
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationAccept.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_asDefs.h"
+#include "lte/gateway/c/core/oai/tasks/amf/amf_identity.h"
 
 namespace magma5g {
 // AMF registration procedures
@@ -74,4 +75,13 @@ void ue_context_release_command(
     amf_ue_ngap_id_t amf_ue_ngap_id, gnb_ue_ngap_id_t gnb_ue_ngap_id,
     Ngcause ng_cause);
 
+int get_decrypt_imsi_suci_extension(
+    amf_context_t* amf_context, uint8_t ue_pubkey_identifier,
+    const std::string& ue_pubkey, const std::string& ciphertext,
+    const std::string& mac_tag);
+int amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia);
+void amf_copy_plmn_to_supi(
+    const ImsiM5GSMobileIdentity& imsi, supi_as_imsi_t& supi_imsi);
+int amf_copy_plmn_to_context(
+    const ImsiM5GSMobileIdentity& imsi, ue_m5gmm_context_s* ue_context);
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -70,6 +70,10 @@ class AMFClientServicerBase {
       const ambr_t& state_ambr);
 
   virtual bool set_smf_session(SetSMSessionContext& request);
+  virtual bool get_decrypt_imsi_info(
+      const uint8_t ue_pubkey_identifier, const std::string& ue_pubkey,
+      const std::string& ciphertext, const std::string& mac_tag,
+      amf_ue_ngap_id_t ue_id);
 };
 
 class AMFClientServicer : public AMFClientServicerBase {
@@ -125,6 +129,12 @@ class AMFClientServicer : public AMFClientServicerBase {
   }
 
   bool set_smf_session(SetSMSessionContext& request) { return true; }
+  bool get_decrypt_imsi_info(
+      const uint8_t ue_pubkey_identifier, const std::string& ue_pubkey,
+      const std::string& ciphertext, const std::string& mac_tag,
+      amf_ue_ngap_id_t ue_id) override {
+    return true;
+  }
 #endif /* MME_UNIT_TEST */
 
  private:

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -18,6 +18,8 @@ extern "C" {
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
+#include "lte/gateway/c/core/oai/common/conversions.h"
+
 #ifdef __cplusplus
 }
 #endif
@@ -31,11 +33,13 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/amf/amf_sap.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_recv.h"
+#include "lte/gateway/c/core/oai/tasks/amf/amf_identity.h"
 
 extern amf_config_t amf_config;
 namespace magma5g {
 extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 AmfMsg amf_msg_obj;
+extern std::unordered_map<imsi64_t, guti_and_amf_id_t> amf_supi_guti_map;
 static int identification_t3570_handler(zloop_t* loop, int timer_id, void* arg);
 int nas_proc_establish_ind(
     const amf_ue_ngap_id_t ue_id, const bool is_mm_ctx_new,
@@ -466,6 +470,115 @@ int amf_nas_proc_authentication_info_answer(
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
 
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
+}
+
+int amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia) {
+  imsi64_t imsi64                = INVALID_IMSI64;
+  int rc                         = RETURNerror;
+  amf_context_t* amf_ctxt_p      = NULL;
+  ue_m5gmm_context_s* ue_context = NULL;
+  int amf_cause                  = -1;
+
+  // Local imsi to be put in imsi defined in 3gpp_23.003.h
+  supi_as_imsi_t supi_imsi;
+  amf_guti_m5g_t amf_guti;
+  guti_and_amf_id_t guti_and_amf_id;
+  const bool is_amf_ctx_new = true;
+  OAILOG_FUNC_IN(LOG_AMF_APP);
+
+  ue_context = amf_ue_context_exists_amf_ue_ngap_id(aia->ue_id);
+
+  IMSI_STRING_TO_IMSI64((char*) aia->imsi, &imsi64);
+
+  OAILOG_DEBUG(LOG_AMF_APP, "Handling imsi " IMSI_64_FMT "\n", imsi64);
+
+  if (ue_context) {
+    amf_ctxt_p = &ue_context->amf_context;
+  }
+
+  if (!(amf_ctxt_p)) {
+    OAILOG_ERROR(
+        LOG_NAS_AMF, "That's embarrassing as we don't know this IMSI\n");
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+  }
+
+  amf_ue_ngap_id_t amf_ue_ngap_id = ue_context->amf_ue_ngap_id;
+
+  OAILOG_DEBUG(
+      LOG_NAS_AMF,
+      "Received decrypted imsi Information Answer from Subscriberdb for"
+      " UE ID = " AMF_UE_NGAP_ID_FMT,
+      amf_ue_ngap_id);
+
+  amf_registration_request_ies_t* params =
+      new (amf_registration_request_ies_t)();
+
+  params->imsi = new imsi_t();
+
+  supi_imsi.plmn.mcc_digit1 =
+      ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit1;
+  supi_imsi.plmn.mcc_digit2 =
+      ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit2;
+  supi_imsi.plmn.mcc_digit3 =
+      ue_context->amf_context.m5_guti.guamfi.plmn.mcc_digit3;
+  supi_imsi.plmn.mnc_digit1 =
+      ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit1;
+  supi_imsi.plmn.mnc_digit2 =
+      ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit2;
+  supi_imsi.plmn.mnc_digit3 =
+      ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit3;
+
+  memcpy(&supi_imsi.msin, aia->imsi, MSIN_MAX_LENGTH);
+
+  // Copy entire supi_imsi to param->imsi->u.value
+  memcpy(&params->imsi->u.value, &supi_imsi, IMSI_BCD8_SIZE);
+
+  if (supi_imsi.plmn.mnc_digit3 != 0xf) {
+    params->imsi->u.value[0] = ((supi_imsi.plmn.mcc_digit1 << 4) & 0xf0) |
+                               (supi_imsi.plmn.mcc_digit2 & 0xf);
+    params->imsi->u.value[1] = ((supi_imsi.plmn.mcc_digit3 << 4) & 0xf0) |
+                               (supi_imsi.plmn.mnc_digit1 & 0xf);
+    params->imsi->u.value[2] = ((supi_imsi.plmn.mnc_digit2 << 4) & 0xf0) |
+                               (supi_imsi.plmn.mnc_digit3 & 0xf);
+  }
+
+  amf_app_generate_guti_on_supi(&amf_guti, &supi_imsi);
+  amf_ue_context_on_new_guti(
+      ue_context, reinterpret_cast<guti_m5_t*>(&amf_guti));
+
+  ue_context->amf_context.m5_guti.m_tmsi = amf_guti.m_tmsi;
+  ue_context->amf_context.m5_guti.guamfi = amf_guti.guamfi;
+  imsi64                                 = amf_imsi_to_imsi64(params->imsi);
+  guti_and_amf_id.amf_guti               = amf_guti;
+  guti_and_amf_id.amf_ue_ngap_id         = aia->ue_id;
+
+  if (amf_supi_guti_map.size() == 0) {
+    // first entry.
+    amf_supi_guti_map.insert(
+        std::pair<imsi64_t, guti_and_amf_id_t>(imsi64, guti_and_amf_id));
+  } else {
+    /* already elements exist then check if same imsi already present
+     * if same imsi then update/overwrite the element
+     */
+    std::unordered_map<imsi64_t, guti_and_amf_id_t>::iterator found_imsi =
+        amf_supi_guti_map.find(imsi64);
+    if (found_imsi == amf_supi_guti_map.end()) {
+      // it is new entry to map
+      amf_supi_guti_map.insert(
+          std::pair<imsi64_t, guti_and_amf_id_t>(imsi64, guti_and_amf_id));
+    } else {
+      // Overwrite the second element.
+      found_imsi->second = guti_and_amf_id;
+    }
+  }
+
+  params->decode_status = ue_context->amf_context.decode_status;
+  /*
+   * Execute the requested new UE registration procedure
+   * This will initiate identity req in DL.
+   */
+  rc = amf_proc_registration_request(aia->ue_id, is_amf_ctx_new, params);
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.h
@@ -104,6 +104,15 @@ class ImsiM5GSMobileIdentity {
   uint8_t msin_digit4 : 4;
   uint8_t msin_digit5 : 4;
   uint8_t numOfValidImsiDigits : 4;
+#define EPHEMERAL_PUBLIC_KEY_LENGTH 32
+#define PROFILE_A 1
+#define PROFILE_B 2
+#define PROFILE_B_LEN 1
+  uint8_t empheral_public_key[EPHEMERAL_PUBLIC_KEY_LENGTH + PROFILE_B_LEN + 1];
+#define CIPHERTEXT_LENGTH 5
+  uint8_t ciphertext[CIPHERTEXT_LENGTH + 1];
+#define MAC_TAG_LENGTH 8
+  uint8_t mac_tag[MAC_TAG_LENGTH + 1];
 };
 
 // 5GS mobile identity information element for type of identity or "SUCI" SPEC :

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -123,6 +123,25 @@ uint8_t NAS5GPktSnapShot::registration_reject[4] = {0x00, 0x00, 0x00, 0x00};
 
 uint8_t NAS5GPktSnapShot::security_mode_reject[4] = {0x7e, 0x00, 0x5f, 0x24};
 
+uint8_t NAS5GPktSnapShot::suci_ext_reg_req_buffer[65] = {
+    0x7e, 0x00, 0x41, 0x79, 0x00, 0x35, 0x01, 0x22, 0x62, 0x54, 0xf0,
+    0xff, 0x01, 0x00, 0x18, 0x23, 0x93, 0xb0, 0xcc, 0x25, 0xc5, 0x59,
+    0x11, 0xea, 0x6e, 0x7d, 0x2a, 0x09, 0xd5, 0xf2, 0x10, 0x1d, 0x8c,
+    0x92, 0x6c, 0xf0, 0xac, 0x4c, 0x5a, 0x87, 0x3e, 0x5f, 0xc7, 0x62,
+    0xa0, 0x4f, 0x95, 0xbc, 0xde, 0xc1, 0x1d, 0x0b, 0xfd, 0x9e, 0xed,
+    0x41, 0xe2, 0x02, 0xe6, 0x2e, 0x04, 0x80, 0xe0, 0x80, 0xe0};
+
+uint8_t empheral_public_key[] = {
+    0x18, 0x23, 0x93, 0xb0, 0xcc, 0x25, 0xc5, 0x59, 0x11, 0xea, 0x6e,
+    0x7d, 0x2a, 0x09, 0xd5, 0xf2, 0x10, 0x1d, 0x8c, 0x92, 0x6c, 0xf0,
+    0xac, 0x4c, 0x5a, 0x87, 0x3e, 0x5f, 0xc7, 0x62, 0xa0, 0x4f, 0x0};
+
+uint8_t ciphertext[] = {0x95, 0xbc, 0xde, 0xc1, 0x1d, 0x0};
+
+uint8_t mac_tag[] = {0x0b, 0xfd, 0x9e, 0xed, 0x41, 0xe2, 0x02, 0xe6, 0x0};
+
+ImsiM5GSMobileIdentity plmn;
+
 class AmfNas5GTest : public ::testing::Test {
  protected:
   NAS5GPktSnapShot nas5g_pkt_snap;
@@ -170,6 +189,56 @@ TEST_F(AmfNas5GTest, test_amf_ue_register_req_msg) {
 
   EXPECT_EQ(
       reg_request.m5gs_mobile_identity.mobile_identity.imsi.mcc_digit2, 0x0);
+}
+
+TEST_F(AmfNas5GTest, test_amf_ue_suci_ext_register_req_msg) {
+  uint32_t len = nas5g_pkt_snap.get_suci_ext_reg_req_buffer_len();
+
+  decode_res = decode_registration_request_msg(
+      &reg_request, nas5g_pkt_snap.suci_ext_reg_req_buffer, len);
+
+  EXPECT_EQ(decode_res, true);
+
+  EXPECT_EQ(
+      reg_request.extended_protocol_discriminator.extended_proto_discriminator,
+      M5G_MOBILITY_MANAGEMENT_MESSAGES);
+
+  //  Type is registration Request
+  EXPECT_EQ(reg_request.message_type.msg_type, REG_REQUEST);
+
+  //  Registration Type is Initial Registration
+  EXPECT_EQ(reg_request.m5gs_reg_type.type_val, 1);
+
+  //  5GS Mobile Identity SUCI FORMAT
+  EXPECT_EQ(
+      reg_request.m5gs_mobile_identity.mobile_identity.imsi.type_of_identity,
+      M5GSMobileIdentityMsg_SUCI_IMSI);
+
+  //  5GS Mobile SUCI extenstions
+
+  for (int i = 0; i < EPHEMERAL_PUBLIC_KEY_LENGTH; ++i) {
+    EXPECT_EQ(
+        reg_request.m5gs_mobile_identity.mobile_identity.imsi
+            .empheral_public_key[i],
+        empheral_public_key[i])
+        << "Vectors x and y differ at index " << i;
+  }
+
+  for (int i = 0; i < CIPHERTEXT_LENGTH; ++i) {
+    EXPECT_EQ(
+        reg_request.m5gs_mobile_identity.mobile_identity.imsi.ciphertext[i],
+        ciphertext[i]);
+  }
+
+  for (int i = 0; i < MAC_TAG_LENGTH; ++i) {
+    EXPECT_EQ(
+        reg_request.m5gs_mobile_identity.mobile_identity.imsi.mac_tag[i],
+        mac_tag[i]);
+  }
+
+  EXPECT_EQ(
+      reg_request.m5gs_mobile_identity.mobile_identity.imsi.protect_schm_id,
+      0x1);
 }
 
 TEST_F(AmfNas5GTest, test_amf_ue_guti_register_req_msg) {
@@ -487,6 +556,26 @@ TEST_F(AmfUeContextTest, test_smf_context_creation) {
   smf_context            = amf_insert_smf_context(ue_context, pdu_session_id);
   EXPECT_TRUE(0 == smf_context->n_active_pdus);
   EXPECT_TRUE(0 == smf_context->pdu_session_version);
+}
+
+TEST_F(AmfUeContextTest, test_amf_plmn) {
+  plmn.mcc_digit2 = 0;
+  plmn.mcc_digit1 = 0;
+  plmn.mnc_digit3 = 0x0f;
+  plmn.mcc_digit3 = 1;
+  plmn.mnc_digit2 = 1;
+  plmn.mnc_digit1 = 0;
+
+  supi_as_imsi_t supi_imsi;
+  amf_copy_plmn_to_supi(plmn, supi_imsi);
+  amf_copy_plmn_to_context(plmn, ue_context);
+  EXPECT_EQ(
+      memcmp(
+          reinterpret_cast<const void*>(
+              &ue_context->amf_context.m5_guti.guamfi.plmn),
+          reinterpret_cast<const void*>(&supi_imsi.plmn),
+          sizeof(ue_context->amf_context.m5_guti.guamfi.plmn)),
+      0);
 }
 
 /* Test for registration reject */

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -234,7 +234,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcNoTMSI) {
   /* Check whether security mode procedure is initiated */
   EXPECT_TRUE(validate_smc_procedure(ue_id, 0));
 
-  /* Send uplinkg nas message for security mode complete response from UE */
+  /* Send uplink nas message for security mode complete response from UE */
   rc = send_uplink_nas_message_ue_smc_response(
       amf_app_desc_p, ue_id, plmn, ue_smc_response_hexbuf,
       sizeof(ue_smc_response_hexbuf));
@@ -283,7 +283,7 @@ TEST_F(AMFAppProcedureTest, TestDeRegistration) {
       sizeof(ue_auth_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  /* Send uplinkg nas message for security mode complete response from UE */
+  /* Send uplink nas message for security mode complete response from UE */
   rc = send_uplink_nas_message_ue_smc_response(
       amf_app_desc_p, ue_id, plmn, ue_smc_response_hexbuf,
       sizeof(ue_smc_response_hexbuf));
@@ -805,7 +805,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
   res = validate_smc_procedure(ue_id, 0);
   EXPECT_TRUE(res == true);
 
-  // Send uplinkg nas message for security mode complete response from UE
+  // Send uplink nas message for security mode complete response from UE
   rc = send_uplink_nas_message_ue_smc_response(
       amf_app_desc_p, ue_id, plmn, ue_smc_response_hexbuf,
       sizeof(ue_smc_response_hexbuf));

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -19,6 +19,7 @@
 extern "C" {
 #include "lte/gateway/c/core/oai/common/common_types.h"
 #include "lte/gateway/c/core/oai/include/amf_config.h"
+#include "lte/gateway/c/core/oai/include/amf_app_messages_types.h"
 }
 #include "lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h"
@@ -65,6 +66,20 @@ class AMFAppProcedureTest : public ::testing::Test {
                  .mcc_digit3 = 1,
                  .mnc_digit2 = 1,
                  .mnc_digit1 = 0};
+
+  itti_amf_decrypted_imsi_info_ans_t decrypted_imsi = {
+      .imsi        = "222456000000001",
+      .imsi_length = 15,
+      .result      = 1,
+      .ue_id       = 1};
+
+  const uint8_t intital_ue_message_suci_ext_hexbuf[65] = {
+      0x7e, 0x00, 0x41, 0x79, 0x00, 0x35, 0x01, 0x09, 0xf1, 0x07, 0x00,
+      0x00, 0x01, 0x04, 0xc8, 0xfc, 0x0c, 0xe5, 0x47, 0x9a, 0x51, 0x5d,
+      0xab, 0xf2, 0xf3, 0x45, 0xae, 0xb4, 0x66, 0x92, 0xd6, 0xff, 0x7a,
+      0x5f, 0x4f, 0x57, 0x2a, 0x47, 0x99, 0xf2, 0x33, 0x69, 0x35, 0x16,
+      0x40, 0x31, 0xbd, 0x3f, 0x84, 0x41, 0x26, 0xdf, 0x5b, 0x47, 0x06,
+      0x41, 0xe2, 0xa9, 0x57, 0x2e, 0x04, 0xf0, 0xf0, 0xf0, 0xf0};
 
   const uint8_t initial_ue_message_hexbuf[25] = {
       0x7e, 0x00, 0x41, 0x79, 0x00, 0x0d, 0x01, 0x22, 0x62,
@@ -752,6 +767,57 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_Invalid_PDUSession_Identity) {
 
   EXPECT_TRUE(rc == RETURNok);
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
+TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
+  amf_ue_ngap_id_t ue_id = 0;
+
+  // Send the initial UE message
+  imsi64_t imsi64 = 0;
+  int rc          = RETURNok;
+  imsi64          = send_initial_ue_message_no_tmsi(
+      amf_app_desc_p, 36, 1, 1, 0, plmn, intital_ue_message_suci_ext_hexbuf,
+      sizeof(intital_ue_message_suci_ext_hexbuf));
+
+  rc = amf_decrypt_imsi_info_answer(&decrypted_imsi);
+  EXPECT_TRUE(rc == RETURNok);
+
+  // Check if UE Context is created with correct imsi
+  bool res = false;
+  res      = get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id);
+  EXPECT_TRUE(res == true);
+
+  // Send the authentication response message from subscriberdb
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  // Validate if authentication procedure is initialized as expected
+  res = validate_auth_procedure(ue_id, 0);
+  EXPECT_TRUE(res == true);
+
+  // Send uplink nas message for auth response from UE
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  // Check whether security mode procedure is initiated
+  res = validate_smc_procedure(ue_id, 0);
+  EXPECT_TRUE(res == true);
+
+  // Send uplinkg nas message for security mode complete response from UE
+  rc = send_uplink_nas_message_ue_smc_response(
+      amf_app_desc_p, ue_id, plmn, ue_smc_response_hexbuf,
+      sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  // Send uplink nas message for registration complete response from UE
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  amf_app_handle_deregistration_req(ue_id);
 }
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/util_nas5g_pkt.h
+++ b/lte/gateway/c/core/oai/test/amf/util_nas5g_pkt.h
@@ -40,9 +40,14 @@ class NAS5GPktSnapShot {
   static uint8_t registration_reject[4];
   static uint8_t security_mode_reject[4];
   static uint8_t service_req_signaling[13];
+  static uint8_t suci_ext_reg_req_buffer[65];
 
   uint32_t get_reg_req_buffer_len() {
     return sizeof(reg_req_buffer) / sizeof(unsigned char);
+  }
+
+  uint32_t get_suci_ext_reg_req_buffer_len() {
+    return sizeof(suci_ext_reg_req_buffer) / sizeof(unsigned char);
   }
 
   uint32_t get_reg_resync_buffer_len() {

--- a/lte/gateway/c/core/oai/test/n11/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/n11/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(smf_service_client
 	LIB_N11 gtest gtest_main pthread protobuf rt yaml-cpp
     )
 target_link_libraries(auth_service_client
-	LIB_N11 gtest gtest_main pthread protobuf grpc++ dl m rt yaml-cpp
+	LIB_N11 TASK_AMF_APP gtest gtest_main pthread protobuf grpc++ dl m rt yaml-cpp
     )
 
 add_test(test_smf_service_client smf_service_client)


### PR DESCRIPTION
Signed-off-by: Kaleemullah Mohammed <kaleemullah.mohammed@wavelabs.ai>

 Supported below AMF changes for SUPI Registration
 1) Decoding of SUCI extensions IEs
 2) Implementing GRPC with subscriberdb to deconceal IMSI
 3) Triggering registration procedures
 
Test:
1) Tested with UERANSIM
2) UT Test code


## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
![test_oai](https://user-images.githubusercontent.com/83354949/140967056-c093fd86-393b-43b6-9b8a-88b41703c21d.jpg)
![UT](https://user-images.githubusercontent.com/83354949/141088170-87fecc50-167e-4a63-9032-86ff75e44fdf.jpg)
![UT2](https://user-images.githubusercontent.com/83354949/141700149-0ee2eb65-7685-4924-a132-72733da7155f.jpg)
