### PR TITLE
chore(ci): build mme before running unit tests

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -229,7 +229,7 @@ jobs:
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma
           run: |
             cd /workspaces/magma/lte/gateway
             make test_li_agent
@@ -252,6 +252,77 @@ jobs:
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
 
+  sctpd_test:
+    needs: path_filter
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    name: sctpd test job
+    runs-on: ubuntu-latest
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Devcontainer Image
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the devontainer image!"
+      - name: Build SCTPD with Debug build type
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make build_sctpd BUILD_TYPE=Debug
+      - name: Run SCTPD tests with Debug build type
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make test_sctpd BUILD_TYPE=Debug
+      - name: Build SCTPD with RelWithDebInfo build type
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make build_sctpd BUILD_TYPE=RelWithDebInfo
+      - name: Run SCTPD tests with RelWithDebInfo build type
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make test_sctpd BUILD_TYPE=RelWithDebInfo
+      - name: Extract commit title
+        # yamllint enable
+        if: failure() && github.event_name == 'push'
+        id: commit
+        run: |
+            str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+            echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "Github action sctpd_test failed"
+          SLACK_USERNAME: "AGW workflow"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+
   mme_test:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
@@ -261,39 +332,46 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
       - uses: actions/checkout@v2
-      - name: Run sctpd tests with Debug build type
+      - name: Setup Devcontainer Image
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the devontainer image!"
+      - name: Build MME with Debug build type
         uses: addnab/docker-run-action@v2
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma
           run: |
             cd /workspaces/magma/lte/gateway
-            make test_sctpd BUILD_TYPE=Debug
-      - name: Run sctpd tests with RelWithDebInfo build type
+            make build_oai BUILD_TYPE=Debug;
+      - name: Run MME tests with Debug build type
         uses: addnab/docker-run-action@v2
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
-          run: |
-            cd /workspaces/magma/lte/gateway
-            make test_sctpd BUILD_TYPE=RelWithDebInfo
-      - name: Run mme tests with Debug build type
-        uses: addnab/docker-run-action@v2
-        with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
-          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma
           run: |
             cd /workspaces/magma/lte/gateway
             make test_oai BUILD_TYPE=Debug;
-      - name: Run mme tests with RelWithDebInfo build type
+      - name: Build MME with RelWithDebInfo type
         uses: addnab/docker-run-action@v2
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma -e ABC=123
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma/lte/gateway
+            make build_oai BUILD_TYPE=RelWithDebInfo;
+      - name: Run MME tests with RelWithDebInfo build type
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: --volume ${{ env.MAGMA_ROOT }}:/workspaces/magma --volume ${{ env.MAGMA_ROOT }}/lte/gateway/configs:/etc/magma
           run: |
             cd /workspaces/magma/lte/gateway
             make test_oai BUILD_TYPE=RelWithDebInfo;


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
@electronjoe  noticed that `make build_oai` was leading to errors on master. Turns out `make test_oai` passes but `make build_oai` fails. Modifying the CI job to do both in separate steps.

Error seen locally
```
[2031/2033] Linking CXX executable test/spgw_task/spgw_procedures_test
FAILED: test/spgw_task/spgw_procedures_test
: && /usr/lib/ccache/c++  -g -DDEBUG_IS_ON=1 -g -O0 -fprofile-arcs -ftest-coverage  -fsanitize=address -fsanitize=undefined -fprofile-arcs -ftest-coverage test/spgw_task/CMakeFiles/spgw_procedures_test.dir/test_spgw_procedures.cpp.o  -o test/spgw_task/spgw_procedures_test -L/usr/src/googletest/googlemock/lib -Wl,-rpath,/usr/src/googletest/googlemock/lib:/usr/local/lib  test/spgw_task/libSPGW_TASK_TEST_LIB.a  tasks/sgw/libTASK_SGW.a  tasks/gtpv1-u/libTASK_GTPV1U.a  lib/openflow/controller/libLIB_OPENFLOW_CONTROLLER.a  lib/pipelined_client/libLIB_PIPELINED_CLIENT.a  tasks/nas/libTASK_NAS.a  tasks/mme_app/libTASK_MME_APP.a  tasks/sgw_s8/libTASK_SGW_S8.a  tasks/s1ap/libTASK_S1AP.a  tasks/sgw/libTASK_SGW.a  tasks/gtpv1-u/libTASK_GTPV1U.a  lib/openflow/controller/libLIB_OPENFLOW_CONTROLLER.a  lib/pipelined_client/libLIB_PIPELINED_CLIENT.a  tasks/nas/libTASK_NAS.a  tasks/mme_app/libTASK_MME_APP.a  tasks/sgw_s8/libTASK_SGW_S8.a  tasks/s1ap/libTASK_S1AP.a  -lfluid_base  -lfluid_msg  lib/secu/libLIB_SECU.a  -lnettle  tasks/s6a/libTASK_S6A.a  lib/s6a_proxy/libLIB_S6A_PROXY.a  tasks/s6a/libTASK_S6A.a  lib/s6a_proxy/libLIB_S6A_PROXY.a  -lconfig  lib/directoryd/libLIB_DIRECTORYD.a  lib/event_client/libLIB_EVENT_CLIENT.a  /home/vagrant/build/c/core/common/eventd/libEVENTD.a  tasks/sctp/libTASK_SCTP_SERVER.a  tasks/sgs/libTASK_SGS.a  lib/sgs_client/libLIB_SGS_CLIENT.a  common/redis_utils/libredis_utils.a  -lfolly  lib/s8_proxy/libLIB_S8_PROXY.a  lib/mobility_client/libLIB_MOBILITY_CLIENT.a  lib/pcef/libLIB_PCEF.a  lib/mobility_client/libLIB_MOBILITY_CLIENT.a  lib/pcef/libLIB_PCEF.a  -lcpp_redis  -ltacopie  tasks/service303/libTASK_SERVICE303.a  /home/vagrant/build/c/core/common/async_grpc/libASYNC_GRPC.a  /usr/lib/x86_64-linux-gnu/libprotobuf.so  -pthread  test/mock_tasks/libMOCK_TASKS.a  common/libCOMMON.a  lib/hashtable/libLIB_HASHTABLE.a  lib/itti/libLIB_ITTI.a  lib/3gpp/libLIB_3GPP.a  lib/message_utils/libLIB_MESSAGE_UTILS.a  tasks/s1ap/libLIB_S1AP.a  tasks/ngap/libLIB_NGAP.a  common/libCOMMON.a  lib/hashtable/libLIB_HASHTABLE.a  lib/itti/libLIB_ITTI.a  lib/3gpp/libLIB_3GPP.a  lib/message_utils/libLIB_MESSAGE_UTILS.a  tasks/s1ap/libLIB_S1AP.a  tasks/ngap/libLIB_NGAP.a  -llfds710  -lssl  -lcrypto  common/glogwrapper/libglogwrapper.a  /home/vagrant/build/c/core/common/sentry/libMAGMA_SENTRY.a  /usr/local/lib/libsentry.so  /home/vagrant/build/c/core/common/service303/libSERVICE303_LIB.a  /home/vagrant/build/c/core/common/service_registry/libSERVICE_REGISTRY.a  /home/vagrant/build/c/core/common/config/libMAGMA_CONFIG.a  -lglog  -ldl  -lprometheus-cpp  -lprotobuf  -lgrpc  -lgrpc++  -lczmq  lib/bstr/libLIB_BSTR.a  -lgmock_main  -lgtest  -lgtest_main  -lgmock  -lpthread  -lrt  -lyaml-cpp && :
/usr/bin/ld: lib/s8_proxy/libLIB_S8_PROXY.a(s8_client_api.cpp.o): in function `recv_s8_delete_session_response(unsigned long, unsigned int, grpc::Status const&, magma::feg::DeleteSessionResponsePgw&)':
/home/vagrant/magma/lte/gateway/c/core/oai/lib/s8_proxy/s8_client_api.cpp:149: undefined reference to `grpc_service_task_zmq_ctx'
/usr/bin/ld: lib/s8_proxy/libLIB_S8_PROXY.a(s8_client_api.cpp.o): in function `recv_s8_create_session_response(unsigned long, unsigned int, bearer_qos_s, grpc::Status const&, magma::feg::CreateSessionResponsePgw&)':
/home/vagrant/magma/lte/gateway/c/core/oai/lib/s8_proxy/s8_client_api.cpp:193: undefined reference to `grpc_service_task_zmq_ctx'
/usr/bin/ld: lib/mobility_client/libLIB_MOBILITY_CLIENT.a(MobilityClientAPI.cpp.o): in function `handle_allocate_ipv4_address_status(grpc::Status const&, in_addr, int, char const*, char const*, char const*, unsigned int, unsigned char)':
/home/vagrant/magma/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.cpp:153: undefined reference to `grpc_service_task_zmq_ctx'
/usr/bin/ld: lib/mobility_client/libLIB_MOBILITY_CLIENT.a(MobilityClientAPI.cpp.o): in function `handle_allocate_ipv6_address_status(grpc::Status const&, in6_addr, int, char const*, char const*, char const*, unsigned int, unsigned char)':
/home/vagrant/magma/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.cpp:273: undefined reference to `grpc_service_task_zmq_ctx'
/usr/bin/ld: lib/mobility_client/libLIB_MOBILITY_CLIENT.a(MobilityClientAPI.cpp.o): in function `handle_allocate_ipv4v6_address_status(grpc::Status const&, in_addr, in6_addr, int, char const*, char const*, char const*, unsigned int, unsigned char)':
/home/vagrant/magma/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.cpp:379: undefined reference to `grpc_service_task_zmq_ctx'
/usr/bin/ld: lib/pcef/libLIB_PCEF.a(pcef_handlers.cpp.o):/home/vagrant/magma/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp:133: more undefined references to `grpc_service_task_zmq_ctx' follow
collect2: error: ld returned 1 exit status
[2032/2033] Linking CXX executable oai_mme/mme
/usr/bin/ld: warning: libnettle.so.7, needed by /lib/x86_64-linux-gnu/librtmp.so.1, may conflict with libnettle.so.4
[2033/2033] Linking CXX executable test/sgw_s8_task/sgw_s8_test
```

(There's a typo in the job name in the screen shot, Debug type should be RelWithDebInfo in the step that fails)
<img width="1405" alt="Screen Shot 2021-11-12 at 10 06 53 AM" src="https://user-images.githubusercontent.com/37634144/141488443-ea4fe222-6fa3-42a6-a064-3533266297e4.png">

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
