### PR TITLE
ci: GITHUB_TOKEN access in composite actions

### DIFF
--- a/.github/workflows/composite/docker-builder/action.yml
+++ b/.github/workflows/composite/docker-builder/action.yml
@@ -13,8 +13,6 @@ inputs:
     default: type=sha
   DOCKERFILE:
     required: true
-  GITHUB_TOKEN:
-    required: true
 
 runs:
   using: composite
@@ -37,8 +35,8 @@ runs:
       with:
         registry: ${{ inputs.REGISTRY }}
         username: ${{ github.repository_owner }}
-        password: ${{ inputs.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'push' && github.ref_name == 'master' && inputs.GITHUB_TOKEN != null }}
+        password: ${{ github.token }}
+      if: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}
     - name: Build and push Docker image
       id: docker_build
       uses: docker/build-push-action@v2
@@ -48,4 +46,4 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         # without docker/metadata-action will only be accessible by hash
-        push: ${{ github.event_name == 'push' && github.ref_name == 'master' && inputs.GITHUB_TOKEN != null }}
+        push: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}

--- a/.github/workflows/docker-builder-bazel-base.yml
+++ b/.github/workflows/docker-builder-bazel-base.yml
@@ -37,4 +37,3 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE }}
-          GITHUB_TOKEN: $${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -37,4 +37,3 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE }}
-          GITHUB_TOKEN: $${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -37,4 +37,3 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE }}
-          GITHUB_TOKEN: $${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Fritz Lehnert <Fritz.Lehnert@tngtech.com>

## Summary

Github Actions were refactored to use the relatively new feature of Github composite actions.
For a docker push action the question of access to the `GITHUB_TOKEN` arises.

* While in the [original refeactoring](https://github.com/magma/magma/commit/06697b50db077ae090ccbe595c2ed38034f627eb#diff-61dc0f25a71b867e2e96ea0229335e066501eadf8f276ff55b81d4cfe9bf40c5R16-R41) there seemed not to be any general mistake, the [authentication against the GHCR still failed](https://github.com/magma/magma/runs/4265735623), indicating a problem with login credentials.
* On the other hand, the [original implemenation](https://github.com/magma/magma/commit/37ff458b25900fcf0ef3f37ba47267c2c23f8414#diff-5a710cc1366531dd79364c96fedb1060a064e1017145446c396b231705aa64cdR42) did use the same credentials in the same way with [a working CI build](https://github.com/magma/magma/runs/4268105983).

There was only a tiny hint within the log, that it might be that input variables of composite actions to weird things, when used for secrets handover. I understand [the documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) in a way, that `secrets.GITHUB_TOKEN` is the preferred way to access the credentials, and `github.token` would be equivalent to that. However, it turns out that those statements are **not** equivalent, because their scoping and accessibility are different.

**It turns out that `github.token` is accessible within composite actions, while `secrets.GITHUB_TOKEN` is not and cannot easily be passed in as an input!**

So in summary, this should fix the new composite action workflow. When merged and everything works as expected, I would remove the than deprecated workflows, i.e. revert https://github.com/magma/magma/pull/10460.

## Test Plan

- On personal repository the action worked with the alternative way of accessing Github token credentials. See [here](https://github.com/Neudrino/magma/runs/4286371231?check_suite_focus=true).

## Additional Information

Working Github action credentials:
![2021-11-22 GHCR login positive](https://user-images.githubusercontent.com/13189449/142865860-f8423642-a124-4713-81cd-15ae19d0ef7e.png)

Failing Github composite action credentials:
![2021-11-22 GHCR login negative](https://user-images.githubusercontent.com/13189449/142865856-3d4e2fe9-cdba-498d-9273-9d70060d3c6c.png)
