### PR TITLE
fix(nms): update webpack-hot-middleware to pick up security patch

### DIFF
--- a/nms/packages/magmalte/package.json
+++ b/nms/packages/magmalte/package.json
@@ -100,7 +100,7 @@
     "webpack-bundle-analyzer": "^3.9.0",
     "webpack-cli": "^3.2.3",
     "webpack-dev-middleware": "^3.7.2",
-    "webpack-hot-middleware": "^2.25.0",
+    "webpack-hot-middleware": "^2.25.1",
     "webpack-manifest-plugin": "^2.0.4"
   }
 }

--- a/nms/yarn.lock
+++ b/nms/yarn.lock
@@ -2982,10 +2982,10 @@ ansi-gray@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-html@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-  integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
+ansi-html-community@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
+  integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
 ansi-red@^0.1.1:
   version "0.1.1"
@@ -7437,10 +7437,10 @@ html-encoding-sniffer@^2.0.1:
   dependencies:
     whatwg-encoding "^1.0.5"
 
-html-entities@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.3.1.tgz#fb9a1a4b5b14c5daba82d3e34c6ae4fe701a0e44"
-  integrity sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==
+html-entities@^2.1.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.2.tgz#760b404685cb1d794e4f4b744332e3b00dcfe488"
+  integrity sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -14746,15 +14746,15 @@ webpack-dev-middleware@^3.7.2:
     range-parser "^1.2.1"
     webpack-log "^2.0.0"
 
-webpack-hot-middleware@^2.25.0:
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.25.0.tgz#4528a0a63ec37f8f8ef565cf9e534d57d09fe706"
-  integrity sha512-xs5dPOrGPCzuRXNi8F6rwhawWvQQkeli5Ro48PRuQh8pYPCPmNnltP9itiUPT4xI8oW+y0m59lyyeQk54s5VgA==
+webpack-hot-middleware@^2.25.1:
+  version "2.25.1"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.25.1.tgz#581f59edf0781743f4ca4c200fd32c9266c6cf7c"
+  integrity sha512-Koh0KyU/RPYwel/khxbsDz9ibDivmUbrRuKSSQvW42KSDdO4w23WI3SkHpSUKHE76LrFnnM/L7JCrpBwu8AXYw==
   dependencies:
-    ansi-html "0.0.7"
-    html-entities "^1.2.0"
+    ansi-html-community "0.0.8"
+    html-entities "^2.1.0"
     querystring "^0.2.0"
-    strip-ansi "^3.0.0"
+    strip-ansi "^6.0.0"
 
 webpack-log@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Signed-off-by: Lucas Gonze <lucas@gonze.com>

fix(nms): update webpack-hot-middleware to pick up security patch

## Summary

Bump version of webpack-hot-middleware to pick up a minor bump that fixes https://github.com/webpack-contrib/webpack-hot-middleware/issues/412. 

Our ticket for this item: https://github.com/ospoco/private-issue-tracker/issues/16

## Test Plan

Ran unit tests: 
`(cd $MAGMA_ROOT/feg/gateway/docker && ./build.py -c && cd ${MAGMA_ROOT}/orc8r/cloud/docker && ./build.py -t) 2>&1 | tee /tmp/build.log`

Got a failure in a component completely unrelated to the change I'm making:
<pre>=== FAIL: services/s8_proxy/servicers TestCreateAndDeleteBearerRequest (1.16s)
Running PGW at 127.0.0.1:56878
E1123 22:48:45.042785   14133 service_config.go:176] Error Loading feg::s8_proxy configs from '/etc/magma/feg/s8_proxy.yml': open /etc/magma/feg/s8_proxy.yml: no such file or directory
E1123 22:48:45.050660   14133 service_config.go:176] Error Loading feg::feg_relay configs from '/etc/magma/feg/feg_relay.yml': open /etc/magma/feg/feg_relay.yml: no such file or directory
FATAL: 2021/11/23 22:48:45 [core] grpc: Server.RegisterService after Server.Serve for "magma.feg.S8ProxyResponder"
FAIL	magma/feg/gateway/services/s8_proxy/servicers	1.163s
</pre>

## Additional Information

- [ ] This change is backwards-breaking


