### PR TITLE
docs(agw): add instructions for testing individual Python services

### DIFF
--- a/docs/readmes/lte/dev_unit_testing.md
+++ b/docs/readmes/lte/dev_unit_testing.md
@@ -42,6 +42,27 @@ The list of services to test are configured in the following files.
 - `orc8r/gateway/python/defs.mk`
 - `lte/gateway/python/defs.mk`
 
+To run unit tests for a single Python service, select a name of the list of services and run
+
+```bash
+[VM] cd magma/lte/gateway
+[VM] make test_python_service MAGMA_SERVICE=<service_name>
+```
+
+In the case that unit tests for a single Python service are started multiple times, it is preferable to avoid the upstream installation process of the virtual environment by adding `DONT_BUILD_ENV=1` to the command, run
+
+```bash
+[VM] cd magma/lte/gateway
+[VM] make test_python_service MAGMA_SERVICE=<service_name> DONT_BUILD_ENV=1
+```
+
+To run unit tests of an arbitrary directory, run
+
+```bash
+[VM] cd magma/lte/gateway
+[VM] make test_python_service UT_PATH=<path_of_the_test_folder>
+```
+
 ### Test C/C++ AGW services
 
 We have several C/C++ services that live in `lte/gateway/c/`.


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

The PR adds AGW test instructions to the documentation which describe how to execute unit tests for individual Python services, see https://github.com/magma/magma/pull/9876.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
