### PR TITLE
fix(agw): Remove cyclic dependency between Logging and ITTI

### DIFF
--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
@@ -67,7 +67,7 @@ const int itti_debug = ITTI_DEBUG_ISSUES | ITTI_DEBUG_MP_STATISTICS;
 
 #define ITTI_DEBUG(m, x, args...)                                              \
   do {                                                                         \
-	/* stdout is redirected to syslog when MME is run via systemd */           \
+    /* stdout is redirected to syslog when MME is run via systemd */           \
     if ((m) &itti_debug) fprintf(stdout, "[ITTI][D]" x, ##args);               \
   } while (0);
 
@@ -135,8 +135,8 @@ status_code_e send_msg_to_task(
     assert(rc == 0);
     pthread_mutex_unlock(&task_zmq_ctx_p->send_mutex);
   } else {
-	  ITTI_DEBUG(ITTI_DEBUG_SEND,
-        "Sending msg using uninitialized context. %s to %s!\n",
+    ITTI_DEBUG(
+        ITTI_DEBUG_SEND, "Sending msg using uninitialized context. %s to %s!\n",
         itti_get_message_name(message->ittiMsgHeader.messageId),
         itti_get_task_name(destination_task_id));
   }

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <malloc.h>
 #include <stdint.h>
+#include <liblfds710.h>
 
 #include "lte/gateway/c/core/oai/common/assertions.h"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
@@ -52,7 +52,6 @@
 
 #include "lte/gateway/c/core/oai/lib/itti/signals.h"
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
-#include "lte/gateway/c/core/oai/common/log.h"
 
 /* ITTI DEBUG groups */
 #define ITTI_DEBUG_POLL (1 << 0)
@@ -67,6 +66,7 @@ const int itti_debug = ITTI_DEBUG_ISSUES | ITTI_DEBUG_MP_STATISTICS;
 
 #define ITTI_DEBUG(m, x, args...)                                              \
   do {                                                                         \
+	/* stdout is redirected to syslog when MME is run via systemd */           \
     if ((m) &itti_debug) fprintf(stdout, "[ITTI][D]" x, ##args);               \
   } while (0);
 
@@ -134,7 +134,7 @@ status_code_e send_msg_to_task(
     assert(rc == 0);
     pthread_mutex_unlock(&task_zmq_ctx_p->send_mutex);
   } else {
-    OAI_FPRINTF_ERR(
+	  ITTI_DEBUG(ITTI_DEBUG_SEND,
         "Sending msg using uninitialized context. %s to %s!\n",
         itti_get_message_name(message->ittiMsgHeader.messageId),
         itti_get_task_name(destination_task_id));
@@ -442,7 +442,7 @@ void itti_wait_tasks_end(task_zmq_ctx_t* task_ctx) {
     signal_handle(&end, task_ctx);
   }
 
-  OAILOG_INFO(LOG_ITTI, "Closing all tasks");
+  ITTI_DEBUG(ITTI_DEBUG_EXIT, "Closing all tasks");
   sleep(1);
 
   do {
@@ -481,7 +481,7 @@ void itti_wait_tasks_end(task_zmq_ctx_t* task_ctx) {
     }
   } while ((ready_tasks > 0) && (retries--));
 
-  OAILOG_INFO(LOG_ITTI, "ready_tasks %d", ready_tasks);
+  ITTI_DEBUG(ITTI_DEBUG_EXIT, "ready_tasks %d", ready_tasks);
   itti_desc.running = 0;
 
   free_wrapper((void**) &itti_desc.threads);

--- a/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/core/oai/lib/itti/intertask_interface.c
@@ -67,7 +67,7 @@ const int itti_debug = ITTI_DEBUG_ISSUES | ITTI_DEBUG_MP_STATISTICS;
 
 #define ITTI_DEBUG(m, x, args...)                                              \
   do {                                                                         \
-    if ((m) &itti_debug) OAILOG_DEBUG(LOG_ITTI, x, ##args);                    \
+    if ((m) &itti_debug) fprintf(stdout, "[ITTI][D]" x, ##args);               \
   } while (0);
 
 /* Global message size */

--- a/lte/gateway/c/core/oai/lib/itti/signals.c
+++ b/lte/gateway/c/core/oai/lib/itti/signals.c
@@ -45,11 +45,6 @@
 #include "lte/gateway/c/core/oai/lib/itti/signals.h"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
 
-#if defined(LOG_D) && defined(LOG_E)
-#define SIG_DEBUG(x, args...) OAILOG_D(EMU, x, ##args)
-#define SIG_ERROR(x, args...) OAILOG_E(EMU, x, ##args)
-#endif
-
 #ifndef SIG_DEBUG
 #define SIG_DEBUG(x, args...)                                                  \
   do {                                                                         \


### PR DESCRIPTION

## Summary

Linked to issue #9732 

Replaced in lte/gateway/c/core/oai/lib/itti/*.c all calls to OAILOG_* by fprintf()

