### PR TITLE
feat: Magma Domain Domain Proxy - helm charts

### DIFF
--- a/.github/workflows/config/yamllint_config.yml
+++ b/.github/workflows/config/yamllint_config.yml
@@ -9,6 +9,7 @@ yaml-files:
 
 ignore: |
   **/templates/*.yaml
+  **/templates/**/*.yaml
 
 rules:
   braces: enable

--- a/dp/cloud/helm/dp/charts/domain-proxy/.helmignore
+++ b/dp/cloud/helm/dp/charts/domain-proxy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/dp/cloud/helm/dp/charts/domain-proxy/Chart.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/Chart.yaml
@@ -1,0 +1,61 @@
+---
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+appVersion: "0.1.0"
+version: 0.1.0
+description: A Helm chart for magma orchestrator's domain-proxy module.
+name: domain-proxy
+engine: gotpl
+sources:
+  - https://github.com/magma/magma
+keywords:
+  - magma
+  - orc8r
+  - dp
+type: application
+
+long_description: |
+  This Chart will deploy the following:
+
+  - 1 x Configuration controller
+  - 1 x protocol controller with 80/443 TCP port exposed with either ingress/contour ingress resource.
+  - 1 x radio controller with GRPC 50053/TCP port.
+  - All using Kubernetes Deployment
+  - 1 x job for Postgres database migration.
+
+  ## Installation.
+
+  ### From Source.
+
+  ```console
+  $ git clone
+  $ cd dp/cloud/helm/dp
+  $ helm dep update domain-proxy
+  $ helm install --name myname --namespace mynamespace domain-proxy
+  ```
+
+  ### Certificates.
+
+  In order to work properly Domain proxy requires set of certificates. To enable chart to consume them place them inside.
+  `certificates` directory and setup proper certificate paths in your `values.yaml` file.
+
+  ## Development.
+
+  ### Local Deployment using Minikube.
+  If you're running locally in Minikube, see the `examples/minikube_values.yml` file.
+
+  To run local development environment:
+
+  ```console
+  $ make
+  ```

--- a/dp/cloud/helm/dp/charts/domain-proxy/README.md
+++ b/dp/cloud/helm/dp/charts/domain-proxy/README.md
@@ -1,0 +1,202 @@
+
+Domain-proxy
+===========
+
+A Helm chart for magma orchestrator's domain-proxy module.
+
+This Chart will deploy the following:
+
+- 1 x Configuration controller
+- 1 x protocol controller with 80/443 TCP port exposed with either ingress/contour ingress resource.
+- 1 x radio controller with GRPC 50053/TCP port.
+- All using Kubernetes Deployment
+- 1 x job for Postgres database migration.
+
+## Installation.
+
+### From Source.
+
+```console
+$ git clone
+$ cd dp/cloud/helm/dp
+$ helm dep update domain-proxy
+$ helm install --name myname --namespace mynamespace domain-proxy
+```
+
+### Certificates.
+
+In order to work properly Domain proxy requires set of certificates. To enable chart to consume them place them inside.
+`certificates` directory and setup proper certificate paths in your `values.yaml` file.
+
+## Development.
+
+### Local Deployment using Minikube.
+If you're running locally in Minikube, see the `examples/minikube_values.yml` file.
+
+To run local development environment:
+
+```console
+$ make
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Domain-proxy chart and their default values.
+
+| Parameter                | Description             | Default        |
+| ------------------------ | ----------------------- | -------------- |
+| `create` | Deploy Domain Proxy Chart. | `true` |
+| `nameOverride` | Replaces the name of the chart in the `Chart.yaml` file. | `""` |
+| `fullnameOverride` | Completely replaces the helm release generated name. | `""` |
+| `configuration_controller.sasEndpointUrl` | Endpoint where sas request should be send. | `""` |
+| `configuration_controller.requestProcessingInterval` | How often configuration controller will send requests to SAS. In seconds. | `"10"` |
+| `configuration_controller.database` | Database configuration. | `{}` |
+| `configuration_controller.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
+| `configuration_controller.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `configuration_controller.enabled` | Enables deployment of the given service. | `true` |
+| `configuration_controller.name` | Domain proxy component name. | `"configuration-controller"` |
+| `configuration_controller.image.repository` | Docker image repository. | `"configuration-controller"` |
+| `configuration_controller.image.pullPolicy` | Default the pull policy of all containers in that pod. | `"IfNotPresent"` |
+| `configuration_controller.image.tag` | Overrides the image tag whose default is the chart appVersion. | `""` |
+| `configuration_controller.replicaCount` | How many replicas of particular component should be created. | `1` |
+| `configuration_controller.imagePullSecrets` | Name of the secret that contains container image registry keys | `[]` |
+| `configuration_controller.serviceAccount.create` | Specifies whether a service account should be created | `false` |
+| `configuration_controller.serviceAccount.annotations` | Annotations to add to the service account | `{}` |
+| `configuration_controller.serviceAccount.name` | The name of the service account to use,If not set and create is true, a name is generated using the fullname template. | `""` |
+| `configuration_controller.podAnnotations` | Additional pod annotations | `{}` |
+| `configuration_controller.podSecurityContext` | Holds pod-level security attributes | `{}` |
+| `configuration_controller.securityContext` | Holds security configuration that will be applied to a container. | `{}` |
+| `configuration_controller.service.enable` | Whether to enable kubernetes service for dp component. | `true` |
+| `configuration_controller.service.port` | Default port of enabled kubernetes service. | `8080` |
+| `configuration_controller.tlsConfig` | tls configuration for communication with SAS. | `{}` |
+| `configuration_controller.ingress.enabled` | Enable kubernetes ingress resource. | `false` |
+| `configuration_controller.ingress.annotations` | Annotations to kubernetes ingress resource. | `{}` |
+| `configuration_controller.ingress.hosts` |  | `[]` |
+| `configuration_controller.ingress.tls` | Kubernetes secret name for tls termination on ingress kubernetes resource. | `[]` |
+| `configuration_controller.resources` | Resource requests and limits of Pod. | `{}` |
+| `configuration_controller.readinessProbe` | Readines probe definition. | `{}` |
+| `configuration_controller.livenessProbe` | Livenes probe definition. | `{}` |
+| `configuration_controller.autoscaling.enabled` | Enables horizontal pod autscaler kubernetes resource. | `false` |
+| `configuration_controller.autoscaling.minReplicas` | Minimum number of dp component replicas. | `1` |
+| `configuration_controller.autoscaling.maxReplicas` | Maximum number of dp component replicas. | `100` |
+| `configuration_controller.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization threshold in perecents when new replica should be created | `80` |
+| `configuration_controller.podDisruptionBudget.enabled` | Creates kubernetes podDisruptionBudget resource. | `false` |
+| `configuration_controller.podDisruptionBudget.minAvailable` | Minimum available pods for dp component. | `1` |
+| `configuration_controller.podDisruptionBudget.maxUnavailable` | Maximum unavailable pods for dp component. | `""` |
+| `configuration_controller.nodeSelector` | Kubernetes node selection constraint. | `{}` |
+| `configuration_controller.tolerations` | Allow the pods to schedule onto nodes with matching taints. | `[]` |
+| `configuration_controller.affinity` | Constrain which nodes your pod is eligible to be scheduled on. | `{}` |
+| `protocol_controller.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
+| `protocol_controller.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `protocol_controller.enabled` | Enables deployment of the given dp component. | `true` |
+| `protocol_controller.name` | Domain proxy component name. | `"protocol-controller"` |
+| `protocol_controller.image.repository` | Docker image repository. | `"protocol-controller"` |
+| `protocol_controller.image.tag` | Overrides the image tag whose default is the chart appVersion. | `""` |
+| `protocol_controller.image.pullPolicy` | Default the pull policy of all containers in that pod. | `"IfNotPresent"` |
+| `protocol_controller.replicaCount` | How many replicas of particular component should be created. | `1` |
+| `protocol_controller.imagePullSecrets` | Name of the secret that contains container image registry keys. | `[]` |
+| `protocol_controller.serviceAccount.create` | Specifies whether a service account should be created | `false` |
+| `protocol_controller.serviceAccount.annotations` | Annotations to add to the service account | `{}` |
+| `protocol_controller.serviceAccount.name` | The name of the service account to use,If not set and create is true, a name is generated using the fullname template. | `""` |
+| `protocol_controller.podAnnotations` | Additional pod annotations. | `{}` |
+| `protocol_controller.podSecurityContext` | Holds pod-level security attributes. | `{}` |
+| `protocol_controller.securityContext` | Holds security configuration that will be applied to a container. | `{}` |
+| `protocol_controller.service.enable` | Whether to enable kubernetes service for dp component. | `true` |
+| `protocol_controller.service.port` | Default port of enabled kubernetes service. | `8080` |
+| `protocol_controller.tlsConfig` |  | `{}` |
+| `protocol_controller.apiPrefix` | Protocol controller URL API prefix. | `"/sas/v1"` |
+| `protocol_controller.ingress.enabled` | Enable kubernetes ingress resource. | `false` |
+| `protocol_controller.ingress.annotations` | Annotations to kubernetes ingress resource. | `{}` |
+| `protocol_controller.ingress.hosts` |  | `[]` |
+| `protocol_controller.ingress.tls` | Kubernetes secret name for tls termination on ingress kubernetes resource. | `[]` |
+| `protocol_controller.httpproxy.enabled` | Enables contour httpproxy CRD. | `false` |
+| `protocol_controller.httpproxy.annotations` | Aditional annotations. | `{}` |
+| `protocol_controller.httpproxy.virtualhost` |  | `{}` |
+| `protocol_controller.resources` | Resource requests and limits of Pod. | `{}` |
+| `protocol_controller.readinessProbe` | Readines probe definition. | `{}` |
+| `protocol_controller.livenessProbe` | Livenes probe definition. | `{}` |
+| `protocol_controller.autoscaling.enabled` | Enables horizontal pod autscaler kubernetes resource. | `false` |
+| `protocol_controller.autoscaling.minReplicas` | Minimum number of dp component replicas. | `1` |
+| `protocol_controller.autoscaling.maxReplicas` | Maximum number of dp component replicas. | `100` |
+| `protocol_controller.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization threshold in perecents when new replica should be created. | `80` |
+| `protocol_controller.podDisruptionBudget.enabled` | Creates kubernetes podDisruptionBudget resource. | `false` |
+| `protocol_controller.podDisruptionBudget.minAvailable` | Minimum available pods for dp component. | `1` |
+| `protocol_controller.podDisruptionBudget.maxUnavailable` | Minimum available pods for dp component. | `""` |
+| `protocol_controller.nodeSelector` | Kubernetes node selection constraint. | `{}` |
+| `protocol_controller.tolerations` | Allow the pods to schedule onto nodes with matching taints. | `[]` |
+| `protocol_controller.affinity` | Constrain which nodes your pod is eligible to be scheduled on. | `{}` |
+| `radio_controller.database` |  | `{}` |
+| `radio_controller.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
+| `radio_controller.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `radio_controller.enabled` | Enables deployment of the given dp component. | `true` |
+| `radio_controller.name` | Domain proxy component name. | `"radio-controller"` |
+| `radio_controller.image.repository` | Docker image repository. | `"radio-controller"` |
+| `radio_controller.image.tag` | Overrides the image tag whose default is the chart appVersion. | `""` |
+| `radio_controller.image.pullPolicy` | Default the pull policy of all containers in that pod. | `"IfNotPresent"` |
+| `radio_controller.replicaCount` | How many replicas of particular component should be created. | `1` |
+| `radio_controller.imagePullSecrets` | Name of the secret that contains container image registry keys. | `[]` |
+| `radio_controller.serviceAccount.create` | Specifies whether a service account should be created. | `false` |
+| `radio_controller.serviceAccount.annotations` | Annotations to add to the service account. | `{}` |
+| `radio_controller.serviceAccount.name` | The name of the service account to use,If not set and create is true, a name is generated using the fullname template. | `""` |
+| `radio_controller.podAnnotations` | Additional pod annotations. | `{}` |
+| `radio_controller.podSecurityContext` | Holds pod-level security attributes. | `{}` |
+| `radio_controller.securityContext` | Holds security configuration that will be applied to a container. | `{}` |
+| `radio_controller.resources` | Resource requests and limits of Pod. | `{}` |
+| `radio_controller.readinessProbe` | Readines probe definition. | `{}` |
+| `radio_controller.livenessProbe` | Livenes probe definition. | `{}` |
+| `radio_controller.autoscaling.enabled` | Enables horizontal pod autscaler kubernetes resource. | `false` |
+| `radio_controller.autoscaling.minReplicas` | Minimum number of dp component replicas. | `1` |
+| `radio_controller.autoscaling.maxReplicas` | Maximum number of dp component replicas. | `100` |
+| `radio_controller.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization threshold in perecents when new replica should be created | `80` |
+| `radio_controller.podDisruptionBudget.enabled` | Creates kubernetes podDisruptionBudget resource. | `false` |
+| `radio_controller.podDisruptionBudget.minAvailable` | Minimum available pods for dp component. | `1` |
+| `radio_controller.podDisruptionBudget.maxUnavailable` | Maximum unavailable pods for dp component. | `""` |
+| `radio_controller.nodeSelector` | Kubernetes node selection constraint. | `{}` |
+| `radio_controller.tolerations` | Allow the pods to schedule onto nodes with matching taints. | `[]` |
+| `radio_controller.affinity` | Constrain which nodes your pod is eligible to be scheduled on. | `{}` |
+| `active_mode_controller.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
+| `active_mode_controller.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `active_mode_controller.enabled` | Enables deployment of the given dp component. | `true` |
+| `active_mode_controller.name` | Domain proxy component name. | `"active-mode-controller"` |
+| `active_mode_controller.image.repository` | Docker image repository. | `"active-mode-controller"` |
+| `active_mode_controller.image.tag` | Overrides the image tag whose default is the chart appVersion. | `""` |
+| `active_mode_controller.image.pullPolicy` | Default the pull policy of all containers in that pod. | `"IfNotPresent"` |
+| `active_mode_controller.replicaCount` | How many replicas of particular component should be created. | `1` |
+| `active_mode_controller.imagePullSecrets` | Name of the secret that contains container image registry keys. | `[]` |
+| `active_mode_controller.serviceAccount.create` | Specifies whether a service account should be created. | `false` |
+| `active_mode_controller.serviceAccount.annotations` | Annotations to add to the service account. | `{}` |
+| `active_mode_controller.serviceAccount.name` | The name of the service account to use,If not set and create is true, a name is generated using the fullname template. | `""` |
+| `active_mode_controller.podAnnotations` | Additional pod annotations. | `{}` |
+| `active_mode_controller.podSecurityContext` | Holds pod-level security attributes. | `{}` |
+| `active_mode_controller.securityContext` | Holds security configuration that will be applied to a container. | `{}` |
+| `active_mode_controller.resources` | Resource requests and limits of Pod. | `{}` |
+| `active_mode_controller.readinessProbe` | Readines probe definition. | `{}` |
+| `active_mode_controller.livenessProbe` | Livenes probe definition. | `{}` |
+| `active_mode_controller.autoscaling.enabled` | Enables horizontal pod autscaler kubernetes resource. | `false` |
+| `active_mode_controller.autoscaling.minReplicas` | Minimum number of dp component replicas. | `1` |
+| `active_mode_controller.autoscaling.maxReplicas` | Maximum number of dp component replicas. | `100` |
+| `active_mode_controller.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization threshold in perecents when new replica should be created | `80` |
+| `active_mode_controller.podDisruptionBudget.enabled` | Creates kubernetes podDisruptionBudget resource. | `false` |
+| `active_mode_controller.podDisruptionBudget.minAvailable` | Minimum available pods for dp component. | `1` |
+| `active_mode_controller.podDisruptionBudget.maxUnavailable` | Maximum unavailable pods for dp component. | `""` |
+| `active_mode_controller.nodeSelector` | Kubernetes node selection constraint. | `{}` |
+| `active_mode_controller.tolerations` | Allow the pods to schedule onto nodes with matching taints. | `[]` |
+| `active_mode_controller.affinity` | Constrain which nodes your pod is eligible to be scheduled on. | `{}` |
+| `db_service.database` |  | `{}` |
+| `db_service.enabled` | Enables deployment of the given service. | `true` |
+| `db_service.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
+| `db_service.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `db_service.name` | Domain proxy component name. | `"db-service"` |
+| `db_service.image.repository` | Docker image repository. | `"db-service"` |
+| `db_service.image.pullPolicy` | Default the pull policy of all containers in that pod. | `"IfNotPresent"` |
+| `db_service.image.tag` | Overrides the image tag whose default is the chart appVersion. | `""` |
+| `db_service.imagePullSecrets` | Name of the secret that contains container image registry keys | `[]` |
+| `db_service.serviceAccount.create` | Specifies whether a service account should be created. | `false` |
+| `db_service.serviceAccount.annotations` | Annotations to add to the service account. | `{}` |
+| `db_service.serviceAccount.name` | The name of the service account to use,If not set and create is true, a name is generated using the fullname template. | `""` |
+
+
+
+---
+_Documentation generated by [Frigate](https://frigate.readthedocs.io)._
+

--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/aws_contour_values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/aws_contour_values.yaml
@@ -1,0 +1,284 @@
+---
+dp:
+  create: true
+  nameOverride: ""
+  fullnameOverride: ""
+
+  configuration_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: configuration-controller
+
+    sasEndpointUrl: "https://fake-sas-service/v1.2"
+
+    image:
+      repository: domainproxyfw1/configuration-controller
+      pullPolicy: IfNotPresent
+      tag: "latest"
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    service:
+      enable: true
+      port: 8080
+
+    tlsConfig:
+      paths:
+        cert: "certificates/configuration_controller/device_c.cert"
+        key: "certificates/configuration_controller/device_c.key"
+        ca: "certificates/configuration_controller/ca.cert"
+
+    ingress:
+      enabled: false
+      annotations: {}
+      hosts: []
+      tls: []
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  protocol_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: protocol-controller
+
+    image:
+      repository: domainproxyfw1/protocol-controller
+      tag: "latest"
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    service:
+      enable: true
+      port: 8080
+
+    tlsConfig:
+      paths:
+        cert: "certificates/protocol_controller/domain_proxy_bundle.cert"
+        key: "certificates/protocol_controller/domain_proxy_server.key"
+        ca: "certificates/protocol_controller/ca.cert"
+
+    apiPrefix: "/sas/v1"
+
+    ingress:
+      enabled: false
+      annotations: {}
+      hosts: []
+      tls: []
+
+    httpproxy:
+      enabled: true
+      annotations: {}
+      virtualhost:
+        fqdn: domain-proxy
+        path: /sas
+        tls:
+          secretName: domain-proxy-pc
+          caSecret: domain-proxy-pc-ca
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  radio_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: radio-controller
+
+    image:
+      repository: domainproxyfw1/radio-controller
+      tag: "latest"
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  active_mode_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: active-mode-controller
+
+    image:
+      repository: active-mode-controller
+      tag: ""
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+    podSecurityContext: {}
+    securityContext: {}
+    resources: {}
+    readinessProbe: {}
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  db_service:
+
+    enabled: true
+    nameOverride: ""
+    fullnameOverride: ""
+    name: db-service
+
+    image:
+      repository: domainproxyfw1/db-service
+      pullPolicy: IfNotPresent
+      tag: "latest"
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      # Specifies whether a service account should be created
+      create: false
+      # Annotations to add to the service account
+      annotations: {}
+      # The name of the service account to use.
+      # If not set and create is true, a name is generated using the fullname template
+      name: ""

--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/aws_nginx_values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/aws_nginx_values.yaml
@@ -1,0 +1,297 @@
+---
+dp:
+  create: true
+  nameOverride: ""
+  fullnameOverride: ""
+
+  configuration_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: configuration-controller
+    sasEndpointUrl: "https://fake-sas-service/v1.2"
+
+    image:
+      repository: domainproxyfw1/configuration-controller
+      pullPolicy: IfNotPresent
+      tag: "latest"
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    service:
+      enable: true
+      port: 8080
+
+    tlsConfig:
+      paths:
+        cert: "certificates/configuration_controller/device_c.cert"
+        key: "certificates/configuration_controller/device_c.key"
+        ca: "certificates/configuration_controller/ca.cert"
+
+    ingress:
+      enabled: false
+      annotations: {}
+      hosts: []
+      tls: []
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  protocol_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: protocol-controller
+
+    imageConfig:
+      pullPolicy: IfNotPresent
+
+    image:
+      repository: domainproxyfw1/protocol-controller
+      tag: "latest"
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    service:
+      enable: true
+      port: 8080
+
+    tlsConfig:
+      paths:
+        cert: "certificates/protocol_controller/domain_proxy_bundle.cert"
+        key: "certificates/protocol_controller/domain_proxy_server.key"
+        ca: "certificates/protocol_controller/ca.cert"
+
+    apiPrefix: "/sas/v1"
+
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+        nginx.ingress.kubernetes.io/auth-tls-secret: "default/domain-proxy-pc-ca"
+        nginx.ingress.kubernetes.io/default-backend: "domain-proxy-protocol-controller"
+        kubernetes.io/ingress.class: "nginx"
+
+      hosts:
+        - host: domain-proxy
+          paths:
+            - path: /sas
+              pathType: ImplementationSpecific
+      tls:
+        - secretName: domain-proxy-pc
+          hosts:
+            - domain-proxy
+
+    httpproxy:
+      enabled: false
+      annotations: {}
+      virtualhost: {}
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  radio_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: radio-controller
+
+    imageConfig:
+      pullPolicy: IfNotPresent
+
+    image:
+      repository: domainproxyfw1/radio-controller
+      tag: "latest"
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+
+  active_mode_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: active-mode-controller
+
+    image:
+      repository: active-mode-controller
+      tag: ""
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+    podSecurityContext: {}
+    securityContext: {}
+    resources: {}
+    readinessProbe: {}
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  db_service:
+
+    enabled: true
+    nameOverride: ""
+    fullnameOverride: ""
+    name: db-service
+
+    image:
+      repository: domainproxyfw1/db-service
+      pullPolicy: IfNotPresent
+      tag: ""
+
+    extraEnv: {}
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      # Specifies whether a service account should be created
+      create: false
+      # Annotations to add to the service account
+      annotations: {}
+      # The name of the service account to use.
+      # If not set and create is true, a name is generated using the fullname template
+      name: ""

--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/minikube_values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/minikube_values.yaml
@@ -1,0 +1,301 @@
+---
+dp:
+  create: true
+  nameOverride: ""
+  fullnameOverride: ""
+
+  configuration_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: configuration-controller
+    sasEndpointUrl: "https://fake-sas-service/v1.2"
+
+    database: {}
+
+    image:
+      repository: configuration-controller
+      pullPolicy: IfNotPresent
+      tag: ""
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    extraEnv: {}
+
+    service:
+      enable: true
+      port: 8080
+
+    tlsConfig:
+      paths:
+        cert: "certificates/configuration_controller/device_c.cert"
+        key: "certificates/configuration_controller/device_c.key"
+        ca: "certificates/configuration_controller/ca.cert"
+
+    ingress:
+      enabled: false
+      annotations: {}
+      hosts: []
+      tls: []
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  protocol_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: protocol-controller
+
+    image:
+      repository: protocol-controller
+      tag: ""
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    extraEnv: {}
+
+    service:
+      enable: true
+      port: 8080
+
+    tlsConfig:
+      paths:
+        cert: "certificates/protocol_controller/domain_proxy_bundle.cert"
+        key: "certificates/protocol_controller/domain_proxy_server.key"
+        ca: "certificates/protocol_controller/ca.cert"
+
+    apiPrefix: "/sas/v1"
+
+    ingress:
+      enabled: false
+      annotations: {}
+      hosts: []
+      tls: []
+
+    httpproxy:
+      enabled: true
+      annotations: {}
+      virtualhost:
+        fqdn: domain-proxy
+        path: "/sas/v1"
+        tls: {}
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  radio_controller:
+
+    database: {}
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: radio-controller
+
+    image:
+      repository: radio-controller
+      tag: ""
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    extraEnv: {}
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  active_mode_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: active-mode-controller
+
+    image:
+      repository: active-mode-controller
+      tag: ""
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+    podSecurityContext: {}
+    securityContext: {}
+
+    extraEnv: {}
+    resources: {}
+    readinessProbe: {}
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  db_service:
+
+    database: {}
+
+    enabled: true
+    nameOverride: ""
+    fullnameOverride: ""
+    name: db-service
+
+    image:
+      repository: db-service
+      pullPolicy: IfNotPresent
+      tag: ""
+
+    extraEnv: {}
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      # Specifies whether a service account should be created
+      create: false
+      # Annotations to add to the service account
+      annotations: {}
+      # The name of the service account to use.
+      # If not set and create is true, a name is generated using the fullname template
+      name: ""

--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/minikube_values_nginx.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/minikube_values_nginx.yaml
@@ -1,0 +1,286 @@
+---
+dp:
+  create: true
+  nameOverride: ""
+  fullnameOverride: ""
+
+  configuration_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: configuration-controller
+    sasEndpointUrl: "https://fake-sas-service/v1.2"
+
+    image:
+      repository: configuration-controller
+      pullPolicy: IfNotPresent
+      tag: ""
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    service:
+      enable: true
+      port: 8080
+
+    tlsConfig:
+      paths:
+        cert: "certificates/configuration_controller/device_c.cert"
+        key: "certificates/configuration_controller/device_c.key"
+        ca: "certificates/configuration_controller/ca.cert"
+
+    ingress:
+      enabled: false
+      annotations: {}
+      hosts: []
+      tls: []
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  protocol_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: protocol-controller
+
+    image:
+      repository: protocol-controller
+      tag: ""
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    service:
+      enable: true
+      port: 8080
+
+    tlsConfig:
+      paths:
+        cert: "certificates/protocol_controller/domain_proxy_bundle.cert"
+        key: "certificates/protocol_controller/domain_proxy_server.key"
+        ca: "certificates/protocol_controller/ca.cert"
+
+    apiPrefix: "/sas/v1"
+
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+        nginx.ingress.kubernetes.io/default-backend: "domain-proxy-protocol-controller"
+        kubernetes.io/ingress.class: "nginx"
+      hosts:
+        - host: domain-proxy
+          paths:
+            - path: /sas/v1
+              pathType: ImplementationSpecific
+
+    httpproxy:
+      enabled: false
+      annotations: {}
+      virtualhost: {}
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  radio_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: radio-controller
+
+    image:
+      repository: radio-controller
+      tag: ""
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+
+    podSecurityContext: {}
+
+    securityContext: {}
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+    readinessProbe: {}
+
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+    nodeSelector: {}
+
+    tolerations: []
+
+    affinity: {}
+
+  active_mode_controller:
+
+    nameOverride: ""
+    fullnameOverride: ""
+    enabled: true
+    name: active-mode-controller
+
+    image:
+      repository: active-mode-controller
+      tag: ""
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podAnnotations: {}
+    podSecurityContext: {}
+    securityContext: {}
+    resources: {}
+    readinessProbe: {}
+    livenessProbe: {}
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+
+    podDisruptionBudget:
+      enabled: false
+      minAvailable: 1
+      maxUnavailable: ""
+
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  db_service:
+
+    enabled: true
+    nameOverride: ""
+    fullnameOverride: ""
+    name: db-service
+
+    image:
+      repository: db-service
+      pullPolicy: IfNotPresent
+      tag: ""
+
+    imagePullSecrets: []
+
+    serviceAccount:
+      # Specifies whether a service account should be created
+      create: false
+      # Annotations to add to the service account
+      annotations: {}
+      # The name of the service account to use.
+      # If not set and create is true, a name is generated using the fullname template
+      name: ""

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/NOTES.txt
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/NOTES.txt
@@ -1,0 +1,9 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/_helpers.tpl
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/_helpers.tpl
@@ -1,0 +1,309 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "domain-proxy.name" -}}
+{{- default .Chart.Name .Values.dp.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "domain-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Match labels
+*/}}
+{{- define "domain-proxy.common.matchLabels" -}}
+app.kubernetes.io/name: {{ include "domain-proxy.name" . }}
+app.kubernetes.io/release: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Meta labels
+*/}}
+{{- define "domain-proxy.common.metaLabels" -}}
+helm.sh/chart: {{ include "domain-proxy.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Configuration controller match labels
+*/}}
+{{- define "domain-proxy.configuration_controller.matchLabels" -}}
+component: {{ .Values.dp.configuration_controller.name | quote }}
+{{ include "domain-proxy.common.matchLabels" . }}
+{{- end -}}
+
+{{/*
+Configuration controller labels
+*/}}
+{{- define "domain-proxy.configuration_controller.labels" -}}
+{{ include "domain-proxy.configuration_controller.matchLabels" . }}
+{{ include "domain-proxy.common.metaLabels" . }}
+{{- end -}}
+
+{{/*
+Active mode controller match labels
+*/}}
+{{- define "domain-proxy.active_mode_controller.matchLabels" -}}
+component: {{ .Values.dp.active_mode_controller.name | quote }}
+{{ include "domain-proxy.common.matchLabels" . }}
+{{- end -}}
+
+{{/*
+Active mode controller labels
+*/}}
+{{- define "domain-proxy.active_mode_controller.labels" -}}
+{{ include "domain-proxy.active_mode_controller.matchLabels" . }}
+{{ include "domain-proxy.common.metaLabels" . }}
+{{- end -}}
+
+{{/*
+Protocol controller match labels
+*/}}
+{{- define "domain-proxy.protocol_controller.matchLabels" -}}
+component: {{ .Values.dp.protocol_controller.name | quote }}
+{{ include "domain-proxy.common.matchLabels" . }}
+{{- end -}}
+
+{{/*
+Protocol controller labels
+*/}}
+{{- define "domain-proxy.protocol_controller.labels" -}}
+{{ include "domain-proxy.protocol_controller.matchLabels" . }}
+{{ include "domain-proxy.common.metaLabels" . }}
+{{- end -}}
+
+{{/*
+Radio controller match labels
+*/}}
+{{- define "domain-proxy.radio_controller.matchLabels" -}}
+component: {{ .Values.dp.radio_controller.name | quote }}
+{{ include "domain-proxy.common.matchLabels" . }}
+{{- end -}}
+
+{{/*
+Radio controller labels
+*/}}
+{{- define "domain-proxy.radio_controller.labels" -}}
+{{ include "domain-proxy.radio_controller.matchLabels" . }}
+{{ include "domain-proxy.common.metaLabels" . }}
+{{- end -}}
+
+{{/*
+DB service labels
+*/}}
+{{- define "domain-proxy.db_service.labels" -}}
+{{ include "domain-proxy.common.metaLabels" . }}
+{{- end -}}
+
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "domain-proxy.fullname" -}}
+{{- if .Values.dp.fullnameOverride }}
+{{- .Values.dp.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.dp.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Create a fully qualified configuration_controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "domain-proxy.configuration_controller.fullname" -}}
+{{- if .Values.dp.configuration_controller.fullnameOverride -}}
+{{- .Values.dp.configuration_controller.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.dp.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.dp.configuration_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.dp.configuration_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified protocol_controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "domain-proxy.protocol_controller.fullname" -}}
+{{- if .Values.dp.protocol_controller.fullnameOverride -}}
+{{- .Values.dp.protocol_controller.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.dp.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.dp.protocol_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.dp.protocol_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified radio_controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "domain-proxy.radio_controller.fullname" -}}
+{{- if .Values.dp.radio_controller.fullnameOverride -}}
+{{- .Values.dp.radio_controller.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.dp.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.dp.radio_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.dp.radio_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified db_service name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "domain-proxy.db_service.fullname" -}}
+{{- if .Values.dp.db_service.fullnameOverride -}}
+{{- .Values.dp.db_service.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.dp.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.dp.db_service.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.dp.db_service.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified active_mode_controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "domain-proxy.active_mode_controller.fullname" -}}
+{{- if .Values.dp.active_mode_controller.fullnameOverride -}}
+{{- .Values.dp.active_mode_controller.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.dp.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.dp.active_mode_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.dp.active_mode_controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "domain-proxy.deployment.apiVersion" -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "domain-proxy.ingress.apiVersion" -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for job.
+*/}}
+{{- define "domain-proxy.job.apiVersion" -}}
+{{- print "batch/v1" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for HTTPProxy.
+*/}}
+{{- define "httpproxy.apiVersion" -}}
+{{- print "projectcontour.io/v1" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for configuration controller
+*/}}
+{{- define "domain-proxy.configuration_controller.serviceAccountName" -}}
+{{- if .Values.dp.configuration_controller.serviceAccount.create }}
+{{- default (include "domain-proxy.fullname" .) .Values.dp.configuration_controller.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.dp.configuration_controller.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for protocol controller
+*/}}
+{{- define "domain-proxy.protocol_controller.serviceAccountName" -}}
+{{- if .Values.dp.protocol_controller.serviceAccount.create }}
+{{- default (include "domain-proxy.fullname" .) .Values.dp.protocol_controller.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.dp.protocol_controller.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for radio controller
+*/}}
+{{- define "domain-proxy.radio_controller.serviceAccountName" -}}
+{{- if .Values.dp.radio_controller.serviceAccount.create }}
+{{- default (include "domain-proxy.fullname" .) .Values.dp.radio_controller.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.dp.radio_controller.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for db service
+*/}}
+{{- define "domain-proxy.db_service.serviceAccountName" -}}
+{{- if .Values.dp.db_service.serviceAccount.create }}
+{{- default (include "domain-proxy.fullname" .) .Values.dp.db_service.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.dp.db_service.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for active mode controller
+*/}}
+{{- define "domain-proxy.active_mode_controller.serviceAccountName" -}}
+{{- if .Values.dp.active_mode_controller.serviceAccount.create }}
+{{- default (include "domain-proxy.fullname" .) .Values.dp.active_mode_controller.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.dp.active_mode_controller.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Define the domain-proxy.namespace template
+*/}}
+{{- define "domain-proxy.namespace" -}}
+{{ printf "namespace: %s" .Release.Namespace }}
+{{- end -}}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/active_mode_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/active_mode_controller/deployment.yaml
@@ -1,0 +1,80 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- if and .Values.dp.create .Values.dp.active_mode_controller.enabled -}}
+apiVersion: {{ template "domain-proxy.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "domain-proxy.active_mode_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.active_mode_controller.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.dp.active_mode_controller.autoscaling.enabled }}
+  replicas: {{ .Values.dp.active_mode_controller.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.active_mode_controller.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.dp.active_mode_controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "domain-proxy.active_mode_controller.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.dp.active_mode_controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "domain-proxy.active_mode_controller.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.dp.active_mode_controller.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.dp.active_mode_controller.name }}
+          securityContext:
+            {{- toYaml .Values.dp.active_mode_controller.securityContext | nindent 12 }}
+          image: {{ .Values.dp.active_mode_controller.image.repository -}}:{{- .Values.dp.active_mode_controller.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.dp.active_mode_controller.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.dp.active_mode_controller.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+          envFrom:
+          - configMapRef:
+              name: {{ include "domain-proxy.configuration_controller.fullname" . }}-common
+          {{- if .Values.dp.active_mode_controller.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.dp.active_mode_controller.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dp.active_mode_controller.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.dp.active_mode_controller.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.dp.active_mode_controller.resources | nindent 12 }}
+      {{- with .Values.dp.active_mode_controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dp.active_mode_controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dp.active_mode_controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/active_mode_controller/hpa.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/active_mode_controller/hpa.yaml
@@ -1,0 +1,43 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- if and .Values.dp.create .Values.dp.active_mode_controller.enabled -}}
+{{- if .Values.dp.active_mode_controller.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "domain-proxy.active_mode_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.active_mode_controller.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "domain-proxy.active_mode_controller.fullname" . }}
+  minReplicas: {{ .Values.dp.active_mode_controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.dp.active_mode_controller.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.dp.active_mode_controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.dp.active_mode_controller.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.dp.active_mode_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.dp.active_mode_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/active_mode_controller/pdb.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/active_mode_controller/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.dp.create .Values.dp.active_mode_controller.enabled .Values.dp.active_mode_controller.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "domain-proxy.active_mode_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.active_mode_controller.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.dp.active_mode_controller.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.dp.active_mode_controller.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.active_mode_controller.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/active_mode_controller/serviceaccount.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/active_mode_controller/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.dp.create .Values.dp.active_mode_controller.enabled -}}
+{{- if .Values.dp.active_mode_controller.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "domain-proxy.serviceAccountName.active_mode_controller" . }}
+  labels:
+    {{- include "domain-proxy.active_mode_controller.labels" . | nindent 4 }}
+  {{- with .Values.dp.active_mode_controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/ca.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/ca.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.dp.create -}}
+{{- $fullName := include "domain-proxy.fullname" . -}}
+{{- $secret := printf "%s-%s" $fullName "cc-ca" -}}
+{{- if not (lookup "v1" "Secret" .Release.Namespace $secret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-cc-ca
+type: Opaque
+data:
+{{- $pathca := printf "%s" .Values.dp.configuration_controller.tlsConfig.paths.ca }}
+  ca.crt: |
+{{ (.Files.Get $pathca) | b64enc | indent 4 }}
+{{- end -}}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/ccm.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/ccm.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.dp.create .Values.dp.configuration_controller.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{-  include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}-common
+{{ include "domain-proxy.namespace" . | indent 2 }}
+data:
+{{- if .Values.dp.configuration_controller.requestProcessingInterval }}
+  REQUEST_PROCESSING_INTERVAL_SEC: {{ quote .Values.dp.configuration_controller.requestProcessingInterval }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/cm.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/cm.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.dp.create .Values.dp.configuration_controller.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{-  include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+{{ include "domain-proxy.namespace" . | indent 2 }}
+data:
+{{- if .Values.dp.configuration_controller.sasEndpointUrl }}
+  SAS_URL: {{ .Values.dp.configuration_controller.sasEndpointUrl }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/deployment.yaml
@@ -1,0 +1,81 @@
+{{- if and .Values.dp.create .Values.dp.configuration_controller.enabled -}}
+apiVersion: {{ template "domain-proxy.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.dp.configuration_controller.autoscaling.enabled }}
+  replicas: {{ .Values.dp.configuration_controller.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.configuration_controller.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.dp.configuration_controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "domain-proxy.configuration_controller.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.dp.configuration_controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "domain-proxy.configuration_controller.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.dp.configuration_controller.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.dp.configuration_controller.name }}
+          image: {{ .Values.dp.configuration_controller.image.repository -}}:{{- .Values.dp.configuration_controller.image.tag | default .Chart.AppVersion  }}
+          imagePullPolicy: {{ .Values.dp.configuration_controller.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.dp.configuration_controller.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+          {{- if .Values.dp.configuration_controller.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.dp.configuration_controller.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dp.configuration_controller.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.dp.configuration_controller.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.dp.configuration_controller.resources | nindent 12 }}
+          volumeMounts:
+            - name: tls
+              mountPath: /backend/configuration_controller/certs
+              readOnly: true
+          envFrom:
+          - configMapRef:
+              name: {{ include "domain-proxy.configuration_controller.fullname" . }}-common
+          - configMapRef:
+              name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+          - secretRef:
+              name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+      volumes:
+        - name: tls
+          projected:
+            sources:
+            - secret:
+                name: {{ include "domain-proxy.fullname" . -}}-cc
+            - secret:
+                name: {{ include "domain-proxy.fullname" . -}}-cc-ca
+      {{- with .Values.dp.configuration_controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dp.configuration_controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dp.configuration_controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/hpa.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.dp.create .Values.dp.configuration_controller.autoscaling.enabled  .Values.dp.configuration_controller.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  minReplicas: {{ .Values.dp.configuration_controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.dp.configuration_controller.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.dp.configuration_controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.dp.configuration_controller.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.dp.configuration_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.dp.configuration_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/ingress.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.dp.create .Values.dp.configuration_controller.ingress.enabled -}}
+{{- $fullName := include "domain-proxy.configuration_controller.fullname" . -}}
+{{- $svcPort := .Values.dp.configuration_controller.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: apiVersion: {{ template "domain-proxy.ingress.apiVersion" . }}
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+  {{- with .Values.dp.configuration_controller.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.dp.configuration_controller.ingress.tls }}
+  tls:
+    {{- range .Values.dp.configuration_controller.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.dp.configuration_controller.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/pdb.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.dp.create .Values.dp.configuration_controller.enabled .Values.dp.configuration_controller.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.dp.configuration_controller.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.dp.configuration_controller.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.configuration_controller.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/secret.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/secret.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.dp.create .Values.dp.configuration_controller.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  labels:
+    {{-  include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.dp.configuration_controller.database }}
+  {{- with .Values.dp.configuration_controller.database }}
+  {{ if eq .driver "postgres" }}
+  SQLALCHEMY_DB_URI: {{ printf "postgresql+psycopg2://%s:%s@%s:%d/%s" .user .pass .host (.port | int) .db | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/service.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/service.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.dp.create .Values.dp.configuration_controller.service.enable -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "domain-proxy.configuration_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: {{ .Values.dp.configuration_controller.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "domain-proxy.configuration_controller.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/serviceaccount.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.dp.create .Values.dp.configuration_controller.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "domain-proxy.serviceAccountName.configuration_controller" . }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+  {{- with .Values.dp.configuration_controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/tls.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/tls.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.dp.create -}}
+{{- $fullName := include "domain-proxy.fullname" . -}}
+{{- $secret := printf "%s-%s" $fullName "cc" -}}
+{{- if not (lookup "v1" "Secret" .Release.Namespace $secret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-cc
+type: kubernetes.io/tls
+data:
+{{- $pathcrt := printf "%s" .Values.dp.configuration_controller.tlsConfig.paths.cert }}
+{{- $pathkey := printf "%s" .Values.dp.configuration_controller.tlsConfig.paths.key }}
+  tls.crt: |
+{{ (.Files.Get $pathcrt) | b64enc | indent 4 }}
+  tls.key: |
+{{ (.Files.Get $pathkey) | b64enc | indent 4 }}
+{{- end -}}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/db_service/job.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/db_service/job.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.dp.create .Values.dp.db_service.enabled -}}
+apiVersion: {{ template "domain-proxy.job.apiVersion" . }}
+kind: Job
+metadata:
+  name: {{ include "domain-proxy.db_service.fullname" . }}-{{ .Release.Revision }}
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    spec:
+      {{- with .Values.dp.db_service.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "domain-proxy.db_service.serviceAccountName" . }}
+      containers:
+      - name: {{ .Values.dp.db_service.name }}
+        image: {{ .Values.dp.db_service.image.repository -}}:{{- .Values.dp.db_service.image.tag | default .Chart.AppVersion }}
+        env:
+          {{- range $key, $value := .Values.dp.db_service.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value }}
+          {{- end }}
+        envFrom:
+          - secretRef:
+              name: {{ include "domain-proxy.db_service.fullname" . }}
+      restartPolicy: Never
+      initContainers:
+      - name: {{ .Values.dp.db_service.name }}-init
+        image: {{ .Values.dp.db_service.image.repository -}}:{{- .Values.dp.db_service.image.tag | default .Chart.AppVersion }}
+        env:
+          {{- range $key, $value := .Values.dp.db_service.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value }}
+          {{- end }}
+        envFrom:
+          - secretRef:
+              name: {{ include "domain-proxy.db_service.fullname" . }}
+        command: ["alembic"]
+        args: ["upgrade","head"]
+  backoffLimit: 10
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/db_service/secret.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/db_service/secret.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.dp.create .Values.dp.db_service.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "domain-proxy.db_service.fullname" . }}
+  labels:
+    {{-  include "domain-proxy.db_service.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.dp.db_service.database }}
+  {{- with .Values.dp.db_service.database }}
+  {{ if eq .driver "postgres" }}
+  SQLALCHEMY_DB_URI: {{ printf "postgresql+psycopg2://%s:%s@%s:%d/%s" .user .pass .host (.port | int) .db | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/db_service/serviceaccount.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/db_service/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.dp.create .Values.dp.db_service.enabled -}}
+{{- if .Values.dp.db_service.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "domain-proxy.serviceAccountName.db_service" . }}
+  labels:
+    {{- include "domain-proxy.db_service.labels" . | nindent 4 }}
+  {{- with .Values.dp.db_service.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/ca.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/ca.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.dp.create -}}
+{{- $fullName := include "domain-proxy.fullname" . -}}
+{{- if .Values.dp.protocol_controller.tlsConfig.paths.ca -}}
+{{- if (empty (lookup "v1" "Secret" .Release.Namespace "${fullName}-pc-ca")) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-pc-ca
+type: Opaque
+data:
+{{- $pathca := printf "%s" .Values.dp.protocol_controller.tlsConfig.paths.ca }}
+  ca.crt: |
+{{ (.Files.Get $pathca) | b64enc | indent 4 }}
+{{- end }}
+{{- end -}}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/cm.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/cm.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.dp.create -}}
+{{- if .Values.dp.protocol_controller.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{-  include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+  name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+{{ include "domain-proxy.namespace" . | indent 2 }}
+data:
+{{- if .Values.dp.protocol_controller.apiPrefix }}
+  API_PREFIX: {{ .Values.dp.protocol_controller.apiPrefix }}
+{{- end }}
+  GRPC_SERVICE: {{ include "domain-proxy.radio_controller.fullname" . }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/deployment.yaml
@@ -1,0 +1,67 @@
+{{- if and .Values.dp.create .Values.dp.protocol_controller.enabled -}}
+apiVersion: {{ template "domain-proxy.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.dp.protocol_controller.autoscaling.enabled }}
+  replicas: {{ .Values.dp.protocol_controller.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.protocol_controller.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.dp.protocol_controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "domain-proxy.protocol_controller.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.dp.protocol_controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "domain-proxy.protocol_controller.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.dp.protocol_controller.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.dp.protocol_controller.name }}
+          securityContext:
+            {{- toYaml .Values.dp.protocol_controller.securityContext | nindent 12 }}
+          image: {{ .Values.dp.protocol_controller.image.repository -}}:{{- .Values.dp.protocol_controller.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.dp.protocol_controller.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.dp.protocol_controller.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+          {{- if .Values.dp.protocol_controller.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.dp.protocol_controller.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dp.protocol_controller.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.dp.protocol_controller.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.dp.protocol_controller.resources | nindent 12 }}
+          envFrom:
+          - configMapRef:
+              name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+      {{- with .Values.dp.protocol_controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dp.protocol_controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dp.protocol_controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/hpa.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.dp.create .Values.dp.protocol_controller.autoscaling.enabled .Values.dp.protocol_controller.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+  minReplicas: {{ .Values.dp.protocol_controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.dp.protocol_controller.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.dp.protocol_controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.dp.protocol_controller.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.dp.protocol_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.dp.protocol_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/httpproxy.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/httpproxy.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.dp.create .Values.dp.protocol_controller.httpproxy.enabled -}}
+{{- $fullName := include "domain-proxy.protocol_controller.fullname" . -}}
+{{- $svcPort := .Values.dp.protocol_controller.service.port -}}
+{{- $caSecret := printf "%s/%s-pc-ca" .Release.Namespace (include "domain-proxy.fullname" .) -}}
+{{- $tlsSecret := printf "%s-pc" (include "domain-proxy.fullname" .) -}}
+apiVersion: {{ template "httpproxy.apiVersion" . }}
+kind: HTTPProxy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+  {{- with .Values.dp.protocol_controller.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  virtualhost:
+    fqdn: {{ .Values.dp.protocol_controller.httpproxy.virtualhost.fqdn | quote }}
+    tls:
+      secretName: {{ default $tlsSecret .Values.dp.protocol_controller.httpproxy.virtualhost.tls.secretName }}
+      clientValidation:
+      {{- if .Values.dp.protocol_controller.tlsConfig.paths.ca }}
+        caSecret: {{ $caSecret }}
+      {{ else }}
+        caSecret: {{ .Values.dp.protocol_controller.httpproxy.virtualhost.tls.caSecret }}
+      {{- end }}
+  routes:
+    - conditions:
+        - prefix: {{ .Values.dp.protocol_controller.httpproxy.virtualhost.path }}
+      services:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/ingress.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/ingress.yaml
@@ -1,0 +1,56 @@
+{{- if and .Values.dp.create .Values.dp.protocol_controller.ingress.enabled -}}
+{{- $fullName := include "domain-proxy.protocol_controller.fullname" . -}}
+{{- $svcPort := .Values.dp.protocol_controller.service.port -}}
+{{- $caSecret := printf "%s/%s-pc-ca" .Release.Namespace (include "domain-proxy.fullname" .) -}}
+{{- $tlsSecret := printf "%s-pc" (include "domain-proxy.fullname" .) -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: {{ template "domain-proxy.ingress.apiVersion" . }}
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "domain-proxy.configuration_controller.labels" . | nindent 4 }}
+  annotations:
+  {{- if .Values.dp.protocol_controller.tlsConfig.paths.ca }} 
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ $caSecret }}
+  {{- end }}
+  {{- with .Values.dp.protocol_controller.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.dp.protocol_controller.ingress.tls }}
+  tls:
+    {{- range .Values.dp.protocol_controller.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ default $tlsSecret .secretName }}
+    {{- end }}
+  {{ else }}
+  tls:
+    - hosts:
+    {{- range .Values.dp.protocol_controller.ingress.hosts }}
+        - {{ .host | quote }}
+    {{- end }}
+      secretName: {{ default $tlsSecret .secretName }}
+  {{- end }}
+  rules:
+    {{- range .Values.dp.protocol_controller.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/pdb.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.dp.create .Values.dp.protocol_controller.enabled .Values.dp.protocol_controller.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.dp.protocol_controller.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.dp.protocol_controller.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.protocol_controller.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/service.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/service.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.dp.create .Values.dp.protocol_controller.service.enable -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "domain-proxy.protocol_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: {{ .Values.dp.protocol_controller.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "domain-proxy.protocol_controller.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/serviceaccount.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.dp.create .Values.dp.protocol_controller.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "domain-proxy.serviceAccountName.protocol_controller" . }}
+  labels:
+    {{- include "domain-proxy.protocol_controller.labels" . | nindent 4 }}
+  {{- with .Values.dp.protocol_controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/tls.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/tls.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.dp.create -}}
+{{- $fullName := include "domain-proxy.fullname" . -}}
+{{- if .Values.dp.protocol_controller.tlsConfig -}}
+{{- if (empty (lookup "v1" "Secret" .Release.Namespace "${fullName}-pc")) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-pc
+type: kubernetes.io/tls
+data:
+{{- $pathcrt := printf "%s" .Values.dp.protocol_controller.tlsConfig.paths.cert }}
+{{- $pathkey := printf "%s" .Values.dp.protocol_controller.tlsConfig.paths.key }}
+  tls.crt: |
+{{ (.Files.Get $pathcrt) | b64enc | indent 4 }}
+  tls.key: |
+{{ (.Files.Get $pathkey) | b64enc | indent 4 }}
+{{- end }}
+{{- end -}}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/deployment.yaml
@@ -1,0 +1,80 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- if and .Values.dp.create .Values.dp.radio_controller.enabled -}}
+apiVersion: {{ template "domain-proxy.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.dp.radio_controller.autoscaling.enabled }}
+  replicas: {{ .Values.dp.radio_controller.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.radio_controller.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.dp.radio_controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "domain-proxy.radio_controller.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.dp.radio_controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "domain-proxy.radio_controller.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.dp.radio_controller.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.dp.radio_controller.name }}
+          securityContext:
+            {{- toYaml .Values.dp.radio_controller.securityContext | nindent 12 }}
+          image: {{ .Values.dp.radio_controller.image.repository -}}:{{- .Values.dp.radio_controller.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.dp.radio_controller.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.dp.radio_controller.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+          {{- if .Values.dp.radio_controller.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.dp.radio_controller.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dp.radio_controller.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.dp.radio_controller.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.dp.radio_controller.resources | nindent 12 }}
+          envFrom:
+          - secretRef:
+              name: {{ include "domain-proxy.radio_controller.fullname" . }}
+      {{- with .Values.dp.radio_controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dp.radio_controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dp.radio_controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/hpa.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/hpa.yaml
@@ -1,0 +1,43 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- if and .Values.dp.create .Values.dp.radio_controller.enabled -}}
+{{- if .Values.dp.radio_controller.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  minReplicas: {{ .Values.dp.radio_controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.dp.radio_controller.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.dp.radio_controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.dp.radio_controller.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.dp.radio_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.dp.radio_controller.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/orc8r-service.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/orc8r-service.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.dp.create .Values.dp.radio_controller.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Namespace }}-dp-service
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 9180
+      targetPort: 50053
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "domain-proxy.radio_controller.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/pdb.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.dp.create .Values.dp.radio_controller.enabled .Values.dp.radio_controller.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.dp.radio_controller.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.dp.radio_controller.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.radio_controller.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/secret.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/secret.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.dp.create .Values.dp.radio_controller.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  labels:
+    {{-  include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.dp.radio_controller.database }}
+  {{- with .Values.dp.radio_controller.database }}
+  {{ if eq .driver "postgres" }}
+  SQLALCHEMY_DB_URI: {{ printf "postgresql+psycopg2://%s:%s@%s:%d/%s" .user .pass .host (.port | int) .db | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/service.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/service.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.dp.create .Values.dp.radio_controller.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "domain-proxy.radio_controller.fullname" . }}
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 50053
+      targetPort: 50053
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "domain-proxy.radio_controller.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/serviceaccount.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.dp.create .Values.dp.radio_controller.enabled -}}
+{{- if .Values.dp.radio_controller.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "domain-proxy.serviceAccountName.radio_controller" . }}
+  labels:
+    {{- include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+  {{- with .Values.dp.radio_controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/tests/protocol_controller-test.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/tests/protocol_controller-test.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.dp.protocol_controller.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-pc-test"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: {{ .Release.Name }}-pc-test
+      image: curlimages/curl
+      imagePullPolicy: "Always"
+      args:
+        - --silent
+        - http://{{ include "domain-proxy.protocol_controller.fullname" . }}:8080/sas/v1
+  restartPolicy: Never
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/tests/radio_controller-test.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/tests/radio_controller-test.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.dp.radio_controller.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-rc-test"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: {{ .Release.Name }}-rc-test
+      image: subfuzion/netcat
+      imagePullPolicy: "Always"
+      args:
+        - "-zv"
+        - {{ include "domain-proxy.radio_controller.fullname" . }}
+        - "50053"
+  restartPolicy: Never
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/values.yaml
@@ -1,0 +1,444 @@
+# Default values for domain-proxy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+#
+---
+dp:
+  create: true # Deploy Domain Proxy Chart.
+  nameOverride: ""  # Replaces the name of the chart in the `Chart.yaml` file.
+  fullnameOverride: ""  # Completely replaces the helm release generated name.
+
+  configuration_controller:
+
+    sasEndpointUrl: ""  # Endpoint where sas request should be send.
+    requestProcessingInterval: "10" # How often configuration controller will send requests to SAS. In seconds.
+
+    database: {} # Database configuration.
+      #driver: postgres      # postgres
+      #db: dp          # DB Name
+      #host: db
+      #port: 5432
+      #user: postgres
+      #pass: postgres
+
+    nameOverride: ""  # Replaces service part of the dp component deployment name.
+    fullnameOverride: ""  # Completely replaces dp component deployment name.
+    enabled: true  # Enables deployment of the given service.
+    name: configuration-controller  # Domain proxy component name.
+
+    image:
+      repository: configuration-controller  # Docker image repository.
+      pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
+      tag: ""  # Overrides the image tag whose default is the chart appVersion.
+
+    replicaCount: 1  # How many replicas of particular component should be created.
+
+    imagePullSecrets: []  # Name of the secret that contains container image registry keys
+
+    serviceAccount:
+      create: false  # Specifies whether a service account should be created
+      annotations: {}  # Annotations to add to the service account
+      name: ""  # The name of the service account to use,If not set and create is true, a name is generated using the fullname template.
+
+    podAnnotations: {}  # Additional pod annotations
+
+    podSecurityContext: {}  # Holds pod-level security attributes
+    #  fsGroup: 2000
+
+    securityContext: {}  # Holds security configuration that will be applied to a container.
+    #  capabilities:
+    #    drop:
+    #      - ALL
+    #  readOnlyRootFilesystem: true
+    #  runAsNonRoot: true
+    #  runAsUser: 1000
+
+    service:
+      enable: true  # Whether to enable kubernetes service for dp component.
+      port: 8080  # Default port of enabled kubernetes service.
+
+    # If paths are set chart will generate kubernetes Secret resources for ingress. Mutually exclusive with ingress.tls.
+    tlsConfig: {} # tls configuration for communication with SAS.
+      #paths:
+      #  cert: ""  # Client/Server TLS certificate path.
+      #  key: ""  # Client/Server TLS private key path.
+      #  ca: ""  # Certificate Authority certifcate chain path.
+
+    ingress:
+      enabled: false  # Enable kubernetes ingress resource.
+      annotations: {}  # Annotations to kubernetes ingress resource.
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+      hosts: []
+        #- host: chart-example.local  # Host header wildcards for kubernetes ingress resource.
+        #  paths:
+        #    - path: /  # Path header wildcards for kubernetes ingress resource.
+        #      backend:
+        #        serviceName: chart-example.local  # Kubernetes Service resource name where traffic should be passed.
+        #        servicePort: 80  # Kubernetes Service port where traffic should be passed.
+      tls: []  # Kubernetes secret name for tls termination on ingress kubernetes resource.
+      #  - secretName: chart-example-tls
+      #    hosts:
+      #      - chart-example.local
+
+    resources: {}  # Resource requests and limits of Pod.
+    #  We usually recommend not to specify default resources and to leave this as a conscious
+    #  choice for the user. This also increases chances charts run on environments with little
+    #  resources, such as Minikube. If you do want to specify resources, uncomment the following
+    #  lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    #  limits:
+    #    cpu: 100m
+    #    memory: 128Mi
+    #  requests:
+    #    cpu: 100m
+    #    memory: 128Mi
+
+    readinessProbe: {}  # Readines probe definition.
+    #  Example httpGet probe
+    #  httpGet:
+    #    path: /
+    #    port: http
+
+    livenessProbe: {}  # Livenes probe definition.
+    #  Example httpget probe
+    #  httpGet:
+    #    path: /
+    #    port: http
+
+    autoscaling:
+      enabled: false  # Enables horizontal pod autscaler kubernetes resource.
+      minReplicas: 1  # Minimum number of dp component replicas.
+      maxReplicas: 100  # Maximum number of dp component replicas.
+      targetCPUUtilizationPercentage: 80  # Target CPU utilization threshold in perecents when new replica should be created
+      # targetMemoryUtilizationPercentage: 80  # Target CPU utilization threshold in perecents when new replica should be created
+      # You can use one of these
+
+    # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+    podDisruptionBudget:
+      enabled: false  # Creates kubernetes podDisruptionBudget resource.
+      minAvailable: 1  # Minimum available pods for dp component.
+      maxUnavailable: ""  # Maximum unavailable pods for dp component.
+      # You can use either one.
+
+    nodeSelector: {}  # Kubernetes node selection constraint.
+
+    tolerations: []  # Allow the pods to schedule onto nodes with matching taints.
+
+    affinity: {}  # Constrain which nodes your pod is eligible to be scheduled on.
+
+  protocol_controller:
+
+    nameOverride: ""  # Replaces service part of the dp component deployment name.
+    fullnameOverride: ""  # Completely replaces dp component deployment name.
+    enabled: true  # Enables deployment of the given dp component.
+    name: protocol-controller  # Domain proxy component name.
+
+    image:
+      repository: protocol-controller  # Docker image repository.
+      tag: ""  # Overrides the image tag whose default is the chart appVersion.
+      pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
+
+
+    replicaCount: 1  # How many replicas of particular component should be created.
+
+    imagePullSecrets: []  # Name of the secret that contains container image registry keys.
+
+    serviceAccount:
+      create: false  # Specifies whether a service account should be created
+      annotations: {}  # Annotations to add to the service account
+      name: ""  # The name of the service account to use,If not set and create is true, a name is generated using the fullname template.
+
+    podAnnotations: {}  # Additional pod annotations.
+
+    podSecurityContext: {}  # Holds pod-level security attributes.
+    #  fsGroup: 2000
+
+    securityContext: {}  # Holds security configuration that will be applied to a container.
+    #  capabilities:
+    #    drop:
+    #      - ALL
+    #  readOnlyRootFilesystem: true
+    #  runAsNonRoot: true
+    #  runAsUser: 1000
+
+    service:
+      enable: true  # Whether to enable kubernetes service for dp component.
+      port: 8080  # Default port of enabled kubernetes service.
+
+
+    # If paths are set chart will generate kubernetes Secret resources for ingress. Mutually exclusive with ingress.tls.
+    tlsConfig: {}
+      #paths:
+      #  cert: ""  # Client/Server TLS certificate path.
+      #  key: ""  # Client/Server TLS private key path.
+      #  ca: ""  # Certificate Authority certifcate chain path.
+
+    apiPrefix: "/sas/v1"  # Protocol controller URL API prefix.
+
+    # Currently you can choose between standard kubernetes resource and Contour httpproxy CRD.
+    # https://projectcontour.io/docs/v1.16.0/config/fundamentals/
+    ingress:
+      enabled: false  # Enable kubernetes ingress resource.
+      annotations: {}  # Annotations to kubernetes ingress resource.
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+      #
+      hosts: []
+        #- host: chart-example.local  # Host header wildcards for kubernetes ingress resource.
+        #  paths:
+        #    - path: /  # Path header wildcards for kubernetes ingress resource.
+        #      backend:
+        #        serviceName: chart-example.local  # Kubernetes Service resource name where traffic should be passed.
+        #        servicePort: 80  # Kubernetes Service port where traffic should be passed.
+      tls: []  # Kubernetes secret name for tls termination on ingress kubernetes resource.
+      #  - secretName: chart-example-tls
+      #    hosts:
+      #      - chart-example.local
+
+    # Pick either httpproxy orn ingress.
+    httpproxy:
+      enabled: false  # Enables contour httpproxy CRD.
+      annotations: {}  # Aditional annotations.
+      virtualhost: {}
+        #fqdn: chart-example.local  # Host header wildcards for kubernetes ingress resource.
+        #path: /example  # Path header wildcards for kubernetes ingress resource.
+        #tls: {}  # Kubernetes secret name for tls termination on ingress kubernetes resource.
+        # secretName: chart-example-tls
+        # caSecret: chart-example-ca
+
+    resources: {}  # Resource requests and limits of Pod.
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+    readinessProbe: {}  # Readines probe definition.
+    # Example httpGet probe
+    # httpGet:
+    #   path: /
+    #   port: http
+
+    livenessProbe: {}  # Livenes probe definition.
+    # Example httpget probe
+    # httpGet:
+    #   path: /
+    #   port: http
+
+    autoscaling:
+      enabled: false  # Enables horizontal pod autscaler kubernetes resource.
+      minReplicas: 1  # Minimum number of dp component replicas.
+      maxReplicas: 100  # Maximum number of dp component replicas.
+      targetCPUUtilizationPercentage: 80  # Target CPU utilization threshold in perecents when new replica should be created.
+      # targetMemoryUtilizationPercentage: 80 # Target CPU utilization threshold in perecents when new replica should be created.
+      # # You can use one of these.
+
+    # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+    podDisruptionBudget:
+      enabled: false  # Creates kubernetes podDisruptionBudget resource.
+      minAvailable: 1  # Minimum available pods for dp component.
+      maxUnavailable: ""  # Minimum available pods for dp component.
+      # You can use either one.
+
+    nodeSelector: {}  # Kubernetes node selection constraint.
+
+    tolerations: []  # Allow the pods to schedule onto nodes with matching taints.
+
+    affinity: {}  # Constrain which nodes your pod is eligible to be scheduled on.
+
+  radio_controller:
+
+    database: {}
+      #driver: postgres      # postgres
+      #db: dp          # DB Name
+      #host: db
+      #port: 5432
+      #user: postgres
+      #pass: postgres
+
+    nameOverride: ""  # Replaces service part of the dp component deployment name.
+    fullnameOverride: ""  # Completely replaces dp component deployment name.
+    enabled: true  # Enables deployment of the given dp component.
+    name: radio-controller  # Domain proxy component name.
+
+    image:
+      repository: radio-controller  # Docker image repository.
+      tag: ""  # Overrides the image tag whose default is the chart appVersion.
+      pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
+
+    replicaCount: 1  # How many replicas of particular component should be created.
+
+    imagePullSecrets: []  # Name of the secret that contains container image registry keys.
+
+    serviceAccount:
+      create: false  # Specifies whether a service account should be created.
+      annotations: {}  # Annotations to add to the service account.
+      name: ""  # The name of the service account to use,If not set and create is true, a name is generated using the fullname template.
+
+    podAnnotations: {}  # Additional pod annotations.
+
+    podSecurityContext: {}  # Holds pod-level security attributes.
+    # fsGroup: 2000
+
+    securityContext: {}  # Holds security configuration that will be applied to a container.
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+    resources: {}  # Resource requests and limits of Pod.
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+    readinessProbe: {}  # Readines probe definition.
+    # Example httpGet probe
+    # httpGet:
+    #   path: /
+    #   port: http
+
+    livenessProbe: {}  # Livenes probe definition.
+    # Example httpget probe
+    # httpGet:
+    #   path: /
+    #   port: http
+
+    autoscaling:
+      enabled: false  # Enables horizontal pod autscaler kubernetes resource.
+      minReplicas: 1  # Minimum number of dp component replicas.
+      maxReplicas: 100  # Maximum number of dp component replicas.
+      targetCPUUtilizationPercentage: 80  # Target CPU utilization threshold in perecents when new replica should be created
+      # targetMemoryUtilizationPercentage: 80 # Target CPU utilization threshold in perecents when new replica should be created
+      # You can use one of these
+
+    # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+    podDisruptionBudget:
+      enabled: false  # Creates kubernetes podDisruptionBudget resource.
+      minAvailable: 1  # Minimum available pods for dp component.
+      maxUnavailable: ""  # Maximum unavailable pods for dp component.
+      # You can use either one.
+
+    nodeSelector: {}  # Kubernetes node selection constraint.
+
+    tolerations: []  # Allow the pods to schedule onto nodes with matching taints.
+
+    affinity: {}  # Constrain which nodes your pod is eligible to be scheduled on.
+  active_mode_controller:
+
+    nameOverride: ""  # Replaces service part of the dp component deployment name.
+    fullnameOverride: ""  # Completely replaces dp component deployment name.
+    enabled: true  # Enables deployment of the given dp component.
+    name: active-mode-controller  # Domain proxy component name.
+
+    image:
+      repository: active-mode-controller  # Docker image repository.
+      tag: ""  # Overrides the image tag whose default is the chart appVersion.
+      pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
+
+    replicaCount: 1  # How many replicas of particular component should be created.
+
+    imagePullSecrets: []  # Name of the secret that contains container image registry keys.
+
+    serviceAccount:
+      create: false  # Specifies whether a service account should be created.
+      annotations: {}  # Annotations to add to the service account.
+      name: ""  # The name of the service account to use,If not set and create is true, a name is generated using the fullname template.
+
+    podAnnotations: {}  # Additional pod annotations.
+
+    podSecurityContext: {}  # Holds pod-level security attributes.
+    # fsGroup: 2000
+
+    securityContext: {}  # Holds security configuration that will be applied to a container.
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+    resources: {}  # Resource requests and limits of Pod.
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+    readinessProbe: {}  # Readines probe definition.
+    # Example httpGet probe
+    # httpGet:
+    #   path: /
+    #   port: http
+
+    livenessProbe: {}  # Livenes probe definition.
+    # Example httpget probe
+    # httpGet:
+    #   path: /
+    #   port: http
+
+    autoscaling:
+      enabled: false  # Enables horizontal pod autscaler kubernetes resource.
+      minReplicas: 1  # Minimum number of dp component replicas.
+      maxReplicas: 100  # Maximum number of dp component replicas.
+      targetCPUUtilizationPercentage: 80  # Target CPU utilization threshold in perecents when new replica should be created
+      # targetMemoryUtilizationPercentage: 80 # Target CPU utilization threshold in perecents when new replica should be created
+      # You can use one of these
+
+    # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+    podDisruptionBudget:
+      enabled: false  # Creates kubernetes podDisruptionBudget resource.
+      minAvailable: 1  # Minimum available pods for dp component.
+      maxUnavailable: ""  # Maximum unavailable pods for dp component.
+      # You can use either one.
+
+    nodeSelector: {}  # Kubernetes node selection constraint.
+
+    tolerations: []  # Allow the pods to schedule onto nodes with matching taints.
+
+    affinity: {}  # Constrain which nodes your pod is eligible to be scheduled on.
+
+  db_service:
+
+    database: {}
+      #driver: postgres      # postgres
+      #db: dp          # DB Name
+      #host: db
+      #port: 5432
+      #user: postgres
+      #pass: postgres
+
+    enabled: true  # Enables deployment of the given service.
+    nameOverride: ""  # Replaces service part of the dp component deployment name.
+    fullnameOverride: ""  # Completely replaces dp component deployment name.
+    name: db-service  # Domain proxy component name.
+
+    image:
+      repository: db-service  # Docker image repository.
+      pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
+      tag: ""  # Overrides the image tag whose default is the chart appVersion.
+
+    imagePullSecrets: []  # Name of the secret that contains container image registry keys
+
+    serviceAccount:
+      create: false  # Specifies whether a service account should be created.
+      annotations: {}  # Annotations to add to the service account.
+      name: ""  # The name of the service account to use,If not set and create is true, a name is generated using the fullname template.

--- a/dp/skaffold.yaml
+++ b/dp/skaffold.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: skaffold/v2beta23
 kind: Config
 metadata:
@@ -42,7 +43,7 @@ deploy:
         - host:
             command: ["kubectl", "apply", "-f", "./tools/deployment/vendor/postgresql.yml"]
         - host:
-            command: ["kubectl", "rollout", "status", "--watch", "--timeout=600s","statefulset/postgres-database"]
+            command: ["kubectl", "rollout", "status", "--watch", "--timeout=600s", "statefulset/postgres-database"]
     releases:
       - name: domain-proxy
         createNamespace: true
@@ -51,7 +52,6 @@ deploy:
           - ./cloud/helm/dp/charts/domain-proxy/examples/minikube_values.yaml
         namespace: default
         version: "0.1.0"
-        #wait: true
         artifactOverrides:
           dp.active_mode_controller:
             image: active-mode-controller
@@ -91,7 +91,7 @@ profiles:
             configuration_controller:
               extraEnv:
                 APP_CONFIG: "TestConfig"
-                REQUEST_PROCESSING_INTERVAL_SEC: "'1'" # bug in helm: https://github.com/helm/helm/issues/4775
+                REQUEST_PROCESSING_INTERVAL_SEC: "'1'"  #  bug in helm: https://github.com/helm/helm/issues/4775
             radio_controller:
               extraEnv:
                 APP_CONFIG: "TestConfig"

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -229,3 +229,56 @@ nms:
 
 logging:
   enabled: ${enable_logging}
+
+dp:
+  create: ${dp_enabled}
+
+  configuration_controller:
+    sasEndpointUrl: "${dp_sas_endpoint_url}"
+    image:
+      repository: "${docker_registry}/configuration-controller"
+      tag: "${docker_tag}"
+
+    database:
+      driver: postgres
+      db: ${orc8r_db_name}
+      host: ${orc8r_db_host}
+      port: ${orc8r_db_port}
+      user: ${orc8r_db_user}
+      pass: ${orc8r_db_pass}
+
+  protocol_controller:
+    image:
+      repository: "${docker_registry}/protocol-controller"
+      tag: "${docker_tag}"
+
+  radio_controller:
+    image:
+      repository: "${docker_registry}/radio-controller"
+      tag: "${docker_tag}"
+
+    database:
+      driver: postgres
+      db: ${orc8r_db_name}
+      host: ${orc8r_db_host}
+      port: ${orc8r_db_port}
+      user: ${orc8r_db_user}
+      pass: ${orc8r_db_pass}
+
+  active_mode_controller:
+    image:
+      repository: "${docker_registry}/active-mode-controller"
+      tag: "${docker_tag}"
+
+  db_service:
+    image:
+      repository: "${docker_registry}/db-service"
+      tag: "${docker_tag}"
+
+    database:
+      driver: postgres
+      db: ${orc8r_db_name}
+      host: ${orc8r_db_host}
+      port: ${orc8r_db_port}
+      user: ${orc8r_db_user}
+      pass: ${orc8r_db_pass}

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -337,3 +337,7 @@ cloudwatch:
 # logging sub-chart configuration.
 logging:
   enabled: true
+
+# Domain proxy sub-chart configuration. Set true to enable.
+dp:
+  enabled: true

--- a/orc8r/tools/helm/package.sh
+++ b/orc8r/tools/helm/package.sh
@@ -221,6 +221,7 @@ else
     update_and_send_to_artifactory "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"
     update_and_send_to_artifactory "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/"
     update_and_send_to_artifactory "$MAGMA_ROOT/fbinternal/cloud/helm/fbinternal-orc8r/"
+    update_and_send_to_artifactory "$MAGMA_ROOT/dp/cloud/helm/dp/charts/domain-proxy"
   fi
 
   if [[ $ONLY_PACKAGE = false ]]; then


### PR DESCRIPTION
Signed-off-by: Marcin Trojanowski <marcin.trojanowski@freedomfi.com>

[WIP]: Magma Domain Proxy

## Summary
As concluded in https://github.com/magma/magma/pull/10230
This set of PRs is a proposal of a merge of Domain Proxy development into Magma codebase.

As discussed in a community meeting with @talkhasib , @hcgatewood, @jpad-freedomfi, @aswin-alexander, @bbarritt and others, this PR is a first step of discussion on how to include the ongoing development of vendor neutral Domain Proxy code into Magma's codebase.

The PR consists of a few commit's, each commit intended to target a specific section of magma code and its ownership.
Please review and comment if this division makes logical sense. We could either proceed with having one PR with such commits, or we can issue individual PRs per each section/domain.

Currently we have 5 PRs in this set which breaks code in somewhat more reviewable chunks:
1) Helm charts integration - this development has already been reviewed by @hcgatewood 
2) Orchestrator deployment integration
3) Domain Proxy: AGW side - integration with AGW/enodebd (LTE module) based on Baicells 436Q eNB
4) Domain Proxy: ORC8R side - domain proxy microservices that interact with AGW/enodebd and SAS server
5) Github workflows

The Domain Proxy part presented here, with minor alternations done due to rebase onto magmas master, has been fully tested in a local lab - helm, deployment, DProxy in orc8r interface with AGW, Baicells 436Q eNB able to be fully configured.

The code is now capable of acquiring and maintaining a SAS grant on behalf of a Baicells 436Q and fully configure it for transmission via TR069.