### PR TITLE
feat(orc8r): Include a configuration to deploy an additional namespce for staging orc8r

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/k8s.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/k8s.tf
@@ -17,6 +17,13 @@ resource "kubernetes_namespace" "orc8r" {
   }
 }
 
+resource "kubernetes_namespace" "staging-orc8r" {
+  count = var.orc8r_staging_namespace != "" ? 1 : 0
+  metadata {
+    name = var.orc8r_staging_namespace
+  }
+}
+
 resource "kubernetes_namespace" "monitoring" {
   metadata {
     name = var.monitoring_kubernetes_namespace

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -75,6 +75,12 @@ variable "monitoring_kubernetes_namespace" {
   default     = "monitoring"
 }
 
+variable "orc8r_staging_namespace" {
+  description = "K8s namespace to install staging Orchestrator components into."
+  type        = string
+  default     = ""
+}
+
 ##############################################################################
 # General Orchestrator configuration
 ##############################################################################


### PR DESCRIPTION



## Summary

1. Include a new variable to define the orc8r staging namespace (default empty)
2. Include a new resource creating the namespace when the variable is not empty

## Test Plan

If main.tf includes:

```
module "orc8r-app" {
  ...
  orc8r_staging_namespace = "orc8r-staging"
  ...
}
```

Terraform plan shows:

```
  # module.orc8r-app.kubernetes_namespace.staging-orc8r[0] will be created
  + resource "kubernetes_namespace" "staging-orc8r" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "orc8r-staging"
          + resource_version = (known after apply)
          + self_link        = (known after apply)
          + uid              = (known after apply)
        }
    }
```

After terraform apply the namespace can be seen:

```
# kubectl get namespace
NAME              STATUS   AGE
default           Active   6d
kube-node-lease   Active   6d
kube-public       Active   6d
kube-system       Active   6d
monitoring        Active   44m
orc8r             Active   44m
orc8r-staging     Active   6s
```

**Attention**

OBS1: In case the namespace variable is removed after apply. Terraform will delete the existing namespace and all the content deploied on it will be lost (Need to be very carefull with this.)

OBS1: In case the namespace variable is changed after apply. Terraform will delete the existing namespace and create a new one with the updated name. All the content in the previous namespace will be lost.



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
