### PR TITLE
feat(nms): Add support to configure IPv6 address and IPv6 GW IP for SGi

### DIFF
--- a/nms/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -746,6 +746,30 @@ export function EPCEdit(props: Props) {
               />
             </AltFormField>
           )}
+          <AltFormField label={'SGi management Gateway IPv6 address'}>
+            <OutlinedInput
+              data-testid="gwSgiIpv6"
+              placeholder="2001:4860:4860:0:0:0:0:1"
+              type="string"
+              fullWidth={true}
+              value={EPCConfig.sgi_management_iface_ipv6_gw ?? ''}
+              onChange={({target}) =>
+                handleEPCChange('sgi_management_iface_ipv6_gw', target.value)
+              }
+            />
+          </AltFormField>
+          <AltFormField label={'SGi management interface IPv6 address'}>
+            <OutlinedInput
+              data-testid="sgiStaticIpv6"
+              placeholder="2001:4860:4860:0:0:0:0:8888/64"
+              type="string"
+              fullWidth={true}
+              value={EPCConfig.sgi_management_iface_ipv6_addr ?? ''}
+              onChange={({target}) =>
+                handleEPCChange('sgi_management_iface_ipv6_addr', target.value)
+              }
+            />
+          </AltFormField>
         </List>
       </DialogContent>
       <DialogActions>

--- a/nms/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -450,11 +450,21 @@ describe('<AddEditGatewayButton />', () => {
 
     // Verify EPC Edit
     const natEnabled = getByTestId('natEnabled').firstChild;
+    const gwSgiIpv6 = getByTestId('gwSgiIpv6').firstChild;
+    const sgiStaticIpv6 = getByTestId('sgiStaticIpv6').firstChild;
     if (
       natEnabled instanceof HTMLElement &&
-      natEnabled.firstChild instanceof HTMLElement
+      natEnabled.firstChild instanceof HTMLElement &&
+      gwSgiIpv6 instanceof HTMLInputElement &&
+      sgiStaticIpv6 instanceof HTMLInputElement
     ) {
       fireEvent.click(natEnabled.firstChild);
+      fireEvent.change(gwSgiIpv6, {
+        target: {value: '2001:4860:4860:0:0:0:0:1'},
+      });
+      fireEvent.change(sgiStaticIpv6, {
+        target: {value: '2001:4860:4860:0:0:0:0:8888'},
+      });
     } else {
       throw 'invalid type';
     }
@@ -474,6 +484,8 @@ describe('<AddEditGatewayButton />', () => {
         sgi_management_iface_gw: '',
         sgi_management_iface_static_ip: '',
         sgi_management_iface_vlan: '',
+        sgi_management_iface_ipv6_gw: '2001:4860:4860:0:0:0:0:1',
+        sgi_management_iface_ipv6_addr: '2001:4860:4860:0:0:0:0:8888',
       },
     });
 
@@ -584,6 +596,8 @@ describe('<AddEditGatewayButton />', () => {
             sgi_management_iface_gw: '',
             sgi_management_iface_static_ip: '',
             sgi_management_iface_vlan: '',
+            sgi_management_iface_ipv6_gw: '2001:4860:4860:0:0:0:0:1',
+            sgi_management_iface_ipv6_addr: '2001:4860:4860:0:0:0:0:8888',
           },
           ran: {pci: 260, transmit_enabled: true},
         },
@@ -680,6 +694,8 @@ describe('<AddEditGatewayButton />', () => {
           sgi_management_iface_gw: '',
           sgi_management_iface_static_ip: '',
           sgi_management_iface_vlan: '',
+          sgi_management_iface_ipv6_gw: '2001:4860:4860:0:0:0:0:1',
+          sgi_management_iface_ipv6_addr: '2001:4860:4860:0:0:0:0:8888',
         },
         ran: {
           pci: 260,


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add support to configure IPv6 address and IPv6 GW IP for SGi



<img width="1792" alt="Capture d’écran 2021-11-15 à 13 31 09" src="https://user-images.githubusercontent.com/26038920/141782939-7f9b6761-23e6-47f5-8494-a0ca851f3d67.png">

## Test Plan

Edit/Add gateway EPC config
Modified GatewayConfigTest unit test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
