### PR TITLE
feat: Magma Domain Proxy - orc8r deploy

### DIFF
--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -804,3 +804,52 @@ service:
     Required: false
     ConfigApps:
       - tf
+  dp_enabled:
+    Description: Whether Orchestrator domain proxy module should be enabled.
+    Type: bool
+    Default: false
+    Required: false
+    ConfigApps:
+      - tf
+  dp_orc8r_chart_version:
+    Description: Version of the Orchestrator domain proxy module Helm chart to install.
+    Type: string
+    Default: 0.1.0
+    Required: false
+    ConfigApps:
+      - tf
+  dp_api_prefix:
+    Description: Protocol controller URL API prefix.
+    Type: string
+    Default: /sas/v1
+    Required: false
+    ConfigApps:
+      - tf
+  dp_sas_endpoint_url:
+    Description: Endpoint where sas request should be send.
+    Type: string
+    Default: ''
+    Required: true
+    ConfigApps:
+      - tf
+  dp_sas_crt:
+    Description: SAS certificate filename.
+    Type: string
+    Default: 'tls.crt'
+    Required: true
+    ConfigApps:
+      - tf
+  dp_sas_key:
+    Description: SAS private key filename.
+    Type: string
+    Default: 'tls.key'
+    Required: true
+    ConfigApps:
+      - tf
+  dp_sas_ca:
+    Description: SAS CA filename.
+    Type: string
+    Default: 'ca.crt'
+    Required: true
+    ConfigApps:
+      - tf

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
@@ -129,16 +129,35 @@ resource "helm_release" "fbinternal-orc8r" {
   }
 }
 
+resource "helm_release" "dp-orc8r" {
+  count = var.orc8r_deployment_type == "all" ? 1 : 0
+
+  name                = "domain-proxy"
+  namespace           = kubernetes_namespace.orc8r.metadata[0].name
+  repository          = var.helm_repo
+  repository_username = var.helm_user
+  repository_password = var.helm_pass
+  chart               = "domain-proxy"
+  version             = var.dp_orc8r_chart_version
+  keyring             = ""
+  timeout             = 600
+  values              = [data.template_file.orc8r_values.rendered]
+
+  set_sensitive {
+    name  = "controller.spec.database.pass"
+    value = var.orc8r_db_pass
+  }
+}
 
 data "template_file" "orc8r_values" {
   template = file("${path.module}/templates/orc8r-values.tpl")
   vars = {
     orc8r_chart_version = var.orc8r_chart_version
-    image_pull_secret = kubernetes_secret.artifactory.metadata.0.name
-    docker_registry   = var.docker_registry
-    docker_tag        = local.orc8r_tag
+    image_pull_secret   = kubernetes_secret.artifactory.metadata.0.name
+    docker_registry     = var.docker_registry
+    docker_tag          = local.orc8r_tag
 
-    magma_uuid = var.magma_uuid
+    magma_uuid     = var.magma_uuid
     certs_secret   = kubernetes_secret.orc8r_certs.metadata.0.name
     configs_secret = kubernetes_secret.orc8r_configs.metadata.0.name
     envdir_secret  = kubernetes_secret.orc8r_envdir.metadata.0.name
@@ -171,7 +190,7 @@ data "template_file" "orc8r_values" {
     orc8r_db_user    = var.orc8r_db_user
     orc8r_db_pass    = var.orc8r_db_pass
 
-    deploy_nms  = var.deploy_nms
+    deploy_nms = var.deploy_nms
 
     metrics_pvc_promcfg  = kubernetes_persistent_volume_claim.storage["promcfg"].metadata.0.name
     metrics_pvc_promdata = kubernetes_persistent_volume_claim.storage["promdata"].metadata.0.name
@@ -188,8 +207,11 @@ data "template_file" "orc8r_values" {
     alertmanager_url          = format("%s-alertmanager:9093", var.helm_deployment_name)
     prometheus_url            = format("%s-prometheus:9090", var.helm_deployment_name)
 
-    prometheus_configurer_version = var.prometheus_configurer_version
+    prometheus_configurer_version   = var.prometheus_configurer_version
     alertmanager_configurer_version = var.alertmanager_configurer_version
+
+    dp_enabled          = var.dp_enabled
+    dp_sas_endpoint_url = var.dp_sas_endpoint_url
 
     thanos_enabled        = var.thanos_enabled
     thanos_bucket         = var.thanos_enabled ? aws_s3_bucket.thanos_object_store_bucket[0].bucket : ""

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
@@ -144,6 +144,31 @@ resource "kubernetes_secret" "fluentd_certs" {
   depends_on = [null_resource.orc8r_seed_secrets]
 }
 
+resource "kubernetes_secret" "dp_sas_certs" {
+  count = var.dp_enabled ? 1 : 0
+  type = "kubernetes.io/tls"
+  metadata {
+    name      = "domain-proxy-cc"
+    namespace = kubernetes_namespace.orc8r.metadata[0].name
+  }
+  data = {
+    "tls.crt" = file("${var.seed_certs_dir}/${var.dp_sas_crt}")
+    "tls.key" = file("${var.seed_certs_dir}/${var.dp_sas_key}")
+  }
+}
+
+resource "kubernetes_secret" "dp_sas_ca" {
+  count = var.dp_enabled ? 1 : 0
+  type = "Opaque"
+  metadata {
+    name      = "domain-proxy-cc-ca"
+    namespace = kubernetes_namespace.orc8r.metadata[0].name
+  }
+  data = {
+    "ca.crt" = file("${var.seed_certs_dir}/${var.dp_sas_ca}")
+  }
+}
+
 data "aws_secretsmanager_secret" "orc8r_secrets" {
   name = var.secretsmanager_orc8r_name
 }

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -248,6 +248,7 @@ dp:
       pass: ${orc8r_db_pass}
 
   protocol_controller:
+    enabled: false
     image:
       repository: "${docker_registry}/protocol-controller"
       tag: "${docker_tag}"

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -209,6 +209,12 @@ variable "wifi_orc8r_chart_version" {
   default     = "0.2.2"
 }
 
+variable "dp_orc8r_chart_version" {
+  description = "Version of the orchestrator domain proxy module Helm chart to install."
+  type        = string
+  default     = "0.1.1"
+}
+
 variable "orc8r_tag" {
   description = "Image tag for Orchestrator components."
   type        = string
@@ -494,4 +500,45 @@ variable "cloudwatch_exporter_enabled" {
   description = "Enable cloudwatch exporter"
   default     = false
   type        = bool
+}
+
+
+##############################################################################
+# Domain proxy variables
+##############################################################################
+
+variable "dp_enabled" {
+  description = "Enable domain proxy"
+  type        = bool
+  default     = false
+}
+
+variable "dp_sas_endpoint_url" {
+  description = "Sas endpoint url where to connect DP to."
+  type        = string
+  default     = ""
+}
+
+variable "dp_api_prefix" {
+  description = "Protocol controller api prefix."
+  type        = string
+  default     = "/sas/v1"
+}
+
+variable "dp_sas_crt" {
+  description = "SAS certificate filename."
+  type        = string
+  default     = "tls.crt"
+}
+
+variable "dp_sas_key" {
+  description = "SAS private key filename."
+  type        = string
+  default     = "tls.key"
+}
+
+variable "dp_sas_ca" {
+  description = "SAS CA filename."
+  type        = string
+  default     = "ca.crt"
 }


### PR DESCRIPTION
Signed-off-by: Marcin Trojanowski <marcin.trojanowski@freedomfi.com>

feat: Magma Domain Proxy

## Summary
As concluded in https://github.com/magma/magma/pull/10230
This set of PRs is a proposal of a merge of Domain Proxy development into Magma codebase.

As discussed in a community meeting with @talkhasib , @hcgatewood, @jpad-freedomfi, @aswin-alexander, @bbarritt and others, this PR is a first step of discussion on how to include the ongoing development of vendor neutral Domain Proxy code into Magma's codebase.

The PR consists of a few commit's, each commit intended to target a specific section of magma code and its ownership.
Please review and comment if this division makes logical sense. We could either proceed with having one PR with such commits, or we can issue individual PRs per each section/domain.

Currently we have 5 PRs in this set which breaks code in somewhat more reviewable chunks:
1) Helm charts integration - this development has already been reviewed by @hcgatewood 
2) Orchestrator deployment integration
3) Domain Proxy: AGW side - integration with AGW/enodebd (LTE module) based on Baicells 436Q eNB
4) Domain Proxy: ORC8R side - domain proxy microservices that interact with AGW/enodebd and SAS server
5) Github workflows

The Domain Proxy part presented here, with minor alternations done due to rebase onto magmas master, has been fully tested in a local lab - helm, deployment, DProxy in orc8r interface with AGW, Baicells 436Q eNB able to be fully configured.

The code is now capable of acquiring and maintaining a SAS grant on behalf of a Baicells 436Q and fully configure it for transmission via TR069.