### PR TITLE
fix(feg): Incorrect conversion between integer types

### DIFF
--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -44,6 +44,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.26.0
+	gotest.tools/gotestsum v1.7.0 // indirect
 	layeh.com/radius v0.0.0-20201203135236-838e26d0c9be
 	magma/feg/cloud/go v0.0.0
 	magma/feg/cloud/go/protos v0.0.0

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -134,6 +134,7 @@ github.com/facebookincubator/prometheus-edge-hub v1.1.0/go.mod h1:MXZSK377xnwne4
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fiorix/go-diameter/v4 v4.0.4 h1:/nw5zEmEW7pmP9YUYjOfU1GomR0LupKdYy52yd1j3NM=
 github.com/fiorix/go-diameter/v4 v4.0.4/go.mod h1:Qx/+pf+c9sBUHWq1d7EH3bkdwN8U0mUpdy9BieDw6UQ=

--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
@@ -399,7 +399,7 @@ func getMSCCAVP(requestType credit_control.CreditRequestType, credits *UsedCredi
 		avpGroup = append(avpGroup, diam.NewAVP(avp.RequestedServiceUnit, avp.Mbit, 0, &diam.GroupedAVP{AVP: usuGrp}))
 	}
 
-	if serviceIdentifier >= 0 {
+	if serviceIdentifier >= 0 && serviceIdentifier <= 4294967295 { //check if is in bounds of Unsigned32 type
 		avpGroup = append(
 			avpGroup,
 			diam.NewAVP(avp.ServiceIdentifier, avp.Mbit, 0, datatype.Unsigned32(serviceIdentifier)))

--- a/feg/gateway/tgpp/utils.go
+++ b/feg/gateway/tgpp/utils.go
@@ -33,7 +33,7 @@ func GetPlmnID(imsi string, mncLen int) []byte {
 	}
 	imsiBytes := [6]byte{}
 	for i := 0; i < 6; i++ {
-		v, err := strconv.Atoi(imsi[i : i+1])
+		v, err := strconv.ParseInt(imsi[i:i+1], 10, 8)
 		if err != nil {
 			glog.Errorf("Invalid Digit '%s' in IMSI '%s': %v", imsi[i:i+1], imsi, err)
 		}

--- a/feg/gateway/tgpp/utils.go
+++ b/feg/gateway/tgpp/utils.go
@@ -33,9 +33,12 @@ func GetPlmnID(imsi string, mncLen int) []byte {
 	}
 	imsiBytes := [6]byte{}
 	for i := 0; i < 6; i++ {
-		v, err := strconv.ParseInt(imsi[i:i+1], 10, 8)
+		v, err := strconv.Atoi(imsi[i : i+1])
 		if err != nil {
 			glog.Errorf("Invalid Digit '%s' in IMSI '%s': %v", imsi[i:i+1], imsi, err)
+		}
+		if v < 0 || v > 255 {
+			glog.Errorf("Digit '%d' in IMSI '%s' is outside the bounds of byte type", v, imsi)
 		}
 		imsiBytes[i] = byte(v)
 	}

--- a/feg/gateway/tools/gw_csfb_service_cli/main.go
+++ b/feg/gateway/tools/gw_csfb_service_cli/main.go
@@ -157,7 +157,7 @@ func marshalLocationUpdateAccept() (decode.SGsMessageType, *any.Any, error) {
 func marshalLocationUpdateReject() (decode.SGsMessageType, *any.Any, error) {
 	var rejectCause []byte
 	if len(flag.Args()) == 2 {
-		rejectCauseCode, err := strconv.Atoi(flag.Arg(1))
+		rejectCauseCode, err := strconv.ParseInt(flag.Arg(1), 10, 8)
 		if err != nil {
 			return decode.SGsAPLocationUpdateReject, nil, err
 		}

--- a/feg/gateway/tools/gw_csfb_service_cli/main.go
+++ b/feg/gateway/tools/gw_csfb_service_cli/main.go
@@ -157,9 +157,12 @@ func marshalLocationUpdateAccept() (decode.SGsMessageType, *any.Any, error) {
 func marshalLocationUpdateReject() (decode.SGsMessageType, *any.Any, error) {
 	var rejectCause []byte
 	if len(flag.Args()) == 2 {
-		rejectCauseCode, err := strconv.ParseInt(flag.Arg(1), 10, 8)
+		rejectCauseCode, err := strconv.Atoi(flag.Arg(1))
 		if err != nil {
 			return decode.SGsAPLocationUpdateReject, nil, err
+		}
+		if rejectCauseCode < 0 || rejectCauseCode > 255 {
+			return decode.SGsAPLocationUpdateReject, nil, fmt.Errorf("Number %d is outside the bounds of byte type", rejectCauseCode)
 		}
 		rejectCause = []byte{byte(rejectCauseCode)}
 	} else {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
fix(feg): fix incorrect conversion between integer types

## Summary

<!-- Enumerate changes you made and why you made them -->
- /magma/feg/gateway/tgpp/utils.go -> GetPlmnID()
   String was parsed into an int using strconv.Atoi which can cause incorrect conversion  if int is converted into another integer type of a smaller size. A check was added to see if number is in limits for type byte (0-255)

- /magma/feg/gateway/tools/gw_csfb_service_cli/main.go -> marshalLocationUpdateReject()
   String was parsed into an int using strconv.Atoi which can cause incorrect conversion  if int is converted into another integer type of a smaller size. A check was added to see if number is in limits for type byte (0-255)

- /magma/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
   String was parsed into an int using strconv.Atoi which can cause incorrect conversion  if int is converted into another integer type of a smaller size. Added check if variable is in bounds of Unsigned32 type (0-4294967295)

Fixes are for alerts:
- https://github.com/magma/magma/security/code-scanning/14?query=ref%3Arefs%2Fheads%2Fmaster
- https://github.com/magma/magma/security/code-scanning/15?query=ref%3Arefs%2Fheads%2Fmaster
- https://github.com/magma/magma/security/code-scanning/13?query=ref%3Arefs%2Fheads%2Fmaster

