### PR TITLE
fix(ci): GHCR access restrictions from GITHUB_TOKEN in new CI

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,87 @@
+---
+name: "Dockerfile Push"
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+    paths:
+      - .devcontainer/Dockerfile
+      - .github/workflows/docker-push.yml
+      - lte/gateway/docker/mme/Dockerfile.ubuntu20.04
+      - lte/gateway/docker/python-precommit/Dockerfile
+  schedule:
+    # Run four times a day (hours zero, six, twelve and eighteen)
+    - cron: '0 0,6,12,18 * * *'
+
+jobs:
+  build_python_precommit_dockerfile:
+    env:
+      DOCKERFILE: lte/gateway/docker/python-precommit/Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/magma/python-precommit
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: "Login to GHCR"
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_devcontainer_dockerfile:
+    env:
+      DOCKERFILE: .devcontainer/Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/magma/devcontainer
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: "Login to GHCR"
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dockerfile-health.yml
+++ b/.github/workflows/dockerfile-health.yml
@@ -1,0 +1,51 @@
+---
+name: "Dockerfile Health"
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - .devcontainer/Dockerfile
+      - .github/workflows/dockerfile-health.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build_devcontainer_dockerfile:
+    env:
+      DOCKERFILE: .devcontainer/Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Check Out Repo
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            magma/mme_builder_focal
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Docker Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=docker,dest=/tmp/mme_builder.tar


### PR DESCRIPTION
... make reactivation of the older CI necessary until the access is granted.

This reverts commit 513485801116a63f4ab6b6f0b5d8c88357223e16.
This partly reverts commit 9a82f48ae333632819b74c511b92db08d2078a38.

Signed-off-by: Fritz Lehnert <Fritz.Lehnert@tngtech.com>
