### PR TITLE
fix(orc8r): Fix the file run.py to able to execute run.py -- metrics

### DIFF
--- a/orc8r/cloud/docker/run.py
+++ b/orc8r/cloud/docker/run.py
@@ -41,7 +41,7 @@ def main() -> None:
         if args.thanos:
             f.append('thanos')
         file_args = _make_file_args(f)
-        compose_line = 'COMPOSE_FILE={}  {}\n'.format(
+        compose_line = 'COMPOSE_FILE={}  \n{}\n'.format(
             ':'.join(file_args),
             DO_NOT_COMMIT,
         )


### PR DESCRIPTION
Signed-off-by: Tales Mota Machado <tales@radtonics.com>

## Summary

There's a change was made on v1.4 that fixed this problem.
I reapply this change to make permanet.

Fix one issue:

- `run.py --metrics` throws error `ERROR: .FileNotFoundError: [Errno 2] No such file or directory: './docker-compose.override.yml  # DO NOT COMMIT THIS CHANGE'`

As related on issue #5661. 

## Test Plan
Test locally
