### PR TITLE
chore(mme): remove possible redundancy at grpc_service cmake

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/CMakeLists.txt
@@ -75,14 +75,12 @@ generate_cpp_protos("${AMFSRV_M5G_CPP_PROTOS}" "${PROTO_SRCS}"
     "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_OUT_DIR})
 generate_grpc_protos("${AMFSRV_M5G_GRPC_PROTOS}" "${PROTO_SRCS}"
     "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_OUT_DIR})
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # S8a
 set(S8SRV_FEG_CPP_PROTOS s8_proxy)
 set(S8SRV_FEG_GRPC_PROTOS s8_proxy)
 set(S8SRV_LTE_CPP_PROTOS oai/spgw_state  oai/common_types oai/std_3gpp_types)
 set(S8SRV_LTE_GRPC_PROTOS oai/spgw_state  oai/common_types oai/std_3gpp_types)
-set(SGW_S8_INCLUDES ${PROJECT_SOURCE_DIR}/lib/s8_proxy ${PROJECT_SOURCE_DIR}/tasks/sgw)
 generate_cpp_protos("${S8SRV_FEG_CPP_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${FEG_PROTO_DIR} ${FEG_OUT_DIR})
 generate_grpc_protos("${S8SRV_FEG_GRPC_PROTOS}" "${PROTO_SRCS}"
@@ -92,7 +90,7 @@ generate_cpp_protos("${S8SRV_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
 generate_grpc_protos("${S8SRV_LTE_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_OUT_DIR})
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR} ${SGW_S8_INCLUDES})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories("${MAGMA_ROOT}/orc8r/gateway/c/common/logging")
 
 if (EMBEDDED_SGW)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Removed possible duplicate and unnecessary lines

## Test Plan

make test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
