### PR TITLE
test(mme): Adding back timer service restart tests to sanity

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -153,6 +153,9 @@ s1aptests/test_attach_detach_with_mobilityd_restart.py \
 s1aptests/test_idle_mode_with_mme_restart.py \
 s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py \
 s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py \
+s1aptests/test_mobile_reachability_timer_with_mme_restart.py \
+s1aptests/test_implicit_detach_timer_with_mme_restart.py \
+s1aptests/test_ics_timer_expiry_with_mme_restart.py \
 s1aptests/test_paging_after_mme_restart.py \
 s1aptests/test_attach_nw_initiated_detach_fail.py \
 s1aptests/test_tau_ta_updating.py \
@@ -237,9 +240,6 @@ s1aptests/test_restore_config_after_non_sanity.py
 #---------------
 
 # Enable these tests once the CI job time-out has increased
-# s1aptests/test_mobile_reachability_timer_with_mme_restart.py \
-# s1aptests/test_implicit_detach_timer_with_mme_restart.py \
-# s1aptests/test_ics_timer_expiry_with_mme_restart.py \
 
 # s1aptests/test_attach_dl_udp_data.py \
 # s1aptests/test_attach_dl_tcp_data.py \


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
