### PR TITLE
fix(ci): Only trigger integ tests on push and not on PR

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -13,6 +13,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.event == 'push'
     steps:
       - uses: actions/checkout@v2
       - name: Run docker compose

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -13,6 +13,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   lte-integ-test:
     runs-on: macos-10.15
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.event == 'push'
     steps:
       - run: echo "::set-output name=date::$(date +'%m-%d-%Y--%H-%M-%S')"
         id: date


### PR DESCRIPTION
Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Currently LTE/CWF integ tests are launched on PR which should not happen

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
