### PR TITLE
feat: Add mme app latency  metric

### DIFF
--- a/lte/gateway/c/core/oai/include/service303_messages_types.h
+++ b/lte/gateway/c/core/oai/include/service303_messages_types.h
@@ -39,10 +39,12 @@ typedef struct application_mme_app_stats_msg {
   uint32_t nb_ue_connected;
   uint32_t nb_default_eps_bearers;
   uint32_t nb_s1u_bearers;
+  uint32_t nb_mme_app_last_msg_latency;
 } application_mme_app_stats_msg_t;
 
 typedef struct application_s1ap_stats_msg {
   uint32_t nb_enb_connected;
+  uint32_t nb_s1ap_last_msg_latency;
 } application_s1ap_stats_msg_t;
 
 #endif /* FILE_SERVICE303_MESSAGES_TYPES_SEEN */

--- a/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
+++ b/lte/gateway/c/core/oai/lib/message_utils/service303_message_utils.c
@@ -54,6 +54,8 @@ int send_mme_app_stats_to_service303(
       stats_msg->nb_default_eps_bearers;
   message_p->ittiMsg.application_mme_app_stats_msg.nb_s1u_bearers =
       stats_msg->nb_s1u_bearers;
+  message_p->ittiMsg.application_mme_app_stats_msg.nb_mme_app_last_msg_latency =
+      stats_msg->nb_mme_app_last_msg_latency;
   return send_msg_to_task(task_zmq_ctx_p, TASK_SERVICE303, message_p);
 }
 
@@ -68,5 +70,7 @@ int send_s1ap_stats_to_service303(
   }
   message_p->ittiMsg.application_s1ap_stats_msg.nb_enb_connected =
       stats_msg->nb_enb_connected;
+  message_p->ittiMsg.application_s1ap_stats_msg.nb_s1ap_last_msg_latency =
+      stats_msg->nb_s1ap_last_msg_latency;
   return send_msg_to_task(task_zmq_ctx_p, TASK_SERVICE303, message_p);
 }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -555,6 +555,8 @@ static int handle_stats_timer(zloop_t* loop, int id, void* arg) {
   stats_msg.nb_ue_connected        = mme_app_desc_p->nb_ue_connected;
   stats_msg.nb_default_eps_bearers = mme_app_desc_p->nb_default_eps_bearers;
   stats_msg.nb_s1u_bearers         = mme_app_desc_p->nb_s1u_bearers;
+  stats_msg.nb_mme_app_last_msg_latency = mme_app_last_msg_latency;
+
   return send_mme_app_stats_to_service303(
       &mme_app_task_zmq_ctx, TASK_MME_APP, &stats_msg);
 }

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -569,7 +569,8 @@ void s1ap_remove_enb(s1ap_state_t* state, enb_description_t* enb_ref) {
 static int handle_stats_timer(zloop_t* loop, int id, void* arg) {
   s1ap_state_t* s1ap_state_p = get_s1ap_state(false);
   application_s1ap_stats_msg_t stats_msg;
-  stats_msg.nb_enb_connected = s1ap_state_p->num_enbs;
+  stats_msg.nb_enb_connected         = s1ap_state_p->num_enbs;
+  stats_msg.nb_s1ap_last_msg_latency = s1ap_last_msg_latency;
   return send_s1ap_stats_to_service303(
       &s1ap_task_zmq_ctx, TASK_S1AP, &stats_msg);
 }

--- a/lte/gateway/c/core/oai/tasks/service303/service303_mme_stats.c
+++ b/lte/gateway/c/core/oai/tasks/service303/service303_mme_stats.c
@@ -28,12 +28,17 @@ void service303_mme_app_statistics_read(
   set_gauge("ue_connected", stats_msg_p->nb_ue_connected, label);
   set_gauge("default_eps_bearers", stats_msg_p->nb_default_eps_bearers, label);
   set_gauge("s1u_bearers", stats_msg_p->nb_s1u_bearers, label);
+  set_gauge(
+      "mme_app_last_msg_latency", stats_msg_p->nb_mme_app_last_msg_latency,
+      label);
 }
 
 void service303_s1ap_statistics_read(
     application_s1ap_stats_msg_t* stats_msg_p) {
   size_t label = 0;
   set_gauge("enb_connected", stats_msg_p->nb_enb_connected, label);
+  set_gauge(
+      "s1ap_last_msg_latency", stats_msg_p->nb_s1ap_last_msg_latency, label);
 }
 
 void service303_statistics_display(void) {


### PR DESCRIPTION
Signed-off-by: Wally Rodriguez B <wallyrb@fb.com>

## Summary

Add mme app latency  metric. 
- For MME APP re-using the already calculated latency mme_app_last_msg_latency
- For S1AP re-using the already calculated latency s1ap_last_msg_latency

## Test Plan

- Tested in local environment

```
(python) vagrant@magma-dev-focal:~/magma/lte/gateway$ service303_cli.py metrics mme

....

name: "mme_app_last_msg_latency"
help: ""
type: GAUGE
metric {
  gauge {
    value: 2601.0
  }
}

name: "s1ap_last_msg_latency"
help: ""
type: GAUGE
metric {
  gauge {
    value: 65762.0
  }
}


```
![image](https://user-images.githubusercontent.com/37117037/144385492-22923742-91c3-41ff-8dd6-551379c2e6c3.png)

