### PR TITLE
chore(ci): install clang-format-11 in Magma VM provisioning

### DIFF
--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -438,6 +438,14 @@
     pkg:
       - clangd-12
 
+# TODO: preburn this
+- name: Install clang-format-11 c/c++ formatting tooling
+  retries: 5
+  apt:
+    state: latest
+    pkg:
+      - clang-format-11
+
 - name: Symlink system wide bazelrc into the VM
   file:
     src: '/home/vagrant/magma/experimental/bazel-base/bazelrcs/vm.bazelrc'


### PR DESCRIPTION
This to allow cut-over to clang-format-11 as part of #6187.

`clang-format-11` is already installed in our VS Code Devcontainer image.  This parity will enable a single PR to simultaneously format the repo to google style clang-format-11 AND cut over our VM/Devcontainer formatting tooling.

## Test Plan

Destroyed and rebuilt Magma VM

```
vagrant ssh magma
cd magma/lte/gateway
make format_all
```

And confirmed no formatting changes.

Further...

```
vagrant@magma-dev-focal:~$ which clang-format
/usr/bin/clang-format
vagrant@magma-dev-focal:~$ ls -l /usr/bin/clang-format
lrwxrwxrwx 1 root root 30 Jun 17 23:44 /usr/bin/clang-format -> /etc/alternatives/clang-format
vagrant@magma-dev-focal:~$ ls -l /etc/alternatives/clang-format
lrwxrwxrwx 1 root root 23 Jun 17 23:44 /etc/alternatives/clang-format -> /usr/bin/clang-format-7
```

And finally.

```
vagrant@magma-dev-focal:~$ ls -lh /usr/bin/clang-format-11
lrwxrwxrwx 1 root root 31 Oct 30  2020 /usr/bin/clang-format-11 -> ../lib/llvm-11/bin/clang-format
```

Signed-off-by: Scott Moeller <electronjoe@gmail.com>