### PR TITLE
feat(feg): Add gitattributes override for SBI generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 /orc8r/cloud/go/obsidian/swagger/v1/swagger.yml linguist-generated
 # NMS bindings are generated
 /nms/packages/magmalte/generated/MagmaAPIBindings.js linguist-generated
+# SBI openapi interface generated files
+/feg/gateway/sbi/specs/** linguist-generated


### PR DESCRIPTION
Signed-off-by: GANESH IRRINKI <ganesh.irrinki@wavelabs.ai>
## Summary
As requested [here](https://github.com/magma/magma/pull/9524/#issuecomment-970736747) and [here](https://github.com/magma/magma/pull/9524/#issuecomment-971345407)  adding generated file override for all SBI openapi generated files.

The files were merged in #9524.

