### PR TITLE
feat(orc8r): Support Minikube Orc8r with local container registry

### DIFF
--- a/docs/readmes/orc8r/dev_minikube.md
+++ b/docs/readmes/orc8r/dev_minikube.md
@@ -10,14 +10,6 @@ Deploying Orc8r on Minikube is the easiest way to test changes to the Helm chart
 
 ## Prerequisites
 
-### Build and publish images
-
-> NOTE: you can skip this step if you want to use the official container images at [artifactory.magmacore.org](https://artifactory.magmacore.org/).
-
-Follow the instructions at [Building Orchestrator](./dev_build.md#build-and-publish-container-images).
-
-In the end, your container images should be published to a registry.
-
 ### Spin up Minikube
 
 Set up Minikube with the following command, including sufficient resources and seeding the metrics config files
@@ -39,6 +31,22 @@ helm upgrade --install \
     postgresql \
     bitnami/postgresql
 ```
+
+### Build and publish images
+
+> NOTE: skip this step if you want to use the official container images at [artifactory.magmacore.org](https://artifactory.magmacore.org/).
+
+There are 2 ways you can publish your own images: to a private registry, or to a localhost registry. Choose an option, then complete the relevant prerequisites:
+
+1. Publish to private registry (specifically, we'll use [DockerHub](https://hub.docker.com/))
+   - `docker login`
+    - Use `registry.hub.docker.com/USERNAME` as your registry name
+2. Publish to localhost registry (specifically, we'll use the [local Docker registry via Minikube](https://minikube.sigs.k8s.io/docs/handbook/registry/#docker-on-macos))
+    - `minikube addons enable registry`
+    - `docker run --rm -it --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"`
+    - Use `localhost:5000` as your registry name
+
+After completing the prerequisites listed above, follow the instructions at [Building Orchestrator](./dev_build.md#build-and-publish-container-images) to publish container images to the chosen registry.
 
 ## Install
 
@@ -84,7 +92,7 @@ helm template orc8r charts/secrets \
 
 ### Create values file
 
-A minimal values file is at `${MAGMA_ROOT}/orc8r/cloud/helm/orc8r/examples/minikube_values.yml`
+A minimal values file is at `${MAGMA_ROOT}/orc8r/cloud/helm/orc8r/examples/minikube.values.yaml`
 
 - Copy that file to `${MAGMA_ROOT}/orc8r/cloud/helm/orc8r.values.yaml`
 - Replace `IMAGE_REGISTRY_URL` with your registry and `IMAGE_TAG` with your tag

--- a/orc8r/tools/docker/publish.sh
+++ b/orc8r/tools/docker/publish.sh
@@ -64,7 +64,9 @@ fi
 echo "Pushing docker images for ${PROJECT}... ${IMAGE}:${IMAGE_ID}"
 echo "Logging into the docker registry..."
 if [[ -z "${USERNAME}" ]]; then
-  docker login "${REGISTRY}"
+  echo ""
+  echo "> Ensure you have run: docker login '${REGISTRY}'"
+  echo ""
 else
   [[ -z "${USERNAME}" ]] || [[ -z "${PASSFILE}" ]] && usage
   docker login "${REGISTRY}" -u "${USERNAME}" --password-stdin < "${PASSFILE}"


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Previously, we required that Orc8r container images be uploaded to a non-local registry (generally DockerHub), then pulling those images back down to local when applying the Helm charts. This is painful and a terrible hit to validation cycle time.

Instead, Minikube supports using the local Docker daemon's registry as its source registry. This PR fixes a small blocker, and documents how to accomplish this.

## Test Plan

- Manual

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->