### PR TITLE
chore: silence gazelle warnings seen with Bazel build

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -918,6 +918,10 @@ def go_repositories():
         importpath = "google.golang.org/protobuf",
         sum = "h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=",
         version = "v1.27.1",
+        # Taken from https://github.com/bazelbuild/bazel-gazelle/issues/610#issuecomment-803234610
+        build_extra_args = [
+            "-exclude=**/testdata",
+        ],
     )
     go_repository(
         name = "org_golang_x_crypto",
@@ -981,6 +985,11 @@ def go_repositories():
     )
     go_repository(
         name = "org_golang_x_tools",
+        # Taken from https://github.com/bazelbuild/bazel-gazelle/issues/610#issuecomment-803234610
+        build_extra_args = [
+            "-exclude=**/testdata",
+            "-exclude=go/packages/packagestest",
+        ],
         importpath = "golang.org/x/tools",
         sum = "h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=",
         version = "v0.1.1",


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This was bothering me for a while and I finally got around to fixing it. Bazel / Gazelle was spitting out tons of warnings whenever a target that included src/go was built. (See logs attached at https://github.com/magma/magma/issues/10439)

I got the solution from this GitHub issue: https://github.com/magma/magma/issues/10439
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Everything builds fine, no more warnings :)
Also ran the following to make sure everything is committed
```
bazel build //src/go/...
bazel run //:gazelle -- update-repos -from_file=src/go/go.mod -to_macro=bazel/go_repositories.bzl%go_repositories
bazel run //:gazelle
bazel run //:buildifier
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
