### PR TITLE
chore(mme): migrate non-system includes to use of quotes

### DIFF
--- a/lte/gateway/c/core/oai/include/state_manager.h
+++ b/lte/gateway/c/core/oai/include/state_manager.h
@@ -21,18 +21,18 @@
 extern "C" {
 #endif
 
-#include <lte/gateway/c/core/oai/common/assertions.h>
-#include <lte/gateway/c/core/oai/common/common_defs.h>
+#include "lte/gateway/c/core/oai/common/assertions.h"
+#include "lte/gateway/c/core/oai/common/common_defs.h"
 #include <cstdlib>
-#include <lte/gateway/c/core/oai/common/log.h>
-#include <lte/gateway/c/core/oai/lib/hashtable/hashtable.h>
+#include "lte/gateway/c/core/oai/common/log.h"
+#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
 
 #ifdef __cplusplus
 }
 #endif
 
 #include <unordered_map>
-#include <lte/gateway/c/core/oai/common/conversions.h>
+#include "lte/gateway/c/core/oai/common/conversions.h"
 #include "lte/gateway/c/core/oai/common/redis_utils/redis_client.h"
 
 namespace {

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface_init.h
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface_init.h
@@ -55,14 +55,14 @@ const task_info_t tasks_info[] = {
     {0, "TASK_UNKNOWN", "ipc:///run/IPC_TASK_UNKNOWN"},
 #define TASK_DEF(tHREADiD)                                                     \
   {tHREADiD##_THREAD, #tHREADiD, "ipc:///run/IPC_" #tHREADiD},
-#include <lte/gateway/c/core/oai/include/tasks_def.h>
+#include "lte/gateway/c/core/oai/include/tasks_def.h"
 #undef TASK_DEF
 };
 
 /* Map message id to message information */
 const message_info_t messages_info[] = {
 #define MESSAGE_DEF(iD, sTRUCT, fIELDnAME) {iD, sizeof(sTRUCT), #iD},
-#include <lte/gateway/c/core/oai/include/messages_def.h>
+#include "lte/gateway/c/core/oai/include/messages_def.h"
 #undef MESSAGE_DEF
 };
 

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h
@@ -67,12 +67,12 @@
 /* Extract the instance from a message */
 #define ITTI_MESSAGE_GET_INSTANCE(mESSAGE) ((mESSAGE)->ittiMsgHeader.instance)
 
-#include <lte/gateway/c/core/oai/include/messages_types.h>
+#include "lte/gateway/c/core/oai/include/messages_types.h"
 
 /* This enum defines messages ids. Each one is unique. */
 typedef enum {
 #define MESSAGE_DEF(iD, sTRUCT, fIELDnAME) iD,
-#include <lte/gateway/c/core/oai/include/messages_def.h>
+#include "lte/gateway/c/core/oai/include/messages_def.h"
 #undef MESSAGE_DEF
 
   MESSAGES_ID_MAX,
@@ -83,7 +83,7 @@ typedef enum {
   THREAD_NULL = 0,
 
 #define TASK_DEF(tHREADiD) THREAD_##tHREADiD,
-#include <lte/gateway/c/core/oai/include/tasks_def.h>
+#include "lte/gateway/c/core/oai/include/tasks_def.h"
 #undef TASK_DEF
 
   THREAD_MAX,
@@ -93,7 +93,7 @@ typedef enum {
 //! Sub-tasks id, to defined offset form thread id
 typedef enum {
 #define TASK_DEF(tHREADiD) tHREADiD##_THREAD = THREAD_##tHREADiD,
-#include <lte/gateway/c/core/oai/include/tasks_def.h>
+#include "lte/gateway/c/core/oai/include/tasks_def.h"
 #undef TASK_DEF
 } task_thread_id_t;
 
@@ -102,7 +102,7 @@ typedef enum {
   TASK_UNKNOWN = 0,
 
 #define TASK_DEF(tHREADiD) tHREADiD,
-#include <lte/gateway/c/core/oai/include/tasks_def.h>
+#include "lte/gateway/c/core/oai/include/tasks_def.h"
 #undef TASK_DEF
 
   TASK_MAX,
@@ -111,7 +111,7 @@ typedef enum {
 
 typedef union msg_s {
 #define MESSAGE_DEF(iD, sTRUCT, fIELDnAME) sTRUCT fIELDnAME;
-#include <lte/gateway/c/core/oai/include/messages_def.h>
+#include "lte/gateway/c/core/oai/include/messages_def.h"
 #undef MESSAGE_DEF
 } msg_t;
 

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -18,8 +18,8 @@
 #include <grpcpp/impl/codegen/status.h>
 #include <cstring>
 #include <string>
-#include <lte/gateway/c/core/oai/common/conversions.h>
-#include <lte/gateway/c/core/oai/common/common_defs.h>
+#include "lte/gateway/c/core/oai/common/conversions.h"
+#include "lte/gateway/c/core/oai/common/common_defs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/lte/gateway/c/core/oai/lib/s6a_proxy/s6a_client_api.cpp
+++ b/lte/gateway/c/core/oai/lib/s6a_proxy/s6a_client_api.cpp
@@ -20,7 +20,7 @@
 #include <string.h>
 #include <string>
 #include <iostream>
-#include <lte/gateway/c/core/oai/common/conversions.h>
+#include "lte/gateway/c/core/oai/common/conversions.h"
 
 #include "lte/gateway/c/core/oai/lib/s6a_proxy/s6a_client_api.h"
 #include "lte/gateway/c/core/oai/lib/s6a_proxy/S6aClient.h"

--- a/lte/gateway/c/core/oai/tasks/grpc_service/spgw_service_handler.c
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/spgw_service_handler.c
@@ -16,7 +16,7 @@
  */
 #include <string.h>
 #include <sys/types.h>
-#include <lte/gateway/c/core/oai/common/conversions.h>
+#include "lte/gateway/c/core/oai/common/conversions.h"
 
 #include "lte/gateway/c/core/oai/common/common_types.h"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <lte/gateway/c/core/oai/lib/3gpp/3gpp_29.274.h>
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_29.274.h"
 #include <inttypes.h>
 #include <netinet/in.h>
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_hss_reset.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_hss_reset.c
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <pthread.h>
 #include <stdbool.h>
-#include <lte/gateway/c/core/oai/include/mme_app_state.h>
+#include "lte/gateway/c/core/oai/include/mme_app_state.h"
 
 #include "lte/gateway/c/core/oai/common/common_defs.h"
 #include "lte/gateway/c/core/oai/common/log.h"

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_reset.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_reset.c
@@ -32,7 +32,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
-#include <lte/gateway/c/core/oai/include/mme_app_state.h>
+#include "lte/gateway/c/core/oai/include/mme_app_state.h"
 
 #include "lte/gateway/c/core/oai/common/log.h"
 #include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_fsm.h"

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.h
@@ -21,7 +21,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/include/mme_config.h"
 }
 
-#include <lte/gateway/c/core/oai/include/state_manager.h>
+#include "lte/gateway/c/core/oai/include/state_manager.h"
 #include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_converter.h"
 #include "orc8r/gateway/c/common/config/includes/ServiceConfigLoader.h"
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPayloadContainer.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPayloadContainer.h
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include <string.h>
 #include <sstream>
-#include <lte/gateway/c/core/oai/tasks/nas5g/include/SmfMessage.h>
+#include "lte/gateway/c/core/oai/tasks/nas5g/include/SmfMessage.h"
 #define PAYLOAD_CONTAINER_CONTENTS_MAX_LEN 8192
 
 namespace magma5g {

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.c
@@ -23,7 +23,7 @@
 */
 #include "lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_itti_messaging.h"
 
-#include <lte/gateway/c/core/oai/include/mme_app_ue_context.h>
+#include "lte/gateway/c/core/oai/include/mme_app_ue_context.h"
 
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
 #include "lte/gateway/c/core/oai/common/log.h"

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_cancel_loc.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_cancel_loc.c
@@ -23,7 +23,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <lte/gateway/c/core/oai/common/conversions.h>
+#include "lte/gateway/c/core/oai/common/conversions.h"
 
 #include "lte/gateway/c/core/oai/common/assertions.h"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -30,7 +30,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <netinet/in.h>
-#include <lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.h>
+#include "lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.h"
 
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_paging.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_paging.c
@@ -20,7 +20,7 @@
 #include <netinet/in.h>
 #include <stdlib.h>
 #include <sys/socket.h>
-#include <lte/gateway/c/core/oai/common/conversions.h>
+#include "lte/gateway/c/core/oai/common/conversions.h"
 
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
 #include "lte/gateway/c/core/oai/common/log.h"

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state.cpp
@@ -18,7 +18,7 @@
 #include "lte/gateway/c/core/oai/include/spgw_state.h"
 
 #include <cstdlib>
-#include <lte/gateway/c/core/oai/common/conversions.h>
+#include "lte/gateway/c/core/oai/common/conversions.h"
 
 extern "C" {
 #include "lte/gateway/c/core/oai/common/assertions.h"

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.cpp
@@ -18,7 +18,7 @@
 #include "lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.h"
 
 extern "C" {
-#include <lte/gateway/c/core/oai/common/dynamic_memory_check.h>
+#include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/common/common_defs.h"
 }
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state.cpp
@@ -14,7 +14,7 @@ limitations under the License.
 #include "lte/gateway/c/core/oai/include/sgw_s8_state.h"
 
 #include <cstdlib>
-#include <lte/gateway/c/core/oai/common/conversions.h>
+#include "lte/gateway/c/core/oai/common/conversions.h"
 
 extern "C" {
 #include "lte/gateway/c/core/oai/common/assertions.h"

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.cpp
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 extern "C" {
-#include <lte/gateway/c/core/oai/common/dynamic_memory_check.h>
+#include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/common/backtrace.h"
 }
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.h
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.h
@@ -13,7 +13,7 @@ limitations under the License.
 
 #pragma once
 
-#include <lte/gateway/c/core/oai/include/state_manager.h>
+#include "lte/gateway/c/core/oai/include/state_manager.h"
 #include "lte/gateway/c/core/oai/include/sgw_s8_state.h"
 #include "lte/protos/oai/sgw_state.pb.h"
 #include "lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_converter.h"

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -35,7 +35,7 @@ const task_info_t tasks_info[] = {
     {THREAD_NULL, "TASK_UNKNOWN", "ipc://IPC_TASK_UNKNOWN"},
 #define TASK_DEF(tHREADiD)                                                     \
   {THREAD_##tHREADiD, #tHREADiD, "ipc://IPC_" #tHREADiD},
-#include <lte/gateway/c/core/oai/include/tasks_def.h>
+#include "lte/gateway/c/core/oai/include/tasks_def.h"
 #undef TASK_DEF
 };
 

--- a/lte/gateway/c/core/oai/test/itti/test_itti.cpp
+++ b/lte/gateway/c/core/oai/test/itti/test_itti.cpp
@@ -29,14 +29,14 @@ const task_info_t tasks_info[] = {
     {THREAD_NULL, "TASK_UNKNOWN", "ipc://IPC_TASK_UNKNOWN"},
 #define TASK_DEF(tHREADiD)                                                     \
   {THREAD_##tHREADiD, #tHREADiD, "ipc://IPC_" #tHREADiD},
-#include <lte/gateway/c/core/oai/include/tasks_def.h>
+#include "lte/gateway/c/core/oai/include/tasks_def.h"
 #undef TASK_DEF
 };
 
 /* Map message id to message information */
 const message_info_t messages_info[] = {
 #define MESSAGE_DEF(iD, sTRUCT, fIELDnAME) {iD, sizeof(sTRUCT), #iD},
-#include <lte/gateway/c/core/oai/include/messages_def.h>
+#include "lte/gateway/c/core/oai/include/messages_def.h"
 #undef MESSAGE_DEF
 };
 

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -27,14 +27,14 @@ const task_info_t tasks_info[] = {
     {THREAD_NULL, "TASK_UNKNOWN", "ipc://IPC_TASK_UNKNOWN"},
 #define TASK_DEF(tHREADiD)                                                     \
   {THREAD_##tHREADiD, #tHREADiD, "ipc://IPC_" #tHREADiD},
-#include <lte/gateway/c/core/oai/include/tasks_def.h>
+#include "lte/gateway/c/core/oai/include/tasks_def.h"
 #undef TASK_DEF
 };
 
 /* Map message id to message information */
 const message_info_t messages_info[] = {
 #define MESSAGE_DEF(iD, sTRUCT, fIELDnAME) {iD, sizeof(sTRUCT), #iD},
-#include <lte/gateway/c/core/oai/include/messages_def.h>
+#include "lte/gateway/c/core/oai/include/messages_def.h"
 #undef MESSAGE_DEF
 };
 

--- a/lte/gateway/c/core/oai/test/ngap/mock_utils.h
+++ b/lte/gateway/c/core/oai/test/ngap/mock_utils.h
@@ -26,13 +26,13 @@ const task_info_t tasks_info[] = {
     {THREAD_NULL, "TASK_UNKNOWN", "ipc://IPC_TASK_UNKNOWN"},
 #define TASK_DEF(tHREADiD)                                                     \
   {THREAD_##tHREADiD, #tHREADiD, "ipc://IPC_" #tHREADiD},
-#include <lte/gateway/c/core/oai/include/tasks_def.h>
+#include "lte/gateway/c/core/oai/include/tasks_def.h"
 #undef TASK_DEF
 };
 
 /* Map message id to message information */
 const message_info_t messages_info[] = {
 #define MESSAGE_DEF(iD, sTRUCT, fIELDnAME) {iD, sizeof(sTRUCT), #iD},
-#include <lte/gateway/c/core/oai/include/messages_def.h>
+#include "lte/gateway/c/core/oai/include/messages_def.h"
 #undef MESSAGE_DEF
 };


### PR DESCRIPTION
It has come to light that we sometimes use system include syntax for in-repo includes (e.g. `#include <path/to/magma/include.h>`).  Google style (and Bazel enforced behavior) wants these to be quoted includes (e.g. `#include "path/to/magma/include.h"`). Note I'm unable to find the explicit [Google Style recommendation](https://google.github.io/styleguide/cppguide.html) on this topic, but all examples in the Google Style guide use quoted includes for repo-contained resources.

I authored a [script](https://gist.github.com/electronjoe/b2702953aae58dc07dd0ba8f131a2846) to find and fixup all instances.

## Test Plan

Compilation success, unit test execution.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>