### PR TITLE
fix(amf): AMF is sending UE Context Release command when there is a unsuccessful PDU session setup

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -119,6 +119,7 @@ int amf_as_send(amf_as_t* msg) {
 static int amf_as_establish_req(amf_as_establish_t* msg, int* amf_cause) {
   amf_security_context_t* amf_security_context = NULL;
   amf_nas_message_decode_status_t decode_status;
+  memset(&decode_status, 0, sizeof(decode_status));
   int decoder_rc                       = 1;
   int rc                               = RETURNerror;
   tai_t originating_tai                = {0};

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -25,6 +25,10 @@ namespace magma5g {
 status_code_e AMFClientServicerBase::amf_send_msg_to_task(
     task_zmq_ctx_t* task_zmq_ctx_p, task_id_t destination_task_id,
     MessageDef* message) {
+  OAILOG_INFO(
+      LOG_AMF_APP, "Sending msg to :[%s] id: [%d]-[%s]\n",
+      itti_get_task_name(destination_task_id), ITTI_MSG_ID(message),
+      ITTI_MSG_NAME(message));
   return (send_msg_to_task(task_zmq_ctx_p, destination_task_id, message));
 }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -347,15 +347,14 @@ static int pdu_session_resource_release_t3592_handler(
 ***************************************************************************/
 int amf_smf_process_pdu_session_packet(
     amf_ue_ngap_id_t ue_id, ULNASTransportMsg* msg, int amf_cause) {
-  int rc = M5G_AS_SUCCESS;
-  SmfMsg reject_req;
+  int rc                = RETURNok;
   amf_smf_t amf_smf_msg = {};
   std::shared_ptr<smf_context_t> smf_ctx;
-  char imsi[IMSI_BCD_DIGITS_MAX + 1];
-  protocol_configuration_options_t* msg_pco;
+  char imsi[IMSI_BCD_DIGITS_MAX + 1]        = {0};
+  protocol_configuration_options_t* msg_pco = nullptr;
 
   if (!msg) {
-    return rc;
+    return RETURNerror;
   }
 
   if (amf_cause != AMF_CAUSE_SUCCESS) {
@@ -372,7 +371,7 @@ int amf_smf_process_pdu_session_packet(
     OAILOG_ERROR(
         LOG_AMF_APP, "ue context not found for the ue_id :" AMF_UE_NGAP_ID_FMT,
         ue_id);
-    OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
+    OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
   }
 
   if (msg->payload_container.smf_msg.header.message_type ==
@@ -402,11 +401,11 @@ int amf_smf_process_pdu_session_packet(
       return rc;
     }
     smf_ctx = amf_get_smf_context_by_pdu_session_id(
-      ue_context, msg->payload_container.smf_msg.header.pdu_session_id);
+        ue_context, msg->payload_container.smf_msg.header.pdu_session_id);
 
-    if (smf_ctx && smf_ctx->duplicate_pdu_session_est_req_count > 1) {
+    if (smf_ctx && smf_ctx->duplicate_pdu_session_est_req_count > 0) {
       OAILOG_DEBUG(
-        LOG_AMF_APP, "Duplicate PDU Session Establishment Request, Dropped");
+          LOG_AMF_APP, "Duplicate PDU Session Establishment Request, Dropped");
       return rc;
     }
   }
@@ -424,7 +423,7 @@ int amf_smf_process_pdu_session_packet(
     OAILOG_ERROR(
         LOG_AMF_APP, "pdu session  not found for session_id = %u\n",
         msg->payload_container.smf_msg.header.pdu_session_id);
-    OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
+    OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
   }
 
   amf_smf_msg.pdu_session_id =
@@ -446,10 +445,11 @@ int amf_smf_process_pdu_session_packet(
       sm_free_protocol_configuration_options(&msg_pco);
 
       if (amf_cause != SMF_CAUSE_SUCCESS) {
-        rc = amf_send_pdusession_reject(
-            &reject_req, msg->payload_container.smf_msg.header.pdu_session_id,
+        rc = amf_pdu_session_establishment_reject(
+            ue_id, msg->payload_container.smf_msg.header.pdu_session_id,
             msg->payload_container.smf_msg.header.procedure_transaction_id,
-            amf_cause);
+            static_cast<uint8_t>(amf_cause));
+
         return rc;
       }
 
@@ -905,7 +905,7 @@ int amf_send_n11_update_location_req(amf_ue_ngap_id_t ue_id) {
  ***************************************************************************/
 int handle_sm_message_routing_failure(
     amf_ue_ngap_id_t ue_id, ULNASTransportMsg* ulmsg, M5GMmCause m5gmmcause) {
-  nas5g_error_code_t rc    = M5G_AS_SUCCESS;
+  int rc                   = RETURNok;
   DLNASTransportMsg* dlmsg = nullptr;
   uint32_t bytes           = 0;
   uint32_t len             = 0;
@@ -926,7 +926,7 @@ int handle_sm_message_routing_failure(
     OAILOG_ERROR(
         LOG_AMF_APP, "UE Context not found for UE ID: " AMF_UE_NGAP_ID_FMT,
         ue_id);
-    return M5G_AS_FAILURE;
+    return RETURNerror;
   }
 
   // Message construction for PDU Establishment Reject
@@ -996,11 +996,12 @@ int handle_sm_message_routing_failure(
       buffer->data, &msg, len, &ue_context->amf_context._security);
   if (bytes > 0) {
     buffer->slen = bytes;
-    amf_app_handle_nas_dl_req(ue_id, buffer, rc);
+    rc           = amf_app_handle_nas_dl_req(ue_id, buffer, M5G_AS_SUCCESS);
 
   } else {
     OAILOG_WARNING(LOG_AMF_APP, "NAS encode failed \n");
     bdestroy_wrapper(&buffer);
+    return RETURNerror;
   }
   return rc;
 }
@@ -1141,9 +1142,9 @@ int construct_pdu_session_reject_dl_req(
  ***************************************************************************/
 int amf_pdu_session_establishment_reject(
     amf_ue_ngap_id_t ue_id, uint8_t session_id, uint8_t pti, uint8_t cause) {
-  nas5g_error_code_t rc = M5G_AS_SUCCESS;
-  uint32_t bytes        = 0;
-  uint32_t len          = 0;
+  int rc         = RETURNok;
+  uint32_t bytes = 0;
+  uint32_t len   = 0;
   bstring buffer;
   ue_m5gmm_context_s* ue_context = nullptr;
   amf_nas_message_t msg          = {};
@@ -1154,7 +1155,7 @@ int amf_pdu_session_establishment_reject(
     OAILOG_ERROR(
         LOG_AMF_APP, "UE Context not found for UE ID: " AMF_UE_NGAP_ID_FMT,
         ue_id);
-    return M5G_AS_FAILURE;
+    return RETURNerror;
   }
 
   len = construct_pdu_session_reject_dl_req(
@@ -1163,7 +1164,7 @@ int amf_pdu_session_establishment_reject(
 
   if (len <= 0) {
     OAILOG_WARNING(LOG_AMF_APP, "PDU Construction is failed \n");
-    return M5G_AS_FAILURE;
+    return RETURNerror;
   }
   buffer = bfromcstralloc(len, "\0");
   bytes  = nas5g_message_encode(
@@ -1171,12 +1172,12 @@ int amf_pdu_session_establishment_reject(
 
   if (bytes > 0) {
     buffer->slen = bytes;
-    amf_app_handle_nas_dl_req(ue_id, buffer, rc);
+    amf_app_handle_nas_dl_req(ue_id, buffer, M5G_AS_SUCCESS);
 
   } else {
     OAILOG_WARNING(LOG_AMF_APP, "NAS encode failed \n");
     bdestroy_wrapper(&buffer);
-    rc = M5G_AS_FAILURE;
+    rc = RETURNerror;
   }
   return rc;
 }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -1172,7 +1172,7 @@ int amf_pdu_session_establishment_reject(
 
   if (bytes > 0) {
     buffer->slen = bytes;
-    amf_app_handle_nas_dl_req(ue_id, buffer, M5G_AS_SUCCESS);
+    rc           = amf_app_handle_nas_dl_req(ue_id, buffer, M5G_AS_SUCCESS);
 
   } else {
     OAILOG_WARNING(LOG_AMF_APP, "NAS encode failed \n");

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -74,6 +74,8 @@ class AMFClientServicerBase {
 
 class AMFClientServicer : public AMFClientServicerBase {
  public:
+  std::vector<uint8_t>
+      msgtype_stack;  // stack maintains type of msgs sent to ngap
   static AMFClientServicer& getInstance();
 
   AMFClientServicer(AMFClientServicer const&) = delete;
@@ -84,6 +86,7 @@ class AMFClientServicer : public AMFClientServicerBase {
       task_zmq_ctx_t* task_zmq_ctx_p, task_id_t destination_task_id,
       MessageDef* message_p) override {
     OAILOG_DEBUG(LOG_AMF_APP, " Mock is Enabled \n");
+    msgtype_stack.push_back(ITTI_MSG_ID(message_p));
     itti_free_msg_content(message_p);
     free(message_p);
     return RETURNok;

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -74,7 +74,7 @@ class AMFClientServicerBase {
 
 class AMFClientServicer : public AMFClientServicerBase {
  public:
-  std::vector<uint8_t>
+  std::vector<MessagesIds>
       msgtype_stack;  // stack maintains type of msgs sent to ngap
   static AMFClientServicer& getInstance();
 

--- a/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
@@ -177,17 +177,16 @@ int nas5g_message_decode(
      */
     bytes =
         _nas5g_message_plain_decode(buffer, &msg->header, &msg->plain, length);
-
-    OAILOG_DEBUG(
-        LOG_AMF_APP, "[%s] Msg plain decode bytes[0-%d]\n%s",
-        get_message_type_str(msg->plain.amf.header.message_type).c_str(), bytes,
-        uint8_to_hex_string(buffer, bytes).c_str());
   }
 
   if (bytes < 0) {
     OAILOG_ERROR(LOG_AMF_APP, "NAS Decode failed");
     OAILOG_FUNC_RETURN(LOG_AMF_APP, bytes);
   }
+  OAILOG_DEBUG(
+      LOG_AMF_APP, "[%s] Msg plain decode bytes[0-%d]\n%s",
+      get_message_type_str(msg->plain.amf.header.message_type).c_str(), bytes,
+      uint8_to_hex_string(buffer, bytes).c_str());
 
   OAILOG_INFO(
       LOG_AMF_APP, "Decoded msg(nas5g) id: [%x]-name [%s]",

--- a/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
@@ -90,11 +90,10 @@ int create_session_grpc_req_on_gnb_setup_rsp(
   inet_ntop(AF_INET, message->gnb_gtp_teid_ip_addr, ipv4_str, INET_ADDRSTRLEN);
   req_rat_specific->mutable_gnode_endpoint()->set_end_ipv4_addr(ipv4_str);
 
-  OAILOG_DEBUG(
-      LOG_AMF_APP, "Sending PDU session Establishment 2nd Request to SMF");
-
   OAILOG_INFO(
-      LOG_AMF_APP, "Sending msg(grpc) to :[sessiond] for ue: [%s]\n", imsi);
+      LOG_AMF_APP,
+      "Sending msg(grpc) to :[sessiond] for ue: [%s] pdu session :[%u]\n", imsi,
+      message->pdu_session_id);
 
   AMFClientServicer::getInstance().set_smf_session(req);
 
@@ -118,8 +117,9 @@ int amf_smf_create_ipv4_session_grpc_req(
   amf_context_t* amf_ctxt_p         = NULL;
 
   OAILOG_INFO(
-      LOG_AMF_APP, "Sending msg(grpc) to :[sessiond] for ue: [%s] session\n",
-      imsi);
+      LOG_AMF_APP,
+      "Sending msg(grpc) to :[sessiond] for ue: [%s] pdu session: [%u]\n", imsi,
+      pdu_session_id);
 
   IMSI_STRING_TO_IMSI64((char*) imsi, &imsi64);
   ue_mm_context = lookup_ue_ctxt_by_imsi(imsi64);
@@ -168,8 +168,10 @@ int amf_smf_create_pdu_session(
   }
 
   OAILOG_INFO(
-      LOG_AMF_APP, "Sending msg(grpc) to :[mobilityd] for ue: [%s] ip-addr\n",
-      imsi);
+      LOG_AMF_APP,
+      "Sending msg(grpc) to :[mobilityd] for ue: [%s] ip-addr pdu session: "
+      "[%u]\n",
+      imsi, message->pdu_session_id);
   AMFClientServicer::getInstance().allocate_ipv4_address(
       imsi, smf_ctx->dnn.c_str(), message->pdu_session_id, message->pti,
       AF_INET, message->gnb_gtp_teid, message->gnb_gtp_teid_ip_addr, 4);
@@ -202,7 +204,9 @@ int release_session_gprc_req(amf_smf_release_t* message, char* imsi) {
 
   OAILOG_INFO(
       LOG_AMF_APP,
-      "Sending msg(grpc) to :[sessiond] for ue: [%s] release session\n", imsi);
+      "Sending msg(grpc) to :[sessiond] for ue: [%s] release,  pdu session: "
+      "[%d]\n",
+      imsi, message->pdu_session_id);
 
   AMFClientServicer::getInstance().set_smf_session(req);
 

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -136,6 +136,18 @@ void send_initial_context_response(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id) {
   itti_amf_app_initial_context_setup_rsp_t ics_resp = {};
 
+  // apn profile received from subscriberd during location update
+  ue_m5gmm_context_s* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+
+  ASSERT_NE(nullptr, ue_context_p);
+
+  apn_config_profile_t& profile = ue_context_p->amf_context.apn_config_profile;
+  profile.nb_apns               = 1;
+  strncpy(
+      profile.apn_configuration[0].service_selection, "internet",
+      SERVICE_SELECTION_MAX_LENGTH - 1);
+
   ics_resp.ue_id = ue_id;
 
   amf_app_handle_initial_context_setup_rsp(amf_app_desc_p, &ics_resp);
@@ -175,18 +187,6 @@ int send_uplink_nas_pdu_session_establishment_request(
 
   originating_tai.plmn = plmn;
   originating_tai.tac  = 1;
-
-  ue_m5gmm_context_s* ue_context_p =
-      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
-
-  if (!ue_context_p) {
-    return RETURNerror;
-  }
-  apn_config_profile_t& profile = ue_context_p->amf_context.apn_config_profile;
-  profile.nb_apns               = 1;
-  strncpy(
-      profile.apn_configuration[0].service_selection, "internet",
-      SERVICE_SELECTION_MAX_LENGTH - 1);
 
   int rc = RETURNerror;
   rc     = amf_app_handle_uplink_nas_message(

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -144,9 +144,7 @@ void send_initial_context_response(
 
   apn_config_profile_t& profile = ue_context_p->amf_context.apn_config_profile;
   profile.nb_apns               = 1;
-  strncpy(
-      profile.apn_configuration[0].service_selection, "internet",
-      SERVICE_SELECTION_MAX_LENGTH - 1);
+  strncpy(profile.apn_configuration[0].service_selection, "internet", 8);
 
   ics_resp.ue_id = ue_id;
 
@@ -362,13 +360,10 @@ int send_uplink_nas_pdu_session_release_message(
   originating_tai.plmn = plmn;
   originating_tai.tac  = 1;
 
-  int rc     = RETURNerror;
-  int status = amf_app_handle_uplink_nas_message(
+  int rc = RETURNerror;
+  rc     = amf_app_handle_uplink_nas_message(
       amf_app_desc_p, pdu_session_req, ue_id, originating_tai);
 
-  if (status > 0) {
-    rc = RETURNok;
-  }
   return (rc);
 }
 

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -115,7 +115,7 @@ uint8_t NAS5GPktSnapShot::service_req_signaling[13] = {
 
 // service request with service type data and without IE uplink
 // data status
-uint8_t service_request_without_uplink_status[] = {
+uint8_t service_request_without_uplink_status[17] = {
     0x7e, 0x00, 0x4c, 0x1b, 0x00, 0x07, 0xf4, 0x01, 0x00,
     0x17, 0xd7, 0xb7, 0x33, 0x50, 0x02, 0x20, 0x00};
 

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -1132,6 +1132,7 @@ TEST_F(
     test_amf_initial_ue_message_connected_mode_sunny_day) {
   NAS5GPktSnapShot nas5g_pkt_snap;
   ServiceRequestMsg service_request;
+  memset(&service_request, 0, sizeof(service_request));
   bool decode_res                               = 0;
   amf_nas_message_decode_status_t decode_status = {0};
   MessageDef* message_p                         = NULL;

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -189,9 +189,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcNoTMSI) {
       sizeof(initial_ue_message_hexbuf));
 
   /* Check if UE Context is created with correct imsi */
-  bool res = false;
-  res      = get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id);
-  EXPECT_TRUE(res == true);
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
 
   /* Send the authentication response message from subscriberdb */
   int rc = RETURNok;
@@ -199,8 +197,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcNoTMSI) {
   EXPECT_TRUE(rc == RETURNok);
 
   /* Validate if authentication procedure is initialized as expected */
-  res = validate_auth_procedure(ue_id, 0);
-  EXPECT_TRUE(res == true);
+  EXPECT_TRUE(validate_auth_procedure(ue_id, 0));
 
   /* Send uplink nas message for auth response from UE */
   rc = send_uplink_nas_message_ue_auth_response(
@@ -209,8 +206,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcNoTMSI) {
   EXPECT_TRUE(rc == RETURNok);
 
   /* Check whether security mode procedure is initiated */
-  res = validate_smc_procedure(ue_id, 0);
-  EXPECT_TRUE(res == true);
+  EXPECT_TRUE(validate_smc_procedure(ue_id, 0));
 
   /* Send uplinkg nas message for security mode complete response from UE */
   rc = send_uplink_nas_message_ue_smc_response(
@@ -238,9 +234,7 @@ TEST_F(AMFAppProcedureTest, TestDeRegistration) {
       sizeof(initial_ue_message_hexbuf));
 
   /* Check if UE Context is created with correct imsi */
-  bool res = false;
-  res      = get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id);
-  EXPECT_TRUE(res == true);
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
 
   /* Send the authentication response message from subscriberdb */
   rc = send_proc_authentication_info_answer(imsi, ue_id, true);
@@ -285,9 +279,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
       sizeof(initial_ue_message_hexbuf));
 
   /* Check if UE Context is created with correct imsi */
-  bool res = false;
-  res      = get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id);
-  EXPECT_TRUE(res == true);
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
 
   /* Send the authentication response message from subscriberdb */
   rc = send_proc_authentication_info_answer(imsi, ue_id, true);
@@ -363,8 +355,10 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
 }
 
 TEST_F(AMFAppProcedureTest, TestPDUSessionFailure_dnn_not_subscribed) {
-  int rc                 = RETURNerror;
-  amf_ue_ngap_id_t ue_id = 0;
+  int rc                        = RETURNerror;
+  amf_ue_ngap_id_t ue_id        = 0;
+  AMFClientServicer& clientstub = AMFClientServicer::getInstance();
+  clientstub.msgtype_stack.clear();
 
   /* Send the initial UE message */
   imsi64_t imsi64 = 0;
@@ -373,9 +367,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionFailure_dnn_not_subscribed) {
       sizeof(initial_ue_message_hexbuf));
 
   /* Check if UE Context is created with correct imsi */
-  bool res = false;
-  res      = get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id);
-  EXPECT_TRUE(res == true);
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
 
   /* Send the authentication response message from subscriberdb */
   rc = send_proc_authentication_info_answer(imsi, ue_id, true);
@@ -406,13 +398,13 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionFailure_dnn_not_subscribed) {
       amf_app_desc_p, ue_id, plmn,
       ue_pdu_session_est_req_dnn_not_subscried_hexbuf,
       sizeof(ue_pdu_session_est_req_dnn_not_subscried_hexbuf));
-  EXPECT_GE(rc, RETURNok);
+  EXPECT_EQ(rc, RETURNok);
   ue_m5gmm_context_t* ue_context_p =
       amf_ue_context_exists_amf_ue_ngap_id(ue_id);
-  // ue context should be exist
-  ASSERT_NE(nullptr, ue_context_p);
-  // smf context should be present
-  EXPECT_EQ(0, ue_context_p->amf_context.smf_ctxt_map.size());
+  // ue context should exist
+  ASSERT_NE(ue_context_p, nullptr);
+  // smf context should not be present
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 0);
 
   /* Send uplink nas message for deregistration complete response from UE */
   rc = send_uplink_nas_ue_deregistration_request(
@@ -420,11 +412,17 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionFailure_dnn_not_subscribed) {
       sizeof(ue_initiated_dereg_hexbuf));
 
   EXPECT_TRUE(rc == RETURNok);
+  EXPECT_TRUE(
+      clientstub.msgtype_stack.back() == NGAP_UE_CONTEXT_RELEASE_COMMAND);
+  clientstub.msgtype_stack.pop_back();
+  EXPECT_TRUE(clientstub.msgtype_stack.back() == NGAP_NAS_DL_DATA_REQ);
 }
 
 TEST_F(AMFAppProcedureTest, TestPDUSession_missing_dnn) {
-  int rc                 = RETURNerror;
-  amf_ue_ngap_id_t ue_id = 0;
+  int rc                        = RETURNerror;
+  amf_ue_ngap_id_t ue_id        = 0;
+  AMFClientServicer& clientstub = AMFClientServicer::getInstance();
+  clientstub.msgtype_stack.clear();
 
   /* Send the initial UE message */
   imsi64_t imsi64 = 0;
@@ -433,9 +431,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_missing_dnn) {
       sizeof(initial_ue_message_hexbuf));
 
   /* Check if UE Context is created with correct imsi */
-  bool res = false;
-  res      = get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id);
-  EXPECT_TRUE(res == true);
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
 
   /* Send the authentication response message from subscriberdb */
   rc = send_proc_authentication_info_answer(imsi, ue_id, true);
@@ -464,7 +460,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_missing_dnn) {
   ue_m5gmm_context_t* ue_context_p =
       amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   // ue context should be exist
-  ASSERT_NE(nullptr, ue_context_p);
+  ASSERT_NE(ue_context_p, nullptr);
   memset(
       &ue_context_p->amf_context.apn_config_profile, 0,
       sizeof(ue_context_p->amf_context.apn_config_profile));
@@ -473,13 +469,13 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_missing_dnn) {
   rc = send_uplink_nas_pdu_session_establishment_request(
       amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_missing_dnn_hexbuf,
       sizeof(ue_pdu_session_est_req_missing_dnn_hexbuf));
-  EXPECT_GE(rc, RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   ue_context_p = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   // ue context should be exist
-  ASSERT_NE(nullptr, ue_context_p);
+  ASSERT_NE(ue_context_p, nullptr);
   // smf context should be present
-  EXPECT_EQ(0, ue_context_p->amf_context.smf_ctxt_map.size());
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 0);
 
   /* Send uplink nas message for deregistration complete response from UE */
   rc = send_uplink_nas_ue_deregistration_request(
@@ -487,11 +483,17 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_missing_dnn) {
       sizeof(ue_initiated_dereg_hexbuf));
 
   EXPECT_TRUE(rc == RETURNok);
+  EXPECT_TRUE(
+      clientstub.msgtype_stack.back() == NGAP_UE_CONTEXT_RELEASE_COMMAND);
+  clientstub.msgtype_stack.pop_back();
+  EXPECT_TRUE(clientstub.msgtype_stack.back() == NGAP_NAS_DL_DATA_REQ);
 }
 
 TEST_F(AMFAppProcedureTest, TestPDUSession_unknown_pdu_session_type) {
-  int rc                 = RETURNerror;
-  amf_ue_ngap_id_t ue_id = 0;
+  int rc                        = RETURNerror;
+  amf_ue_ngap_id_t ue_id        = 0;
+  AMFClientServicer& clientstub = AMFClientServicer::getInstance();
+  clientstub.msgtype_stack.clear();
 
   /* Send the initial UE message */
   imsi64_t imsi64 = 0;
@@ -500,9 +502,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_unknown_pdu_session_type) {
       sizeof(initial_ue_message_hexbuf));
 
   /* Check if UE Context is created with correct imsi */
-  bool res = false;
-  res      = get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id);
-  EXPECT_TRUE(res == true);
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
 
   /* Send the authentication response message from subscriberdb */
   rc = send_proc_authentication_info_answer(imsi, ue_id, true);
@@ -533,14 +533,14 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_unknown_pdu_session_type) {
       amf_app_desc_p, ue_id, plmn,
       ue_pdu_session_est_req_unknown_session_type_hexbuf,
       sizeof(ue_pdu_session_est_req_unknown_session_type_hexbuf));
-  EXPECT_GE(rc, RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   ue_m5gmm_context_t* ue_context_p =
       amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   // ue context should be exist
-  ASSERT_NE(nullptr, ue_context_p);
+  ASSERT_NE(ue_context_p, nullptr);
   // smf context should be present
-  EXPECT_EQ(0, ue_context_p->amf_context.smf_ctxt_map.size());
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 0);
 
   /* Send uplink nas message for deregistration complete response from UE */
   rc = send_uplink_nas_ue_deregistration_request(
@@ -548,48 +548,58 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_unknown_pdu_session_type) {
       sizeof(ue_initiated_dereg_hexbuf));
 
   EXPECT_TRUE(rc == RETURNok);
+  EXPECT_TRUE(
+      clientstub.msgtype_stack.back() == NGAP_UE_CONTEXT_RELEASE_COMMAND);
+  clientstub.msgtype_stack.pop_back();
+  EXPECT_TRUE(clientstub.msgtype_stack.back() == NGAP_NAS_DL_DATA_REQ);
 }
 
 TEST_F(AMFAppProcedureTest, TestPDUSession_Invalid_PDUSession_Identity) {
-  int rc                 = RETURNerror;
-  amf_ue_ngap_id_t ue_id = 0;
+  int rc                        = RETURNerror;
+  amf_ue_ngap_id_t ue_id        = 0;
+  AMFClientServicer& clientstub = AMFClientServicer::getInstance();
+  clientstub.msgtype_stack.clear();
 
   /* Send the initial UE message */
   imsi64_t imsi64 = 0;
   imsi64          = send_initial_ue_message_no_tmsi(
       amf_app_desc_p, 36, 1, 1, 0, plmn, initial_ue_message_hexbuf,
       sizeof(initial_ue_message_hexbuf));
+  EXPECT_TRUE(
+      clientstub.msgtype_stack.back() == AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION);
 
   /* Check if UE Context is created with correct imsi */
-  bool res = false;
-  res      = get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id);
-  EXPECT_TRUE(res == true);
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
 
   ue_m5gmm_context_t* ue_context_p =
       amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   // ue context should be exist
-  ASSERT_NE(nullptr, ue_context_p);
+  ASSERT_NE(ue_context_p, nullptr);
   nas5g_auth_info_proc_t* auth_info_proc =
       get_nas5g_cn_procedure_auth_info(&ue_context_p->amf_context);
 
-  ASSERT_NE(nullptr, auth_info_proc);
+  ASSERT_NE(auth_info_proc, nullptr);
 
   /* Send the authentication response message from subscriberdb */
   rc = send_proc_authentication_info_answer(imsi, ue_id, true);
   EXPECT_TRUE(rc == RETURNok);
 
+  EXPECT_TRUE(clientstub.msgtype_stack.back() == NGAP_NAS_DL_DATA_REQ);
   /* Send uplink nas message for auth response from UE */
   rc = send_uplink_nas_message_ue_auth_response(
       amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
       sizeof(ue_auth_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
+  EXPECT_TRUE(clientstub.msgtype_stack.back() == NGAP_NAS_DL_DATA_REQ);
   /* Send uplink nas message for security mode complete response from UE */
   rc = send_uplink_nas_message_ue_smc_response(
       amf_app_desc_p, ue_id, plmn, ue_smc_response_hexbuf,
       sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
+  EXPECT_TRUE(
+      clientstub.msgtype_stack.back() == NGAP_INITIAL_CONTEXT_SETUP_REQ);
   send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
@@ -612,6 +622,8 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_Invalid_PDUSession_Identity) {
   rc = send_pdu_session_response_itti();
   EXPECT_TRUE(rc == RETURNok);
 
+  EXPECT_TRUE(
+      clientstub.msgtype_stack.back() == NGAP_PDUSESSION_RESOURCE_SETUP_REQ);
   /* Send pdu resource setup response  from UE */
   rc = send_pdu_resource_setup_response(ue_id);
   EXPECT_TRUE(rc == RETURNok);
@@ -621,71 +633,51 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_Invalid_PDUSession_Identity) {
 
   ue_context_p = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   // ue context should be exist
-  ASSERT_NE(nullptr, ue_context_p);
+  ASSERT_NE(ue_context_p, nullptr);
   // smf context should be present
-  EXPECT_EQ(1, ue_context_p->amf_context.smf_ctxt_map.size());
-
-  /* Send duplicate uplink nas message for pdu session establishment request
-   * from UE */
-  rc = send_uplink_nas_pdu_session_establishment_request(
-      amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
-      sizeof(ue_pdu_session_est_req_hexbuf));
-  EXPECT_GE(rc, RETURNok);
-
-  // smf context should be present
-  EXPECT_EQ(1, ue_context_p->amf_context.smf_ctxt_map.size());
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 1);
   std::shared_ptr<smf_context_t> smf_ctx =
       amf_get_smf_context_by_pdu_session_id(ue_context_p, 1);
-  EXPECT_EQ(1, smf_ctx->duplicate_pdu_session_est_req_count);
+  EXPECT_EQ(smf_ctx->duplicate_pdu_session_est_req_count, 0);
+  EXPECT_EQ(smf_ctx->pdu_session_state, ACTIVE);
+
+  for (uint8_t i = 1; i < 5; ++i) {
+    /* Send duplicate uplink nas message for pdu session establishment request
+     * from UE */
+    rc = send_uplink_nas_pdu_session_establishment_request(
+        amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
+        sizeof(ue_pdu_session_est_req_hexbuf));
+    EXPECT_EQ(rc, RETURNok);
+
+    // smf context should be present
+    EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 1);
+    smf_ctx = amf_get_smf_context_by_pdu_session_id(ue_context_p, 1);
+    EXPECT_EQ(smf_ctx->duplicate_pdu_session_est_req_count, i);
+    EXPECT_TRUE(
+        clientstub.msgtype_stack.back() == NGAP_PDUSESSION_RESOURCE_SETUP_REQ);
+  }
 
   /* Send duplicate uplink nas message for pdu session establishment request
    * from UE */
   rc = send_uplink_nas_pdu_session_establishment_request(
       amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
       sizeof(ue_pdu_session_est_req_hexbuf));
-  EXPECT_GE(rc, RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   // smf context should be present
-  EXPECT_EQ(1, ue_context_p->amf_context.smf_ctxt_map.size());
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 1);
   smf_ctx = amf_get_smf_context_by_pdu_session_id(ue_context_p, 1);
-  EXPECT_EQ(2, smf_ctx->duplicate_pdu_session_est_req_count);
+  EXPECT_EQ(smf_ctx->duplicate_pdu_session_est_req_count, 4);
+  EXPECT_TRUE(clientstub.msgtype_stack.back() == NGAP_NAS_DL_DATA_REQ);
 
-  /* Send duplicate uplink nas message for pdu session establishment request
-   * from UE */
-  rc = send_uplink_nas_pdu_session_establishment_request(
-      amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
-      sizeof(ue_pdu_session_est_req_hexbuf));
-  EXPECT_GE(rc, RETURNok);
+  /* Send uplink nas message for pdu session release request from UE */
+  rc = send_uplink_nas_pdu_session_release_message(
+      amf_app_desc_p, ue_id, plmn, pdu_sess_release_hexbuf,
+      sizeof(pdu_sess_release_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
 
-  // smf context should be present
-  EXPECT_EQ(1, ue_context_p->amf_context.smf_ctxt_map.size());
-  smf_ctx = amf_get_smf_context_by_pdu_session_id(ue_context_p, 1);
-  EXPECT_EQ(3, smf_ctx->duplicate_pdu_session_est_req_count);
-
-  /* Send duplicate uplink nas message for pdu session establishment request
-   * from UE */
-  rc = send_uplink_nas_pdu_session_establishment_request(
-      amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
-      sizeof(ue_pdu_session_est_req_hexbuf));
-  EXPECT_GE(rc, RETURNok);
-
-  // smf context should be present
-  EXPECT_EQ(1, ue_context_p->amf_context.smf_ctxt_map.size());
-  smf_ctx = amf_get_smf_context_by_pdu_session_id(ue_context_p, 1);
-  EXPECT_EQ(4, smf_ctx->duplicate_pdu_session_est_req_count);
-
-  /* Send duplicate uplink nas message for pdu session establishment request
-   * from UE */
-  rc = send_uplink_nas_pdu_session_establishment_request(
-      amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
-      sizeof(ue_pdu_session_est_req_hexbuf));
-  EXPECT_GE(rc, RETURNok);
-
-  // smf context should be present
-  EXPECT_EQ(1, ue_context_p->amf_context.smf_ctxt_map.size());
-  smf_ctx = amf_get_smf_context_by_pdu_session_id(ue_context_p, 1);
-  EXPECT_EQ(4, smf_ctx->duplicate_pdu_session_est_req_count);
-
+  EXPECT_TRUE(
+      clientstub.msgtype_stack.back() == NGAP_PDUSESSIONRESOURCE_REL_REQ);
   /* Send uplink nas message for pdu session release complete from UE */
   rc = send_uplink_nas_pdu_session_release_message(
       amf_app_desc_p, ue_id, plmn, pdu_sess_release_complete_hexbuf,
@@ -701,6 +693,10 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_Invalid_PDUSession_Identity) {
       sizeof(ue_initiated_dereg_hexbuf));
 
   EXPECT_TRUE(rc == RETURNok);
+  EXPECT_TRUE(
+      clientstub.msgtype_stack.back() == NGAP_UE_CONTEXT_RELEASE_COMMAND);
+  clientstub.msgtype_stack.pop_back();
+  EXPECT_TRUE(clientstub.msgtype_stack.back() == NGAP_NAS_DL_DATA_REQ);
 }
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -185,11 +185,11 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcNoTMSI) {
   amf_ue_ngap_id_t ue_id = 0;
   std::vector<MessagesIds> expected_Ids{
       AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
-                                            // idication to ngap
+                                            // indication to ngap
       NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
       NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
-      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // InitialConext Setup Request to UE &
-                                       // Registaration Accept
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
       NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
   };
 
@@ -240,11 +240,11 @@ TEST_F(AMFAppProcedureTest, TestDeRegistration) {
   amf_ue_ngap_id_t ue_id = 0;
   std::vector<MessagesIds> expected_Ids{
       AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
-                                            // idication to ngap
+                                            // indication to ngap
       NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
       NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
-      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // InitialConext Setup Request to UE &
-                                       // Registaration Accept
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
       NGAP_NAS_DL_DATA_REQ,            // Deregistaration Accept
       NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
   };
@@ -296,11 +296,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
   amf_ue_ngap_id_t ue_id = 0;
   std::vector<MessagesIds> expected_Ids{
       AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
-                                            // idication to ngap
+                                            // indication to ngap
       NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
       NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
-      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // InitialConext Setup Request to UE &
-                                       // Registaration Accept
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
       NGAP_PDUSESSION_RESOURCE_SETUP_REQ,  // PDU Resource Setup Request to GNB
                                            // & PDU Session Establishment Accept
       NGAP_PDUSESSIONRESOURCE_REL_REQ,  // PDU Session Resource Release Command
@@ -396,11 +396,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionFailure_dnn_not_subscribed) {
   amf_ue_ngap_id_t ue_id = 0;
   std::vector<MessagesIds> expected_Ids{
       AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
-                                            // idication to ngap
+                                            // indication to ngap
       NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
       NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
-      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // InitialConext Setup Request to UE &
-                                       // Registaration Accept
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
       NGAP_NAS_DL_DATA_REQ,  // PDU Session Establishment Request with failure
                              // mm cause
       NGAP_NAS_DL_DATA_REQ,  // Deregistaration Accept
@@ -467,11 +467,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_missing_dnn) {
   amf_ue_ngap_id_t ue_id = 0;
   std::vector<MessagesIds> expected_Ids{
       AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
-                                            // idication to ngap
+                                            // indication to ngap
       NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
       NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
-      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // InitialConext Setup Request to UE &
-                                       // Registaration Accept
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
       NGAP_NAS_DL_DATA_REQ,  // PDU Session Establishment Request with failure
                              // sm cause
       NGAP_NAS_DL_DATA_REQ,  // Deregistaration Accept
@@ -545,11 +545,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_unknown_pdu_session_type) {
   amf_ue_ngap_id_t ue_id = 0;
   std::vector<MessagesIds> expected_Ids{
       AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
-                                            // idication to ngap
+                                            // indication to ngap
       NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
       NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
-      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // InitialConext Setup Request to UE &
-                                       // Registaration Accept
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
       NGAP_NAS_DL_DATA_REQ,  // PDU Session Establishment Request with failure
                              // sm cause
       NGAP_NAS_DL_DATA_REQ,  // Deregistaration Accept
@@ -617,11 +617,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_Invalid_PDUSession_Identity) {
   amf_ue_ngap_id_t ue_id = 0;
   std::vector<MessagesIds> expected_Ids{
       AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
-                                            // idication to ngap
+                                            // indication to ngap
       NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
       NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
-      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // InitialConext Setup Request to UE &
-                                       // Registaration Accept
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
       NGAP_PDUSESSION_RESOURCE_SETUP_REQ,  // PDU Resource Setup Request to GNB
                                            // & PDU Session Establishment Accept
       NGAP_NAS_DL_DATA_REQ,  // PDU Session Establishment Request with failure


### PR DESCRIPTION
Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
below are three issues handled:

1. AMF is sending UEContextRelease towards UE in the case of the DNN_NOT_SUBSCRIBED scenario.
       handle_sm_message_routing_failure API passing  M5G_AS_FAILURE to amf_app_handle_nas_dl_req.
       it was incorrect behavior.
		  
2. when AMF receives Duplicate PDUSessionEstablishment request, 
   AMF is not dropping subsequent PDU Session Requests with the same PDU Session ID. 
   
3. In the case of the "DNN_NOT_SUBSCRIBED" failure case, AMF is not clearing SMF context from AMF context.

## Test Plan

 1. Recreated Failure case,  AMF is  triggered UEContextRelease message  for DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED failure.
 
![image](https://user-images.githubusercontent.com/83060027/142772606-fccac166-1ac2-4371-8898-e3e36e4dcf94.png)

 2. fix for(1), UEContextRelease will not trigger for DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED.
 
![image](https://user-images.githubusercontent.com/83060027/142772642-65279d9f-dec6-48cc-a7be-394c6f3bbe4e.png)
[mme_reg_19_11_21.log](https://github.com/magma/magma/files/7576715/mme_reg_19_11_21.log)


 3. SMF Context is not clearing in case of DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED failure.
     we can observe (1) case pcap. after the 5th request, AMF is triggering "Invalid PDU Session Identity"
	after fix, AMF will trigger only  DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED failure.
	
![image](https://user-images.githubusercontent.com/83060027/142772722-fb552e95-1de5-475c-acb6-6a95773ca526.png)
[mme_reg_19_11_21_1.log](https://github.com/magma/magma/files/7576719/mme_reg_19_11_21_1.log)

 4. amf should drop duplicate PDU Session Request if AMF is already processing PDU Session with same PDU Session ID.
    In this case, we can identify based GRPC requests towards SMF. resolved issue and AMF will drop subsequent PDUs
![image](https://user-images.githubusercontent.com/83060027/142850773-edec9877-ab3f-4a72-b388-3ed9722d4faf.png)
[mme_reg_22_nov_21.log](https://github.com/magma/magma/files/7580424/mme_reg_22_nov_21.log)

 5. verified basic Registration and PDU Session Setup, Release, and Deregistration.
 
![image](https://user-images.githubusercontent.com/83060027/142772813-c5a0b479-b01d-4b45-b66a-4f1842c03392.png)
[mme_reg_pdu_release_dreg.log](https://github.com/magma/magma/files/7576725/mme_reg_pdu_release_dreg.log)

 6. added Unit test case support for Negative scenerios
                       1. MISSING_OR_UNKNOWN_DNN
			2. UNKNOWN_PDU_SESSION_TYPE
			3. DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED
			4. INVALID_PDU_SESSION_IDENTITY
		
![image](https://user-images.githubusercontent.com/83060027/142773077-fd4e9c0c-db4e-40ac-afda-0cdd225cac54.png)
	
Other Issue Identified During UT:
  7. decode_status value uninitialized, due to this Identity message triggering after Initial Reg instead of Authentication message. 
  8. Random failure of test_amf_service_request_without_uplinkDataStatus_RainyDay testcase (test_amf_encode_decode.cpp)  
      due to uninitilized ServiceRequestMsg.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
