### PR TITLE
chore(magmad): enable selective opt-in logging to Sentry for magmad

### DIFF
--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -175,4 +175,4 @@ restart_timeout_threshold: 15
 
 # [Experimental] Enable Sentry for this service
 # Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled
+sentry: send_selected_errors

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -20,6 +20,7 @@ import metrics_pb2
 import prometheus_client.core
 import requests
 import snowflake
+from magma.common.sentry import SEND_TO_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos import metricsd_pb2
 from orc8r.protos.common_pb2 import Void
@@ -138,6 +139,7 @@ class MetricsCollector(object):
                 "Metrics upload error for service %s (chunk %d)! "
                 "[%s] %s", service_name, chunk, err.code(),
                 err.details(),
+                extra=SEND_TO_MONITORING,
             )
         else:
             logging.debug(
@@ -297,6 +299,7 @@ class MetricsCollector(object):
             logging.error(
                 "Prometheus Target Metrics upload error! [%s] %s",
                 err.code(), err.details(),
+                extra=SEND_TO_MONITORING,
             )
         else:
             logging.debug(

--- a/orc8r/gateway/python/magma/magmad/proxy_client.py
+++ b/orc8r/gateway/python/magma/magmad/proxy_client.py
@@ -15,6 +15,7 @@ import logging
 
 import aioh2
 import h2.events
+from magma.common.sentry import SEND_TO_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos.sync_rpc_service_pb2 import GatewayResponse, SyncRPCResponse
 
@@ -104,7 +105,10 @@ class ControlProxyHttpClient(object):
                 "terminated by cloud",
             )
         except Exception as e:  # pylint: disable=broad-except
-            logging.error("[SyncRPC] Exception in proxy_client: %s", e)
+            logging.error(
+                "[SyncRPC] Exception in proxy_client: %s", e,
+                extra=SEND_TO_MONITORING,
+            )
             sync_rpc_response_queue.put(
                 SyncRPCResponse(
                     heartBeat=False, reqId=req_id,

--- a/orc8r/gateway/python/magma/magmad/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/magmad/rpc_servicer.py
@@ -23,6 +23,12 @@ from google.protobuf import json_format
 from google.protobuf.json_format import MessageToJson
 from google.protobuf.struct_pb2 import Struct
 from magma.common.rpc_utils import return_void, set_grpc_err
+from magma.common.sentry import (
+    SEND_TO_MONITORING,
+    SentryStatus,
+    get_sentry_status,
+    send_uncaught_errors_to_monitoring,
+)
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
 from magma.common.stateless_agw import (
@@ -35,6 +41,8 @@ from magma.magmad.check.network_check import ping, traceroute
 from magma.magmad.generic_command.command_executor import CommandExecutor
 from magma.magmad.service_manager import ServiceManager
 from orc8r.protos import magmad_pb2, magmad_pb2_grpc
+
+enable_sentry_wrapper = get_sentry_status("magmad") == SentryStatus.SEND_SELECTED_ERRORS
 
 
 class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
@@ -81,6 +89,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
         magmad_pb2_grpc.add_MagmadServicer_to_server(self, server)
 
     @return_void
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def StartServices(self, _, context):
         """
         Start all magma services
@@ -88,6 +97,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
         self._loop.create_task(self._service_manager.start_services())
 
     @return_void
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def StopServices(self, _, context):
         """
         Stop all magma services
@@ -95,6 +105,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
         self._loop.create_task(self._service_manager.stop_services())
 
     @return_void
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def Reboot(self, _, context):
         """
         Reboot the gateway device
@@ -107,6 +118,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
         self._loop.create_task(run_reboot())
 
     @return_void
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def RestartServices(self, request, context):
         """
         Restart specified magma services.
@@ -122,6 +134,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
         self._loop.create_task(run_restart())
 
     @return_void
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def SetConfigs(self, request, context):
         """
         Set the stored mconfig to a specific value. Restarts all services
@@ -146,10 +159,12 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
         )
         self._magma_service.reload_mconfig()
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetConfigs(self, _, context):
         # TODO: support streaming mconfig manager impl
         return self._mconfig_manager.load_mconfig()
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def RunNetworkTests(self, request, context):
         """
         Execute some specified network commands to check gateway network health
@@ -165,6 +180,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
             traceroutes=traceroute_results,
         )
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetGatewayId(self, _, context):
         """
         Get gateway hardware ID
@@ -173,6 +189,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
             gateway_id=snowflake.snowflake(),
         )
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GenericCommand(self, request, context):
         """
         Execute generic command. This method will run the command with params
@@ -226,6 +243,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
             logging.error(
                 'Error running command %s! %s: %s',
                 request.command, e.__class__.__name__, e,
+                extra=SEND_TO_MONITORING,
             )
             set_grpc_err(
                 context,
@@ -235,6 +253,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
 
         return response
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def TailLogs(self, request, context):
         """
         Provides an infinite stream of logs to the client. The client can stop
@@ -291,6 +310,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
             except queue.Empty:
                 pass
 
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def CheckStateless(self, _, context):
         """
         Check the stateless mode on AGW
@@ -303,6 +323,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
         return magmad_pb2.CheckStatelessResponse(agw_mode=status)
 
     @return_void
+    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ConfigureStateless(self, request, context):
         """
         Change the stateless mode on AGW, with one of the following:


### PR DESCRIPTION
## Summary

Adds decorators to grpc endpoints of rpc_servicer.py in magmad. Also includes broad exception blocks of magmad to send errors to Sentry. The idea here is to send unexpected errors to Sentry and to avoid sending frequent application errors.

## Test Plan

Compare to high frequency Sentry logs to avoid tagging respective errors.

## Context

In Sentry's opt-in mode only the most important errors should be sent to Sentry.