### PR TITLE
feat: Magma Domain Proxy -  AGW LTE enodebd

### DIFF
--- a/lte/gateway/configs/enodebd.yml
+++ b/lte/gateway/configs/enodebd.yml
@@ -35,6 +35,12 @@ sas:
   sas_location: "indoor"
   sas_height_type: "AMSL"
 
+# primSync determines the primary source for synchronization.
+# Used by FreedomFi One eNB.
+# "GNSS" - When using SAS client in eNB, GPS is used.
+# "FREE_RUNNING" - When using Domain Proxy, GPS is not required.
+prim_src: "GNSS"
+
 # Reboot eNodeB if eNodeB should be connected to MME but isn't
 # This is a workaround for a bug with BaiCells eNodeB where the S1 connection
 # gets into a bad state

--- a/lte/gateway/python/defs.mk
+++ b/lte/gateway/python/defs.mk
@@ -10,7 +10,7 @@
 # limitations under the License.
 #
 PYTHON_SRCS=$(MAGMA_ROOT)/lte/gateway/python $(MAGMA_ROOT)/orc8r/gateway/python
-PROTO_LIST:=orc8r_protos lte_protos feg_protos
+PROTO_LIST:=orc8r_protos lte_protos feg_protos dp_protos
 SWAGGER_LIST:=lte_swagger_specs orc8r_swagger_specs
 
 # Path to the test files

--- a/lte/gateway/python/magma/enodebd/data_models/data_model_parameters.py
+++ b/lte/gateway/python/magma/enodebd/data_models/data_model_parameters.py
@@ -45,6 +45,8 @@ class ParameterName():
     UL_BANDWIDTH = 'UL bandwidth'
     SUBFRAME_ASSIGNMENT = 'Subframe assignment'
     SPECIAL_SUBFRAME_PATTERN = 'Special subframe pattern'
+    POWER_SPECTRAL_DENSITY = 'Power Spectral Density'
+    RADIO_ENABLE = "Radio Enable"
 
     # Other LTE parameters
     ADMIN_STATE = 'Admin state'
@@ -84,6 +86,11 @@ class ParameterName():
     PERF_MGMT_UPLOAD_URL = 'Perf mgmt upload URL'
     PERF_MGMT_USER = 'Perf mgmt username'
     PERF_MGMT_PASSWORD = 'Perf mgmt password'
+
+    SAS_ENABLED = 'SAS enabled'
+    SAS_FCC_ID = 'SAS FCC ID'
+    SAS_USER_ID = 'SAS User ID'
+    SAS_RADIO_ENABLE = 'SAS Radio Enable'
 
 
 class TrParameterType():

--- a/lte/gateway/python/magma/enodebd/device_config/cbrs_consts.py
+++ b/lte/gateway/python/magma/enodebd/device_config/cbrs_consts.py
@@ -1,0 +1,19 @@
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+SAS_MIN_POWER_SPECTRAL_DENSITY = -137
+SAS_MAX_POWER_SPECTRAL_DENSITY = 37
+BAND = 48
+BAND48_NOFFS_DL = 55240
+BAND48_LOW_FREQ_MHZ = 3550
+SAS_BANDWIDTHS = (5, 10, 15, 20)

--- a/lte/gateway/python/magma/enodebd/device_config/configuration_util.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_util.py
@@ -10,9 +10,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from bisect import bisect_right
 from typing import NamedTuple, Optional
 
 from lte.protos.mconfig.mconfigs_pb2 import EnodebD
+from magma.enodebd.device_config.cbrs_consts import (
+    BAND48_LOW_FREQ_MHZ,
+    BAND48_NOFFS_DL,
+    SAS_BANDWIDTHS,
+)
+from magma.enodebd.exceptions import ConfigurationError
 
 EnodebConfig = NamedTuple(
     'EnodebConfig', [
@@ -23,45 +30,121 @@ EnodebConfig = NamedTuple(
 
 
 def get_enb_rf_tx_desired(mconfig: EnodebD, enb_serial: str) -> bool:
-    """ True if the mconfig specifies to enable transmit on the eNB """
+    """
+    Get transmit enabled for eNB.
+
+    Args:
+        mconfig: enodebd mconfig
+        enb_serial: eNB serial number
+
+    Raises:
+        KeyError: when eNB is missing from enodebd mconfig
+
+    Returns:
+        True if the mconfig specifies to enable transmit on the eNB
+    """
+    mconfig_serials_no = len(mconfig.enb_configs_by_serial)
     if mconfig.enb_configs_by_serial is not None and \
-            len(mconfig.enb_configs_by_serial) > 0:
+            mconfig_serials_no > 0:
         if enb_serial in mconfig.enb_configs_by_serial:
-            enb_config = mconfig.enb_configs_by_serial[enb_serial]
+            enb_config = mconfig.enb_configs_by_serial.get(enb_serial)
             return enb_config.transmit_enabled
-        else:
-            raise KeyError('Missing eNB from mconfig: %s' % enb_serial)
+        raise KeyError('Missing eNB from mconfig: %s' % enb_serial)
     return mconfig.allow_enodeb_transmit
 
 
 def is_enb_registered(mconfig: EnodebD, enb_serial: str) -> bool:
     """
-    True if either:
-        - the eNodeB is registered by serial to the Access Gateway
-        or
-        - the Access Gateway accepts all eNodeB devices
+    Check if enb is known to enodebd.
+
+    Args:
+        mconfig: enodebd mconfig
+        enb_serial: eNB serial number
+
+    Returns:
+        True if either:
+            - the eNodeB is registered by serial to the Access Gateway
+            or
+            - the Access Gateway accepts all eNodeB devices
     """
+    mconfig_serials_no = len(mconfig.enb_configs_by_serial)
     if mconfig.enb_configs_by_serial is not None and \
-            len(mconfig.enb_configs_by_serial) > 0:
-        if enb_serial in mconfig.enb_configs_by_serial:
-            return True
-        else:
-            return False
+            mconfig_serials_no > 0:
+        return enb_serial in mconfig.enb_configs_by_serial
     return True
 
 
 def find_enb_by_cell_id(mconfig: EnodebD, cell_id: int) \
         -> Optional[EnodebConfig]:
     """
-    Returns eNB config if:
-        - the eNodeB is registered by serial to the Access Gateway
-        - cell ID is found in eNB status by serial
-    else: returns None
+    Find eNB by Cell ID
+
+    Args:
+        mconfig: enodebd mconfig
+        cell_id: Cell ID
+
+    Returns:
+        eNB config if:
+            - the eNodeB is registered by serial to the Access Gateway
+            - cell ID is found in eNB status by serial
+        else: returns None
     """
+    mconfig_serials_no = len(mconfig.enb_configs_by_serial)
     if mconfig.enb_configs_by_serial is not None and \
-            len(mconfig.enb_configs_by_serial) > 0:
+            mconfig_serials_no > 0:
         for sn, enb in mconfig.enb_configs_by_serial.items():
             if cell_id == enb.cell_id:
                 config = EnodebConfig(serial_num=sn, config=enb)
                 return config
     return None
+
+
+def calc_bandwidth_mhz(low_freq_hz: int, high_freq_hz: int) -> float:
+    """
+    Calculate bandwidth in mhz for CBRS
+
+    Args:
+        low_freq_hz: int, Low frequency limit taken from available channel
+        high_freq_hz: int, High frequency limit taken from available channel
+
+    Returns:
+        Bandwidth in mhz
+
+    Raises:
+        ConfigurationError: if bandwidth is not supported by the device
+    """
+    bandwidth_mhz = (high_freq_hz - low_freq_hz) / 1e6
+    i = bisect_right(SAS_BANDWIDTHS, bandwidth_mhz)
+    if not i:
+        raise ConfigurationError('Unknown/unsupported bandwidth specification (%f)' % bandwidth_mhz)
+    return SAS_BANDWIDTHS[i - 1]
+
+
+def calc_bandwidth_rbs(bandwidth_mhz: float) -> str:
+    """
+    Convert bandwidth in mhz to rbs
+
+    Args:
+        bandwidth_mhz: float, Bandwidth in mhz
+
+    Returns:
+        Bandwidth in rbs
+    """
+    bandwidth_rbs = int(5 * bandwidth_mhz)
+    return str(bandwidth_rbs)
+
+
+def calc_earfcn(low_freq_hz: int, high_freq_hz: int) -> int:
+    """
+    Calculate EARFCN in mhz for CBRS
+
+    Args:
+        low_freq_hz: int, Low frequency limit taken from available channel
+        high_freq_hz: int, High frequency limit taken from available channel
+
+    Returns:
+        EARFCN in mhz
+    """
+    mid_frequency_mhz = (high_freq_hz + low_freq_hz) / 2e6
+    earfcn = 10 * (mid_frequency_mhz - BAND48_LOW_FREQ_MHZ) + BAND48_NOFFS_DL
+    return int(earfcn)

--- a/lte/gateway/python/magma/enodebd/device_config/enodeb_configuration.py
+++ b/lte/gateway/python/magma/enodebd/device_config/enodeb_configuration.py
@@ -158,4 +158,4 @@ class EnodebConfiguration():
         tr_param = trparam_model.get_parameter(param_name)
         if tr_param is None:
             logger.warning('Parameter <%s> not defined in model', param_name)
-            raise ConfigurationError("Parameter not defined in model.")
+            raise ConfigurationError(f"Parameter not defined in model: {param_name}")

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qrtb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qrtb.py
@@ -1,0 +1,767 @@
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from typing import Any, Callable, Dict, List, Optional
+
+from dp.protos.enodebd_dp_pb2 import CBSDRequest, CBSDStateResult
+from magma.common.service import MagmaService
+from magma.enodebd.data_models import transform_for_magma
+from magma.enodebd.data_models.data_model import DataModel, TrParam
+from magma.enodebd.data_models.data_model_parameters import (
+    ParameterName,
+    TrParameterType,
+)
+from magma.enodebd.device_config.cbrs_consts import (
+    BAND,
+    SAS_MAX_POWER_SPECTRAL_DENSITY,
+    SAS_MIN_POWER_SPECTRAL_DENSITY,
+)
+from magma.enodebd.device_config.configuration_util import (
+    calc_bandwidth_mhz,
+    calc_bandwidth_rbs,
+    calc_earfcn,
+)
+from magma.enodebd.device_config.enodeb_config_postprocessor import (
+    EnodebConfigurationPostProcessor,
+)
+from magma.enodebd.device_config.enodeb_configuration import EnodebConfiguration
+from magma.enodebd.devices.device_utils import EnodebDeviceName
+from magma.enodebd.dp_client import get_cbsd_state
+from magma.enodebd.exceptions import ConfigurationError
+from magma.enodebd.logger import EnodebdLogger
+from magma.enodebd.state_machines.acs_state_utils import process_inform_message
+from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
+from magma.enodebd.state_machines.enb_acs_impl import BasicEnodebAcsStateMachine
+from magma.enodebd.state_machines.enb_acs_states import (
+    AcsMsgAndTransition,
+    AcsReadMsgResult,
+    AddObjectsState,
+    DeleteObjectsState,
+    EnbSendRebootState,
+    EnodebAcsState,
+    ErrorState,
+    GetObjectParametersState,
+    GetParametersState,
+    NotifyDPState,
+    SendGetTransientParametersState,
+    SetParameterValuesState,
+    WaitEmptyMessageState,
+    WaitGetObjectParametersState,
+    WaitGetParametersState,
+    WaitGetTransientParametersState,
+    WaitInformMRebootState,
+    WaitInformState,
+    WaitRebootResponseState,
+    WaitSetParameterValuesState,
+)
+from magma.enodebd.state_machines.timer import StateMachineTimer
+from magma.enodebd.tr069 import models
+
+logger = EnodebdLogger
+
+
+class BaicellsQRTBHandler(BasicEnodebAcsStateMachine):
+    """
+    BaicellsQRTB State Machine
+    """
+
+    def __init__(
+            self,
+            service: MagmaService,
+    ) -> None:
+        self._state_map = {}
+        super().__init__(service, use_param_key=False)
+
+    def reboot_asap(self) -> None:
+        """
+        Transition to 'reboot' state
+        """
+        self.transition('reboot')
+
+    def is_enodeb_connected(self) -> bool:
+        """
+        Check if enodebd has received an Inform from the enodeb
+
+        Returns:
+            bool
+        """
+        return not isinstance(self.state, WaitInformState)
+
+    def _init_state_map(self) -> None:
+        self._state_map = {
+            # RemWait state seems not needed for QRTB
+            'wait_inform': WaitInformState(self, when_done='wait_empty', when_boot=None),
+            'wait_empty': WaitEmptyMessageState(self, when_done='get_transient_params'),
+            'get_transient_params': SendGetTransientParametersState(self, when_done='wait_get_transient_params'),
+            'wait_get_transient_params': WaitGetTransientParametersState(
+                self,
+                when_get='get_params',
+                when_get_obj_params='get_obj_params',
+                when_delete='delete_objs',
+                when_add='add_objs',
+                when_set='set_params',
+                when_skip='end_session',
+                request_all_params=True,
+            ),
+            'get_params': GetParametersState(self, when_done='wait_get_params', request_all_params=True),
+            'wait_get_params': WaitGetParametersState(self, when_done='get_obj_params'),
+            'get_obj_params': GetObjectParametersState(self, when_done='wait_get_obj_params', request_all_params=True),
+            'wait_get_obj_params': WaitGetObjectParametersState(
+                self, when_delete='delete_objs', when_add='add_objs',
+                when_set='set_params', when_skip='end_session',
+            ),
+            'delete_objs': DeleteObjectsState(self, when_add='add_objs', when_skip='set_params'),
+            'add_objs': AddObjectsState(self, when_done='set_params'),
+            'set_params': SetParameterValuesState(self, when_done='wait_set_params'),
+            'wait_set_params': WaitSetParameterValuesState(
+                self, when_done='check_get_params',
+                when_apply_invasive='reboot',
+            ),
+            'check_get_params': GetParametersState(
+                self,
+                when_done='check_wait_get_params',
+                request_all_params=True,
+            ),
+            'check_wait_get_params': WaitGetParametersState(self, when_done='end_session'),
+            'end_session': BaicellsQRTBEndSessionState(self, when_done='notify_dp'),
+            'notify_dp': BaicellsQRTBNotifyDPState(self, when_inform='wait_inform'),
+            'reboot': EnbSendRebootState(self, when_done='wait_reboot'),
+            'wait_reboot': WaitRebootResponseState(self, when_done='wait_post_reboot_inform'),
+            'wait_post_reboot_inform': BaicellsQRTBWaitInformRebootState(
+                self,
+                when_done='wait_queued_events_post_reboot',
+                when_timeout='wait_inform_post_reboot',
+            ),
+            "wait_queued_events_post_reboot": BaicellsQRTBQueuedEventsWaitState(
+                self,
+                when_done='wait_inform_post_reboot',
+            ),
+            'wait_inform_post_reboot': WaitInformState(self, when_done='wait_empty_post_reboot', when_boot=None),
+            'wait_empty_post_reboot': WaitEmptyMessageState(
+                self, when_done='get_transient_params',
+                when_missing='check_optional_params',
+            ),
+            # The states below are entered when an unexpected message type is
+            # received
+            'unexpected_fault': ErrorState(self, inform_transition_target='wait_inform'),
+        }
+
+    @property
+    def device_name(self) -> str:
+        """
+        Return the device name
+
+        Returns:
+            device name
+        """
+        return EnodebDeviceName.BAICELLS_QRTB
+
+    @property
+    def data_model_class(self) -> DataModel:
+        """
+        Return the class of the data model
+
+        Returns:
+            DataModel
+        """
+        return BaicellsQRTBTrDataModel
+
+    @property
+    def config_postprocessor(self) -> EnodebConfigurationPostProcessor:
+        """
+        Return the instance of config postprocessor
+
+        Returns:
+            EnodebConfigurationPostProcessor
+        """
+        return BaicellsQRTBTrConfigurationInitializer()
+
+    @property
+    def state_map(self) -> Dict[str, EnodebAcsState]:
+        """
+        Return the state map for the State Machine
+
+        Returns:
+            Dict[str, EnodebAcsState]
+        """
+        return self._state_map
+
+    @property
+    def disconnected_state_name(self) -> str:
+        """
+        Return the string representation of a disconnected state
+
+        Returns:
+            str
+        """
+        return 'wait_inform'
+
+    @property
+    def unexpected_fault_state_name(self) -> str:
+        """
+        Return the string representation of an unexpected fault state
+
+        Returns:
+            str
+        """
+        return 'unexpected_fault'
+
+
+class BaicellsQRTBEndSessionState(EnodebAcsState):
+    """ To end a TR-069 session, send an empty HTTP response
+
+    For Baicells QRTB we can expect an inform message on
+    End Session state, either a queued one or a periodic one
+    """
+
+    def __init__(
+            self,
+            acs: EnodebAcsStateMachine,
+            when_done: str,
+    ):
+        super().__init__()
+        self.acs = acs
+        self.done_transition = when_done
+
+    def get_msg(self, message: Any) -> AcsMsgAndTransition:
+        """
+        Send back a message to enb
+
+        Args:
+            message (Any): TR069 message
+
+        Returns:
+            AcsMsgAndTransition
+        """
+        request = models.DummyInput()
+        return AcsMsgAndTransition(msg=request, next_state=self.done_transition)
+
+    def state_description(self) -> str:
+        """
+        Describe the state
+
+        Returns:
+            str
+        """
+        return 'Completed provisioning eNB. Notifying DP.'
+
+
+class BaicellsQRTBQueuedEventsWaitState(EnodebAcsState):
+    """
+    We've already received an Inform message. This state is to handle a
+    Baicells eNodeB issue.
+
+    After eNodeB is rebooted, hold off configuring it for some time.
+
+    In this state, just hang at responding to Inform, and then ending the
+    TR-069 session.
+    """
+
+    CONFIG_DELAY_AFTER_BOOT = 60
+
+    def __init__(self, acs: EnodebAcsStateMachine, when_done: str):
+        super().__init__()
+        self.acs = acs
+        self.done_transition = when_done
+        self.wait_timer = None
+
+    def enter(self):
+        """
+        Perform additional actions on state enter
+        """
+        self.wait_timer = StateMachineTimer(self.CONFIG_DELAY_AFTER_BOOT)
+        logger.info(
+            'Holding off of eNB configuration for %s seconds. ',
+            self.CONFIG_DELAY_AFTER_BOOT,
+        )
+
+    def exit(self):
+        """
+        Perform additional actions on state exit
+        """
+        self.wait_timer = None
+
+    def read_msg(self, message: Any) -> AcsReadMsgResult:
+        """
+        Read incoming message
+
+        Args:
+            message (Any): TR069 message
+
+        Returns:
+            AcsReadMsgResult
+        """
+        if not isinstance(message, models.Inform):
+            return AcsReadMsgResult(msg_handled=False, next_state=None)
+        process_inform_message(
+            message, self.acs.data_model,
+            self.acs.device_cfg,
+        )
+        return AcsReadMsgResult(msg_handled=True, next_state=None)
+
+    def get_msg(self, message: Any) -> AcsMsgAndTransition:
+        """
+        Send back a message to enb
+
+        Args:
+            message (Any): TR069 message
+
+        Returns:
+            AcsMsgAndTransition
+        """
+        if self.wait_timer.is_done():
+            return AcsMsgAndTransition(
+                msg=models.DummyInput(),
+                next_state=self.done_transition,
+            )
+        remaining = self.wait_timer.seconds_remaining()
+        logger.info(
+            'Waiting with eNB configuration for %s more seconds. ',
+            remaining,
+        )
+        return AcsMsgAndTransition(msg=models.DummyInput(), next_state=None)
+
+    def state_description(self) -> str:
+        """
+        Describe the state
+
+        Returns:
+            str
+        """
+        remaining = self.wait_timer.seconds_remaining()
+        return 'Waiting for eNB REM to run for %d more seconds before ' \
+               'resuming with configuration.' % remaining
+
+
+class BaicellsQRTBWaitInformRebootState(WaitInformMRebootState):
+    """
+    BaicellsQRTB WaitInformRebootState implementation
+    """
+    INFORM_EVENT_CODE = '1 BOOT'
+
+
+class BaicellsQRTBNotifyDPState(NotifyDPState):
+    """
+        BaicellsQRTB NotifyDPState implementation
+    """
+
+    def enter(self):
+        """
+        Enter the state
+        """
+        request = CBSDRequest(
+            serial_number=self.acs.device_cfg.get_parameter(ParameterName.SERIAL_NUMBER),
+        )
+        state = get_cbsd_state(request)
+        qrtb_update_desired_config_from_cbsd_state(state, self.acs.desired_cfg)
+
+
+class BaicellsQRTBTrDataModel(DataModel):
+    """
+    Class to represent relevant data model parameters from TR-196/TR-098/TR-181.
+    This class is effectively read-only
+
+    This is for Baicells QRTB based on software BaiBS_QRTB_2.6.2.
+    Tested on hw version E01 and A01
+    """
+    # Parameters to query when reading eNodeB config
+    LOAD_PARAMETERS = [ParameterName.DEVICE]
+    # Mapping of TR parameter paths to aliases
+    DEVICE_PATH = 'Device.'
+    FAPSERVICE_PATH = DEVICE_PATH + 'Services.FAPService.1.'
+    PARAMETERS = {
+        # Top-level objects
+        ParameterName.DEVICE: TrParam(
+            path=DEVICE_PATH, is_invasive=True, type=TrParameterType.OBJECT,
+            is_optional=False,
+        ),
+        ParameterName.FAP_SERVICE: TrParam(
+            path=FAPSERVICE_PATH, is_invasive=True, type=TrParameterType.OBJECT,
+            is_optional=False,
+        ),
+
+        # Device info parameters
+        ParameterName.GPS_STATUS: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.X_COM_GPS_Status', is_invasive=True,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.PTP_STATUS: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.X_COM_1588_Status', is_invasive=True,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.MME_STATUS: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.X_COM_MME_Status', is_invasive=True,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.REM_STATUS: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.X_COM_REM_Status', is_invasive=True,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.LOCAL_GATEWAY_ENABLE: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.X_COM_LTE_LGW_Switch',
+            is_invasive=False, type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.GPS_ENABLE: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.X_COM_GpsSyncEnable', is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.GPS_LAT: TrParam(
+            path=DEVICE_PATH + 'FAP.GPS.LockedLatitude', is_invasive=True,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        ParameterName.GPS_LONG: TrParam(
+            path=DEVICE_PATH + 'FAP.GPS.LockedLongitude', is_invasive=True,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        ParameterName.SW_VERSION: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.SoftwareVersion', is_invasive=True,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.SERIAL_NUMBER: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.SerialNumber', is_invasive=True,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+
+        # Capabilities
+        ParameterName.DUPLEX_MODE_CAPABILITY: TrParam(
+            path=FAPSERVICE_PATH + 'Capabilities.LTE.DuplexMode',
+            is_invasive=True, type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.BAND_CAPABILITY: TrParam(
+            path=FAPSERVICE_PATH + 'Capabilities.LTE.BandsSupported',
+            is_invasive=True, type=TrParameterType.STRING, is_optional=False,
+        ),
+
+        # RF-related parameters
+        ParameterName.EARFCNDL: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.EARFCNDL', is_invasive=True,
+            type=TrParameterType.UNSIGNED_INT, is_optional=False,
+        ),
+        ParameterName.EARFCNUL: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.EARFCNUL', is_invasive=True,
+            type=TrParameterType.UNSIGNED_INT, is_optional=False,
+        ),
+        ParameterName.BAND: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.FreqBandIndicator', is_invasive=True,
+            type=TrParameterType.UNSIGNED_INT, is_optional=False,
+        ),
+        ParameterName.PCI: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.PhyCellID', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.DL_BANDWIDTH: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.DLBandwidth',
+            is_invasive=True, type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.UL_BANDWIDTH: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.ULBandwidth',
+            is_invasive=True, type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.RADIO_ENABLE: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.X_COM_RadioEnable',
+            is_invasive=True, type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.SUBFRAME_ASSIGNMENT: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.RAN.PHY.TDDFrame.SubFrameAssignment', is_invasive=True,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        ParameterName.SPECIAL_SUBFRAME_PATTERN: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.RAN.PHY.TDDFrame.SpecialSubframePatterns', is_invasive=True,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        ParameterName.CELL_ID: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.RAN.Common.CellIdentity',
+            is_invasive=True, type=TrParameterType.UNSIGNED_INT, is_optional=False,
+        ),
+        ParameterName.POWER_SPECTRAL_DENSITY: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.PowerSpectralDensity',
+            is_invasive=False, type=TrParameterType.UNSIGNED_INT, is_optional=False,
+        ),
+
+        # Other LTE parameters
+        ParameterName.ADMIN_STATE: TrParam(
+            path=FAPSERVICE_PATH + 'FAPControl.LTE.AdminState', is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.OP_STATE: TrParam(
+            path=FAPSERVICE_PATH + 'FAPControl.LTE.OpState', is_invasive=True,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.RF_TX_STATUS: TrParam(
+            path=FAPSERVICE_PATH + 'FAPControl.LTE.RFTxStatus', is_invasive=True,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+
+        # Core network parameters
+        ParameterName.MME_IP: TrParam(
+            path=FAPSERVICE_PATH + 'FAPControl.LTE.Gateway.S1SigLinkServerList',
+            is_invasive=True, type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.MME_PORT: TrParam(
+            path=FAPSERVICE_PATH + 'FAPControl.LTE.Gateway.S1SigLinkPort', is_invasive=True,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        ParameterName.NUM_PLMNS: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNListNumberOfEntries',
+            is_invasive=True, type=TrParameterType.INT, is_optional=False,
+        ),
+
+        # PLMN arrays are added below
+        ParameterName.PLMN: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.', is_invasive=True,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.TAC: TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.EPC.TAC', is_invasive=True,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        ParameterName.IP_SEC_ENABLE: TrParam(
+            path=DEVICE_PATH + 'Services.FAPService.Ipsec.IPSEC_ENABLE',
+            is_invasive=False, type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.MME_POOL_ENABLE: TrParam(
+            path=FAPSERVICE_PATH + 'FAPControl.LTE.Gateway.X_COM_MmePool.Enable',
+            is_invasive=True, type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+
+        # Management server parameters
+        ParameterName.PERIODIC_INFORM_ENABLE: TrParam(
+            path=DEVICE_PATH + 'ManagementServer.PeriodicInformEnable',
+            is_invasive=True, type=TrParameterType.BOOLEAN,
+            is_optional=False,
+        ),
+        ParameterName.PERIODIC_INFORM_INTERVAL: TrParam(
+            path=DEVICE_PATH + 'ManagementServer.PeriodicInformInterval',
+            is_invasive=True, type=TrParameterType.UNSIGNED_INT,
+            is_optional=False,
+        ),
+
+        # Performance management parameters
+        ParameterName.PERF_MGMT_ENABLE: TrParam(
+            path=DEVICE_PATH + 'FAP.PerfMgmt.Config.1.Enable', is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+        ParameterName.PERF_MGMT_UPLOAD_INTERVAL: TrParam(
+            path=DEVICE_PATH + 'FAP.PerfMgmt.Config.1.PeriodicUploadInterval', is_invasive=False,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        ParameterName.PERF_MGMT_UPLOAD_URL: TrParam(
+            path=DEVICE_PATH + 'FAP.PerfMgmt.Config.1.URL', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+
+        # SAS parameters
+        ParameterName.SAS_FCC_ID: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.SAS.FccId', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.SAS_USER_ID: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.SAS.UserId', is_invasive=False,
+            type=TrParameterType.STRING, is_optional=False,
+        ),
+        ParameterName.SAS_ENABLED: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.SAS.enableMode', is_invasive=False,
+            type=TrParameterType.INT, is_optional=False,
+        ),
+        ParameterName.SAS_RADIO_ENABLE: TrParam(
+            path=DEVICE_PATH + 'DeviceInfo.SAS.RadioEnable', is_invasive=False,
+            type=TrParameterType.BOOLEAN, is_optional=False,
+        ),
+    }
+
+    NUM_PLMNS_IN_CONFIG = 6
+    for i in range(1, NUM_PLMNS_IN_CONFIG + 1):  # noqa: WPS604
+        PARAMETERS[(ParameterName.PLMN_N) % i] = TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.' % i, is_invasive=True, type=TrParameterType.STRING,
+            is_optional=False,
+        )
+        PARAMETERS[ParameterName.PLMN_N_CELL_RESERVED % i] = TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.CellReservedForOperatorUse' % i, is_invasive=True,
+            type=TrParameterType.BOOLEAN,
+            is_optional=False,
+        )
+        PARAMETERS[ParameterName.PLMN_N_ENABLE % i] = TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.Enable' % i, is_invasive=True,
+            type=TrParameterType.BOOLEAN,
+            is_optional=False,
+        )
+        PARAMETERS[ParameterName.PLMN_N_PRIMARY % i] = TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.IsPrimary' % i, is_invasive=True,
+            type=TrParameterType.BOOLEAN,
+            is_optional=False,
+        )
+        PARAMETERS[ParameterName.PLMN_N_PLMNID % i] = TrParam(
+            path=FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.PLMNID' % i, is_invasive=True,
+            type=TrParameterType.STRING,
+            is_optional=False,
+        )
+
+    TRANSFORMS_FOR_MAGMA = {
+        # We don't set GPS, so we don't need transform for enb
+        ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
+        ParameterName.GPS_LONG: transform_for_magma.gps_tr181,
+    }
+
+    @classmethod
+    def get_parameter(cls, param_name: ParameterName) -> Optional[TrParam]:
+        """
+        Retrieve parameter by its name
+
+        Args:
+            param_name (ParameterName): parameter name to retrieve
+
+        Returns:
+            Optional[TrParam]
+        """
+        return cls.PARAMETERS.get(param_name)
+
+    @classmethod
+    def _get_magma_transforms(
+            cls,
+    ) -> Dict[ParameterName, Callable[[Any], Any]]:
+        return cls.TRANSFORMS_FOR_MAGMA
+
+    @classmethod
+    def _get_enb_transforms(cls) -> Dict[ParameterName, Callable[[Any], Any]]:
+        return {}
+
+    @classmethod
+    def get_load_parameters(cls) -> List[ParameterName]:
+        """
+        Retrieve all load parameters
+
+        Returns:
+             List[ParameterName]
+        """
+        return cls.LOAD_PARAMETERS
+
+    @classmethod
+    def get_num_plmns(cls) -> int:
+        """
+        Retrieve the number of all PLMN parameters
+
+        Returns:
+            int
+        """
+        return cls.NUM_PLMNS_IN_CONFIG
+
+    @classmethod
+    def get_parameter_names(cls) -> List[ParameterName]:
+        """
+        Retrieve all parameter names
+
+        Returns:
+            List[ParameterName]
+        """
+        excluded_params = [
+            str(ParameterName.DEVICE),
+            str(ParameterName.FAP_SERVICE),
+        ]
+        names = list(
+            filter(
+                lambda x: (not str(x).startswith('PLMN')) and (str(x) not in excluded_params),
+                cls.PARAMETERS.keys(),
+            ),
+        )
+        return names
+
+    @classmethod
+    def get_numbered_param_names(cls) -> Dict[ParameterName, List[ParameterName]]:
+        """
+        Retrieve parameter names of all objects
+
+        Returns:
+            Dict[ParameterName, List[ParameterName]]
+        """
+        names = {}
+        for i in range(1, cls.NUM_PLMNS_IN_CONFIG + 1):
+            params = []
+            params.append(ParameterName.PLMN_N_CELL_RESERVED % i)
+            params.append(ParameterName.PLMN_N_ENABLE % i)
+            params.append(ParameterName.PLMN_N_PRIMARY % i)
+            params.append(ParameterName.PLMN_N_PLMNID % i)
+            names[ParameterName.PLMN_N % i] = params
+        return names
+
+
+class BaicellsQRTBTrConfigurationInitializer(EnodebConfigurationPostProcessor):
+    """
+    Overrides desired config on the State Machine
+    """
+
+    def postprocess(self, mconfig: Any, service_cfg: Any, desired_cfg: EnodebConfiguration) -> None:
+        """
+        Add some params to the desired config
+
+        Args:
+            mconfig (Any): mconfig
+            service_cfg (Any): service config
+            desired_cfg (EnodebConfiguration): desired config
+        """
+        desired_cfg.set_parameter(ParameterName.SAS_ENABLED, 1)
+
+        desired_cfg.set_parameter_for_object(
+            ParameterName.PLMN_N_CELL_RESERVED % 1, True,  # noqa: WPS345,WPS425
+            ParameterName.PLMN_N % 1,  # noqa: WPS345
+        )
+        parameters_to_delete = [
+            ParameterName.RADIO_ENABLE, ParameterName.POWER_SPECTRAL_DENSITY,
+            ParameterName.EARFCNDL, ParameterName.EARFCNUL, ParameterName.BAND,
+            ParameterName.DL_BANDWIDTH, ParameterName.UL_BANDWIDTH,
+            ParameterName.SAS_RADIO_ENABLE,
+        ]
+        for p in parameters_to_delete:
+            if desired_cfg.has_parameter(p):
+                desired_cfg.delete_parameter(p)
+
+
+def qrtb_update_desired_config_from_cbsd_state(state: CBSDStateResult, config: EnodebConfiguration) -> None:
+    """
+    Call grpc endpoint on the Domain Proxy to update the desired config based on sas grant
+
+    Args:
+        state (CBSDStateResult): state result as received from DP
+        config (EnodebConfiguration): configuration to update
+    """
+    logger.debug("Updating desired config based on sas grant")
+    config.set_parameter(ParameterName.SAS_RADIO_ENABLE, state.radio_enabled)
+
+    if not state.radio_enabled:
+        return
+
+    earfcn = calc_earfcn(state.channel.low_frequency_hz, state.channel.high_frequency_hz)
+    bandwidth_mhz = calc_bandwidth_mhz(state.channel.low_frequency_hz, state.channel.high_frequency_hz)
+    bandwidth_rbs = calc_bandwidth_rbs(bandwidth_mhz)
+    psd = _calc_psd(state.channel.max_eirp_dbm_mhz)
+
+    params_to_set = {
+        ParameterName.SAS_RADIO_ENABLE: True,
+        ParameterName.BAND: BAND,
+        ParameterName.DL_BANDWIDTH: bandwidth_rbs,
+        ParameterName.UL_BANDWIDTH: bandwidth_rbs,
+        ParameterName.EARFCNDL: earfcn,
+        ParameterName.EARFCNUL: earfcn,
+        ParameterName.POWER_SPECTRAL_DENSITY: psd,
+    }
+
+    for param, value in params_to_set.items():
+        config.set_parameter(param, value)
+
+
+def _calc_psd(eirp: float) -> int:
+    psd = int(eirp)
+    if not SAS_MIN_POWER_SPECTRAL_DENSITY <= psd <= SAS_MAX_POWER_SPECTRAL_DENSITY:  # noqa: WPS508
+        raise ConfigurationError(
+            'Power Spectral Density %d exceeds allowed range [%d, %d]' %
+            (psd, SAS_MIN_POWER_SPECTRAL_DENSITY, SAS_MAX_POWER_SPECTRAL_DENSITY),
+        )
+    return psd

--- a/lte/gateway/python/magma/enodebd/devices/device_map.py
+++ b/lte/gateway/python/magma/enodebd/devices/device_map.py
@@ -17,6 +17,7 @@ from magma.enodebd.devices.baicells import BaicellsHandler
 from magma.enodebd.devices.baicells_old import BaicellsOldHandler
 from magma.enodebd.devices.baicells_qafa import BaicellsQAFAHandler
 from magma.enodebd.devices.baicells_qafb import BaicellsQAFBHandler
+from magma.enodebd.devices.baicells_qrtb import BaicellsQRTBHandler
 from magma.enodebd.devices.baicells_rts import BaicellsRTSHandler
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.devices.experimental.cavium import CaviumHandler
@@ -33,6 +34,7 @@ DEVICE_HANDLER_BY_NAME = {
     EnodebDeviceName.BAICELLS_QAFA: BaicellsQAFAHandler,
     EnodebDeviceName.BAICELLS_QAFB: BaicellsQAFBHandler,
     EnodebDeviceName.BAICELLS_RTS: BaicellsRTSHandler,
+    EnodebDeviceName.BAICELLS_QRTB: BaicellsQRTBHandler,
     EnodebDeviceName.CAVIUM: CaviumHandler,
     EnodebDeviceName.FREEDOMFI_ONE: FreedomFiOneHandler,
 }

--- a/lte/gateway/python/magma/enodebd/dp_client.py
+++ b/lte/gateway/python/magma/enodebd/dp_client.py
@@ -1,0 +1,47 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import grpc
+from dp.protos.enodebd_dp_pb2 import CBSDRequest, CBSDStateResult
+from dp.protos.enodebd_dp_pb2_grpc import DPServiceStub
+from magma.common.service_registry import ServiceRegistry
+from magma.enodebd.logger import EnodebdLogger
+
+logger = EnodebdLogger
+
+DP_SERVICE_NAME = "dp_service"
+DEFAULT_GRPC_TIMEOUT = 20
+
+
+def get_cbsd_state(request: CBSDRequest) -> CBSDStateResult:
+    """
+    Make RPC call to 'GetCBSDState' method of dp service
+    """
+    try:
+        chan = ServiceRegistry.get_rpc_channel(
+            DP_SERVICE_NAME,
+            ServiceRegistry.CLOUD,
+        )
+    except ValueError:
+        logger.error('Cant get RPC channel to %s', DP_SERVICE_NAME)
+        return CBSDStateResult(radio_enabled=False)
+    client = DPServiceStub(chan)
+    try:
+        res = client.GetCBSDState(request, DEFAULT_GRPC_TIMEOUT)
+    except grpc.RpcError as err:
+        logger.warning(
+            "GetCBSDState error: [%s] %s",
+            err.code(),
+            err.details(),
+        )
+        return CBSDStateResult(radio_enabled=False)
+    return res

--- a/lte/gateway/python/magma/enodebd/tests/baicells_qrtb_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_qrtb_tests.py
@@ -1,0 +1,727 @@
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# pylint: disable=protected-access
+from time import sleep
+from unittest import TestCase, mock
+
+from dp.protos.enodebd_dp_pb2 import CBSDRequest, CBSDStateResult, LteChannel
+from magma.enodebd.data_models.data_model import ParameterName
+from magma.enodebd.device_config.configuration_init import build_desired_config
+from magma.enodebd.device_config.enodeb_configuration import EnodebConfiguration
+from magma.enodebd.devices.baicells_qrtb import (
+    BaicellsQRTBNotifyDPState,
+    BaicellsQRTBQueuedEventsWaitState,
+    BaicellsQRTBTrDataModel,
+    BaicellsQRTBWaitInformRebootState,
+    qrtb_update_desired_config_from_cbsd_state,
+)
+from magma.enodebd.devices.device_utils import EnodebDeviceName
+from magma.enodebd.exceptions import ConfigurationError
+from magma.enodebd.state_machines.enb_acs_states import (
+    WaitEmptyMessageState,
+    WaitInformState,
+)
+from magma.enodebd.tests.test_utils.enb_acs_builder import (
+    EnodebAcsStateMachineBuilder,
+)
+from magma.enodebd.tests.test_utils.enodeb_handler import EnodebHandlerTestCase
+from magma.enodebd.tests.test_utils.tr069_msg_builder import (
+    Param,
+    Tr069MessageBuilder,
+)
+from magma.enodebd.tr069 import models
+
+DEFAULT_INFORM_PARAMS = [
+    Param('Device.DeviceInfo.HardwareVersion', 'string', 'E01'),
+    Param('Device.DeviceInfo.SAS.RadioEnable', 'boolean', 'false'),
+    Param('Device.DeviceInfo.SoftwareVersion', 'string', 'BaiBS_QRTB_2.6.2'),
+    Param('Device.DeviceInfo.X_COM_STATION_RUN_Time', 'string', '0d 0h 2m 3s'),
+    Param('Device.RootDataModelVersion', 'float', '2.8'),
+    Param('Device.Services.FAPService.1.FAPControl.LTE.OpState', 'boolean', 'false'),
+    Param('Device.Services.FAPService.1.FAPControl.LTE.RFTxStatus', 'boolean', 'false'),
+    Param('Device.Services.FAPService.1.FAPControl.LTE.X_COM_HSS.HaloBEnableState', 'int', '0'),
+    Param('Device.Services.FAPService.1.FAPControl.LTE.X_COM_HSS.HaloBMode', 'int', '0'),
+    Param('Device.Services.FAPService.1.FAPControl.X_RADISYS_COM_AlarmStatus', 'string', 'Cleared'),
+    Param('Device.Services.FAPService.2.FAPControl.LTE.OpState', 'boolean', 'false'),
+    Param('Device.Services.FAPService.2.FAPControl.LTE.RFTxStatus', 'boolean', 'false'),
+    Param('Device.Services.FAPService.2.FAPControl.LTE.X_COM_HSS.HaloBEnableState', 'int', '0'),
+    Param('Device.Services.FAPService.2.FAPControl.LTE.X_COM_HSS.HaloBMode', 'int', '0'),
+]
+
+GET_TRANSIENT_PARAMS_RESPONSE_PARAMS = [
+    Param('Device.DeviceInfo.X_COM_1588_Status', 'int', '0'),
+    Param('Device.DeviceInfo.X_COM_GPS_Status', 'int', '1'),
+    Param('Device.DeviceInfo.X_COM_MME_Status', 'int', '0'),
+    Param('Device.FAP.GPS.LockedLatitude', 'int', '40002899'),
+    Param('Device.FAP.GPS.LockedLongitude', 'unsigned', '-105287994'),
+    Param('Device.Services.FAPService.1.FAPControl.LTE.OpState', 'boolean', 'false'),
+    Param('Device.Services.FAPService.1.FAPControl.LTE.RFTxStatus', 'boolean', 'false'),
+]
+
+GET_PARAMS_RESPONSE_PARAMS = [
+    Param('Device.DeviceInfo.SAS.FccId', 'str', '2AG32MBS3100196N'),
+    Param('Device.DeviceInfo.SAS.UserId', 'str', 'M0LK4T'),
+    Param('Device.DeviceInfo.SerialNumber', 'str', '120200024019APP0105'),
+    Param('Device.DeviceInfo.X_COM_GpsSyncEnable', 'boolean', 'true'),
+    Param('Device.DeviceInfo.X_COM_LTE_LGW_Switch', 'int', '0'),
+    Param('Device.DeviceInfo.X_COM_REM_Status', 'int', '0'),
+    Param('Device.DeviceInfo.SAS.enableMode', 'int', '1'),
+    Param('Device.FAP.PerfMgmt.Config.1.Enable', 'boolean', 'true'),
+    Param('Device.FAP.PerfMgmt.Config.1.PeriodicUploadInterval', 'int', '300'),
+    Param('Device.FAP.PerfMgmt.Config.1.URL', 'string', 'http://192.168.60.142:8081/'),
+    Param('Device.ManagementServer.PeriodicInformEnable', 'bool', 'true'),
+    Param('Device.ManagementServer.PeriodicInformInterval', 'int', '5'),
+    Param('Device.Services.FAPService.1.Capabilities.LTE.BandsSupported', 'int', '7'),
+    Param('Device.Services.FAPService.1.Capabilities.LTE.DuplexMode', 'string', 'TDDMode'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNListNumberOfEntries', 'int', '1'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.EPC.TAC', 'int', '1'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.CellRestriction.CellReservedForOperatorUse', 'int', '0'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.Common.CellIdentity', 'int', '138777000'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.PHY.TDDFrame.SpecialSubframePatterns', 'int', '7'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.PHY.TDDFrame.SubFrameAssignment', 'int', '2'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.DLBandwidth', 'str', '100'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.EARFCNDL', 'int', '39150'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.EARFCNUL', 'int', '39150'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.FreqBandIndicator', 'int', '40'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.PhyCellID', 'int', '260'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.ReferenceSignalPower', 'unsigned', '-24'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.ULBandwidth', 'int', '100'),
+    Param('Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.X_COM_RadioEnable', 'bool', 'false'),
+    Param('Device.Services.FAPService.1.FAPControl.LTE.AdminState', 'bool', 'false'),
+    Param('Device.Services.FAPService.1.FAPControl.LTE.Gateway.S1SigLinkPort', 'int', '36412'),
+    Param('Device.Services.FAPService.1.FAPControl.LTE.Gateway.S1SigLinkServerList', 'string', '192.168.60.142'),
+    Param('Device.Services.FAPService.1.FAPControl.LTE.Gateway.X_COM_MmePool.Enable', 'boolean', 'false'),
+    Param('Device.Services.FAPService.Ipsec.IPSEC_ENABLE', 'boolean', 'false'),
+]
+
+MOCK_CBSD_STATE = CBSDStateResult(
+    radio_enabled=True,
+    channel=LteChannel(
+        low_frequency_hz=3550_000_000,
+        high_frequency_hz=3570_000_000,
+        max_eirp_dbm_mhz=34,
+    ),
+)
+
+
+class SasToRfConfigTests(TestCase):
+    def test_bandwidth_20MHz(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3550_000_000,
+            high_frequency_hz=3570_000_000,
+            max_eirp_dbm_mhz=34,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        qrtb_update_desired_config_from_cbsd_state(state, config)
+        self.assert_config_updated(config, '100', 55340, 34)
+
+    def test_bandwidth_15MHz(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3555_000_000,
+            high_frequency_hz=3570_000_000,
+            max_eirp_dbm_mhz=37,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        qrtb_update_desired_config_from_cbsd_state(state, config)
+        self.assert_config_updated(config, '75', 55365, 37)
+
+    def test_bandwidth_10MHz(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3600_000_000,
+            high_frequency_hz=3610_000_000,
+            max_eirp_dbm_mhz=24,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        qrtb_update_desired_config_from_cbsd_state(state, config)
+        self.assert_config_updated(config, '50', 55790, 24)
+
+    def test_bandwidth_5MHz(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3600_000_000,
+            high_frequency_hz=3605_000_000,
+            max_eirp_dbm_mhz=22,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        qrtb_update_desired_config_from_cbsd_state(state, config)
+        self.assert_config_updated(config, '25', 55765, 22)
+
+    def test_unsupported_bandwidth_3MHz(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3550_000_000,
+            high_frequency_hz=3553_000_000,
+            max_eirp_dbm_mhz=17,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        with self.assertRaises(ConfigurationError):
+            qrtb_update_desired_config_from_cbsd_state(state, config)
+
+    def test_unsupported_bandwidth_1_4MHz(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3550_000_000,
+            high_frequency_hz=3551_400_000,
+            max_eirp_dbm_mhz=10,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        with self.assertRaises(ConfigurationError):
+            qrtb_update_desired_config_from_cbsd_state(state, config)
+
+    def test_bandwidth_non_default_MHz(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3690_000_000,
+            high_frequency_hz=3698_000_000,
+            max_eirp_dbm_mhz=1,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        qrtb_update_desired_config_from_cbsd_state(state, config)
+        self.assert_config_updated(config, '25', 56680, 1)
+
+    def test_too_low_bandwidth(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3550_000_000,
+            high_frequency_hz=3551_000_000,
+            max_eirp_dbm_mhz=10,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        with self.assertRaises(ConfigurationError):
+            qrtb_update_desired_config_from_cbsd_state(state, config)
+
+    def test_omit_other_params_when_radio_disabled(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3550_000_000,
+            high_frequency_hz=3560_000_000,
+            max_eirp_dbm_mhz=-100,
+        )
+        state = CBSDStateResult(
+            radio_enabled=False,
+            channel=channel,
+        )
+        qrtb_update_desired_config_from_cbsd_state(state, config)
+        self.assertEqual(
+            config.get_parameter(
+                ParameterName.SAS_RADIO_ENABLE,
+            ), False,
+        )
+
+    def test_power_spectral_density_below_range(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3550_000_000,
+            high_frequency_hz=3560_000_000,
+            max_eirp_dbm_mhz=-138,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        with self.assertRaises(ConfigurationError):
+            qrtb_update_desired_config_from_cbsd_state(state, config)
+
+    def test_power_spectral_density_above_range(self) -> None:
+        config = EnodebConfiguration(BaicellsQRTBTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3550_000_000,
+            high_frequency_hz=3560_000_000,
+            max_eirp_dbm_mhz=38,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        with self.assertRaises(ConfigurationError):
+            qrtb_update_desired_config_from_cbsd_state(state, config)
+
+    def assert_config_updated(self, config: EnodebConfiguration, bandwidth: str, earfcn: int, eirp: int) -> None:
+        expected_values = {
+            ParameterName.SAS_RADIO_ENABLE: True,
+            ParameterName.DL_BANDWIDTH: bandwidth,
+            ParameterName.UL_BANDWIDTH: bandwidth,
+            ParameterName.EARFCNDL: earfcn,
+            ParameterName.EARFCNUL: earfcn,
+            ParameterName.POWER_SPECTRAL_DENSITY: eirp,
+            ParameterName.BAND: 48,
+        }
+        for key, value in expected_values.items():
+            self.assertEqual(config.get_parameter(key), value)
+
+
+class BaicellsQRTBHandlerTests(EnodebHandlerTestCase):
+
+    @mock.patch('magma.enodebd.devices.baicells_qrtb.get_cbsd_state')
+    def test_notify_dp_sets_values_received_by_dp_in_desired_config(self, mock_get_state) -> None:
+        expected_final_param_values = {
+            ParameterName.UL_BANDWIDTH: '100',
+            ParameterName.DL_BANDWIDTH: '100',
+            ParameterName.EARFCNUL: 55340,
+            ParameterName.EARFCNDL: 55340,
+            ParameterName.POWER_SPECTRAL_DENSITY: 34,
+        }
+        test_user = 'test_user'
+        test_fcc_id = 'fcc_id'
+        test_serial_number = '123'
+
+        acs_state_machine = EnodebAcsStateMachineBuilder.build_acs_state_machine(EnodebDeviceName.BAICELLS_QRTB)
+
+        acs_state_machine.desired_cfg = EnodebConfiguration(BaicellsQRTBTrDataModel())
+
+        acs_state_machine.device_cfg.set_parameter(ParameterName.SAS_USER_ID, test_user)
+        acs_state_machine.device_cfg.set_parameter(ParameterName.SAS_FCC_ID, test_fcc_id)
+        acs_state_machine.device_cfg.set_parameter(ParameterName.SERIAL_NUMBER, test_serial_number)
+
+        for param in expected_final_param_values:
+            with self.assertRaises(KeyError):
+                acs_state_machine.desired_cfg.get_parameter(param)
+
+        # Skip previous steps not to duplicate the code
+        acs_state_machine.transition('check_wait_get_params')
+        req = Tr069MessageBuilder.param_values_qrtb_response(
+            [], models.GetParameterValuesResponse,
+        )
+
+        mock_get_state.return_value = MOCK_CBSD_STATE
+
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        mock_get_state.assert_called_with(
+            CBSDRequest(serial_number=test_serial_number),
+        )
+
+        self.assertTrue(isinstance(resp, models.DummyInput))
+
+        for param, value in expected_final_param_values.items():
+            self.assertEqual(
+                value, acs_state_machine.desired_cfg.get_parameter(param),
+            )
+
+    def test_manual_reboot(self) -> None:
+        """
+        Test a scenario where a Magma user goes through the enodebd CLI to
+        reboot the Baicells eNodeB.
+
+        This checks the scenario where the command is not sent in the middle
+        of a TR-069 provisioning session.
+        """
+        acs_state_machine = EnodebAcsStateMachineBuilder.build_acs_state_machine(EnodebDeviceName.BAICELLS_QRTB)
+
+        # User uses the CLI tool to get eNodeB to reboot
+        acs_state_machine.reboot_asap()
+
+        # And now the Inform message arrives from the eNodeB
+        inform_msg = \
+            Tr069MessageBuilder.get_qrtb_inform(
+                params=DEFAULT_INFORM_PARAMS,
+                oui='48BF74',
+                enb_serial='1202000181186TB0006',
+                event_codes=['2 PERIODIC'],
+            )
+        resp = acs_state_machine.handle_tr069_message(inform_msg)
+        self.assertTrue(
+            isinstance(resp, models.InformResponse),
+            'In reboot sequence, state machine should still '
+            'respond to an Inform with InformResponse.',
+        )
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(
+            isinstance(resp, models.Reboot),
+            'In reboot sequence, state machine should send a '
+            'Reboot message.',
+        )
+        req = Tr069MessageBuilder.get_reboot_response()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(
+            isinstance(resp, models.DummyInput),
+            'State machine should end TR-069 session after '
+            'receiving a RebootResponse',
+        )
+
+    def test_manual_reboot_during_provisioning(self) -> None:
+        """
+        Test a scenario where a Magma user goes through the enodebd CLI to
+        reboot the Baicells eNodeB.
+
+        This checks the scenario where the command is sent in the middle
+        of a TR-069 provisioning session.
+        """
+        acs_state_machine = EnodebAcsStateMachineBuilder.build_acs_state_machine(EnodebDeviceName.BAICELLS_QRTB)
+
+        # Send an Inform message, wait for an InformResponse
+        inform_msg = Tr069MessageBuilder.get_qrtb_inform(
+            params=DEFAULT_INFORM_PARAMS,
+            oui='48BF74',
+            enb_serial='1202000181186TB0006',
+            event_codes=['2 PERIODIC'],
+        )
+        resp = acs_state_machine.handle_tr069_message(inform_msg)
+        self.assertTrue(
+            isinstance(resp, models.InformResponse),
+            'Should respond with an InformResponse',
+        )
+
+        # Send an empty http request to kick off the rest of provisioning
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # Expect a request for an optional parameter, three times
+        self.assertTrue(
+            isinstance(resp, models.GetParameterValues),
+            'State machine should be requesting param values',
+        )
+        req = Tr069MessageBuilder.get_fault()
+
+        # User uses the CLI tool to get eNodeB to reboot
+        acs_state_machine.reboot_asap()
+
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(
+            isinstance(resp, models.Reboot),
+            'In reboot sequence, state machine should send a '
+            'Reboot message.',
+        )
+        req = Tr069MessageBuilder.get_reboot_response()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(
+            isinstance(resp, models.DummyInput),
+            'State machine should end TR-069 session after '
+            'receiving a RebootResponse',
+        )
+
+    @mock.patch('magma.enodebd.devices.baicells_qrtb.get_cbsd_state')
+    def test_provision(self, mock_get_state) -> None:
+        mock_get_state.return_value = MOCK_CBSD_STATE
+
+        acs_state_machine = EnodebAcsStateMachineBuilder.build_acs_state_machine(EnodebDeviceName.BAICELLS_QRTB)
+        data_model = BaicellsQRTBTrDataModel()
+
+        # Send an Inform message, wait for an InformResponse
+        inform_msg = Tr069MessageBuilder.get_qrtb_inform(
+            params=DEFAULT_INFORM_PARAMS,
+            oui='48BF74',
+            enb_serial='1202000181186TB0006',
+            event_codes=['2 PERIODIC'],
+        )
+        resp = acs_state_machine.handle_tr069_message(inform_msg)
+        self.assertTrue(
+            isinstance(resp, models.InformResponse),
+            'Should respond with an InformResponse',
+        )
+
+        # Send an empty http request to kick off the rest of provisioning
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # Expect a request for transient params
+        self.assertTrue(
+            isinstance(resp, models.GetParameterValues),
+            'State machine should be requesting param values',
+        )
+
+        should_ask_for = [p.name for p in GET_TRANSIENT_PARAMS_RESPONSE_PARAMS]
+        self.verify_acs_asking_enb_for_params(should_ask_for, resp)
+
+        # Send back some typical values
+        req = Tr069MessageBuilder.param_values_qrtb_response(
+            GET_TRANSIENT_PARAMS_RESPONSE_PARAMS, models.GetParameterValuesResponse,
+        )
+
+        # And then SM should request all parameter values from the data model
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(
+            isinstance(resp, models.GetParameterValues),
+            'State machine should be requesting param values',
+        )
+
+        should_ask_for = [
+            data_model.get_parameter(
+                pn,
+            ).path for pn in data_model.get_parameter_names()
+        ]
+        self.verify_acs_asking_enb_for_params(should_ask_for, resp)
+
+        # Send back typical values
+        req = Tr069MessageBuilder.param_values_qrtb_response(
+            GET_PARAMS_RESPONSE_PARAMS,
+            models.GetParameterValuesResponse,
+        )
+
+        # SM will be requesting object parameter values
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(
+            isinstance(resp, models.GetParameterValues),
+            'State machine should be requesting object param vals',
+        )
+
+        should_ask_for = [
+            'Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.1.CellReservedForOperatorUse',
+            'Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.1.Enable',
+            'Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.1.IsPrimary',
+            'Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.1.PLMNID',
+        ]
+
+        self.verify_acs_asking_enb_for_params(should_ask_for, resp)
+
+        # Send back some typical values for object parameters
+        req = Tr069MessageBuilder.get_object_param_values_response(
+            cell_reserved_for_operator_use='true', enable='true', is_primary='true', plmnid='00101',
+        )
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # All the radio responses were intentionally crafted so that they match enodebd desired config.
+        # Therefore the provisioning ends here. The radio goes directly into end_session -> notify_dp state
+        self.assertTrue(
+            isinstance(resp, models.DummyInput),
+            'State machine should send back an empty message',
+        )
+
+        self.assertIsInstance(
+            acs_state_machine.state,
+            BaicellsQRTBNotifyDPState,
+        )
+
+    def verify_acs_asking_enb_for_params(self, should_ask_for, response):
+        param_values_that_enodebd_actually_asked_for = response.ParameterNames.string
+
+        self.assertEqual(
+            sorted(should_ask_for),
+            sorted(param_values_that_enodebd_actually_asked_for),
+        )
+
+
+class BaicellsQRTBStatesTests(EnodebHandlerTestCase):
+    """Testing Baicells QRTB specific states"""
+
+    @mock.patch('magma.enodebd.devices.baicells_qrtb.get_cbsd_state')
+    def test_end_session_and_notify_dp_transition(self, mock_get_state):
+        """Testing if SM steps in and out of BaicellsQRTBWaitNotifyDPState as per state map"""
+
+        mock_get_state.return_value = MOCK_CBSD_STATE
+
+        acs_state_machine = provision_clean_sm(
+            state='check_wait_get_params',
+        )
+
+        msg = Tr069MessageBuilder.param_values_qrtb_response(
+            GET_PARAMS_RESPONSE_PARAMS,
+            models.GetParameterValuesResponse,
+        )
+
+        # SM should transition from check_wait_get_params to end_session -> notify_dp automatically
+        # upon receiving response from the radio
+        acs_state_machine.handle_tr069_message(msg)
+
+        self.assertIsInstance(
+            acs_state_machine.state,
+            BaicellsQRTBNotifyDPState,
+        )
+
+        msg = Tr069MessageBuilder.get_inform(event_codes=['1 BOOT'])
+
+        # SM should go into wait_inform state, respond with Inform response and transition to wait_empty
+        acs_state_machine.handle_tr069_message(msg)
+
+        self.assertIsInstance(acs_state_machine.state, WaitEmptyMessageState)
+
+    def test_wait_post_reboot_inform_transition(self):
+        """Testing if SM steps in and out of BaicellsQRTBWaitInformRebootState as per state map"""
+        acs_state_machine = provision_clean_sm(state='wait_reboot')
+
+        acs_state_machine.handle_tr069_message(models.RebootResponse())
+
+        self.assertIsInstance(
+            acs_state_machine.state,
+            BaicellsQRTBWaitInformRebootState,
+        )
+
+        msg = Tr069MessageBuilder.get_inform(event_codes=['1 BOOT'])
+
+        acs_state_machine.handle_tr069_message(msg)
+
+        self.assertIsInstance(
+            acs_state_machine.state,
+            BaicellsQRTBQueuedEventsWaitState,
+        )
+
+    @mock.patch.object(BaicellsQRTBQueuedEventsWaitState, 'CONFIG_DELAY_AFTER_BOOT', new=0.5)
+    def test_wait_queued_events_post_reboot_transition(self):
+        """Testing if we step in and out of BaicellsQRTBQueuedEventsWaitState as per state map"""
+        acs_state_machine = provision_clean_sm(
+            state='wait_post_reboot_inform',
+        )
+
+        msg = Tr069MessageBuilder.get_inform(event_codes=['1 BOOT'])
+
+        acs_state_machine.handle_tr069_message(msg)
+
+        self.assertIsInstance(
+            acs_state_machine.state,
+            BaicellsQRTBQueuedEventsWaitState,
+        )
+
+        msg = Tr069MessageBuilder.get_inform()
+
+        # Need to wait after reboot, timeout set to 0.5 sec
+        sleep(1)
+
+        acs_state_machine.handle_tr069_message(msg)
+
+        self.assertIsInstance(acs_state_machine.state, WaitInformState)
+
+
+class BaicellsQRTBConfigTests(EnodebHandlerTestCase):
+    def test_frequency_related_params_removed_in_postprocessor(self):
+        acs_state_machine = provision_clean_sm()
+        acs_state_machine.device_cfg.set_parameter(ParameterName.IP_SEC_ENABLE, 'false')
+
+        parameters_to_delete = [
+            ParameterName.RADIO_ENABLE, ParameterName.POWER_SPECTRAL_DENSITY,
+            ParameterName.EARFCNDL, ParameterName.EARFCNUL, ParameterName.BAND,
+            ParameterName.DL_BANDWIDTH, ParameterName.UL_BANDWIDTH,
+            ParameterName.SAS_RADIO_ENABLE,
+        ]
+        for p in parameters_to_delete:
+            acs_state_machine.device_cfg.set_parameter(p, 'some_value')
+
+        desired_cfg = build_desired_config(
+            acs_state_machine.mconfig,
+            acs_state_machine.service_config,
+            acs_state_machine.device_cfg,
+            acs_state_machine.data_model,
+            acs_state_machine.config_postprocessor,
+        )
+        for p in parameters_to_delete:
+            self.assertFalse(desired_cfg.has_parameter(p))
+
+    def test_device_and_desired_config_discrepancy_after_initial_configuration(self):
+        """
+        Testing a situation where device_cfg and desired_cfg are already present on the state machine,
+        because the initial configuration of the radio has occurred, but then the configs have diverged
+        (e.g. as a result of domain-proxy setting different values on the desired config)
+        """
+        # Skipping previous states
+        acs_state_machine = provision_clean_sm('wait_get_transient_params')
+
+        # Need to set this param on the device_cfg first, otherwise we won't be able to generate the desired_cfg
+        # using 'build_desired_config' function
+        acs_state_machine.device_cfg.set_parameter(ParameterName.IP_SEC_ENABLE, 'false')
+
+        acs_state_machine.desired_cfg = build_desired_config(
+            acs_state_machine.mconfig,
+            acs_state_machine.service_config,
+            acs_state_machine.device_cfg,
+            acs_state_machine.data_model,
+            acs_state_machine.config_postprocessor,
+        )
+
+        prepare_device_cfg_same_as_desired_cfg(acs_state_machine)
+
+        # Let's say that while in 'wait_for_dp' state, the DP asked us to change this param's value in the desired_cfg
+        acs_state_machine.desired_cfg.set_parameter(ParameterName.EARFCNDL, 5)
+
+        req = Tr069MessageBuilder.param_values_qrtb_response(
+            GET_TRANSIENT_PARAMS_RESPONSE_PARAMS,
+            models.GetParameterValuesResponse,
+        )
+
+        # ACS asking for all params from data model
+        acs_state_machine.handle_tr069_message(req)
+
+        req = Tr069MessageBuilder.param_values_qrtb_response(
+            GET_PARAMS_RESPONSE_PARAMS, models.GetParameterValuesResponse,
+        )
+
+        # ACS asking for object params
+        acs_state_machine.handle_tr069_message(req)
+        req = Tr069MessageBuilder.get_object_param_values_response(
+            cell_reserved_for_operator_use='true', enable='true', is_primary='true', plmnid='00101',
+        )
+
+        # ACS should ask the radio to correct the only parameter that doesn't match the desired config - EARFCNDL
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        self.assertIsInstance(resp, models.SetParameterValues)
+        self.assertEqual(1, len(resp.ParameterList.ParameterValueStruct))
+        self.assertEqual(
+            'Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.EARFCNDL',
+            resp.ParameterList.ParameterValueStruct[0].Name,
+        )
+        self.assertEqual('5', resp.ParameterList.ParameterValueStruct[0].Value.Data)
+
+    def test_sas_enable_mode_is_enabled(self):
+        acs_state_machine = provision_clean_sm()
+        acs_state_machine.device_cfg.set_parameter(ParameterName.IP_SEC_ENABLE, 'false')
+
+        acs_state_machine.desired_cfg = build_desired_config(
+            acs_state_machine.mconfig,
+            acs_state_machine.service_config,
+            acs_state_machine.device_cfg,
+            acs_state_machine.data_model,
+            acs_state_machine.config_postprocessor,
+        )
+
+        self.assertEqual(1, acs_state_machine.desired_cfg.get_parameter(ParameterName.SAS_ENABLED))
+
+
+def prepare_device_cfg_same_as_desired_cfg(acs_state_machine):
+    # Setting all regular params in the device_cfg to the same values as those in desired_cfg
+    for param in acs_state_machine.desired_cfg.get_parameter_names():
+        acs_state_machine.device_cfg.set_parameter(param, acs_state_machine.desired_cfg.get_parameter(param))
+
+    # Setting all object params in the device_cfg to the same values as those in desired_cfg
+    for obj in acs_state_machine.desired_cfg.get_object_names():
+        acs_state_machine.device_cfg.add_object(obj)
+        for param in acs_state_machine.desired_cfg.get_parameter_names_for_object(obj):
+            val = acs_state_machine.desired_cfg.get_parameter_for_object(param, obj)
+            acs_state_machine.device_cfg.set_parameter_for_object(param, val, obj)
+
+
+def provision_clean_sm(state=None):
+    acs_state_machine = EnodebAcsStateMachineBuilder.build_acs_state_machine(EnodebDeviceName.BAICELLS_QRTB)
+    acs_state_machine.desired_cfg = EnodebConfiguration(
+        BaicellsQRTBTrDataModel(),
+    )
+    if state is not None:
+        acs_state_machine.transition(state)
+    return acs_state_machine

--- a/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
@@ -12,18 +12,29 @@ limitations under the License.
 """
 import logging
 import os
+from unittest import TestCase, mock
 from unittest.mock import Mock, call, patch
 
+from dp.protos.enodebd_dp_pb2 import CBSDStateResult, LteChannel
 from lte.protos.mconfig import mconfigs_pb2
 from magma.common.service import MagmaService
 from magma.enodebd.data_models.data_model_parameters import ParameterName
-from magma.enodebd.devices.device_map import get_device_handler_from_name
+from magma.enodebd.device_config.cbrs_consts import BAND
+from magma.enodebd.device_config.configuration_init import build_desired_config
+from magma.enodebd.device_config.enodeb_configuration import EnodebConfiguration
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.devices.freedomfi_one import (
+    SAS_KEY,
     FreedomFiOneConfigurationInitializer,
+    FreedomFiOneEndSessionState,
+    FreedomFiOneGetInitState,
+    FreedomFiOneNotifyDPState,
+    FreedomFiOneTrDataModel,
     SASParameters,
     StatusParameters,
+    ff_one_update_desired_config_from_cbsd_state,
 )
+from magma.enodebd.exceptions import ConfigurationError
 from magma.enodebd.tests.test_utils.config_builder import EnodebConfigBuilder
 from magma.enodebd.tests.test_utils.enb_acs_builder import (
     EnodebAcsStateMachineBuilder,
@@ -31,10 +42,20 @@ from magma.enodebd.tests.test_utils.enb_acs_builder import (
 from magma.enodebd.tests.test_utils.enodeb_handler import EnodebHandlerTestCase
 from magma.enodebd.tests.test_utils.tr069_msg_builder import Tr069MessageBuilder
 from magma.enodebd.tr069 import models
+from parameterized import parameterized
 
 SRC_CONFIG_DIR = os.path.join(
     os.environ.get('MAGMA_ROOT'),
     'lte/gateway/configs',
+)
+
+MOCK_CBSD_STATE = CBSDStateResult(
+    radio_enabled=True,
+    channel=LteChannel(
+        low_frequency_hz=3550_000_000,
+        high_frequency_hz=3570_000_000,
+        max_eirp_dbm_mhz=15,
+    ),
 )
 
 
@@ -173,9 +194,16 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
         )
         param_val_list.append(
             Tr069MessageBuilder.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.FCCIdentificationNumber',
+                val_type='string',
+                data='P27-SCE4255W',
+            ),
+        )
+        param_val_list.append(
+            Tr069MessageBuilder.get_parameter_value_struct(
                 name='Device.Services.FAPService.1.FAPControl.LTE.X_000E8F_SAS.UserContactInformation',
                 val_type='string',
-                data='M0LK4T',
+                data='M0LK4T',  # TODO do not take it from the radio. Embed it in config somewhere
             ),
         )
         param_val_list.append(
@@ -397,44 +425,8 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
         )
         return msg
 
-    def _get_service_config(self):
-        return {
-            "tr069": {
-                "interface": "eth1",
-                "port": 48080,
-                "perf_mgmt_port": 8081,
-                "public_ip": "192.88.99.142",
-            },
-            "reboot_enodeb_on_mme_disconnected": True,
-            "s1_interface": "eth1",
-            "sas": {
-                "sas_enabled": True,
-                "sas_server_url":
-                    "https://spectrum-connect.federatedwireless.com/v1.2/",
-                "sas_uid": "M0LK4T",
-                "sas_category": "A",
-                "sas_channel_type": "GAA",
-                "sas_cert_subject": "/C=TW/O=Sercomm/OU=WInnForum CBSD "
-                                    "Certificate/CN=P27-SCE4255W:%s",
-                "sas_icg_group_id": "",
-                "sas_location": "indoor",
-                "sas_height_type": "AMSL",
-            },
-            "sentry": "disabled",
-        }
-
-    def build_freedomfi_one_acs_state_machine(self):
-        service = EnodebAcsStateMachineBuilder.build_magma_service(
-            mconfig=EnodebConfigBuilder.get_mconfig(),
-            service_config=self._get_service_config(),
-        )
-        handler_class = get_device_handler_from_name(
-            EnodebDeviceName.FREEDOMFI_ONE,
-        )
-        acs_state_machine = handler_class(service)
-        return acs_state_machine
-
-    def test_provision(self) -> None:
+    @mock.patch('magma.enodebd.devices.freedomfi_one.get_cbsd_state')
+    def test_provision(self, mock_get_state) -> None:
         """
         Test the basic provisioning workflow
         1 - enodeb sends Inform, enodebd sends InformResponse
@@ -443,8 +435,19 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
         4 - enodebd sends get param values, updates the device state
         5 - enodebd, sets fields including SAS fields.
         """
+
+        mock_get_state.return_value = MOCK_CBSD_STATE
+
         logging.root.level = logging.DEBUG
-        acs_state_machine = self.build_freedomfi_one_acs_state_machine()
+        acs_state_machine = EnodebAcsStateMachineBuilder.build_acs_state_machine(EnodebDeviceName.FREEDOMFI_ONE)
+        acs_state_machine._service.config = get_service_config()
+        acs_state_machine.desired_cfg = build_desired_config(
+            acs_state_machine.mconfig,
+            acs_state_machine.service_config,
+            acs_state_machine.device_cfg,
+            acs_state_machine.data_model,
+            acs_state_machine.config_postprocessor,
+        )
 
         inform = Tr069MessageBuilder.get_inform(
             oui="000E8F",
@@ -502,6 +505,54 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             'Provisioning completed with Dummy response',
         )
 
+
+class FreedomFiOneStatesTests(EnodebHandlerTestCase):
+    """Testing FreedomfiOne specific states"""
+
+    @parameterized.expand([
+        (False, FreedomFiOneNotifyDPState),
+        (True, FreedomFiOneEndSessionState),
+    ])
+    @mock.patch('magma.enodebd.devices.freedomfi_one.get_cbsd_state')
+    def test_end_session_and_notify_dp_transition_depending_on_sas_enabled_flag(
+            self, sas_enabled, expected_state, mock_get_state,
+    ):
+        """Testing if SM steps in and out of FreedomFiOneWaitNotifyDPState as per state map depending on whether
+        sas_enabled param is set to True or False in the service config"""
+
+        mock_get_state.return_value = MOCK_CBSD_STATE
+
+        acs_state_machine = EnodebAcsStateMachineBuilder.build_acs_state_machine(EnodebDeviceName.FREEDOMFI_ONE)
+        acs_state_machine._service.config = get_service_config(sas_enabled=sas_enabled)
+        acs_state_machine.desired_cfg = build_desired_config(
+            acs_state_machine.mconfig,
+            acs_state_machine.service_config,
+            acs_state_machine.device_cfg,
+            acs_state_machine.data_model,
+            acs_state_machine.config_postprocessor,
+        )
+
+        # Need to fill these values in the device_cfg if we're going to transition to notify_dp state
+        acs_state_machine.device_cfg.set_parameter(SASParameters.SAS_USER_ID, 'test_user')
+        acs_state_machine.device_cfg.set_parameter(SASParameters.SAS_FCC_ID, 'test_fcc')
+        acs_state_machine.device_cfg.set_parameter(ParameterName.SERIAL_NUMBER, 'test_sn')
+        acs_state_machine.transition('check_wait_get_params')
+
+        msg = Tr069MessageBuilder.param_values_qrtb_response([], models.GetParameterValuesResponse)
+
+        # SM should transition from check_wait_get_params to end_session -> notify_dp automatically
+        # upon receiving response from the radio
+        acs_state_machine.handle_tr069_message(msg)
+
+        self.assertIsInstance(acs_state_machine.state, expected_state)
+
+        msg = Tr069MessageBuilder.get_inform(event_codes=['1 BOOT'])
+
+        # SM should go into wait_inform state, respond with Inform response and transition to FreedomFiOneGetInitState
+        acs_state_machine.handle_tr069_message(msg)
+
+        self.assertIsInstance(acs_state_machine.state, FreedomFiOneGetInitState)
+
     def test_manual_reboot_during_provisioning(self) -> None:
         """
         Test a scenario where a Magma user goes through the enodebd CLI to
@@ -511,7 +562,7 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
         of a TR-069 provisioning session.
         """
         logging.root.level = logging.DEBUG
-        acs_state_machine = self.build_freedomfi_one_acs_state_machine()
+        acs_state_machine = EnodebAcsStateMachineBuilder.build_acs_state_machine(EnodebDeviceName.FREEDOMFI_ONE)
 
         # Send an Inform message, wait for an InformResponse
         inform = Tr069MessageBuilder.get_inform(
@@ -553,10 +604,16 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             'receiving a RebootResponse',
         )
 
-    def test_post_processing(self) -> None:
+    @parameterized.expand([
+        (True, "GNSS"),
+        (False, "GNSS"),
+        (True, "some_other_value"),
+        (False, "some_other_value"),
+    ])
+    def test_post_processing(self, sas_enabled, prim_src) -> None:
         """ Test FreedomFi One specific post processing functionality"""
 
-        acs_state_machine = self.build_freedomfi_one_acs_state_machine()
+        acs_state_machine = EnodebAcsStateMachineBuilder.build_acs_state_machine(EnodebDeviceName.FREEDOMFI_ONE)
         cfg_desired = Mock()
         acs_state_machine.device_cfg.set_parameter(
             ParameterName.SERIAL_NUMBER,
@@ -566,7 +623,8 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
         cfg_init = FreedomFiOneConfigurationInitializer(acs_state_machine)
         cfg_init.postprocess(
             EnodebConfigBuilder.get_mconfig(),
-            self._get_service_config(), cfg_desired,
+            get_service_config(sas_enabled=sas_enabled, prim_src=prim_src),
+            cfg_desired,
         )
         expected = [
             call.delete_parameter('EARFCNDL'),
@@ -574,35 +632,37 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             call.delete_parameter('UL bandwidth'),
             call.set_parameter(
                 'tunnel_ref',
-                'Device.IP.Interface.1.IPv4Address.1.',
+                value='Device.IP.Interface.1.IPv4Address.1.',
             ),
-            call.set_parameter('prim_src', 'GNSS'),
-            call.set_parameter('carrier_agg_enable', True),
-            call.set_parameter('carrier_number', 2),
-            call.set_parameter('contiguous_cc', 0),
-            call.set_parameter('web_ui_enable', False),
-            call.set_parameter('sas_enabled', True),
-            call.set_parameter(
-                'sas_server_url',
-                'https://spectrum-connect.federatedwireless.com/v1.2/',
-            ),
-            call.set_parameter('sas_uid', 'M0LK4T'),
-            call.set_parameter('sas_category', 'A'),
-            call.set_parameter('sas_channel_type', 'GAA'),
-            call.set_parameter(
-                'sas_cert_subject',
-                '/C=TW/O=Sercomm/OU=WInnForum CBSD Certificate/CN=P27-SCE4255W:%s',
-            ),
-            call.set_parameter('sas_location', 'indoor'),
-            call.set_parameter('sas_height_type', 'AMSL'),
+            call.set_parameter('prim_src', prim_src),
+            call.set_parameter('carrier_agg_enable', value=True),
+            call.set_parameter('carrier_number', value=2),
+            call.set_parameter('contiguous_cc', value=0),
+            call.set_parameter('web_ui_enable', value=False),
+            call.set_parameter('sas_enabled', sas_enabled),
             call.set_parameter_for_object(
                 param_name='PLMN 1 cell reserved',
                 value=True, object_name='PLMN 1',
             ),
         ]
-        cfg_desired.mock_calls.sort()
-        expected.sort()
-        self.assertEqual(cfg_desired.mock_calls, expected)
+        if sas_enabled:
+            expected += [
+                call.set_parameter(
+                    'sas_server_url',
+                    'https://spectrum-connect.federatedwireless.com/v1.2/',
+                ),
+                call.set_parameter('sas_uid', 'M0LK4T'),
+                call.set_parameter('sas_category', 'A'),
+                call.set_parameter('sas_channel_type', 'GAA'),
+                call.set_parameter(
+                    'sas_cert_subject',
+                    '/C=TW/O=Sercomm/OU=WInnForum CBSD Certificate/CN=P27-SCE4255W:%s',
+                ),
+                call.set_parameter('sas_location', 'indoor'),
+                call.set_parameter('sas_height_type', 'AMSL'),
+            ]
+
+        cfg_desired.assert_has_calls(expected, any_order=True)
 
         # Check without sas config
         service_cfg = {
@@ -612,6 +672,7 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
                 "perf_mgmt_port": 8081,
                 "public_ip": "192.88.99.142",
             },
+            "prim_src": prim_src,
             "reboot_enodeb_on_mme_disconnected": True,
             "s1_interface": "eth1",
         }
@@ -626,21 +687,20 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             call.delete_parameter('UL bandwidth'),
             call.set_parameter(
                 'tunnel_ref',
-                'Device.IP.Interface.1.IPv4Address.1.',
+                value='Device.IP.Interface.1.IPv4Address.1.',
             ),
-            call.set_parameter('prim_src', 'GNSS'),
-            call.set_parameter('carrier_agg_enable', True),
-            call.set_parameter('carrier_number', 2),
-            call.set_parameter('contiguous_cc', 0),
-            call.set_parameter('web_ui_enable', False),
+            call.set_parameter('sas_enabled', False),
+            call.set_parameter('prim_src', prim_src),
+            call.set_parameter('carrier_agg_enable', value=True),
+            call.set_parameter('carrier_number', value=2),
+            call.set_parameter('contiguous_cc', value=0),
+            call.set_parameter('web_ui_enable', value=False),
             call.set_parameter_for_object(
                 param_name='PLMN 1 cell reserved',
                 value=True, object_name='PLMN 1',
             ),
         ]
-        cfg_desired.mock_calls.sort()
-        expected.sort()
-        self.assertEqual(cfg_desired.mock_calls, expected)
+        cfg_desired.assert_has_calls(expected, any_order=True)
 
         service_cfg['web_ui_enable_list'] = ["2006CW5000023"]
 
@@ -650,14 +710,15 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             call.delete_parameter('UL bandwidth'),
             call.set_parameter(
                 'tunnel_ref',
-                'Device.IP.Interface.1.IPv4Address.1.',
+                value='Device.IP.Interface.1.IPv4Address.1.',
             ),
-            call.set_parameter('prim_src', 'GNSS'),
-            call.set_parameter('carrier_agg_enable', True),
-            call.set_parameter('carrier_number', 2),
-            call.set_parameter('contiguous_cc', 0),
-            call.set_parameter('web_ui_enable', False),
-            call.set_parameter('web_ui_enable', True),
+            call.set_parameter('sas_enabled', False),
+            call.set_parameter('prim_src', prim_src),
+            call.set_parameter('carrier_agg_enable', value=True),
+            call.set_parameter('carrier_number', value=2),
+            call.set_parameter('contiguous_cc', value=0),
+            call.set_parameter('web_ui_enable', value=False),
+            call.set_parameter('web_ui_enable', value=True),
             call.set_parameter_for_object(
                 param_name='PLMN 1 cell reserved',
                 value=True, object_name='PLMN 1',
@@ -668,24 +729,20 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
             EnodebConfigBuilder.get_mconfig(),
             service_cfg, cfg_desired,
         )
-        cfg_desired.mock_calls.sort()
-        expected.sort()
-        self.assertEqual(cfg_desired.mock_calls, expected)
+        cfg_desired.assert_has_calls(expected, any_order=True)
 
     @patch('magma.configuration.service_configs.CONFIG_DIR', SRC_CONFIG_DIR)
     def test_service_cfg_parsing(self):
         """ Test the parsing of the service config file for enodebd.yml"""
+        self.maxDiff = None
         service = MagmaService('enodebd', mconfigs_pb2.EnodebD())
         service_cfg = service.config
-        service_cfg_1 = self._get_service_config()
+        service_cfg_1 = get_service_config()
         service_cfg_1['web_ui_enable_list'] = []
-        service_cfg_1[FreedomFiOneConfigurationInitializer.SAS_KEY][
-            SASParameters.SAS_UID
-        ] = "INVALID_ID"
-        service_cfg_1[FreedomFiOneConfigurationInitializer.SAS_KEY][
-            SASParameters.SAS_CERT_SUBJECT
-        ] = "INVALID_CERT_SUBJECT"
-        self.assertEqual(service_cfg, service_cfg_1)
+        service_cfg_1["prim_src"] = "GNSS"
+        service_cfg_1[SAS_KEY][SASParameters.SAS_UID] = "INVALID_ID"
+        service_cfg_1[SAS_KEY][SASParameters.SAS_CERT_SUBJECT] = "INVALID_CERT_SUBJECT"
+        self.assertDictEqual(service_cfg, service_cfg_1)
 
     def test_status_nodes(self):
         """ Test that the status of the node is valid"""
@@ -820,3 +877,141 @@ class FreedomFiOneTests(EnodebHandlerTestCase):
         ]
         status.set_magma_device_cfg(n8, device_config)
         self.assertEqual(expected, device_config.mock_calls)
+
+
+class TXParamsTests(TestCase):
+    @parameterized.expand([
+        (3550_000_000, 3560_000_000, 19, '50', 55290, 24),
+        (3555_000_000, 3570_000_000, 17, '75', 55365, 23),
+        (3600_000_000, 3605_000_000, 19, '25', 55765, 20),
+    ])
+    def test_tx_parameters_with_eirp_within_range(
+            self,
+            low_frequency_hz,
+            high_frequency_hz,
+            max_eirp_dbm_mhz,
+            expected_bw_rbs,
+            expected_earfcn,
+            expected_tx_power,
+    ) -> None:
+        """Test that tx parameters of the enodeb are calculated correctly when eirp received from SAS
+        is within acceptable range for the given bandwidth"""
+        desired_config = EnodebConfiguration(FreedomFiOneTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=low_frequency_hz,
+            high_frequency_hz=high_frequency_hz,
+            max_eirp_dbm_mhz=max_eirp_dbm_mhz,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+
+        ff_one_update_desired_config_from_cbsd_state(state, desired_config)
+        self.assert_config_updated(
+            config=desired_config,
+            bandwidth=expected_bw_rbs,
+            earfcn=expected_earfcn,
+            tx_power=expected_tx_power,
+            radio_enabled=True,
+        )
+
+    @parameterized.expand([
+        (30,),
+        (-10,),
+    ])
+    def test_tx_parameters_with_eirp_out_of_range(self, max_eirp_dbm_mhz) -> None:
+        """Test that tx parameters calculations raise an exception when eirp received from SAS
+        is outside of acceptable range for the given bandwidth"""
+        desired_config = EnodebConfiguration(FreedomFiOneTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3550_000_000,
+            high_frequency_hz=3570_000_000,
+            max_eirp_dbm_mhz=max_eirp_dbm_mhz,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        with self.assertRaises(ConfigurationError):
+            ff_one_update_desired_config_from_cbsd_state(state, desired_config)
+
+    @parameterized.expand([
+        (3550_000_000, 3551_000_000),
+        (3550_000_000, 3552_000_000),
+    ])
+    def test_tx_parameters_with_unsupported_bandwidths(self, low_frequency_hz, high_frequency_hz) -> None:
+        """Test that tx parameters calculations raise an exception for unsupported bandwidth ranges"""
+        desired_config = EnodebConfiguration(FreedomFiOneTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=low_frequency_hz,
+            high_frequency_hz=high_frequency_hz,
+            max_eirp_dbm_mhz=5,
+        )
+        state = CBSDStateResult(
+            radio_enabled=True,
+            channel=channel,
+        )
+        with self.assertRaises(ConfigurationError):
+            ff_one_update_desired_config_from_cbsd_state(state, desired_config)
+
+    def test_tx_parameters_not_set_when_radio_disabled(self):
+        """Test that tx parameters of the enodeb are not set when ADMIN_STATE is disabled on the radio"""
+        desired_config = EnodebConfiguration(FreedomFiOneTrDataModel())
+        channel = LteChannel(
+            low_frequency_hz=3550_000_000,
+            high_frequency_hz=3570_000_000,
+            max_eirp_dbm_mhz=20,
+        )
+        state = CBSDStateResult(
+            radio_enabled=False,
+            channel=channel,
+        )
+
+        ff_one_update_desired_config_from_cbsd_state(state, desired_config)
+        self.assertEqual(1, len(desired_config.get_parameter_names()))
+        self.assertEqual(False, desired_config.get_parameter(ParameterName.ADMIN_STATE))
+
+    def assert_config_updated(
+            self, config: EnodebConfiguration, bandwidth: str, earfcn: int, tx_power: int, radio_enabled: bool,
+    ) -> None:
+        expected_values = {
+            ParameterName.ADMIN_STATE: radio_enabled,
+            ParameterName.DL_BANDWIDTH: bandwidth,
+            ParameterName.UL_BANDWIDTH: bandwidth,
+            ParameterName.EARFCNDL: earfcn,
+            ParameterName.EARFCNUL: earfcn,
+            SASParameters.TX_POWER_CONFIG: tx_power,
+            SASParameters.FREQ_BAND1: BAND,
+            SASParameters.FREQ_BAND2: BAND,
+        }
+        for key, value in expected_values.items():
+            self.assertEqual(config.get_parameter(key), value)
+
+
+def get_service_config(sas_enabled: bool = True, prim_src: str = "GNSS"):
+    return {
+        "tr069": {
+            "interface": "eth1",
+            "port": 48080,
+            "perf_mgmt_port": 8081,
+            "public_ip": "192.88.99.142",
+        },
+        "reboot_enodeb_on_mme_disconnected": True,
+        "s1_interface": "eth1",
+        "sas": {
+            "sas_enabled": sas_enabled,
+            "sas_server_url":
+                "https://spectrum-connect.federatedwireless.com/v1.2/",
+            "sas_uid": "M0LK4T",
+            "sas_category": "A",
+            "sas_channel_type": "GAA",
+            "sas_cert_subject": "/C=TW/O=Sercomm/OU=WInnForum CBSD "
+                                "Certificate/CN=P27-SCE4255W:%s",
+            "sas_icg_group_id": "",
+            "sas_location": "indoor",
+            "sas_height_type": "AMSL",
+        },
+        'sentry': 'disabled',
+        'prim_src': prim_src,
+    }

--- a/lte/gateway/python/magma/enodebd/tests/get_params_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/get_params_tests.py
@@ -1,0 +1,68 @@
+"""
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from magma.enodebd.data_models.data_model_parameters import ParameterName
+from magma.enodebd.device_config.configuration_init import build_desired_config
+from magma.enodebd.devices.baicells_qrtb import BaicellsQRTBTrDataModel
+from magma.enodebd.devices.device_utils import EnodebDeviceName
+from magma.enodebd.state_machines.acs_state_utils import (
+    get_object_params_to_get,
+)
+from magma.enodebd.tests.test_utils.enb_acs_builder import (
+    EnodebAcsStateMachineBuilder,
+)
+from magma.enodebd.tests.test_utils.enodeb_handler import EnodebHandlerTestCase
+from parameterized import parameterized
+
+
+class GetParamsTestCase(EnodebHandlerTestCase):
+    @parameterized.expand([
+        (True, True, 4),
+        (True, False, 4),
+        (False, True, 0),
+        (False, False, 4),
+    ])
+    def test_get_object_params_to_get(
+            self, request_all_params: bool, with_desired_config: bool, expected_object_names_list_len: int,
+    ):
+        acs_state_machine = self._prepare_sm()
+        data_model = BaicellsQRTBTrDataModel()
+
+        if with_desired_config:
+            acs_state_machine.desired_cfg = self._prepare_desired_cfg_for_sm(acs_state_machine)
+
+        obj_names = get_object_params_to_get(
+            desired_cfg=acs_state_machine.desired_cfg,
+            device_cfg=acs_state_machine.device_cfg,
+            data_model=data_model,
+            request_all_params=request_all_params,
+        )
+
+        self.assertEqual(expected_object_names_list_len, len(obj_names))
+
+    @staticmethod
+    def _prepare_sm():
+        sm = EnodebAcsStateMachineBuilder.build_acs_state_machine(EnodebDeviceName.BAICELLS_QRTB)
+        sm.device_cfg.set_parameter(ParameterName.IP_SEC_ENABLE, False)
+        sm.device_cfg.set_parameter(ParameterName.NUM_PLMNS, 1)
+        return sm
+
+    @staticmethod
+    def _prepare_desired_cfg_for_sm(sm):
+        return build_desired_config(
+            sm.mconfig,
+            sm.service_config,
+            sm.device_cfg,
+            sm.data_model,
+            sm.config_postprocessor,
+        )

--- a/lte/gateway/python/magma/enodebd/tests/spyne_mods_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/spyne_mods_tests.py
@@ -1,0 +1,67 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from datetime import datetime
+from unittest import TestCase
+
+from magma.enodebd.tr069 import models
+from magma.enodebd.tr069.spyne_mods import as_dict
+
+
+class SpineModsTests(TestCase):
+    def test_as_dict(self):
+        inp = models.Inform(
+            DeviceId=models.DeviceIdStruct(
+                Manufacturer='some_manufacturer',
+                OUI='123456',
+                ProductClass='some_product_class',
+                SerialNumber='some_serial_number',
+            ),
+            Event=models.EventList(
+                EventStruct=[
+                    models.EventStruct(
+                        EventCode='some_event_code',
+                        CommandKey='some_command_key',
+                    ),
+                    models.EventStruct(
+                        EventCode='other_event_code',
+                        CommandKey='other_command_key',
+                    ),
+                ],
+            ),
+            MaxEnvelopes=1234,
+            CurrentTime=datetime.fromisoformat('2021-09-15 16:15:43.351680'),
+        )
+        out = as_dict(inp)
+        expected = {
+            'DeviceId': {
+                'Manufacturer': 'some_manufacturer',
+                'OUI': '123456',
+                'ProductClass': 'some_product_class',
+                'SerialNumber': 'some_serial_number',
+            },
+            'Event': {
+                'EventStruct': [
+                    {
+                        'EventCode': 'some_event_code',
+                        'CommandKey': 'some_command_key',
+                    },
+                    {
+                        'EventCode': 'other_event_code',
+                        'CommandKey': 'other_command_key',
+                    },
+                ],
+            },
+            'MaxEnvelopes': '1234',
+            'CurrentTime': '2021-09-15 16:15:43.351680',
+        }
+        self.assertEqual(out, expected)

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
@@ -55,9 +55,10 @@ class EnodebAcsStateMachineBuilder:
     def build_acs_state_machine(
         cls,
         device: EnodebDeviceName = EnodebDeviceName.BAICELLS,
+        service_config: Dict = None,
     ) -> EnodebAcsStateMachine:
         # Build the state_machine
-        service = cls.build_magma_service(device)
+        service = cls.build_magma_service(device, service_config)
         handler_class = get_device_handler_from_name(device)
         acs_state_machine = handler_class(service)
         return acs_state_machine

--- a/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
+++ b/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 from magma.enodebd.logger import EnodebdLogger as logger
 from magma.enodebd.state_machines.enb_acs_manager import StateMachineManager
+from magma.enodebd.tr069.spyne_mods import as_dict
 from spyne.decorator import rpc
 from spyne.model.complex import ComplexModelBase
 from spyne.server.wsgi import WsgiMethodContext
@@ -91,18 +92,12 @@ class AutoConfigServer(ServiceBase):
         message: ComplexModelBase,
     ) -> ComplexModelBase:
         # Log incoming msg
-        if hasattr(message, 'as_dict'):
-            logger.debug('Handling TR069 message: %s', str(type(message)))
-        else:
-            logger.debug('Handling TR069 message.')
+        logger.debug('Handling TR069 message: %s', str(as_dict(message)))
 
         req = cls._get_tr069_response_from_sm(ctx, message)
 
         # Log outgoing msg
-        if hasattr(req, 'as_dict'):
-            logger.debug('Sending TR069 message: %s', str(req.as_dict()))
-        else:
-            logger.debug('Sending TR069 message.')
+        logger.debug('Sending TR069 message: %s', str(as_dict(req)))
 
         # Set header
         ctx.out_header = models.ID(mustUnderstand='1')

--- a/lte/gateway/python/magma/enodebd/tr069/spyne_mods.py
+++ b/lte/gateway/python/magma/enodebd/tr069/spyne_mods.py
@@ -20,6 +20,8 @@ modifications are required because:
 3) Minor enhancements for debug-ability
 """
 
+from typing import Any, Dict, List, Union
+
 from lxml import etree
 from magma.enodebd.logger import EnodebdLogger as logger
 from spyne.application import Application
@@ -153,3 +155,20 @@ class Tr069Soap11(Soap11):
 
         # Keep XSD namespace
         etree.cleanup_namespaces(ctx.out_document, keep_ns_prefixes=['xsd'])
+
+
+def as_dict(x: Any) -> Union[Dict, List, str]:
+    """
+    Represent TR069 payloads as python dictionaries. Used mostly for debug
+
+    Args:
+        x (Any): element to represent as dict
+
+    Returns:
+        Union[Dict, List, str]
+    """
+    if hasattr(x, 'as_dict'):
+        return {k: as_dict(v) for k, v in x.as_dict().items()}
+    elif isinstance(x, list):
+        return [as_dict(v) for v in x]
+    return str(x)

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -139,6 +139,7 @@ setup(
             'nose==1.3.7',
             'coverage',
             'iperf3',
+            'parameterized==0.8.1',
         ],
     },
 )


### PR DESCRIPTION
Signed-off-by: Marcin Trojanowski <marcin.trojanowski@freedomfi.com>

[WIP]: Magma Domain Proxy

## Summary
As concluded in https://github.com/magma/magma/pull/10230
This set of PRs is a proposal of a merge of Domain Proxy development into Magma codebase.

As discussed in a community meeting with @talkhasib , @hcgatewood, @jpad-freedomfi, @aswin-alexander, @bbarritt and others, this PR is a first step of discussion on how to include the ongoing development of vendor neutral Domain Proxy code into Magma's codebase.

The PR consists of a few commit's, each commit intended to target a specific section of magma code and its ownership.
Please review and comment if this division makes logical sense. We could either proceed with having one PR with such commits, or we can issue individual PRs per each section/domain.

Currently we have 5 PRs in this set which breaks code in somewhat more reviewable chunks:
1) Helm charts integration - this development has already been reviewed by @hcgatewood 
2) Orchestrator deployment integration
3) Domain Proxy: AGW side - integration with AGW/enodebd (LTE module) based on Baicells 436Q eNB
4) Domain Proxy: ORC8R side - domain proxy microservices that interact with AGW/enodebd and SAS server
5) Github workflows

The Domain Proxy part presented here, with minor alternations done due to rebase onto magmas master, has been fully tested in a local lab - helm, deployment, DProxy in orc8r interface with AGW, Baicells 436Q eNB able to be fully configured.

The code is now capable of acquiring and maintaining a SAS grant on behalf of a Baicells 436Q and fully configure it for transmission via TR069.