### PR TITLE
fix(ci): Fix Testim reports success count

### DIFF
--- a/ci-scripts/post_testim_report.py
+++ b/ci-scripts/post_testim_report.py
@@ -53,7 +53,7 @@ def get_test_count(test_data):
     Returns:
         int: total test count
     """
-    return test_data.get("testsuites").get("testsuite").get("@tests")
+    return int(test_data.get("testsuites").get("testsuite").get("@tests"))
 
 
 def get_test_failures(test_data):
@@ -118,12 +118,13 @@ def header_blocks(test_count, failures):
                 "text": 'Daily Tests - PASSED',
             },
         })
+    successes = test_count - len(failures)
     blocks.append({
         "type": "context",
         "elements": [
             {
                 "type": "mrkdwn",
-                "text": f'Passed *{len(failures)}/{test_count}* tests',
+                "text": f'Passed *{successes}/{test_count}* tests',
             },
         ],
     })


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Fixing the Testim slack reports. There was a small issue where the reported count of passed tests was actually just the count of failed tests. This fix changes that. An example of the issue here:
![Screen Shot 2021-11-17 at 3 46 52 PM](https://user-images.githubusercontent.com/804385/142300374-0e8b13c4-5391-4156-a3a4-8a8d9bee093d.png)

## Test Plan

Ran a limited test set of 6 tests, and then reported them to Slack through the same script that Github actions runs daily to report to Slack.

![Screen Shot 2021-11-17 at 3 46 14 PM](https://user-images.githubusercontent.com/804385/142300260-678e1406-bb01-486a-b739-f75755347b14.png)


## Additional Information

- [ ] This change is backwards-breaking
