### PR TITLE
feat(feg): N7 Proxy SM Policy Update request implementation

### DIFF
--- a/feg/gateway/services/n7_n40_proxy/n7/model_conversion_test.go
+++ b/feg/gateway/services/n7_n40_proxy/n7/model_conversion_test.go
@@ -28,14 +28,21 @@ import (
 )
 
 const (
-	IMSI1          = "123456789012345"
-	SESSION_ID1    = IMSI1 + "-1234"
-	UE_IPV4        = "10.1.2.3"
-	PDU_SESSION_ID = 10
-	GPSI1          = "9876543210"
-	APN1           = "apn.magma.com"
-	MON_KEY1       = "mon_key_1"
-	MON_KEY2       = "mon_key_2"
+	IMSI1              = "123456789012345"
+	SESSION_ID1        = IMSI1 + "-1234"
+	UE_IPV4            = "10.1.2.3"
+	PDU_SESSION_ID     = 10
+	GPSI1              = "9876543210"
+	APN1               = "apn.magma.com"
+	MON_KEY1           = "mon_key_1"
+	MON_KEY2           = "mon_key_2"
+	IMSI2              = "543210987654321"
+	SESSION_ID2        = IMSI2 + "-1234"
+	MON_KEY3           = "mon_key_3"
+	MON_KEY4           = "mon_key_4"
+	SM_POLICY_ID2      = "271827"
+	SM_POLICY_ID3      = "315149"
+	BASE_SM_POLICY_URL = "https://example.com//npcf-smpolicycontrol/v1/sm-policies/"
 )
 
 var (
@@ -57,6 +64,8 @@ var (
 	UsageTotal2        uint64 = UsageTx2 + UsageRx2
 	UnkRuleId                 = n7_sbi.FailureCodeUNKRULEID
 	IncorrectFlow             = n7_sbi.FailureCodeINCORFLOWINFO
+	SmPolicyUrl2              = BASE_SM_POLICY_URL + SM_POLICY_ID2
+	SmPolicyUrl3              = BASE_SM_POLICY_URL + SM_POLICY_ID3
 )
 
 func TestSmPolicyContextFromProto(t *testing.T) {
@@ -453,4 +462,248 @@ func TestSmPolicyDeleteFromProto(t *testing.T) {
 	_, err := json.Marshal(reqBody)
 	require.NoError(t, err)
 	assert.Equal(t, &expected, reqBody)
+}
+
+func TestSmPolicyUpdateFromProto(t *testing.T) {
+	umUpdateReqProto := []*protos.UsageMonitoringUpdateRequest{
+		{
+			Update: &protos.UsageMonitorUpdate{
+				MonitoringKey: []byte(MON_KEY1),
+				Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+				BytesTx:       UsageTx1,
+				BytesRx:       UsageRx1,
+			},
+			SessionId:    SESSION_ID1,
+			Sid:          IMSI1,
+			TgppCtx:      &protos.TgppContext{GxDestHost: SmPolicyUrl2},
+			EventTrigger: protos.EventTrigger_USAGE_REPORT,
+			RatType:      protos.RATType_TGPP_NR,
+		},
+		{
+			Update: &protos.UsageMonitorUpdate{
+				MonitoringKey: []byte(MON_KEY2),
+				Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+				BytesTx:       UsageTx2,
+				BytesRx:       UsageRx2,
+			},
+			SessionId:    SESSION_ID1,
+			Sid:          IMSI1,
+			TgppCtx:      &protos.TgppContext{GxDestHost: SmPolicyUrl2},
+			EventTrigger: protos.EventTrigger_USAGE_REPORT,
+			RatType:      protos.RATType_TGPP_NR,
+		},
+		{
+			Update: &protos.UsageMonitorUpdate{
+				MonitoringKey: []byte(MON_KEY3),
+				Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+				BytesTx:       UsageTx2,
+				BytesRx:       UsageRx2,
+			},
+			SessionId:    SESSION_ID2,
+			Sid:          IMSI2,
+			TgppCtx:      &protos.TgppContext{GxDestHost: SmPolicyUrl3},
+			EventTrigger: protos.EventTrigger_USAGE_REPORT,
+			RatType:      protos.RATType_TGPP_NR,
+		},
+	}
+	expectedCtxs := map[string]n7.SmPolicyUpdateReqCtx{
+		SESSION_ID1: {
+			SmPolicyId:    SM_POLICY_ID2,
+			SessionId:     SESSION_ID1,
+			IMSI:          IMSI1,
+			MonitoringKey: []byte(MON_KEY1),
+			Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+			TgppCtx:       &protos.TgppContext{GxDestHost: SmPolicyUrl2},
+			ReqBody: &n7_sbi.PostSmPoliciesSmPolicyIdUpdateJSONRequestBody{
+				RatType:    &RatTypeNR,
+				AccessType: &AccessType3gpp,
+				AccuUsageReports: &[]n7_sbi.AccuUsageReport{
+					{
+						RefUmIds:         MON_KEY1,
+						VolUsageUplink:   n7.GetSbiVolume(UsageTx1),
+						VolUsageDownlink: n7.GetSbiVolume(UsageRx1),
+						VolUsage:         n7.GetSbiVolume(UsageTotal1),
+					},
+					{
+						RefUmIds:         MON_KEY2,
+						VolUsageUplink:   n7.GetSbiVolume(UsageTx2),
+						VolUsageDownlink: n7.GetSbiVolume(UsageRx2),
+						VolUsage:         n7.GetSbiVolume(UsageTotal2),
+					},
+				},
+			},
+		},
+		SESSION_ID2: {
+			SmPolicyId:    SM_POLICY_ID3,
+			SessionId:     SESSION_ID2,
+			IMSI:          IMSI2,
+			MonitoringKey: []byte(MON_KEY3),
+			Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+			TgppCtx:       &protos.TgppContext{GxDestHost: SmPolicyUrl3},
+			ReqBody: &n7_sbi.PostSmPoliciesSmPolicyIdUpdateJSONRequestBody{
+				RatType:    &RatTypeNR,
+				AccessType: &AccessType3gpp,
+				AccuUsageReports: &[]n7_sbi.AccuUsageReport{
+					{
+						RefUmIds:         MON_KEY3,
+						VolUsageUplink:   n7.GetSbiVolume(UsageTx2),
+						VolUsageDownlink: n7.GetSbiVolume(UsageRx2),
+						VolUsage:         n7.GetSbiVolume(UsageTotal2),
+					},
+				},
+			},
+		},
+	}
+
+	updateCtxs := n7.GetSmPolicyUpdateRequestsN7(umUpdateReqProto)
+	require.Equal(t, 2, len(updateCtxs))
+
+	for _, updateCtx := range updateCtxs {
+		_, err := json.Marshal(updateCtx.ReqBody)
+		assert.NoError(t, err)
+		expected, found := expectedCtxs[updateCtx.SessionId]
+		assert.True(t, found)
+		assert.Equal(t, &expected, updateCtx)
+	}
+}
+
+func TestSmPolicyUpdateResponseFromProto(t *testing.T) {
+	policyDecisionStr := `{
+		"pccRules": {
+			"rule1": {
+				"pccRuleId": "rule1",
+				"flowInfos": [{
+					"flowDescription": "permit in ip from 0.0.0.0/0 to 4.2.2.4"
+				}],
+				"precedence": 1,
+				"refQosData": ["qos_data1"],
+				"refChgData": ["chg_data1"],
+				"refUmData": ["um_data1"],
+				"refCondData": "cond_data1"
+			},
+			"static_rule1": {
+				"pccRuleId": "static_rule1",
+				"refCondData": "cond_data1"
+			},
+			"remove_rule1": null,
+			"remove_rule2": null
+		},
+		"qosDesc": {
+			"qos_data1": {
+				"qodId": "qos_data1",
+				"5qi": 5,
+				"maxbrUl": "200000",
+				"maxbrDl": "500000",
+				"gbrUl": "100000",
+				"gbrDl": "250000"
+			}
+		},
+		"chgDecs": {
+			"chg_data1": {
+				"chgId": "chg_data1",
+				"online": true,
+				"ratingGroup": 1,
+				"serviceId": 12
+			}
+		},
+		"umDecs": {
+			"um_data1": {
+				"umId": "um_data1",
+				"volumeThreshold": 4000000,
+				"volumeThresholdUplink": 1500000,
+				"volumeThresholdDownlink": 3500000
+			}
+		},
+		"conds": {
+			"cond_data1": {
+				"condId": "cond_data1",
+				"activationTime": "2021-10-22T12:42:31Z",
+				"deactivationTime": "2021-10-22T14:42:31Z"
+			}
+		},
+		"policyCtrlReqTriggers": ["RE_TIMEOUT"],
+		"revalidationTime": "2021-10-22T14:42:31Z",
+		"online": true
+	}`
+	// Unmarshal json to openapi struct
+	var policyDecision n7_sbi.SmPolicyDecision
+	err := json.Unmarshal([]byte(policyDecisionStr), &policyDecision)
+	require.NoError(t, err)
+
+	smUpdateCtx := &n7.SmPolicyUpdateReqCtx{
+		SmPolicyId:    SM_POLICY_ID3,
+		SessionId:     SESSION_ID2,
+		IMSI:          IMSI2,
+		MonitoringKey: []byte("um_data1"),
+		Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+		TgppCtx:       &protos.TgppContext{GxDestHost: SmPolicyUrl2},
+	}
+	responsesProto := n7.GetUsageMonitoringResponsesProto(smUpdateCtx, &policyDecision)
+
+	expectedStaticRules := []string{"static_rule1"}
+	for i, staticRule := range responsesProto[0].StaticRulesToInstall {
+		assert.Equal(t, expectedStaticRule(expectedStaticRules[i]), staticRule)
+	}
+	expectedDynamicRules := []struct {
+		ruleId string
+		monKey string
+	}{
+		{ruleId: "rule1", monKey: "um_data1"},
+	}
+	for i, dynamicRule := range responsesProto[0].DynamicRulesToInstall {
+		expRule := expectedDynamicRules[i]
+		assert.Equal(t, expectedDynamicRule(expRule.ruleId, expRule.monKey), dynamicRule)
+	}
+	assert.ElementsMatch(t, []string{"remove_rule1", "remove_rule2"}, responsesProto[0].RulesToRemove)
+	assert.Equal(t, []protos.EventTrigger{protos.EventTrigger_REVALIDATION_TIMEOUT}, responsesProto[0].EventTriggers)
+	assert.Equal(t, expectedUmCredit("um_data1"), responsesProto[0].Credit)
+	assert.Equal(t, n7.ConvertToProtoTimeStamp(&DeactTime), responsesProto[0].RevalidationTime)
+	assert.Equal(t, smUpdateCtx.SessionId, responsesProto[0].SessionId)
+	assert.Equal(t, smUpdateCtx.IMSI, responsesProto[0].Sid)
+	assert.Equal(t, &protos.TgppContext{GxDestHost: SmPolicyUrl2}, responsesProto[0].TgppCtx)
+	assert.True(t, responsesProto[0].Success)
+}
+
+func expectedStaticRule(ruleId string) *protos.StaticRuleInstall {
+	return &protos.StaticRuleInstall{
+		RuleId:           ruleId,
+		ActivationTime:   n7.ConvertToProtoTimeStamp(&ActTime),
+		DeactivationTime: n7.ConvertToProtoTimeStamp(&DeactTime),
+	}
+}
+
+func expectedDynamicRule(ruleId string, monKey string) *protos.DynamicRuleInstall {
+	return &protos.DynamicRuleInstall{
+		PolicyRule: &protos.PolicyRule{
+			Id:            ruleId,
+			Priority:      1,
+			RatingGroup:   1,
+			MonitoringKey: []byte(monKey),
+			FlowList: []*protos.FlowDescription{{
+				Match: &protos.FlowMatch{
+					IpSrc: &protos.IPAddress{Address: []byte("0.0.0.0/0")},
+					IpDst: &protos.IPAddress{Address: []byte("4.2.2.4")},
+				},
+			}},
+			TrackingType:      protos.PolicyRule_OCS_AND_PCRF,
+			ServiceIdentifier: &protos.ServiceIdentifier{Value: 12},
+			Online:            true,
+			Offline:           false,
+		},
+		ActivationTime:   n7.ConvertToProtoTimeStamp(&ActTime),
+		DeactivationTime: n7.ConvertToProtoTimeStamp(&DeactTime),
+	}
+}
+
+func expectedUmCredit(monKey string) *protos.UsageMonitoringCredit {
+	return &protos.UsageMonitoringCredit{
+		Action:        protos.UsageMonitoringCredit_CONTINUE,
+		MonitoringKey: []byte(monKey),
+		Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+		GrantedUnits: &protos.GrantedUnits{
+			Total: &protos.CreditUnit{IsValid: true, Volume: 4000000},
+			Tx:    &protos.CreditUnit{IsValid: true, Volume: 1500000},
+			Rx:    &protos.CreditUnit{IsValid: true, Volume: 3500000},
+		},
+	}
 }

--- a/feg/gateway/services/n7_n40_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/n7_n40_proxy/servicers/session_controller.go
@@ -99,8 +99,11 @@ func (srv *CentralSessionController) UpdateSession(
 	ctx context.Context,
 	request *protos.UpdateSessionRequest,
 ) (*protos.UpdateSessionResponse, error) {
-
-	return (&protos.UnimplementedCentralSessionControllerServer{}).UpdateSession(ctx, request)
+	reqCtxts := n7.GetSmPolicyUpdateRequestsN7(request.UsageMonitors)
+	responses := srv.sendMutlipleSmPolicyUpdateRequests(reqCtxts)
+	return &protos.UpdateSessionResponse{
+		UsageMonitorResponses: responses,
+	}, nil
 }
 
 // TerminateSession handles a session termination

--- a/feg/gateway/services/n7_n40_proxy/servicers/update_session.go
+++ b/feg/gateway/services/n7_n40_proxy/servicers/update_session.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/golang/glog"
+
+	"magma/feg/gateway/services/n7_n40_proxy/metrics"
+	"magma/feg/gateway/services/n7_n40_proxy/n7"
+	"magma/lte/cloud/go/protos"
+)
+
+// sendMutlipleSmPolicyUpdateRequests sends multiple parallel update requests to PCF and
+// returns the accumulated the responses from PCF
+func (srv *CentralSessionController) sendMutlipleSmPolicyUpdateRequests(
+	reqCtxs []*n7.SmPolicyUpdateReqCtx,
+) []*protos.UsageMonitoringUpdateResponse {
+	var wg sync.WaitGroup
+	respChan := make(chan []*protos.UsageMonitoringUpdateResponse)
+	ctx, cancel := context.WithTimeout(context.Background(), srv.cfg.RequestTimeout)
+	defer cancel()
+
+	accResponses := []*protos.UsageMonitoringUpdateResponse{}
+	for _, reqCtx := range reqCtxs {
+		tmpReqCtx := reqCtx // don't use loop variable in func closure
+		wg.Add(1)
+		// Send updates in parallel and accumulate results when all done
+		go func() {
+			defer wg.Done()
+			responses := srv.sendSingleSmPolicyUpdate(ctx, tmpReqCtx)
+			respChan <- responses
+		}()
+	}
+
+	// goroutine that waits for all updates to complete and close the response channel
+	go func() {
+		wg.Wait()
+		close(respChan)
+	}()
+
+	// Accumulate the responses. The channel is closed when all sends are done
+	for responses := range respChan {
+		accResponses = append(accResponses, responses...)
+	}
+	return accResponses
+}
+
+func (srv *CentralSessionController) sendSingleSmPolicyUpdate(
+	ctx context.Context,
+	updateCtx *n7.SmPolicyUpdateReqCtx,
+) []*protos.UsageMonitoringUpdateResponse {
+	resp, err := srv.policyClient.PostSmPoliciesSmPolicyIdUpdateWithResponse(
+		ctx, updateCtx.SmPolicyId, *updateCtx.ReqBody)
+	if err == nil && resp.StatusCode() != http.StatusOK {
+		err = fmt.Errorf("http error status-code=%d", resp.StatusCode())
+	}
+	metrics.ReportUpdateSmPolicy(err)
+	if err != nil {
+		glog.Errorf("SmPolicyUpdate request failed: %s policyId=%s", err, updateCtx.SmPolicyId)
+		// Return failure usage monitoring response
+		response := n7.GetUsageMonitoringUpdateResponseProto(updateCtx, false)
+		return []*protos.UsageMonitoringUpdateResponse{response}
+	}
+	return n7.GetUsageMonitoringResponsesProto(updateCtx, resp.JSON200)
+}

--- a/feg/gateway/services/n7_n40_proxy/servicers/update_session_test.go
+++ b/feg/gateway/services/n7_n40_proxy/servicers/update_session_test.go
@@ -1,0 +1,377 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	n7_sbi "magma/feg/gateway/sbi/specs/TS29512NpcfSMPolicyControl"
+	"magma/feg/gateway/services/n7_n40_proxy/n7"
+	"magma/lte/cloud/go/protos"
+)
+
+const (
+	IMSI3_NOPREFIX     = "543210987654321"
+	MON_KEY3           = "mon_key_3"
+	MON_KEY4           = "mon_key_4"
+	SM_POLICY_ID2      = "271827"
+	SM_POLICY_ID3      = "315149"
+	BASE_SM_POLICY_URL = "https://example.com//npcf-smpolicycontrol/v1/sm-policies/"
+	SESS_ID1_NO_PREFIX = IMSI1_NOPREFIX + "-1234"
+	SESS_ID2_NO_PREFIX = IMSI2_NOPREFIX + "-1234"
+	SESS_ID3_NO_PREFIX = IMSI3_NOPREFIX + "-1234"
+)
+
+var (
+	SmPolicyUrl2 = BASE_SM_POLICY_URL + SM_POLICY_ID2
+	SmPolicyUrl3 = BASE_SM_POLICY_URL + SM_POLICY_ID3
+)
+
+func TestOneUpdateSession(t *testing.T) {
+	srv, _, mockN7 := createCentralSessionControllerForTest(t, false)
+	defer srv.Close()
+
+	mockN7.On("PostSmPoliciesSmPolicyIdUpdateWithResponse",
+		mock.Anything,
+		mock.MatchedBy(func(argSmPolicyId string) bool {
+			return argSmPolicyId == SM_POLICY_ID2
+		}),
+		mock.MatchedBy(matchSmPolicyUpdate()),
+	).Return(createSingleSmPolicyUpdateResponse(t), nil).Once()
+
+	updateReqs := &protos.UpdateSessionRequest{
+		UsageMonitors: createSingleUmUpdateReqProto(),
+	}
+	response, err := srv.UpdateSession(context.Background(), updateReqs)
+	require.NoError(t, err)
+	mockN7.AssertExpectations(t)
+	require.Equal(t, 2, len(response.UsageMonitorResponses))
+	for _, res := range response.UsageMonitorResponses {
+		assert.True(t, res.Success)
+	}
+}
+
+func TestMultiUpdateSession(t *testing.T) {
+	srv, _, mockN7 := createCentralSessionControllerForTest(t, false)
+	defer srv.Close()
+
+	mockN7.On("PostSmPoliciesSmPolicyIdUpdateWithResponse",
+		mock.Anything,
+		mock.MatchedBy(func(argSmPolicyId string) bool {
+			return argSmPolicyId == SM_POLICY_ID2 || argSmPolicyId == SM_POLICY_ID3
+		}),
+		mock.MatchedBy(matchSmPolicyUpdate()),
+	).Return(newSmPolicyUpdateResponse(t), nil).Times(2)
+
+	updateReqs := &protos.UpdateSessionRequest{
+		UsageMonitors: createUmUpdateReqProto(),
+	}
+	response, err := srv.UpdateSession(context.Background(), updateReqs)
+	require.NoError(t, err)
+	mockN7.AssertExpectations(t)
+	require.Equal(t, 2, len(response.UsageMonitorResponses))
+	for _, res := range response.UsageMonitorResponses {
+		assert.True(t, res.Success)
+	}
+}
+
+func TestMultiUpdateTimeoutSession(t *testing.T) {
+	srv, _, mockN7 := createCentralSessionControllerForTest(t, false)
+	defer srv.Close()
+
+	mockN7.On("PostSmPoliciesSmPolicyIdUpdateWithResponse",
+		mock.Anything,
+		mock.MatchedBy(func(argSmPolicyId string) bool {
+			return argSmPolicyId == SM_POLICY_ID2 || argSmPolicyId == SM_POLICY_ID3
+		}),
+		mock.MatchedBy(matchSmPolicyUpdate()),
+	).Return(newSmPolicyUpdateResponse(t), nil).Once()
+	mockN7.On("PostSmPoliciesSmPolicyIdUpdateWithResponse",
+		mock.Anything,
+		mock.MatchedBy(func(argSmPolicyId string) bool {
+			return argSmPolicyId == SM_POLICY_ID2 || argSmPolicyId == SM_POLICY_ID3
+		}),
+		mock.MatchedBy(matchSmPolicyUpdate()),
+	).Return(nil, &url.Error{Err: context.DeadlineExceeded}).Once()
+
+	updateReqs := &protos.UpdateSessionRequest{
+		UsageMonitors: createUmUpdateReqProto(),
+	}
+	response, err := srv.UpdateSession(context.Background(), updateReqs)
+	require.NoError(t, err)
+	mockN7.AssertExpectations(t)
+	require.Equal(t, 2, len(response.UsageMonitorResponses))
+	successCount := 0
+	failureCount := 0
+	for _, res := range response.UsageMonitorResponses {
+		if res.Success {
+			successCount++
+		} else {
+			failureCount++
+		}
+	}
+	assert.Equal(t, 1, successCount)
+	assert.Equal(t, 1, failureCount)
+}
+
+func matchSmPolicyUpdate() interface{} {
+	expectedReqs := map[string]*n7_sbi.PostSmPoliciesSmPolicyIdUpdateJSONRequestBody{
+		SM_POLICY_ID2: {
+			RatType:    &RatTypeNR,
+			AccessType: &AccessType3gpp,
+			AccuUsageReports: &[]n7_sbi.AccuUsageReport{
+				{
+					RefUmIds:         MON_KEY1,
+					VolUsageUplink:   n7.GetSbiVolume(UsageTx1),
+					VolUsageDownlink: n7.GetSbiVolume(UsageRx1),
+					VolUsage:         n7.GetSbiVolume(UsageTotal1),
+				},
+				{
+					RefUmIds:         MON_KEY2,
+					VolUsageUplink:   n7.GetSbiVolume(UsageTx2),
+					VolUsageDownlink: n7.GetSbiVolume(UsageRx2),
+					VolUsage:         n7.GetSbiVolume(UsageTotal2),
+				},
+			},
+		},
+		SM_POLICY_ID3: {
+			RatType:    &RatTypeNR,
+			AccessType: &AccessType3gpp,
+			AccuUsageReports: &[]n7_sbi.AccuUsageReport{
+				{
+					RefUmIds:         MON_KEY3,
+					VolUsageUplink:   n7.GetSbiVolume(UsageTx2),
+					VolUsageDownlink: n7.GetSbiVolume(UsageRx2),
+					VolUsage:         n7.GetSbiVolume(UsageTotal2),
+				},
+			},
+		},
+	}
+
+	return func(reqBody n7_sbi.PostSmPoliciesSmPolicyIdUpdateJSONRequestBody) bool {
+		return reflect.DeepEqual(expectedReqs[SM_POLICY_ID2], &reqBody) ||
+			reflect.DeepEqual(expectedReqs[SM_POLICY_ID3], &reqBody)
+	}
+}
+
+func createUmUpdateReqProto() []*protos.UsageMonitoringUpdateRequest {
+	return []*protos.UsageMonitoringUpdateRequest{
+		{
+			Update: &protos.UsageMonitorUpdate{
+				MonitoringKey: []byte(MON_KEY1),
+				Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+				BytesTx:       UsageTx1,
+				BytesRx:       UsageRx1,
+			},
+			SessionId:    SESS_ID1_NO_PREFIX,
+			Sid:          IMSI1,
+			TgppCtx:      &protos.TgppContext{GxDestHost: SmPolicyUrl2},
+			EventTrigger: protos.EventTrigger_USAGE_REPORT,
+			RatType:      protos.RATType_TGPP_NR,
+		},
+		{
+			Update: &protos.UsageMonitorUpdate{
+				MonitoringKey: []byte(MON_KEY2),
+				Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+				BytesTx:       UsageTx2,
+				BytesRx:       UsageRx2,
+			},
+			SessionId:    SESS_ID1_NO_PREFIX,
+			Sid:          IMSI1,
+			TgppCtx:      &protos.TgppContext{GxDestHost: SmPolicyUrl2},
+			EventTrigger: protos.EventTrigger_USAGE_REPORT,
+			RatType:      protos.RATType_TGPP_NR,
+		},
+		{
+			Update: &protos.UsageMonitorUpdate{
+				MonitoringKey: []byte(MON_KEY3),
+				Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+				BytesTx:       UsageTx2,
+				BytesRx:       UsageRx2,
+			},
+			SessionId:    SESS_ID3_NO_PREFIX,
+			Sid:          IMSI3_NOPREFIX,
+			TgppCtx:      &protos.TgppContext{GxDestHost: SmPolicyUrl3},
+			EventTrigger: protos.EventTrigger_USAGE_REPORT,
+			RatType:      protos.RATType_TGPP_NR,
+		},
+	}
+}
+
+func createSingleUmUpdateReqProto() []*protos.UsageMonitoringUpdateRequest {
+	return []*protos.UsageMonitoringUpdateRequest{
+		{
+			Update: &protos.UsageMonitorUpdate{
+				MonitoringKey: []byte(MON_KEY1),
+				Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+				BytesTx:       UsageTx1,
+				BytesRx:       UsageRx1,
+			},
+			SessionId:    SESS_ID1_NO_PREFIX,
+			Sid:          IMSI1,
+			TgppCtx:      &protos.TgppContext{GxDestHost: SmPolicyUrl2},
+			EventTrigger: protos.EventTrigger_USAGE_REPORT,
+			RatType:      protos.RATType_TGPP_NR,
+		},
+		{
+			Update: &protos.UsageMonitorUpdate{
+				MonitoringKey: []byte(MON_KEY2),
+				Level:         protos.MonitoringLevel_PCC_RULE_LEVEL,
+				BytesTx:       UsageTx2,
+				BytesRx:       UsageRx2,
+			},
+			SessionId:    SESS_ID1_NO_PREFIX,
+			Sid:          IMSI1,
+			TgppCtx:      &protos.TgppContext{GxDestHost: SmPolicyUrl2},
+			EventTrigger: protos.EventTrigger_USAGE_REPORT,
+			RatType:      protos.RATType_TGPP_NR,
+		},
+	}
+}
+
+func createSingleSmPolicyUpdateResponse(t *testing.T) *n7_sbi.PostSmPoliciesSmPolicyIdUpdateResponse {
+	policyDecisionStr := `{
+		"pccRules": {
+			"rule1": {
+				"pccRuleId": "rule1",
+				"flowInfos": [{
+					"flowDescription": "permit in ip from 0.0.0.0/0 to 4.2.2.4"
+				}],
+				"precedence": 1,
+				"refUmData": ["mon_key1"],
+				"refCondData": "cond_data1"
+			},
+			"rule2": {
+				"pccRuleId": "rule2",
+				"flowInfos": [{
+					"flowDescription": "permit in ip from 0.0.0.0/0 to 4.2.2.4"
+				}],
+				"precedence": 1,
+				"refUmData": ["mon_key2"],
+				"refCondData": "cond_data1"
+			}
+		},
+		"umDecs": {
+			"mon_key1": {
+				"umId": "mon_key1",
+				"volumeThreshold": 4000000,
+				"volumeThresholdUplink": 1500000,
+				"volumeThresholdDownlink": 3500000
+			},
+			"mon_key2": {
+				"umId": "mon_key2",
+				"volumeThreshold": 4000000,
+				"volumeThresholdUplink": 1500000,
+				"volumeThresholdDownlink": 3500000
+			}
+		},
+		"conds": {
+			"cond_data1": {
+				"condId": "cond_data1",
+				"activationTime": "2021-10-22T12:42:31Z",
+				"deactivationTime": "2021-10-22T14:42:31Z"
+			}
+		},
+		"policyCtrlReqTriggers": ["RE_TIMEOUT"],
+		"revalidationTime": "2021-10-22T14:42:31Z",
+		"online": true
+	}`
+	// Unmarshal json to openapi struct
+	var policyDecision n7_sbi.SmPolicyDecision
+	err := json.Unmarshal([]byte(policyDecisionStr), &policyDecision)
+	require.NoError(t, err)
+
+	return &n7_sbi.PostSmPoliciesSmPolicyIdUpdateResponse{
+		JSON200:      &policyDecision,
+		HTTPResponse: &http.Response{StatusCode: 200},
+	}
+}
+
+func newSmPolicyUpdateResponse(t *testing.T) *n7_sbi.PostSmPoliciesSmPolicyIdUpdateResponse {
+	policyDecisionStr := `{
+		"pccRules": {
+			"rule1": {
+				"pccRuleId": "rule1",
+				"flowInfos": [{
+					"flowDescription": "permit in ip from 0.0.0.0/0 to 4.2.2.4"
+				}],
+				"precedence": 1,
+				"refQosData": ["qos_data1"],
+				"refChgData": ["chg_data1"],
+				"refUmData": ["um_data1"],
+				"refCondData": "cond_data1"
+			},
+			"static_rule1": {
+				"pccRuleId": "static_rule1",
+				"refCondData": "cond_data1"
+			},
+			"remove_rule1": null,
+			"remove_rule2": null
+		},
+		"qosDesc": {
+			"qos_data1": {
+				"qodId": "qos_data1",
+				"5qi": 5,
+				"maxbrUl": "200000",
+				"maxbrDl": "500000",
+				"gbrUl": "100000",
+				"gbrDl": "250000"
+			}
+		},
+		"chgDecs": {
+			"chg_data1": {
+				"chgId": "chg_data1",
+				"online": true,
+				"ratingGroup": 1,
+				"serviceId": 12
+			}
+		},
+		"umDecs": {
+			"um_data1": {
+				"umId": "um_data1",
+				"volumeThreshold": 4000000,
+				"volumeThresholdUplink": 1500000,
+				"volumeThresholdDownlink": 3500000
+			}
+		},
+		"conds": {
+			"cond_data1": {
+				"condId": "cond_data1",
+				"activationTime": "2021-10-22T12:42:31Z",
+				"deactivationTime": "2021-10-22T14:42:31Z"
+			}
+		},
+		"policyCtrlReqTriggers": ["RE_TIMEOUT"],
+		"revalidationTime": "2021-10-22T14:42:31Z",
+		"online": true
+	}`
+	// Unmarshal json to openapi struct
+	var policyDecision n7_sbi.SmPolicyDecision
+	err := json.Unmarshal([]byte(policyDecisionStr), &policyDecision)
+	require.NoError(t, err)
+
+	return &n7_sbi.PostSmPoliciesSmPolicyIdUpdateResponse{
+		JSON200:      &policyDecision,
+		HTTPResponse: &http.Response{StatusCode: 200},
+	}
+}


### PR DESCRIPTION
Signed-off-by: GANESH IRRINKI <ganesh.irrinki@wavelabs.ai>
## Summary
- Parse the multiple user monitoring updates received on the CentralSessionController UpdateSession request and conver them to SmPolicyUpdateContextData. This produces multiple SmPolicyUpdate requests
- Send all the update requests to PCF in paralle and wait for the responses
- Accumulate all the sent responses and populate UsageMonitoringReportResponse to be sent as a response to CentralSessionController UpdateSession





