### PR TITLE
fix(orc8r): Logging of sensitive information

### DIFF
--- a/orc8r/cloud/go/http2/http2_log.go
+++ b/orc8r/cloud/go/http2/http2_log.go
@@ -22,8 +22,8 @@ import (
 //LogRequestWithVerbosity prints out request when the service binary is run
 // with log_verbosity verbosity
 func LogRequestWithVerbosity(req *http.Request, verbosity glog.Level) {
-	glog.V(verbosity).Infof("Printing request metadata: \nHeader: %v\n"+
-		"Host: %v\nURL: %v\nTrailer: %v\nProto: %v\nRequestURI: %v\n"+
-		"RemoteAddr: %v\nMethod: %v\n", req.Header, req.Host, req.URL,
+	glog.V(verbosity).Infof("Printing request metadata: \nHost: %v\n"+
+		"URL: %v\nTrailer: %v\nProto: %v\nRequestURI: %v\n"+
+		"RemoteAddr: %v\nMethod: %v\n", req.Host, req.URL,
 		req.Trailer, req.Proto, req.RequestURI, req.RemoteAddr, req.Method)
 }

--- a/orc8r/cloud/go/http2/http2_log.go
+++ b/orc8r/cloud/go/http2/http2_log.go
@@ -21,6 +21,7 @@ import (
 
 //LogRequestWithVerbosity prints out request when the service binary is run
 // with log_verbosity verbosity
+
 func LogRequestWithVerbosity(req *http.Request, verbosity glog.Level) {
 	glog.V(verbosity).Infof("Printing request metadata: \nHost: %v\n"+
 		"URL: %v\nTrailer: %v\nProto: %v\nRequestURI: %v\n"+

--- a/orc8r/cloud/go/http2/http2_log.go
+++ b/orc8r/cloud/go/http2/http2_log.go
@@ -21,7 +21,6 @@ import (
 
 //LogRequestWithVerbosity prints out request when the service binary is run
 // with log_verbosity verbosity
-
 func LogRequestWithVerbosity(req *http.Request, verbosity glog.Level) {
 	glog.V(verbosity).Infof("Printing request metadata: \nHost: %v\n"+
 		"URL: %v\nTrailer: %v\nProto: %v\nRequestURI: %v\n"+


### PR DESCRIPTION
fix(orc8) - Fix: Logging of sensitive information

## Summary
- orc8r/cloud/go/http2/http2_log.go:27 -> LogRequestWithVerbosity()
   Sensitive data: request.Header removed from log.

Fix is for alert:
https://github.com/magma/magma/security/code-scanning/5?query=ref%3Arefs%2Fheads%2Fmaster
