### PR TITLE
test(mme): Add unit test for idle active transition

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -59,7 +59,8 @@ void send_activate_message_to_mme_app() {
 }
 
 void send_mme_app_initial_ue_msg(
-    const uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn) {
+    const uint8_t* nas_msg, uint8_t nas_msg_length, const plmn_t& plmn,
+    guti_eps_mobile_identity_t& guti) {
   MessageDef* message_p =
       itti_alloc_new_message(TASK_S1AP, S1AP_INITIAL_UE_MESSAGE);
   ITTI_MSG_LASTHOP_LATENCY(message_p)               = 0;
@@ -71,6 +72,11 @@ void send_mme_app_initial_ue_msg(
   S1AP_INITIAL_UE_MESSAGE(message_p).tai.tac            = 1;
   S1AP_INITIAL_UE_MESSAGE(message_p).ecgi.plmn          = plmn;
   S1AP_INITIAL_UE_MESSAGE(message_p).ecgi.cell_identity = {0, 0, 0};
+  if (guti.m_tmsi) {
+    S1AP_INITIAL_UE_MESSAGE(message_p).is_s_tmsi_valid     = true;
+    S1AP_INITIAL_UE_MESSAGE(message_p).opt_s_tmsi.m_tmsi   = guti.m_tmsi;
+    S1AP_INITIAL_UE_MESSAGE(message_p).opt_s_tmsi.mme_code = guti.mme_code;
+  }
   send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
   return;
 }

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -18,21 +18,25 @@
 #include <stdio.h>
 
 #include "feg/protos/s6a_proxy.pb.h"
-#include "../mock_tasks/mock_tasks.h"
+#include "lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h"
 #include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.h"
 #include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.h"
 #include "lte/gateway/c/core/oai/lib/s6a_proxy/proto_msg_to_itti_msg.h"
 #include "lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h"
 
 extern "C" {
+#include "lte/gateway/c/core/oai/lib/bstr/bstrlib.c"
+#include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/common/common_types.h"
 #include "lte/gateway/c/core/oai/include/mme_config.h"
 #include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_extern.h"
 #include "lte/gateway/c/core/oai/include/mme_app_state.h"
+#include "lte/gateway/c/core/oai/tasks/nas/api/network/nas_message.h"
 }
 
 using ::testing::_;
-using ::testing::Return;
+using ::testing::DoAll;
+using ::testing::SaveArg;
 
 extern bool mme_hss_associated;
 extern bool mme_sctp_bounded;
@@ -110,6 +114,7 @@ class MmeAppProcedureTest : public ::testing::Test {
   }
 
   virtual void TearDown() {
+    bdestroy_wrapper(&nas_msg);
     send_terminate_message_fatal(&task_zmq_ctx_main);
     destroy_task_context(&task_zmq_ctx_main);
     itti_free_desc_threads();
@@ -118,6 +123,8 @@ class MmeAppProcedureTest : public ::testing::Test {
   }
 
  protected:
+  itti_s1ap_nas_dl_data_req_t msg_nas_dl_data = {0};
+  bstring nas_msg                             = NULL;
   std::shared_ptr<MockS1apHandler> s1ap_handler;
   std::shared_ptr<MockS6aHandler> s6a_handler;
   std::shared_ptr<MockSpgwHandler> spgw_handler;
@@ -147,14 +154,16 @@ class MmeAppProcedureTest : public ::testing::Test {
       0x00, 0xf1, 0x10, 0x00, 0x01, 0x01, 0x46, 0x93, 0xe8, 0xb8};
   const uint8_t nas_msg_detach_accept[8] = {0x17, 0x88, 0x16, 0x67,
                                             0xd3, 0x02, 0x07, 0x46};
+  const uint8_t nas_msg_service_req[4]   = {0xc7, 0x02, 0x79, 0xe0};
 
-  std::string imsi = "001010000000001";
-  plmn_t plmn      = {.mcc_digit2 = 0,
+  std::string imsi                = "001010000000001";
+  plmn_t plmn                     = {.mcc_digit2 = 0,
                  .mcc_digit1 = 0,
                  .mnc_digit3 = 0x0f,
                  .mcc_digit3 = 1,
                  .mnc_digit2 = 1,
                  .mnc_digit1 = 0};
+  guti_eps_mobile_identity_t guti = {0};
 };
 
 TEST_F(MmeAppProcedureTest, TestInitialUeMessageFaultyNasMsg) {
@@ -172,7 +181,8 @@ TEST_F(MmeAppProcedureTest, TestInitialUeMessageFaultyNasMsg) {
                                 0x00, 0x10, 0x02, 0xe0, 0xe0, 0x00, 0x04, 0x02,
                                 0x01, 0xd0, 0x11, 0x40, 0x08, 0x04, 0x02, 0x60,
                                 0x04, 0x00, 0x02, 0x1c, 0x00};
-  send_mme_app_initial_ue_msg(nas_msg_faulty, sizeof(nas_msg_faulty), plmn);
+  send_mme_app_initial_ue_msg(
+      nas_msg_faulty, sizeof(nas_msg_faulty), plmn, guti);
 
   // Wait for DL NAS Transport for once
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
@@ -201,7 +211,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyDetach) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -292,7 +302,7 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachEpsOnlyDetach) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_guti_attach_req, sizeof(nas_msg_guti_attach_req), plmn);
+      nas_msg_guti_attach_req, sizeof(nas_msg_guti_attach_req), plmn, guti);
 
   // Wait for DL NAS Transport for once
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
@@ -389,7 +399,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAirFailure) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing negative S6A response for AIR
   send_authentication_info_resp(imsi, false);
@@ -430,7 +440,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAirTimeout) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Wait for context release request; MME should be sending attach reject
   // as well as context release command
@@ -468,7 +478,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyUlaFailure) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -524,7 +534,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachExpiredNasTimers) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -624,7 +634,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectAuthRetxFailure) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -665,7 +675,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectSmcRetxFailure) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -710,7 +720,7 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachExpiredIdentity) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_guti_attach_req, sizeof(nas_msg_guti_attach_req), plmn);
+      nas_msg_guti_attach_req, sizeof(nas_msg_guti_attach_req), plmn, guti);
 
   // Wait for DL NAS Transport up to retransmission limit
   for (int i = 0; i < NAS_RETX_LIMIT; ++i) {
@@ -809,7 +819,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectIdentRetxFailure) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -850,7 +860,7 @@ TEST_F(MmeAppProcedureTest, TestIcsRequestTimeout) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -911,7 +921,7 @@ TEST_F(MmeAppProcedureTest, TestCreateSessionFailure) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -977,7 +987,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedDetach) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -1077,7 +1087,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedExpiredDetach) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -1179,7 +1189,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedDetachRetxFailure) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -1279,7 +1289,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleDetach) {
 
   // Construction and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
-      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
 
   // Sending AIA to mme_app mimicing successful S6A response for AIR
   send_authentication_info_resp(imsi, true);
@@ -1354,6 +1364,159 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleDetach) {
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
   EXPECT_EQ(mme_state_p->nb_ue_idle, 1);
   EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+  // Constructing and sending Detach Request to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_detach_req, sizeof(nas_msg_detach_req), plmn);
+
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp();
+
+  // Wait for context release request
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
+
+TEST_F(MmeAppProcedureTest, TestAttachIdleServiceReqDetach) {
+  mme_app_desc_t* mme_state_p =
+      magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  std::condition_variable cv;
+  std::mutex mx;
+  std::unique_lock<std::mutex> lock(mx);
+
+  MME_APP_EXPECT_CALLS(3, 2, 2, 1, 1, 1, 1, 2, 1, 1, 4);
+
+  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  send_mme_app_initial_ue_msg(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
+
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(msg_nas_dl_data.mme_ue_s1ap_id, 1);
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp(REQUEST_ACCEPTED);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  nas_message_t nas_msg_decoded = {0};
+  emm_security_context_t emm_security_context;
+  nas_message_decode_status_t decode_status;
+  status_code_e decoder_rc;
+  decoder_rc = nas_message_decode(
+      nas_msg->data, &nas_msg_decoded, nas_msg->slen,
+      (void*) &emm_security_context, &decode_status);
+  EXPECT_EQ(nas_msg->slen, 67);
+  EXPECT_EQ(decoder_rc, nas_msg->slen);
+  guti = nas_msg_decoded.plain.emm.attach_accept.guti.guti;
+  bdestroy_wrapper(
+      &nas_msg_decoded.plain.emm.attach_accept.esmmessagecontainer);
+  // Destruction at tear down is not sufficient as ICS occurs
+  // twice in this test case.
+  bdestroy_wrapper(&nas_msg);
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
+  // Send context release request mimicing S1AP
+  send_context_release_req(S1AP_RADIO_EUTRAN_GENERATED_REASON, TASK_S1AP);
+
+  // Constructing and sending Release Access Bearer Response to mme_app
+  // mimicing SPGW
+  sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
+
+  // Wait for context release request
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after context release request is processed
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 1);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+
+  // Constructing and sending Service Request
+  send_mme_app_initial_ue_msg(
+      nas_msg_service_req, sizeof(nas_msg_service_req), plmn, guti);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
   // Constructing and sending Detach Request to mme_app
   // mimicing S1AP
   send_mme_app_uplink_data_ind(

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -42,8 +42,10 @@ const message_info_t messages_info[] = {
 
 class MockS1apHandler {
  public:
-  MOCK_METHOD0(s1ap_generate_downlink_nas_transport, void());
-  MOCK_METHOD0(s1ap_handle_conn_est_cnf, void());
+  MOCK_METHOD1(
+      s1ap_generate_downlink_nas_transport,
+      void(itti_s1ap_nas_dl_data_req_t cb_req));
+  MOCK_METHOD1(s1ap_handle_conn_est_cnf, void(bstring nas_pdu));
   MOCK_METHOD0(s1ap_handle_ue_context_release_command, void());
 };
 

--- a/lte/gateway/c/core/oai/test/mock_tasks/s1ap_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/s1ap_mock.cpp
@@ -40,7 +40,8 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S1AP_NAS_DL_DATA_REQ: {
-      s1ap_handler_->s1ap_generate_downlink_nas_transport();
+      s1ap_handler_->s1ap_generate_downlink_nas_transport(
+          S1AP_NAS_DL_DATA_REQ(received_message_p));
     } break;
 
     case S1AP_E_RAB_SETUP_REQ: {
@@ -54,7 +55,8 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case MME_APP_CONNECTION_ESTABLISHMENT_CNF: {
-      s1ap_handler_->s1ap_handle_conn_est_cnf();
+      s1ap_handler_->s1ap_handle_conn_est_cnf(bstrcpy(
+          MME_APP_CONNECTION_ESTABLISHMENT_CNF(received_message_p).nas_pdu[0]));
     } break;
 
     case MME_APP_S1AP_MME_UE_ID_NOTIFICATION: {


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Added unit test for task mme_app for service request in idle mode.
- Added actions to save messages for DL NAS and ICS. ICS one is used to grab the GUTI information supplied by MME. DL NAS is currently unused but in future PRs, it will be used to add verifications against message contents.
 
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run `make test_oai` 50 times:
```
vagrant@magma-dev-focal:~/magma/lte/gateway$ for i in {1..50}; do make test_oai | grep "Test  #5: test_mme_app";done
 5/19 Test  #5: test_mme_app ......................   Passed   33.71 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.31 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.11 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.22 sec
 5/19 Test  #5: test_mme_app ......................   Passed   32.64 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.50 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.66 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.53 sec
 5/19 Test  #5: test_mme_app ......................   Passed   32.37 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.24 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.93 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.13 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.97 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.89 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.92 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.17 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.34 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.17 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.26 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.78 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.39 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.68 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.10 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.00 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.14 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.36 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.96 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.90 sec
 5/19 Test  #5: test_mme_app ......................   Passed   32.98 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.31 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.03 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.40 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.22 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.59 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.68 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.82 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.38 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.58 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.26 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.21 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.25 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.20 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.21 sec
 5/19 Test  #5: test_mme_app ......................   Passed   33.14 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.78 sec
 5/19 Test  #5: test_mme_app ......................   Passed   35.66 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.16 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.16 sec
 5/19 Test  #5: test_mme_app ......................   Passed   36.09 sec
 5/19 Test  #5: test_mme_app ......................   Passed   34.28 sec
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
