### PR TITLE
chore(ci): increase timeout for sessiond tests to 20 min

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -35,7 +35,9 @@ jobs:
         with:
           filters: |
             filesChanged:
-              - [".github/workflows/agw-workflow.yml", "orc8r/**", "lte/**"]
+              - '.github/workflows/agw-workflow.yml'
+              - 'orc8r/**'
+              - 'lte/**'
       - name: Save should_not_skip output
         if: always()
         run: |
@@ -467,7 +469,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run session_manager tests
-        timeout-minutes: 10
+        timeout-minutes: 20
         uses: addnab/docker-run-action@v2
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
this job seems to be always timing out: https://github.com/magma/magma/runs/4159354545?check_suite_focus=true
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
