### PR TITLE
chore(ci): Disable build on PR of agw

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -86,6 +86,7 @@ jobs:
           pip install artifactory
           python ci-scripts/helm_repo_rotation.py
   agw-build:
+    if: github.event_name == 'push'
     runs-on: macos-10.15
     outputs:
       artifacts: ${{ steps.publish_packages.outputs.artifact }}

--- a/.github/workflows/deploy-build-from-pr.yml
+++ b/.github/workflows/deploy-build-from-pr.yml
@@ -68,14 +68,6 @@ jobs:
             var issue_number = Number(fs.readFileSync('./NR'));
             console.log(String(issue_number))
             core.setOutput('issue_number',issue_number );
-      - name: upload to artifactory
-        continue-on-error: true
-        run: |
-          for i in `ls -a1 *.deb`
-          do
-            echo "Pushing package $i to JFROG artifiactory: https://artifactory.magmacore.org/artifactory/debian-ci/pool"
-            curl -uci-bot:${{ secrets.JFROG_CIBOT_APIKEYS }} -XPUT "https://artifactory.magmacore.org/artifactory/debian-ci/pool/$i;deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64" -T $i
-          done
       - name: extract images
         run: |
           for IMAGES in `ls -a1 *.gz`


### PR DESCRIPTION

## Summary

Disable build on PR of agw

Too much load on the vagrant cloud causing rate limiting on the vm download

## Test Plan

on PR

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
