### PR TITLE
fix(mme): correct S8a proto generation for grpc_service

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/CMakeLists.txt
@@ -77,6 +77,7 @@ generate_grpc_protos("${AMFSRV_M5G_GRPC_PROTOS}" "${PROTO_SRCS}"
     "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_OUT_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
+# S8a
 set(S8SRV_FEG_CPP_PROTOS s8_proxy)
 set(S8SRV_FEG_GRPC_PROTOS s8_proxy)
 set(S8SRV_LTE_CPP_PROTOS oai/spgw_state  oai/common_types oai/std_3gpp_types)
@@ -88,7 +89,7 @@ generate_grpc_protos("${S8SRV_FEG_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${FEG_PROTO_DIR} ${FEG_OUT_DIR})
 generate_cpp_protos("${S8SRV_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_OUT_DIR})
-generate_grpc_protos("${S8SRV_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
+generate_grpc_protos("${S8SRV_LTE_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_OUT_DIR})
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${SGW_S8_INCLUDES})


### PR DESCRIPTION
Fix for #9580 `make build_oai` failure in devcontainer.

## Test Plan

Validated that `test build_oai` succeeds in GH Codespaces under this PR, while it fails without this PR on master).

Signed-off-by: Scott Harrison Moeller <smoeller@fb.com>