### PR TITLE
fix(feg): Incorrect conversion between integer types

### DIFF
--- a/feg/gateway/policydb/flow_parser.go
+++ b/feg/gateway/policydb/flow_parser.go
@@ -173,5 +173,8 @@ func parseAddress(addr string) (*address, error) {
 	if err != nil {
 		return nil, err
 	}
+	if portInt < 0 || portInt > 4294967295 {
+		return nil, fmt.Errorf("Number %d is outside the boundaries of unit32 type", portInt)
+	}
 	return &address{ip: ipAddr, version: version, port: uint32(portInt)}, nil
 }

--- a/feg/gateway/policydb/flow_parser.go
+++ b/feg/gateway/policydb/flow_parser.go
@@ -136,7 +136,7 @@ func parseProto(proto string) (protos.FlowMatch_IPProto, error) {
 	if proto == "ip" {
 		return protos.FlowMatch_IPPROTO_IP, nil
 	}
-	protoInt, err := strconv.Atoi(proto)
+	protoInt, err := strconv.ParseInt(proto, 10, 32)
 	if err != nil {
 		return protos.FlowMatch_IPPROTO_IP, err
 	}

--- a/feg/gateway/policydb/flow_parser_test.go
+++ b/feg/gateway/policydb/flow_parser_test.go
@@ -53,6 +53,15 @@ func TestFlowProto(t *testing.T) {
 	udp, err := policydb.GetFlowDescriptionFromFlowString("permit in 17 from any to any")
 	assert.NoError(t, err)
 	assert.Equal(t, udp.Match.IpProto, protos.FlowMatch_IPPROTO_UDP)
+
+	//test out of range int32 number
+	protoOutOfRange, err := policydb.GetFlowDescriptionFromFlowString("permit in 4294967313 from any to any")
+	assert.Error(t, err)
+	assert.Nil(t, protoOutOfRange)
+
+	protoNotNumber, err := policydb.GetFlowDescriptionFromFlowString("permit in not_number from any to any")
+	assert.Error(t, err)
+	assert.Nil(t, protoNotNumber)
 }
 
 func TestFlowAddresses(t *testing.T) {

--- a/feg/gateway/policydb/flow_parser_test.go
+++ b/feg/gateway/policydb/flow_parser_test.go
@@ -111,6 +111,15 @@ func TestFlowAddresses(t *testing.T) {
 	assert.Equal(t, flow5.UdpSrc, uint32(0))
 	assert.Equal(t, flow5.IpDst, (*protos.IPAddress)(nil))
 	assert.Equal(t, flow5.TcpDst, uint32(0))
+
+	//test out of range uint32 number
+	flow6Desc, err := policydb.GetFlowDescriptionFromFlowString("permit in 6 from b522::10 4294967313 to any")
+	assert.Error(t, err)
+	assert.Nil(t, flow6Desc)
+
+	flow7Desc, err := policydb.GetFlowDescriptionFromFlowString("permit in 6 from b522::10 not_number to any")
+	assert.Error(t, err)
+	assert.Nil(t, flow7Desc)
 }
 
 func TestAll(t *testing.T) {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
fix(feg): fix incorrect conversion between integer types

## Summary

<!-- Enumerate changes you made and why you made them -->
- magma/feg/gateway/policydb/flow_parser.go -> parseProto()
- magma/feg/gateway/policydb/flow_parser.go -> parseAddress()

   String was parsed into an int using strconv.Atoi which can cause incorrect conversion  if int is converted into another integer type of a smaller size. Fixed to strconv. ParseInt function. A check was created to see if number is in limits for type uint32

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

- magma/feg/gateway/policydb/flow_parser_test.go
In tests TestFlowProto() and TestFlowAddresses() added tests for out of range int32 and Uint32 numbers.
![Screenshot 2021-11-10 at 15 01 06](https://user-images.githubusercontent.com/15000134/141429400-3aea6930-4c3c-496b-bab5-3d8dcac85030.png)




## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
