### PR TITLE
fix(ci/firebase) Always push to firebase. Even on failure

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -665,7 +665,7 @@ jobs:
           SLACK_FOOTER: ' '
   Publish_to_firebase:
     name: Publish to firebase
-    if: github.event_name == 'push'
+    if: always() && github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: [agw-build]
     steps:


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>

## Summary

We need to push failed builds to Firebase database for visibility and tracking

## Test Plan

testing on ci_firebase_always branch