### PR TITLE
chore: mark set_session_manager_handler_test as flaky

### DIFF
--- a/lte/gateway/c/session_manager/test/BUILD.bazel
+++ b/lte/gateway/c/session_manager/test/BUILD.bazel
@@ -271,6 +271,7 @@ cc_test(
     name = "set_session_manager_handler_test",
     size = "small",
     srcs = ["test_set_session_manager_handler.cpp"],
+    flaky = True,
     deps = [
         ":matchers",
         ":protobuf_creators",


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This test is slightly flaky
<img width="1246" alt="Screen Shot 2021-11-11 at 8 50 05 AM" src="https://user-images.githubusercontent.com/37634144/141309820-5d8d9f36-1769-4268-b702-ad3f5e805c79.png">

Command: 
```sh
bazel test //lte/gateway/c/session_manager/test:set_session_manager_handler_test --cache_test_results=no --runs_per_test=100 --test_output=errors
```

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
