### PR TITLE
fix(amf): SSC Mode setting incorrectly in PDU Session Establisment accept message

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -752,7 +752,8 @@ int amf_app_handle_pdu_session_accept(
   smf_msg->msg.pdu_session_estab_accept.message_type.msg_type =
       PDU_SESSION_ESTABLISHMENT_ACCEPT;
   smf_msg->msg.pdu_session_estab_accept.pdu_session_type.type_val = 1;
-  smf_msg->msg.pdu_session_estab_accept.ssc_mode.mode_val         = 1;
+  smf_msg->msg.pdu_session_estab_accept.ssc_mode.mode_val =
+      (pdu_session_resp->selected_ssc_mode + 1);
 
   memset(
       &(smf_msg->msg.pdu_session_estab_accept.pdu_address.address_info), 0, 12);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSSCMode.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSSCMode.cpp
@@ -33,7 +33,11 @@ int SSCModeMsg::DecodeSSCModeMsg(
     decoded++;
   }
 
-  ssc_mode->mode_val = (*buffer & 0x07);
+  if (iei > 0) {
+    ssc_mode->mode_val = (*buffer & 0x07);
+  } else {
+    ssc_mode->mode_val = (*buffer >> 4) & 0x07;
+  }
   MLOG(MDEBUG) << "DecodeSSCModeMsg__: mode_val = " << std::hex
                << int(ssc_mode->mode_val);
 
@@ -53,8 +57,11 @@ int SSCModeMsg::EncodeSSCModeMsg(
     MLOG(MDEBUG) << "In EncodeSSCModeMsg: iei" << std::hex << int(*buffer);
     encoded++;
   }
-
-  *buffer = 0x00 | (*buffer & 0xf0) | (ssc_mode->mode_val & 0x07);
+  if (iei > 0) {
+    *buffer = 0x00 | (*buffer & 0xf0) | (ssc_mode->mode_val & 0x07);
+  } else {
+    *buffer = 0x00 | (*buffer & 0x0f) | ((ssc_mode->mode_val & 0x07) << 4);
+  }
   MLOG(MDEBUG) << "EncodeSSCModeMsg__: mode_val = " << std::hex << int(*buffer);
 
   return (encoded);

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -795,7 +795,7 @@ TEST(test_optional_dnn_pdu, test_pdu_session_establish_optional) {
   bstring buffer;
   amf_nas_message_t msg = {};
 
-  // build uplinknastransport //
+  // build uplinknastransport
   // uplink nas transport(pdu session request)
   uint8_t pdu[44] = {0x7e, 0x00, 0x67, 0x01, 0x00, 0x15, 0x2e, 0x01, 0x01,
                      0xc1, 0xff, 0xff, 0x91, 0xa1, 0x28, 0x01, 0x00, 0x7b,
@@ -812,8 +812,11 @@ TEST(test_optional_dnn_pdu, test_pdu_session_establish_optional) {
   decode_res = decode_ul_nas_transport_msg(&pdu_sess_est_req, pdu, len);
 
   EXPECT_EQ(decode_res, true);
-  // build uplinknastransport
-
+  // SSC mode check
+  EXPECT_EQ(
+      pdu_sess_est_req.payload_container.smf_msg.msg.pdu_session_estab_request
+          .ssc_mode.mode_val,
+      1);
   EXPECT_EQ(pdu_sess_est_req.nssai.sst, 1);
   uint8_t dnn[9] = {0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74};
   EXPECT_EQ(memcmp(pdu_sess_est_req.dnn.dnn, dnn, pdu_sess_est_req.dnn.len), 0);
@@ -825,6 +828,11 @@ TEST(test_optional_dnn_pdu, test_pdu_session_establish_optional) {
   ULNASTransportMsg decode_pdu_sess_est_req = {};
   decode_res = decode_ul_nas_transport_msg(&decode_pdu_sess_est_req, pdu, len);
   EXPECT_EQ(decode_res, true);
+  // SSC mode Check
+  EXPECT_EQ(
+      decode_pdu_sess_est_req.payload_container.smf_msg.msg
+          .pdu_session_estab_request.ssc_mode.mode_val,
+      1);
   EXPECT_EQ(decode_pdu_sess_est_req.nssai.sst, 1);
   EXPECT_EQ(memcmp(pdu_sess_est_req.dnn.dnn, dnn, pdu_sess_est_req.dnn.len), 0);
 
@@ -1406,6 +1414,8 @@ TEST(test_optional_pdu, test_pdu_session_accept_optional) {
 
   // PDU Session type : IPv4 (pdu_address.type_val = 1)
   EXPECT_EQ(smf_msg->msg.pdu_session_estab_accept.pdu_address.type_val, 1);
+  // SSC mode check
+  EXPECT_EQ(smf_msg->msg.pdu_session_estab_accept.ssc_mode.mode_val, 1);
   // NSSAI
   EXPECT_EQ(smf_msg->msg.pdu_session_estab_accept.nssai.sst, 3);
   uint8_t sd[3] = {0x03, 0x06, 0x09};
@@ -1433,6 +1443,8 @@ TEST(test_optional_pdu, test_pdu_session_accept_optional) {
   EXPECT_GT(decode_res, 0);
 
   EXPECT_EQ(smf_msg->msg.pdu_session_estab_accept.pdu_address.type_val, 1);
+  // SSC mode check
+  EXPECT_EQ(smf_msg->msg.pdu_session_estab_accept.ssc_mode.mode_val, 1);
   EXPECT_EQ(smf_msg->msg.pdu_session_estab_accept.nssai.sst, 3);
   EXPECT_EQ(smf_msg->msg.pdu_session_estab_accept.nssai.sd[0], sd[0]);
   EXPECT_EQ(smf_msg->msg.pdu_session_estab_accept.nssai.sd[1], sd[1]);


### PR DESCRIPTION
Signed-off-by: shashidhar-patil <shashidhar.patil@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Issue: SSC mode was being set incorrectly.

Info: 
- SSC mode is an optional parameter in PDU session establishment request message and its length is 1 byte.
- SSC mode is a mandatory parameter in PDU session establishment accept message and its length is 1 nibble (1/2 octet).

Changes: 
Changes are made in the encoding and decoding logic to account for the optional parameter case.

Spec references:
![MicrosoftTeams-image (5)](https://user-images.githubusercontent.com/89975652/143243308-67b2fa0d-de67-426f-bdf9-29e4e7c58b8a.png)

![MicrosoftTeams-image (6)](https://user-images.githubusercontent.com/89975652/143272847-7e0efd86-0046-44cb-a178-9716f99c277e.png)

 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Verified basic sanity with UERANSIM.
- Please find attached logs and pcap snap for basic registration.

Pcap Snap:
![sscPcap](https://user-images.githubusercontent.com/89975652/143211444-aebb1ba0-f56c-47d0-a8dd-3029acfdf5a6.png)

Test_oai Snap:
![sscModeTest](https://user-images.githubusercontent.com/89975652/143243541-2f90cb0c-c393-4593-90aa-bfada28d7f5d.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

