### PR TITLE
chore(nms): upgrade axios from 0.21.1 to 0.21.2

### DIFF
--- a/nms/package.json
+++ b/nms/package.json
@@ -16,10 +16,10 @@
     "@babel/register": "^7.13.16",
     "@babel/runtime": "^7.14.0",
     "@fbcnms/util": "^0.1.0",
+    "axios": "^0.21.2",
     "babel-plugin-fbt": "^0.10.4",
     "babel-plugin-fbt-runtime": "^0.9.9",
     "babel-plugin-lodash": "^3.3.4",
-    "axios": "^0.21.1",
     "fbt": "^0.10.6"
   },
   "devDependencies": {

--- a/nms/yarn.lock
+++ b/nms/yarn.lock
@@ -3293,6 +3293,13 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
+axios@^0.21.2:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -6765,6 +6772,11 @@ follow-redirects@^1.10.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
   integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
+
+follow-redirects@^1.14.0:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
+  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Signed-off-by: Nikola Knezevic <nkcodeplus@gmail.com>

upgrade axios from 0.21.1 to 0.21.2 in nms

## Summary

https://github.com/magma/magma/security/dependabot/nms/fbcnms-projects/magmalte/package.json/axios/open


## Additional Information

- [ ] This change is backwards-breaking

