### PR TITLE
fix(mme): set the correct criticality for handoverResourceAllocation

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -2470,7 +2470,7 @@ status_code_e s1ap_mme_handle_handover_request(
       S1ap_ProcedureCode_id_HandoverResourceAllocation;
   pdu.choice.initiatingMessage.value.present =
       S1ap_InitiatingMessage__value_PR_HandoverRequest;
-  pdu.choice.initiatingMessage.criticality = S1ap_Criticality_ignore;
+  pdu.choice.initiatingMessage.criticality = S1ap_Criticality_reject;
   out = &pdu.choice.initiatingMessage.value.choice.HandoverRequest;
 
   /* MME-UE-ID: mandatory */


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

Based on 3gpp spec [ts 36.413 r15](https://www.etsi.org/deliver/etsi_ts/136400_136499/136413/15.10.00_60/ts_136413v151000p.pdf), criticality must be set to reject for handoverResourceAllocation,

<img width="555" alt="Screenshot 2021-11-17 at 3 21 31 PM" src="https://user-images.githubusercontent.com/8215369/142298208-fce0f11e-e7d2-404f-ab03-cf720a51341f.png">

This is causing an asn.1 decoding issue for our partner during some handover testing.

Same here,
c/core/oai/tasks/s1ap/messages/asn1/r15/s1ap-15.6.0.asn1 (L341)

## Test Plan

fab integ_test