### PR TITLE
fix(agw): Updating import path for load test protos

### DIFF
--- a/lte/gateway/python/load_tests/common.py
+++ b/lte/gateway/python/load_tests/common.py
@@ -17,7 +17,15 @@ from typing import List
 
 from lte.protos.subscriberdb_pb2 import SubscriberID
 
-IMPORT_PATH = str(Path.home()) + '/magma'
+parents = Path.cwd().parents
+parts = Path.cwd().parts
+home = str(Path.home())
+if 'lte' in parts and len(parents) > 3:
+    # Get relative import path for protos
+    IMPORT_PATH = parents[3]
+else:
+    IMPORT_PATH = str(home) + '/magma'
+
 RESULTS_PATH = '/var/tmp'
 PROTO_DIR = 'lte/protos'
 
@@ -76,6 +84,7 @@ def benchmark_grpc_request(
     output_file: str,
     num_reqs: int,
     address: str,
+    import_path: str = None,
 ):
     """Run GHZ based GRPC benchmarking
 
@@ -87,9 +96,13 @@ def benchmark_grpc_request(
         num_reqs (int): number of requests to send
         address (str): address to the service being benchmarked
     """
+    import_path = import_path or IMPORT_PATH
+    if not Path(import_path).exists():
+        print('Protobuf import path directory does not exist, exiting')
+        return
     cmd_list = [
         'ghz',
-        '--insecure', '--proto', proto_path, '-i', IMPORT_PATH, '--total',
+        '--insecure', '--proto', proto_path, '-i', import_path, '--total',
         str(num_reqs), '--call', full_request_type, '-D', input_file,
         '-O', 'json', '-o', output_file, address,
     ]

--- a/lte/gateway/python/load_tests/loadtest_mobilityd.py
+++ b/lte/gateway/python/load_tests/loadtest_mobilityd.py
@@ -53,7 +53,9 @@ PROTO_PATH = PROTO_DIR + '/mobilityd.proto'
 
 def _load_subs(num_subs: int) -> List[SubscriberID]:
     client = SubscriberDBStub(
-        ServiceRegistry.get_rpc_channel(SUBSCRIBERDB_SERVICE_NAME, ServiceRegistry.LOCAL),
+        ServiceRegistry.get_rpc_channel(
+            SUBSCRIBERDB_SERVICE_NAME, ServiceRegistry.LOCAL,
+        ),
     )
     sids = []
 
@@ -70,7 +72,9 @@ def _load_subs(num_subs: int) -> List[SubscriberID]:
 
 def _cleanup_subs():
     client = SubscriberDBStub(
-        ServiceRegistry.get_rpc_channel(SUBSCRIBERDB_SERVICE_NAME, ServiceRegistry.LOCAL),
+        ServiceRegistry.get_rpc_channel(
+            SUBSCRIBERDB_SERVICE_NAME, ServiceRegistry.LOCAL,
+        ),
     )
 
     for sid in client.ListSubscribers(Void()).sids:
@@ -151,7 +155,8 @@ def create_parser():
         parser_allocate,
         parser_release,
     ]:
-        cmd.add_argument("--num", default=2000, help="--num")
+        cmd.add_argument("--num", default=2000, help="Number of requests")
+        cmd.add_argument("--import_path", help="Protobuf dir import path")
 
     # Add function callbacks
     parser_allocate.set_defaults(func=parser_allocate)
@@ -177,6 +182,7 @@ def main():
     )
 
     if args.cmd == 'allocate':
+        _cleanup_subs()
         _setup_ip_block(client)
         input_file = 'allocate_data.json'
         request_type = 'AllocateIPAddress'
@@ -190,6 +196,7 @@ def main():
             output_file=make_output_file_path(request_type),
             num_reqs=args.num,
             address=MOBILITYD_PORT,
+            import_path=args.import_path,
         )
         _cleanup_subs()
 
@@ -206,6 +213,7 @@ def main():
             output_file=make_output_file_path(request_type),
             num_reqs=args.num,
             address=MOBILITYD_PORT,
+            import_path=args.import_path,
         )
 
     print('Done')

--- a/lte/gateway/python/load_tests/loadtest_pipelined.py
+++ b/lte/gateway/python/load_tests/loadtest_pipelined.py
@@ -66,13 +66,17 @@ def _build_activate_flows_data(ue_dict, disable_qos: bool, input_file: str):
                         flow_list=[
                             FlowDescription(
                                 match=FlowMatch(
-                                    ip_dst=convert_ipv4_str_to_ip_proto(ue.ipv4_src),
+                                    ip_dst=convert_ipv4_str_to_ip_proto(
+                                        ue.ipv4_src,
+                                    ),
                                     direction=FlowMatch.UPLINK,
                                 ),
                             ),
                             FlowDescription(
                                 match=FlowMatch(
-                                    ip_src=convert_ipv4_str_to_ip_proto(ue.ipv4_dst),
+                                    ip_src=convert_ipv4_str_to_ip_proto(
+                                        ue.ipv4_dst,
+                                    ),
                                     direction=FlowMatch.DOWNLINK,
                                 ),
                             ),
@@ -127,6 +131,7 @@ def activate_flows_test(args):
         input_file=input_file,
         output_file=make_output_file_path(request_type),
         num_reqs=args.num_of_ues, address=PIPELINED_PORT,
+        import_path=args.import_path,
     )
 
 
@@ -143,6 +148,7 @@ def deactivate_flows_test(args):
         input_file=input_file,
         output_file=make_output_file_path(request_type),
         num_reqs=args.num_of_ues, address=PIPELINED_PORT,
+        import_path=args.import_path,
     )
 
 
@@ -174,6 +180,9 @@ def create_parser():
         subcmd.add_argument(
             '--disable_qos', help='If we want to disable QOS',
             action="store_true",
+        )
+        subcmd.add_argument(
+            '--import_path', default=None, help='Protobuf import path directory',
         )
     parser_activate.set_defaults(func=activate_flows_test)
     parser_deactivate.set_defaults(func=deactivate_flows_test)

--- a/lte/gateway/python/load_tests/loadtest_sessiond.py
+++ b/lte/gateway/python/load_tests/loadtest_sessiond.py
@@ -40,7 +40,7 @@ PROTO_PATH = PROTO_DIR + '/session_manager.proto'
 SERVICE_NAME = 'magma.lte.LocalSessionManager'
 
 
-def _handle_create_session_benchmarking(subs: List[SubscriberID]):
+def _handle_create_session_benchmarking(subs: List[SubscriberID], import_path: str = None):
     _build_create_session_data(subs)
     request_type = 'CreateSession'
     benchmark_grpc_request(
@@ -50,6 +50,7 @@ def _handle_create_session_benchmarking(subs: List[SubscriberID]):
         make_output_file_path(request_type),
         len(subs),
         SESSIOND_PORT,
+        import_path=import_path,
     )
 
 
@@ -76,7 +77,7 @@ def _build_create_session_data(subs: List[SubscriberID]):
         json.dump(reqs, file, separators=(',', ':'))
 
 
-def _handle_end_session_benchmarking(subs: List[SubscriberID]):
+def _handle_end_session_benchmarking(subs: List[SubscriberID], import_path: str = None):
     _build_end_session_data(subs)
     request_type = 'EndSession'
     benchmark_grpc_request(
@@ -86,6 +87,7 @@ def _handle_end_session_benchmarking(subs: List[SubscriberID]):
         make_output_file_path(request_type),
         len(subs),
         SESSIOND_PORT,
+        import_path=import_path,
     )
 
 
@@ -127,11 +129,14 @@ def _create_parser() -> argparse.ArgumentParser:
 
     # Add arguments
     for cmd in (parser_create, parser_end):
-        cmd.add_argument("--num", default=5, help="--num")
+        cmd.add_argument("--num", default=5, help="number of requests")
         cmd.add_argument(
             '--service_name',
             default='magma.lte.LocalSessionManager',
             help='proto service name',
+        )
+        cmd.add_argument(
+            '--import_path', default=None, help='Protobuf import path directory',
         )
 
     # Add function callbacks
@@ -153,10 +158,10 @@ def main():
     print('Preparing %s load test...' % args.cmd)
     subs = generate_subs(int(args.num))
     if args.cmd == 'create':
-        _handle_create_session_benchmarking(subs)
+        _handle_create_session_benchmarking(subs, args.import_path)
 
     elif args.cmd == 'end':
-        _handle_end_session_benchmarking(subs)
+        _handle_end_session_benchmarking(subs, args.import_path)
 
     print('Done')
 


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- For AGW deployments on docker, magma folder path can be placed different from home path. This PR updates the import path of protos so it works for all deployments.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make load_test on VM
- running load tests individually on docker pods

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
