### PR TITLE
test(mme): Network initiated bearer activation and deactivation

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -2863,6 +2863,7 @@ void mme_app_handle_create_dedicated_bearer_rsp(
       "Sending Activate Dedicated Bearer Response to SPGW for "
       "ue-id: " MME_UE_S1AP_ID_FMT "\n",
       ue_context_p->mme_ue_s1ap_id);
+  update_mme_app_stats_s1u_bearer_add();
   send_pcrf_bearer_actv_rsp(ue_context_p, ebi, REQUEST_ACCEPTED);
   OAILOG_FUNC_OUT(LOG_MME_APP);
 #endif

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -611,11 +611,10 @@ imsi64_t mme_app_handle_initial_ue_message(
         "INITIAL UE Message: Valid mme_code %u and S-TMSI %u received from "
         "eNB.\n",
         initial_pP->opt_s_tmsi.mme_code, initial_pP->opt_s_tmsi.m_tmsi);
-    guti_t guti = {
-        .gummei.plmn     = {0},
-        .gummei.mme_gid  = 0,
-        .gummei.mme_code = 0,
-        .m_tmsi          = INVALID_M_TMSI};
+    guti_t guti = {.gummei.plmn     = {0},
+                   .gummei.mme_gid  = 0,
+                   .gummei.mme_code = 0,
+                   .m_tmsi          = INVALID_M_TMSI};
     plmn_t plmn;
     COPY_PLMN(plmn, (initial_pP->tai.plmn));
     is_guti_valid =
@@ -1115,7 +1114,7 @@ status_code_e mme_app_handle_create_sess_resp(
         "Create Session Response Cause value = (%d) for ue_id =(%u)\n",
         create_sess_resp_pP->cause.cause_value, ue_context_p->mme_ue_s1ap_id);
     create_session_response_fail.cause =
-        (pdn_conn_rsp_cause_t) (create_sess_resp_pP->cause.cause_value);
+        (pdn_conn_rsp_cause_t)(create_sess_resp_pP->cause.cause_value);
     goto error_handling_csr_failure;
   }
   increment_counter("mme_spgw_create_session_rsp", 1, 1, "result", "success");

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -611,10 +611,11 @@ imsi64_t mme_app_handle_initial_ue_message(
         "INITIAL UE Message: Valid mme_code %u and S-TMSI %u received from "
         "eNB.\n",
         initial_pP->opt_s_tmsi.mme_code, initial_pP->opt_s_tmsi.m_tmsi);
-    guti_t guti = {.gummei.plmn     = {0},
-                   .gummei.mme_gid  = 0,
-                   .gummei.mme_code = 0,
-                   .m_tmsi          = INVALID_M_TMSI};
+    guti_t guti = {
+        .gummei.plmn     = {0},
+        .gummei.mme_gid  = 0,
+        .gummei.mme_code = 0,
+        .m_tmsi          = INVALID_M_TMSI};
     plmn_t plmn;
     COPY_PLMN(plmn, (initial_pP->tai.plmn));
     is_guti_valid =
@@ -1114,7 +1115,7 @@ status_code_e mme_app_handle_create_sess_resp(
         "Create Session Response Cause value = (%d) for ue_id =(%u)\n",
         create_sess_resp_pP->cause.cause_value, ue_context_p->mme_ue_s1ap_id);
     create_session_response_fail.cause =
-        (pdn_conn_rsp_cause_t)(create_sess_resp_pP->cause.cause_value);
+        (pdn_conn_rsp_cause_t) (create_sess_resp_pP->cause.cause_value);
     goto error_handling_csr_failure;
   }
   increment_counter("mme_spgw_create_session_rsp", 1, 1, "result", "success");
@@ -2940,15 +2941,6 @@ void mme_app_handle_create_dedicated_bearer_rej(
     }
   }
   OAILOG_FUNC_OUT(LOG_MME_APP);
-}
-
-//------------------------------------------------------------------------------
-// See 3GPP TS 23.401 version 10.13.0 Release 10: 5.4.4.2 MME Initiated
-// Dedicated Bearer Deactivation
-void mme_app_trigger_mme_initiated_dedicated_bearer_deactivation_procedure(
-    mme_app_desc_t* mme_app_desc_p, ue_mm_context_t* const ue_context,
-    const pdn_cid_t cid) {
-  OAILOG_DEBUG(LOG_MME_APP, "TODO \n");
 }
 
 /**

--- a/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
@@ -43,6 +43,7 @@
 #include "lte/gateway/c/core/oai/include/mme_app_state.h"
 #include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer.h"
 #include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.h"
+#include "lte/gateway/c/core/oai/include/mme_app_statistics.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -342,6 +343,7 @@ pdn_cid_t esm_proc_eps_bearer_context_deactivate_accept(
       free_wrapper((void**) &ue_context_p->pdn_contexts[pid]);
       // Free bearer context entry
       if (ue_context_p->bearer_contexts[bid]) {
+        update_mme_app_stats_s1u_bearer_sub();
         free_wrapper((void**) &ue_context_p->bearer_contexts[bid]);
       }
     }
@@ -352,6 +354,7 @@ pdn_cid_t esm_proc_eps_bearer_context_deactivate_accept(
         "for UE (ue_id=" MME_UE_S1AP_ID_FMT ", ebi=%d)\n",
         ue_context_p->mme_ue_s1ap_id, ebi);
     // Remove dedicated bearer context
+    update_mme_app_stats_s1u_bearer_sub();
     free_wrapper((void**) &ue_context_p->bearer_contexts[bid]);
   }
   /* In case of PDN disconnect, no need to inform MME/SPGW as the session would

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -5352,7 +5352,7 @@ status_code_e s1ap_mme_handle_erab_rel_response(
   }
   S1AP_E_RAB_REL_RSP(message_p).mme_ue_s1ap_id = ue_ref_p->mme_ue_s1ap_id;
   S1AP_E_RAB_REL_RSP(message_p).enb_ue_s1ap_id = ue_ref_p->enb_ue_s1ap_id;
-  S1AP_E_RAB_REL_RSP(message_p).e_rab_rel_list.no_of_items           = 1;
+  S1AP_E_RAB_REL_RSP(message_p).e_rab_rel_list.no_of_items           = 0;
   S1AP_E_RAB_REL_RSP(message_p).e_rab_failed_to_rel_list.no_of_items = 0;
 
   const S1ap_E_RABList_t* const e_rab_list = &ie->value.choice.E_RABList;

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <gtest/gtest.h>
+#include <cstdint>
 #include <thread>
 
 #include "feg/protos/s6a_proxy.pb.h"
@@ -27,6 +28,11 @@ namespace magma {
 namespace lte {
 
 extern task_zmq_ctx_t task_zmq_ctx_main;
+
+#define DEFAULT_LBI 5
+#define DEFAULT_TEID 1
+#define DEFAULT_MME_S1AP_UE_ID 1
+#define DEFAULT_eNB_S1AP_UE_ID 0
 
 void nas_config_timer_reinit(nas_config_t* nas_conf, uint32_t timeout_msec) {
   nas_conf->t3402_min  = 1;
@@ -227,7 +233,7 @@ void send_ics_response() {
   MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p)
       .e_rab_setup_list.item[0]
       .gtp_teid                     = 0;
-  uint8_t transport_address_buff[4] = {0, 0, 0, 0};
+  uint8_t transport_address_buff[4] = {192, 168, 60, 141};
   MME_APP_INITIAL_CONTEXT_SETUP_RSP(message_p)
       .e_rab_setup_list.item[0]
       .transport_layer_address = blk2bstr(transport_address_buff, 4);
@@ -316,12 +322,95 @@ void send_s11_deactivate_bearer_req(
   itti_s11_nw_init_deactv_bearer_request_t* s11_bearer_deactv_request =
       &message_p->ittiMsg.s11_nw_init_deactv_bearer_request;
 
-  s11_bearer_deactv_request->s11_mme_teid          = 1;
+  s11_bearer_deactv_request->s11_mme_teid          = DEFAULT_TEID;
   s11_bearer_deactv_request->delete_default_bearer = delete_default_bearer;
   s11_bearer_deactv_request->no_of_bearers         = no_of_bearers_to_be_deact;
   memcpy(
       s11_bearer_deactv_request->ebi, ebi_to_be_deactivated,
       (sizeof(ebi_t) * no_of_bearers_to_be_deact));
+  send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
+  return;
+}
+
+void send_s11_create_bearer_req() {
+  MessageDef* message_p = itti_alloc_new_message(
+      TASK_SPGW_APP, S11_NW_INITIATED_ACTIVATE_BEARER_REQUEST);
+  itti_s11_nw_init_actv_bearer_request_t* s11_actv_bearer_request =
+      &message_p->ittiMsg.s11_nw_init_actv_bearer_request;
+  s11_actv_bearer_request->s11_mme_teid = DEFAULT_TEID;
+  s11_actv_bearer_request->lbi          = DEFAULT_LBI;
+  s11_actv_bearer_request->eps_bearer_qos.gbr.br_dl =
+      10000;  // arbitrary number
+  s11_actv_bearer_request->eps_bearer_qos.gbr.br_ul =
+      10000;  // arbitrary number
+  s11_actv_bearer_request->eps_bearer_qos.mbr.br_dl =
+      100000;  // arbitrary number
+  s11_actv_bearer_request->eps_bearer_qos.mbr.br_ul =
+      100000;                                        // arbitrary number
+  s11_actv_bearer_request->eps_bearer_qos.pci = 1;   // 0 or 1
+  s11_actv_bearer_request->eps_bearer_qos.pl  = 10;  // arbitrary number
+  s11_actv_bearer_request->eps_bearer_qos.pvi = 0;   // 0 or 1
+  s11_actv_bearer_request->context_teid       = DEFAULT_TEID;
+  s11_actv_bearer_request->tft.ebit =
+      TRAFFIC_FLOW_TEMPLATE_PARAMETER_LIST_IS_NOT_INCLUDED;
+  s11_actv_bearer_request->tft.numberofpacketfilters = 1;
+  s11_actv_bearer_request->tft.packetfilterlist.createnewtft[0].direction =
+      TRAFFIC_FLOW_TEMPLATE_UPLINK_ONLY;
+  s11_actv_bearer_request->tft.packetfilterlist.createnewtft[0]
+      .eval_precedence = 250;
+  s11_actv_bearer_request->tft.packetfilterlist.createnewtft[0]
+      .packetfiltercontents.protocolidentifier_nextheader = 6;
+  s11_actv_bearer_request->tft.packetfilterlist.createnewtft[0]
+      .packetfiltercontents.flags |=
+      (TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG |
+       TRAFFIC_FLOW_TEMPLATE_SINGLE_REMOTE_PORT_FLAG);
+  for (int i = 0; i < TRAFFIC_FLOW_TEMPLATE_IPV4_ADDR_SIZE; ++i) {
+    s11_actv_bearer_request->tft.packetfilterlist.createnewtft[0]
+        .packetfiltercontents.ipv4remoteaddr[i]
+        .addr = 8;
+    s11_actv_bearer_request->tft.packetfilterlist.createnewtft[0]
+        .packetfiltercontents.ipv4remoteaddr[i]
+        .mask = 255;
+  }
+  s11_actv_bearer_request->tft.packetfilterlist.createnewtft[0]
+      .packetfiltercontents.singleremoteport = 80;
+
+  s11_actv_bearer_request->s1_u_sgw_fteid.ipv4                = true;
+  s11_actv_bearer_request->s1_u_sgw_fteid.ipv4_address.s_addr = 100;
+
+  s11_actv_bearer_request->s1_u_sgw_fteid.teid           = DEFAULT_TEID;
+  s11_actv_bearer_request->s1_u_sgw_fteid.interface_type = S1_U_SGW_GTP_U;
+  send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
+  return;
+}
+
+void send_erab_setup_rsp() {
+  MessageDef* message_p =
+      itti_alloc_new_message(TASK_S1AP, S1AP_E_RAB_SETUP_RSP);
+
+  S1AP_E_RAB_SETUP_RSP(message_p).mme_ue_s1ap_id = DEFAULT_MME_S1AP_UE_ID;
+  S1AP_E_RAB_SETUP_RSP(message_p).enb_ue_s1ap_id = DEFAULT_eNB_S1AP_UE_ID;
+  S1AP_E_RAB_SETUP_RSP(message_p).e_rab_setup_list.no_of_items           = 0;
+  S1AP_E_RAB_SETUP_RSP(message_p).e_rab_failed_to_setup_list.no_of_items = 0;
+  S1AP_E_RAB_SETUP_RSP(message_p).e_rab_setup_list.item[0].e_rab_id      = 6;
+  uint8_t transport_address_buff[4] = {192, 168, 60, 141};
+  S1AP_E_RAB_SETUP_RSP(message_p)
+      .e_rab_setup_list.item[0]
+      .transport_layer_address = blk2bstr(transport_address_buff, 4);
+  S1AP_E_RAB_SETUP_RSP(message_p).e_rab_setup_list.item[0].gtp_teid =
+      DEFAULT_TEID;
+  S1AP_E_RAB_SETUP_RSP(message_p).e_rab_setup_list.no_of_items = 1;
+  send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
+  return;
+}
+
+void send_erab_release_rsp() {
+  MessageDef* message_p = itti_alloc_new_message(TASK_S1AP, S1AP_E_RAB_REL_RSP);
+  S1AP_E_RAB_REL_RSP(message_p).mme_ue_s1ap_id = DEFAULT_MME_S1AP_UE_ID;
+  S1AP_E_RAB_REL_RSP(message_p).enb_ue_s1ap_id = DEFAULT_eNB_S1AP_UE_ID;
+  S1AP_E_RAB_REL_RSP(message_p).e_rab_rel_list.no_of_items           = 1;
+  S1AP_E_RAB_REL_RSP(message_p).e_rab_failed_to_rel_list.no_of_items = 0;
+  S1AP_E_RAB_REL_RSP(message_p).e_rab_rel_list.item[0].e_rab_id      = 6;
   send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
   return;
 }

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -94,9 +94,16 @@ void send_modify_bearer_resp(
     const std::vector<int>& bearer_to_remove);
 
 void sgw_send_release_access_bearer_response(gtpv2c_cause_value_t cause);
+
 void send_s11_deactivate_bearer_req(
     uint8_t no_of_bearers_to_be_deact, uint8_t* ebi_to_be_deactivated,
     bool delete_default_bearer);
+
+void send_s11_create_bearer_req();
+
+void send_erab_setup_rsp();
+
+void send_erab_release_rsp();
 
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -54,7 +54,9 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
-    default: { } break; }
+    default: {
+    } break;
+  }
 
   itti_free_msg_content(received_message_p);
   free(received_message_p);
@@ -155,14 +157,19 @@ class MmeAppProcedureTest : public ::testing::Test {
   const uint8_t nas_msg_detach_accept[8] = {0x17, 0x88, 0x16, 0x67,
                                             0xd3, 0x02, 0x07, 0x46};
   const uint8_t nas_msg_service_req[4]   = {0xc7, 0x02, 0x79, 0xe0};
+  const uint8_t nas_msg_activate_ded_bearer_accept[9] = {
+      0x27, 0x9f, 0x98, 0x05, 0x82, 0x02, 0x62, 0x00, 0xc6};
+  const uint8_t nas_msg_deactivate_ded_bearer_accept[9] = {
+      0x27, 0x66, 0x5f, 0x4e, 0x87, 0x03, 0x62, 0x00, 0xce};
 
-  std::string imsi                = "001010000000001";
-  plmn_t plmn                     = {.mcc_digit2 = 0,
-                 .mcc_digit1 = 0,
-                 .mnc_digit3 = 0x0f,
-                 .mcc_digit3 = 1,
-                 .mnc_digit2 = 1,
-                 .mnc_digit1 = 0};
+  std::string imsi = "001010000000001";
+  plmn_t plmn      = {
+      .mcc_digit2 = 0,
+      .mcc_digit1 = 0,
+      .mnc_digit3 = 0x0f,
+      .mcc_digit3 = 1,
+      .mnc_digit2 = 1,
+      .mnc_digit1 = 0};
   guti_eps_mobile_identity_t guti = {0};
 };
 
@@ -1040,7 +1047,6 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedDetach) {
   EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
 
   uint8_t ebi_to_be_deactivated = 5;
-
   // Constructing and sending deactivate bearer request
   // for default bearer that should trigger session termination
   send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, true);
@@ -1140,7 +1146,6 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedExpiredDetach) {
   EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
 
   uint8_t ebi_to_be_deactivated = 5;
-
   // Constructing and sending deactivate bearer request
   // for default bearer that should trigger session termination
   send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, true);
@@ -1242,7 +1247,6 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedDetachRetxFailure) {
   EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
 
   uint8_t ebi_to_be_deactivated = 5;
-
   // Constructing and sending deactivate bearer request
   // for default bearer that should trigger session termination
   send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, true);
@@ -1541,6 +1545,145 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleServiceReqDetach) {
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
   EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
   EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
+
+TEST_F(MmeAppProcedureTest, TestNwInitiatedActivateDeactivateBearerRequest) {
+  mme_app_desc_t* mme_state_p =
+      magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  std::condition_variable cv;
+  std::mutex mx;
+  std::unique_lock<std::mutex> lock(mx);
+
+  MME_APP_EXPECT_CALLS(3, 1, 1, 1, 1, 1, 1, 1, 0, 1, 4);
+
+  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  send_mme_app_initial_ue_msg(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti);
+
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp(REQUEST_ACCEPTED);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+
+  // Send activate dedicated bearer request mimicing S1AP
+  send_s11_create_bearer_req();
+  EXPECT_CALL(*s1ap_handler, s1ap_generate_s1ap_e_rab_setup_req()).Times(1);
+
+  // Send ERAB Setup Response mimicing S1AP
+  send_erab_setup_rsp();
+
+  // Constructing and sending Activate Dedicated Bearer Accept to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_activate_ded_bearer_accept,
+      sizeof(nas_msg_activate_ded_bearer_accept), plmn);
+  EXPECT_CALL(*spgw_handler, sgw_handle_nw_initiated_actv_bearer_rsp())
+      .Times(1);
+
+  // Check MME state after Bearer Activation
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 2);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+
+  uint8_t ebi_to_be_deactivated = 6;
+  // Constructing and sending deactivate bearer request
+  // for default bearer that should trigger session termination
+  send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, false);
+  EXPECT_CALL(*s1ap_handler, s1ap_generate_s1ap_e_rab_rel_cmd()).Times(1);
+
+  // Send ERAB Release Response mimicing S1AP
+  send_erab_release_rsp();
+
+  // Constructing and sending Deactivate Dedicated Bearer Accept to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_deactivate_ded_bearer_accept,
+      sizeof(nas_msg_deactivate_ded_bearer_accept), plmn);
+
+  // Check MME state after Bearer Deactivation
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+
+  // Constructing and sending Detach Request to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_detach_req, sizeof(nas_msg_detach_req), plmn);
+
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp();
+
+  // Wait for context release request
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
 
   // Sleep to ensure that messages are received and contexts are released
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -54,9 +54,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
 
   switch (ITTI_MSG_ID(received_message_p)) {
-    default: {
-    } break;
-  }
+    default: { } break; }
 
   itti_free_msg_content(received_message_p);
   free(received_message_p);
@@ -162,14 +160,13 @@ class MmeAppProcedureTest : public ::testing::Test {
   const uint8_t nas_msg_deactivate_ded_bearer_accept[9] = {
       0x27, 0x66, 0x5f, 0x4e, 0x87, 0x03, 0x62, 0x00, 0xce};
 
-  std::string imsi = "001010000000001";
-  plmn_t plmn      = {
-      .mcc_digit2 = 0,
-      .mcc_digit1 = 0,
-      .mnc_digit3 = 0x0f,
-      .mcc_digit3 = 1,
-      .mnc_digit2 = 1,
-      .mnc_digit1 = 0};
+  std::string imsi                = "001010000000001";
+  plmn_t plmn                     = {.mcc_digit2 = 0,
+                 .mcc_digit1 = 0,
+                 .mnc_digit3 = 0x0f,
+                 .mcc_digit3 = 1,
+                 .mnc_digit2 = 1,
+                 .mnc_digit1 = 0};
   guti_eps_mobile_identity_t guti = {0};
 };
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -1547,7 +1547,9 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleServiceReqDetach) {
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
 }
 
-TEST_F(MmeAppProcedureTest, TestNwInitiatedActivateDeactivateBearerRequest) {
+TEST_F(
+    MmeAppProcedureTest,
+    TestNwInitiatedActivateDeactivateDedicatedBearerRequest) {
   mme_app_desc_t* mme_state_p =
       magma::lte::MmeNasStateManager::getInstance().get_state(false);
   std::condition_variable cv;
@@ -1610,7 +1612,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedActivateDeactivateBearerRequest) {
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
   EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
 
-  // Send activate dedicated bearer request mimicing S1AP
+  // Send activate dedicated bearer request mimicing SPGW
   send_s11_create_bearer_req();
   EXPECT_CALL(*s1ap_handler, s1ap_generate_s1ap_e_rab_setup_req()).Times(1);
 
@@ -1636,7 +1638,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedActivateDeactivateBearerRequest) {
 
   uint8_t ebi_to_be_deactivated = 6;
   // Constructing and sending deactivate bearer request
-  // for default bearer that should trigger session termination
+  // for dedicated bearer that should trigger ERAB Release Command
   send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, false);
   EXPECT_CALL(*s1ap_handler, s1ap_generate_s1ap_e_rab_rel_cmd()).Times(1);
 

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -47,6 +47,8 @@ class MockS1apHandler {
       void(itti_s1ap_nas_dl_data_req_t cb_req));
   MOCK_METHOD1(s1ap_handle_conn_est_cnf, void(bstring nas_pdu));
   MOCK_METHOD0(s1ap_handle_ue_context_release_command, void());
+  MOCK_METHOD0(s1ap_generate_s1ap_e_rab_setup_req, void());
+  MOCK_METHOD0(s1ap_generate_s1ap_e_rab_rel_cmd, void());
 };
 
 class MockMmeAppHandler {
@@ -88,6 +90,7 @@ class MockSpgwHandler {
   MOCK_METHOD0(sgw_handle_delete_session_request, void());
   MOCK_METHOD0(sgw_handle_modify_bearer_request, void());
   MOCK_METHOD0(sgw_handle_release_access_bearers_request, void());
+  MOCK_METHOD0(sgw_handle_nw_initiated_actv_bearer_rsp, void());
 };
 
 class MockService303Handler {

--- a/lte/gateway/c/core/oai/test/mock_tasks/s1ap_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/s1ap_mock.cpp
@@ -45,6 +45,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S1AP_E_RAB_SETUP_REQ: {
+      s1ap_handler_->s1ap_generate_s1ap_e_rab_setup_req();
     } break;
 
     case S1AP_E_RAB_MODIFICATION_CNF: {
@@ -72,6 +73,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S1AP_E_RAB_REL_CMD: {
+      s1ap_handler_->s1ap_generate_s1ap_e_rab_rel_cmd();
     } break;
 
     case S1AP_PATH_SWITCH_REQUEST_ACK: {

--- a/lte/gateway/c/core/oai/test/mock_tasks/spgw_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/spgw_mock.cpp
@@ -49,9 +49,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       spgw_handler_->sgw_handle_nw_initiated_actv_bearer_rsp();
     } break;
 
-    default: {
-    } break;
-  }
+    default: { } break; }
   itti_free_msg_content(received_message_p);
   free(received_message_p);
 

--- a/lte/gateway/c/core/oai/test/mock_tasks/spgw_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/spgw_mock.cpp
@@ -44,7 +44,14 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       spgw_handler_->sgw_handle_release_access_bearers_request();
     } break;
 
-    default: { } break; }
+    case S11_NW_INITIATED_ACTIVATE_BEARER_RESP: {
+      // Handle Dedicated bearer Activation Rsp from MME
+      spgw_handler_->sgw_handle_nw_initiated_actv_bearer_rsp();
+    } break;
+
+    default: {
+    } break;
+  }
   itti_free_msg_content(received_message_p);
   free(received_message_p);
 


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Added unit test for network initiated bearer activation and deactivation.
- Fixed issues in counting s1u bearers.
- Fixed an enumeration bug

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
`make test_oai`
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
