### PR TITLE
test(mme): SPGW Unit test for dedicated bearer activation/deactivation

### DIFF
--- a/lte/gateway/c/core/oai/include/sgw_context_manager.h
+++ b/lte/gateway/c/core/oai/include/sgw_context_manager.h
@@ -30,7 +30,7 @@ extern "C" {
 #include <stdint.h>
 
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.007.h"
-
+#include "lte/gateway/c/core/oai/common/common_defs.h"
 #include "lte/gateway/c/core/oai/include/spgw_state.h"
 
 #define INITIAL_SGW_S8_S1U_TEID 0x7FFFFFFF
@@ -59,7 +59,7 @@ s_plus_p_gw_eps_bearer_context_information_t* sgw_cm_get_spgw_context(
 spgw_ue_context_t* spgw_get_ue_context(imsi64_t imsi64);
 spgw_ue_context_t* spgw_create_or_get_ue_context(imsi64_t imsi64);
 
-int spgw_update_teid_in_ue_context(imsi64_t imsi64, teid_t teid);
+status_code_e spgw_update_teid_in_ue_context(imsi64_t imsi64, teid_t teid);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.c
@@ -328,7 +328,7 @@ status_code_e spgw_handle_nw_initiated_bearer_actv_req(
 }
 
 //------------------------------------------------------------------------------
-int32_t spgw_handle_nw_initiated_bearer_deactv_req(
+status_code_e spgw_handle_nw_initiated_bearer_deactv_req(
     const itti_gx_nw_init_deactv_bearer_request_t* const bearer_req_p,
     imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SPGW_APP);

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.h
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.h
@@ -46,7 +46,7 @@ status_code_e spgw_handle_nw_initiated_bearer_actv_req(
     const itti_gx_nw_init_actv_bearer_request_t* const bearer_req_p,
     imsi64_t imsi64, gtpv2c_cause_value_t* failed_cause);
 
-int32_t spgw_handle_nw_initiated_bearer_deactv_req(
+status_code_e spgw_handle_nw_initiated_bearer_deactv_req(
     const itti_gx_nw_init_deactv_bearer_request_t* const bearer_req_p,
     imsi64_t imsi64);
 

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -1728,7 +1728,7 @@ status_code_e sgw_handle_nw_initiated_deactv_bearer_rsp(
               (eps_bearer_ctxt_p->paa.pdn_type == IPv4_AND_v6)) {
             ue_ipv6 = &eps_bearer_ctxt_p->paa.ipv6_address;
           }
-
+#if !MME_UNIT_TEST
           rc = gtp_tunnel_ops->del_tunnel(
               enb, enb_ipv6, eps_bearer_ctxt_p->paa.ipv4_address, ue_ipv6,
               eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
@@ -1745,6 +1745,8 @@ status_code_e sgw_handle_nw_initiated_deactv_bearer_rsp(
                 LOG_SPGW_APP, imsi64,
                 "Removed dedicated bearer context for (ebi = %d)\n", ebi);
           }
+#endif
+
           sgw_free_eps_bearer_context(
               &spgw_ctxt->sgw_eps_bearer_context_information.pdn_connection
                    .sgw_eps_bearers_array[EBI_TO_INDEX(ebi)]);
@@ -1810,6 +1812,7 @@ status_code_e sgw_handle_nw_initiated_deactv_bearer_rsp(
             enb_ipv6 =
                 &eps_bearer_ctxt_p->enb_ip_address_S1u.address.ipv6_address;
           }
+#if !MME_UNIT_TEST
           rc = gtp_tunnel_ops->del_tunnel(
               enb, enb_ipv6, eps_bearer_ctxt_p->paa.ipv4_address, ue_ipv6,
               eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
@@ -1822,6 +1825,7 @@ status_code_e sgw_handle_nw_initiated_deactv_bearer_rsp(
                 eps_bearer_ctxt_p->enb_teid_S1u,
                 eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up);
           }
+#endif
         }
 
         sgw_free_eps_bearer_context(

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
@@ -83,6 +83,26 @@ bool is_num_s1_bearers_valid(
   return false;
 }
 
+int get_num_pending_create_bearer_procedures(
+    sgw_eps_bearer_context_information_t* ctxt_p) {
+  if (ctxt_p == nullptr) {
+    return 0;
+  }
+
+  int num_pending_create_procedures = 0;
+  if (ctxt_p->pending_procedures) {
+    pgw_base_proc_t* base_proc = NULL;
+
+    LIST_FOREACH(base_proc, ctxt_p->pending_procedures, entries) {
+      if (PGW_BASE_PROC_TYPE_NETWORK_INITATED_CREATE_BEARER_REQUEST ==
+          base_proc->type) {
+        num_pending_create_procedures++;
+      }
+    }
+  }
+  return num_pending_create_procedures;
+}
+
 void fill_create_session_request(
     itti_s11_create_session_request_t* session_request_p,
     const std::string& imsi_str, teid_t mme_s11_teid, int bearer_id,
@@ -231,100 +251,137 @@ void fill_release_access_bearer_request(
       DEFAULT_EDNS_IP;
   release_access_bearers_req->edns_peer_ip.addr_v4.sin_family = AF_INET;
   release_access_bearers_req->originating_node                = NODE_TYPE_MME;
-  void fill_packet_filter_content(packet_filter_contents_t * pf_content) {
-    // TODO : Parameterize the protocol, IP Address and port numbers
-    pf_content->flags = TRAFFIC_FLOW_TEMPLATE_PROTOCOL_NEXT_HEADER_FLAG |
-                        TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG |
-                        TRAFFIC_FLOW_TEMPLATE_SINGLE_REMOTE_PORT_FLAG;
+}
 
-    pf_content->protocolidentifier_nextheader = IPPROTO_TCP;
+void fill_packet_filter_content(packet_filter_contents_t* pf_content) {
+  // TODO : Parameterize the protocol, IP Address and port numbers
+  pf_content->flags = TRAFFIC_FLOW_TEMPLATE_PROTOCOL_NEXT_HEADER_FLAG |
+                      TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG |
+                      TRAFFIC_FLOW_TEMPLATE_SINGLE_REMOTE_PORT_FLAG;
 
-    // iPerf server port
-    pf_content->singleremoteport = 5001;
+  pf_content->protocolidentifier_nextheader = IPPROTO_TCP;
 
-    // Remote address as 192.168.129.42/24
-    pf_content->ipv4remoteaddr[0].addr = 192;
-    pf_content->ipv4remoteaddr[1].addr = 168;
-    pf_content->ipv4remoteaddr[2].addr = 129;
-    pf_content->ipv4remoteaddr[3].addr = 42;
-    pf_content->ipv4remoteaddr[0].mask = 255;
-    pf_content->ipv4remoteaddr[1].mask = 255;
-    pf_content->ipv4remoteaddr[2].mask = 255;
-    pf_content->ipv4remoteaddr[3].mask = 0;
+  // iPerf server port
+  pf_content->singleremoteport = 5001;
+
+  // Remote address as 192.168.129.42/24
+  pf_content->ipv4remoteaddr[0].addr = 192;
+  pf_content->ipv4remoteaddr[1].addr = 168;
+  pf_content->ipv4remoteaddr[2].addr = 129;
+  pf_content->ipv4remoteaddr[3].addr = 42;
+  pf_content->ipv4remoteaddr[0].mask = 255;
+  pf_content->ipv4remoteaddr[1].mask = 255;
+  pf_content->ipv4remoteaddr[2].mask = 255;
+  pf_content->ipv4remoteaddr[3].mask = 0;
+}
+
+void fill_nw_initiated_activate_bearer_request(
+    itti_gx_nw_init_actv_bearer_request_t* gx_nw_init_actv_req_p,
+    std::string imsi_str, ebi_t lbi, bearer_qos_t qos) {
+  gx_nw_init_actv_req_p->imsi_length = imsi_str.size();
+  strncpy(gx_nw_init_actv_req_p->imsi, imsi_str.c_str(), imsi_str.size());
+  gx_nw_init_actv_req_p->lbi            = lbi;
+  gx_nw_init_actv_req_p->eps_bearer_qos = qos;
+
+  strncpy(
+      gx_nw_init_actv_req_p->policy_rule_name, DEFAULT_POLICY_RULE_NAME,
+      DEFAULT_POLICY_RULE_NAME_LEN);
+  gx_nw_init_actv_req_p->policy_rule_name[DEFAULT_POLICY_RULE_NAME_LEN] = '\0';
+  gx_nw_init_actv_req_p->policy_rule_name_length = DEFAULT_POLICY_RULE_NAME_LEN;
+
+  traffic_flow_template_t* ul_tft = &gx_nw_init_actv_req_p->ul_tft;
+  traffic_flow_template_t* dl_tft = &gx_nw_init_actv_req_p->dl_tft;
+  memset(ul_tft, 0, sizeof(traffic_flow_template_t));
+  memset(dl_tft, 0, sizeof(traffic_flow_template_t));
+
+  ul_tft->tftoperationcode = TRAFFIC_FLOW_TEMPLATE_OPCODE_CREATE_NEW_TFT;
+  dl_tft->tftoperationcode = TRAFFIC_FLOW_TEMPLATE_OPCODE_CREATE_NEW_TFT;
+  ul_tft->ebit = TRAFFIC_FLOW_TEMPLATE_PARAMETER_LIST_IS_NOT_INCLUDED;
+  dl_tft->ebit = TRAFFIC_FLOW_TEMPLATE_PARAMETER_LIST_IS_NOT_INCLUDED;
+
+  // create one uplink tft
+  ul_tft->packetfilterlist.createnewtft[0].direction =
+      TRAFFIC_FLOW_TEMPLATE_UPLINK_ONLY;
+  ul_tft->packetfilterlist.createnewtft[0].eval_precedence = qos.pl;
+  fill_packet_filter_content(
+      &ul_tft->packetfilterlist.createnewtft[0].packetfiltercontents);
+
+  // create one downlink tft
+  dl_tft->packetfilterlist.createnewtft[0].direction =
+      TRAFFIC_FLOW_TEMPLATE_DOWNLINK_ONLY;
+  dl_tft->packetfilterlist.createnewtft[0].eval_precedence = qos.pl;
+  fill_packet_filter_content(
+      &dl_tft->packetfilterlist.createnewtft[0].packetfiltercontents);
+}
+
+void fill_nw_initiated_activate_bearer_response(
+    itti_s11_nw_init_actv_bearer_rsp_t* nw_actv_bearer_resp,
+    teid_t mme_s11_teid, teid_t sgw_s11_cp_teid, teid_t sgw_s11_ded_teid,
+    teid_t s1u_enb_ded_teid, ebi_t eps_bearer_id, gtpv2c_cause_value_t cause,
+    plmn_t plmn) {
+  nw_actv_bearer_resp->sgw_s11_teid = sgw_s11_cp_teid;
+  COPY_PLMN_IN_ARRAY_FMT(nw_actv_bearer_resp->serving_network, plmn);
+  nw_actv_bearer_resp->cause.cause_value = cause;
+
+  int msg_bearer_index = 0;
+  nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
+      .eps_bearer_id = eps_bearer_id;
+  nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
+      .cause.cause_value = REQUEST_ACCEPTED;
+
+  // Fill eNB S1u Fteid with new teid for dedicated bearer
+  nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
+      .s1u_enb_fteid = {.ipv4           = true,
+                        .interface_type = S1_U_ENODEB_GTP_U,
+                        .teid           = s1u_enb_ded_teid,
+                        .ipv4_address   = {.s_addr = DEFAULT_ENB_IP}};
+
+  // Fill SGW S1u Fteid
+  nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
+      .s1u_sgw_fteid = {.ipv4           = true,
+                        .interface_type = S1_U_SGW_GTP_U,
+                        .teid           = sgw_s11_ded_teid,
+                        .ipv4_address   = {.s_addr = DEFAULT_SGW_IP}};
+
+  nw_actv_bearer_resp->bearer_contexts.num_bearer_context = 1;
+}
+
+void fill_nw_initiated_deactivate_bearer_request(
+    itti_gx_nw_init_deactv_bearer_request_t* gx_nw_init_deactv_req_p,
+    std::string imsi_str, ebi_t lbi, ebi_t eps_bearer_id) {
+  gx_nw_init_deactv_req_p->imsi_length = imsi_str.size();
+  strncpy(gx_nw_init_deactv_req_p->imsi, imsi_str.c_str(), imsi_str.size());
+  gx_nw_init_deactv_req_p->lbi           = lbi;
+  gx_nw_init_deactv_req_p->no_of_bearers = 1;
+  gx_nw_init_deactv_req_p->ebi[0]        = eps_bearer_id;
+}
+
+void fill_nw_initiated_deactivate_bearer_response(
+    itti_s11_nw_init_deactv_bearer_rsp_t* nw_deactv_bearer_resp,
+    uint64_t test_imsi64, bool delete_default_bearer,
+    gtpv2c_cause_value_t cause, ebi_t ebi[], unsigned int num_bearer_context,
+    teid_t sgw_s11_context_teid) {
+  nw_deactv_bearer_resp->delete_default_bearer = delete_default_bearer;
+  nw_deactv_bearer_resp->cause.cause_value     = cause;
+
+  if (delete_default_bearer) {
+    nw_deactv_bearer_resp->lbi  = (ebi_t*) calloc(1, sizeof(ebi_t));
+    *nw_deactv_bearer_resp->lbi = ebi[0];
+    nw_deactv_bearer_resp->bearer_contexts.bearer_contexts[0]
+        .cause.cause_value = cause;
+  } else {
+    for (int i = 0; i < num_bearer_context; i++) {
+      nw_deactv_bearer_resp->bearer_contexts.bearer_contexts[i].eps_bearer_id =
+          ebi[i];
+      nw_deactv_bearer_resp->bearer_contexts.bearer_contexts[i]
+          .cause.cause_value = cause;
+    }
   }
-
-  void fill_nw_initiated_activate_bearer_request(
-      itti_gx_nw_init_actv_bearer_request_t * gx_nw_init_actv_req_p,
-      std::string imsi_str, ebi_t lbi, bearer_qos_t qos) {
-    gx_nw_init_actv_req_p->imsi_length = imsi_str.size();
-    strncpy(gx_nw_init_actv_req_p->imsi, imsi_str.c_str(), imsi_str.size());
-    gx_nw_init_actv_req_p->lbi            = lbi;
-    gx_nw_init_actv_req_p->eps_bearer_qos = qos;
-
-    strncpy(
-        gx_nw_init_actv_req_p->policy_rule_name, DEFAULT_POLICY_RULE_NAME,
-        DEFAULT_POLICY_RULE_NAME_LEN);
-    gx_nw_init_actv_req_p->policy_rule_name[DEFAULT_POLICY_RULE_NAME_LEN] =
-        '\0';
-    gx_nw_init_actv_req_p->policy_rule_name_length =
-        DEFAULT_POLICY_RULE_NAME_LEN;
-
-    traffic_flow_template_t* ul_tft = &gx_nw_init_actv_req_p->ul_tft;
-    traffic_flow_template_t* dl_tft = &gx_nw_init_actv_req_p->dl_tft;
-    memset(ul_tft, 0, sizeof(traffic_flow_template_t));
-    memset(dl_tft, 0, sizeof(traffic_flow_template_t));
-
-    ul_tft->tftoperationcode = TRAFFIC_FLOW_TEMPLATE_OPCODE_CREATE_NEW_TFT;
-    dl_tft->tftoperationcode = TRAFFIC_FLOW_TEMPLATE_OPCODE_CREATE_NEW_TFT;
-    ul_tft->ebit = TRAFFIC_FLOW_TEMPLATE_PARAMETER_LIST_IS_NOT_INCLUDED;
-    dl_tft->ebit = TRAFFIC_FLOW_TEMPLATE_PARAMETER_LIST_IS_NOT_INCLUDED;
-
-    // create one uplink tft
-    ul_tft->packetfilterlist.createnewtft[0].direction =
-        TRAFFIC_FLOW_TEMPLATE_UPLINK_ONLY;
-    ul_tft->packetfilterlist.createnewtft[0].eval_precedence = qos.pl;
-    fill_packet_filter_content(
-        &ul_tft->packetfilterlist.createnewtft[0].packetfiltercontents);
-
-    // create one downlink tft
-    dl_tft->packetfilterlist.createnewtft[0].direction =
-        TRAFFIC_FLOW_TEMPLATE_DOWNLINK_ONLY;
-    dl_tft->packetfilterlist.createnewtft[0].eval_precedence = qos.pl;
-    fill_packet_filter_content(
-        &dl_tft->packetfilterlist.createnewtft[0].packetfiltercontents);
-  }
-
-  void fill_nw_initiated_activate_bearer_response(
-      itti_s11_nw_init_actv_bearer_rsp_t * nw_actv_bearer_resp,
-      teid_t mme_s11_teid, teid_t sgw_s11_cp_teid, teid_t sgw_s11_ded_teid,
-      teid_t s1u_enb_ded_teid, ebi_t eps_bearer_id, gtpv2c_cause_value_t cause,
-      plmn_t plmn) {
-    nw_actv_bearer_resp->sgw_s11_teid = sgw_s11_cp_teid;
-    COPY_PLMN_IN_ARRAY_FMT(nw_actv_bearer_resp->serving_network, plmn);
-    nw_actv_bearer_resp->cause.cause_value = cause;
-
-    int msg_bearer_index = 0;
-    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
-        .eps_bearer_id = eps_bearer_id;
-    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
-        .cause.cause_value = REQUEST_ACCEPTED;
-
-    // Fill eNB S1u Fteid with new teid for dedicated bearer
-    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
-        .s1u_enb_fteid = {.ipv4           = true,
-                          .interface_type = S1_U_ENODEB_GTP_U,
-                          .teid           = s1u_enb_ded_teid,
-                          .ipv4_address   = {.s_addr = DEFAULT_ENB_IP}};
-
-    // Fill SGW S1u Fteid
-    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
-        .s1u_sgw_fteid = {.ipv4           = true,
-                          .interface_type = S1_U_SGW_GTP_U,
-                          .teid           = sgw_s11_ded_teid,
-                          .ipv4_address   = {.s_addr = DEFAULT_SGW_IP}};
-
-    nw_actv_bearer_resp->bearer_contexts.num_bearer_context = 1;
-  }
+  nw_deactv_bearer_resp->bearer_contexts.num_bearer_context =
+      num_bearer_context;
+  nw_deactv_bearer_resp->imsi             = test_imsi64;
+  nw_deactv_bearer_resp->s_gw_teid_s11_s4 = sgw_s11_context_teid;
+}
 
 }  // namespace lte
-}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
@@ -296,20 +296,34 @@ void fill_release_access_bearer_request(
 
   void fill_nw_initiated_activate_bearer_response(
       itti_s11_nw_init_actv_bearer_rsp_t * nw_actv_bearer_resp,
-      teid_t mme_s11_teid, teid_t sgw_s11_context_teid, int bearer_index,
-      ebi_t eps_bearer_id, gtpv2c_cause_value_t cause, plmn_t plmn) {
-    nw_actv_bearer_resp->sgw_s11_teid = sgw_s11_context_teid;
+      teid_t mme_s11_teid, teid_t sgw_s11_cp_teid, teid_t sgw_s11_ded_teid,
+      teid_t s1u_enb_ded_teid, ebi_t eps_bearer_id, gtpv2c_cause_value_t cause,
+      plmn_t plmn) {
+    nw_actv_bearer_resp->sgw_s11_teid = sgw_s11_cp_teid;
     COPY_PLMN_IN_ARRAY_FMT(nw_actv_bearer_resp->serving_network, plmn);
     nw_actv_bearer_resp->cause.cause_value = cause;
-    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[bearer_index]
+
+    int msg_bearer_index = 0;
+    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
         .eps_bearer_id = eps_bearer_id;
-    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[bearer_index]
+    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
         .cause.cause_value = REQUEST_ACCEPTED;
-    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[bearer_index]
-        .s1u_enb_fteid.teid = DEFAULT_ENB_GTP_TEID;
-    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[bearer_index]
-        .s1u_sgw_fteid.teid = DEFAULT_ENB_GTP_TEID;
-    nw_actv_bearer_resp->bearer_contexts.num_bearer_context++;
+
+    // Fill eNB S1u Fteid with new teid for dedicated bearer
+    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
+        .s1u_enb_fteid = {.ipv4           = true,
+                          .interface_type = S1_U_ENODEB_GTP_U,
+                          .teid           = s1u_enb_ded_teid,
+                          .ipv4_address   = {.s_addr = DEFAULT_ENB_IP}};
+
+    // Fill SGW S1u Fteid
+    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[msg_bearer_index]
+        .s1u_sgw_fteid = {.ipv4           = true,
+                          .interface_type = S1_U_SGW_GTP_U,
+                          .teid           = sgw_s11_ded_teid,
+                          .ipv4_address   = {.s_addr = DEFAULT_SGW_IP}};
+
+    nw_actv_bearer_resp->bearer_contexts.num_bearer_context = 1;
   }
 
 }  // namespace lte

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
@@ -14,11 +14,14 @@
 #include "lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h"
 
 #include <cstdint>
+#include <cstring>
 
 extern "C" {
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.003.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.007.h"
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_29.274.h"
+#include "lte/gateway/c/core/oai/include/gx_messages_types.h"
 #include "lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.h"
 #include "lte/gateway/c/core/oai/include/s11_messages_types.h"
 #include "lte/gateway/c/core/oai/common/itti_free_defined_msg.h"
@@ -228,7 +231,86 @@ void fill_release_access_bearer_request(
       DEFAULT_EDNS_IP;
   release_access_bearers_req->edns_peer_ip.addr_v4.sin_family = AF_INET;
   release_access_bearers_req->originating_node                = NODE_TYPE_MME;
-}
+  void fill_packet_filter_content(packet_filter_contents_t * pf_content) {
+    // TODO : Parameterize the protocol, IP Address and port numbers
+    pf_content->flags = TRAFFIC_FLOW_TEMPLATE_PROTOCOL_NEXT_HEADER_FLAG |
+                        TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG |
+                        TRAFFIC_FLOW_TEMPLATE_SINGLE_REMOTE_PORT_FLAG;
+
+    pf_content->protocolidentifier_nextheader = IPPROTO_TCP;
+
+    // iPerf server port
+    pf_content->singleremoteport = 5001;
+
+    // Remote address as 192.168.129.42/24
+    pf_content->ipv4remoteaddr[0].addr = 192;
+    pf_content->ipv4remoteaddr[1].addr = 168;
+    pf_content->ipv4remoteaddr[2].addr = 129;
+    pf_content->ipv4remoteaddr[3].addr = 42;
+    pf_content->ipv4remoteaddr[0].mask = 255;
+    pf_content->ipv4remoteaddr[1].mask = 255;
+    pf_content->ipv4remoteaddr[2].mask = 255;
+    pf_content->ipv4remoteaddr[3].mask = 0;
+  }
+
+  void fill_nw_initiated_activate_bearer_request(
+      itti_gx_nw_init_actv_bearer_request_t * gx_nw_init_actv_req_p,
+      std::string imsi_str, ebi_t lbi, bearer_qos_t qos) {
+    gx_nw_init_actv_req_p->imsi_length = imsi_str.size();
+    strncpy(gx_nw_init_actv_req_p->imsi, imsi_str.c_str(), imsi_str.size());
+    gx_nw_init_actv_req_p->lbi            = lbi;
+    gx_nw_init_actv_req_p->eps_bearer_qos = qos;
+
+    strncpy(
+        gx_nw_init_actv_req_p->policy_rule_name, DEFAULT_POLICY_RULE_NAME,
+        DEFAULT_POLICY_RULE_NAME_LEN);
+    gx_nw_init_actv_req_p->policy_rule_name[DEFAULT_POLICY_RULE_NAME_LEN] =
+        '\0';
+    gx_nw_init_actv_req_p->policy_rule_name_length =
+        DEFAULT_POLICY_RULE_NAME_LEN;
+
+    traffic_flow_template_t* ul_tft = &gx_nw_init_actv_req_p->ul_tft;
+    traffic_flow_template_t* dl_tft = &gx_nw_init_actv_req_p->dl_tft;
+    memset(ul_tft, 0, sizeof(traffic_flow_template_t));
+    memset(dl_tft, 0, sizeof(traffic_flow_template_t));
+
+    ul_tft->tftoperationcode = TRAFFIC_FLOW_TEMPLATE_OPCODE_CREATE_NEW_TFT;
+    dl_tft->tftoperationcode = TRAFFIC_FLOW_TEMPLATE_OPCODE_CREATE_NEW_TFT;
+    ul_tft->ebit = TRAFFIC_FLOW_TEMPLATE_PARAMETER_LIST_IS_NOT_INCLUDED;
+    dl_tft->ebit = TRAFFIC_FLOW_TEMPLATE_PARAMETER_LIST_IS_NOT_INCLUDED;
+
+    // create one uplink tft
+    ul_tft->packetfilterlist.createnewtft[0].direction =
+        TRAFFIC_FLOW_TEMPLATE_UPLINK_ONLY;
+    ul_tft->packetfilterlist.createnewtft[0].eval_precedence = qos.pl;
+    fill_packet_filter_content(
+        &ul_tft->packetfilterlist.createnewtft[0].packetfiltercontents);
+
+    // create one downlink tft
+    dl_tft->packetfilterlist.createnewtft[0].direction =
+        TRAFFIC_FLOW_TEMPLATE_DOWNLINK_ONLY;
+    dl_tft->packetfilterlist.createnewtft[0].eval_precedence = qos.pl;
+    fill_packet_filter_content(
+        &dl_tft->packetfilterlist.createnewtft[0].packetfiltercontents);
+  }
+
+  void fill_nw_initiated_activate_bearer_response(
+      itti_s11_nw_init_actv_bearer_rsp_t * nw_actv_bearer_resp,
+      teid_t mme_s11_teid, teid_t sgw_s11_context_teid, int bearer_index,
+      ebi_t eps_bearer_id, gtpv2c_cause_value_t cause, plmn_t plmn) {
+    nw_actv_bearer_resp->sgw_s11_teid = sgw_s11_context_teid;
+    COPY_PLMN_IN_ARRAY_FMT(nw_actv_bearer_resp->serving_network, plmn);
+    nw_actv_bearer_resp->cause.cause_value = cause;
+    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[bearer_index]
+        .eps_bearer_id = eps_bearer_id;
+    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[bearer_index]
+        .cause.cause_value = REQUEST_ACCEPTED;
+    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[bearer_index]
+        .s1u_enb_fteid.teid = DEFAULT_ENB_GTP_TEID;
+    nw_actv_bearer_resp->bearer_contexts.bearer_contexts[bearer_index]
+        .s1u_sgw_fteid.teid = DEFAULT_ENB_GTP_TEID;
+    nw_actv_bearer_resp->bearer_contexts.num_bearer_context++;
+  }
 
 }  // namespace lte
-}  // namespace magma
+}  // namespace lte

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -32,6 +32,7 @@ namespace lte {
 #define UNASSIGNED_UE_IP 0
 #define DEFAULT_UE_IP 0xc0a8800a  // 192.168.128.10
 #define DEFAULT_VLAN 0
+#define DEFAULT_ENB_IP 0xc0a88129  // 192.168.129.41
 #define DEFAULT_ENB_GTP_TEID 1
 #define ERROR_SGW_S11_TEID 100
 #define DEFAULT_EDNS_IP 0x7f000001  // localhost
@@ -69,14 +70,19 @@ void fill_delete_session_request(
     itti_s11_delete_session_request_t* delete_session_req, teid_t mme_s11_teid,
     teid_t sgw_s11_context_teid, ebi_t eps_bearer_id, plmn_t test_plmn);
 
-<<<<<<< HEAD
 void fill_release_access_bearer_request(
     itti_s11_release_access_bearers_request_t* release_access_bearers_req,
     teid_t mme_s11_teid, teid_t sgw_s11_context_teid);
-=======
+
 void fill_nw_initiated_activate_bearer_request(
     itti_gx_nw_init_actv_bearer_request_t* gx_nw_init_actv_req_p,
     std::string imsi_str, ebi_t lbi, bearer_qos_t qos);
->>>>>>> 66bdda718 (Add unit test for dedicated bearer)
+
+void fill_nw_initiated_activate_bearer_response(
+    itti_s11_nw_init_actv_bearer_rsp_t* nw_actv_bearer_resp,
+    teid_t mme_s11_teid, teid_t sgw_s11_cp_teid, teid_t sgw_s11_ded_teid,
+    teid_t s1u_enb_ded_teid, ebi_t eps_bearer_id, gtpv2c_cause_value_t cause,
+    plmn_t plmn);
+
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -37,6 +37,8 @@ namespace lte {
 #define DEFAULT_EDNS_IP 0x7f000001  // localhost
 #define DEFAULT_SGW_IP 0x7f000001   // localhost
 #define DEFAULT_ENB_IP 0xc0a83c8d   // 192.168.60.141
+#define DEFAULT_POLICY_RULE_NAME "Policy_Rule0"
+#define DEFAULT_POLICY_RULE_NAME_LEN 12
 
 bool is_num_sessions_valid(
     uint64_t imsi64, int expected_num_ue_contexts, int expected_num_teids);
@@ -67,8 +69,14 @@ void fill_delete_session_request(
     itti_s11_delete_session_request_t* delete_session_req, teid_t mme_s11_teid,
     teid_t sgw_s11_context_teid, ebi_t eps_bearer_id, plmn_t test_plmn);
 
+<<<<<<< HEAD
 void fill_release_access_bearer_request(
     itti_s11_release_access_bearers_request_t* release_access_bearers_req,
     teid_t mme_s11_teid, teid_t sgw_s11_context_teid);
+=======
+void fill_nw_initiated_activate_bearer_request(
+    itti_gx_nw_init_actv_bearer_request_t* gx_nw_init_actv_req_p,
+    std::string imsi_str, ebi_t lbi, bearer_qos_t qos);
+>>>>>>> 66bdda718 (Add unit test for dedicated bearer)
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -12,12 +12,12 @@
  */
 #include <string>
 
-#include "lte/gateway/c/core/oai/include/spgw_state.h"
-
 extern "C" {
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
 #include "lte/gateway/c/core/oai/include/sgw_context_manager.h"
 #include "lte/gateway/c/core/oai/include/sgw_ie_defs.h"
+#include "lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.h"
+#include "lte/gateway/c/core/oai/include/spgw_state.h"
 }
 
 namespace magma {
@@ -46,6 +46,9 @@ bool is_num_sessions_valid(
 
 bool is_num_s1_bearers_valid(
     teid_t context_teid, int expected_num_active_bearers);
+
+int get_num_pending_create_bearer_procedures(
+    sgw_eps_bearer_context_information_t* ctxt_p);
 
 void fill_create_session_request(
     itti_s11_create_session_request_t* session_request_p,
@@ -83,6 +86,16 @@ void fill_nw_initiated_activate_bearer_response(
     teid_t mme_s11_teid, teid_t sgw_s11_cp_teid, teid_t sgw_s11_ded_teid,
     teid_t s1u_enb_ded_teid, ebi_t eps_bearer_id, gtpv2c_cause_value_t cause,
     plmn_t plmn);
+
+void fill_nw_initiated_deactivate_bearer_request(
+    itti_gx_nw_init_deactv_bearer_request_t* gx_nw_init_deactv_req_p,
+    std::string imsi_str, ebi_t lbi, ebi_t eps_bearer_id);
+
+void fill_nw_initiated_deactivate_bearer_response(
+    itti_s11_nw_init_deactv_bearer_rsp_t* nw_deactv_bearer_resp,
+    uint64_t test_imsi64, bool delete_default_bearer,
+    gtpv2c_cause_value_t cause, ebi_t ebi[], unsigned int num_bearer_context,
+    teid_t sgw_s11_context_teid);
 
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
@@ -136,7 +136,7 @@ TEST_F(SPGWAppProcedureTest, TestCreateSessionSuccess) {
   return_code = sgw_handle_s11_create_session_request(
       spgw_state, &sample_session_req_p, test_imsi64);
 
-  ASSERT_EQ(return_code, RETURNok);
+  EXPECT_EQ(return_code, RETURNok);
 
   // Verify that a UE context exists in SPGW state after CSR is received
   spgw_ue_context_t* ue_context_p = spgw_get_ue_context(test_imsi64);
@@ -629,7 +629,7 @@ TEST_F(SPGWAppProcedureTest, TestReleaseBearerError) {
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
 }
 
-MATCHER_P2(check_params_in_create_bearer_req, lbi, tft, "") {
+MATCHER_P2(check_params_in_actv_bearer_req, lbi, tft, "") {
   auto cb_req_rcvd_at_mme =
       static_cast<itti_s11_nw_init_actv_bearer_request_t>(arg);
   if (cb_req_rcvd_at_mme.lbi != lbi) {
@@ -658,14 +658,14 @@ TEST_F(SPGWAppProcedureTest, TestDedicatedBearerActivation) {
   return_code = sgw_handle_s11_create_session_request(
       spgw_state, &sample_session_req_p, test_imsi64);
 
-  ASSERT_EQ(return_code, RETURNok);
+  EXPECT_EQ(return_code, RETURNok);
 
   // Verify that a UE context exists in SPGW state after CSR is received
   spgw_ue_context_t* ue_context_p = spgw_get_ue_context(test_imsi64);
-  ASSERT_TRUE(ue_context_p != nullptr);
+  EXPECT_TRUE(ue_context_p != nullptr);
 
   // Verify that teid is created
-  ASSERT_FALSE(LIST_EMPTY(&ue_context_p->sgw_s11_teid_list));
+  EXPECT_FALSE(LIST_EMPTY(&ue_context_p->sgw_s11_teid_list));
   teid_t ue_sgw_teid =
       LIST_FIRST(&ue_context_p->sgw_s11_teid_list)->sgw_s11_teid;
 
@@ -678,7 +678,7 @@ TEST_F(SPGWAppProcedureTest, TestDedicatedBearerActivation) {
            .pdn_connection,
       DEFAULT_EPS_BEARER_ID);
 
-  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
+  EXPECT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
 
   // send an IP alloc response to SPGW
   itti_ip_allocation_response_t test_ip_alloc_resp = {};
@@ -688,10 +688,10 @@ TEST_F(SPGWAppProcedureTest, TestDedicatedBearerActivation) {
   return_code = sgw_handle_ip_allocation_rsp(
       spgw_state, &test_ip_alloc_resp, test_imsi64);
 
-  ASSERT_EQ(return_code, RETURNok);
+  EXPECT_EQ(return_code, RETURNok);
 
   // check if IP address is allocated after this message is done
-  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == DEFAULT_UE_IP);
+  EXPECT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == DEFAULT_UE_IP);
 
   // send pcef create session response to SPGW
   itti_pcef_create_session_response_t sample_pcef_csr_resp;
@@ -715,10 +715,10 @@ TEST_F(SPGWAppProcedureTest, TestDedicatedBearerActivation) {
   return_code =
       sgw_handle_modify_bearer_request(&sample_modify_bearer_req, test_imsi64);
 
-  ASSERT_EQ(return_code, RETURNok);
+  EXPECT_EQ(return_code, RETURNok);
 
   // verify that exactly one session exists in SPGW state
-  ASSERT_TRUE(is_num_sessions_valid(spgw_state, test_imsi64, 1, 1));
+  EXPECT_TRUE(is_num_sessions_valid(test_imsi64, 1, 1));
 
   // send network initiated dedicated bearer activation request from Session
   // Manager
@@ -732,7 +732,7 @@ TEST_F(SPGWAppProcedureTest, TestDedicatedBearerActivation) {
   // check that MME gets a bearer activation request
   EXPECT_CALL(
       *mme_app_handler, mme_app_handle_nw_init_ded_bearer_actv_req(
-                            check_params_in_create_bearer_req(
+                            check_params_in_actv_bearer_req(
                                 sample_gx_nw_init_ded_bearer_actv_req.lbi,
                                 sample_gx_nw_init_ded_bearer_actv_req.ul_tft)))
       .Times(1);
@@ -741,10 +741,22 @@ TEST_F(SPGWAppProcedureTest, TestDedicatedBearerActivation) {
       spgw_state, &sample_gx_nw_init_ded_bearer_actv_req, test_imsi64,
       &failed_cause);
 
-  ASSERT_EQ(return_code, RETURNok);
+  EXPECT_EQ(return_code, RETURNok);
+
+  // check number of pending procedures
+  EXPECT_EQ(
+      get_num_pending_create_bearer_procedures(
+          &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information),
+      1);
 
   // fetch new SGW teid for the pending bearer procedure
-  teid_t ue_ded_bearer_sgw_teid = 100;
+  pgw_ni_cbr_proc_t* pgw_ni_cbr_proc = pgw_get_procedure_create_bearer(
+      &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information);
+  EXPECT_TRUE(pgw_ni_cbr_proc != nullptr);
+  sgw_eps_bearer_entry_wrapper_t* spgw_eps_bearer_entry_p =
+      LIST_FIRST(pgw_ni_cbr_proc->pending_eps_bearers);
+  teid_t ue_ded_bearer_sgw_teid =
+      spgw_eps_bearer_entry_p->sgw_eps_bearer_entry->s_gw_teid_S1u_S12_S4_up;
 
   // send bearer activation response from MME
   itti_s11_nw_init_actv_bearer_rsp_t sample_nw_init_ded_bearer_actv_resp = {};
@@ -755,11 +767,389 @@ TEST_F(SPGWAppProcedureTest, TestDedicatedBearerActivation) {
   return_code = sgw_handle_nw_initiated_actv_bearer_rsp(
       &sample_nw_init_ded_bearer_actv_resp, test_imsi64);
 
+  EXPECT_EQ(return_code, RETURNok);
+
   // check that bearer is created
+  EXPECT_TRUE(is_num_s1_bearers_valid(ue_sgw_teid, 2));
+
+  // check that no pending procedure is left
+  EXPECT_EQ(
+      get_num_pending_create_bearer_procedures(
+          &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information),
+      0);
 
   // Sleep to ensure that messages are received and contexts are released
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
 }
 
+MATCHER_P2(
+    check_params_in_deactv_bearer_req, num_bearers, eps_bearer_id_array, "") {
+  auto db_req_rcvd_at_mme =
+      static_cast<itti_s11_nw_init_deactv_bearer_request_t>(arg);
+  if (db_req_rcvd_at_mme.no_of_bearers != num_bearers) {
+    return false;
+  }
+  if (memcmp(
+          db_req_rcvd_at_mme.ebi, eps_bearer_id_array,
+          sizeof(db_req_rcvd_at_mme.ebi))) {
+    return false;
+  }
+  return true;
+}
+
+TEST_F(SPGWAppProcedureTest, TestDedicatedBearerDeactivation) {
+  spgw_state_t* spgw_state  = get_spgw_state(false);
+  status_code_e return_code = RETURNerror;
+  // expect call to MME create session response
+  itti_s11_create_session_request_t sample_session_req_p = {};
+  fill_create_session_request(
+      &sample_session_req_p, test_imsi_str, DEFAULT_MME_S11_TEID,
+      DEFAULT_BEARER_INDEX, sample_default_bearer_context, test_plmn);
+
+  // trigger create session req to SPGW
+  return_code = sgw_handle_s11_create_session_request(
+      spgw_state, &sample_session_req_p, test_imsi64);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // Verify that a UE context exists in SPGW state after CSR is received
+  spgw_ue_context_t* ue_context_p = spgw_get_ue_context(test_imsi64);
+  EXPECT_TRUE(ue_context_p != nullptr);
+
+  // Verify that teid is created
+  EXPECT_FALSE(LIST_EMPTY(&ue_context_p->sgw_s11_teid_list));
+  teid_t ue_sgw_teid =
+      LIST_FIRST(&ue_context_p->sgw_s11_teid_list)->sgw_s11_teid;
+
+  // Verify that no IP address is allocated for this UE
+  s_plus_p_gw_eps_bearer_context_information_t* spgw_eps_bearer_ctxt_info_p =
+      sgw_cm_get_spgw_context(ue_sgw_teid);
+
+  sgw_eps_bearer_ctxt_t* eps_bearer_ctxt_p = sgw_cm_get_eps_bearer_entry(
+      &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information
+           .pdn_connection,
+      DEFAULT_EPS_BEARER_ID);
+
+  EXPECT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
+
+  // send an IP alloc response to SPGW
+  itti_ip_allocation_response_t test_ip_alloc_resp = {};
+  fill_ip_allocation_response(
+      &test_ip_alloc_resp, SGI_STATUS_OK, ue_sgw_teid, DEFAULT_EPS_BEARER_ID,
+      DEFAULT_UE_IP, DEFAULT_VLAN);
+  return_code = sgw_handle_ip_allocation_rsp(
+      spgw_state, &test_ip_alloc_resp, test_imsi64);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // check if IP address is allocated after this message is done
+  EXPECT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == DEFAULT_UE_IP);
+
+  // send pcef create session response to SPGW
+  itti_pcef_create_session_response_t sample_pcef_csr_resp;
+  fill_pcef_create_session_response(
+      &sample_pcef_csr_resp, PCEF_STATUS_OK, ue_sgw_teid, DEFAULT_EPS_BEARER_ID,
+      SGI_STATUS_OK);
+
+  // check if MME gets a create session response
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_create_sess_resp()).Times(1);
+
+  spgw_handle_pcef_create_session_response(
+      spgw_state, &sample_pcef_csr_resp, test_imsi64);
+
+  // create sample modify default bearer request
+  itti_s11_modify_bearer_request_t sample_modify_bearer_req = {};
+  fill_modify_bearer_request(
+      &sample_modify_bearer_req, DEFAULT_MME_S11_TEID, ue_sgw_teid,
+      DEFAULT_ENB_GTP_TEID, DEFAULT_BEARER_INDEX, DEFAULT_EPS_BEARER_ID);
+
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_modify_bearer_rsp()).Times(1);
+  return_code =
+      sgw_handle_modify_bearer_request(&sample_modify_bearer_req, test_imsi64);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // verify that exactly one session exists in SPGW state
+  EXPECT_TRUE(is_num_sessions_valid(test_imsi64, 1, 1));
+
+  // send network initiated dedicated bearer activation request from Session
+  // Manager
+  itti_gx_nw_init_actv_bearer_request_t sample_gx_nw_init_ded_bearer_actv_req =
+      {};
+  gtpv2c_cause_value_t failed_cause = REQUEST_ACCEPTED;
+  fill_nw_initiated_activate_bearer_request(
+      &sample_gx_nw_init_ded_bearer_actv_req, test_imsi_str,
+      DEFAULT_EPS_BEARER_ID, sample_dedicated_bearer_qos);
+
+  // check that MME gets a bearer activation request
+  EXPECT_CALL(
+      *mme_app_handler, mme_app_handle_nw_init_ded_bearer_actv_req(
+                            check_params_in_actv_bearer_req(
+                                sample_gx_nw_init_ded_bearer_actv_req.lbi,
+                                sample_gx_nw_init_ded_bearer_actv_req.ul_tft)))
+      .Times(1);
+
+  return_code = spgw_handle_nw_initiated_bearer_actv_req(
+      spgw_state, &sample_gx_nw_init_ded_bearer_actv_req, test_imsi64,
+      &failed_cause);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // check number of pending procedures
+  EXPECT_EQ(
+      get_num_pending_create_bearer_procedures(
+          &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information),
+      1);
+
+  // fetch new SGW teid for the pending bearer procedure
+  pgw_ni_cbr_proc_t* pgw_ni_cbr_proc = pgw_get_procedure_create_bearer(
+      &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information);
+  EXPECT_TRUE(pgw_ni_cbr_proc != nullptr);
+  sgw_eps_bearer_entry_wrapper_t* spgw_eps_bearer_entry_p =
+      LIST_FIRST(pgw_ni_cbr_proc->pending_eps_bearers);
+  teid_t ue_ded_bearer_sgw_teid =
+      spgw_eps_bearer_entry_p->sgw_eps_bearer_entry->s_gw_teid_S1u_S12_S4_up;
+
+  // send bearer activation response from MME
+  ebi_t ded_eps_bearer_id = DEFAULT_EPS_BEARER_ID + 1;
+  itti_s11_nw_init_actv_bearer_rsp_t sample_nw_init_ded_bearer_actv_resp = {};
+  fill_nw_initiated_activate_bearer_response(
+      &sample_nw_init_ded_bearer_actv_resp, DEFAULT_MME_S11_TEID, ue_sgw_teid,
+      ue_ded_bearer_sgw_teid, DEFAULT_ENB_GTP_TEID + 1, ded_eps_bearer_id,
+      REQUEST_ACCEPTED, test_plmn);
+  return_code = sgw_handle_nw_initiated_actv_bearer_rsp(
+      &sample_nw_init_ded_bearer_actv_resp, test_imsi64);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // check that bearer is created
+  EXPECT_TRUE(is_num_s1_bearers_valid(ue_sgw_teid, 2));
+
+  // check that no pending procedure is left
+  EXPECT_EQ(
+      get_num_pending_create_bearer_procedures(
+          &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information),
+      0);
+
+  // send deactivate request for dedicated bearer from Session Manager
+  itti_gx_nw_init_deactv_bearer_request_t
+      sample_gx_nw_init_ded_bearer_deactv_req = {};
+  fill_nw_initiated_deactivate_bearer_request(
+      &sample_gx_nw_init_ded_bearer_deactv_req, test_imsi_str,
+      DEFAULT_EPS_BEARER_ID, ded_eps_bearer_id);
+
+  // check that MME gets a bearer deactivation request
+  EXPECT_CALL(
+      *mme_app_handler,
+      mme_app_handle_nw_init_bearer_deactv_req(
+          check_params_in_deactv_bearer_req(
+              sample_gx_nw_init_ded_bearer_deactv_req.no_of_bearers,
+              sample_gx_nw_init_ded_bearer_deactv_req.ebi)))
+      .Times(1);
+
+  return_code = spgw_handle_nw_initiated_bearer_deactv_req(
+      &sample_gx_nw_init_ded_bearer_deactv_req, test_imsi64);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // send a delete dedicated bearer response from MME
+  itti_s11_nw_init_deactv_bearer_rsp_t sample_nw_init_ded_bearer_deactv_resp =
+      {};
+  int num_bearers_to_delete   = 1;
+  ebi_t eps_bearer_id_array[] = {ded_eps_bearer_id};
+
+  fill_nw_initiated_deactivate_bearer_response(
+      &sample_nw_init_ded_bearer_deactv_resp, test_imsi64, false,
+      REQUEST_ACCEPTED, eps_bearer_id_array, num_bearers_to_delete,
+      ue_sgw_teid);
+  return_code = sgw_handle_nw_initiated_deactv_bearer_rsp(
+      spgw_state, &sample_nw_init_ded_bearer_deactv_resp, test_imsi64);
+  EXPECT_EQ(return_code, RETURNok);
+
+  // check that bearer is deleted
+  EXPECT_TRUE(is_num_s1_bearers_valid(ue_sgw_teid, 1));
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
+
+TEST_F(
+    SPGWAppProcedureTest, TestDedicatedBearerDeactivationDeleteDefaultBearer) {
+  spgw_state_t* spgw_state  = get_spgw_state(false);
+  status_code_e return_code = RETURNerror;
+  // expect call to MME create session response
+  itti_s11_create_session_request_t sample_session_req_p = {};
+  fill_create_session_request(
+      &sample_session_req_p, test_imsi_str, DEFAULT_MME_S11_TEID,
+      DEFAULT_BEARER_INDEX, sample_default_bearer_context, test_plmn);
+
+  // trigger create session req to SPGW
+  return_code = sgw_handle_s11_create_session_request(
+      spgw_state, &sample_session_req_p, test_imsi64);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // Verify that a UE context exists in SPGW state after CSR is received
+  spgw_ue_context_t* ue_context_p = spgw_get_ue_context(test_imsi64);
+  EXPECT_TRUE(ue_context_p != nullptr);
+
+  // Verify that teid is created
+  EXPECT_FALSE(LIST_EMPTY(&ue_context_p->sgw_s11_teid_list));
+  teid_t ue_sgw_teid =
+      LIST_FIRST(&ue_context_p->sgw_s11_teid_list)->sgw_s11_teid;
+
+  // Verify that no IP address is allocated for this UE
+  s_plus_p_gw_eps_bearer_context_information_t* spgw_eps_bearer_ctxt_info_p =
+      sgw_cm_get_spgw_context(ue_sgw_teid);
+
+  sgw_eps_bearer_ctxt_t* eps_bearer_ctxt_p = sgw_cm_get_eps_bearer_entry(
+      &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information
+           .pdn_connection,
+      DEFAULT_EPS_BEARER_ID);
+
+  EXPECT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
+
+  // send an IP alloc response to SPGW
+  itti_ip_allocation_response_t test_ip_alloc_resp = {};
+  fill_ip_allocation_response(
+      &test_ip_alloc_resp, SGI_STATUS_OK, ue_sgw_teid, DEFAULT_EPS_BEARER_ID,
+      DEFAULT_UE_IP, DEFAULT_VLAN);
+  return_code = sgw_handle_ip_allocation_rsp(
+      spgw_state, &test_ip_alloc_resp, test_imsi64);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // check if IP address is allocated after this message is done
+  EXPECT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == DEFAULT_UE_IP);
+
+  // send pcef create session response to SPGW
+  itti_pcef_create_session_response_t sample_pcef_csr_resp;
+  fill_pcef_create_session_response(
+      &sample_pcef_csr_resp, PCEF_STATUS_OK, ue_sgw_teid, DEFAULT_EPS_BEARER_ID,
+      SGI_STATUS_OK);
+
+  // check if MME gets a create session response
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_create_sess_resp()).Times(1);
+
+  spgw_handle_pcef_create_session_response(
+      spgw_state, &sample_pcef_csr_resp, test_imsi64);
+
+  // create sample modify default bearer request
+  itti_s11_modify_bearer_request_t sample_modify_bearer_req = {};
+  fill_modify_bearer_request(
+      &sample_modify_bearer_req, DEFAULT_MME_S11_TEID, ue_sgw_teid,
+      DEFAULT_ENB_GTP_TEID, DEFAULT_BEARER_INDEX, DEFAULT_EPS_BEARER_ID);
+
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_modify_bearer_rsp()).Times(1);
+  return_code =
+      sgw_handle_modify_bearer_request(&sample_modify_bearer_req, test_imsi64);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // verify that exactly one session exists in SPGW state
+  EXPECT_TRUE(is_num_sessions_valid(test_imsi64, 1, 1));
+
+  // send network initiated dedicated bearer activation request from Session
+  // Manager
+  itti_gx_nw_init_actv_bearer_request_t sample_gx_nw_init_ded_bearer_actv_req =
+      {};
+  gtpv2c_cause_value_t failed_cause = REQUEST_ACCEPTED;
+  fill_nw_initiated_activate_bearer_request(
+      &sample_gx_nw_init_ded_bearer_actv_req, test_imsi_str,
+      DEFAULT_EPS_BEARER_ID, sample_dedicated_bearer_qos);
+
+  // check that MME gets a bearer activation request
+  EXPECT_CALL(
+      *mme_app_handler, mme_app_handle_nw_init_ded_bearer_actv_req(
+                            check_params_in_actv_bearer_req(
+                                sample_gx_nw_init_ded_bearer_actv_req.lbi,
+                                sample_gx_nw_init_ded_bearer_actv_req.ul_tft)))
+      .Times(1);
+
+  return_code = spgw_handle_nw_initiated_bearer_actv_req(
+      spgw_state, &sample_gx_nw_init_ded_bearer_actv_req, test_imsi64,
+      &failed_cause);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // check number of pending procedures
+  EXPECT_EQ(
+      get_num_pending_create_bearer_procedures(
+          &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information),
+      1);
+
+  // fetch new SGW teid for the pending bearer procedure
+  pgw_ni_cbr_proc_t* pgw_ni_cbr_proc = pgw_get_procedure_create_bearer(
+      &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information);
+  EXPECT_TRUE(pgw_ni_cbr_proc != nullptr);
+  sgw_eps_bearer_entry_wrapper_t* spgw_eps_bearer_entry_p =
+      LIST_FIRST(pgw_ni_cbr_proc->pending_eps_bearers);
+  teid_t ue_ded_bearer_sgw_teid =
+      spgw_eps_bearer_entry_p->sgw_eps_bearer_entry->s_gw_teid_S1u_S12_S4_up;
+
+  // send bearer activation response from MME
+  ebi_t ded_eps_bearer_id = DEFAULT_EPS_BEARER_ID + 1;
+  itti_s11_nw_init_actv_bearer_rsp_t sample_nw_init_ded_bearer_actv_resp = {};
+  fill_nw_initiated_activate_bearer_response(
+      &sample_nw_init_ded_bearer_actv_resp, DEFAULT_MME_S11_TEID, ue_sgw_teid,
+      ue_ded_bearer_sgw_teid, DEFAULT_ENB_GTP_TEID + 1, ded_eps_bearer_id,
+      REQUEST_ACCEPTED, test_plmn);
+  return_code = sgw_handle_nw_initiated_actv_bearer_rsp(
+      &sample_nw_init_ded_bearer_actv_resp, test_imsi64);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // check that bearer is created
+  EXPECT_TRUE(is_num_s1_bearers_valid(ue_sgw_teid, 2));
+
+  // check that no pending procedure is left
+  EXPECT_EQ(
+      get_num_pending_create_bearer_procedures(
+          &spgw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information),
+      0);
+
+  // send deactivate request for dedicated bearer from Session Manager
+  itti_gx_nw_init_deactv_bearer_request_t
+      sample_gx_nw_init_ded_bearer_deactv_req = {};
+  fill_nw_initiated_deactivate_bearer_request(
+      &sample_gx_nw_init_ded_bearer_deactv_req, test_imsi_str,
+      DEFAULT_EPS_BEARER_ID, ded_eps_bearer_id);
+
+  // check that MME gets a bearer deactivation request
+  EXPECT_CALL(
+      *mme_app_handler,
+      mme_app_handle_nw_init_bearer_deactv_req(
+          check_params_in_deactv_bearer_req(
+              sample_gx_nw_init_ded_bearer_deactv_req.no_of_bearers,
+              sample_gx_nw_init_ded_bearer_deactv_req.ebi)))
+      .Times(1);
+
+  return_code = spgw_handle_nw_initiated_bearer_deactv_req(
+      &sample_gx_nw_init_ded_bearer_deactv_req, test_imsi64);
+
+  EXPECT_EQ(return_code, RETURNok);
+
+  // send a delete dedicated bearer response from MME
+  itti_s11_nw_init_deactv_bearer_rsp_t sample_nw_init_ded_bearer_deactv_resp =
+      {};
+  int num_bearers_to_delete   = 2;
+  ebi_t eps_bearer_id_array[] = {DEFAULT_EPS_BEARER_ID, ded_eps_bearer_id};
+
+  fill_nw_initiated_deactivate_bearer_response(
+      &sample_nw_init_ded_bearer_deactv_resp, test_imsi64, true,
+      REQUEST_ACCEPTED, eps_bearer_id_array, num_bearers_to_delete,
+      ue_sgw_teid);
+  return_code = sgw_handle_nw_initiated_deactv_bearer_rsp(
+      spgw_state, &sample_nw_init_ded_bearer_deactv_resp, test_imsi64);
+  EXPECT_EQ(return_code, RETURNok);
+
+  // check that session is removed
+  EXPECT_TRUE(is_num_sessions_valid(test_imsi64, 0, 0));
+
+  free(sample_nw_init_ded_bearer_deactv_resp.lbi);
+
+  // Sleep to ensure that messages are received and contexts are released
+  std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));
+}
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
@@ -730,11 +730,12 @@ TEST_F(SPGWAppProcedureTest, TestDedicatedBearerActivation) {
       DEFAULT_EPS_BEARER_ID, sample_dedicated_bearer_qos);
 
   // check that MME gets a bearer activation request
-  /*EXPECT_CALL(
+  EXPECT_CALL(
       *mme_app_handler, mme_app_handle_nw_init_ded_bearer_actv_req(
                             check_params_in_create_bearer_req(
-                                sample_gx_nw_init_ded_bearer_actv_req.lbi)))
-      .Times(1);*/
+                                sample_gx_nw_init_ded_bearer_actv_req.lbi,
+                                sample_gx_nw_init_ded_bearer_actv_req.ul_tft)))
+      .Times(1);
 
   return_code = spgw_handle_nw_initiated_bearer_actv_req(
       spgw_state, &sample_gx_nw_init_ded_bearer_actv_req, test_imsi64,
@@ -742,7 +743,17 @@ TEST_F(SPGWAppProcedureTest, TestDedicatedBearerActivation) {
 
   ASSERT_EQ(return_code, RETURNok);
 
+  // fetch new SGW teid for the pending bearer procedure
+  teid_t ue_ded_bearer_sgw_teid = 100;
+
   // send bearer activation response from MME
+  itti_s11_nw_init_actv_bearer_rsp_t sample_nw_init_ded_bearer_actv_resp = {};
+  fill_nw_initiated_activate_bearer_response(
+      &sample_nw_init_ded_bearer_actv_resp, DEFAULT_MME_S11_TEID, ue_sgw_teid,
+      ue_ded_bearer_sgw_teid, DEFAULT_ENB_GTP_TEID + 1,
+      DEFAULT_EPS_BEARER_ID + 1, REQUEST_ACCEPTED, test_plmn);
+  return_code = sgw_handle_nw_initiated_actv_bearer_rsp(
+      &sample_nw_init_ded_bearer_actv_resp, test_imsi64);
 
   // check that bearer is created
 


### PR DESCRIPTION
## Summary

This PR adds unit tests for 
- Network initiated dedicated bearer activation
- Network initiated dedicated bearer deactivation 
- Network initiated dedicated bearer deactivation with delete default bearer set to true

Minor fixes on function return types are also included

## Test Plan

Functional testing with `make test_oai`
Regression testing with S1ap integration tests:
- test_attach_detach.py
- test_attach_detach_dedicated.py
