### PR TITLE
feat(feg): N7 Proxy SM Policy Delete implementation

### DIFF
--- a/feg/gateway/services/n7_n40_proxy/n7/model_conversion.go
+++ b/feg/gateway/services/n7_n40_proxy/n7/model_conversion.go
@@ -16,6 +16,8 @@ package n7
 import (
 	b64 "encoding/base64"
 	"fmt"
+	"net/url"
+	"path"
 	"strconv"
 	"time"
 
@@ -65,6 +67,14 @@ func GetSmPolicyContextDataN7(
 	}
 
 	return reqBody
+}
+
+func GetSmPolicyDeleteReqBody(
+	request *protos.SessionTerminateRequest,
+) *n7_sbi.PostSmPoliciesSmPolicyIdDeleteJSONRequestBody {
+	return &n7_sbi.PostSmPoliciesSmPolicyIdDeleteJSONRequestBody{
+		AccuUsageReports: getUmReportN7(request.MonitorUsages),
+	}
 }
 
 func getSbiRatType(ratType protos.RATType) *sbi.RatType {
@@ -130,6 +140,30 @@ func getSbiPduSesionType(pduSessionType protos.PduSessionType) sbi.PduSessionTyp
 	default:
 		return sbi.PduSessionTypeIPV4
 	}
+}
+
+func getUmReportN7(umUpdates []*protos.UsageMonitorUpdate) *[]n7_sbi.AccuUsageReport {
+	reports := []n7_sbi.AccuUsageReport{}
+
+	for _, umUpdate := range umUpdates {
+		reports = append(reports, getAccUsageReportN7(umUpdate))
+	}
+
+	return &reports
+}
+
+func getAccUsageReportN7(umUpdate *protos.UsageMonitorUpdate) n7_sbi.AccuUsageReport {
+	return n7_sbi.AccuUsageReport{
+		RefUmIds:         string(umUpdate.MonitoringKey),
+		VolUsageDownlink: GetSbiVolume(umUpdate.BytesRx), // Output == Rx == Downlink
+		VolUsageUplink:   GetSbiVolume(umUpdate.BytesTx), // Input == Tx == Uplink
+		VolUsage:         GetSbiVolume(umUpdate.BytesRx + umUpdate.BytesTx),
+	}
+}
+
+func GetSbiVolume(bytes uint64) *common5g.Volume {
+	outBytes := common5g.Volume(int64(bytes))
+	return &outBytes
 }
 
 // From SBI types to proto
@@ -529,6 +563,23 @@ func ConvertToProtoTimeStamp(srcTime *time.Time) *timestamp.Timestamp {
 
 func GenNotifyUrl(apiRoot string, sessionId string) sbi.Uri {
 	return sbi.Uri(fmt.Sprintf("%s/%s", apiRoot, b64.URLEncoding.EncodeToString([]byte(sessionId))))
+}
+
+// GetSmPolicyId returns the SmPolicyId from the TgppContext.
+// PolicyUrl is of the form https://{pcf-host}/npcf-smpolicycontrol/v1/sm-policies/{smPolicyId}
+func GetSmPolicyId(tgppCtx *protos.TgppContext) (string, error) {
+	if tgppCtx == nil {
+		return "", fmt.Errorf("couldn't get url from TgppContext: nil TgppCtx")
+	}
+	policyUrl := tgppCtx.GetGxDestHost()
+	if len(policyUrl) == 0 {
+		return "", fmt.Errorf("empty PolicyUrl in TgppCtx")
+	}
+	parsedUrl, err := url.Parse(policyUrl)
+	if err != nil {
+		return "", fmt.Errorf("policyUrl parse error: %s", err)
+	}
+	return path.Base(parsedUrl.Path), nil
 }
 
 func getSbiIpv4(ipv4 string) *sbi.Ipv4Addr {

--- a/feg/gateway/services/n7_n40_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/n7_n40_proxy/servicers/session_controller.go
@@ -15,6 +15,7 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -64,17 +65,21 @@ func (srv *CentralSessionController) CreateSession(
 	request *protos.CreateSessionRequest,
 ) (*protos.CreateSessionResponse, error) {
 	if err := validateCreateSessionRequest(request); err != nil {
+		err = fmt.Errorf("CreateSessionRequest failed to validate: %s", err)
+		glog.Error(err)
 		return nil, err
 	}
 
 	policy, policyId, err := srv.getSmPolicyRules(request)
 	metrics.ReportCreateSmPolicy(err)
 	if err != nil {
+		err = fmt.Errorf("CreateSessionRequest failed to get SMPolicyRules: %s", err)
+		glog.Error(err)
 		return nil, err
 	}
 	err = srv.injectOmnipresentRules(policy)
 	if err != nil {
-		glog.Errorf("Failed to inject omnipresent rules %s", err)
+		glog.Errorf("CreateSessionRequest Failed to inject omnipresent rules %s", err)
 	}
 	return n7.GetCreateSessionResponseProto(request, policy, policyId), nil
 }
@@ -94,6 +99,27 @@ func (srv *CentralSessionController) TerminateSession(
 	ctx context.Context,
 	request *protos.SessionTerminateRequest,
 ) (*protos.SessionTerminateResponse, error) {
-
-	return (&protos.UnimplementedCentralSessionControllerServer{}).TerminateSession(ctx, request)
+	if err := validateSessionTerminateRequest(request); err != nil {
+		err = fmt.Errorf("SessionTerminateRequest failed to validate: %s", err)
+		glog.Error(err)
+		return nil, err
+	}
+	smPolicyId, err := n7.GetSmPolicyId(request.GetTgppCtx())
+	if err != nil {
+		err = fmt.Errorf("TerminateSession failed to get policyId: %s", err)
+		glog.Error(err)
+		return nil, err
+	}
+	reqBody := n7.GetSmPolicyDeleteReqBody(request)
+	err = srv.sendSmPolicyDelete(smPolicyId, reqBody)
+	metrics.ReportDeleteSmPolicy(err)
+	if err != nil {
+		err = fmt.Errorf("SessionTerminateRequest failed to send SM Policy Delete: %s", err)
+		glog.Error(err)
+		return nil, err
+	}
+	return &protos.SessionTerminateResponse{
+		Sid:       request.GetCommonContext().GetSid().GetId(),
+		SessionId: request.SessionId,
+	}, nil
 }

--- a/feg/gateway/services/n7_n40_proxy/servicers/terminate_session.go
+++ b/feg/gateway/services/n7_n40_proxy/servicers/terminate_session.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	n7_sbi "magma/feg/gateway/sbi/specs/TS29512NpcfSMPolicyControl"
+	"magma/lte/cloud/go/protos"
+)
+
+func validateSessionTerminateRequest(req *protos.SessionTerminateRequest) error {
+	subscriber := req.GetCommonContext().GetSid()
+	if subscriber == nil || subscriber.GetId() == "" {
+		return fmt.Errorf("missing subscriber information on create session request %+v", req)
+	}
+	if req.SessionId == "" {
+		return fmt.Errorf("missing magma sessionId information on create session request %+v", req)
+	}
+	return nil
+}
+
+func (srv *CentralSessionController) sendSmPolicyDelete(
+	smPolicyId string,
+	reqBody *n7_sbi.PostSmPoliciesSmPolicyIdDeleteJSONRequestBody,
+) error {
+	reqCtx, cancel := context.WithTimeout(context.Background(), srv.cfg.RequestTimeout)
+	defer cancel()
+	resp, err := srv.policyClient.PostSmPoliciesSmPolicyIdDeleteWithResponse(reqCtx, smPolicyId, *reqBody)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusNoContent {
+		return fmt.Errorf("SmPolicyDelete request failure: status-code=%d policy-id=%s", resp.StatusCode(), smPolicyId)
+	}
+	return nil
+}

--- a/feg/gateway/services/n7_n40_proxy/servicers/terminate_session_test.go
+++ b/feg/gateway/services/n7_n40_proxy/servicers/terminate_session_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	n7_sbi "magma/feg/gateway/sbi/specs/TS29512NpcfSMPolicyControl"
+	"magma/feg/gateway/services/n7_n40_proxy/n7"
+	"magma/lte/cloud/go/protos"
+)
+
+const (
+	MON_KEY1  = "mon_key_1"
+	MON_KEY2  = "mon_key_2"
+	POLICY_ID = "12345"
+)
+
+var (
+	UsageTx1    uint64 = 3000000
+	UsageRx1    uint64 = 7000000
+	UsageTotal1 uint64 = UsageTx1 + UsageRx1
+	UsageTx2    uint64 = 8000000
+	UsageRx2    uint64 = 14000000
+	UsageTotal2 uint64 = UsageTx2 + UsageRx2
+)
+
+func TestTerminateSession(t *testing.T) {
+	srv, _, mockN7 := createCentralSessionControllerForTest(t, false)
+	expectedArg := n7_sbi.PostSmPoliciesSmPolicyIdDeleteJSONRequestBody{
+		AccuUsageReports: &[]n7_sbi.AccuUsageReport{
+			{
+				RefUmIds:         MON_KEY1,
+				VolUsageUplink:   n7.GetSbiVolume(UsageTx1),
+				VolUsageDownlink: n7.GetSbiVolume(UsageRx1),
+				VolUsage:         n7.GetSbiVolume(UsageTotal1),
+			},
+			{
+				RefUmIds:         MON_KEY2,
+				VolUsageUplink:   n7.GetSbiVolume(UsageTx2),
+				VolUsageDownlink: n7.GetSbiVolume(UsageRx2),
+				VolUsage:         n7.GetSbiVolume(UsageTotal2),
+			},
+		},
+	}
+
+	mockN7.On("PostSmPoliciesSmPolicyIdDeleteWithResponse", mock.Anything, POLICY_ID, expectedArg).
+		Return(&n7_sbi.PostSmPoliciesSmPolicyIdDeleteResponse{
+			HTTPResponse: &http.Response{StatusCode: 204},
+		}, nil).Once()
+
+	termSessProto := defaultTerminateSessionRequest(IMSI1)
+	response, err := srv.TerminateSession(context.Background(), termSessProto)
+	require.NoError(t, err)
+	mockN7.AssertExpectations(t)
+	assert.Equal(t, defaultTerminateSessionResponse(IMSI1), response)
+}
+
+func TestTerminateSessionTimeout(t *testing.T) {
+	srv, _, mockN7 := createCentralSessionControllerForTest(t, false)
+	mockN7.On("PostSmPoliciesSmPolicyIdDeleteWithResponse", mock.Anything, POLICY_ID, mock.Anything).
+		Return(nil, &url.Error{Err: context.DeadlineExceeded}).Once()
+
+	termSessProto := defaultTerminateSessionRequest(IMSI1)
+	response, err := srv.TerminateSession(context.Background(), termSessProto)
+	require.Error(t, err)
+	mockN7.AssertExpectations(t)
+	assert.Nil(t, response)
+}
+
+func TestTerminateSessionErrResp(t *testing.T) {
+	srv, _, mockN7 := createCentralSessionControllerForTest(t, false)
+	mockN7.On("PostSmPoliciesSmPolicyIdDeleteWithResponse", mock.Anything, POLICY_ID, mock.Anything).
+		Return(&n7_sbi.PostSmPoliciesSmPolicyIdDeleteResponse{
+			HTTPResponse: &http.Response{StatusCode: 404},
+		}, nil).Once()
+
+	termSessProto := defaultTerminateSessionRequest(IMSI1)
+	response, err := srv.TerminateSession(context.Background(), termSessProto)
+	require.Error(t, err)
+	mockN7.AssertExpectations(t)
+	assert.Nil(t, response)
+}
+
+func defaultTerminateSessionRequest(imsi string) *protos.SessionTerminateRequest {
+	return &protos.SessionTerminateRequest{
+		SessionId: SESS_ID1,
+		CommonContext: &protos.CommonSessionContext{
+			Sid:     &protos.SubscriberID{Id: IMSI1},
+			RatType: protos.RATType_TGPP_NR,
+			UeIpv4:  UE_IPV4,
+		},
+		TgppCtx: &protos.TgppContext{GxDestHost: SmPolicyUrl},
+		MonitorUsages: []*protos.UsageMonitorUpdate{
+			{
+				MonitoringKey: []byte(MON_KEY1),
+				BytesTx:       UsageTx1,
+				BytesRx:       UsageRx1,
+			},
+			{
+				MonitoringKey: []byte(MON_KEY2),
+				BytesTx:       UsageTx2,
+				BytesRx:       UsageRx2,
+			},
+		},
+	}
+}
+
+func defaultTerminateSessionResponse(imsi string) *protos.SessionTerminateResponse {
+	return &protos.SessionTerminateResponse{
+		Sid:       imsi,
+		SessionId: SESS_ID1,
+	}
+}


### PR DESCRIPTION
Signed-off-by: GANESH IRRINKI <ganesh.irrinki@wavelabs.ai>

## Summary
- Convert SessionTerminateRequest proto message received on the CentralSessionController to N7 SmPolicyDeleteData message.
- Using the N7 Openapi generated code send the SmPolicyDelete to PCF
- Check the N7 delete response and then construct SessionTerminateResponse proto and send it as a grpc response.
