### PR TITLE
fix(agw): force upgrade ca-certs on upgrade agw (#9595)

### DIFF
--- a/lte/gateway/release/upgrade_magma.sh
+++ b/lte/gateway/release/upgrade_magma.sh
@@ -29,7 +29,7 @@ if grep -q 'Debian' /etc/issue; then
 fi
 
 apt update
-apt install -y apt-transport-https gnupg2
+apt install -y apt-transport-https gnupg2 wget ca-certificates
 
 # We have changed the name too many time we have to wipe all versions
 rm -rf /etc/apt/sources.list.d/*


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
