### PR TITLE
feat(orc8r): increase workgroups size if blue-green-orc8r is enabled

### DIFF
--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -738,3 +738,20 @@ service:
     Required: false
     ConfigApps:
       - tf
+  enable_orc8r_blue_green_deployment:
+    Description: >-
+      Enable the deployment for a blue & green Orc8r instances in the same
+      infrastructure
+    Type: bool
+    Default: false
+    Required: false
+    ConfigApps:
+      - tf
+  blue_green_worker_groups:
+    Description: >-
+      Worker group configuration for EKS. Default value is 1 worker group
+      consisting of 5 t3.medium instances.
+    Type: any
+    Required: false
+    ConfigApps:
+      - tf

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/eks.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/eks.tf
@@ -11,6 +11,10 @@
 # limitations under the License.
 ################################################################################
 
+locals {
+  orc8r_worker_group = var.enable_orc8r_blue_green_deployment ? var.blue_green_worker_groups : var.eks_worker_groups
+}
+
 resource "tls_private_key" "eks_workers" {
   count = var.eks_worker_group_key == null ? 1 : 0
 
@@ -49,7 +53,7 @@ module "eks" {
   }
   worker_additional_security_group_ids = concat([aws_security_group.default.id], var.eks_worker_additional_sg_ids)
   workers_additional_policies          = var.eks_worker_additional_policy_arns
-  worker_groups                        = var.thanos_enabled ? concat(var.eks_worker_groups, var.thanos_worker_groups) : var.eks_worker_groups
+  worker_groups                        = var.thanos_enabled ? concat(local.orc8r_worker_group, var.thanos_worker_groups) : local.orc8r_worker_group
 
   map_roles = var.eks_map_roles
   map_users = var.eks_map_users

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
@@ -50,6 +50,13 @@ variable "magma_uuid" {
 variable "global_tags" {
   default = {}
 }
+
+variable "enable_orc8r_blue_green_deployment" {
+  description = "Flag to enable the deployment for a blue & green Orc8r instances in the same infrastructure"
+  type        = bool
+  default     = false
+}
+
 ##############################################################################
 # K8s configuration
 ##############################################################################
@@ -72,7 +79,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   description = "Kubernetes version for the EKS cluster."
   type        = string
-  default     = "1.17"
+  default     = "1.21"
 }
 
 variable "eks_worker_group_key" {
@@ -132,6 +139,26 @@ variable "thanos_worker_groups" {
     },
   ]
 
+}
+
+variable "blue_green_worker_groups" {
+  # Check the docs at https://github.com/terraform-aws-modules/terraform-aws-eks
+  # for the complete set of valid properties for these objects. This worker group exists
+  # in order to increase the capacity of the EKS resources to accommodate a second instance
+  # of the Orc8r/NMS
+  description = "Worker group configuration for EKS. Default value is 1 worker group consisting of 5 t3.medium instances."
+  type        = any
+  default = [
+    {
+      name                 = "wg-1"
+      instance_type        = "t3.medium"
+      asg_desired_capacity = 8
+      asg_min_size         = 1
+      asg_max_size         = 8
+      autoscaling_enabled  = false
+      kubelet_extra_args = "" // object types must be identical (see thanos_worker_groups)
+    },
+  ]
 }
 
 variable "eks_map_roles" {


### PR DESCRIPTION
Signed-off-by: Joary Paulo Wanzeler Fortuna <joarypl@fb.com>

## Summary

In terraform the [eks.worker_group](https://github.com/terraform-aws-modules/terraform-aws-eks#input_worker_groups) defines the size and amount of EC2 machines to be deployed in a given k8s cluster, orc8r by default uses 3 x t3.larget.
When deploying a blue-green orc8r setup a different set of machines is needed with more machines of smaller size 5 x t3.medium.

In order to maintain backwards compatibility it is proposed to have a flag indicating the a blue-green deployment is needed. Activation of this flag forces the usage of a different terraform variable pre-configured for blue-green deployment.

1. Include two new variables in orc8r-aws terraform configurations:
    1. Flag to enabled the blue-green deployment
    2. WorkerGroup configuration defaults for a blue-green deployment
1. Configure the EKS module to use blue-green WG values if `enable_orc8r_blue_green_deployment`is active


## Test Plan

With main.tf:

```
module "orc8r" {
   ...
   enable_orc8r_blue_green_deployment = true 
   ...
}
```

terraform plan shows:
```
  # module.orc8r.module.eks.aws_autoscaling_group.workers[0] will be created
  + resource "aws_autoscaling_group" "workers" {
      + arn                       = (known after apply)
      + availability_zones        = (known after apply)
      + default_cooldown          = (known after apply)
      + desired_capacity          = 5
      + force_delete              = false
      + force_delete_warm_pool    = false
      + health_check_grace_period = 300
      + health_check_type         = (known after apply)
      + id                        = (known after apply)
      + launch_configuration      = (known after apply)
      + max_instance_lifetime     = 0
      + max_size                  = 5
      + metrics_granularity       = "1Minute"
      + min_size                  = 1
      + name                      = (known after apply)
      + name_prefix               = "orc8r-wg-1"
      + protect_from_scale_in     = false
      + service_linked_role_arn   = (known after apply)
      + suspended_processes       = [
          + "AZRebalance",
        ]
      + termination_policies      = []
      + vpc_zone_identifier       = [
          + "subnet-0a59aa8e9d94571cd",
          + "subnet-0b488fb0d17e3b66f",
          + "subnet-0ea68e1c0df662ec2",
        ]
      + wait_for_capacity_timeout = "10m"

      + tag {
          + key                 = "Name"
          + propagate_at_launch = true
          + value               = "orc8r-wg-1-eks_asg"
        }
      + tag {
          + key                 = "k8s.io/cluster/orc8r"
          + propagate_at_launch = true
          + value               = "owned"
        }
      + tag {
          + key                 = "kubernetes.io/cluster/orc8r"
          + propagate_at_launch = true
          + value               = "owned"
        }
    }
```

With main.tf:

```
module "orc8r" {
   ...
   enable_orc8r_blue_green_deployment = false # Or not existing 
   ...
}
```

```
  # module.orc8r.module.eks.aws_autoscaling_group.workers[0] will be created
  + resource "aws_autoscaling_group" "workers" {
      + arn                       = (known after apply)
      + availability_zones        = (known after apply)
      + default_cooldown          = (known after apply)
      + desired_capacity          = 3
      + force_delete              = false
      + force_delete_warm_pool    = false
      + health_check_grace_period = 300
      + health_check_type         = (known after apply)
      + id                        = (known after apply)
      + launch_configuration      = (known after apply)
      + max_instance_lifetime     = 0
      + max_size                  = 3
      + metrics_granularity       = "1Minute"
      + min_size                  = 1
      + name                      = (known after apply)
      + name_prefix               = "orc8r-wg-1"
      + protect_from_scale_in     = false
      + service_linked_role_arn   = (known after apply)
      + suspended_processes       = [
          + "AZRebalance",
        ]
      + termination_policies      = []
      + vpc_zone_identifier       = [
          + "subnet-0a59aa8e9d94571cd",
          + "subnet-0b488fb0d17e3b66f",
          + "subnet-0ea68e1c0df662ec2",
        ]
      + wait_for_capacity_timeout = "10m"

      + tag {
          + key                 = "Name"
          + propagate_at_launch = true
          + value               = "orc8r-wg-1-eks_asg"
        }
      + tag {
          + key                 = "k8s.io/cluster/orc8r"
          + propagate_at_launch = true
          + value               = "owned"
        }
      + tag {
          + key                 = "kubernetes.io/cluster/orc8r"
          + propagate_at_launch = true
          + value               = "owned"
        }
    }
```


AWS EC2 instances after deployment with `enable_orc8r_blue_green_deployment` enabled (5x t3.medium)

![image](https://user-images.githubusercontent.com/1166157/141018931-ce8b7eee-c4ab-4021-bc25-498144409f47.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
