### PR TITLE
fix(cwg): guard cwf-integ-test assertions from out of index

### DIFF
--- a/cwf/gateway/integ_tests/assertions.go
+++ b/cwf/gateway/integ_tests/assertions.go
@@ -34,7 +34,9 @@ func (tr *TestRunner) AuthenticateAndAssertSuccess(imsi string) {
 
 	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
 	assert.NotNil(tr.t, eapMessage, "EAP Message from authentication is nil")
-	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), "UE Authentication did not return success")
+	if eapMessage != nil {
+		assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), "UE Authentication did not return success")
+	}
 }
 
 // Trigger a UE Authentication with the IMSI and called station ID.
@@ -45,7 +47,9 @@ func (tr *TestRunner) AuthenticateWithCalledIDAndAssertSuccess(imsi, calledStati
 
 	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
 	assert.NotNil(tr.t, eapMessage, "EAP Message from authentication is nil")
-	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), "UE Authentication did not return success")
+	if eapMessage != nil {
+		assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), "UE Authentication did not return success")
+	}
 }
 
 // AuthenticateAndAssertSuccessWithRetries triggers a UE Authentication with the IMSI. Assert that the authentication
@@ -81,7 +85,9 @@ func (tr *TestRunner) AuthenticateAndAssertSuccessWithRetries(imsi string, maxRe
 	}
 	assert.NoError(tr.t, err)
 	assert.NotNil(tr.t, eapMessage, "EAP Message from authentication is nil")
-	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), "UE Authentication did not return success")
+	if eapMessage != nil {
+		assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), "UE Authentication did not return success")
+	}
 
 }
 
@@ -93,7 +99,9 @@ func (tr *TestRunner) AuthenticateAndAssertFail(imsi string) {
 
 	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
 	assert.NotNil(tr.t, eapMessage)
-	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.FailureCode))
+	if eapMessage != nil {
+		assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.FailureCode))
+	}
 }
 
 // Trigger a UE Disconnect and assert it succeeds.


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Noticed that in some failure cases we get to out of index errors: https://github.com/magma/magma/runs/4197587303?check_suite_focus=true

This is bad because this will make the test run abort without trying the failed tests again.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
