### PR TITLE
ci(agw): Python3 is required in Bazel builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -69,7 +69,8 @@ RUN echo "Install general purpose packages" && \
         ninja-build \
         perl \
         pkg-config \
-        python2.7 \
+        python3 \
+        python-is-python3 \
         redis-server \
         ruby \
         rubygems \
@@ -119,8 +120,7 @@ RUN echo "Install 3rd party dependencies" && \
     echo "Install ZeroMQ" && \
     apt-get install -y libczmq-dev && \
     echo "Install dependencies for Sentry Native" && \
-    apt-get install -y libcurl4-openssl-dev && \
-    ln -s /usr/bin/python2.7 /usr/local/bin/python
+    apt-get install -y libcurl4-openssl-dev
 
 RUN ["/bin/bash", "-c", "if [[ -v GIT_PROXY ]]; then git config --global http.proxy $GIT_PROXY; fi"]
 

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -20,20 +20,19 @@ RUN apt-get update && \
         git \
         gnupg2 \
         g++ \
+        libssl-dev \
         python3 \
         python-is-python3 \
-        zip \
         unzip \
         vim \
         wget \
-        libssl-dev
+        zip \
 
 # Install bazel
 WORKDIR /usr/sbin
 RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
     chmod +x bazelisk-linux-amd64 && \
     ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
-
 
 # Install Folly as a static library in the container
 RUN apt-get install -y --no-install-recommends cmake
@@ -94,7 +93,7 @@ RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
 RUN apt-get -y install --no-install-recommends \
     libtool=2.4.6-14
 
-# TODO(GH9710): Generate asn1c with Bazel - also this repo is really old :o 
+# TODO(GH9710): Generate asn1c with Bazel - also this repo is really old :o
 RUN git clone https://gitlab.eurecom.fr/oai/asn1c.git && \
     cd asn1c && \
     git checkout f12568d617dbf48497588f8e227d70388fa217c9 && \

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && \
         git \
         gnupg2 \
         g++ \
-        python-dev \
+        python3 \
+        python-is-python3 \
         zip \
         unzip \
         vim \


### PR DESCRIPTION
## Summary

Within orc8r Python 3 is implemented as requirement for focal fossa. https://github.com/magma/magma/blob/master/orc8r/gateway/python/python.mk#L24

This is the first step to add the required packages for the usage of Bazel with Python. More iterations might be necessary, however, the feedback loop might be quite long.

## Test plan

CI docker builds ensure a valid docker image.

## Additional Information

This PR relates to https://github.com/magma/magma/pull/10188 and extracts / implements some prerequisits for running Bazel with Python.
