### PR TITLE
fix: Update BASE_REFERENCE in AMIS workflow

### DIFF
--- a/.github/workflows/amis-workflow.yml
+++ b/.github/workflows/amis-workflow.yml
@@ -35,8 +35,10 @@ jobs:
         run: |
             if ${{ github.event_name == 'workflow_dispatch' }}; then
               echo AWS_ACCOUNT="LF" >> $GITHUB_ENV
+              echo BASE_REFERENCE=${{ github.base_ref }} >> $GITHUB_ENV
             elif ${{ github.event_name == 'schedule' }}; then
               echo AWS_ACCOUNT="FB" >> $GITHUB_ENV
+              echo BASE_REFERENCE="master" >> $GITHUB_ENV
             fi
       - name: Propagate AWS credentials to ansible and create version
         run: |
@@ -116,7 +118,7 @@ jobs:
             sed -i -e '/^packageRepoHost: /s/:.*$/: '"${{ env.PACKAGE_REPO_HOST }}"'/' ${{ env.VARS_DIR }}/build.yaml
             sed -i -e '/^awsAgwAmi: /s/:.*$/: ami-09e67e426f25ce0d7/' ${{ env.VARS_DIR }}/cluster.yaml
             # TODO Overwriting the previous buildAgwVersion to the current branch
-            sed -i -e '/^buildAgwVersion: /s/:.*$/: '"refs\/heads\/${{ github.base_ref }}"'/' ${{ env.VARS_DIR }}/build.yaml
+            sed -i -e '/^buildAgwVersion: /s/:.*$/: '"refs\/heads\/${{ env.BASE_REFERENCE }}"'/' ${{ env.VARS_DIR }}/build.yaml
       - name: Generate AGW AMI
         timeout-minutes: 30
         run: |


### PR DESCRIPTION
Set BASE_REFERENCE to "master" for schedule triggered
runs since github.base_ref is not available.
Use github.base_ref for workflow triggers.

Signed-off-by: Jessica Wagantall <jwagantall@linuxfoundation.org>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
