### PR TITLE
fix(feg): Incorrect conversion between integer types

### DIFF
--- a/feg/gateway/tools/hello_cli/main.go
+++ b/feg/gateway/tools/hello_cli/main.go
@@ -45,6 +45,9 @@ func main() {
 	defer conn.Close()
 	cl := protos.NewHelloClient(conn)
 	fmt.Printf("Sending  Greeting: '%s', Code: %d\n", msg, code)
+	if code < 0 || code > 4294967295 {
+		log.Fatal(fmt.Errorf("Code %d is outside the bounds of unit32 type", code))
+	}
 	res, err := cl.SayHello(context.Background(), &protos.HelloRequest{Greeting: msg, GrpcErrCode: uint32(code)})
 	if err != nil {
 		log.Fatal(err)

--- a/feg/gateway/tools/s6a_cli/main.go
+++ b/feg/gateway/tools/s6a_cli/main.go
@@ -321,6 +321,9 @@ func getPlmnID(imsi string, mncLen int) ([3]byte, error) {
 		if err != nil {
 			return [3]byte{}, fmt.Errorf("Invalid Digit '%s' in IMSI '%s': %v", imsi[i:i+1], imsi, err)
 		}
+		if v < 0 || v > 255 {
+			return [3]byte{}, fmt.Errorf("Number %d is outside the boundaries of byte type", v)
+		}
 		imsiBytes[i] = byte(v)
 	}
 	// see https://www.arib.or.jp/english/html/overview/doc/STD-T63v10_70/5_Appendix/Rel11/29/29272-bb0.pdf#page=73

--- a/feg/gateway/tools/swx_cli/main.go
+++ b/feg/gateway/tools/swx_cli/main.go
@@ -235,6 +235,10 @@ func sendSar(addr string, client swxClient) int {
 }
 
 func sendMar(addr string, client swxClient) int {
+	if numVectors < 0 || numVectors > 4294967295 {
+		fmt.Printf("numVectors %d is outside the bounds of unit32 type", numVectors)
+		return 2
+	}
 	req := &protos.AuthenticationRequest{
 		UserName:             imsi,
 		SipNumAuthVectors:    uint32(numVectors),


### PR DESCRIPTION
fix(feg): fix incorrect conversion between integer types

## Summary
- feg/gateway/tools/gw_csfb_service_cli/main.go:164 -> main()
   String was parsed into an int which can cause incorrect conversion  if int is converted into another integer type of a smaller size. Added check if variable is in bounds of Unsigned32 type (0-4294967295)

- feg/gateway/tools/s6a_cli/main.go:324 -> getPlmnID()
   String was parsed into an int which can cause incorrect conversion  if int is converted into another integer type of a smaller size. Added check if variable is in bounds of byte type (0-255)

- feg/gateway/tools/swx_cli/main.go:240 -> sendMar()
   String was parsed into an int which can cause incorrect conversion  if int is converted into another integer type of a smaller size. Added check if variable is in bounds of Unsigned32 type (0-4294967295)

Fixes are for alerts:
https://github.com/magma/magma/security/code-scanning/16?query=ref%3Arefs%2Fheads%2Fmaster
https://github.com/magma/magma/security/code-scanning/17?query=ref%3Arefs%2Fheads%2Fmaster
https://github.com/magma/magma/security/code-scanning/18?query=ref%3Arefs%2Fheads%2Fmaster

