### PR TITLE
fix(amf): Addressing the warnings during compilation

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -21,7 +21,6 @@
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/common/assertions.h"
 
-static bool parse_bool(const char* str);
 void served_tai_config_init(served_tai_t* served_tai);
 void clear_served_tai_config(served_tai_t* served_tai);
 
@@ -395,16 +394,6 @@ int amf_config_parse_file(
   }  // NGP Setting is not NULL
   config_destroy(&cfg);
   return 0;
-}
-
-static bool parse_bool(const char* str) {
-  if (strcasecmp(str, "yes") == 0) return true;
-  if (strcasecmp(str, "true") == 0) return true;
-  if (strcasecmp(str, "no") == 0) return false;
-  if (strcasecmp(str, "false") == 0) return false;
-  if (strcasecmp(str, "") == 0) return false;
-
-  Fatal("Error in config file: got \"%s\" but expected bool\n", str);
 }
 
 /***************************************************************************

--- a/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
@@ -299,7 +299,6 @@ int amf_proc_security_mode_control(
   bool security_context_is_new = false;
   int amf_ea                   = M5G_NAS_SECURITY_ALGORITHMS_5G_EA0;
   int amf_ia                   = M5G_NAS_SECURITY_ALGORITHMS_5G_IA0;
-  uint8_t snni[32]             = {0};
   uint8_t ak_sqn[6]            = {0};
 
   OAILOG_DEBUG(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -213,17 +213,7 @@ void clear_amf_smf_context(std::shared_ptr<smf_context_t> smf_ctx) {
 int pdu_session_release_request_process(
     ue_m5gmm_context_s* ue_context, std::shared_ptr<smf_context_t> smf_ctx,
     amf_ue_ngap_id_t amf_ue_ngap_id, bool retransmit) {
-  int rc                = 1;
-  amf_smf_t amf_smf_msg = {};
-  // amf_cause = amf_smf_handle_pdu_release_request(
-  //              msg, &amf_smf_msg);
-
-  int smf_cause             = SMF_CAUSE_SUCCESS;
-  amf_smf_msg.u.release.pti = smf_ctx->smf_proc_data.pti.pti;
-  amf_smf_msg.u.release.pdu_session_id =
-      smf_ctx->smf_proc_data.pdu_session_identity.pdu_session_id;
-  amf_smf_msg.u.release.cause_value = smf_cause;
-
+  int rc = RETURNerror;
   OAILOG_DEBUG(
       LOG_AMF_APP, "sending PDU session resource release request to gNB \n");
 
@@ -839,7 +829,6 @@ int amf_smf_handle_ip_address_response(
 int amf_send_n11_update_location_req(amf_ue_ngap_id_t ue_id) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   ue_m5gmm_context_s* ue_context_p = NULL;
-  MessageDef* message_p            = NULL;
   int rc                           = RETURNok;
 
   OAILOG_INFO(
@@ -897,12 +886,9 @@ int handle_sm_message_routing_failure(
     amf_ue_ngap_id_t ue_id, ULNASTransportMsg* ulmsg, M5GMmCause m5gmmcause) {
   nas5g_error_code_t rc    = M5G_AS_FAILURE;
   DLNASTransportMsg* dlmsg = nullptr;
-  SmfMsg* smf_msg          = nullptr;
   uint32_t bytes           = 0;
   uint32_t len             = 0;
-  uint32_t container_len   = 0;
   bstring buffer;
-  smf_context_t* smf_ctx         = nullptr;
   ue_m5gmm_context_s* ue_context = nullptr;
   amf_nas_message_t msg          = {};
 

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -472,10 +472,8 @@ int amf_nas_proc_authentication_info_answer(
 int amf_handle_s6a_update_location_ans(
     const s6a_update_location_ans_t* ula_pP) {
   imsi64_t imsi64                   = INVALID_IMSI64;
-  int rc                            = RETURNerror;
   amf_context_t* amf_ctxt_p         = NULL;
   ue_m5gmm_context_s* ue_mm_context = NULL;
-  int amf_cause                     = -1;
   OAILOG_FUNC_IN(LOG_AMF_APP);
 
   IMSI_STRING_TO_IMSI64((char*) ula_pP->imsi, &imsi64);
@@ -520,10 +518,6 @@ int amf_handle_s6a_update_location_ans(
 
 /* Cleanup all procedures in amf_context */
 void amf_nas_proc_clean_up(ue_m5gmm_context_s* ue_context_p) {
-  // Check if registrion procedure exists
-  nas_amf_registration_proc_t* registration_proc =
-      get_nas_specific_procedure_registration(&(ue_context_p->amf_context));
-
   // Delete registration procedures
   amf_delete_registration_proc(&(ue_context_p->amf_context));
 }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPayloadContainer.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPayloadContainer.cpp
@@ -55,7 +55,7 @@ int PayloadContainerMsg::EncodePayloadContainerMsg(
       &payload_container->smf_msg, payload_container->contents,
       payload_container->len);
 
-  if (ielen != encoded) {
+  if (static_cast<int>(ielen) != encoded) {
     MLOG(MDEBUG) << "WARNING: mismatch IE length :" << ielen
                  << " encoded SmfMsg length :" << encoded;
   }

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -796,7 +796,7 @@ status_code_e ngap_amf_handle_initial_context_setup_response(
       // Info: need to update 38413 for this
 
       pduSessionSetupListCtxRes =
-          (Ngap_PDUSessionResourceSetupItemSURes_t*) ie->value.choice
+          (Ngap_PDUSessionResourceSetupItemCxtRes_t*) ie->value.choice
               .PDUSessionResourceSetupListCxtRes.list.array[item];
       AMF_APP_INITIAL_CONTEXT_SETUP_RSP(message_p)
           .PDU_Session_Resource_Setup_Response_Transfer.item[item]

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -565,7 +565,7 @@ status_code_e ngap_generate_downlink_nas_transport(
 /*ngap initial context setup request message to gNB*/
 void ngap_handle_conn_est_cnf(
     ngap_state_t* state,
-    const Ngap_initial_context_setup_request_t* const conn_est_cnf_pP) {
+    Ngap_initial_context_setup_request_t* const conn_est_cnf_pP) {
   /*
    * We received create session response from on N11 interface abstraction.
    * At least one bearer has been established. We can now send ngap initial
@@ -813,7 +813,7 @@ void ngap_handle_conn_est_cnf(
 
       ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
 
-      const pdusession_setup_item_t* pdu_session_item =
+      pdusession_setup_item_t* pdu_session_item =
           &conn_est_cnf_pP->PDU_Session_Resource_Setup_Transfer_List.item[i];
 
       Ngap_PDUSessionResourceSetupItemCxtReq_t* session_context =
@@ -833,7 +833,7 @@ void ngap_handle_conn_est_cnf(
                   1, sizeof(Ngap_PDUSessionResourceSetupRequestTransfer_t));
 
       // filling PDU TX Structure
-      const pdu_session_resource_setup_request_transfer_t*
+      pdu_session_resource_setup_request_transfer_t*
           amf_pdu_ses_setup_transfer_req =
               &(pdu_session_item->PDU_Session_Resource_Setup_Request_Transfer);
 
@@ -1021,7 +1021,7 @@ static int get_ue_ref(
 
 /* ngap_build_pdu_session_resource_setup_request_transfer */
 int ngap_fill_pdu_session_resource_setup_request_transfer(
-    const pdu_session_resource_setup_request_transfer_t* session_transfer,
+    pdu_session_resource_setup_request_transfer_t* session_transfer,
     Ngap_PDUSessionResourceSetupRequestTransfer_t* transfer_request) {
   OAILOG_FUNC_IN(LOG_NGAP);
 
@@ -1172,8 +1172,7 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
 
   uint8_t* buffer_p = NULL;
   uint32_t length   = 0;
-  const pdu_session_resource_setup_request_transfer_t*
-      amf_pdu_ses_setup_transfer_req;
+  pdu_session_resource_setup_request_transfer_t* amf_pdu_ses_setup_transfer_req;
 
   /*
    * We have found the UE in the list.

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.h
@@ -72,7 +72,7 @@ status_code_e ngap_amf_handle_nas_non_delivery(
 
 void ngap_handle_conn_est_cnf(
     ngap_state_t* state,
-    const Ngap_initial_context_setup_request_t* const conn_est_cnf_p);
+    Ngap_initial_context_setup_request_t* const conn_est_cnf_p);
 
 /** \brief communicates amf_ue_id to Ngap.
  * \param state ngap state

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_common.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_common.h
@@ -794,5 +794,5 @@ status_code_e ngap_send_msg_to_task(
  @returns 0 on success
  **/
 int ngap_fill_pdu_session_resource_setup_request_transfer(
-    const pdu_session_resource_setup_request_transfer_t* session_transfer,
+    pdu_session_resource_setup_request_transfer_t* session_transfer,
     Ngap_PDUSessionResourceSetupRequestTransfer_t* transfer_request);

--- a/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
@@ -164,9 +164,6 @@ static nw_rc_t s11_mme_send_udp_msg(
 static nw_rc_t s11_mme_start_timer_wrapper(
     nw_gtpv2c_timer_mgr_handle_t tmrMgrHandle, uint32_t timeoutMilliSec,
     uint32_t tmrType, void* timeoutArg, nw_gtpv2c_timer_handle_t* hTmr) {
-  long timer_id;
-  int ret = 0;
-
   if (tmrType == NW_GTPV2C_TMR_TYPE_REPETITIVE) {
     *hTmr = (nw_gtpv2c_timer_handle_t) start_timer(
         &s11_task_zmq_ctx, timeoutMilliSec, TIMER_REPEAT_FOREVER,


### PR DESCRIPTION
Signed-off-by: RahulKalsangra <rahul.kalsangra@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
Remove unused variable from files to avoid warning
cast some variable for suitable comparison
## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Capture Packet

![packet10401](https://user-images.githubusercontent.com/51331971/142976180-dcae9fee-8cfe-4050-83ca-0433415b7e3a.png)


TestLog

![test10401](https://user-images.githubusercontent.com/51331971/142976184-728eedb9-058a-44e0-83a4-7ecd0b39c4b1.png)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
