### PR TITLE
feat(sessiond): Support usage reporting and charging for 5G

### DIFF
--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -376,6 +376,7 @@ cc_library(
         ":pipelined_client",
         ":session_credit",
         ":session_store",
+        ":session_events",
         "//lte/protos:mconfigs_cpp_proto",
         "//orc8r/gateway/c/common/logging",
         "@com_github_grpc_grpc//:grpc++",

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -410,51 +410,29 @@ void LocalEnforcer::aggregate_records(
     const std::string &imsi = record.sid(), &ip = record.ue_ipv4();
     const uint32_t teid = record.teid();
     // TODO IPv6 add ipv6 to search criteria
-    SessionSearchCriteria criteria(imsi, IMSI_AND_UE_IPV4_OR_IPV6, ip);
+    SessionSearchCriteria criteria(
+        imsi, IMSI_AND_UE_IPV4_OR_IPV6_OR_TEID, ip, teid);
     auto session_it = session_store_.find_session(session_map, criteria);
     if (!session_it) {
-      MLOG(MERROR) << "Could not find an active session for 4G " << imsi
-                   << " and " << ip << " during record aggregation";
-      if (teid) {
-        SessionSearchCriteria criteria(imsi, IMSI_AND_TEID, teid);
-        auto session_it = session_store_.find_session(session_map, criteria);
-        if (!session_it) {
-          dead_sessions_to_cleanup.insert(record);
-          continue;
-        }
-        auto& session                 = **session_it;
-        const std::string& session_id = session->get_session_id();
-        sessions_with_reporting_flows.insert(
-            ImsiAndSessionID(imsi, session_id));
-        if (record.bytes_tx() > 0 || record.bytes_rx() > 0) {
-          MLOG(MDEBUG) << session_id << " used " << record.bytes_tx()
-                       << " tx bytes and " << record.bytes_rx()
-                       << " rx bytes for rule " << record.rule_id();
-        }
-        session->add_rule_usage(
-            record.rule_id(), record.rule_version(), record.bytes_tx(),
-            record.bytes_rx(), record.dropped_tx(), record.dropped_rx(),
-            &session_update[imsi][session_id]);
-        continue;
-      } else {
-        dead_sessions_to_cleanup.insert(record);
-        continue;
-      }
-    } else {
-      auto& session                 = **session_it;
-      const std::string& session_id = session->get_session_id();
-      sessions_with_reporting_flows.insert(ImsiAndSessionID(imsi, session_id));
-      if (record.bytes_tx() > 0 || record.bytes_rx() > 0) {
-        MLOG(MDEBUG) << session_id << " used " << record.bytes_tx()
-                     << " tx bytes and " << record.bytes_rx()
-                     << " rx bytes for rule " << record.rule_id();
-      }
-
-      session->add_rule_usage(
-          record.rule_id(), record.rule_version(), record.bytes_tx(),
-          record.bytes_rx(), record.dropped_tx(), record.dropped_rx(),
-          &session_update[imsi][session_id]);
+      MLOG(MERROR) << "Could not find an 4G and 5G active session for " << imsi
+                   << " and " << ip << " or " << teid
+                   << " during record aggregation";
+      dead_sessions_to_cleanup.insert(record);
+      continue;
     }
+    auto& session                 = **session_it;
+    const std::string& session_id = session->get_session_id();
+    sessions_with_reporting_flows.insert(ImsiAndSessionID(imsi, session_id));
+    if (record.bytes_tx() > 0 || record.bytes_rx() > 0) {
+      MLOG(MDEBUG) << session_id << " used " << record.bytes_tx()
+                   << " tx bytes and " << record.bytes_rx()
+                   << " rx bytes for rule " << record.rule_id();
+    }
+
+    session->add_rule_usage(
+        record.rule_id(), record.rule_version(), record.bytes_tx(),
+        record.bytes_rx(), record.dropped_tx(), record.dropped_rx(),
+        &session_update[imsi][session_id]);
   }
   if (records.records().size() > 0) {
     MLOG(MINFO) << "Received stats for " << sessions_with_reporting_flows.size()

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -411,7 +411,7 @@ void LocalEnforcer::aggregate_records(
     const uint32_t teid = record.teid();
     // TODO IPv6 add ipv6 to search criteria
     SessionSearchCriteria criteria(
-        imsi, IMSI_AND_UE_IPV4_OR_IPV6_OR_TEID, ip, teid);
+        imsi, IMSI_AND_UE_IPV4_OR_IPV6_OR_UPF_TEID, ip, teid);
     auto session_it = session_store_.find_session(session_map, criteria);
     if (!session_it) {
       MLOG(MERROR) << "Could not find an 4G and 5G active session for " << imsi

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -219,9 +219,9 @@ SessionState::SessionState(
       config_(cfg),
       current_version_(0),
       rtx_counter_(0),
+      subscriber_quota_state_(SubscriberQuotaUpdate_Type_VALID_QUOTA),
       static_rules_(rule_store),
       credit_map_(4, &ccHash, &ccEqual),
-      subscriber_quota_state_(SubscriberQuotaUpdate_Type_VALID_QUOTA),
       session_level_key_("") {}
 
 /* get-set methods of new messages  for 5G*/

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -219,7 +219,10 @@ SessionState::SessionState(
       config_(cfg),
       current_version_(0),
       rtx_counter_(0),
-      static_rules_(rule_store) {}
+      static_rules_(rule_store),
+      credit_map_(4, &ccHash, &ccEqual),
+      subscriber_quota_state_(SubscriberQuotaUpdate_Type_VALID_QUOTA),
+      session_level_key_("") {}
 
 /* get-set methods of new messages  for 5G*/
 uint32_t SessionState::get_current_version() {
@@ -849,10 +852,13 @@ void SessionState::get_updates(
     UpdateSessionRequest* update_request_out,
     std::vector<std::unique_ptr<ServiceAction>>* actions_out,
     SessionStateUpdateCriteria* session_uc) {
-  if (curr_state_ != SESSION_ACTIVE) return;
-  get_charging_updates(update_request_out, actions_out, session_uc);
-  get_monitor_updates(update_request_out, session_uc);
-  get_event_trigger_updates(update_request_out, session_uc);
+  if (curr_state_ == SESSION_ACTIVE || curr_state_ == ACTIVE) {
+    get_charging_updates(update_request_out, actions_out, session_uc);
+    get_monitor_updates(update_request_out, session_uc);
+    get_event_trigger_updates(update_request_out, session_uc);
+  } else {
+    return;
+  }
 }
 
 SubscriberQuotaUpdate_Type SessionState::get_subscriber_quota_state() const {

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.h
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.h
@@ -36,11 +36,11 @@ limitations under the License.
 
 #include "AmfServiceClient.h"
 #include "PipelinedClient.h"
-#include "LocalEnforcer.h"
 #include "RuleStore.h"
 #include "SessionState.h"
 #include "SessionStore.h"
 #include "StoreClient.h"
+#include "SessionEvents.h"
 #include "Types.h"
 #include "lte/protos/pipelined.pb.h"
 #include "lte/protos/session_manager.pb.h"

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.h
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.h
@@ -36,6 +36,7 @@ limitations under the License.
 
 #include "AmfServiceClient.h"
 #include "PipelinedClient.h"
+#include "LocalEnforcer.h"
 #include "RuleStore.h"
 #include "SessionState.h"
 #include "SessionStore.h"
@@ -70,6 +71,8 @@ class SessionStateEnforcer {
       std::unordered_multimap<std::string, uint32_t> pdr_map,
       std::shared_ptr<PipelinedClient> pipelined_client,
       std::shared_ptr<AmfServiceClient> amf_srv_client,
+      SessionReporter* reporter,
+      std::shared_ptr<EventsReporter> events_reporter,
       magma::mconfig::SessionD mconfig,
       long session_force_termination_timeout_ms,
       uint32_t session_max_rtx_count);
@@ -226,6 +229,8 @@ class SessionStateEnforcer {
   std::unordered_multimap<std::string, uint32_t> pdr_map_;
   std::shared_ptr<PipelinedClient> pipelined_client_;
   std::shared_ptr<AmfServiceClient> amf_srv_client_;
+  SessionReporter* reporter_;
+  std::shared_ptr<EventsReporter> events_reporter_;
   magma::mconfig::SessionD mconfig_;
   // Timer used to forcefully terminate session context on time out
   long session_force_termination_timeout_ms_;

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -321,6 +321,31 @@ optional<SessionVector::iterator> SessionStore::find_session(
           return it;
         }
         break;  // break IMSI_AND_PDUID
+
+      case IMSI_AND_UE_IPV4_OR_IPV6_OR_TEID:
+        switch (context.rat_type()) {
+          case RATType::TGPP_WLAN:
+            return it;
+            break;
+          case RATType::TGPP_LTE:
+            if (context.ue_ipv4() == criteria.secondary_key ||
+                context.ue_ipv6() == criteria.secondary_key) {
+              return it;
+            }
+            break;
+          case RATType::TGPP_NR:
+            if ((*it)->get_upf_local_teid() == criteria.tertiary_key_unit32) {
+              return it;
+            }
+            break;
+          default:
+            MLOG(MERROR)
+                << "Search criteria for IMSI_AND_UE_IPV4_OR_IPV6_OR_TEID"
+                   " not implemented for this RAT "
+                << context.rat_type();
+            break;
+        }
+        break;  // break  IMSI_AND_UE_IPV4_OR_IPV6_OR_TEID
     }
     continue;
   }

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -322,7 +322,7 @@ optional<SessionVector::iterator> SessionStore::find_session(
         }
         break;  // break IMSI_AND_PDUID
 
-      case IMSI_AND_UE_IPV4_OR_IPV6_OR_TEID:
+      case IMSI_AND_UE_IPV4_OR_IPV6_OR_UPF_TEID:
         switch (context.rat_type()) {
           case RATType::TGPP_WLAN:
             return it;
@@ -340,7 +340,7 @@ optional<SessionVector::iterator> SessionStore::find_session(
             break;
           default:
             MLOG(MERROR)
-                << "Search criteria for IMSI_AND_UE_IPV4_OR_IPV6_OR_TEID"
+                << "Search criteria for IMSI_AND_UE_IPV4_OR_IPV6_OR_UPF_TEID"
                    " not implemented for this RAT "
                 << context.rat_type();
             break;

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -45,13 +45,14 @@ using SessionUpdate = std::unordered_map<
     std::string, std::unordered_map<std::string, SessionStateUpdateCriteria>>;
 
 enum SessionSearchCriteriaType {
-  IMSI_AND_APN             = 0,
-  IMSI_AND_SESSION_ID      = 1,
-  IMSI_AND_UE_IPV4         = 2,
-  IMSI_AND_UE_IPV4_OR_IPV6 = 3,
-  IMSI_AND_BEARER          = 4,
-  IMSI_AND_TEID            = 5,
-  IMSI_AND_PDUID           = 6,
+  IMSI_AND_APN                     = 0,
+  IMSI_AND_SESSION_ID              = 1,
+  IMSI_AND_UE_IPV4                 = 2,
+  IMSI_AND_UE_IPV4_OR_IPV6         = 3,
+  IMSI_AND_BEARER                  = 4,
+  IMSI_AND_TEID                    = 5,
+  IMSI_AND_PDUID                   = 6,
+  IMSI_AND_UE_IPV4_OR_IPV6_OR_TEID = 7,
 };
 
 struct SessionSearchCriteria {
@@ -59,6 +60,7 @@ struct SessionSearchCriteria {
   SessionSearchCriteriaType search_type;
   std::string secondary_key;
   uint32_t secondary_key_unit32;
+  uint32_t tertiary_key_unit32;
 
   SessionSearchCriteria(
       const std::string p_imsi, SessionSearchCriteriaType p_type,
@@ -71,6 +73,14 @@ struct SessionSearchCriteria {
       : imsi(p_imsi),
         search_type(p_type),
         secondary_key_unit32(secondary_key_unit32) {}
+
+  SessionSearchCriteria(
+      const std::string p_imsi, SessionSearchCriteriaType p_type,
+      const std::string p_secondary_key, const uint32_t tertiary_key_unit32)
+      : imsi(p_imsi),
+        search_type(p_type),
+        secondary_key(p_secondary_key),
+        tertiary_key_unit32(tertiary_key_unit32) {}
 };
 
 /**

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -45,13 +45,13 @@ using SessionUpdate = std::unordered_map<
     std::string, std::unordered_map<std::string, SessionStateUpdateCriteria>>;
 
 enum SessionSearchCriteriaType {
-  IMSI_AND_APN                     = 0,
-  IMSI_AND_SESSION_ID              = 1,
-  IMSI_AND_UE_IPV4                 = 2,
-  IMSI_AND_UE_IPV4_OR_IPV6         = 3,
-  IMSI_AND_BEARER                  = 4,
-  IMSI_AND_TEID                    = 5,
-  IMSI_AND_PDUID                   = 6,
+  IMSI_AND_APN                         = 0,
+  IMSI_AND_SESSION_ID                  = 1,
+  IMSI_AND_UE_IPV4                     = 2,
+  IMSI_AND_UE_IPV4_OR_IPV6             = 3,
+  IMSI_AND_BEARER                      = 4,
+  IMSI_AND_TEID                        = 5,
+  IMSI_AND_PDUID                       = 6,
   IMSI_AND_UE_IPV4_OR_IPV6_OR_UPF_TEID = 7,
 };
 

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -52,7 +52,7 @@ enum SessionSearchCriteriaType {
   IMSI_AND_BEARER                  = 4,
   IMSI_AND_TEID                    = 5,
   IMSI_AND_PDUID                   = 6,
-  IMSI_AND_UE_IPV4_OR_IPV6_OR_TEID = 7,
+  IMSI_AND_UE_IPV4_OR_IPV6_OR_UPF_TEID = 7,
 };
 
 struct SessionSearchCriteria {

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -90,22 +90,6 @@ SessionConfig SetMessageManagerHandler::m5g_build_session_config(
   return cfg;
 }
 
-bool SetMessageManagerHandler::validate_session_request(
-    const SessionConfig cfg) {
-  const auto rat_type               = cfg.common_context.rat_type();
-  const CommonSessionContext common = cfg.common_context;
-  if (rat_type != TGPP_NR) {
-    // We don't support outside of 5G
-    std::ostringstream failure_stream;
-    failure_stream << "Received an invalid RAT type " << rat_type;
-    std::string failure_msg = failure_stream.str();
-    MLOG(MERROR) << failure_msg;
-    events_reporter_->session_create_failure(cfg, failure_msg);
-    return false;
-  }
-  return true;
-}
-
 /* Handling set message from AMF
  * check if it is INITIAL_REQUEST or EXISTING_PDU_SESSION
  * if it is INITIAL_REQUEST need to create the session context in SessionMap

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -170,8 +170,7 @@ void SetMessageManagerHandler::SetAmfSessionContext(
         /* it's new UE establisment request and need to create the session
          * context
          */
-        bool status = validate_session_request(cfg);
-        if (!status) {
+        if (!validate_session_request(cfg)) {
           Status status(
               grpc::FAILED_PRECONDITION, "Received an invalid RAT type ");
           response_callback(status, SmContextVoid());
@@ -314,12 +313,11 @@ void SetMessageManagerHandler::send_create_session(
   bool success = m5g_enforcer_->m5g_init_session_credit(
       *session_map_ptr, imsi, session_id, new_cfg);
   if (!success) {
-    MLOG(MERROR) << "Failed to initialize SessionStore for 5G session "
-                 << session_id;
     std::ostringstream failure_stream;
-    failure_stream
-        << "Failed to initialize SessionStore for 5G session of IMSI " << imsi;
+    failure_stream << "Failed to initialize SessionStore for 5G session "
+                   << session_id;
     std::string failure_msg = failure_stream.str();
+    MLOG(MERROR) << failure_msg;
     events_reporter_->session_create_failure(new_cfg, failure_msg);
     return;
   } else {

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -110,8 +110,7 @@ void SetMessageManagerHandler::SetAmfSessionContext(
   m5g_enforcer_->get_event_base().runInEventBaseThread([this, response_callback,
                                                         request_cpy]() {
     // extract values from proto
-    std::string imsi = request_cpy.common_context().sid().id();
-    std::string dnn  = request_cpy.common_context().apn();
+    std::string imsi    = request_cpy.common_context().sid().id();
     const auto rat_type = request_cpy.common_context().rat_type();
     if (rat_type != TGPP_NR) {
       // We don't support outside of 5G
@@ -119,8 +118,7 @@ void SetMessageManagerHandler::SetAmfSessionContext(
       failure_stream << "Received an invalid RAT type " << rat_type;
       std::string failure_msg = failure_stream.str();
       MLOG(MERROR) << failure_msg;
-      Status status(
-           grpc::FAILED_PRECONDITION, failure_msg);
+      Status status(grpc::FAILED_PRECONDITION, failure_msg);
       response_callback(status, SmContextVoid());
       return;
     }

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.h
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.h
@@ -80,7 +80,8 @@ class SetMessageManagerHandler : public SetMessageManager {
  public:
   SetMessageManagerHandler(
       std::shared_ptr<SessionStateEnforcer> m5genforcer,
-      SessionStore& session_store, SessionReporter* reporter);
+      SessionStore& session_store, SessionReporter* reporter,
+      std::shared_ptr<EventsReporter> events_reporter);
   ~SetMessageManagerHandler() {}
 
   /* Paging, idle state change notifcation receiving */
@@ -128,7 +129,11 @@ class SetMessageManagerHandler : public SetMessageManager {
   SessionStore& session_store_;
   std::shared_ptr<SessionStateEnforcer> m5g_enforcer_;
   SessionReporter* reporter_;
+  std::shared_ptr<EventsReporter> events_reporter_;
   SessionIDGenerator id_gen_;
+
+  bool validate_session_request(const SessionConfig cfg);
+
 };  // end of class SetMessageManagerHandlerImpl
 
 }  // end namespace magma

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -443,12 +443,14 @@ int main(int argc, char* argv[]) {
     std::unordered_multimap<std::string, uint32_t> pdr_map;
     conv_session_enforcer = std::make_shared<magma::SessionStateEnforcer>(
         rule_store, *session_store, pdr_map, pipelined_client, amf_srv_client,
-        mconfig, config["session_force_termination_timeout_ms"].as<long>(),
+        reporter.get(), events_reporter, mconfig,
+        config["session_force_termination_timeout_ms"].as<long>(),
         session_max_rtx_count);
     // 5G related async msg handler service framework creation
     auto conv_set_message_handler =
         std::make_unique<magma::SetMessageManagerHandler>(
-            conv_session_enforcer, *session_store, reporter.get());
+            conv_session_enforcer, *session_store, reporter.get(),
+            events_reporter);
     MLOG(MINFO) << "Initialized SetMessageManagerHandler";
     // 5G specific services to handle set messages from AMF and mme
     conv_set_message_service = new magma::AmfPduSessionSmContextAsyncService(

--- a/lte/gateway/c/session_manager/test/BUILD.bazel
+++ b/lte/gateway/c/session_manager/test/BUILD.bazel
@@ -43,6 +43,7 @@ cc_library(
         ":consts",
         "//lte/gateway/c/session_manager:diameter_codes",
         "//lte/gateway/c/session_manager:stored_state",
+        "//lte/gateway/c/session_manager:session_store",
         "//lte/protos:mconfigs_cpp_proto",
         "//lte/protos:pipelined_cpp_grpc",
         "//lte/protos:session_manager_cpp_grpc",

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -326,4 +326,19 @@ MATCHER_P(CheckSrvResponse, expected_response, "") {
   return (unit_res && ul_ambr_res && dl_ambr_res);
 }
 
+MATCHER_P(CheckSendRequest, expected_request, "") {
+  auto req  = static_cast<const CreateSessionRequest>(arg);
+  auto imsi = req.common_context().sid().id();
+
+  auto apn      = req.common_context().apn();
+  auto rat_type = req.common_context().rat_type();
+
+  auto imsi_exp = expected_request.common_context().sid().id();
+
+  auto apn_exp      = expected_request.common_context().apn();
+  auto rat_type_exp = expected_request.common_context().rat_type();
+
+  return (imsi == imsi_exp && apn == apn_exp && rat_type == rat_type_exp);
+}
+
 };  // namespace magma

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -341,4 +341,15 @@ MATCHER_P(CheckSendRequest, expected_request, "") {
   return (imsi == imsi_exp && apn == apn_exp && rat_type == rat_type_exp);
 }
 
+MATCHER_P(SessionCheck, request, "") {
+  auto req = static_cast<const SessionState::SessionInfo>(arg);
+
+  auto imsi_req = req.subscriber_id;
+  uint32_t teid = req.local_f_teid;
+
+  bool res = request.subscriber_id == imsi_req && request.local_f_teid == teid;
+
+  return res;
+}
+
 };  // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -16,7 +16,7 @@
 
 #include "Consts.h"
 #include "ProtobufCreators.h"
-
+#include <gtest/gtest.h>
 namespace magma {
 
 CommonSessionContext build_common_context(
@@ -501,6 +501,44 @@ DynamicRuleInstall create_dynamic_rule_install(const PolicyRule& rule) {
   DynamicRuleInstall rule_install;
   rule_install.mutable_policy_rule()->CopyFrom(rule);
   return rule_install;
+}
+
+void assert_charging_credit(
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& session_id, Bucket bucket,
+    const std::vector<std::pair<uint32_t, uint64_t>>& volumes) {
+  EXPECT_TRUE(session_map.find(imsi) != session_map.end());
+  bool found = false;
+  for (const auto& session : session_map.find(imsi)->second) {
+    if (session->get_session_id() == session_id) {
+      found = true;
+      for (auto& volume_pair : volumes) {
+        EXPECT_EQ(
+            session->get_charging_credit(volume_pair.first, bucket),
+            volume_pair.second);
+      }
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+void assert_monitor_credit(
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& session_id, Bucket bucket,
+    const std::vector<std::pair<std::string, uint64_t>>& volumes) {
+  EXPECT_TRUE(session_map.find(imsi) != session_map.end());
+  bool found = false;
+  for (const auto& session : session_map.find(imsi)->second) {
+    if (session->get_session_id() == session_id) {
+      found = true;
+      for (auto& volume_pair : volumes) {
+        EXPECT_EQ(
+            session->get_monitor(volume_pair.first, bucket),
+            volume_pair.second);
+      }
+    }
+  }
+  EXPECT_TRUE(found);
 }
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -21,6 +21,7 @@
 
 #include "DiameterCodes.h"
 #include "StoredState.h"
+#include "SessionStore.h"
 
 namespace magma {
 using namespace lte;
@@ -191,7 +192,15 @@ PolicyRule create_policy_rule(
 PolicyRule create_policy_rule_with_qos(
     const std::string& rule_id, const std::string& m_key, const uint32_t rg,
     const int qci);
+void assert_charging_credit(
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& session_id, Bucket bucket,
+    const std::vector<std::pair<uint32_t, uint64_t>>& volumes);
 
+void assert_monitor_credit(
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& session_id, Bucket bucket,
+    const std::vector<std::pair<std::string, uint64_t>>& volumes);
 void create_granted_units(
     uint64_t* total, uint64_t* tx, uint64_t* rx, GrantedUnits* gsu);
 

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -353,4 +353,14 @@ class MockAmfServiceClient : public AmfServiceClient {
       bool(const magma::SetSmNotificationContext&));
 };
 
+class MockMobilitydClient : public MobilitydClient {
+ public:
+  MockMobilitydClient() {
+    ON_CALL(*this, get_subscriberid_from_ipv4(_, _)).WillByDefault(Return());
+  }
+  MOCK_METHOD2(
+      get_subscriberid_from_ipv4,
+      void(const IPAddress&, std::function<void(Status status, SubscriberID)>));
+};
+
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -110,44 +110,6 @@ class LocalEnforcerTest : public ::testing::Test {
     rule_store->insert_rule(rule);
   }
 
-  void assert_charging_credit(
-      SessionMap& session_map, const std::string& imsi,
-      const std::string& session_id, Bucket bucket,
-      const std::vector<std::pair<uint32_t, uint64_t>>& volumes) {
-    EXPECT_TRUE(session_map.find(imsi) != session_map.end());
-    bool found = false;
-    for (const auto& session : session_map.find(imsi)->second) {
-      if (session->get_session_id() == session_id) {
-        found = true;
-        for (auto& volume_pair : volumes) {
-          EXPECT_EQ(
-              session->get_charging_credit(volume_pair.first, bucket),
-              volume_pair.second);
-        }
-      }
-    }
-    EXPECT_TRUE(found);
-  }
-
-  void assert_monitor_credit(
-      SessionMap& session_map, const std::string& imsi,
-      const std::string& session_id, Bucket bucket,
-      const std::vector<std::pair<std::string, uint64_t>>& volumes) {
-    EXPECT_TRUE(session_map.find(imsi) != session_map.end());
-    bool found = false;
-    for (const auto& session : session_map.find(imsi)->second) {
-      if (session->get_session_id() == session_id) {
-        found = true;
-        for (auto& volume_pair : volumes) {
-          EXPECT_EQ(
-              session->get_monitor(volume_pair.first, bucket),
-              volume_pair.second);
-        }
-      }
-    }
-    EXPECT_TRUE(found);
-  }
-
   void assert_session_is_in_final_state(
       SessionMap& session_map, const std::string& imsi,
       const std::string& session_id, const CreditKey& charging_key,

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -708,22 +708,13 @@ TEST_F(SessionManagerHandlerTest, test_create_session_policy_report) {
 
   grpc::ServerContext server_context;
 
-  CreateSessionResponse create_response;
-  create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
-      "rule1");
-  create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
-      "rule2");
-  create_credit_update_response(
-      IMSI1, SESSION_ID_1, 1, 1536, create_response.mutable_credits()->Add());
-  create_credit_update_response(
-      IMSI1, SESSION_ID_1, 2, 1024, create_response.mutable_credits()->Add());
-
   // create expected request for report_create_session call
   CreateSessionRequest expected_request;
   expected_request.mutable_common_context()->CopyFrom(request.common_context());
   expected_request.mutable_rat_specific_context()->CopyFrom(
       request.rat_specific_context());
 
+  // Create session request towards policydb
   EXPECT_CALL(
       *reporter, report_create_session(CheckSendRequest(expected_request), _))
       .Times(1);
@@ -736,63 +727,76 @@ TEST_F(SessionManagerHandlerTest, test_create_session_policy_report) {
   // Run session creation in the EventBase loop
   evb->loopOnce();
   evb->loopOnce();
+
+  // Set the sessionconfig
   SessionConfig cfg;
   cfg.common_context       = request.common_context();
   cfg.rat_specific_context = request.rat_specific_context();
   cfg.rat_specific_context.mutable_m5gsm_session_context()->set_ssc_mode(
       SSC_MODE_3);
-  CreateSessionResponse response;
+
   auto session_map = session_store->read_sessions({IMSI1});
   auto it          = session_map.find(IMSI1);
+
   EXPECT_FALSE(it == session_map.end());
   EXPECT_EQ(session_map[IMSI1].size(), 1);
 
   auto& session_temp = session_map[IMSI1][0];
   EXPECT_EQ(session_temp->get_config().common_context.sid().id(), IMSI1);
 
-  std::string session_id = id_gen_.gen_session_id(IMSI1);
+  // Init the session
   session_enforcer->m5g_init_session_credit(
-      session_map, IMSI1, session_id, cfg);
+      session_map, IMSI1, SESSION_ID_1, cfg);
+
+  CreateSessionResponse response;
   response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
   create_credit_update_response(
-      IMSI1, session_id, 1, 1025, response.mutable_credits()->Add());
+      IMSI1, SESSION_ID_1, 1, 1025, response.mutable_credits()->Add());
+  // Create the session state
   SessionUpdate update = SessionStore::get_default_session_update(session_map);
-  SessionSearchCriteria criteria(IMSI1, IMSI_AND_SESSION_ID, session_id);
+  SessionSearchCriteria criteria(IMSI1, IMSI_AND_SESSION_ID, SESSION_ID_1);
   auto session_it = session_store->find_session(session_map, criteria);
   auto& session_t = **session_it;
-  SessionStateUpdateCriteria* session_uc = &update[IMSI1][session_id];
+  SessionStateUpdateCriteria* session_uc = &update[IMSI1][SESSION_ID_1];
   session_t->set_config(cfg, session_uc);
+
   EXPECT_TRUE(session_t->is_5g_session());
 
   session_enforcer->update_session_with_policy(session_t, response, session_uc);
   session_t->set_upf_teid_endpoint("192.168.200.1", 2147483647, session_uc);
+  // Fill the sess_info
+  SessionState::SessionInfo sess_info;
+  sess_info.local_f_teid  = 2147483647;
+  sess_info.subscriber_id = IMSI1;
+
+  // Event report for session creation
   EXPECT_CALL(
       *events_reporter,
-      session_created(IMSI1, session_id, testing::_, testing::_))
+      session_created(IMSI1, SESSION_ID_1, testing::_, testing::_))
       .Times(1);
 
+  // Set upf session info
+  EXPECT_CALL(
+      *pipelined_client, set_upf_session(SessionCheck(sess_info), _, _, _))
+      .Times(1);
+
+  // Update the session
   session_enforcer->m5g_update_session_context(
       session_map, IMSI1, session_t, update);
 
   bool write_success =
       session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(write_success);
-
   auto session_map_2 = session_store->read_sessions(SessionRead{IMSI1});
   EXPECT_EQ(session_map_2[IMSI1].front()->get_request_number(), 1);
 }
 
 TEST_F(SessionManagerHandlerTest, test_terminate_session_policy_report) {
-  CreateSessionResponse response;
-  create_credit_update_response(
-      IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
-  create_credit_update_response(
-      IMSI1, SESSION_ID_1, 2, 2048, response.mutable_credits()->Add());
   magma::SetSMSessionContext request;
   set_sm_session_context(&request);
 
   grpc::ServerContext server_context;
-
+  // create session and expect one call
   set_session_manager->SetAmfSessionContext(
       &server_context, &request,
       [this](grpc::Status status, SmContextVoid Void) {});
@@ -800,6 +804,7 @@ TEST_F(SessionManagerHandlerTest, test_terminate_session_policy_report) {
   // Run session creation in the EventBase loop
   evb->loopOnce();
   evb->loopOnce();
+  // Set the session config
   SessionConfig cfg;
   cfg.common_context       = request.common_context();
   cfg.rat_specific_context = request.rat_specific_context();
@@ -812,18 +817,23 @@ TEST_F(SessionManagerHandlerTest, test_terminate_session_policy_report) {
   EXPECT_EQ(session_map[IMSI1].size(), 1);
   auto& session_temp = session_map[IMSI1][0];
   EXPECT_EQ(session_temp->get_config().common_context.sid().id(), IMSI1);
+  // create session state
   SessionUpdate update = SessionStore::get_default_session_update(session_map);
   uint32_t pdu_id      = 5;
-  SessionSearchCriteria id1_success_sid(IMSI1, IMSI_AND_PDUID, pdu_id);
-  auto session_it = session_store->find_session(session_map, id1_success_sid);
+  SessionSearchCriteria criteria(IMSI1, IMSI_AND_PDUID, pdu_id);
+  auto session_it = session_store->find_session(session_map, criteria);
   auto& session   = **session_it;
   auto session_i  = session->get_session_id();
+  // SessionTerminateRequest towards policydb
   EXPECT_CALL(
       *reporter,
       report_terminate_session(CheckTerminateRequestCount(IMSI1, 0, 0), _))
       .Times(1);
+
+  // Event report for session terminate
   EXPECT_CALL(*events_reporter, session_terminated(IMSI1, testing::_)).Times(1);
 
+  // session complete terminate
   session_enforcer->m5g_complete_termination(
       session_map, IMSI1, session_i, update);
 
@@ -833,7 +843,10 @@ TEST_F(SessionManagerHandlerTest, test_terminate_session_policy_report) {
 TEST_F(SessionManagerHandlerTest, test_single_record_5g) {
   magma::SetSMSessionContext request;
   set_sm_session_context(&request);
+  // Add static rule
   insert_static_rule(1, "", "rule1");
+
+  // Make Session Response from polcydb
   CreateSessionResponse response;
   auto credits = response.mutable_credits();
   create_credit_update_response(IMSI1, SESSION_ID_1, 1, 1024, credits->Add());
@@ -842,32 +855,43 @@ TEST_F(SessionManagerHandlerTest, test_single_record_5g) {
   auto rules_to_install = response.mutable_static_rules();
   rules_to_install->Add()->CopyFrom(rule1);
 
+  // Fill the RuleRecordTable
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(
       IMSI1, "192.168.128.11", "rule1", 16, 32, 2147483647, record_list->Add());
+  // Set the session config
   SessionConfig cfg;
   cfg.common_context       = request.common_context();
   cfg.rat_specific_context = request.rat_specific_context();
   cfg.rat_specific_context.mutable_m5gsm_session_context()->set_ssc_mode(
       SSC_MODE_3);
+
   grpc::ServerContext server_context;
+  // create session and expect one call
   set_session_manager->SetAmfSessionContext(
       &server_context, &request,
       [this](grpc::Status status, SmContextVoid Void) {});
 
   // Run session creation in the EventBase loop
   evb->loopOnce();
+
   auto session_map = session_store->read_sessions({IMSI1});
+  // Init the session
   session_enforcer->m5g_init_session_credit(
       session_map, IMSI1, SESSION_ID_1, cfg);
+  // Read the session and create session state
   SessionSearchCriteria criteria(IMSI1, IMSI_AND_SESSION_ID, SESSION_ID_1);
   auto session_it = session_store->find_session(session_map, criteria);
   auto& session_t = **session_it;
   auto update     = SessionStore::get_default_session_update(session_map);
+  // Update the policy
   session_enforcer->update_session_with_policy(session_t, response, nullptr);
+  // Update the session
   session_enforcer->m5g_update_session_context(
       session_map, IMSI1, session_t, update);
+
+  // Report Traffic
   local_enforcer->aggregate_records(session_map, table, update);
   assert_charging_credit(
       session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 1024}});
@@ -876,24 +900,28 @@ TEST_F(SessionManagerHandlerTest, test_single_record_5g) {
 TEST_F(SessionManagerHandlerTest, test_update_session_credits_and_rules_5g) {
   magma::SetSMSessionContext request;
   set_sm_session_context(&request);
-
+  // Add static rule
   insert_static_rule(1, "", "rule1");
-
+  // Make Session Response from polcydb
   CreateSessionResponse response;
   auto credits = response.mutable_credits();
   create_credit_update_response(IMSI1, SESSION_ID_1, 1, 4096, credits->Add());
+  // Set session config
   SessionConfig cfg;
   cfg.common_context       = request.common_context();
   cfg.rat_specific_context = request.rat_specific_context();
   cfg.rat_specific_context.mutable_m5gsm_session_context()->set_ssc_mode(
       SSC_MODE_3);
+
   grpc::ServerContext server_context;
+  // create session and expect one call
   set_session_manager->SetAmfSessionContext(
       &server_context, &request,
       [this](grpc::Status status, SmContextVoid Void) {});
 
   // Run session creation in the EventBase loop
   evb->loopOnce();
+  // Read the session and create the session state
   auto session_map = session_store->read_sessions({IMSI1});
   session_enforcer->m5g_init_session_credit(
       session_map, IMSI1, SESSION_ID_1, cfg);
@@ -901,21 +929,25 @@ TEST_F(SessionManagerHandlerTest, test_update_session_credits_and_rules_5g) {
   auto session_it = session_store->find_session(session_map, criteria);
   auto& session_t = **session_it;
   auto update     = SessionStore::get_default_session_update(session_map);
+
+  // Update the policy
   session_enforcer->update_session_with_policy(session_t, response, nullptr);
+  // Update the session
   session_enforcer->m5g_update_session_context(
       session_map, IMSI1, session_t, update);
 
   assert_charging_credit(
       session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 4096}});
-
+  // Add the statis rule
   insert_static_rule(1, "1", "rule1");
-
+  // Fill the RuleRecordTable
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(IMSI1, "rule1", 1024, 1024, record_list->Add());
-  // auto update = SessionStore::get_default_session_update(session_map);
   auto uc = get_default_update_criteria();
   session_map[IMSI1][0]->increment_rule_stats("rule1", &uc);
+
+  // Report Traffic
   local_enforcer->aggregate_records(session_map, table, update);
 
   session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
@@ -938,6 +970,7 @@ TEST_F(SessionManagerHandlerTest, test_update_session_credits_and_rules_5g) {
       monitor_updates_response->Add());
 
   session_map = session_store->read_sessions(SessionRead{IMSI1});
+  // Update the session credits and rules
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
 

--- a/lte/gateway/c/session_manager/test/test_upf_node_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_upf_node_state.cpp
@@ -42,11 +42,13 @@ class SetUPFNodeState : public ::testing::Test {
  public:
   virtual void SetUp() {
     rule_store    = std::make_shared<StaticRuleStore>();
+    reporter      = std::make_shared<MockSessionReporter>();
     session_store = std::make_shared<SessionStore>(
         rule_store, std::make_shared<MeteringReporter>());
     std::unordered_multimap<std::string, uint32_t> pdr_map;
     auto pipelined_client = std::make_shared<magma::AsyncPipelinedClient>();
     amf_srv_client        = std::make_shared<magma::AsyncAmfServiceClient>();
+    events_reporter       = std::make_shared<MockEventsReporter>();
 
     magma::mconfig::SessionD mconfig;
     mconfig.set_log_level(magma::orc8r::LogLevel::INFO);
@@ -56,7 +58,8 @@ class SetUPFNodeState : public ::testing::Test {
 
     session_enforcer = std::make_shared<magma::SessionStateEnforcer>(
         rule_store, *session_store, pdr_map, pipelined_client, amf_srv_client,
-        mconfig, config["session_force_termination_timeout_ms"].as<int32_t>(),
+        reporter.get(), events_reporter, mconfig,
+        config["session_force_termination_timeout_ms"].as<int32_t>(),
         session_max_rtx_count);
 
     set_interface_for_up_mock =
@@ -73,6 +76,8 @@ class SetUPFNodeState : public ::testing::Test {
   std::shared_ptr<AsyncAmfServiceClient> amf_srv_client;
   std::shared_ptr<MockSetInterfaceForUserPlane> set_interface_for_up_mock;
   std::shared_ptr<UPFSessionConfigState> sess_config;
+  std::shared_ptr<MockSessionReporter> reporter;
+  std::shared_ptr<MockEventsReporter> events_reporter;
 };  // End of class
 
 // Testing the functionality of SetUPFNodeState


### PR DESCRIPTION
Signed-off-by: prabina pattnaik <prabinak@wavelabs.ai>

## Summary

Used same session store for 4G/5G and have extend to use `SessionSearchCriteria` as below searching parameters:
```
1) IMSI_AND_UE_IPV4_OR_IPV6 for 4G session.
2) IMSI_AND_TEID for 5G session
```
The gRPC  ReportRuleStats method handled for 4g and 5g usage report from pipelined.

Now it is working as below conditions:
1) Start search the session in session store with IMSI_AND_UE_IPV4_OR_IPV6 if will get it then add usage report and procced it.
2) If will not get then start search the session with IMSI_AND_TEID and will get it then add usage report and procced it. 
3) If both are not getting session info then will trigger for clean-up rules as a dead_sessions_cleanup 


## Test Plan
Test logs:

```

Nov 10 20:29:21 magma-dev-focal sessiond[581028]: I1110 20:29:21.639640 581165 GrpcMagmaUtils.cpp:58]
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:   magma.lte.RuleRecordTable {
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:       records {
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:         sid: "IMSI12345"
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:         rule_id: "allowlist_sid-IMSI12345-BLR"
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:         ue_ipv4: "192.168.128.11"
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:         rule_version: 1
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:         teid: 2147483647
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:       }
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:       records {
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:         sid: "IMSI12345"
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:         rule_id: "internal_default_drop_flow_rule"
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:         ue_ipv4: "192.168.128.11"
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:         teid: 2147483647
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:       }
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:       epoch: 1636576045
Nov 10 20:29:21 magma-dev-focal sessiond[581028]:   }
Nov 10 20:29:21 magma-dev-focal sessiond[581028]: I1110 20:29:21.641161 581028 LocalSessionManagerHandler.cpp:96] Aggregating 2 records
Nov 10 20:29:21 magma-dev-focal sessiond[581028]: I1110 20:29:21.641211 581028 LocalEnforcer.cpp:416] Could not find an active session for 4G IMSI12345 and 192.168.128.11 during record aggregation
Nov 10 20:29:21 magma-dev-focal sessiond[581028]: I1110 20:29:21.641330 581028 LocalEnforcer.cpp:416] Could not find an active session for 4G IMSI12345 and 192.168.128.11 during record aggregation
Nov 10 20:29:21 magma-dev-focal sessiond[581028]: I1110 20:29:21.641374 581028 LocalEnforcer.cpp:461] Received stats for 1 active sessions and 0 stale sessions

```
