### PR TITLE
fix(amf): fix for the issue #10185

### DIFF
--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_38.413.h
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_38.413.h
@@ -245,6 +245,9 @@ typedef struct Ngap_initial_context_setup_request_s {
   ran_ue_ngap_id_t
       ran_ue_ngap_id;  // This IE uniquely identifies the UE association over
                        // the NG interface within the NG-RAN node
+  ngap_ue_aggregate_maximum_bit_rate_t
+      ue_aggregate_max_bit_rate;  // UE_AGGREGATED_BITRATE as specified in
+                                  // as specified in 38.413 [9.3.1.58]
   guamfi_t Ngap_guami;
   Ngap_PDUSessionID_t
       Pdu_Session_ID;  // PDU Session for a UE. The definition and use of the

--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -660,6 +660,13 @@ int amf_send_registration_accept(amf_context_t* amf_context) {
           "Started for ue id: " AMF_UE_NGAP_ID_FMT,
           registration_proc->T3550.id, registration_proc->ue_id);
     }
+
+    // s6a update location request
+    int rc =
+        amf_send_n11_update_location_req(ue_m5gmm_context_p->amf_ue_ngap_id);
+    if (rc == RETURNerror) {
+      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: n11_update_location_req failure\n");
+    }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
@@ -110,8 +110,10 @@ int pdu_session_resource_setup_request(
    * leveraged ambr calculation from qos_params_to_eps_qos and 24-501 spec used
    */
   ambr_calculation_pdu_session(smf_context, &dl_pdu_ambr, &ul_pdu_ambr);
-  ngap_pdu_ses_setup_req->ue_aggregate_maximum_bit_rate.dl = dl_pdu_ambr;
-  ngap_pdu_ses_setup_req->ue_aggregate_maximum_bit_rate.ul = ul_pdu_ambr;
+  ngap_pdu_ses_setup_req->ue_aggregate_maximum_bit_rate.dl =
+      ue_context->amf_context.subscribed_ue_ambr.br_dl;
+  ngap_pdu_ses_setup_req->ue_aggregate_maximum_bit_rate.ul =
+      ue_context->amf_context.subscribed_ue_ambr.br_ul;
 
   // Hardcoded number of pdu sessions as 1
   ngap_pdu_ses_setup_req->pduSessionResource_setup_list.no_of_items = 1;
@@ -122,10 +124,8 @@ int pdu_session_resource_setup_request(
   /* preparing for PDU_Session_Resource_Setup_Transfer.
    * amf_pdu_ses_setup_transfer_req is the structure to be filled.
    */
-  amf_pdu_ses_setup_transfer_req.pdu_aggregate_max_bit_rate.dl =
-      ue_context->amf_context.subscribed_ue_ambr.br_dl;
-  amf_pdu_ses_setup_transfer_req.pdu_aggregate_max_bit_rate.ul =
-      ue_context->amf_context.subscribed_ue_ambr.br_ul;
+  amf_pdu_ses_setup_transfer_req.pdu_aggregate_max_bit_rate.dl = dl_pdu_ambr;
+  amf_pdu_ses_setup_transfer_req.pdu_aggregate_max_bit_rate.ul = ul_pdu_ambr;
 
   // UPF teid 4 octet and respective ip address are from SMF context
   memcpy(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -432,7 +432,7 @@ int amf_reg_acceptmsg(const guti_m5_t* guti, amf_nas_message_t* nas_msg) {
   uint8_t* offset;
   uint32_t encoded_tmsi = ntohl(guti->m_tmsi);
 
-  offset = reinterpret_cast<uint8_t*> & encoded_tmsi;
+  offset = reinterpret_cast<uint8_t*>(&encoded_tmsi);
 
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg.mobile_id
       .mobile_identity.guti.tmsi1 = *offset;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -13,6 +13,7 @@
 
 #include <sstream>
 #include <thread>
+#include <memory>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -431,7 +432,7 @@ int amf_reg_acceptmsg(const guti_m5_t* guti, amf_nas_message_t* nas_msg) {
   uint8_t* offset;
   uint32_t encoded_tmsi = ntohl(guti->m_tmsi);
 
-  offset = (uint8_t*) &encoded_tmsi;
+  offset = reinterpret_cast<uint8_t*> & encoded_tmsi;
 
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg.mobile_id
       .mobile_identity.guti.tmsi1 = *offset;
@@ -913,7 +914,8 @@ static int amf_as_security_req(
   /*
    * Setup the NAS security message
    */
-  if (amf_msg) switch (msg->msg_type) {
+  if (amf_msg) {
+    switch (msg->msg_type) {
       case AMF_AS_MSG_TYPE_IDENT:
         size = amf_identity_request(msg, &amf_msg->msg.identityrequestmsg);
         nas_msg.header.security_header_type =
@@ -966,7 +968,6 @@ static int amf_as_security_req(
             (const char*) abba_buff, 2);
         nas_msg.plain.amf.msg.authenticationrequestmsg.auth_rand.iei = 0x21;
         nas_msg.plain.amf.msg.authenticationrequestmsg.auth_autn.iei = 0x20;
-
       } break;
       case AMF_AS_MSG_TYPE_SMC: {
         size = 8;
@@ -1022,6 +1023,7 @@ static int amf_as_security_req(
             "message 0x%.2x is not valid\n",
             msg->msg_type);
     }
+  }
 
   if (size > 0) {
     amf_context_t* amf_ctx                       = NULL;
@@ -1103,7 +1105,8 @@ static int amf_as_security_rej(
   /*
    * Setup the NAS security message
    */
-  if (amf_msg) switch (msg->msg_type) {
+  if (amf_msg) {
+    switch (msg->msg_type) {
       case AMF_AS_MSG_TYPE_AUTH: {
         size = amf_auth_reject(msg, &amf_msg->msg.authenticationrejectmsg);
         nas_msg.header.security_header_type =
@@ -1120,6 +1123,7 @@ static int amf_as_security_rej(
       }
       default: { OAILOG_DEBUG(LOG_AMF_APP, " Invalid as msg type \n"); }
     }
+  }
 
   if (size > 0) {
     amf_context_t* amf_ctx                       = NULL;
@@ -1205,54 +1209,54 @@ int initial_context_setup_request(
   req->Security_Key = (unsigned char*) &amf_ctx->_security.kgnb;
   memcpy(&req->Ngap_guami, &amf_ctx->m5_guti.guamfi, sizeof(guamfi_t));
 
-  if (ue_context->mm_state == REGISTERED_IDLE) {
+  req->ue_aggregate_max_bit_rate.dl = amf_ctx->subscribed_ue_ambr.br_dl;
+  req->ue_aggregate_max_bit_rate.ul = amf_ctx->subscribed_ue_ambr.br_ul;
+
+  for (const auto& it : ue_context->amf_context.smf_ctxt_map) {
     pdusession_setup_item_t* item = nullptr;
     pdu_resource_transfer_ie = &req->PDU_Session_Resource_Setup_Transfer_List;
 
-    for (const auto& it : ue_context->amf_context.smf_ctxt_map) {
-      std::shared_ptr<smf_context_t> smf_context = it.second;
-      if (smf_context->pdu_session_state == ACTIVE) {
-        uint8_t item_num     = 0;
-        uint64_t ul_pdu_ambr = 0;
-        uint64_t dl_pdu_ambr = 0;
-        pdu_resource_transfer_ie->no_of_items += 1;
-        item_num = pdu_resource_transfer_ie->no_of_items - 1;
-        item     = &pdu_resource_transfer_ie->item[item_num];
-        ambr_calculation_pdu_session(smf_context, &dl_pdu_ambr, &ul_pdu_ambr);
+    std::shared_ptr<smf_context_t> smf_context = it.second;
+    if (smf_context->pdu_session_state == ACTIVE) {
+      uint8_t item_num     = 0;
+      uint64_t ul_pdu_ambr = 0;
+      uint64_t dl_pdu_ambr = 0;
+      pdu_resource_transfer_ie->no_of_items += 1;
+      item_num = pdu_resource_transfer_ie->no_of_items - 1;
+      item     = &pdu_resource_transfer_ie->item[item_num];
+      ambr_calculation_pdu_session(smf_context, &dl_pdu_ambr, &ul_pdu_ambr);
 
-        // pdu session id
-        item->Pdu_Session_ID =
-            smf_context->smf_proc_data.pdu_session_identity.pdu_session_id;
+      // pdu session id
+      item->Pdu_Session_ID =
+          smf_context->smf_proc_data.pdu_session_identity.pdu_session_id;
 
-        // pdu ambr
-        item->PDU_Session_Resource_Setup_Request_Transfer
-            .pdu_aggregate_max_bit_rate.dl = amf_ctx->subscribed_ue_ambr.br_dl;
-        item->PDU_Session_Resource_Setup_Request_Transfer
-            .pdu_aggregate_max_bit_rate.ul = amf_ctx->subscribed_ue_ambr.br_ul;
+      // pdu ambr
+      item->PDU_Session_Resource_Setup_Request_Transfer
+          .pdu_aggregate_max_bit_rate.dl = dl_pdu_ambr;
+      item->PDU_Session_Resource_Setup_Request_Transfer
+          .pdu_aggregate_max_bit_rate.ul = ul_pdu_ambr;
 
-        // pdu session type
-        item->PDU_Session_Resource_Setup_Request_Transfer.pdu_ip_type.pdn_type =
-            smf_context->pdu_address.pdn_type;
+      // pdu session type
+      item->PDU_Session_Resource_Setup_Request_Transfer.pdu_ip_type.pdn_type =
+          smf_context->pdu_address.pdn_type;
 
-        // up transport info
-        memcpy(
-            &item->PDU_Session_Resource_Setup_Request_Transfer
-                 .up_transport_layer_info.gtp_tnl.gtp_tied,
-            smf_context->gtp_tunnel_id.upf_gtp_teid, GNB_TEID_LEN);
-        item->PDU_Session_Resource_Setup_Request_Transfer
-            .up_transport_layer_info.gtp_tnl.endpoint_ip_address = blk2bstr(
-            &smf_context->gtp_tunnel_id.upf_gtp_teid_ip_addr,
-            GNB_IPV4_ADDR_LEN);
+      // up transport info
+      memcpy(
+          &item->PDU_Session_Resource_Setup_Request_Transfer
+               .up_transport_layer_info.gtp_tnl.gtp_tied,
+          smf_context->gtp_tunnel_id.upf_gtp_teid, GNB_TEID_LEN);
+      item->PDU_Session_Resource_Setup_Request_Transfer.up_transport_layer_info
+          .gtp_tnl.endpoint_ip_address = blk2bstr(
+          &smf_context->gtp_tunnel_id.upf_gtp_teid_ip_addr, GNB_IPV4_ADDR_LEN);
 
-        // qos flow list
-        memcpy(
-            &item->PDU_Session_Resource_Setup_Request_Transfer
-                 .qos_flow_setup_request_list.qos_flow_req_item,
-            &smf_context->pdu_resource_setup_req
-                 .pdu_session_resource_setup_request_transfer
-                 .qos_flow_setup_request_list.qos_flow_req_item,
-            sizeof(qos_flow_setup_request_item));
-      }
+      // qos flow list
+      memcpy(
+          &item->PDU_Session_Resource_Setup_Request_Transfer
+               .qos_flow_setup_request_list.qos_flow_req_item,
+          &smf_context->pdu_resource_setup_req
+               .pdu_session_resource_setup_request_transfer
+               .qos_flow_setup_request_list.qos_flow_req_item,
+          sizeof(qos_flow_setup_request_item));
     }
   }
 
@@ -1304,6 +1308,8 @@ uint16_t amf_as_establish_cnf(
   amf_context_t* amf_ctx                       = NULL;
   amf_security_context_t* amf_security_context = NULL;
   amf_ctx                                      = amf_context_get(msg->ue_id);
+  ue_m5gmm_context_s* ue_mm_context =
+      amf_ue_context_exists_amf_ue_ngap_id(msg->ue_id);
   if (amf_ctx) {
     if (IS_AMF_CTXT_PRESENT_SECURITY(amf_ctx)) {
       amf_security_context                  = &amf_ctx->_security;
@@ -1374,13 +1380,17 @@ uint16_t amf_as_establish_cnf(
       derive_5gkey_gnb(
           amf_security_context->kamf, as_msg->nas_ul_count,
           amf_security_context->kgnb);
-      initial_context_setup_request(as_msg->ue_id, amf_ctx, as_msg->nas_msg);
       registration_proc->registration_accept_sent++;
-      OAILOG_FUNC_RETURN(LOG_NAS_AMF, ret_val);
-    } else if (
-        (state == REGISTERED_IDLE) || ((state == REGISTERED_CONNECTED) &&
-                                       (msg->nas_info == AMF_AS_NAS_INFO_SR))) {
+    }
+
+    if ((ue_mm_context->ue_context_request) ||
+        ((msg->nas_info == AMF_AS_NAS_INFO_SR) &&
+         (msg->pdu_session_status_ie &
+          AMF_AS_PDU_SESSION_REACTIVATION_STATUS))) {
       initial_context_setup_request(as_msg->ue_id, amf_ctx, as_msg->nas_msg);
+    } else {
+      amf_app_handle_nas_dl_req(as_msg->ue_id, as_msg->nas_msg, M5G_AS_SUCCESS);
+      ue_mm_context->mm_state = REGISTERED_CONNECTED;
     }
 
     as_msg->err_code = M5G_AS_SUCCESS;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.h
@@ -36,6 +36,9 @@ int amf_as_send(amf_as_t* msg);
 // primitive
 int amf_as_send_ng(const amf_as_t* msg);
 
+int initial_context_setup_request(
+    amf_ue_ngap_id_t ue_id, amf_context_t* amf_ctx, bstring nas_msg);
+
 // For _AMFAS_DATA_REQ primitive
 uint16_t amf_as_data_req(
     const amf_as_data_t* msg, m5g_dl_info_transfer_req_t* as_msg);

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -1237,18 +1237,18 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
 
     ngap_pdusession_setup_item_ies->pDUSessionID = session_item->Pdu_Session_ID;
 
-    ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU =
-        calloc(1, sizeof(Ngap_NAS_PDU_t));
-    ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->size =
-        blength(pdusession_resource_setup_req->nas_pdu);
-
     if (pdusession_resource_setup_req->nas_pdu) {
+      ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU =
+          calloc(1, sizeof(Ngap_NAS_PDU_t));
+
       ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->buf = calloc(
           blength(pdusession_resource_setup_req->nas_pdu), sizeof(uint8_t));
+      ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->size =
+          blength(pdusession_resource_setup_req->nas_pdu);
 
       memcpy(
           ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->buf,
-          bdata(pdusession_resource_setup_req->nas_pdu),
+          pdusession_resource_setup_req->nas_pdu->data,
           ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->size);
     }
 

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -1242,13 +1242,15 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
     ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->size =
         blength(pdusession_resource_setup_req->nas_pdu);
 
-    ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->buf = calloc(
-        blength(pdusession_resource_setup_req->nas_pdu), sizeof(uint8_t));
+    if (pdusession_resource_setup_req->nas_pdu) {
+      ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->buf = calloc(
+          blength(pdusession_resource_setup_req->nas_pdu), sizeof(uint8_t));
 
-    memcpy(
-        ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->buf,
-        bdata(pdusession_resource_setup_req->nas_pdu),
-        ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->size);
+      memcpy(
+          ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->buf,
+          bdata(pdusession_resource_setup_req->nas_pdu),
+          ngap_pdusession_setup_item_ies->pDUSessionNAS_PDU->size);
+    }
 
     /*NSSAI*/
     ngap_pdusession_setup_item_ies->s_NSSAI.sST.size = 1;

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -882,6 +882,25 @@ void ngap_handle_conn_est_cnf(
       free(pduSessionResourceSetupRequestTransferIEs);
 
     } /*for loop*/
+
+    ie = CALLOC(1, sizeof(Ngap_InitialContextSetupRequestIEs_t));
+
+    ie->id          = Ngap_ProtocolIE_ID_id_UEAggregateMaximumBitRate;
+    ie->criticality = Ngap_Criticality_reject;
+    ie->value.present =
+        Ngap_InitialContextSetupRequestIEs__value_PR_UEAggregateMaximumBitRate;
+
+    Ngap_UEAggregateMaximumBitRate_t* UEAggregateMaximumBitRate = NULL;
+    UEAggregateMaximumBitRate = &ie->value.choice.UEAggregateMaximumBitRate;
+
+    asn_uint642INTEGER(
+        &UEAggregateMaximumBitRate->uEAggregateMaximumBitRateUL,
+        conn_est_cnf_pP->ue_aggregate_max_bit_rate.ul);
+
+    asn_uint642INTEGER(
+        &UEAggregateMaximumBitRate->uEAggregateMaximumBitRateDL,
+        conn_est_cnf_pP->ue_aggregate_max_bit_rate.dl);
+    ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
   }
 
   if (conn_est_cnf_pP->nas_pdu) {
@@ -1291,6 +1310,25 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
     free(pduSessionResourceSetupRequestTransferIEs);
 
   } /*for loop*/
+
+  ie = CALLOC(1, sizeof(Ngap_PDUSessionResourceSetupRequestIEs_t));
+
+  ie->id          = Ngap_ProtocolIE_ID_id_UEAggregateMaximumBitRate;
+  ie->criticality = Ngap_Criticality_reject;
+  ie->value.present =
+      Ngap_PDUSessionResourceSetupRequestIEs__value_PR_UEAggregateMaximumBitRate;
+
+  Ngap_UEAggregateMaximumBitRate_t* UEAggregateMaximumBitRate = NULL;
+  UEAggregateMaximumBitRate = &ie->value.choice.UEAggregateMaximumBitRate;
+
+  asn_uint642INTEGER(
+      &UEAggregateMaximumBitRate->uEAggregateMaximumBitRateUL,
+      pdusession_resource_setup_req->ue_aggregate_maximum_bit_rate.ul);
+
+  asn_uint642INTEGER(
+      &UEAggregateMaximumBitRate->uEAggregateMaximumBitRateDL,
+      pdusession_resource_setup_req->ue_aggregate_maximum_bit_rate.dl);
+  ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
 
   if (ngap_amf_encode_pdu(&pdu, &buffer_p, &length) < 0) {
     OAILOG_ERROR(LOG_NGAP, "Encoding of IEs failed \n");


### PR DESCRIPTION
fix(amf): fix for the issue #10185

## Summary

1. Skipping  ICS procedure during registration/service request procedure if NGAP IE UeContextRequest is not present in initial ue NGAP message
2. Trigger ICS procedure during PDU establishment   if NGAP IE UeContextRequest is not present in initial ue NGAP message  
3. Changes to send UeAggMaxBitRate IE in pduSessResourceSetupReq/ICS request messages

## Test Plan

1. Verified basic sanity on NGAP Tester and TVM
2. Verified registration procedure without  UeContextRequest IE on NGAP Tester
 
## Additional Information


