### PR TITLE
fix(amf): Unit test cases for PDUSession Establishment/Release

### DIFF
--- a/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
+++ b/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
@@ -257,6 +257,19 @@ void itti_free_msg_content(MessageDef* const message_p) {
     case AMF_APP_UPLINK_DATA_IND:
       bdestroy_wrapper(&message_p->ittiMsg.amf_app_ul_data_ind.nas_msg);
       break;
+    case NGAP_PDUSESSION_RESOURCE_SETUP_REQ: {
+      itti_ngap_pdusession_resource_setup_req_t* pdusession_resource_setup_req =
+          &NGAP_PDUSESSION_RESOURCE_SETUP_REQ(message_p);
+      Ngap_PDUSession_Resource_Setup_Request_List_t* resource_list =
+          &(pdusession_resource_setup_req->pduSessionResource_setup_list);
+      pdusession_setup_item_t* session_item = &(resource_list->item[0]);
+      pdu_session_resource_setup_request_transfer_t* session_transfer =
+          &(session_item->PDU_Session_Resource_Setup_Request_Transfer);
+      bdestroy_wrapper(&session_transfer->up_transport_layer_info.gtp_tnl
+                            .endpoint_ip_address);
+      bdestroy_wrapper(&pdusession_resource_setup_req->nas_pdu);
+      break;
+    }
 
     default:;
   }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.h
@@ -37,7 +37,7 @@ int amf_app_handle_nas_dl_req(
 int amf_app_handle_uplink_nas_message(
     amf_app_desc_t* amf_app_desc_p, bstring msg, amf_ue_ngap_id_t ue_id,
     const tai_t originating_tai);
-void amf_app_handle_pdu_session_response(
+int amf_app_handle_pdu_session_response(
     itti_n11_create_pdu_session_response_t* pdu_session_resp);
 int amf_app_handle_notification_received(
     itti_n11_received_notification_t* notification);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -617,13 +617,13 @@ int amf_app_handle_pdu_session_response(
       OAILOG_ERROR(
           LOG_AMF_APP, "pdu session  not found for session_id = %u\n",
           pdu_session_resp->pdu_session_id);
-      return rc;
+      return RETURNerror;
     }
     ue_id = ue_context->amf_ue_ngap_id;
   } else {
     OAILOG_ERROR(
         LOG_AMF_APP, "ue context not found for the imsi=%lu\n", imsi64);
-    return rc;
+    return RETURNerror;
   }
 
   get_ambr_unit(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -596,10 +596,9 @@ static void get_ambr_unit(
 /* Received the session created response message from SMF. Populate and Send
  * PDU Session Resource Setup Request message to gNB and  PDU Session
  * Establishment Accept Message to UE*/
-void amf_app_handle_pdu_session_response(
+int amf_app_handle_pdu_session_response(
     itti_n11_create_pdu_session_response_t* pdu_session_resp) {
   DLNASTransportMsg encode_msg;
-  int amf_rc = RETURNerror;
   ue_m5gmm_context_s* ue_context;
   std::shared_ptr<smf_context_t> smf_ctx;
   amf_smf_t amf_smf_msg;
@@ -618,13 +617,13 @@ void amf_app_handle_pdu_session_response(
       OAILOG_ERROR(
           LOG_AMF_APP, "pdu session  not found for session_id = %u\n",
           pdu_session_resp->pdu_session_id);
-      return;
+      return rc;
     }
     ue_id = ue_context->amf_ue_ngap_id;
   } else {
     OAILOG_ERROR(
         LOG_AMF_APP, "ue context not found for the imsi=%lu\n", imsi64);
-    return;
+    return rc;
   }
 
   get_ambr_unit(
@@ -685,7 +684,10 @@ void amf_app_handle_pdu_session_response(
         REGISTERED_CONNECTED, STATE_PDU_SESSION_ESTABLISHMENT_ACCEPT,
         // smf_ctx->pdu_session_state, ue_context, amf_smf_msg, NULL,
         CREATING, ue_context, amf_smf_msg, NULL, pdu_session_resp, ue_id);
+    rc = RETURNok;
   }
+
+  return rc;
 }
 
 /****************************************************************************

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
@@ -131,8 +131,8 @@ int pdu_session_resource_setup_request(
   /* preparing for PDU_Session_Resource_Setup_Transfer.
    * amf_pdu_ses_setup_transfer_req is the structure to be filled.
    */
-  amf_pdu_ses_setup_transfer_req.pdu_aggregate_max_bit_rate.dl = dl_pdu_ambr;
-  amf_pdu_ses_setup_transfer_req.pdu_aggregate_max_bit_rate.ul = ul_pdu_ambr;
+  amf_pdu_ses_setup_transfer_req->pdu_aggregate_max_bit_rate.dl = dl_pdu_ambr;
+  amf_pdu_ses_setup_transfer_req->pdu_aggregate_max_bit_rate.ul = ul_pdu_ambr;
 
   // UPF teid 4 octet and respective ip address are from SMF context
   memcpy(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
@@ -86,7 +86,8 @@ void ambr_calculation_pdu_session(
 int pdu_session_resource_setup_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
     std::shared_ptr<smf_context_t> smf_context, bstring nas_msg) {
-  pdu_session_resource_setup_request_transfer_t amf_pdu_ses_setup_transfer_req;
+  pdu_session_resource_setup_request_transfer_t*
+      amf_pdu_ses_setup_transfer_req                                = nullptr;
   itti_ngap_pdusession_resource_setup_req_t* ngap_pdu_ses_setup_req = nullptr;
   MessageDef* message_p                                             = nullptr;
   uint64_t dl_pdu_ambr;
@@ -121,6 +122,12 @@ int pdu_session_resource_setup_request(
       (Ngap_PDUSessionID_t)
           smf_context->smf_proc_data.pdu_session_identity.pdu_session_id;
 
+  ngap_pdu_ses_setup_req->pduSessionResource_setup_list.no_of_items = 1;
+  // Adding respective header to amf_pdu_ses_setup_transfer_request
+  amf_pdu_ses_setup_transfer_req =
+      &ngap_pdu_ses_setup_req->pduSessionResource_setup_list.item[0]
+           .PDU_Session_Resource_Setup_Request_Transfer;
+
   /* preparing for PDU_Session_Resource_Setup_Transfer.
    * amf_pdu_ses_setup_transfer_req is the structure to be filled.
    */
@@ -129,24 +136,20 @@ int pdu_session_resource_setup_request(
 
   // UPF teid 4 octet and respective ip address are from SMF context
   memcpy(
-      &amf_pdu_ses_setup_transfer_req.up_transport_layer_info.gtp_tnl.gtp_tied,
+      &amf_pdu_ses_setup_transfer_req->up_transport_layer_info.gtp_tnl.gtp_tied,
       smf_context->gtp_tunnel_id.upf_gtp_teid, GNB_TEID_LEN);
-  amf_pdu_ses_setup_transfer_req.up_transport_layer_info.gtp_tnl
+  amf_pdu_ses_setup_transfer_req->up_transport_layer_info.gtp_tnl
       .endpoint_ip_address = blk2bstr(
       &smf_context->gtp_tunnel_id.upf_gtp_teid_ip_addr, GNB_IPV4_ADDR_LEN);
-  amf_pdu_ses_setup_transfer_req.pdu_ip_type.pdn_type = IPv4;
+  amf_pdu_ses_setup_transfer_req->pdu_ip_type.pdn_type = IPv4;
 
   memcpy(
-      &amf_pdu_ses_setup_transfer_req.qos_flow_setup_request_list
+      &amf_pdu_ses_setup_transfer_req->qos_flow_setup_request_list
            .qos_flow_req_item,
       &smf_context->pdu_resource_setup_req
            .pdu_session_resource_setup_request_transfer
            .qos_flow_setup_request_list.qos_flow_req_item,
       sizeof(qos_flow_setup_request_item));
-  // Adding respective header to amf_pdu_ses_setup_transfer_request
-  ngap_pdu_ses_setup_req->pduSessionResource_setup_list.item[0]
-      .PDU_Session_Resource_Setup_Request_Transfer =
-      amf_pdu_ses_setup_transfer_req;
 
   ngap_pdu_ses_setup_req->nas_pdu = nas_msg;
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -15,7 +15,6 @@
 #include "M5GAuthenticationServiceClient.h"
 #include "amf_common.h"
 #include <memory>
-#include "lte/gateway/c/core/oai/lib/mobility_client/MobilityServiceClient.h"
 #include "lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.h"
 #include "lte/gateway/c/core/oai/lib/n11/SmfServiceClient.h"
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -15,6 +15,9 @@
 #include "M5GAuthenticationServiceClient.h"
 #include "amf_common.h"
 #include <memory>
+#include "lte/gateway/c/core/oai/lib/mobility_client/MobilityServiceClient.h"
+#include "lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.h"
+#include "lte/gateway/c/core/oai/lib/n11/SmfServiceClient.h"
 
 using magma5g::AsyncM5GAuthenticationServiceClient;
 
@@ -40,6 +43,36 @@ bool AMFClientServicerBase::get_subs_auth_info_resync(
       AsyncM5GAuthenticationServiceClient::getInstance()
           .get_subs_auth_info_resync(
               imsi, imsi_length, snni, resync_info, resync_info_len, ue_id));
+}
+
+int AMFClientServicerBase::allocate_ipv4_address(
+    const char* subscriber_id, const char* apn, uint32_t pdu_session_id,
+    uint8_t pti, uint32_t pdu_session_type, uint32_t gnb_gtp_teid,
+    uint8_t* gnb_gtp_teid_ip_addr, uint8_t gnb_gtp_teid_ip_addr_len,
+    const ambr_t& subscribed_ue_ambr) {
+  return AsyncM5GMobilityServiceClient::getInstance().allocate_ipv4_address(
+      subscriber_id, apn, pdu_session_id, pti, AF_INET, gnb_gtp_teid,
+      gnb_gtp_teid_ip_addr, gnb_gtp_teid_ip_addr_len, subscribed_ue_ambr);
+}
+
+int AMFClientServicerBase::release_ipv4_address(
+    const char* subscriber_id, const char* apn, const struct in_addr* addr) {
+  return AsyncM5GMobilityServiceClient::getInstance().release_ipv4_address(
+      subscriber_id, apn, addr);
+}
+
+int AMFClientServicerBase::amf_smf_create_pdu_session_ipv4(
+    char* imsi, uint8_t* apn, uint32_t pdu_session_id,
+    uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
+    uint8_t* gnb_gtp_teid_ip_addr, char* ipv4_addr, uint32_t version,
+    const ambr_t& state_ambr) {
+  return AsyncSmfServiceClient::getInstance().amf_smf_create_pdu_session_ipv4(
+      imsi, apn, pdu_session_id, pdu_session_type, gnb_gtp_teid, pti,
+      gnb_gtp_teid_ip_addr, ipv4_addr, version, state_ambr);
+}
+
+bool AMFClientServicerBase::set_smf_session(SetSMSessionContext& request) {
+  return AsyncSmfServiceClient::getInstance().set_smf_session(request);
 }
 
 AMFClientServicer& AMFClientServicer::getInstance() {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -447,6 +447,7 @@ void clear_amf_config(amf_config_t* amf_config) {
   bdestroy_wrapper(&amf_config->short_network_name);
   bdestroy_wrapper(&amf_config->ip_capability);
   bdestroy_wrapper(&amf_config->amf_name);
+  bdestroy_wrapper(&amf_config->default_dnn);
   clear_served_tai_config(&amf_config->served_tai);
   free_partial_lists(amf_config->partial_list, amf_config->num_par_lists);
   amf_config->num_par_lists = 0;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -489,7 +489,8 @@ int amf_smf_process_pdu_session_packet(
         ue_sent_dnn = false;
         dnn_string  = default_dnn;
       } else {
-        dnn_string.copy((char*) msg->dnn.dnn, msg->dnn.len - 1);
+        dnn_string.assign(
+            reinterpret_cast<char*>(msg->dnn.dnn), msg->dnn.len - 1);
       }
 
       int validate = amf_validate_dnn(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -38,6 +38,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_defs.h"
 #include "lte/gateway/c/core/oai/tasks/amf/include/amf_smf_packet_handler.h"
+#include "lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h"
 
 using magma5g::AsyncM5GMobilityServiceClient;
 using magma5g::AsyncSmfServiceClient;
@@ -268,7 +269,7 @@ int pdu_session_resource_release_complete(
 
   if (smf_ctx->pdu_address.pdn_type == IPv4) {
     // Clean up the Mobility IP Address
-    AsyncM5GMobilityServiceClient::getInstance().release_ipv4_address(
+    AMFClientServicer::getInstance().release_ipv4_address(
         imsi, reinterpret_cast<const char*>(smf_ctx->apn),
         &(smf_ctx->pdu_address.ipv4_address));
   }
@@ -484,11 +485,11 @@ int amf_smf_process_pdu_session_packet(
       bool ue_sent_dnn = true;
       std::string dnn_string;
 
-      if (msg->dnn.dnn.empty()) {
+      if (msg->dnn.len <= 0) {
         ue_sent_dnn = false;
         dnn_string  = default_dnn;
       } else {
-        dnn_string = msg->dnn.dnn;
+        dnn_string.copy((char*) msg->dnn.dnn, msg->dnn.len - 1);
       }
 
       int validate = amf_validate_dnn(
@@ -509,7 +510,8 @@ int amf_smf_process_pdu_session_packet(
       } else {
         OAILOG_INFO(
             LOG_AMF_APP,
-            "DNN mismatch or DNN missing, reject with a cause: 91 \n");
+            "DNN is not Supported or not Subscribed, reject with a cause: 91 "
+            "\n");
         M5GMmCause cause_dnn_reject =
             M5GMmCause::DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED;
         rc = handle_sm_message_routing_failure(ue_id, msg, cause_dnn_reject);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -586,7 +586,7 @@ M5GSmCause amf_smf_get_smcause(amf_ue_ngap_id_t ue_id, ULNASTransportMsg* msg) {
   the external DNN because the DNN was not included
   although required or if the DNN could not be resolved.
   */
-  if (msg->dnn.dnn.empty() &&
+  if (msg->dnn.len == 0 &&
       (ue_context->amf_context.apn_config_profile.nb_apns == 0)) {
     cause = M5GSmCause::MISSING_OR_UNKNOWN_DNN;
     return cause;
@@ -680,7 +680,7 @@ int amf_validate_dnn(
   if (dnn_string.empty()) {
     return RETURNok;
   }
-  for (int i = 0; i < MAX_APN_PER_UE; i++) {
+  for (uint8_t i = 0; i < amf_ctxt_p->apn_config_profile.nb_apns; i++) {
     if (strcmp(
             amf_ctxt_p->apn_config_profile.apn_configuration[i]
                 .service_selection,

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -84,31 +84,11 @@ class AMFClientServicer : public AMFClientServicerBase {
       task_zmq_ctx_t* task_zmq_ctx_p, task_id_t destination_task_id,
       MessageDef* message_p) override {
     OAILOG_DEBUG(LOG_AMF_APP, " Mock is Enabled \n");
-    status_code_e rc = RETURNerror;
-    switch (ITTI_MSG_ID(message_p)) {
-      case NGAP_PDUSESSION_RESOURCE_SETUP_REQ: {
-        itti_ngap_pdusession_resource_setup_req_t*
-            pdusession_resource_setup_req =
-                &NGAP_PDUSESSION_RESOURCE_SETUP_REQ(message_p);
-        Ngap_PDUSession_Resource_Setup_Request_List_t* resource_list =
-            &(pdusession_resource_setup_req->pduSessionResource_setup_list);
-        pdusession_setup_item_t* session_item = &(resource_list->item[0]);
-        pdu_session_resource_setup_request_transfer_t* session_transfer =
-            &(session_item->PDU_Session_Resource_Setup_Request_Transfer);
-        bdestroy(session_transfer->up_transport_layer_info.gtp_tnl
-                     .endpoint_ip_address);
-        bdestroy(pdusession_resource_setup_req->nas_pdu);
-        rc = RETURNok;
-        break;
-      }
-      default: { break; }
-    }
-
+    status_code_e rc = RETURNok;
     itti_free_msg_content(message_p);
     free(message_p);
     return rc;
   }
-
   bool get_subs_auth_info(
       const std::string& imsi, uint8_t imsi_length, const char* snni,
       amf_ue_ngap_id_t ue_id) override {

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -24,10 +24,11 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
 #include <memory>
 #include <string>
-#include <lte/protos/session_manager.grpc.pb.h>
-#include <lte/protos/session_manager.pb.h>
+#include "lte/protos/session_manager.grpc.pb.h"
+#include "lte/protos/session_manager.pb.h"
 
 using grpc::Status;
 using magma::lte::SetSmNotificationContext;
@@ -84,10 +85,9 @@ class AMFClientServicer : public AMFClientServicerBase {
       task_zmq_ctx_t* task_zmq_ctx_p, task_id_t destination_task_id,
       MessageDef* message_p) override {
     OAILOG_DEBUG(LOG_AMF_APP, " Mock is Enabled \n");
-    status_code_e rc = RETURNok;
     itti_free_msg_content(message_p);
     free(message_p);
-    return rc;
+    return RETURNok;
   }
   bool get_subs_auth_info(
       const std::string& imsi, uint8_t imsi_length, const char* snni,

--- a/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
@@ -33,6 +33,7 @@ extern "C" {
 #include "lte/protos/session_manager.pb.h"
 #include "lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h"
+#include "include/amf_client_servicer.h"
 
 #define VERSION_0 0
 
@@ -92,7 +93,11 @@ int create_session_grpc_req_on_gnb_setup_rsp(
   OAILOG_DEBUG(
       LOG_AMF_APP, "Sending PDU session Establishment 2nd Request to SMF");
 
-  AsyncSmfServiceClient::getInstance().set_smf_session(req);
+  OAILOG_INFO(
+      LOG_AMF_APP, "Sending msg(grpc) to :[sessiond] for ue: [%s] session\n",
+      imsi);
+
+  AMFClientServicer::getInstance().set_smf_session(req);
 
   return rc;
 }
@@ -129,7 +134,7 @@ int amf_smf_create_ipv4_session_grpc_req(
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
 
-  return AsyncSmfServiceClient::getInstance().amf_smf_create_pdu_session_ipv4(
+  return AMFClientServicer::getInstance().amf_smf_create_pdu_session_ipv4(
       imsi, apn, pdu_session_id, pdu_session_type, gnb_gtp_teid, pti,
       gnb_gtp_teid_ip_addr, ipv4_addr, VERSION_0, state_ambr);
 }
@@ -149,10 +154,6 @@ int amf_smf_create_pdu_session(
   ue_m5gmm_context_s* ue_mm_context = NULL;
   std::shared_ptr<smf_context_t> smf_ctx;
 
-  OAILOG_INFO(
-      LOG_AMF_APP, "Sending msg(grpc) to :[sessiond] for ue: [%s] session\n",
-      imsi);
-
   IMSI_STRING_TO_IMSI64((char*) imsi, &imsi64);
   ue_mm_context = lookup_ue_ctxt_by_imsi(imsi64);
   smf_ctx       = amf_get_smf_context_by_pdu_session_id(
@@ -170,7 +171,7 @@ int amf_smf_create_pdu_session(
   OAILOG_INFO(
       LOG_AMF_APP, "Sending msg(grpc) to :[mobilityd] for ue: [%s] ip-addr\n",
       imsi);
-  AsyncM5GMobilityServiceClient::getInstance().allocate_ipv4_address(
+  AMFClientServicer::getInstance().allocate_ipv4_address(
       imsi, reinterpret_cast<char*>(smf_ctx->apn), message->pdu_session_id,
       message->pti, AF_INET, message->gnb_gtp_teid,
       message->gnb_gtp_teid_ip_addr, 4, amf_ctxt_p->subscribed_ue_ambr);
@@ -200,7 +201,11 @@ int release_session_gprc_req(amf_smf_release_t* message, char* imsi) {
   req_rat_specific->set_procedure_trans_identity(
       (const char*) (&(message->pti)));
 
-  AsyncSmfServiceClient::getInstance().set_smf_session(req);
+  OAILOG_INFO(
+      LOG_AMF_APP,
+      "Sending msg(grpc) to :[sessiond] for ue: [%s] release session\n", imsi);
+
+  AMFClientServicer::getInstance().set_smf_session(req);
 
   return RETURNok;
 }

--- a/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
@@ -94,8 +94,7 @@ int create_session_grpc_req_on_gnb_setup_rsp(
       LOG_AMF_APP, "Sending PDU session Establishment 2nd Request to SMF");
 
   OAILOG_INFO(
-      LOG_AMF_APP, "Sending msg(grpc) to :[sessiond] for ue: [%s] session\n",
-      imsi);
+      LOG_AMF_APP, "Sending msg(grpc) to :[sessiond] for ue: [%s]\n", imsi);
 
   AMFClientServicer::getInstance().set_smf_session(req);
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GDNN.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GDNN.h
@@ -19,9 +19,10 @@ namespace magma5g {
 class DNNMsg {
  public:
 #define DNN_MIN_LENGTH 3
+#define MAX_DNN_LENGTH 102
   uint8_t iei;
   uint8_t len;
-  std::string dnn;
+  uint8_t dnn[MAX_DNN_LENGTH];
 
   DNNMsg();
   ~DNNMsg();

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GDNN.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GDNN.cpp
@@ -43,11 +43,7 @@ int DNNMsg::DecodeDNNMsg(
   DECODE_U8(buffer + decoded, dnn_len, decoded);
   MLOG(MDEBUG) << "dnn_len : " << static_cast<int>(dnn_len);
 
-  MLOG(MDEBUG) << std::string(
-      (const char*) (buffer + decoded), static_cast<int>(dnn_len));
-  dnn_message->dnn =
-      std::string((const char*) (buffer + decoded), static_cast<int>(dnn_len))
-          .c_str();
+  memcpy(dnn_message->dnn, buffer + decoded, dnn_len);
 
   decoded = decoded + dnn_len;
   MLOG(MDEBUG) << "dnn str : " << dnn_message->dnn;
@@ -73,13 +69,13 @@ int DNNMsg::EncodeDNNMsg(
   ENCODE_U8(buffer + encoded, dnn_message->len, encoded);
   MLOG(MDEBUG) << "len : " << static_cast<int>(dnn_message->len);
 
-  ENCODE_U8(buffer + encoded, dnn_message->dnn.length(), encoded);
-  MLOG(MDEBUG) << "dnn len : " << dnn_message->dnn.length();
+  ENCODE_U8(buffer + encoded, dnn_message->len - 1, encoded);
+  MLOG(MDEBUG) << "dnn len : " << dnn_message->len - 1;
 
-  std::copy(dnn_message->dnn.begin(), dnn_message->dnn.end(), buffer + encoded);
-  BUFFER_PRINT_LOG(buffer + encoded, dnn_message->dnn.length());
+  memcpy(buffer + encoded, dnn_message->dnn, dnn_message->len - 1);
+  BUFFER_PRINT_LOG(buffer + encoded, dnn_message->len - 1);
   MLOG(MDEBUG) << "dnn str : " << dnn_message->dnn;
-  encoded = encoded + dnn_message->dnn.length();
+  encoded = encoded + dnn_message->len - 1;
 
   return encoded;
 };

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -1083,8 +1083,8 @@ int ngap_fill_pdu_session_resource_setup_request_transfer(
       session_transfer->up_transport_layer_info.gtp_tnl.endpoint_ip_address
           ->data,
       gtp_tunnel_info->transportLayerAddress.size);
-  bdestroy(
-      session_transfer->up_transport_layer_info.gtp_tnl.endpoint_ip_address);
+  bdestroy_wrapper(
+      &session_transfer->up_transport_layer_info.gtp_tnl.endpoint_ip_address);
 
   /* TEID Information */
   gtp_tunnel_info->gTP_TEID.size = sizeof(uint32_t);

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -171,7 +171,7 @@ int send_uplink_nas_pdu_session_establishment_request(
   bstring pdu_session_est_req;
   tai_t originating_tai = {};
 
-  if ((!amf_app_desc_p) || (!nas_msg) || (0 == nas_msg_length)) {
+  if ((!amf_app_desc_p) || (!nas_msg) || (nas_msg_length == 0)) {
     return RETURNerror;
   }
 
@@ -185,7 +185,7 @@ int send_uplink_nas_pdu_session_establishment_request(
   rc     = amf_app_handle_uplink_nas_message(
       amf_app_desc_p, pdu_session_est_req, ue_id, originating_tai);
 
-  return (rc);
+  return rc;
 }
 
 void create_ip_address_response_itti(
@@ -212,7 +212,7 @@ void create_ip_address_response_itti(
   response.result           = 0;
 }
 
-int send_ip_address_response_grpc() {
+int send_ip_address_response_itti() {
   int rc = RETURNerror;
 
   itti_amf_ip_allocation_response_t response = {};
@@ -263,7 +263,7 @@ void create_pdu_session_response_ipv4_itti(
       AF_INET, "192.168.128.200", response.pdu_address.redirect_server_address);
 }
 
-int send_pdu_session_response_grpc() {
+int send_pdu_session_response_itti() {
   int rc                                          = RETURNerror;
   itti_n11_create_pdu_session_response_t response = {};
   create_pdu_session_response_ipv4_itti(response);

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -160,7 +160,7 @@ int send_uplink_nas_registration_complete(
   return (rc);
 }
 
-/* Create pdu session establishment  request from ue */
+/* Create pdu session establishment request from ue */
 int send_uplink_nas_pdu_session_establishment_request(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
     const uint8_t* nas_msg, uint8_t nas_msg_length) {
@@ -178,6 +178,7 @@ int send_uplink_nas_pdu_session_establishment_request(
 
   ue_m5gmm_context_s* ue_context_p =
       amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+
   if (!ue_context_p) {
     return RETURNerror;
   }
@@ -345,25 +346,25 @@ int send_pdu_notification_response() {
   return rc;
 }
 
-/* Create pdu session release  request from ue */
-int send_uplink_nas_pdu_session_release_request(
+/* Create pdu session release message from ue */
+int send_uplink_nas_pdu_session_release_message(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
     const uint8_t* nas_msg, uint8_t nas_msg_length) {
-  bstring pdu_session_est_req;
+  bstring pdu_session_req;
   tai_t originating_tai = {};
 
   if ((!amf_app_desc_p) || (!nas_msg) || (nas_msg_length == 0)) {
     return RETURNerror;
   }
 
-  pdu_session_est_req = blk2bstr(nas_msg, nas_msg_length);
+  pdu_session_req = blk2bstr(nas_msg, nas_msg_length);
 
   originating_tai.plmn = plmn;
   originating_tai.tac  = 1;
 
   int rc     = RETURNerror;
   int status = amf_app_handle_uplink_nas_message(
-      amf_app_desc_p, pdu_session_est_req, ue_id, originating_tai);
+      amf_app_desc_p, pdu_session_req, ue_id, originating_tai);
 
   if (status > 0) {
     rc = RETURNok;

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -189,34 +189,35 @@ int send_uplink_nas_pdu_session_establishment_request(
 }
 
 void create_ip_address_response_itti(
-    itti_amf_ip_allocation_response_t& response) {
+    itti_amf_ip_allocation_response_t* response) {
+  if (!response) return;
   std::string apn = "internet";
-  std::copy(apn.begin(), apn.end(), std::begin(response.apn));
-  response.default_ambr.br_unit    = BPS;
-  response.default_ambr.br_dl      = 200000000;
-  response.default_ambr.br_ul      = 100000000;
-  response.gnb_gtp_teid            = 0;
-  response.gnb_gtp_teid_ip_addr[0] = 0xc0;
-  response.gnb_gtp_teid_ip_addr[1] = 0xa8;
-  response.gnb_gtp_teid_ip_addr[2] = 0x3c;
-  response.gnb_gtp_teid_ip_addr[3] = 0x96;
-  std::string imsi                 = "222456000000001";
-  std::copy(imsi.begin(), imsi.end(), std::begin(response.imsi));
-  response.imsi_length  = 15;
-  response.paa.pdn_type = IPv4;
-  inet_pton(AF_INET, "192.168.128.254", &(response.paa.ipv4_address));
-  response.paa.vlan         = 1;
-  response.pdu_session_id   = 1;
-  response.pdu_session_type = IPv4;
-  response.pti              = 0x01;
-  response.result           = 0;
+  std::copy(apn.begin(), apn.end(), std::begin(response->apn));
+  response->default_ambr.br_unit    = BPS;
+  response->default_ambr.br_dl      = 200000000;
+  response->default_ambr.br_ul      = 100000000;
+  response->gnb_gtp_teid            = 0;
+  response->gnb_gtp_teid_ip_addr[0] = 0xc0;
+  response->gnb_gtp_teid_ip_addr[1] = 0xa8;
+  response->gnb_gtp_teid_ip_addr[2] = 0x3c;
+  response->gnb_gtp_teid_ip_addr[3] = 0x96;
+  std::string imsi                  = "222456000000001";
+  std::copy(imsi.begin(), imsi.end(), std::begin(response->imsi));
+  response->imsi_length  = 15;
+  response->paa.pdn_type = IPv4;
+  inet_pton(AF_INET, "192.168.128.254", &(response->paa.ipv4_address));
+  response->paa.vlan         = 1;
+  response->pdu_session_id   = 1;
+  response->pdu_session_type = IPv4;
+  response->pti              = 0x01;
+  response->result           = 0;
 }
 
 int send_ip_address_response_itti() {
   int rc = RETURNerror;
 
   itti_amf_ip_allocation_response_t response = {};
-  create_ip_address_response_itti(response);
+  create_ip_address_response_itti(&response);
 
   rc = amf_smf_handle_ip_address_response(&response);
 
@@ -224,49 +225,51 @@ int send_ip_address_response_itti() {
 }
 
 void create_pdu_session_response_ipv4_itti(
-    itti_n11_create_pdu_session_response_t& response) {
+    itti_n11_create_pdu_session_response_t* response) {
+  if (!response) return;
   std::string imsi = "222456000000001";
-  std::copy(imsi.begin(), imsi.end(), std::begin(response.imsi));
+  std::copy(imsi.begin(), imsi.end(), std::begin(response->imsi));
 
-  response.sm_session_fsm_state = sm_session_fsm_state_t::CREATING;
-  response.sm_session_version   = 0;
-  response.pdu_session_id       = 1;
-  response.pdu_session_type     = IPV4;
-  response.selected_ssc_mode    = SSC_MODE_3;
-  response.m5gsm_cause          = M5GSM_OPERATION_SUCCESS;
+  response->sm_session_fsm_state = sm_session_fsm_state_t::CREATING;
+  response->sm_session_version   = 0;
+  response->pdu_session_id       = 1;
+  response->pdu_session_type     = IPV4;
+  response->selected_ssc_mode    = SSC_MODE_3;
+  response->m5gsm_cause          = M5GSM_OPERATION_SUCCESS;
 
-  response.session_ambr.uplink_unit_type   = 0;
-  response.session_ambr.uplink_units       = 100000000;
-  response.session_ambr.downlink_unit_type = 0;
-  response.session_ambr.downlink_units     = 100000000;
+  response->session_ambr.uplink_unit_type   = 0;
+  response->session_ambr.uplink_units       = 100000000;
+  response->session_ambr.downlink_unit_type = 0;
+  response->session_ambr.downlink_units     = 100000000;
 
-  response.qos_list.qos_flow_req_item.qos_flow_identifier = 9;
-  response.qos_list.qos_flow_req_item.qos_flow_level_qos_param
+  response->qos_list.qos_flow_req_item.qos_flow_identifier = 9;
+  response->qos_list.qos_flow_req_item.qos_flow_level_qos_param
       .qos_characteristic.non_dynamic_5QI_desc.fiveQI = 9;
-  response.qos_list.qos_flow_req_item.qos_flow_level_qos_param
+  response->qos_list.qos_flow_req_item.qos_flow_level_qos_param
       .alloc_reten_priority.priority_level = 1;
-  response.qos_list.qos_flow_req_item.qos_flow_level_qos_param
+  response->qos_list.qos_flow_req_item.qos_flow_level_qos_param
       .alloc_reten_priority.pre_emption_cap = SHALL_NOT_TRIGGER_PRE_EMPTION;
-  response.qos_list.qos_flow_req_item.qos_flow_level_qos_param
+  response->qos_list.qos_flow_req_item.qos_flow_level_qos_param
       .alloc_reten_priority.pre_emption_vul = NOT_PREEMPTABLE;
-  response.upf_endpoint.teid[0]             = 0x7f;
-  response.upf_endpoint.teid[1]             = 0xff;
-  response.upf_endpoint.teid[2]             = 0xff;
-  response.upf_endpoint.teid[3]             = 0xff;
-  inet_pton(AF_INET, "192.168.128.200", response.upf_endpoint.end_ipv4_addr);
+  response->upf_endpoint.teid[0]            = 0x7f;
+  response->upf_endpoint.teid[1]            = 0xff;
+  response->upf_endpoint.teid[2]            = 0xff;
+  response->upf_endpoint.teid[3]            = 0xff;
+  inet_pton(AF_INET, "192.168.128.200", response->upf_endpoint.end_ipv4_addr);
 
-  response.always_on_pdu_session_indication     = false;
-  response.allowed_ssc_mode                     = SSC_MODE_3;
-  response.m5gsm_congetion_re_attempt_indicator = true;
-  response.pdu_address.redirect_address_type    = IPV4_1;
+  response->always_on_pdu_session_indication     = false;
+  response->allowed_ssc_mode                     = SSC_MODE_3;
+  response->m5gsm_congetion_re_attempt_indicator = true;
+  response->pdu_address.redirect_address_type    = IPV4_1;
   inet_pton(
-      AF_INET, "192.168.128.200", response.pdu_address.redirect_server_address);
+      AF_INET, "192.168.128.200",
+      response->pdu_address.redirect_server_address);
 }
 
 int send_pdu_session_response_itti() {
   int rc                                          = RETURNerror;
   itti_n11_create_pdu_session_response_t response = {};
-  create_pdu_session_response_ipv4_itti(response);
+  create_pdu_session_response_ipv4_itti(&response);
 
   imsi64_t imsi64;
   IMSI_STRING_TO_IMSI64(response.imsi, &imsi64);
@@ -283,14 +286,15 @@ int send_pdu_session_response_itti() {
 }
 
 void create_pdu_resource_setup_response_itti(
-    itti_ngap_pdusessionresource_setup_rsp_t& response,
+    itti_ngap_pdusessionresource_setup_rsp_t* response,
     amf_ue_ngap_id_t ue_id) {
-  response.amf_ue_ngap_id                                       = ue_id;
-  response.gnb_ue_ngap_id                                       = 1;
-  response.pduSessionResource_setup_list.item[0].Pdu_Session_ID = 1;
-  response.pduSessionResource_setup_list.no_of_items            = 1;
+  if (!response) return;
+  response->amf_ue_ngap_id                                       = ue_id;
+  response->gnb_ue_ngap_id                                       = 1;
+  response->pduSessionResource_setup_list.item[0].Pdu_Session_ID = 1;
+  response->pduSessionResource_setup_list.no_of_items            = 1;
   response_gtp_tunnel_t* tunnel =
-      &response.pduSessionResource_setup_list.item[0]
+      &response->pduSessionResource_setup_list.item[0]
            .PDU_Session_Resource_Setup_Response_Transfer.tunnel;
   tunnel->gTP_TEID[0] = 0x0;
   tunnel->gTP_TEID[1] = 0x0;
@@ -303,7 +307,7 @@ void create_pdu_resource_setup_response_itti(
   tunnel->transportLayerAddress[3] = 0x96;
 
   AssociatedQosFlowList_t* qosFlow =
-      &response.pduSessionResource_setup_list.item[0]
+      &response->pduSessionResource_setup_list.item[0]
            .PDU_Session_Resource_Setup_Response_Transfer.associatedQosFlowList;
   qosFlow->items                = 1;
   qosFlow->QosFlowIdentifier[0] = 9;
@@ -311,7 +315,7 @@ void create_pdu_resource_setup_response_itti(
 int send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id) {
   int rc                                            = RETURNok;
   itti_ngap_pdusessionresource_setup_rsp_t response = {};
-  create_pdu_resource_setup_response_itti(response, ue_id);
+  create_pdu_resource_setup_response_itti(&response, ue_id);
 
   amf_app_handle_resource_setup_response(response);
 
@@ -319,24 +323,25 @@ int send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id) {
 }
 
 void create_pdu_notification_response_itti(
-    itti_n11_received_notification_t& response) {
+    itti_n11_received_notification_t* response) {
+  if (!response) return;
   std::string imsi = "222456000000001";
-  std::copy(imsi.begin(), imsi.end(), std::begin(response.imsi));
-  response.sm_session_fsm_state = CREATING_0;
-  response.sm_session_version   = 0;
-  response.pdu_session_id       = 1;
-  response.request_type         = EXISTING_PDU_SESSION;
-  response.m5g_sm_capability.multi_homed_ipv6_pdu_session = false;
-  response.m5g_sm_capability.reflective_qos               = false;
-  response.m5gsm_cause      = M5GSM_OPERATION_SUCCESS;
-  response.pdu_session_type = IPV4;
-  response.notify_ue_evnt   = PDU_SESSION_STATE_NOTIFY;
+  std::copy(imsi.begin(), imsi.end(), std::begin(response->imsi));
+  response->sm_session_fsm_state = CREATING_0;
+  response->sm_session_version   = 0;
+  response->pdu_session_id       = 1;
+  response->request_type         = EXISTING_PDU_SESSION;
+  response->m5g_sm_capability.multi_homed_ipv6_pdu_session = false;
+  response->m5g_sm_capability.reflective_qos               = false;
+  response->m5gsm_cause      = M5GSM_OPERATION_SUCCESS;
+  response->pdu_session_type = IPV4;
+  response->notify_ue_evnt   = PDU_SESSION_STATE_NOTIFY;
 }
 
 int send_pdu_notification_response() {
   int rc                                    = RETURNerror;
   itti_n11_received_notification_t response = {};
-  create_pdu_notification_response_itti(response);
+  create_pdu_notification_response_itti(&response);
 
   rc = amf_app_handle_notification_received(&response);
 

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 #include "lte/gateway/c/core/oai/test/amf/amf_app_test_util.h"
-
+#include "lte/gateway/c/core/oai/common/conversions.h"
 #include <gtest/gtest.h>
 
 namespace magma5g {
@@ -161,6 +161,212 @@ int send_uplink_nas_registration_complete(
   rc     = amf_app_handle_uplink_nas_message(
       amf_app_desc_p, ue_registration_complete, ue_id, originating_tai);
 
+  return (rc);
+}
+
+/* Create pdu session establishment  request from ue */
+int send_uplink_nas_pdu_session_establishment_request(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length) {
+  bstring pdu_session_est_req;
+  tai_t originating_tai = {};
+
+  if ((!amf_app_desc_p) || (!nas_msg) || (0 == nas_msg_length)) {
+    return RETURNerror;
+  }
+
+  pdu_session_est_req = blk2bstr(nas_msg, nas_msg_length);
+  memcpy(pdu_session_est_req->data, nas_msg, nas_msg_length);
+
+  originating_tai.plmn = plmn;
+  originating_tai.tac  = 1;
+
+  int rc = RETURNerror;
+  rc     = amf_app_handle_uplink_nas_message(
+      amf_app_desc_p, pdu_session_est_req, ue_id, originating_tai);
+
+  return (rc);
+}
+
+void create_ip_address_response_itti(
+    itti_amf_ip_allocation_response_t& response) {
+  std::string apn = "internet";
+  std::copy(apn.begin(), apn.end(), std::begin(response.apn));
+  response.default_ambr.br_unit    = BPS;
+  response.default_ambr.br_dl      = 200000000;
+  response.default_ambr.br_ul      = 100000000;
+  response.gnb_gtp_teid            = 0;
+  response.gnb_gtp_teid_ip_addr[0] = 0xc0;
+  response.gnb_gtp_teid_ip_addr[1] = 0xa8;
+  response.gnb_gtp_teid_ip_addr[2] = 0x3c;
+  response.gnb_gtp_teid_ip_addr[3] = 0x96;
+  std::string imsi                 = "222456000000001";
+  std::copy(imsi.begin(), imsi.end(), std::begin(response.imsi));
+  response.imsi_length  = 15;
+  response.paa.pdn_type = IPv4;
+  inet_pton(AF_INET, "192.168.128.254", &(response.paa.ipv4_address));
+  response.paa.vlan         = 1;
+  response.pdu_session_id   = 1;
+  response.pdu_session_type = IPv4;
+  response.pti              = 0x01;
+  response.result           = 0;
+}
+
+int send_ip_address_response_grpc() {
+  int rc = RETURNerror;
+
+  itti_amf_ip_allocation_response_t response = {};
+  create_ip_address_response_itti(response);
+
+  rc = amf_smf_handle_ip_address_response(&response);
+
+  return rc;
+}
+
+void create_pdu_session_response_ipv4_itti(
+    itti_n11_create_pdu_session_response_t& response) {
+  std::string imsi = "222456000000001";
+  std::copy(imsi.begin(), imsi.end(), std::begin(response.imsi));
+
+  response.sm_session_fsm_state = sm_session_fsm_state_t::CREATING;
+  response.sm_session_version   = 0;
+  response.pdu_session_id       = 1;
+  response.pdu_session_type     = IPV4;
+  response.selected_ssc_mode    = SSC_MODE_3;
+  response.m5gsm_cause          = M5GSM_OPERATION_SUCCESS;
+
+  response.session_ambr.uplink_unit_type   = 0;
+  response.session_ambr.uplink_units       = 100000000;
+  response.session_ambr.downlink_unit_type = 0;
+  response.session_ambr.downlink_units     = 100000000;
+
+  response.qos_list.qos_flow_req_item.qos_flow_identifier = 9;
+  response.qos_list.qos_flow_req_item.qos_flow_level_qos_param
+      .qos_characteristic.non_dynamic_5QI_desc.fiveQI = 9;
+  response.qos_list.qos_flow_req_item.qos_flow_level_qos_param
+      .alloc_reten_priority.priority_level = 1;
+  response.qos_list.qos_flow_req_item.qos_flow_level_qos_param
+      .alloc_reten_priority.pre_emption_cap = SHALL_NOT_TRIGGER_PRE_EMPTION;
+  response.qos_list.qos_flow_req_item.qos_flow_level_qos_param
+      .alloc_reten_priority.pre_emption_vul = NOT_PREEMPTABLE;
+  response.upf_endpoint.teid[0]             = 0x7f;
+  response.upf_endpoint.teid[1]             = 0xff;
+  response.upf_endpoint.teid[2]             = 0xff;
+  response.upf_endpoint.teid[3]             = 0xff;
+  inet_pton(AF_INET, "192.168.128.200", response.upf_endpoint.end_ipv4_addr);
+
+  response.always_on_pdu_session_indication     = false;
+  response.allowed_ssc_mode                     = SSC_MODE_3;
+  response.m5gsm_congetion_re_attempt_indicator = true;
+  response.pdu_address.redirect_address_type    = IPV4_1;
+  inet_pton(
+      AF_INET, "192.168.128.200", response.pdu_address.redirect_server_address);
+}
+
+int send_pdu_session_response_grpc() {
+  int rc                                          = RETURNerror;
+  itti_n11_create_pdu_session_response_t response = {};
+  create_pdu_session_response_ipv4_itti(response);
+
+  imsi64_t imsi64;
+  IMSI_STRING_TO_IMSI64(response.imsi, &imsi64);
+  // Handle smf_context
+  ue_m5gmm_context_s* ue_context = lookup_ue_ctxt_by_imsi(imsi64);
+
+  if (!ue_context) {
+    return RETURNerror;
+  }
+
+  rc = amf_app_handle_pdu_session_response(&response);
+
+  return rc;
+}
+
+void create_pdu_resource_setup_response_itti(
+    itti_ngap_pdusessionresource_setup_rsp_t& response,
+    amf_ue_ngap_id_t ue_id) {
+  response.amf_ue_ngap_id                                       = ue_id;
+  response.gnb_ue_ngap_id                                       = 1;
+  response.pduSessionResource_setup_list.item[0].Pdu_Session_ID = 1;
+  response.pduSessionResource_setup_list.no_of_items            = 1;
+  response_gtp_tunnel_t* tunnel =
+      &response.pduSessionResource_setup_list.item[0]
+           .PDU_Session_Resource_Setup_Response_Transfer.tunnel;
+  tunnel->gTP_TEID[0] = 0x0;
+  tunnel->gTP_TEID[1] = 0x0;
+  tunnel->gTP_TEID[2] = 0x0;
+  tunnel->gTP_TEID[3] = 0x1;
+
+  tunnel->transportLayerAddress[0] = 0xc0;
+  tunnel->transportLayerAddress[1] = 0xa8;
+  tunnel->transportLayerAddress[2] = 0x3c;
+  tunnel->transportLayerAddress[3] = 0x96;
+
+  AssociatedQosFlowList_t* qosFlow =
+      &response.pduSessionResource_setup_list.item[0]
+           .PDU_Session_Resource_Setup_Response_Transfer.associatedQosFlowList;
+  qosFlow->items                = 1;
+  qosFlow->QosFlowIdentifier[0] = 9;
+}
+int send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id) {
+  int rc                                            = RETURNok;
+  itti_ngap_pdusessionresource_setup_rsp_t response = {};
+  create_pdu_resource_setup_response_itti(response, ue_id);
+
+  amf_app_handle_resource_setup_response(response);
+
+  return rc;
+}
+
+void create_pdu_notification_response_itti(
+    itti_n11_received_notification_t& response) {
+  std::string imsi = "222456000000001";
+  std::copy(imsi.begin(), imsi.end(), std::begin(response.imsi));
+  response.sm_session_fsm_state = CREATING_0;
+  response.sm_session_version   = 0;
+  response.pdu_session_id       = 1;
+  response.request_type         = EXISTING_PDU_SESSION;
+  response.m5g_sm_capability.multi_homed_ipv6_pdu_session = false;
+  response.m5g_sm_capability.reflective_qos               = false;
+  response.m5gsm_cause      = M5GSM_OPERATION_SUCCESS;
+  response.pdu_session_type = IPV4;
+  response.notify_ue_evnt   = PDU_SESSION_STATE_NOTIFY;
+}
+
+int send_pdu_notification_response() {
+  int rc                                    = RETURNerror;
+  itti_n11_received_notification_t response = {};
+  create_pdu_notification_response_itti(response);
+
+  rc = amf_app_handle_notification_received(&response);
+
+  return rc;
+}
+
+/* Create pdu session establishment  request from ue */
+int send_uplink_nas_pdu_session_release_request(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length) {
+  bstring pdu_session_est_req;
+  tai_t originating_tai = {};
+
+  if ((!amf_app_desc_p) || (!nas_msg) || (0 == nas_msg_length)) {
+    return RETURNerror;
+  }
+
+  pdu_session_est_req = blk2bstr(nas_msg, nas_msg_length);
+  memcpy(pdu_session_est_req->data, nas_msg, nas_msg_length);
+
+  originating_tai.plmn = plmn;
+  originating_tai.tac  = 1;
+
+  int rc     = RETURNerror;
+  int status = amf_app_handle_uplink_nas_message(
+      amf_app_desc_p, pdu_session_est_req, ue_id, originating_tai);
+
+  if (status > 0) {
+    rc = RETURNok;
+  }
   return (rc);
 }
 

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -60,6 +60,36 @@ int send_uplink_nas_registration_complete(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
     const uint8_t* nas_msg, uint8_t nas_msg_length);
 
+/* Create pdu session establishment  request from ue */
+int send_uplink_nas_pdu_session_establishment_request(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length);
+
+void create_ip_address_response_itti(
+    itti_amf_ip_allocation_response_t& response);
+
+int send_ip_address_response_grpc();
+
+void create_pdu_session_response_ipv4_itti(
+    itti_n11_create_pdu_session_response_t& response);
+
+int send_pdu_session_response_grpc();
+
+void create_pdu_resource_setup_response_itti(
+    itti_ngap_pdusessionresource_setup_rsp_t& response, amf_ue_ngap_id_t ue_id);
+
+int send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id);
+
+void create_pdu_notification_response_itti(
+    itti_n11_received_notification_t& response);
+
+int send_pdu_notification_response();
+
+/* Create pdu session establishment  release from ue */
+int send_uplink_nas_pdu_session_release_request(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length);
+
 int send_uplink_nas_ue_deregistration_request(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
     uint8_t* nas_msg, uint8_t nas_msg_length);

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -85,7 +85,7 @@ void create_pdu_notification_response_itti(
 
 int send_pdu_notification_response();
 
-/* Create pdu session establishment  release from ue */
+/* Create pdu session  release from ue */
 int send_uplink_nas_pdu_session_release_request(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
     const uint8_t* nas_msg, uint8_t nas_msg_length);

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -66,22 +66,22 @@ int send_uplink_nas_pdu_session_establishment_request(
     const uint8_t* nas_msg, uint8_t nas_msg_length);
 
 void create_ip_address_response_itti(
-    itti_amf_ip_allocation_response_t& response);
+    itti_amf_ip_allocation_response_t* response);
 
 int send_ip_address_response_itti();
 
 void create_pdu_session_response_ipv4_itti(
-    itti_n11_create_pdu_session_response_t& response);
+    itti_n11_create_pdu_session_response_t* response);
 
 int send_pdu_session_response_itti();
 
 void create_pdu_resource_setup_response_itti(
-    itti_ngap_pdusessionresource_setup_rsp_t& response, amf_ue_ngap_id_t ue_id);
+    itti_ngap_pdusessionresource_setup_rsp_t* response, amf_ue_ngap_id_t ue_id);
 
 int send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id);
 
 void create_pdu_notification_response_itti(
-    itti_n11_received_notification_t& response);
+    itti_n11_received_notification_t* response);
 
 int send_pdu_notification_response();
 

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -86,7 +86,7 @@ void create_pdu_notification_response_itti(
 int send_pdu_notification_response();
 
 /* Create pdu session  release from ue */
-int send_uplink_nas_pdu_session_release_request(
+int send_uplink_nas_pdu_session_release_message(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
     const uint8_t* nas_msg, uint8_t nas_msg_length);
 

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -68,12 +68,12 @@ int send_uplink_nas_pdu_session_establishment_request(
 void create_ip_address_response_itti(
     itti_amf_ip_allocation_response_t& response);
 
-int send_ip_address_response_grpc();
+int send_ip_address_response_itti();
 
 void create_pdu_session_response_ipv4_itti(
     itti_n11_create_pdu_session_response_t& response);
 
-int send_pdu_session_response_grpc();
+int send_pdu_session_response_itti();
 
 void create_pdu_resource_setup_response_itti(
     itti_ngap_pdusessionresource_setup_rsp_t& response, amf_ue_ngap_id_t ue_id);

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -862,7 +862,7 @@ TEST(test_dnn, test_amf_validate_dnn) {
   ULNASTransportMsg msg;
   bool decode_res = false;
   memset(&msg, 0, sizeof(ULNASTransportMsg));
-  std::string dnn_string((char*) msg.dnn.dnn, msg.dnn.len);
+  std::string dnn_string(reinterpret_cast<char*>(msg.dnn.dnn), msg.dnn.len);
   int idx          = 0;
   bool ue_sent_dnn = true;
   // decoding uplink uplink nas transport(pdu session request)

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -800,7 +800,6 @@ TEST(test_optional_dnn_pdu, test_pdu_session_establish_optional) {
   EXPECT_EQ(decode_res, true);
   // build uplinknastransport
 
-  // std::string dnn("internet");
   uint8_t dnn[9] = {0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74};
   EXPECT_EQ(0, memcmp(pdu_sess_est_req.dnn.dnn, dnn, pdu_sess_est_req.dnn.len));
 
@@ -811,8 +810,6 @@ TEST(test_optional_dnn_pdu, test_pdu_session_establish_optional) {
   ULNASTransportMsg decode_pdu_sess_est_req = {};
   decode_res = decode_ul_nas_transport_msg(&decode_pdu_sess_est_req, pdu, len);
   EXPECT_EQ(decode_res, true);
-  // build uplinknastransport
-  // EXPECT_EQ(dnn, decode_pdu_sess_est_req.dnn.dnn);
   EXPECT_EQ(
       0, memcmp(
              decode_pdu_sess_est_req.dnn.dnn, dnn,

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -800,8 +800,9 @@ TEST(test_optional_dnn_pdu, test_pdu_session_establish_optional) {
   EXPECT_EQ(decode_res, true);
   // build uplinknastransport
 
-  std::string dnn("internet");
-  EXPECT_EQ(dnn, pdu_sess_est_req.dnn.dnn);
+  // std::string dnn("internet");
+  uint8_t dnn[9] = {0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74};
+  EXPECT_EQ(0, memcmp(pdu_sess_est_req.dnn.dnn, dnn, pdu_sess_est_req.dnn.len));
 
   buffer = bfromcstralloc(len, "\0");
   bytes  = pdu_sess_est_req.EncodeULNASTransportMsg(
@@ -811,7 +812,11 @@ TEST(test_optional_dnn_pdu, test_pdu_session_establish_optional) {
   decode_res = decode_ul_nas_transport_msg(&decode_pdu_sess_est_req, pdu, len);
   EXPECT_EQ(decode_res, true);
   // build uplinknastransport
-  EXPECT_EQ(dnn, decode_pdu_sess_est_req.dnn.dnn);
+  // EXPECT_EQ(dnn, decode_pdu_sess_est_req.dnn.dnn);
+  EXPECT_EQ(
+      0, memcmp(
+             decode_pdu_sess_est_req.dnn.dnn, dnn,
+             decode_pdu_sess_est_req.dnn.len));
   bdestroy(buffer);
 }
 
@@ -857,9 +862,9 @@ TEST(test_dnn, test_amf_validate_dnn) {
   ULNASTransportMsg msg;
   bool decode_res = false;
   memset(&msg, 0, sizeof(ULNASTransportMsg));
-  std::string dnn_string = msg.dnn.dnn;
-  int idx                = 0;
-  bool ue_sent_dnn       = true;
+  std::string dnn_string((char*) msg.dnn.dnn, msg.dnn.len);
+  int idx          = 0;
+  bool ue_sent_dnn = true;
   // decoding uplink uplink nas transport(pdu session request)
   decode_res = decode_ul_nas_transport_msg(&msg, pdu, len);
   EXPECT_EQ(decode_res, true);

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -317,13 +317,13 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
   EXPECT_TRUE(rc == RETURNok);
 
   /* Send uplink nas message for pdu session release request from UE */
-  rc = send_uplink_nas_pdu_session_release_request(
+  rc = send_uplink_nas_pdu_session_release_message(
       amf_app_desc_p, ue_id, plmn, pdu_sess_release_hexbuf,
       sizeof(pdu_sess_release_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  /* Send uplink nas message for pdu session release request from UE */
-  rc = send_uplink_nas_pdu_session_release_request(
+  /* Send uplink nas message for pdu session release complete from UE */
+  rc = send_uplink_nas_pdu_session_release_message(
       amf_app_desc_p, ue_id, plmn, pdu_sess_release_complete_hexbuf,
       sizeof(pdu_sess_release_complete_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
@@ -331,7 +331,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
   rc = send_pdu_notification_response();
   EXPECT_TRUE(rc == RETURNok);
 
-  /* Send uplink nas message for registration complete response from UE */
+  /* Send uplink nas message for deregistration complete response from UE */
   rc = send_uplink_nas_ue_deregistration_request(
       amf_app_desc_p, ue_id, plmn, ue_initiated_dereg_hexbuf,
       sizeof(ue_initiated_dereg_hexbuf));

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -49,7 +49,7 @@ class AMFAppProcedureTest : public ::testing::Test {
 
   virtual void TearDown() {
     clear_amf_nas_state();
-    amf_config_free(&amf_config);
+    clear_amf_config(&amf_config);
     destroy_task_context(&amf_app_task_zmq_ctx);
     itti_free_desc_threads();
   }
@@ -302,11 +302,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
   EXPECT_TRUE(rc == RETURNok);
 
   /* Send ip address response  from pipelined */
-  rc = send_ip_address_response_grpc();
+  rc = send_ip_address_response_itti();
   EXPECT_TRUE(rc == RETURNok);
 
   /* Send pdu session setup response  from smf */
-  rc = send_pdu_session_response_grpc();
+  rc = send_pdu_session_response_itti();
   EXPECT_TRUE(rc == RETURNok);
 
   /* Send pdu resource setup response  from UE */

--- a/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
@@ -583,7 +583,8 @@ TEST_F(NgapFlowTest, pdu_sess_resource_setup_req_sunny_day) {
   uint8_t ip_buff[4]           = {0xc0, 0xa8, 0x3c, 0x8e};
   m5g_ue_description_t* ue_ref = NULL;
   itti_ngap_pdusession_resource_setup_req_t* ngap_pdu_ses_setup_req = nullptr;
-  pdu_session_resource_setup_request_transfer_t amf_pdu_ses_setup_transfer_req;
+  pdu_session_resource_setup_request_transfer_t amf_pdu_ses_setup_transfer_req =
+      {};
 
   // Verify sctp association is successful
   EXPECT_EQ(ngap_handle_new_association(state, &peerInfo), RETURNok);


### PR DESCRIPTION


Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Unit test cases for PDUSession Establishment/Release

## Test Plan

 verified memory leaks & code coverage for the below Message Handling
-  PDU Session Establishment Request Handling by AMF
-   PDU Session Release Handling by AMF
        ngap - amf
	amf  - Pipelined
	amf  - smf
- Registration and PDUSession Establishment/Release with UERANSIM
![image](https://user-images.githubusercontent.com/83060027/141168365-65f57c12-7095-46ff-85cf-35d2d942ee1d.png)
[mme_reg_pdu_rel_10_nov_21.log](https://github.com/magma/magma/files/7514965/mme_reg_pdu_rel_10_nov_21.log)

- executed test_oai
![image](https://user-images.githubusercontent.com/83060027/141168170-e468d29e-a2b2-4807-837c-ef6d8ad4a68f.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
