### PR TITLE
feat: migrate containerzed sessiond for AGW to be built with Bazel

### DIFF
--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -60,9 +60,6 @@ RUN apt-get update && apt-get install -y \
   libtool \
   pkg-config \
   libgflags-dev \
-  libgtest-dev \
-  clang-11 \
-  #clang-format-11 \
   libc++-dev \
   protobuf-compiler \
   grpc-dev \
@@ -92,9 +89,7 @@ RUN apt-get update && apt-get install -y \
   libboost-filesystem-dev \
   libboost-regex-dev \
   check \
-  libgtest-dev \
   liblfds710 \
-  google-mock \
   libssl-dev \
   libsctp-dev \
   libtspi-dev \

--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -77,7 +77,6 @@ RUN apt-get update && apt-get install -y \
   libfolly-dev \
   libsctp-dev \
   libpcap-dev \
-  libtins-dev \
   libmnl-dev \
   uuid-dev \
   libcurl4-openssl-dev \
@@ -138,10 +137,12 @@ COPY lte/gateway/docker/mme/configs/ ${MAGMA_ROOT}/lte/gateway/docker/configs/
 
 ARG BUILD_TYPE=RelWithDebInfo
 ENV BUILD_TYPE=$BUILD_TYPE
-RUN bazel build //lte/gateway/c/session_manager:sessiond --define=folly_so=1
-RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_sctpd BUILD_TYPE="${BUILD_TYPE}"
-RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_connection_tracker BUILD_TYPE="${BUILD_TYPE}"
-RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_li_agent BUILD_TYPE="${BUILD_TYPE}"
+RUN bazel build  \
+  //lte/gateway/c/sctpd/src:sctpd \
+  //lte/gateway/c/connection_tracker/src:connectiond \
+  //lte/gateway/c/li_agent/src:liagentd \
+  //lte/gateway/c/session_manager:sessiond \
+  --define=folly_so=1
 RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_oai BUILD_TYPE="${BUILD_TYPE}"
 
 # Prepare config file
@@ -172,7 +173,6 @@ RUN apt-get update && apt-get install -y \
   libyaml-cpp-dev \
   libgoogle-glog-dev \
   libprotoc-dev \
-  libtins-dev \
   libmnl-dev \
   libsctp-dev \
   psmisc \
@@ -229,9 +229,9 @@ COPY --from=builder /usr/local/lib/libaddress_sorting.so /usr/local/lib/
 
 # Copy the build artifacts.
 COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/session_manager/sessiond /usr/local/bin/sessiond
-COPY --from=builder $C_BUILD/li_agent/src/liagentd /usr/local/bin/liagentd
-COPY --from=builder $C_BUILD/sctpd/src/sctpd /usr/local/bin/sctpd
-COPY --from=builder $C_BUILD/connection_tracker/src/connectiond /usr/local/bin/connectiond
+COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/sctpd/src/sctpd /usr/local/bin/sctpd
+COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/connection_tracker/src/connectiond /usr/local/bin/connectiond
+COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/li_agent/src/liagentd /usr/local/bin/liagentd
 COPY --from=builder $C_BUILD/core/oai/oai_mme/mme /usr/local/bin/oai_mme
 
 RUN ldconfig 2> /dev/null

--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -31,13 +31,17 @@ ENV C_BUILD /build/c
 ENV OAI_BUILD $C_BUILD/oai
 ENV TZ=Europe/Paris
 
-ENV CCACHE_DIR $MAGMA_ROOT/.cache/gateway/ccache
+ENV CCACHE_DIR ${MAGMA_ROOT}/.cache/gateway/ccache
 ENV MAGMA_DEV_MODE 0
-ENV XDG_CACHE_HOME $MAGMA_ROOT/.cache
+ENV XDG_CACHE_HOME ${MAGMA_ROOT}/.cache
 
-# Add the magma apt repo
 RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg
+    # Setup necessary tools for adding the Magma repository
+    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg wget && \
+    # Download Bazel
+    wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
+    chmod +x /usr/sbin/bazelisk-linux-amd64 && \
+    ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
 
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
 RUN apt-key add /tmp/jfrog.pub && \
@@ -103,32 +107,50 @@ RUN apt-get update && apt-get install -y \
   libgmp3-dev \
   libczmq-dev
 
+ENV MAGMA_ROOT /magma
+WORKDIR /magma
+
+# Copy Bazel files at root and third_party
+COPY WORKSPACE.bazel BUILD.bazel .bazelignore .bazelrc .bazelversion ${MAGMA_ROOT}/
+COPY bazel/ ${MAGMA_ROOT}/bazel
+
+# Build external dependencies first. This will help not rebuilt all dependencies triggered by Magma changes.
+RUN bazel build \
+  @com_github_grpc_grpc//:grpc++ \
+  @com_github_google_glog//:glog \
+  @protobuf//:protobuf \
+  @prometheus_cpp//:prometheus-cpp \
+  @yaml-cpp//:yaml-cpp \
+  @boost//:iterator \
+  @github_nlohmann_json//:json \
+  @sentry_native//:sentry
+
 # Copy proto files
-COPY feg/protos $MAGMA_ROOT/feg/protos
-COPY feg/gateway/services/aaa/protos $MAGMA_ROOT/feg/gateway/services/aaa/protos
-COPY lte/protos $MAGMA_ROOT/lte/protos
-COPY orc8r/protos $MAGMA_ROOT/orc8r/protos
-COPY protos $MAGMA_ROOT/protos
+COPY feg/protos ${MAGMA_ROOT}/feg/protos
+COPY feg/gateway/services/aaa/protos ${MAGMA_ROOT}/feg/gateway/services/aaa/protos
+COPY lte/protos ${MAGMA_ROOT}/lte/protos
+COPY orc8r/protos ${MAGMA_ROOT}/orc8r/protos
+COPY protos ${MAGMA_ROOT}/protos
 
 # Build session_manager c code
-COPY lte/gateway/Makefile $MAGMA_ROOT/lte/gateway/Makefile
-COPY orc8r/gateway/c/common $MAGMA_ROOT/orc8r/gateway/c/common
-COPY lte/gateway/c $MAGMA_ROOT/lte/gateway/c
+COPY lte/gateway/Makefile ${MAGMA_ROOT}/lte/gateway/Makefile
+COPY orc8r/gateway/c/common ${MAGMA_ROOT}/orc8r/gateway/c/common
+COPY lte/gateway/c ${MAGMA_ROOT}/lte/gateway/c
 
-COPY lte/gateway/python/scripts $MAGMA_ROOT/lte/gateway/python/scripts
-COPY lte/gateway/docker $MAGMA_ROOT/lte/gateway/docker
-COPY lte/gateway/docker/mme/configs/ $MAGMA_ROOT/lte/gateway/docker/configs/
+COPY lte/gateway/python/scripts ${MAGMA_ROOT}/lte/gateway/python/scripts
+COPY lte/gateway/docker ${MAGMA_ROOT}/lte/gateway/docker
+COPY lte/gateway/docker/mme/configs/ ${MAGMA_ROOT}/lte/gateway/docker/configs/
 
 ARG BUILD_TYPE=RelWithDebInfo
 ENV BUILD_TYPE=$BUILD_TYPE
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_session_manager BUILD_TYPE="${BUILD_TYPE}"
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_sctpd BUILD_TYPE="${BUILD_TYPE}"
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_connection_tracker BUILD_TYPE="${BUILD_TYPE}"
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_li_agent BUILD_TYPE="${BUILD_TYPE}"
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_oai BUILD_TYPE="${BUILD_TYPE}"
+RUN bazel build //lte/gateway/c/session_manager:sessiond --define=folly_so=1
+RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_sctpd BUILD_TYPE="${BUILD_TYPE}"
+RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_connection_tracker BUILD_TYPE="${BUILD_TYPE}"
+RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_li_agent BUILD_TYPE="${BUILD_TYPE}"
+RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_oai BUILD_TYPE="${BUILD_TYPE}"
 
 # Prepare config file
-COPY lte/gateway/configs $MAGMA_ROOT/lte/gateway/configs
+COPY lte/gateway/configs ${MAGMA_ROOT}/lte/gateway/configs
 
 # -----------------------------------------------------------------------------
 # Dev/Production image
@@ -211,7 +233,7 @@ COPY --from=builder /usr/local/lib/libfdcore.so.6 /usr/local/lib/
 COPY --from=builder /usr/local/lib/libaddress_sorting.so /usr/local/lib/
 
 # Copy the build artifacts.
-COPY --from=builder $C_BUILD/session_manager/sessiond /usr/local/bin/sessiond
+COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/session_manager/sessiond /usr/local/bin/sessiond
 COPY --from=builder $C_BUILD/li_agent/src/liagentd /usr/local/bin/liagentd
 COPY --from=builder $C_BUILD/sctpd/src/sctpd /usr/local/bin/sctpd
 COPY --from=builder $C_BUILD/connection_tracker/src/connectiond /usr/local/bin/connectiond


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This PR essentially takes the existing Dockerfile for C/C++ services and replaces the following commands
1. `make build_session_manager` -> `bazel build //lte/gateway/c/session_manager:sessiond`
2. `make build_li_agent` -> `bazel build //lte/gateway/c/li_agent/src:liagentd`
3. `make build_session_manager` -> `bazel build //lte/gateway/c/connection_manager/src:connectiond`

## Some build time measurements with 16 core codespaces

Building from scratch (This PR adds ~2 more minutes. This is due to Bazel needing to build more dependencies from scratch (GRPC, prometheus, etc.))
```bash
time sudo docker-compose build gateway_c
# master
sudo docker-compose build gateway_c  3.31s user 1.51s system 0% cpu 14:34.66 total
# this PR
sudo docker-compose build gateway_c  2.96s user 1.65s system 0% cpu 16:26.10 total
```

Building again with modifications in SessionD reduces the build time (This is due to bazel build step of external dependencies being cached in this scenario)
```diff
magma % git diff
diff --git a/lte/gateway/c/session_manager/SessionStore.cpp b/lte/gateway/c/session_manager/SessionStore.cpp
index 5849d78b4..5813c5fbb 100644
--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -121,6 +121,7 @@ void SessionStore::set_and_save_reporting_flag(
 }
 
 void SessionStore::sync_request_numbers(const SessionUpdate& update_criteria) {
+  MLOG(MINFO) << "Hello! This is a small modification";
   // Read the current stored state
   auto subscriber_ids = std::set<std::string>{};
   for (const auto& it : update_criteria) {
``` 
```bash
time sudo docker-compose build gateway_c
# master
sudo docker-compose build gateway_c  1.70s user 1.47s system 0% cpu 7:00.90 total
# this PR
sudo docker-compose build gateway_c  1.99s user 0.77s system 0% cpu 6:31.48 total
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
I will rebase this on top of https://github.com/magma/magma/pull/10537 once it merges. With this change, we can remove libtins from the base runtime image.
- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
