### PR TITLE
fix(agw): Update default GW read timeout value on mobilityd

### DIFF
--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -199,7 +199,8 @@ def main():
             allocated_ip_blocks = ip_address_man.list_added_ip_blocks()
             if ipv4_block not in allocated_ip_blocks:
                 # Cleanup previously allocated IP blocks
-                ip_address_man.remove_ip_blocks(*allocated_ip_blocks, force=True)
+                ip_address_man.remove_ip_blocks(
+                    *allocated_ip_blocks, force=True)
                 ip_address_man.add_ip_block(ipv4_block)
         except OverlappedIPBlocksError:
             logging.warning("Overlapped IPv4 block: %s", ipv4_block)

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -57,7 +57,7 @@ class UplinkGatewayInfo:
         self._backing_map = gw_info_map
         self._read_default_gw_timer = None
         self._read_default_gw_timer6 = None
-        self._read_default_gw_interval_seconds = 20
+        self._read_default_gw_interval_seconds = 5
 
     def get_gw_ip(self, vlan_id: Optional[str] = "", version: int = IPAddress.IPV4) -> Optional[str]:
         """


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Updates timeout value of read default GW to 5
- Increases frequency of reads for faster mobilityd startup

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make integ_test
- make test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
