### PR TITLE
fix(sessiond): Correct gRPC message set (AMF-SMF and SMF-AMF) for UE …

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
@@ -81,10 +81,6 @@ SetSMSessionContext create_sm_pdu_session_v4(
   // Set the Type of Request
   req_rat_specific->set_request_type(magma::lte::RequestType::INITIAL_REQUEST);
 
-  // Set the Address type
-  req_rat_specific->mutable_pdu_address()->set_redirect_address_type(
-      magma::lte::RedirectServer::IPV4);
-
   // Type is IPv4
   req_rat_specific->set_pdu_session_type(magma::lte::PduSessionType::IPV4);
 

--- a/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
@@ -61,6 +61,8 @@ SetSMSessionContext create_sm_pdu_session_v4(
   // Encode APU, storing apn value
   req_common->set_apn((char*) apn);
 
+  // UE IPv4 address set
+  req_common->set_ue_ipv4((char*) ipv4_addr);
   // Encode RAT TYPE
   req_common->set_rat_type(magma::lte::RATType::TGPP_NR);
 
@@ -97,10 +99,6 @@ SetSMSessionContext create_sm_pdu_session_v4(
 
   // Set the PTI
   req_rat_specific->set_procedure_trans_identity((const char*) (&(pti)));
-
-  // Set the PDU Address
-  req_rat_specific->mutable_pdu_address()->set_redirect_server_address(
-      (char*) ipv4_addr);
 
   // Set the default QoS values
   req_rat_specific->mutable_default_ambr()->set_max_bandwidth_ul(

--- a/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -154,7 +154,7 @@ Status AmfServiceImpl::SetSmfSessionContext(
       (redirect_address_type_t) req_m5g.pdu_address().redirect_address_type();
   // PDU IP address coming from SMF in human-readable format has to be packed
   // into 4 raw bytes in hex for NAS5G layer
-  strcpy(ip_str, req_m5g.pdu_address().redirect_server_address().c_str());
+  strcpy(ip_str, req_common.ue_ipv4().c_str());
   inet_pton(AF_INET, ip_str, &(ip_addr.s_addr));
   ip_int = ntohl(ip_addr.s_addr);
   INT32_TO_BUFFER(ip_int, itti_msg.pdu_address.redirect_server_address);

--- a/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
+++ b/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
@@ -75,8 +75,7 @@ TEST(test_create_sm_pdu_session_v4, create_sm_pdu_session_v4) {
       rat_req->mutable_gnode_endpoint()->end_ipv4_addr());
   uint8_t* pti_decoded = (uint8_t*) rat_req->procedure_trans_identity().c_str();
   EXPECT_TRUE(pti == *pti_decoded);
-  EXPECT_TRUE(
-      ipv4_addr == rat_req->mutable_pdu_address()->redirect_server_address());
+  EXPECT_TRUE(ipv4_addr == req_cmn->ue_ipv4());
 }
 
 int main(int argc, char** argv) {

--- a/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
+++ b/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
@@ -38,8 +38,15 @@ TEST(test_create_sm_pdu_session_v4, create_sm_pdu_session_v4) {
   gnb_gtp_teid_ip_addr[1]         = 0x14;
   gnb_gtp_teid_ip_addr[2]         = 0x1E;
   gnb_gtp_teid_ip_addr[3]         = 0x28;
+  std::string gnb_ip_addr;
+  for (int i = 0; i < 4; ++i) {
+    gnb_ip_addr += std::to_string(gnb_gtp_teid_ip_addr[i]);
+    if (i != 3) {
+      gnb_ip_addr += ".";
+    }
+  }
 
-  std::string ipv4_addr("10.20.30.44");
+  std::string ue_ipv4_addr("10.20.30.44");
   uint32_t version = 0;
 
   ambr_t default_ambr;
@@ -47,7 +54,7 @@ TEST(test_create_sm_pdu_session_v4, create_sm_pdu_session_v4) {
   request = magma5g::create_sm_pdu_session_v4(
       (char*) imsi.c_str(), (uint8_t*) apn.c_str(), pdu_session_id,
       pdu_session_type, gnb_gtp_teid, pti, gnb_gtp_teid_ip_addr,
-      (char*) ipv4_addr.c_str(), version, default_ambr);
+      (char*) ue_ipv4_addr.c_str(), version, default_ambr);
 
   auto* rat_req =
       request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
@@ -65,17 +72,14 @@ TEST(test_create_sm_pdu_session_v4, create_sm_pdu_session_v4) {
   EXPECT_TRUE(pdu_session_id == rat_req->pdu_session_id());
   EXPECT_TRUE(
       magma::lte::RequestType::INITIAL_REQUEST == rat_req->request_type());
-  EXPECT_TRUE(
-      magma::lte::RedirectServer::IPV4 ==
-      rat_req->mutable_pdu_address()->redirect_address_type());
+
   EXPECT_TRUE(magma::lte::PduSessionType::IPV4 == rat_req->pdu_session_type());
   EXPECT_TRUE(1 == rat_req->mutable_gnode_endpoint()->teid());
   EXPECT_TRUE(
-      std::string("10.20.30.40") ==
-      rat_req->mutable_gnode_endpoint()->end_ipv4_addr());
+      gnb_ip_addr == rat_req->mutable_gnode_endpoint()->end_ipv4_addr());
   uint8_t* pti_decoded = (uint8_t*) rat_req->procedure_trans_identity().c_str();
   EXPECT_TRUE(pti == *pti_decoded);
-  EXPECT_TRUE(ipv4_addr == req_cmn->ue_ipv4());
+  EXPECT_TRUE(ue_ipv4_addr == req_cmn->ue_ipv4());
 }
 
 int main(int argc, char** argv) {

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -613,14 +613,6 @@ void SessionStateEnforcer::prepare_response_to_access(
       config.rat_specific_context.m5gsm_session_context()
           .pdu_session_req_always_on());
   rsp->set_m5g_sm_congestion_reattempt_indicator(true);
-  rsp->mutable_pdu_address()->set_redirect_address_type(
-      config.rat_specific_context.m5gsm_session_context()
-          .pdu_address()
-          .redirect_address_type());
-  rsp->mutable_pdu_address()->set_redirect_server_address(
-      config.rat_specific_context.m5gsm_session_context()
-          .pdu_address()
-          .redirect_server_address());
   rsp->set_procedure_trans_identity(
       config.rat_specific_context.m5gsm_session_context()
           .procedure_trans_identity());
@@ -677,6 +669,7 @@ void SessionStateEnforcer::prepare_response_to_access(
           .end_ipv4_addr());
 
   rsp_cmn->mutable_sid()->CopyFrom(config.common_context.sid());  // imsi
+  rsp_cmn->set_ue_ipv4(config.common_context.ue_ipv4());
   rsp_cmn->set_apn(config.common_context.apn());
   rsp_cmn->set_sm_session_state(config.common_context.sm_session_state());
   rsp_cmn->set_sm_session_version(config.common_context.sm_session_version());
@@ -883,21 +876,15 @@ void SessionStateEnforcer::set_pdr_attributes(
     const std::string& imsi, std::unique_ptr<SessionState>& session_state,
     SetGroupPDR* rule) {
   const auto& config = session_state->get_config();
+  auto ue_ipv4       = config.common_context.ue_ipv4();
 
-  rule->mutable_pdi()->set_ue_ip_adr(
-      config.rat_specific_context.m5gsm_session_context()
-          .pdu_address()
-          .redirect_server_address());
+  rule->mutable_pdi()->set_ue_ip_adr(ue_ipv4);
   rule->mutable_activate_flow_req()->mutable_sid()->set_id(imsi);
   rule->mutable_deactivate_flow_req()->mutable_sid()->set_id(imsi);
   rule->mutable_activate_flow_req()->set_ip_addr(
-      config.rat_specific_context.m5gsm_session_context()
-          .pdu_address()
-          .redirect_server_address());
+      config.common_context.ue_ipv4());
   rule->mutable_deactivate_flow_req()->set_ip_addr(
-      config.rat_specific_context.m5gsm_session_context()
-          .pdu_address()
-          .redirect_server_address());
+      config.common_context.ue_ipv4());
 }
 
 std::vector<StaticRuleInstall> SessionStateEnforcer::to_vec(

--- a/lte/gateway/python/scripts/smf_upf_integration_cli.py
+++ b/lte/gateway/python/scripts/smf_upf_integration_cli.py
@@ -41,6 +41,7 @@ class CreateAmfSession(object):
         self._set_session = SetSMSessionContext(
             common_context=CommonSessionContext(
                 sid=SubscriberID(id="IMSI12345"),
+                ue_ipv4="192.168.128.11",
                 apn=bytes("BLR", 'utf-8'),
                 rat_type=RATType.Name(2),
                 sm_session_state=SMSessionFSMState.Name(0),
@@ -56,10 +57,6 @@ class CreateAmfSession(object):
                         teid=10000,
                         end_ipv4_addr="192.168.60.141",
                     ),
-                    pdu_address=RedirectServer(
-                        redirect_address_type=RedirectServer.IPV4,
-                        redirect_server_address="192.168.128.11",
-                    ),
                     pdu_session_type=PduSessionType.Name(0),
                     ssc_mode=SscMode.Name(2),
                 ),
@@ -74,6 +71,7 @@ class CreateAmfMultiSession(object):
             SetSMSessionContext(
                 common_context=CommonSessionContext(
                     sid=SubscriberID(id="IMSI12345"),
+                    ue_ipv4="192.168.128.12",
                     apn=bytes("BLR", 'utf-8'),
                     rat_type=RATType.Name(2),
                     sm_session_state=SMSessionFSMState.Name(0),
@@ -89,10 +87,6 @@ class CreateAmfMultiSession(object):
                             teid=10001,
                             end_ipv4_addr="192.168.60.141",
                         ),
-                        pdu_address=RedirectServer(
-                            redirect_address_type=RedirectServer.IPV4,
-                            redirect_server_address="192.168.128.12",
-                        ),
                         pdu_session_type=PduSessionType.Name(0),
                         ssc_mode=SscMode.Name(2),
                     ),
@@ -107,6 +101,7 @@ class ReleaseAmfSession(object):
             SetSMSessionContext(
                 common_context=CommonSessionContext(
                     sid=SubscriberID(id="IMSI12345"),
+                    ue_ipv4="192.168.128.11",
                     apn=bytes("BLR", 'utf-8'),
                     rat_type=RATType.Name(2),
                     sm_session_state=SMSessionFSMState.Name(4),
@@ -117,10 +112,6 @@ class ReleaseAmfSession(object):
                         pdu_session_id=1,
                         request_type=RequestType.Name(
                             1,
-                        ),
-                        pdu_address=RedirectServer(
-                            redirect_address_type=RedirectServer.IPV4,
-                            redirect_server_address="192.168.128.11",
                         ),
                         pdu_session_type=PduSessionType.IPV4,
                     ),
@@ -136,6 +127,7 @@ class CleanAmfSession(object):
                 common_context=CommonSessionContext(
                     sid=SubscriberID(id="IMSI12345"),
                     apn=bytes("BLR", 'utf-8'),
+                    ue_ipv4="192.168.128.12",
                     rat_type=RATType.Name(2),
                     sm_session_state=SMSessionFSMState.Name(4),
                     sm_session_version=6,
@@ -145,10 +137,6 @@ class CleanAmfSession(object):
                         pdu_session_id=1,
                         request_type=RequestType.Name(
                             1,
-                        ),
-                        pdu_address=RedirectServer(
-                            redirect_address_type=RedirectServer.IPV4,
-                            redirect_server_address="192.168.128.12",
                         ),
                         pdu_session_type=PduSessionType.IPV4,
                     ),
@@ -163,6 +151,7 @@ class CreateAmfSecondSubSession(object):
             SetSMSessionContext(
                 common_context=CommonSessionContext(
                     sid=SubscriberID(id="IMSI987654"),
+                    ue_ipv4="192.168.128.110",
                     apn=bytes("BLR", 'utf-8'), rat_type=RATType.Name(2),
                     sm_session_state=SMSessionFSMState.Name(0),
                     sm_session_version=0,
@@ -176,10 +165,6 @@ class CreateAmfSecondSubSession(object):
                         gnode_endpoint=TeidSet(
                             teid=5000,
                             end_ipv4_addr="192.168.60.141",
-                        ),
-                        pdu_address=RedirectServer(
-                            redirect_address_type=RedirectServer.IPV4,
-                            redirect_server_address="192.168.128.110",
                         ),
                         pdu_session_type=PduSessionType.Name(0),
                         ssc_mode=SscMode.Name(2),
@@ -195,6 +180,7 @@ class CreateAmfSecondSubSecondSession(object):
             SetSMSessionContext(
                 common_context=CommonSessionContext(
                     sid=SubscriberID(id="IMSI987654"),
+                    ue_ipv4="192.168.128.111",
                     apn=bytes("BLR", 'utf-8'), rat_type=RATType.Name(2),
                     sm_session_state=SMSessionFSMState.Name(0),
                     sm_session_version=0,
@@ -208,10 +194,6 @@ class CreateAmfSecondSubSecondSession(object):
                         gnode_endpoint=TeidSet(
                             teid=300,
                             end_ipv4_addr="192.168.60.141",
-                        ),
-                        pdu_address=RedirectServer(
-                            redirect_address_type=RedirectServer.IPV4,
-                            redirect_server_address="192.168.128.111",
                         ),
                         pdu_session_type=PduSessionType.Name(0),
                         ssc_mode=SscMode.Name(2),
@@ -227,6 +209,7 @@ class ReleaseAmfSecondSubSession(object):
             SetSMSessionContext(
                 common_context=CommonSessionContext(
                     sid=SubscriberID(id="IMSI987654"),
+                    ue_ipv4="192.168.128.110",
                     apn=bytes("BLR", 'utf-8'), rat_type=RATType.Name(2),
                     sm_session_state=SMSessionFSMState.Name(4),
                     sm_session_version=6,
@@ -236,10 +219,6 @@ class ReleaseAmfSecondSubSession(object):
                         pdu_session_id=2,
                         request_type=RequestType.Name(
                             1,
-                        ),
-                        pdu_address=RedirectServer(
-                            redirect_address_type=RedirectServer.IPV4,
-                            redirect_server_address="192.168.128.110",
                         ),
                         pdu_session_type=PduSessionType.IPV4,
                     ),
@@ -255,6 +234,7 @@ class ReleaseAmfSecondSubSecondSession(object):
                 common_context=CommonSessionContext(
                     sid=SubscriberID(id="IMSI987654"),
                     apn=bytes("BLR", 'utf-8'), rat_type=RATType.Name(2),
+                    ue_ipv4="192.168.128.111",
                     sm_session_state=SMSessionFSMState.Name(4),
                     sm_session_version=6,
                 ),
@@ -263,10 +243,6 @@ class ReleaseAmfSecondSubSecondSession(object):
                         pdu_session_id=2,
                         request_type=RequestType.Name(
                             1,
-                        ),
-                        pdu_address=RedirectServer(
-                            redirect_address_type=RedirectServer.IPV4,
-                            redirect_server_address="192.168.128.111",
                         ),
                         pdu_session_type=PduSessionType.IPV4,
                     ),


### PR DESCRIPTION
…IP address.

Signed-off-by: mehul jindal <mehul.jindal@wavelabs.ai>

## Summary

We have found that UE IP address in gRPC message (AMF-SMF and SMF-AMF) is setting wrong message. So that it is difficult to extend for IPv6 and IPv4IPv6 support.

It should be set below message:
```
message CommonSessionContext {
    SubscriberID sid = 1;
    string ue_ipv4 = 3;
    string apn = 4;
    bytes msisdn = 5;
    RATType rat_type = 6;
    // PDU session state to mirror with AMF or MME
    SMSessionFSMState sm_session_state = 7;
    uint32 sm_session_version = 9;
    string ue_ipv6 = 10;
    // TEIDs corresponding to the default bearer
    Teids teids = 11;
}
```

## Test Plan

We have tested with stub cli `lte/gateway/python/scripts/smf_upf_integration_cli.py`

## Additional Information

Corresponding Zenhub task #10305 
For complete logs, please refer the following comment.

