### PR TITLE
refactor(mme): Remove deprecated DEBUG_IS_ON defines

### DIFF
--- a/lte/gateway/c/core/oai/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/CMakeLists.txt
@@ -41,12 +41,9 @@ add_definitions(-DCMAKER)
 # Generate *.gcno rather than *.c.gcno files for gcov
 set(CMAKE_C_OUTPUT_EXTENSION_REPLACE 1)
 
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -fstack-protector-all -g -DMALLOC_CHECK_=3 -DDEBUG_IS_ON=1 -DTRACE_IS_ON=1 -O0 -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer")
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS} -g -DMALLOC_CHECK_=3  -DDEBUG_IS_ON -O1")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -fstack-protector-all -g -DMALLOC_CHECK_=3 -DTRACE_IS_ON=1 -O0 -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS} -g -DMALLOC_CHECK_=3 -O1")
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=address -fsanitize=undefined")
-
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG_IS_ON=1")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG_IS_ON=1")
 
 # Add Gcov flags
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")

--- a/lte/gateway/c/core/oai/common/assertions.h
+++ b/lte/gateway/c/core/oai/common/assertions.h
@@ -77,11 +77,7 @@
     }                                                                          \
   } while (0)
 
-#if DEBUG_IS_ON
 #define _ASSERT_FINAL_ _Assert_Builtin_Trap_
-#else
-#define _ASSERT_FINAL_ _Assert_Exit_
-#endif
 
 #define Fatal(format, args...)                                                 \
   do {                                                                         \

--- a/lte/gateway/c/core/oai/common/log.h
+++ b/lte/gateway/c/core/oai/common/log.h
@@ -471,7 +471,6 @@ char* bytes_to_hex(char* byte_array, int length, char* hex_array);
         lOgLeVeL, pRoTo, __FILE__, __LINE__, mEsSaGe, sTrEaM, sIzE);           \
     OAI_GCC_DIAG_ON("-Wpointer-sign");                                         \
   } while (0); /*!< \brief trace buffer content */
-#if DEBUG_IS_ON
 #define OAILOG_DEBUG(pRoTo, ...)                                               \
   do {                                                                         \
     log_message(                                                               \
@@ -512,7 +511,6 @@ char* bytes_to_hex(char* byte_array, int length, char* hex_array);
         pRoTo, __FILE__, __LINE__, __FUNCTION__, (long) rEtUrNcOdE);           \
     return rEtUrNcOdE;                                                         \
   } while (0) /*!< \brief informational */
-#endif
 #endif
 #include "lte/gateway/c/core/oai/common/shared_ts_log.h"
 

--- a/lte/gateway/c/core/oai/lib/openflow/controller/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/CMakeLists.txt
@@ -3,7 +3,6 @@ add_compile_options(-std=c++11)
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 set(CMAKE_CXX_FLAGS "-Wno-write-strings -Wno-literal-suffix")
-add_definitions(-DDEBUG_IS_ON=1)
 
 add_library(LIB_OPENFLOW_CONTROLLER
     ControllerMain.cpp

--- a/lte/gateway/c/core/oai/lib/pcef/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/lib/pcef/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_compile_options(-std=c++14)
 
 set(CMAKE_CXX_FLAGS "-Wno-write-strings -Wno-literal-suffix")
-add_definitions(-DDEBUG_IS_ON=1)
 
 # compile the needed protos
 set(PCEF_ORC8R_CPP_PROTOS mconfig/mconfigs)

--- a/lte/gateway/c/core/oai/lib/s6a_proxy/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/lib/s6a_proxy/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_compile_options(-std=c++14)
 
 set(CMAKE_CXX_FLAGS "-Wno-write-strings -Wno-literal-suffix")
-add_definitions(-DDEBUG_IS_ON=1)
 
 # compile the needed protos
 set(S6A_FEG_CPP_PROTOS s6a_proxy)

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -461,14 +461,12 @@ void mme_app_handle_conn_est_cnf(
       if (!j) {
         establishment_cnf_p->nas_pdu[j] = nas_conn_est_cnf_p->nas_msg;
         nas_conn_est_cnf_p->nas_msg     = NULL;
-#if DEBUG_IS_ON
         if (!establishment_cnf_p->nas_pdu[j]) {
           OAILOG_ERROR_UE(
               LOG_MME_APP, emm_context_p->_imsi64,
               "No NAS PDU found ue " MME_UE_S1AP_ID_FMT "\n",
               nas_conn_est_cnf_p->ue_id);
         }
-#endif
       }
       j = j + 1;
     }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -1872,7 +1872,6 @@ void mme_config_display(mme_config_t* config_pP) {
       LOG_CONFIG, "Built with S6A_OVER_GRPC .....................: %d\n",
       S6A_OVER_GRPC);
 
-#if DEBUG_IS_ON
   OAILOG_DEBUG(
       LOG_CONFIG, "Built with CMAKE_BUILD_TYPE ................: %s\n",
       CMAKE_BUILD_TYPE);
@@ -1891,7 +1890,7 @@ void mme_config_display(mme_config_t* config_pP) {
   OAILOG_DEBUG(
       LOG_CONFIG, "Built with TRACE_3GPP_SPEC .................: %d\n",
       TRACE_3GPP_SPEC);
-#endif
+
   OAILOG_INFO(LOG_CONFIG, "Configuration:\n");
   OAILOG_INFO(
       LOG_CONFIG, "- File .................................: %s\n",

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
@@ -170,7 +170,6 @@ inline void emm_ctx_set_imsi(
   ctxt->_imsi   = *imsi;
   ctxt->_imsi64 = imsi64;
   emm_ctx_set_attribute_present(ctxt, EMM_CTXT_MEMBER_IMSI);
-#if DEBUG_IS_ON
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1] = {0};
   IMSI64_TO_STRING(ctxt->_imsi64, imsi_str, ctxt->_imsi.length);
   OAILOG_DEBUG(
@@ -178,7 +177,6 @@ inline void emm_ctx_set_imsi(
       (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
           ->mme_ue_s1ap_id,
       imsi_str);
-#endif
 }
 
 /* Set IMSI, mark it as valid */
@@ -187,7 +185,6 @@ inline void emm_ctx_set_valid_imsi(
   ctxt->_imsi   = *imsi;
   ctxt->_imsi64 = imsi64;
   emm_ctx_set_attribute_valid(ctxt, EMM_CTXT_MEMBER_IMSI);
-#if DEBUG_IS_ON
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1] = {0};
   IMSI64_TO_STRING(ctxt->_imsi64, imsi_str, ctxt->_imsi.length);
   OAILOG_DEBUG(
@@ -195,7 +192,6 @@ inline void emm_ctx_set_valid_imsi(
       (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
           ->mme_ue_s1ap_id,
       imsi_str);
-#endif
   mme_api_notify_imsi(
       (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
           ->mme_ue_s1ap_id,
@@ -217,7 +213,6 @@ inline void emm_ctx_clear_imei(emm_context_t* const ctxt) {
 inline void emm_ctx_set_imei(emm_context_t* const ctxt, imei_t* imei) {
   ctxt->_imei = *imei;
   emm_ctx_set_attribute_present(ctxt, EMM_CTXT_MEMBER_IMEI);
-#if DEBUG_IS_ON
   char imei_str[16];
   IMEI_TO_STRING(imei, imei_str, 16);
   OAILOG_DEBUG(
@@ -225,14 +220,12 @@ inline void emm_ctx_set_imei(emm_context_t* const ctxt, imei_t* imei) {
       (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
           ->mme_ue_s1ap_id,
       imei_str);
-#endif
 }
 
 /* Set IMEI, mark it as valid */
 inline void emm_ctx_set_valid_imei(emm_context_t* const ctxt, imei_t* imei) {
   ctxt->_imei = *imei;
   emm_ctx_set_attribute_valid(ctxt, EMM_CTXT_MEMBER_IMEI);
-#if DEBUG_IS_ON
   char imei_str[16];
   IMEI_TO_STRING(imei, imei_str, 16);
   OAILOG_DEBUG(
@@ -240,7 +233,6 @@ inline void emm_ctx_set_valid_imei(emm_context_t* const ctxt, imei_t* imei) {
       (PARENT_STRUCT(ctxt, struct ue_mm_context_s, emm_context))
           ->mme_ue_s1ap_id,
       imei_str);
-#endif
 }
 
 //------------------------------------------------------------------------------
@@ -694,7 +686,6 @@ struct emm_context_s* emm_context_get_by_imsi(
     emm_context_p = &ue_mm_context->emm_context;
   }
 
-#if DEBUG_IS_ON
   if (emm_context_p) {
     OAILOG_DEBUG(
         LOG_NAS_EMM,
@@ -702,7 +693,6 @@ struct emm_context_s* emm_context_get_by_imsi(
         " context %p by imsi " IMSI_64_FMT "\n",
         ue_mm_context->mme_ue_s1ap_id, emm_context_p, imsi64);
   }
-#endif
   return emm_context_p;
 }
 
@@ -717,7 +707,6 @@ struct emm_context_s* emm_context_get_by_guti(
   if (ue_mm_context) {
     emm_context_p = &ue_mm_context->emm_context;
   }
-#if DEBUG_IS_ON
   if (emm_context_p) {
     OAILOG_DEBUG(
         LOG_NAS_EMM,
@@ -725,7 +714,6 @@ struct emm_context_s* emm_context_get_by_guti(
         " context %p by guti " GUTI_FMT "\n",
         ue_mm_context->mme_ue_s1ap_id, emm_context_p, GUTI_ARG(guti));
   }
-#endif
   return emm_context_p;
 }
 


### PR DESCRIPTION
This compiler flag used to enable or disable debug logging behaviors - but it is exclusively set in our builds today and further if it is not set the OAI MME will not compile (as critical macros are no longer declared, yet are used in code that does not check for DEBUG_IS_ON).

Therefore it is assumed this capability is no longer necessary to maintain.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>