### PR TITLE
fix(ci): do not trigger comment on PR job when trigger is push

### DIFF
--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   comment_pr:
+    if: github.event.workflow_run.event == 'pull_request'
     name: Comment on PR for check ${{ github.event.workflow.name }}
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Issue: Comment On PR job was being triggered on a push on master

## Test Plan

Master ( mechanism already used in deploy from PR job )

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
