### PR TITLE
chore(ci): Move insync checking out of orc8r/cloud tests

### DIFF
--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -55,18 +55,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
-      - name: insync-checkin
-        if: always()
-        id: insync-checkin
-        continue-on-error: true
-        run: |
-            cd ${MAGMA_ROOT}/orc8r/cloud/docker
-            python3 build.py --generate
-            sudo chown -R $USER $MAGMA_ROOT/*
-            git add .
-            echo GIT_STATUS=$(git status) >> $GITHUB_ENV
-            git status
-            git diff-index --quiet HEAD
       - name: deploy-sync-checkin
         if: always()
         id: deploy-sync-checkin
@@ -114,17 +102,6 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to Slack for insync-checkin
-        if: steps.insync-checkin.outcome=='failure' && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action insync-checkin failed"
-          SLACK_USERNAME: "Cloud workflow"
-          SLACK_MESSAGE: "COMMIT TITLE:\n ${{steps.commit.outputs.title}}\n\n\n GIT STATUS OUTPUT:\n ${{env.GIT_STATUS}}"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
       - name: Notify failure to Slack for deploy-sync-checkin
         if: steps.deploy-sync-checkin.outcome=='failure' && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
@@ -132,7 +109,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action insync-checkin failed"
           SLACK_USERNAME: "Cloud workflow"
-          SLACK_MESSAGE: "COMMIT TITLE:\n ${{steps.commit.outputs.title}}\n\n\n GIT STATUS OUTPUT:\n ${{env.GIT_STATUS}}"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '

--- a/.github/workflows/insync-checkin.yml
+++ b/.github/workflows/insync-checkin.yml
@@ -1,0 +1,55 @@
+---
+name: insync-check
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+      - v1.*
+  pull_request:
+    branches:
+      - master
+      - v1.*
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  insync-checkin:
+    name: insync checkin job
+    runs-on: ubuntu-latest
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Run build.py
+        run: |
+          cd ${MAGMA_ROOT}/orc8r/cloud/docker
+          python3 build.py --generate
+          sudo chown -R $USER $MAGMA_ROOT/*
+          git add .
+          echo GIT_STATUS=$(git status) >> $GITHUB_ENV
+          git status
+          git diff-index --quiet HEAD
+      - name: Extract commit title
+        if: failure() && github.event_name == 'push'
+        id: commit
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+      - name: Notify failure to Slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "Github action insync-checkin failed"
+          SLACK_USERNAME: "Cloud workflow"
+          SLACK_MESSAGE: "COMMIT TITLE:\n ${{steps.commit.outputs.title}}\n\n\n GIT STATUS OUTPUT:\n ${{env.GIT_STATUS}}"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '


### PR DESCRIPTION
Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Moving insync check job out of cloud tests as it touches more than orc8r.
Getting rid of path filtering too

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
