### PR TITLE
fix(feg): address linting error on numVectors size comparison

### DIFF
--- a/feg/gateway/tools/swx_cli/main.go
+++ b/feg/gateway/tools/swx_cli/main.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -235,7 +236,7 @@ func sendSar(addr string, client swxClient) int {
 }
 
 func sendMar(addr string, client swxClient) int {
-	if numVectors < 0 || numVectors > 4294967295 {
+	if numVectors > math.MaxUint32 {
 		fmt.Printf("numVectors %d is outside the bounds of unit32 type", numVectors)
 		return 2
 	}


### PR DESCRIPTION
Fixes `feg-workflow` CI on master which presently blocks new PRs. Regression introduced in #10278, in which for some reason `feg-workflow` was not executed by CI.

Linting notes that `uint64` cannot be negative so the first half of this if condition is a no-op.

While we are here, use Golang built-in for maximum `uint32` size comparison instead of magic value.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>