### PR TITLE
feat(ci): Publish lte_integ_test results to Firebase

### DIFF
--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install pre requisites
         run: |
           pip3 install --upgrade pip
-          pip3 install ansible fabric3 jsonpickle requests PyYAML
+          pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
           vagrant plugin install vagrant-vbguest vagrant-disksize
       - name: Open up network interfaces for VM
         run: |
@@ -57,6 +57,17 @@ jobs:
         with:
           files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
+      - name: Publish results to Firebase
+        if: always()
+        env:
+          FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
+          REPORT_FILENAME: "lte_integ_test_${{ github.sha }}.html"
+        run: |
+          npm install -g xunit-viewer
+          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
+          [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
+          [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
+          python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} lte --url $URL
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
         env:

--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -1,0 +1,94 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+from firebase_admin import credentials, db, initialize_app
+
+
+def publish_report(worker_id, build_id, verdict, report):
+    """Publish report to Firebase realtime database"""
+    # Read Firebase service account config from envirenment
+    firebase_config = os.environ["FIREBASE_SERVICE_CONFIG"]
+    config = json.loads(firebase_config)
+
+    cred = credentials.Certificate(config)
+    initialize_app(
+        cred, {
+            'databaseURL': 'https://magma-ci-default-rtdb.firebaseio.com/',
+        },
+    )
+
+    report_dict = {
+        'report': report,
+        'timestamp': int(time.time()),
+        'verdict': verdict,
+    }
+
+    ref = db.reference('/workers')
+    reports_ref = ref.child(worker_id).child('reports').child(build_id)
+    reports_ref.set(report_dict)
+
+
+def url_to_html_redirect(run_id, url):
+    """Convert URL into a redirecting HTML page"""
+    report_url = url
+    if url is None:
+        report_url = 'https://github.com/magma/magma/actions/runs/' + run_id
+
+    return '<script>'\
+           '  window.location.href = "' + report_url + '";'\
+           '</script>'
+
+
+def lte_integ_test(args):
+    """Prepare and publish LTE Integ Test report"""
+    report = url_to_html_redirect(args.run_id, args.url)
+    # Possible args.verdict values are success, failure, or canceled
+    verdict = 'inconclusive'
+    if args.verdict.lower() == 'success':
+        verdict = 'pass'
+    elif args.verdict.lower() == 'failure':
+        verdict = 'fail'
+    publish_report('lte_integ_test', args.build_id, verdict, report)
+
+
+# Create the top-level parser
+parser = argparse.ArgumentParser(
+    description='Traffic CLI that generates traffic to an endpoint',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+
+# Add arguments
+parser.add_argument("--build_id", "-id", required=True, help="build ID")
+parser.add_argument("--verdict", required=True, help="Test verdict")
+parser.add_argument("--run_id", default="none", help="Github Actions Run ID")
+
+# Add subcommands
+subparsers = parser.add_subparsers(title='subcommands', dest='cmd')
+
+# Create the parser for the "lte" command
+parser_lte = subparsers.add_parser('lte')
+parser_lte.add_argument("--url", default="none", help="Report URL", nargs='?')
+parser_lte.set_defaults(func=lte_integ_test)
+
+# Read arguments from the command line
+args = parser.parse_args()
+if not args.cmd:
+    parser.print_usage()
+    sys.exit(1)
+args.func(args)

--- a/ci-scripts/firebase_upload_file.py
+++ b/ci-scripts/firebase_upload_file.py
@@ -1,0 +1,50 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import json
+import os
+
+from firebase_admin import credentials, initialize_app, storage
+
+# Initiate the parser
+parser = argparse.ArgumentParser()
+
+# Add arguments
+parser.add_argument("--filename", "-f", required=True, help="file to upload")
+parser.add_argument("--output", "-o", help="file to print url")
+
+# Read arguments from the command line
+args = parser.parse_args()
+print("Uploading %s to firebase storage" % args.filename)
+
+# Read Firebase service account config from envirenment
+firebase_config = os.environ["FIREBASE_SERVICE_CONFIG"]
+config = json.loads(firebase_config)
+
+cred = credentials.Certificate(config)
+initialize_app(cred, {'storageBucket': 'magma-ci.appspot.com'})
+
+# Upload file
+bucket = storage.bucket()
+blob = bucket.blob(args.filename)
+blob.upload_from_filename(args.filename)
+
+# Make public access from the URL
+blob.make_public()
+
+print("File URL is: ", blob.public_url)
+if args.output:
+    with open(args.output, 'w') as f:
+        f.write(blob.public_url)
+        f.close()


### PR DESCRIPTION
Signed-off-by: Tariq Al-Khasib <talkhasib@fb.com>
## Summary

Publish lte_integ_test results to Firebase. PR implements the following
- Convert all xunit xml files to, easy to read, HTML report
- Upload html test report to Firebase storage. File is big to push as is to db. Db will reference this file
- Upload test report to Firebase database

## Test Plan
HTML Report generation, file upload and Firebase db report are tested on upstream branch