### PR TITLE
fix(orc8r): Change alsologtostderr to logtostderr in tests

### DIFF
--- a/lte/cloud/go/services/ha/servicers/servicer_test.go
+++ b/lte/cloud/go/services/ha/servicers/servicer_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 func init() {
-	//_ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	//_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestHAServicer_GetEnodebOffloadState(t *testing.T) {

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -50,7 +50,7 @@ import (
 )
 
 func init() {
-	// _ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	// _ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestListNetworks(t *testing.T) {

--- a/lte/cloud/go/services/nprobe/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/nprobe/obsidian/handlers/handlers_test.go
@@ -39,7 +39,7 @@ var (
 )
 
 func init() {
-	//_ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	//_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func getNProbeBlobstore(t *testing.T) storage.NProbeStorage {

--- a/orc8r/cloud/go/obsidian/swagger/spec/combine_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/spec/combine_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	//_ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	//_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 var (

--- a/orc8r/cloud/go/service/service_test.go
+++ b/orc8r/cloud/go/service/service_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	// _ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	// _ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 
 	_ = flag.Set("run_echo_server", "true")
 }

--- a/orc8r/cloud/go/services/state/client_api_test.go
+++ b/orc8r/cloud/go/services/state/client_api_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 func init() {
-	//_ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	//_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestStateService(t *testing.T) {

--- a/orc8r/cloud/go/services/state/indexer/index/index_test.go
+++ b/orc8r/cloud/go/services/state/indexer/index/index_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func init() {
-	//_ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	//_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestIndexImpl_HappyPath(t *testing.T) {

--- a/orc8r/cloud/go/services/state/indexer/integ_test.go
+++ b/orc8r/cloud/go/services/state/indexer/integ_test.go
@@ -64,7 +64,7 @@ var (
 )
 
 func init() {
-	//_ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestStateIndexing(t *testing.T) {

--- a/orc8r/cloud/go/services/state/indexer/integ_test.go
+++ b/orc8r/cloud/go/services/state/indexer/integ_test.go
@@ -64,7 +64,7 @@ var (
 )
 
 func init() {
-	_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
+	//_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestStateIndexing(t *testing.T) {

--- a/orc8r/cloud/go/services/state/indexer/reindex/queue_sql_integ_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue_sql_integ_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func init() {
-	// _ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	// _ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestSQLReindexJobQueue_Integration_PopulateJobs(t *testing.T) {

--- a/orc8r/cloud/go/services/state/indexer/reindex/queue_sql_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue_sql_test.go
@@ -37,7 +37,7 @@ var (
 )
 
 func init() {
-	// _ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	// _ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestSqlJobQueue_PopulateJobs(t *testing.T) {

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
@@ -113,7 +113,7 @@ var (
 
 func init() {
 	// TODO(hcgatewood) after resolving racy CI issue, revert most changes from #6329
-	_ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestRun(t *testing.T) {

--- a/orc8r/cloud/go/tools/combine_swagger/combine/combine_test.go
+++ b/orc8r/cloud/go/tools/combine_swagger/combine/combine_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	//_ = flag.Set("alsologtostderr", "true") // uncomment to view logs during test
+	//_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 var (

--- a/orc8r/cloud/test/scale/basic_test.go
+++ b/orc8r/cloud/test/scale/basic_test.go
@@ -58,7 +58,7 @@ import (
 // TODO(hcgatewood): clean up this scale test then add it to daily CI job
 
 func init() {
-	_ = flag.Set("alsologtostderr", "true")
+	_ = flag.Set("logtostderr", "true")
 }
 
 var NSubs int64 = 20_000


### PR DESCRIPTION
fix(orc8r): Change alsologtostderr to logtostderr in tests

## Summary
Changed files:
- magma/orc8r/cloud/go/services/state/indexer/integ_test.go
- magma/lte/cloud/go/services/ha/servicers/servicer_test.go
- magma/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
- magma/lte/cloud/go/services/nprobe/obsidian/handlers/handlers_test.go
- magma/orc8r/cloud/go/obsidian/swagger/spec/combine_test.go
- magma/orc8r/cloud/go/service/service_test.go
- magma/orc8r/cloud/go/services/state/client_api_test.go
- magma/orc8r/cloud/go/services/state/indexer/index/index_test.go
- magma/orc8r/cloud/go/services/state/indexer/reindex/queue_sql_integ_test.go
- magma/orc8r/cloud/go/services/state/indexer/reindex/queue_sql_test.go
- magma/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
- magma/orc8r/cloud/go/tools/combine_swagger/combine/combine_test.go
- magma/orc8r/cloud/test/scale/basic_test.go

   Replaced **alsologtostderr** with just **logtostderr**, which will only log to stderr instead of to both file and stderr in tests


For issue:
https://github.com/magma/magma/issues/9830


## Test Plan
I ran unit tests.

