### PR TITLE
chore(ci): always upload codecov for agw-workflow

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -341,6 +341,14 @@ jobs:
           key: ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-
+      - name: Setup Devcontainer Image
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the devontainer image!"
+            bazel # pull down bazel, if bazel download fails we can fail before we do all the lengthy work below
       - name: Run codecov with CMake (MME / SCTPD / LIAGENT)
         if: always()
         uses: addnab/docker-run-action@v2
@@ -366,6 +374,7 @@ jobs:
             # copy out coverage information into magma so that it's accessible from the CI node
             cp bazel-out/_coverage/_coverage_report.dat $MAGMA_ROOT
       - name: Upload code coverage
+        if: always()
         id: c-cpp-codecov-upload
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
@ardzoht saw a code coverage job failure due to bazel download fail: https://github.com/magma/magma/runs/4228407784?check_suite_focus=true
While the bazel downloading failure should be a flake, it's better to fail early than later in this case (code coverage steps take quite a bit of time). To make this happen, I'm adding a step to just run the bazel command which will trigger the bazel download.
Additionally, we can always attempt a codecov upload even if there is a failure.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
