### PR TITLE
test(mme): SPGW unit test for release access bearer request

### DIFF
--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -2317,6 +2317,7 @@ void sgw_process_release_access_bearer_request(
           eps_bearer_ctxt->p_gw_teid_S5_S8_up,
           eps_bearer_ctxt->s_gw_ip_address_S5_S8_up.address.ipv4_address.s_addr,
           eps_bearer_ctxt->s_gw_teid_S5_S8_up);
+#if !MME_UNIT_TEST  // skip tunnel deletion for unit tests
       if (module == LOG_SPGW_APP) {
         rv = gtp_tunnel_ops->del_tunnel(
             enb, enb_ipv6, eps_bearer_ctxt->paa.ipv4_address, ue_ipv6,
@@ -2350,6 +2351,7 @@ void sgw_process_release_access_bearer_request(
       } else {
         OAILOG_DEBUG(module, "Set the paging rule for IP Addr: %s\n", ip_str);
       }
+#endif
       sgw_release_all_enb_related_information(eps_bearer_ctxt);
     }
   }

--- a/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
@@ -47,6 +47,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S11_RELEASE_ACCESS_BEARERS_RESPONSE: {
+      mme_app_handler_->mme_app_handle_release_access_bearers_resp();
     } break;
 
     case S11_DELETE_SESSION_RESPONSE: {

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -61,6 +61,7 @@ class MockMmeAppHandler {
   MOCK_METHOD0(mme_app_handle_modify_bearer_rsp, void());
   MOCK_METHOD0(mme_app_handle_delete_sess_rsp, void());
   MOCK_METHOD0(nas_proc_dl_transfer_rej, void());
+  MOCK_METHOD0(mme_app_handle_release_access_bearers_resp, void());
 };
 
 class MockSctpHandler {

--- a/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
@@ -38,6 +38,6 @@ set_target_properties(SPGW_TASK_TEST_LIB PROPERTIES LINKER_LANGUAGE CXX)
 
 foreach (sgw_test spgw_state_converter spgw_procedures)
   add_executable(${sgw_test}_test test_${sgw_test}.cpp)
-  target_link_libraries(${sgw_test}_test SPGW_TASK_TEST_LIB)
+  target_link_libraries(${sgw_test}_test SPGW_TASK_TEST_LIB TASK_GRPC_SERVICE)
   add_test(test_${sgw_test} ${sgw_test}_test)
 endforeach (sgw_test)

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
@@ -30,8 +30,7 @@ namespace lte {
 extern task_zmq_ctx_t task_zmq_ctx_main_spgw;
 
 bool is_num_sessions_valid(
-    uint64_t imsi64, int expected_num_ue_contexts,
-    int expected_num_teids) {
+    uint64_t imsi64, int expected_num_ue_contexts, int expected_num_teids) {
   hash_table_ts_t* state_ue_ht = get_spgw_ue_state();
   if (state_ue_ht->num_elements != expected_num_ue_contexts) {
     return false;

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -36,11 +36,10 @@ namespace lte {
 #define ERROR_SGW_S11_TEID 100
 #define DEFAULT_EDNS_IP 0x7f000001  // localhost
 #define DEFAULT_SGW_IP 0x7f000001   // localhost
-#define DEFAULT_ENB_IP 0xc0a83c8d // 192.168.60.141
+#define DEFAULT_ENB_IP 0xc0a83c8d   // 192.168.60.141
 
 bool is_num_sessions_valid(
-    uint64_t imsi64, int expected_num_ue_contexts,
-    int expected_num_teids);
+    uint64_t imsi64, int expected_num_ue_contexts, int expected_num_teids);
 
 bool is_num_s1_bearers_valid(
     teid_t context_teid, int expected_num_active_bearers);

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -33,13 +33,18 @@ namespace lte {
 #define DEFAULT_UE_IP 0xc0a8800a  // 192.168.128.10
 #define DEFAULT_VLAN 0
 #define DEFAULT_ENB_GTP_TEID 1
+#define ERROR_ENB_GTP_TEID 100
 #define ERROR_SGW_S11_TEID 100
 #define DEFAULT_EDNS_IP 0x7f000001  // localhost
 #define DEFAULT_SGW_IP 0x7f000001   // localhost
+#define DEFAULT_ENB_IP 0xc0a83c8d // 192.168.60.141
 
 bool is_num_sessions_valid(
-    spgw_state_t* spgw_state, uint64_t imsi64, int expected_num_ue_contexts,
+    uint64_t imsi64, int expected_num_ue_contexts,
     int expected_num_teids);
+
+bool is_num_s1_bearers_valid(
+    teid_t context_teid, int expected_num_active_bearers);
 
 void fill_create_session_request(
     itti_s11_create_session_request_t* session_request_p,
@@ -63,5 +68,9 @@ void fill_modify_bearer_request(
 void fill_delete_session_request(
     itti_s11_delete_session_request_t* delete_session_req, teid_t mme_s11_teid,
     teid_t sgw_s11_context_teid, ebi_t eps_bearer_id, plmn_t test_plmn);
+
+void fill_release_access_bearer_request(
+    itti_s11_release_access_bearers_request_t* release_access_bearers_req,
+    teid_t mme_s11_teid, teid_t sgw_s11_context_teid);
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -33,7 +33,6 @@ namespace lte {
 #define DEFAULT_UE_IP 0xc0a8800a  // 192.168.128.10
 #define DEFAULT_VLAN 0
 #define DEFAULT_ENB_GTP_TEID 1
-#define ERROR_ENB_GTP_TEID 100
 #define ERROR_SGW_S11_TEID 100
 #define DEFAULT_EDNS_IP 0x7f000001  // localhost
 #define DEFAULT_SGW_IP 0x7f000001   // localhost

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
@@ -511,10 +511,110 @@ TEST_F(SPGWAppProcedureTest, TestReleaseBearerSuccess) {
   fill_release_access_bearer_request(
       &sample_release_bearer_req, DEFAULT_MME_S11_TEID, ue_sgw_teid);
 
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_release_access_bearers_resp())
+      .Times(1);
+
   sgw_handle_release_access_bearers_request(
       &sample_release_bearer_req, test_imsi64);
+
   // verify that eNB information has been cleared
   ASSERT_TRUE(is_num_s1_bearers_valid(ue_sgw_teid, 0));
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
+
+TEST_F(SPGWAppProcedureTest, TestReleaseBearerError) {
+  spgw_state_t* spgw_state  = get_spgw_state(false);
+  status_code_e return_code = RETURNerror;
+  // expect call to MME create session response
+  itti_s11_create_session_request_t sample_session_req_p = {};
+  fill_create_session_request(
+      &sample_session_req_p, test_imsi_str, DEFAULT_MME_S11_TEID,
+      DEFAULT_BEARER_INDEX, sample_default_bearer_context, test_plmn);
+
+  // trigger create session req to SPGW
+  return_code = sgw_handle_s11_create_session_request(
+      spgw_state, &sample_session_req_p, test_imsi64);
+
+  ASSERT_EQ(return_code, RETURNok);
+
+  // Verify that a UE context exists in SPGW state after CSR is received
+  spgw_ue_context_t* ue_context_p = spgw_get_ue_context(test_imsi64);
+  ASSERT_TRUE(ue_context_p != nullptr);
+
+  // Verify that teid is created
+  ASSERT_FALSE(LIST_EMPTY(&ue_context_p->sgw_s11_teid_list));
+  teid_t ue_sgw_teid =
+      LIST_FIRST(&ue_context_p->sgw_s11_teid_list)->sgw_s11_teid;
+
+  // Verify that no IP address is allocated for this UE
+  s_plus_p_gw_eps_bearer_context_information_t* spgw_eps_bearer_ctxt_info_p =
+      sgw_cm_get_spgw_context(ue_sgw_teid);
+
+  sgw_eps_bearer_ctxt_t* eps_bearer_ctxt_p = sgw_cm_get_eps_bearer_entry(
+      &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information
+           .pdn_connection,
+      DEFAULT_EPS_BEARER_ID);
+
+  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
+
+  // send an IP alloc response to SPGW
+  itti_ip_allocation_response_t test_ip_alloc_resp = {};
+  fill_ip_allocation_response(
+      &test_ip_alloc_resp, SGI_STATUS_OK, ue_sgw_teid, DEFAULT_EPS_BEARER_ID,
+      DEFAULT_UE_IP, DEFAULT_VLAN);
+  return_code = sgw_handle_ip_allocation_rsp(
+      spgw_state, &test_ip_alloc_resp, test_imsi64);
+
+  ASSERT_EQ(return_code, RETURNok);
+
+  // check if IP address is allocated after this message is done
+  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == DEFAULT_UE_IP);
+
+  // send pcef create session response to SPGW
+  itti_pcef_create_session_response_t sample_pcef_csr_resp;
+  fill_pcef_create_session_response(
+      &sample_pcef_csr_resp, PCEF_STATUS_OK, ue_sgw_teid, DEFAULT_EPS_BEARER_ID,
+      SGI_STATUS_OK);
+
+  // check if MME gets a create session response
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_create_sess_resp()).Times(1);
+
+  spgw_handle_pcef_create_session_response(
+      spgw_state, &sample_pcef_csr_resp, test_imsi64);
+
+  // send modify default bearer request
+  itti_s11_modify_bearer_request_t sample_modify_bearer_req = {};
+  fill_modify_bearer_request(
+      &sample_modify_bearer_req, DEFAULT_MME_S11_TEID, ue_sgw_teid,
+      DEFAULT_ENB_GTP_TEID, DEFAULT_BEARER_INDEX, DEFAULT_EPS_BEARER_ID);
+
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_modify_bearer_rsp()).Times(1);
+  return_code =
+      sgw_handle_modify_bearer_request(&sample_modify_bearer_req, test_imsi64);
+
+  ASSERT_EQ(return_code, RETURNok);
+
+  // verify that exactly one session exists in SPGW state
+  ASSERT_TRUE(is_num_sessions_valid(test_imsi64, 1, 1));
+
+  // verify that eNB address information exists
+  ASSERT_TRUE(is_num_s1_bearers_valid(ue_sgw_teid, 1));
+
+  // send release access bearer request
+  itti_s11_release_access_bearers_request_t sample_release_bearer_req = {};
+  fill_release_access_bearer_request(
+      &sample_release_bearer_req, DEFAULT_MME_S11_TEID, ERROR_SGW_S11_TEID);
+
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_release_access_bearers_resp())
+      .Times(1);
+
+  sgw_handle_release_access_bearers_request(
+      &sample_release_bearer_req, test_imsi64);
+
+  // verify that eNB information has not been cleared
+  ASSERT_TRUE(is_num_s1_bearers_valid(ue_sgw_teid, 1));
 
   // Sleep to ensure that messages are received and contexts are released
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

## Summary

This change adds success and failure unit test for the release access bearer request handler on SPGW task. 

It also has the following fixes:
1. Add ENodeB IP address in modify bearer request
2. Remove unused SPGW state from is_num_sessions_valid
3. Add a validation function for S1u bearer

## Test Plan

`make test_oai`
