### PR TITLE
chore: Add 'all' checks for buildifier

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,12 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 
 buildifier(
     name = "buildifier",
     lint_mode = "fix",
+    lint_warnings = ["all"],
     mode = "fix",
 )
 
@@ -23,6 +24,9 @@ buildifier_test(
     size = "small",
     timeout = "short",
     srcs = ["//:starlark_files"],
+    lint_mode = "warn",
+    lint_warnings = ["all"],
+    verbose = True,
 )
 
 filegroup(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -34,8 +34,8 @@ http_archive(
     ],
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("//:go_repositories.bzl", "go_repositories")
 
 # gazelle:repository_macro go_repositories.bzl%go_repositories

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//lte/gateway/c/session_manager/test:__pkg__"])
 
 cc_library(

--- a/lte/gateway/c/session_manager/test/BUILD.bazel
+++ b/lte/gateway/c/session_manager/test/BUILD.bazel
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
     name = "consts",


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Bazel has an extensive list of lint warnings / fixes that are available. Enabling all of them isn't a problem with our repository, so I'll just enable them all for now. If we find that some warnings are hard to adhere to, we can start excluding them on a case by case basis.

This PR also modifies the buildifier test to check for all lints as well.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
1. Run the new buildifier test on master and get failures. `bazel test //:check_starlark_format`
2. Run buildifier to auto format `bazel run //:buildifier`
3. Run the test again (it passes! :) )

Test is also run in CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
