### PR TITLE
fix(agw): Update s1ap_utils restart_services cmd to exec_command

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -805,13 +805,14 @@ class MagmadUtil(object):
 
     def restart_services(self, services):
         """
-        Restart a list of magmad services.
+        Restart a list of magmad services. Blocking command.
 
         Args:
             services: List of (str) services names
 
         """
-        self._magmad_client.restart_services(services)
+        for s in services:
+            self.exec_command("sudo systemctl restart magma@{}".format(s))
 
     def enable_service(self, service):
         """


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <ardzoht@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- magmad `restart_services` async gRPC endpoint has been taking more time than usual, which affects s1ap test with service restarts as there's no definitive timeout period
- This PR updates `restart_services` function on s1ap_utils to instead use `exec_command` which will block until the service is effectively restarting

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- using restarts s1ap tests to verify there are no failures due to delayed service restart
- make integ_test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
