### PR TITLE
feat: build CWAG sessiond with Bazel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,3 +54,11 @@
 !protos/
 
 !xwf/gateway/
+
+!bazel/
+!*.bzl
+!*.bazel
+!*.BUILD
+!.bazelrc
+!.bazelignore
+!.bazelversion

--- a/bazel/bazelrcs/cwag.bazelrc
+++ b/bazel/bazelrcs/cwag.bazelrc
@@ -1,0 +1,2 @@
+build --define=disable_sentry_native=1
+build --define=folly_so=1

--- a/cwf/gateway/docker/c/Dockerfile
+++ b/cwf/gateway/docker/c/Dockerfile
@@ -15,65 +15,43 @@
 # Builder image for C binaries and Magma proto files
 # -----------------------------------------------------------------------------
 
-# debian stretch image
-# ARG OS_DIST=debian
-# ARG OS_RELEASE=stretch
-# ARG EXTRA_REPO=https://facebookconnectivity.jfrog.io/artifactory/list/dev/
-# ARG CLANG_VERSION=3.8
-
 # ubuntu bionic image
-ARG OS_DIST=ubuntu
-ARG OS_RELEASE=bionic
-ARG EXTRA_REPO=https://facebookconnectivity.jfrog.io/artifactory/cwf-prod
-ARG CLANG_VERSION=3.9
+ARG OS_DIST=ubuntu OS_RELEASE=bionic EXTRA_REPO=https://facebookconnectivity.jfrog.io/artifactory/cwf-prod
 
 # Stretch is required for c build
 FROM $OS_DIST:$OS_RELEASE AS builder
-ARG OS_DIST
-ARG OS_RELEASE
-ARG EXTRA_REPO
-ARG CLANG_VERSION
+ARG OS_DIST OS_RELEASE EXTRA_REPO
+
+RUN apt-get update && \
+    # Setup necessary tools for adding the Magma repository
+    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg wget && \
+    # Download Bazel
+    wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
+    chmod +x /usr/sbin/bazelisk-linux-amd64 && \
+    ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
 
 # Add the magma apt repo
-RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
-
 RUN apt-key add /tmp/jfrog.pub && \
     apt-add-repository "deb ${EXTRA_REPO} ${OS_RELEASE} main"
-
 
 # Install dependencies required for building
 RUN apt-get -y update && apt-get -y install \
   sudo \
   curl \
-  wget \
   unzip \
   cmake \
   git \
+  gcc \
+  g++ \
   build-essential \
-  autoconf \
-  libtool \
-  pkg-config \
-  libgflags-dev \
-  libgtest-dev \
-  clang-${CLANG_VERSION} \
-  libc++-dev \
-  protobuf-compiler \
-  grpc-dev \
-  ninja-build \
-  autogen \
-  ccache \
-  libprotoc-dev \
-  libxml2-dev \
-  libxslt-dev \
-  libyaml-cpp-dev \
-  nlohmann-json-dev \
-  magma-cpp-redis \
-  libgoogle-glog-dev \
-  prometheus-cpp-dev \
+  # folly deps
   libfolly-dev \
-  magma-libfluid \
+  libgoogle-glog-dev \
+  libgflags-dev \
+  libevent-dev \
+  libdouble-conversion-dev \
+  libiberty-dev \
   libdouble-conversion-dev \
   libboost-chrono-dev \
   libboost-context-dev \
@@ -82,78 +60,60 @@ RUN apt-get -y update && apt-get -y install \
   libboost-regex-dev
 
 ENV MAGMA_ROOT /magma
-ENV C_BUILD /build/c
-ENV OAI_BUILD $C_BUILD/oai
+WORKDIR /magma
 
-ENV CCACHE_DIR $MAGMA_ROOT/.cache/gateway/ccache
-ENV MAGMA_DEV_MODE 1
-ENV XDG_CACHE_HOME $MAGMA_ROOT/.cache
+# Copy Bazel files at root and third_party
+COPY WORKSPACE.bazel BUILD.bazel .bazelignore .bazelrc .bazelversion ${MAGMA_ROOT}/
+COPY bazel/ ${MAGMA_ROOT}/bazel
+
+# Build external dependencies first. This will help not rebuilt all dependencies triggered by Magma changes.
+RUN bazel build \
+  @com_github_grpc_grpc//:grpc++ \
+  @com_github_google_glog//:glog \
+  @protobuf//:protobuf \
+  @prometheus_cpp//:prometheus-cpp \
+  @yaml-cpp//:yaml-cpp \
+  @boost//:iterator \
+  @github_nlohmann_json//:json
 
 # Copy proto files
-COPY feg/protos $MAGMA_ROOT/feg/protos
-COPY feg/gateway/services/aaa/protos $MAGMA_ROOT/feg/gateway/services/aaa/protos
-COPY lte/protos $MAGMA_ROOT/lte/protos
-COPY orc8r/protos $MAGMA_ROOT/orc8r/protos
-COPY protos $MAGMA_ROOT/protos
+COPY feg/protos ${MAGMA_ROOT}/feg/protos
+COPY feg/gateway/services/aaa/protos ${MAGMA_ROOT}/feg/gateway/services/aaa/protos
+COPY lte/protos ${MAGMA_ROOT}/lte/protos
+COPY orc8r/protos ${MAGMA_ROOT}/orc8r/protos
+COPY protos ${MAGMA_ROOT}/protos
 
 # Build session_manager c code
-COPY lte/gateway/Makefile $MAGMA_ROOT/lte/gateway/Makefile
-COPY orc8r/gateway/c/common $MAGMA_ROOT/orc8r/gateway/c/common
-COPY lte/gateway/c $MAGMA_ROOT/lte/gateway/c
-ARG BUILD_TYPE=RelWithDebInfo
-ENV BUILD_TYPE=$BUILD_TYPE
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_session_manager BUILD_TYPE="${BUILD_TYPE}"
+COPY orc8r/gateway/c/common ${MAGMA_ROOT}/orc8r/gateway/c/common
+COPY lte/gateway/c/session_manager ${MAGMA_ROOT}/lte/gateway/c/session_manager
+
+RUN bazel --bazelrc=${MAGMA_ROOT}/bazel/bazelrcs/cwag.bazelrc build //lte/gateway/c/session_manager:sessiond
 
 # -----------------------------------------------------------------------------
 # Dev/Production image
 # -----------------------------------------------------------------------------
 FROM $OS_DIST:$OS_RELEASE AS gateway_c
-ARG OS_DIST
-ARG OS_RELEASE
-ARG EXTRA_REPO
 
-# Add the magma apt repo
-RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg
-COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
+# Copy runtime dependencies
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libboost* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libevent-* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libgflags* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libglog* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libsnappy.* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libdouble-conversion.* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libicui18n.* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libicuuc.* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libicudata.* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/openssl* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libunwind* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/local/lib/libfolly.so /usr/local/lib/
 
-RUN apt-key add /tmp/jfrog.pub && \
-    apt-add-repository "deb $EXTRA_REPO $OS_RELEASE main"
-
-
-# Install runtime dependencies
-RUN apt-get -y update && apt-get -y install \
-  curl \
-  sudo \
-  # install prometheus
-  prometheus-cpp-dev \
-  # install openvswitch
-  magma-libfluid \
-  # install lxml
-  python3-lxml \
-  bridge-utils \
-  # install yaml parser
-  libyaml-cpp-dev \
-  libgoogle-glog-dev \
-  # folly deps
-  libfolly-dev \
-  libdouble-conversion-dev \
-  libboost-chrono-dev \
-  libboost-context-dev \
-  libboost-program-options-dev \
-  libboost-filesystem-dev \
-  libboost-regex-dev \
-  nlohmann-json-dev \
-  redis-server \
-  python-redis \
-  magma-cpp-redis \
-  grpc-dev \
-  protobuf-compiler \
-  libprotoc-dev \
-  netcat
+RUN ldconfig 2> /dev/null
 
 # Copy the build artifacts.
-COPY --from=builder /build/c/session_manager/sessiond /usr/local/bin/sessiond
+COPY --from=builder /magma/bazel-bin/lte/gateway/c/session_manager/sessiond /usr/local/bin/sessiond
 
 # Copy the configs.
 COPY lte/gateway/configs /etc/magma

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -329,6 +329,7 @@ cc_library(
         "//lte/protos:session_manager_cpp_grpc",
         "//orc8r/gateway/c/common/async_grpc:async_grpc_receiver",
         "//orc8r/gateway/c/common/service_registry",
+        "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",
     ],
 )

--- a/lte/gateway/c/session_manager/test/BUILD.bazel
+++ b/lte/gateway/c/session_manager/test/BUILD.bazel
@@ -236,6 +236,7 @@ cc_test(
     name = "proxy_responder_handler_test",
     size = "small",
     srcs = ["test_proxy_responder_handler.cpp"],
+    flaky = True,
     deps = [
         ":matchers",
         ":protobuf_creators",

--- a/orc8r/gateway/c/common/sentry/BUILD.bazel
+++ b/orc8r/gateway/c/common/sentry/BUILD.bazel
@@ -13,20 +13,29 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "disable_sentry_native",
+    values = {"define": "disable_sentry_native=1"},
+)
+
+sentry_deps = [
+    "//orc8r/gateway/c/common/config:service_config_loader",
+    "@yaml-cpp//:yaml-cpp",
+]
+
 cc_library(
     name = "sentry_wrapper",
     srcs = ["SentryWrapper.cpp"],
     hdrs = ["includes/SentryWrapper.h"],
     # TODO(@themarwhal): Enable Sentry by default - GH9302
-    copts = [
-        "-DSENTRY_ENABLED",
-        "-DSENTRY_BUILD_STATIC",
-    ],
+    copts = select({
+        ":disable_sentry_native": [],
+        "//conditions:default": ["-DSENTRY_ENABLED", "-DSENTRY_BUILD_STATIC",],
+    }),
     # TODO(@themarwhal): Migrate to using full path for includes - GH8299
     strip_include_prefix = "/orc8r/gateway/c/common/sentry",
-    deps = [
-        "//orc8r/gateway/c/common/config:service_config_loader",
-        "@sentry_native//:sentry",
-        "@yaml-cpp//:yaml-cpp",
-    ],
+    deps = select({
+        ":disable_sentry_native": sentry_deps,
+        "//conditions:default": sentry_deps + ["@sentry_native//:sentry"],
+    }),
 )


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Blocked on https://github.com/magma/magma/pull/10394

Modified and cleaned up CWAG dockerfile to use bazel to build sessiond. I've also removed unused dependencies to clean up the image. Also add a disable sentry build option as I'm unable to build breakpad on the bionic base.

Some numbers on the difference
* fresh build time increases by 13% (goes from 6min 42 seconds on master to 7 min 38 seconds with this PR - taken on same machine) 
* build with only sessiond changes are about the same
* image size decreases by 58%(945MB on master to 393MB with this PR)

Possible improvements:
* Use docker_rules. My only concern here is that we have a lot of external dependencies needed for C/C++ that will require a lot of work to build with bazel. But maybe we can create out own custom base image with all dependencies and pull that down.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran CWF integ test locally + CI passes


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
