### PR TITLE
feat: commit sctpd/liagent bazel files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,11 +25,9 @@
 		"files.watcherExclude": {
 			"**/.bazel-cache/**": true,
 			"**/.bazel-cache-repo/**": true,
-		},		
-		"bsv.bazel.buildFlags": [
-		],
-		"bsv.bazel.testFlags": [
-		],
+		},
+		"bsv.bazel.buildFlags": [],
+		"bsv.bazel.testFlags": [],
 		"bsv.bes.enabled": false,
 		"bsv.bzl.codesearch.enabled": false,
 		"bsv.bzl.invocation.buildEventPublishAllActions": false,
@@ -46,10 +44,12 @@
 			"--background-index",
 		],
 		"clangd.onConfigChanged": "restart",
-		// Update this field with any new targets that need compilation database generation
+		// Update this field with any new Bazel targets that need compilation database generation
 		"bsv.cc.compdb.targets": [
 			"//lte/gateway/c/session_manager:sessiond",
-			"//lte/gateway/c/connection_tracker/src:main",
+			"//lte/gateway/c/sctpd/src:sctpd",
+			"//lte/gateway/c/li_agent/src:liagentd",
+			"//lte/gateway/c/connection_tracker/src:connectiond",
 		],
 		"multiCommand.commands": [
 			{

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -349,7 +349,7 @@ jobs:
           run: |
             echo "Pulled the devontainer image!"
             bazel # pull down bazel, if bazel download fails we can fail before we do all the lengthy work below
-      - name: Run codecov with CMake (MME / SCTPD / LIAGENT)
+      - name: Run codecov with CMake (MME)
         if: always()
         uses: addnab/docker-run-action@v2
         with:
@@ -360,7 +360,7 @@ jobs:
             cd $MAGMA_ROOT/lte/gateway
             make coverage
             cp $C_BUILD/coverage.info $MAGMA_ROOT
-      - name: Run coverage with Bazel (COMMON / SESSIOND)
+      - name: Run coverage with Bazel (COMMON / SESSIOND / SCTPD / LIAGENT / CONNECTIOND)
         if: always()
         uses: addnab/docker-run-action@v2
         with:

--- a/cpp_repositories.bzl
+++ b/cpp_repositories.bzl
@@ -11,8 +11,8 @@
 
 """All external repositories used for C++/C dependencies"""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def cpp_repositories():
     """Entry point for all external repositories used for C++/C dependencies"""

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -13,29 +13,48 @@ RUN apt-get update && \
         apt-utils \
         build-essential \
         ca-certificates \
+        # dependency of Folly
+        cmake \
         curl \
-        # dependency of @sentry_native//:sentry
-        libcurl4-openssl-dev \
         gcc \
         git \
         gnupg2 \
         g++ \
+        # dependency of @sentry_native//:sentry
+        libcurl4-openssl-dev \
+        # dependency of Folly
+        libgoogle-glog-dev \
+        # dependency of Folly
+        libgflags-dev \
+        # dependency of Folly
+        libboost-all-dev \
+        # dependency of Folly
+        libevent-dev \
+        # dependency of Folly
+        libdouble-conversion-dev \
+        # dependency of Folly
+        libiberty-dev \
+        # dependency of connection_tracker
+        libmnl-dev=1.0.4-2 \ 
+        # dependency of connection_tracker
+        libpcap-dev \
+        # dependency of sctpd
+        libsctp-dev \
         libssl-dev \
+        # dependency of building asn1c
+        libtool=2.4.6-14 \
         python3 \
         python-is-python3 \
         unzip \
         vim \
         wget \
-        zip \
+        zip 
 
 # Install bazel
 WORKDIR /usr/sbin
 RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
     chmod +x bazelisk-linux-amd64 && \
     ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
-
-# Install Folly as a static library in the container
-RUN apt-get install -y --no-install-recommends cmake
 
 ## Install Fmt (Folly Dep)
 RUN git clone https://github.com/fmtlib/fmt.git && cd fmt && \
@@ -45,14 +64,6 @@ RUN git clone https://github.com/fmtlib/fmt.git && cd fmt && \
     make install && \
     cd / && \
     rm -rf fmt
-
-RUN apt-get install -y --no-install-recommends \
-    libgoogle-glog-dev \
-    libgflags-dev \
-    libboost-all-dev \
-    libevent-dev \
-    libdouble-conversion-dev \
-    libiberty-dev
 
 # Facebook Folly C++ lib
 # Note: "Because folly does not provide any ABI compatibility guarantees from
@@ -67,16 +78,6 @@ RUN git clone https://github.com/facebook/folly && cd folly && \
     cd / && \
     rm -rf folly
 
-# libtins is required to build the connection_tracker
-RUN apt-get install -y --no-install-recommends \
-    cmake=3.16.3-1ubuntu1 \
-    libpcap-dev=1.9.1-3 \
-    libmnl-dev=1.0.4-2
-
-# dependency of @sentry_native//:sentry
-RUN apt-get -y install --no-install-recommends \
-    libcurl4-openssl-dev=7.68.0-1ubuntu2.7
-
 # TODO(@themarwhal): this might not be hard to bazelify if we can generate the config
 RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     cd libtins && \
@@ -89,9 +90,6 @@ RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     rm -rf libtins && \
     # symlink to /usr/lib to match Magma VM
     ln -s /usr/local/lib/libtins.so /usr/lib/libtins.so
-
-RUN apt-get -y install --no-install-recommends \
-    libtool=2.4.6-14
 
 # TODO(GH9710): Generate asn1c with Bazel - also this repo is really old :o
 RUN git clone https://gitlab.eurecom.fr/oai/asn1c.git && \

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && \
         python3 \
         python-is-python3 \
         unzip \
+        uuid-dev \
         vim \
         wget \
         zip 

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -13,8 +13,6 @@ RUN apt-get update && \
         apt-utils \
         build-essential \
         ca-certificates \
-        # dependency of Folly
-        cmake \
         curl \
         gcc \
         git \
@@ -22,40 +20,26 @@ RUN apt-get update && \
         g++ \
         # dependency of @sentry_native//:sentry
         libcurl4-openssl-dev \
-        # dependency of Folly
-        libgoogle-glog-dev \
-        # dependency of Folly
-        libgflags-dev \
-        # dependency of Folly
-        libboost-all-dev \
-        # dependency of Folly
-        libevent-dev \
-        # dependency of Folly
-        libdouble-conversion-dev \
-        # dependency of Folly
-        libiberty-dev \
-        # dependency of connection_tracker
-        libmnl-dev=1.0.4-2 \ 
-        # dependency of connection_tracker
-        libpcap-dev \
         # dependency of sctpd
         libsctp-dev \
         libssl-dev \
-        # dependency of building asn1c
-        libtool=2.4.6-14 \
         python3 \
         python-is-python3 \
         unzip \
+        # dependency of liagent
         uuid-dev \
         vim \
         wget \
-        zip 
+        zip
 
 # Install bazel
 WORKDIR /usr/sbin
 RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
     chmod +x bazelisk-linux-amd64 && \
     ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
+
+# Install Folly as a static library in the container
+RUN apt-get install -y --no-install-recommends cmake
 
 ## Install Fmt (Folly Dep)
 RUN git clone https://github.com/fmtlib/fmt.git && cd fmt && \
@@ -65,6 +49,14 @@ RUN git clone https://github.com/fmtlib/fmt.git && cd fmt && \
     make install && \
     cd / && \
     rm -rf fmt
+
+RUN apt-get install -y --no-install-recommends \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    libboost-all-dev \
+    libevent-dev \
+    libdouble-conversion-dev \
+    libiberty-dev
 
 # Facebook Folly C++ lib
 # Note: "Because folly does not provide any ABI compatibility guarantees from
@@ -79,6 +71,11 @@ RUN git clone https://github.com/facebook/folly && cd folly && \
     cd / && \
     rm -rf folly
 
+# libtins is required to build the connection_tracker
+RUN apt-get install -y --no-install-recommends \
+    libpcap-dev=1.9.1-3 \
+    libmnl-dev=1.0.4-2
+
 # TODO(@themarwhal): this might not be hard to bazelify if we can generate the config
 RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     cd libtins && \
@@ -91,6 +88,9 @@ RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
     rm -rf libtins && \
     # symlink to /usr/lib to match Magma VM
     ln -s /usr/local/lib/libtins.so /usr/lib/libtins.so
+
+RUN apt-get -y install --no-install-recommends \
+    libtool=2.4.6-14
 
 # TODO(GH9710): Generate asn1c with Bazel - also this repo is really old :o
 RUN git clone https://gitlab.eurecom.fr/oai/asn1c.git && \

--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -238,11 +238,6 @@ coverage_oai: test_oai
 	lcov -r /tmp/coverage_oai.info.raw "/*/test/*" "/usr/*" "/build/*protos*" -o /tmp/coverage_oai.info
 	rm -f `find $(C_BUILD) -name *.gcda` # Clean up any prior coverage data
 
-coverage_sctpd: test_sctpd
-	lcov --capture --directory $(C_BUILD) --output-file /tmp/coverage_sctpd.info.raw
-	lcov -r /tmp/coverage_sctpd.info.raw "/*/test/*" "/usr/*" "/build/*protos*" -o /tmp/coverage_sctpd.info
-	rm -f `find $(C_BUILD) -name *.gcda` # Clean up any prior coverage data
-
 # format and test c/session_manager
 precommit_sm: format_all test_session_manager
 
@@ -292,11 +287,11 @@ clang_tidy_oai_upload: clang_tidy_oai
 		https://docs.google.com/forms/d/e/1FAIpQLSfHGqOmDhUMAWHSjA_w6NOGqglQBx2IaO1bXLo6zrOE95sRWQ/formResponse?usp=pp_url
 
 ## Generate complete code structural information prior to any test execution
-base_coverage: build_oai build_sctpd
+base_coverage: build_oai
 	lcov --initial --directory $(C_BUILD) -c --output-file /tmp/coverage_initialize.info.raw
 	lcov -r /tmp/coverage_initialize.info.raw "/*/test/*" "/usr/*" "/build/*protos*" -o /tmp/coverage_initialize.info
 	rm -f `find $(C_BUILD) -name *.gcda` # Clean up any prior coverage data
 
 # Combine results of sub-coverages
-coverage: base_coverage coverage_oai coverage_sctpd
-	lcov -a /tmp/coverage_initialize.info -a /tmp/coverage_oai.info -a /tmp/coverage_sctpd.info -o $(C_BUILD)/coverage.info
+coverage: base_coverage coverage_oai
+	lcov -a /tmp/coverage_initialize.info -a /tmp/coverage_oai.info -o $(C_BUILD)/coverage.info

--- a/lte/gateway/c/connection_tracker/src/BUILD.bazel
+++ b/lte/gateway/c/connection_tracker/src/BUILD.bazel
@@ -9,8 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 cc_binary(
-    name = "main",
+    name = "connectiond",
     srcs = ["main.cpp"],
     deps = [
         ":event_tracker",

--- a/lte/gateway/c/core/oai/common/BUILD.bazel
+++ b/lte/gateway/c/core/oai/common/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
 cc_library(

--- a/lte/gateway/c/core/oai/common/glogwrapper/BUILD.bazel
+++ b/lte/gateway/c/core/oai/common/glogwrapper/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
 cc_library(

--- a/lte/gateway/c/core/oai/common/redis_utils/BUILD.bazel
+++ b/lte/gateway/c/core/oai/common/redis_utils/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
 cc_library(

--- a/lte/gateway/c/core/oai/lib/bstr/BUILD.bazel
+++ b/lte/gateway/c/core/oai/lib/bstr/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
 cc_library(

--- a/lte/gateway/c/core/oai/lib/directoryd/BUILD.bazel
+++ b/lte/gateway/c/core/oai/lib/directoryd/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
 cc_library(

--- a/lte/gateway/c/core/oai/lib/event_client/BUILD.bazel
+++ b/lte/gateway/c/core/oai/lib/event_client/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
 cc_library(

--- a/lte/gateway/c/core/oai/lib/hashtable/BUILD.bazel
+++ b/lte/gateway/c/core/oai/lib/hashtable/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
 cc_library(

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -1,0 +1,86 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//lte/gateway/c/li_agent/src:__subpackages__"])
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cpp"],
+    deps = [
+        ":interface_monitor",
+        "//orc8r/gateway/c/common/config:mconfig_loader",
+        "//orc8r/gateway/c/common/service303",
+    ],
+)
+
+cc_library(
+    name = "interface_monitor",
+    srcs = ["InterfaceMonitor.cpp"],
+    hdrs = ["InterfaceMonitor.h"],
+    deps = [
+        ":pdu_generator",
+        "@system_libraries//:libpcap",
+    ],
+)
+
+cc_library(
+    name = "pdu_generator",
+    srcs = ["PDUGenerator.cpp"],
+    hdrs = ["PDUGenerator.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/li_agent/src",
+    deps = [
+        ":mobilityd_client",
+        ":proxy_connector",
+        ":utilities",
+        "//lte/protos:mconfigs_cpp_proto",
+        "//orc8r/gateway/c/common/config:mconfig_loader",
+        "@system_libraries//:libtins",
+        "@system_libraries//:libuuid",
+    ],
+)
+
+cc_library(
+    name = "proxy_connector",
+    srcs = ["ProxyConnector.cpp"],
+    hdrs = ["ProxyConnector.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/li_agent/src",
+    deps = [
+        "//orc8r/gateway/c/common/logging",
+    ],
+)
+
+cc_library(
+    name = "mobilityd_client",
+    srcs = ["MobilitydClient.cpp"],
+    hdrs = ["MobilitydClient.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/li_agent/src",
+    deps = [
+        "//lte/protos:mobilityd_cpp_grpc",
+        "//orc8r/gateway/c/common/async_grpc:async_grpc_receiver",
+        "//orc8r/gateway/c/common/service_registry",
+    ],
+)
+
+cc_library(
+    name = "utilities",
+    srcs = ["Utilities.cpp"],
+    hdrs = ["Utilities.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/li_agent/src",
+    deps = [
+        "//lte/protos:mconfigs_cpp_proto",
+        "//orc8r/gateway/c/common/config:mconfig_loader",
+        "//orc8r/gateway/c/common/service303",
+    ],
+)

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -9,10 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//lte/gateway/c/li_agent/src:__subpackages__"])
 
 cc_binary(
-    name = "main",
+    name = "liagentd",
     srcs = ["main.cpp"],
     deps = [
         ":interface_monitor",
@@ -35,8 +37,6 @@ cc_library(
     name = "pdu_generator",
     srcs = ["PDUGenerator.cpp"],
     hdrs = ["PDUGenerator.h"],
-    # TODO(@smoeller): Migrate to using full path for includes - GH8494
-    strip_include_prefix = "/lte/gateway/c/li_agent/src",
     deps = [
         ":mobilityd_client",
         ":proxy_connector",
@@ -52,8 +52,6 @@ cc_library(
     name = "proxy_connector",
     srcs = ["ProxyConnector.cpp"],
     hdrs = ["ProxyConnector.h"],
-    # TODO(@smoeller): Migrate to using full path for includes - GH8494
-    strip_include_prefix = "/lte/gateway/c/li_agent/src",
     deps = [
         "//orc8r/gateway/c/common/logging",
     ],
@@ -63,8 +61,6 @@ cc_library(
     name = "mobilityd_client",
     srcs = ["MobilitydClient.cpp"],
     hdrs = ["MobilitydClient.h"],
-    # TODO(@smoeller): Migrate to using full path for includes - GH8494
-    strip_include_prefix = "/lte/gateway/c/li_agent/src",
     deps = [
         "//lte/protos:mobilityd_cpp_grpc",
         "//orc8r/gateway/c/common/async_grpc:async_grpc_receiver",
@@ -76,8 +72,6 @@ cc_library(
     name = "utilities",
     srcs = ["Utilities.cpp"],
     hdrs = ["Utilities.h"],
-    # TODO(@smoeller): Migrate to using full path for includes - GH8494
-    strip_include_prefix = "/lte/gateway/c/li_agent/src",
     deps = [
         "//lte/protos:mconfigs_cpp_proto",
         "//orc8r/gateway/c/common/config:mconfig_loader",

--- a/lte/gateway/c/li_agent/src/InterfaceMonitor.cpp
+++ b/lte/gateway/c/li_agent/src/InterfaceMonitor.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include <utility>
 
 #include "lte/gateway/c/li_agent/src/InterfaceMonitor.h"

--- a/lte/gateway/c/li_agent/src/ProxyConnector.cpp
+++ b/lte/gateway/c/li_agent/src/ProxyConnector.cpp
@@ -15,6 +15,7 @@
 #include <arpa/inet.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <unistd.h>
 
 #include "lte/gateway/c/li_agent/src/ProxyConnector.h"
 #include "orc8r/gateway/c/common/logging/magma_logging.h"

--- a/lte/gateway/c/li_agent/src/test/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/test/BUILD.bazel
@@ -1,0 +1,35 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "pdu_generator_test",
+    size = "small",
+    srcs = [
+        "Consts.h",
+        "test_pdu_generator.cpp",
+    ],
+    deps = [
+        ":li_agentd_mocks",
+        "//lte/gateway/c/li_agent/src:mobilityd_client",
+        "//lte/gateway/c/li_agent/src:pdu_generator",
+        "//lte/gateway/c/li_agent/src:utilities",
+        "@com_github_gflags_gflags//:gflags",
+        "@com_github_google_glog//:glog",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "li_agentd_mocks",
+    hdrs = ["LIAgentdMocks.h"],
+)

--- a/lte/gateway/c/li_agent/src/test/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/test/BUILD.bazel
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_test(
     name = "pdu_generator_test",

--- a/lte/gateway/c/li_agent/src/test/test_pdu_generator.cpp
+++ b/lte/gateway/c/li_agent/src/test/test_pdu_generator.cpp
@@ -13,6 +13,7 @@
 
 #include <netinet/ip.h>
 #include <net/ethernet.h>
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include <limits>
@@ -129,8 +130,6 @@ TEST_F(PDUGeneratorTest, test_generator_non_ip_packet) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  FLAGS_logtostderr = 1;
-  FLAGS_v           = 10;
   return RUN_ALL_TESTS();
 }
 

--- a/lte/gateway/c/sctpd/src/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//lte/gateway/c/sctpd/src:__subpackages__"])
 
 cc_binary(
@@ -26,8 +28,6 @@ cc_library(
     name = "sctpd_event_handler",
     srcs = ["sctpd_event_handler.cpp"],
     hdrs = ["sctpd_event_handler.h"],
-    # TODO(@smoeller): Migrate to using full path for includes - GH8494
-    strip_include_prefix = "/lte/gateway/c/sctpd/src",
     deps = [
         ":sctp_connection",
         ":sctpd_uplink_client",
@@ -38,8 +38,6 @@ cc_library(
     name = "sctpd_uplink_client",
     srcs = ["sctpd_uplink_client.cpp"],
     hdrs = ["sctpd_uplink_client.h"],
-    # TODO(@smoeller): Migrate to using full path for includes - GH8494
-    strip_include_prefix = "/lte/gateway/c/sctpd/src",
     deps = [
         ":util",
         "//lte/protos:sctpd_cpp_grpc",
@@ -60,8 +58,6 @@ cc_library(
     name = "sctp_connection",
     srcs = ["sctp_connection.cpp"],
     hdrs = ["sctp_connection.h"],
-    # TODO(@smoeller): Migrate to using full path for includes - GH8494
-    strip_include_prefix = "/lte/gateway/c/sctpd/src",
     deps = [
         ":sctp_desc",
         "//lte/protos:sctpd_cpp_grpc",
@@ -72,8 +68,6 @@ cc_library(
     name = "sctp_desc",
     srcs = ["sctp_desc.cpp"],
     hdrs = ["sctp_desc.h"],
-    # TODO(@smoeller): Migrate to using full path for includes - GH8494
-    strip_include_prefix = "/lte/gateway/c/sctpd/src",
     deps = [
         ":sctp_assoc",
     ],
@@ -83,8 +77,6 @@ cc_library(
     name = "sctp_assoc",
     srcs = ["sctp_assoc.cpp"],
     hdrs = ["sctp_assoc.h"],
-    # TODO(@smoeller): Migrate to using full path for includes - GH8494
-    strip_include_prefix = "/lte/gateway/c/sctpd/src",
     deps = [
         ":util",
     ],

--- a/lte/gateway/c/sctpd/src/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/BUILD.bazel
@@ -1,0 +1,108 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//lte/gateway/c/sctpd/src:__subpackages__"])
+
+cc_binary(
+    name = "sctpd",
+    srcs = ["sctpd.cpp"],
+    linkstatic = True,
+    deps = [
+        ":config",
+        ":sctpd_downlink_impl",
+        ":sctpd_event_handler",
+    ],
+)
+
+cc_library(
+    name = "sctpd_event_handler",
+    srcs = ["sctpd_event_handler.cpp"],
+    hdrs = ["sctpd_event_handler.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/sctpd/src",
+    deps = [
+        ":sctp_connection",
+        ":sctpd_uplink_client",
+    ],
+)
+
+cc_library(
+    name = "sctpd_uplink_client",
+    srcs = ["sctpd_uplink_client.cpp"],
+    hdrs = ["sctpd_uplink_client.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/sctpd/src",
+    deps = [
+        ":util",
+        "//lte/protos:sctpd_cpp_grpc",
+    ],
+)
+
+cc_library(
+    name = "sctpd_downlink_impl",
+    srcs = ["sctpd_downlink_impl.cpp"],
+    hdrs = ["sctpd_downlink_impl.h"],
+    deps = [
+        ":sctp_connection",
+        "//lte/protos:sctpd_cpp_grpc",
+    ],
+)
+
+cc_library(
+    name = "sctp_connection",
+    srcs = ["sctp_connection.cpp"],
+    hdrs = ["sctp_connection.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/sctpd/src",
+    deps = [
+        ":sctp_desc",
+        "//lte/protos:sctpd_cpp_grpc",
+    ],
+)
+
+cc_library(
+    name = "sctp_desc",
+    srcs = ["sctp_desc.cpp"],
+    hdrs = ["sctp_desc.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/sctpd/src",
+    deps = [
+        ":sctp_assoc",
+    ],
+)
+
+cc_library(
+    name = "sctp_assoc",
+    srcs = ["sctp_assoc.cpp"],
+    hdrs = ["sctp_assoc.h"],
+    # TODO(@smoeller): Migrate to using full path for includes - GH8494
+    strip_include_prefix = "/lte/gateway/c/sctpd/src",
+    deps = [
+        ":util",
+    ],
+)
+
+cc_library(
+    name = "util",
+    srcs = ["util.cpp"],
+    hdrs = ["util.h"],
+    deps = [
+        ":config",
+        "//lte/protos:sctpd_cpp_grpc",
+        "//orc8r/gateway/c/common/logging",
+        "@system_libraries//:sctp",
+    ],
+)
+
+cc_library(
+    name = "config",
+    hdrs = ["sctpd.h"],
+)

--- a/lte/gateway/c/sctpd/src/test/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/test/BUILD.bazel
@@ -1,0 +1,36 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "event_handler_test",
+    size = "small",
+    srcs = ["test_event_handler.cpp"],
+    deps = [
+        "//lte/gateway/c/sctpd/src:sctpd_event_handler",
+        "//lte/protos:sctpd_cpp_grpc",
+        "@com_github_google_glog//:glog",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "sctp_desc_test",
+    size = "small",
+    srcs = ["test_sctp_desc.cpp"],
+    deps = [
+        "//lte/gateway/c/sctpd/src:sctp_assoc",
+        "//lte/gateway/c/sctpd/src:sctp_desc",
+        "@com_github_google_glog//:glog",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/protos/BUILD.bazel
+++ b/lte/protos/BUILD.bazel
@@ -133,6 +133,31 @@ proto_library(
     ],
 )
 
+proto_library(
+    name = "sctpd_proto",
+    srcs = ["sctpd.proto"],
+)
+
+cpp_proto_library(
+    name = "sctpd_cpp_proto",
+    protos = [":sctpd_proto"],
+    deps = [
+        ":apn_cpp_proto",
+        "//orc8r/protos:common_cpp_proto",
+        "//orc8r/protos:digest_cpp_proto",
+    ],
+)
+
+cpp_grpc_library(
+    name = "sctpd_cpp_grpc",
+    protos = [":sctpd_proto"],
+    deps = [
+        ":sctpd_cpp_proto",
+        "//orc8r/protos:common_cpp_proto",
+        "//orc8r/protos:digest_cpp_proto",
+    ],
+)
+
 cpp_proto_library(
     name = "session_manager_cpp_proto",
     protos = [":session_manager_proto"],

--- a/orc8r/gateway/c/common/async_grpc/BUILD.bazel
+++ b/orc8r/gateway/c/common/async_grpc/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/orc8r/gateway/c/common/config/BUILD.bazel
+++ b/orc8r/gateway/c/common/config/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/orc8r/gateway/c/common/eventd/BUILD.bazel
+++ b/orc8r/gateway/c/common/eventd/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/orc8r/gateway/c/common/logging/BUILD.bazel
+++ b/orc8r/gateway/c/common/logging/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/orc8r/gateway/c/common/sentry/BUILD.bazel
+++ b/orc8r/gateway/c/common/sentry/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/orc8r/gateway/c/common/service303/BUILD.bazel
+++ b/orc8r/gateway/c/common/service303/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/orc8r/gateway/c/common/service_registry/BUILD.bazel
+++ b/orc8r/gateway/c/common/service_registry/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/third_party/civetweb.BUILD
+++ b/third_party/civetweb.BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 # Dependency of prometheus-cpp
 # modified from https://github.com/jupp0r/prometheus-cpp WORKSPACE @ d8326b2bba945a435f299e7526c403d7a1f68c1f
 package(default_visibility = ["//visibility:public"])

--- a/third_party/cpp_redis.BUILD
+++ b/third_party/cpp_redis.BUILD
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 # We can get rid of this once we upgrade cpp-redis to a more up-to-date version - GH8321
 cc_library(
     name = "cpp_redis",

--- a/third_party/nlohmann_json.BUILD
+++ b/third_party/nlohmann_json.BUILD
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/third_party/sentry_native.BUILD
+++ b/third_party/sentry_native.BUILD
@@ -11,6 +11,8 @@
 
 # Based off of and modified from https://github.com/google/ml-metadata/blob/284af0c9d0d8467b6e69b632f4aedd0f40daac4c/ml_metadata/libmysqlclient.BUILD
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 # Source files generated with cmake.
 configure_out_srcs = [
     # TODO(@themarwhal): Generate a static library - GH9323

--- a/third_party/system_libraries.BUILD
+++ b/third_party/system_libraries.BUILD
@@ -48,14 +48,27 @@ cc_library(
 
 cc_library(
     name = "libtins",
-    srcs = ["usr/lib/libtins.so"],
     linkopts = ["-ltins"],
 )
 
 cc_library(
     name = "libmnl",
-    srcs = ["usr/lib/x86_64-linux-gnu/libmnl.so"],
     linkopts = ["-lmnl"],
+)
+
+cc_library(
+    name = "libpcap",
+    linkopts = ["-lpcap"],
+)
+
+cc_library(
+    name = "libuuid",
+    linkopts = ["-luuid"],
+)
+
+cc_library(
+    name = "sctp",
+    linkopts = ["-lsctp"],
 )
 
 # TODO(GH9710): Generate asn1c with Bazel

--- a/third_party/system_libraries.BUILD
+++ b/third_party/system_libraries.BUILD
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/build_defs/asn1c.bzl
+++ b/tools/build_defs/asn1c.bzl
@@ -107,29 +107,29 @@ def _gen_with_asn1c_impl(ctx):
 
 def _get_attrs():
     return {
-        # This makes it so that the executable asn1c is treated as an input to this rule
-        "_asn1c": attr.label(
-            executable = True,
-            default = Label("@system_libraries//:asn1c"),
-            cfg = "host",
-        ),
         "asn1_file": attr.label(
             mandatory = True,
             allow_single_file = [".asn1"],
             doc = """The asn file asn1c should use to generate files""",
         ),
-        "prefix": attr.string(
-            mandatory = True,
-            doc = """Value that is set to ASN1C_PREFIX""",
+        "files_to_remove": attr.string_list(
+            doc = """A list of file names to remove after code generation""",
         ),
         "flags": attr.string(
             doc = """Command line flags passed to asn1c""",
         ),
+        "prefix": attr.string(
+            mandatory = True,
+            doc = """Value that is set to ASN1C_PREFIX""",
+        ),
         "substitutions": attr.string_dict(
             doc = """A string map of any substitions to be made""",
         ),
-        "files_to_remove": attr.string_list(
-            doc = """A list of file names to remove after code generation""",
+        # This makes it so that the executable asn1c is treated as an input to this rule
+        "_asn1c": attr.label(
+            executable = True,
+            default = Label("@system_libraries//:asn1c"),
+            cfg = "host",
         ),
     }
 

--- a/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
+++ b/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
@@ -39,9 +39,12 @@
 			"-pretty",
 			"--background-index",
 		],
+		// Update this field with any new Bazel targets that need compilation database generation
 		"bsv.cc.compdb.targets": [
 			"//lte/gateway/c/session_manager:sessiond",
-			"//lte/gateway/c/connection_tracker/src:main",
+			"//lte/gateway/c/sctpd/src:sctpd",
+			"//lte/gateway/c/li_agent/src:liagentd",
+			"//lte/gateway/c/connection_tracker/src:connectiond",
 		],
 		"multiCommand.commands": [
 			{


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>
Signed-off-by: Scott Moeller <electronjoe@gmail.com>
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
1. https://github.com/magma/magma/pull/9239 by @electronjoe but rebased with additional changes to bazel-base dockerfile
2. https://github.com/magma/magma/pull/9224 by @electronjoe but rebased with additional changes again
3. Removed all TODOs about using full path as Scott already landed the change to  fix those up
4. Migrate code cov generation of sctpd to be done with Bazel (the job already exists, so adding these new targets is enough to make this work)
5. Modify VSCode configurations so that we can enable code navigation for sctpd and liagentd

## Some nice side effects
1. This change automatically adds liagent code coverage to codecov :) Removing code coverage generation with cmake as it is redundant work.
2. Since I already setup test summary uploads for bazel based C/C++ tests, any test failure for sctpd/common/liagent/sessiond will be uploaded to ci automatically. (same thing with codecov which is point 1)
3. Everything is cached across branches so running C/C++ tests in CI is q u i c k !. (The job in the screen shot is running all tests for sessiond / sctpd / liagent / common and it takes under 4 minutes to build and test which is our good case scenario)
<img width="1423" alt="Screen Shot 2021-11-12 at 3 32 57 PM" src="https://user-images.githubusercontent.com/37634144/141530946-3d2e0d9f-118e-47a5-aed8-44dbe4f397bd.png">

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run all tests in [Magma VM, devcontainer, bazel-base/doker]

Magma VM
<img width="1140" alt="Screen Shot 2021-11-12 at 3 28 57 PM" src="https://user-images.githubusercontent.com/37634144/141530565-ba931209-68f4-4572-bc4b-a348bb518306.png">
Bazel Base Docker
<img width="692" alt="Screen Shot 2021-11-12 at 3 29 27 PM" src="https://user-images.githubusercontent.com/37634144/141530594-f927973c-8e41-4490-890d-bf6544fdd909.png">
Devcontainer - covered by CI

# Code coverage diff
Before
<img width="1142" alt="Screen Shot 2021-11-12 at 5 00 35 PM" src="https://user-images.githubusercontent.com/37634144/141539698-8884bec0-d697-49db-ada0-d0caf395c090.png">

After
<img width="1155" alt="Screen Shot 2021-11-12 at 4 59 09 PM" src="https://user-images.githubusercontent.com/37634144/141539605-8dc25bcc-e9b9-40ac-bb2a-06a4fd87ce15.png">
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
