### PR TITLE
fix(agw): Re-enabled S1 handover test case as part of sanity

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -145,6 +145,7 @@ s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py \
 s1aptests/test_multi_enb_multi_ue_diff_plmn.py \
 s1aptests/test_x2_handover.py \
 s1aptests/test_x2_handover_ping_pong.py \
+s1aptests/test_s1_handover.py \
 s1aptests/test_attach_mobile_reachability_timer_expiry.py \
 s1aptests/test_attach_implicit_detach_timer_expiry.py \
 s1aptests/test_attach_detach_rar_tcp_data.py \
@@ -249,7 +250,6 @@ s1aptests/test_restore_config_after_non_sanity.py
 # s1aptests/test_attach_detach_with_he_policy.py \ GitHubIssue 6439 & PR 6411
 
 # TODO flaky tests we should look at
-# s1aptests/test_s1_handover.py \
 # s1aptests/test_attach_detach_ps_service_not_available.py \
 # s1aptests/test_enb_complete_reset.py \
 # s1aptests/test_attach_detach_multi_ue_looped.py \


### PR DESCRIPTION
## Title
Re-enabled S1 handover test case as part of sanity

## Summary
The S1 Handover test cases were added as part of PR #9523 which was reverted in PR #10007 because the S1 Handover test cases were failing in CI as part of the issue #10123. The S1APTester PR #66 fixes the issue and the test cases are ready to be reenabled under this PR.

## Test plan
Verified with s1 handover test cases individually and as part of sanity/non-sanity

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>