### PR TITLE
fix(agw): Fixing py redis library conflict due to version

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -65,8 +65,8 @@ setup(
         'fire>=0.2.0',
         'glob2>=0.7',
         'aioh2>=0.2.2',
-        'redis>=2.10.5',  # redis-py (Python bindings to redis)
-        'redis-collections>=0.4.2',
+        'redis==3.5.3',  # redis-py (Python bindings to redis)
+        'redis-collections==0.9.1',
         'python-redis-lock>=3.7.0',
         'aiohttp>=0.17.2',
         'grpcio>=1.16.1',


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fixes #10461 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- testing on magma VM:
```
(python) vagrant@magma-dev-focal:~/magma/lte/gateway$ checkin_cli.py
1. -- Testing TCP connection to controller.magma.test:7443 --

> Error: [Errno 111] Connect call failed ('10.0.2.2', 7443)

Suggestions
-----------
- Verify services are running
    - Ensure non-empty service status (sudo service magma@* status)
- Verify cloud address and port in
    - /etc/magma/control_proxy.yml
    - /var/opt/magma/configs/control_proxy.yml
- Check DNS
    - [prod] Check DNS mapping (nslookup hostname)
    - [dev] Check hosts mapping (cat /etc/hosts)
- Make sure you are disconnected from VPN
- Ensure cloud's nginx service is healthy
    - Connect to cloud cluster
    - View cloud pods (kubectl get pods --selector app.kubernetes.io/component=nginx-proxy)
    - Tail cloud logs (stern orc8r-nginx --since 2m)
    - Pods should indicate minimal restarts, tailed logs should
      be free of crashes or fatal logs
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
