### PR TITLE
chore(mme): clean up oai-mme cmake files

### DIFF
--- a/lte/gateway/c/core/oai/oai_mme/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/oai_mme/CMakeLists.txt
@@ -29,13 +29,7 @@ if ("${LFDS}" STREQUAL "LFDS-NOTFOUND")
   message(FATAL_ERROR "LIB LFDS not found, please install it")
 endif ()
 
-add_executable(mme
-    ${PROJECT_SOURCE_DIR}/oai_mme/oai_mme.c
-    ${PROJECT_SOURCE_DIR}/common/itti_free_defined_msg.c
-    ${PROJECT_SOURCE_DIR}/tasks/service303/service303_task.c
-    ${PROJECT_SOURCE_DIR}/tasks/service303/service303_mme_stats.c
-    ${PROJECT_SOURCE_DIR}/tasks/grpc_service/grpc_service_task.c
-    )
+add_executable(mme ${PROJECT_SOURCE_DIR}/oai_mme/oai_mme.c)
 
 target_link_libraries(mme
     -Wl,--start-group

--- a/lte/gateway/c/core/oai/tasks/grpc_service/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(TASK_GRPC_SERVICE
     amf_service_handler.c
     proto_msg_to_itti_msg.cpp
     grpc_service.cpp
+    grpc_service_task.c
     S8ServiceImpl.cpp
     ${PROTO_SRCS}
     ${PROTO_HDRS}
@@ -129,6 +130,7 @@ add_library(TASK_GRPC_SERVICE
     amf_service_handler.c
     proto_msg_to_itti_msg.cpp
     grpc_service.cpp
+    grpc_service_task.c
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     )

--- a/lte/gateway/c/core/oai/tasks/service303/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/service303/CMakeLists.txt
@@ -5,6 +5,8 @@ set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 add_library(TASK_SERVICE303
     service303.cpp
+    service303_task.c
+    service303_mme_stats.c
     )
 
 target_link_libraries(TASK_SERVICE303

--- a/lte/gateway/c/core/oai/test/sgw_s8_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/sgw_s8_task/CMakeLists.txt
@@ -32,9 +32,7 @@ set(SGW_S8_TEST_CONFIG_SRC
     sgw_s8_recv_grpc_messages.cpp
     )
 
-add_executable(sgw_s8_test ${SGW_S8_TEST_CONFIG_SRC}
-              ${PROJECT_SOURCE_DIR}/tasks/grpc_service/grpc_service_task.c
-              )
+add_executable(sgw_s8_test ${SGW_S8_TEST_CONFIG_SRC})
 
 target_link_libraries(sgw_s8_test
     LIB_S8_PROXY


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Seems like a tech debt, so cleaning it up. Cmake files should include all files in its respective directories.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

Built MME locally with the magma VM. Waiting for CI results (OAI-jenkins)
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
