### PR TITLE
fix(pipelined): Check that QosManager is not None before use

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/gy.py
+++ b/lte/gateway/python/magma/pipelined/app/gy.py
@@ -137,8 +137,9 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
             self._datapath,
             imsi,
         )
-        self._qos_mgr.remove_subscriber_qos(imsi)
-        self._remove_he_flows(ip_addr, None)
+        if self._qos_mgr:
+            self._qos_mgr.remove_subscriber_qos(imsi)
+        self._remove_he_flows(ip_addr, "")
 
     def _deactivate_flow_for_rule(self, imsi, ip_addr, rule_id):
         """
@@ -163,7 +164,8 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
             self._datapath, imsi,
             num,
         )
-        self._qos_mgr.remove_subscriber_qos(imsi, num)
+        if self._qos_mgr:
+            self._qos_mgr.remove_subscriber_qos(imsi, num)
         self._remove_he_flows(ip_addr, rule_id)
 
     def _install_flow_for_rule(


### PR DESCRIPTION
## Summary

One of the frequent Sentry errors in Python is that _qos_mgr is
called before it is initialized. Add a check to avoid it.

It seems to me from reading the code that the QoS management
is optional in pipelined and it is okay to skip it if the manager has
not been initialized yet. But I don't know enough about the service
to be sure. Maybe it would be better to log an error?

Fixes #10342
Fixes #10343