### PR TITLE
feat(nms):  Add support to configure PDN type of APN

### DIFF
--- a/nms/packages/magmalte/app/views/traffic/ApnEdit.js
+++ b/nms/packages/magmalte/app/views/traffic/ApnEdit.js
@@ -30,8 +30,11 @@ import FormLabel from '@material-ui/core/FormLabel';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 import React from 'react';
+import Select from '@material-ui/core/Select';
 import Switch from '@material-ui/core/Switch';
 import Text from '../../theme/design-system/Text';
 
@@ -51,6 +54,7 @@ const DEFAULT_APN_CONFIG = {
       preemption_vulnerability: false,
       priority_level: 15,
     },
+    pdn_type: 0,
   },
   apn_name: '',
 };
@@ -106,8 +110,14 @@ type Props = {
   onSave: apn => void,
 };
 
+const PDNTypeEnum = Object.freeze({
+  IPv4: 0,
+  IPv6: 1,
+  IPv4v6: 2,
+  IPv4orv6: 3,
+});
+
 export function ApnEdit(props: Props) {
-  // Name and descritption
   const [error, setError] = useState('');
   const enqueueSnackbar = useEnqueueSnackbar();
   const ctx = useContext(ApnContext);
@@ -120,6 +130,11 @@ export function ApnEdit(props: Props) {
     props.apn?.apn_configuration?.qos_profile ||
       DEFAULT_APN_CONFIG.apn_configuration.qos_profile,
   );
+
+  const [pdnType, setPdnType] = useState<$Values<typeof PDNTypeEnum>>(
+    props.apn?.apn_configuration?.pdn_type ||
+      DEFAULT_APN_CONFIG.apn_configuration.pdn_type,
+  );
   const onSave = async () => {
     if (apn.apn_name === '') {
       throw Error('Invalid Name');
@@ -129,11 +144,12 @@ export function ApnEdit(props: Props) {
       return;
     }
     try {
-      const newApn = {
+      const newApn: apn = {
         ...apn,
         apn_configuration: {
           ambr: maxBandwidth,
           qos_profile: qosProfile,
+          pdn_type: pdnType,
         },
       };
       await ctx.setState(newApn.apn_name, newApn);
@@ -266,6 +282,30 @@ export function ApnEdit(props: Props) {
                 }}
                 checked={qosProfile.preemption_vulnerability}
               />
+            </AltFormField>
+            <AltFormField label={'PDN Type'}>
+              <Select
+                fullWidth={true}
+                variant={'outlined'}
+                value={pdnType || 0}
+                onChange={({target}) => {
+                  // $FlowIgnore: value guaranteed to match the number literals
+                  setPdnType(parseInt(target.value));
+                }}
+                input={<OutlinedInput data-testId="pdnType" />}>
+                <MenuItem value={0}>
+                  <ListItemText primary={'IPv4'} />
+                </MenuItem>
+                <MenuItem value={1}>
+                  <ListItemText primary={'IPv6'} />
+                </MenuItem>
+                <MenuItem value={2}>
+                  <ListItemText primary={'IPv4v6'} />
+                </MenuItem>
+                <MenuItem value={3}>
+                  <ListItemText primary={'IPv4 or v6'} />
+                </MenuItem>
+              </Select>
             </AltFormField>
           </div>
         </List>

--- a/nms/packages/magmalte/app/views/traffic/__tests__/ApnAddTest.js
+++ b/nms/packages/magmalte/app/views/traffic/__tests__/ApnAddTest.js
@@ -152,6 +152,7 @@ describe('<TrafficDashboard />', () => {
     const preemptionCapability = getByTestId('preemptionCapability').firstChild;
     const preemptionVulnerability = getByTestId('preemptionVulnerability')
       .firstChild;
+    const pdnType = getByTestId('pdnType').firstChild;
 
     // test adding an existing apn
     if (apnID instanceof HTMLInputElement) {
@@ -172,7 +173,8 @@ describe('<TrafficDashboard />', () => {
       classID instanceof HTMLInputElement &&
       apnPriority instanceof HTMLInputElement &&
       apnBandwidthUL instanceof HTMLInputElement &&
-      apnBandwidthDL instanceof HTMLInputElement
+      apnBandwidthDL instanceof HTMLInputElement &&
+      pdnType instanceof HTMLElement
     ) {
       fireEvent.change(apnID, {target: {value: 'apn_2'}});
       fireEvent.change(classID, {target: {value: 9}});
@@ -185,6 +187,9 @@ describe('<TrafficDashboard />', () => {
       if (preemptionVulnerability?.firstChild instanceof HTMLElement) {
         fireEvent.click(preemptionVulnerability.firstChild);
       }
+      fireEvent.mouseDown(pdnType);
+      await wait();
+      fireEvent.click(getByText('IPv6'));
     } else {
       throw 'invalid type';
     }
@@ -195,6 +200,7 @@ describe('<TrafficDashboard />', () => {
     const newApn = {
       apn_configuration: {
         ambr: {max_bandwidth_dl: 1000000, max_bandwidth_ul: 1000000},
+        pdn_type: 1,
         qos_profile: {
           class_id: 9,
           preemption_capability: true,
@@ -251,6 +257,7 @@ describe('<TrafficDashboard />', () => {
     const newApn = {
       apn_configuration: {
         ambr: {max_bandwidth_dl: 1000000, max_bandwidth_ul: 1000000},
+        pdn_type: 0,
         qos_profile: {
           class_id: 8,
           preemption_capability: true,

--- a/nms/packages/magmalte/mock/db.json
+++ b/nms/packages/magmalte/mock/db.json
@@ -1440,7 +1440,8 @@
           "preemption_capability": true,
           "preemption_vulnerability": false,
           "priority_level": 15
-        }
+        },
+        "pdn_type": 0
       },
       "apn_name": "internet"
     }


### PR DESCRIPTION
Signed-off-by: HannaFar <hannafarag159@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add support to configure PDN type of a APN

<img width="1281" alt="Capture d’écran 2021-11-15 à 16 32 11" src="https://user-images.githubusercontent.com/26038920/141809285-e9b9e45c-6d76-4f51-9228-22308699cf6d.png">

## Test Plan

Add/Edit APN config
Modified ApnAddTest.js unit test



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
