### PR TITLE
feat: create new Github action for bazel docker image build

### DIFF
--- a/.github/workflows/docker-bazel-base-builder.yml
+++ b/.github/workflows/docker-bazel-base-builder.yml
@@ -1,0 +1,51 @@
+---
+name: "Build Bazel base Docker image"
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+    paths:
+      - experimental/bazel-base/Dockerfile
+      - .github/workflows/docker-bazel-base-builder.yml
+  schedule:
+    - cron: '13 3 * * *'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_STREAM: ${{ github.repository }}/bazel-base
+  IMAGE_TAGS: type=sha
+  DOCKERFILE: experimental/bazel-base/Dockerfile
+
+jobs:
+  build_dockerfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Set up Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # defines the image stream the image is pushed to
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_STREAM }}
+          # defines the image tags added to the image
+          tags: ${{ env.IMAGE_TAGS }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          # without docker/metadata-action will only be accessible by hash
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
         unzip \
         vim \
         wget \
-        zip \
+        zip
 
 # Install bazel
 WORKDIR /usr/sbin


### PR DESCRIPTION
## Summary

* A new Github action is added to build the [Bazel base docker image](https://github.com/magma/magma/blob/master/experimental/bazel-base/Dockerfile).

## Test Plan

* The Github Action defined here runs fine and builds a docker image. See [this run](https://github.com/magma/magma/runs/4222135094?check_suite_focus=true).
* ℹ️ There were temporary builds on PR added for testing of the CI. However, usually the build is only intended for `master` as PR builds are expected to fail on GHCR push due to inability to access credentials.

## Additional Information

* This PR is composite actions ready, i.e. it can easily refactored to introduce and use a composite step for building docker images. Also see https://github.com/magma/magma/pull/10232 for discussion on composite actions. I.e. More base image builds could utilize the same workflow with only minimal CI configuration.
