### PR TITLE
chore: Update codeowners to reflect recent AGW docker vote

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,6 @@
 /orc8r/tools/packer/ @magma/approvers-ci
 /orc8r/cloud/deploy/bare-metal/ @magma/approvers-ci
 /orc8r/cloud/deploy/bare-metal-ansible/ @magma/approvers-ci
-/lte/gateway/docker @magma/approvers-ci
 /lte/gateway/release @magma/approvers-ci
 /lte/gateway/Vagrantfile @magma/approvers-ci
 /cwf/gateway/Vagrantfile @magma/approvers-ci
@@ -42,6 +41,7 @@
 /lte/gateway/c/sctpd @magma/approvers-agw-mme
 /lte/gateway/c/connection_tracker @koolzz @magma/approvers-agw-c
 /lte/gateway/python/integ_tests @magma/approvers-agw-integtests
+/lte/gateway/docker @magma/approvers-agw-containers @magma/approvers-ci
 
 # approvers-agw-pipelined
 /lte/gateway/python/magma/pipelined @magma/approvers-agw-pipelined


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
We recently had a codeowners vote to make @ymasmoudi  and @arunuke owners of lte/gateway/docker. I created a new approvers team to reflect this change.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
