### PR TITLE
fix(pipelined): Flush IPv6 route on bridge reset.

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -447,6 +447,9 @@ class UplinkBridgeController(MagmaController):
         flush_ip = ["ip", ver, "addr", "flush", "dev", if_name]
         subprocess.check_call(flush_ip)
 
+        flush_ip = ["ip", ver, "route", "flush", "dev", if_name]
+        subprocess.check_call(flush_ip)
+
     def _cleanup_ipv4_and_ipv6(self, if_name: str):
         self._cleanup_if(if_name=if_name, flush=True, af_inet=netifaces.AF_INET)
         self._cleanup_if(if_name=if_name, flush=True, af_inet=netifaces.AF_INET6)


### PR DESCRIPTION
This would move default route seamlessly between eth0
and uplink-bridge.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
validated on non-nat setup with IPv6

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
