### PR TITLE
docs(agw): AMF Golang migration proposal

### DIFF
--- a/docs/readmes/proposals/p022_amf_migrate_to_golang.md
+++ b/docs/readmes/proposals/p022_amf_migrate_to_golang.md
@@ -1,0 +1,56 @@
+---
+id: p022_amf_migrate_to_golang
+title: Golang Migration
+hide_title: true
+---
+
+
+# Proposal: Go Migration
+
+Last updated: 19/11/2021
+
+## Abstract
+
+This document describes the steps to migrate progressively, from C++ to Golang, the AMF core.
+
+## Background
+
+Initially, the development of AMF magma was done in C++. used ITTI for interprocess communication between SCTP - NGAP and NGAP - AMF.
+
+## Proposal
+
+The proposal is to migrate AMF into Golang, replace ITTI with Grpc.
+
+## NGAP, AMF_APP, NAS migration
+
+NGAP: define protos for SCTP-NGAP rpc calls, implement client and server functionality on sctp and ngap side.
+      Procedures to be migrated :
+        NG-SETUP request
+        NG-SETUP response
+        NG-SETUP failure
+        NG-SETUP reset
+        Initial UE message
+        Uplink NAS message
+        Initial context setup request 
+        Initial context setup response
+        
+AMF : define protos for NGAP-AMF rpc calls, implement client and server functionality on ngap and amf side.
+      Procedures to be migrated :
+        Registration (request, accept and complete)
+        Identification (request and response)
+        Authentication (request and response)
+        Security mode (command and complete)
+        De-registration (request and accept)
+
+NAS : Migrate encode/decode routines of the following messages from C++ to Golang :
+        Registration reuqest
+        Identity request
+        Identity response
+        Authentication request
+        Authentication response
+        Security mode command
+        Security mode complete
+        Registration accept
+        Registration complete
+        De-Registration request (UE-Originated)
+        De-Registration accept (UE-Originated)


### PR DESCRIPTION
Signed-off-by: chandhu-wavelabs <chandhu.naga@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Migrating AMF from C++ to Golang.
NGAP, AMF_APP and NAS5G will be migrated to Golang.
ITTI will be replaced with Grpc.
**Proposal Architecture :**
![Proposal_architecture](https://user-images.githubusercontent.com/84959602/142619785-3e2422c1-692f-4966-b46c-1e978dc7ac2d.png)
**Existing Architecture :**
![Existing_architecture](https://user-images.githubusercontent.com/84959602/142619792-f6d828ac-cf71-4eac-a1bb-bd8cdbd747f1.png)



## Test Plan
The attached file contains the test cases which are applicable for Golang based AMF.
[Acceptance test plans for 5G-Golang-porting.xlsx](https://github.com/magma/magma/files/7570607/Acceptance.test.plans.for.5G-Golang-porting.xlsx)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
