### PR TITLE
feat: build libtins with Bazel for connectiond and liagentd

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -115,3 +115,11 @@ def cpp_repositories():
         remote = "https://github.com/getsentry/sentry-native",
         shallow_since = "1627998929 +0000",
     )
+
+    http_archive(
+        name = "libtins",
+        build_file = "//bazel/external:libtins.BUILD",
+        url = "https://github.com/mfontanini/libtins/archive/refs/tags/v4.2.tar.gz",
+        strip_prefix = "libtins-4.2",
+        sha256 = "a9fed73e13f06b06a4857d342bb30815fa8c359d00bd69547e567eecbbb4c3a1",
+    )

--- a/bazel/external/libtins.BUILD
+++ b/bazel/external/libtins.BUILD
@@ -1,0 +1,40 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Manually generate config.h from config.h.in
+genrule(
+    name = "generate_config_h",
+    srcs = ["include/tins/config.h.in"],
+    outs = ["include/tins/config.h"],
+    # Substitute #cmakedefine with #define
+    cmd = 'sed "s/\\#cmakedefine/\\#define/" "$<" > "$@"',
+)
+
+cc_library(
+    name = "libtins",
+    srcs = glob(
+        [
+            "src/*.cpp",
+            "src/detail/*.cpp",
+            "src/tcp_ip/*.cpp",
+            "src/utils/*.cpp",
+            "src/dot11/*.cpp",
+        ],
+    ) + [":generate_config_h"],
+    hdrs = glob(
+        ["include/tins/**"],
+    ),
+    includes = ["include"],
+    linkopts = ["-lpcap"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/external/system_libraries.BUILD
+++ b/bazel/external/system_libraries.BUILD
@@ -47,10 +47,10 @@ cc_library(
     }),
 )
 
-cc_library(
-    name = "libtins",
-    linkopts = ["-ltins"],
-)
+# cc_library(
+#     name = "libtins",
+#     linkopts = ["-ltins"],
+# )
 
 cc_library(
     name = "libmnl",

--- a/bazel/external/system_libraries.BUILD
+++ b/bazel/external/system_libraries.BUILD
@@ -47,11 +47,6 @@ cc_library(
     }),
 )
 
-# cc_library(
-#     name = "libtins",
-#     linkopts = ["-ltins"],
-# )
-
 cc_library(
     name = "libmnl",
     linkopts = ["-lmnl"],

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -71,23 +71,11 @@ RUN git clone https://github.com/facebook/folly && cd folly && \
     cd / && \
     rm -rf folly
 
-# libtins is required to build the connection_tracker
 RUN apt-get install -y --no-install-recommends \
+    # used by libtins and connection tracker
     libpcap-dev=1.9.1-3 \
+    # used by connection tracker
     libmnl-dev=1.0.4-2
-
-# TODO(@themarwhal): this might not be hard to bazelify if we can generate the config
-RUN git clone --branch v4.3 https://github.com/mfontanini/libtins.git && \
-    cd libtins && \
-    mkdir build && \
-    cd build && \
-    cmake ../ -DLIBTINS_ENABLE_CXX11=1 && \
-    make -j"$(nproc)" && \
-    make install && \
-    cd / && \
-    rm -rf libtins && \
-    # symlink to /usr/lib to match Magma VM
-    ln -s /usr/local/lib/libtins.so /usr/lib/libtins.so
 
 RUN apt-get -y install --no-install-recommends \
     libtool=2.4.6-14

--- a/lte/gateway/c/connection_tracker/src/BUILD.bazel
+++ b/lte/gateway/c/connection_tracker/src/BUILD.bazel
@@ -14,6 +14,9 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 cc_binary(
     name = "connectiond",
     srcs = ["main.cpp"],
+    copts = [
+        "-DLOG_WITH_GLOG",
+    ],
     deps = [
         ":event_tracker",
         "//lte/protos:mconfigs_cpp_proto",
@@ -38,7 +41,6 @@ cc_library(
     hdrs = ["PacketGenerator.h"],
     deps = [
         "//orc8r/gateway/c/common/logging",
-        #"@system_libraries//:libtins",
-        "@libtins//:libtins",
+        "@libtins",
     ],
 )

--- a/lte/gateway/c/connection_tracker/src/BUILD.bazel
+++ b/lte/gateway/c/connection_tracker/src/BUILD.bazel
@@ -38,6 +38,7 @@ cc_library(
     hdrs = ["PacketGenerator.h"],
     deps = [
         "//orc8r/gateway/c/common/logging",
-        "@system_libraries//:libtins",
+        #"@system_libraries//:libtins",
+        "@libtins//:libtins",
     ],
 )

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -43,7 +43,8 @@ cc_library(
         ":utilities",
         "//lte/protos:mconfigs_cpp_proto",
         "//orc8r/gateway/c/common/config:mconfig_loader",
-        "@system_libraries//:libtins",
+        # "@system_libraries//:libtins",
+        "@libtins//:libtins",
         "@system_libraries//:libuuid",
     ],
 )

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -16,9 +16,13 @@ package(default_visibility = ["//lte/gateway/c/li_agent/src:__subpackages__"])
 cc_binary(
     name = "liagentd",
     srcs = ["main.cpp"],
+    copts = [
+        "-DLOG_WITH_GLOG",
+    ],
     deps = [
         ":interface_monitor",
         "//orc8r/gateway/c/common/config:mconfig_loader",
+        "//orc8r/gateway/c/common/logging",
         "//orc8r/gateway/c/common/service303",
     ],
 )
@@ -43,8 +47,7 @@ cc_library(
         ":utilities",
         "//lte/protos:mconfigs_cpp_proto",
         "//orc8r/gateway/c/common/config:mconfig_loader",
-        # "@system_libraries//:libtins",
-        "@libtins//:libtins",
+        "@libtins",
         "@system_libraries//:libuuid",
     ],
 )

--- a/lte/gateway/c/sctpd/src/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/BUILD.bazel
@@ -16,6 +16,9 @@ package(default_visibility = ["//lte/gateway/c/sctpd/src:__subpackages__"])
 cc_binary(
     name = "sctpd",
     srcs = ["sctpd.cpp"],
+    copts = [
+        "-DLOG_WITH_GLOG",
+    ],
     linkstatic = True,
     deps = [
         ":config",

--- a/orc8r/gateway/c/common/logging/BUILD.bazel
+++ b/orc8r/gateway/c/common/logging/BUILD.bazel
@@ -21,4 +21,5 @@ cc_library(
     ],
     # TODO(@themarwhal): Migrate to using full path for includes - GH8299
     strip_include_prefix = "/orc8r/gateway/c/common/logging",
+    deps = ["@com_github_google_glog//:glog"],
 )

--- a/orc8r/gateway/c/common/sentry/BUILD.bazel
+++ b/orc8r/gateway/c/common/sentry/BUILD.bazel
@@ -30,7 +30,10 @@ cc_library(
     # TODO(@themarwhal): Enable Sentry by default - GH9302
     copts = select({
         ":disable_sentry_native": [],
-        "//conditions:default": ["-DSENTRY_ENABLED", "-DSENTRY_BUILD_STATIC",],
+        "//conditions:default": [
+            "-DSENTRY_ENABLED",
+            "-DSENTRY_BUILD_STATIC",
+        ],
     }),
     # TODO(@themarwhal): Migrate to using full path for includes - GH8299
     strip_include_prefix = "/orc8r/gateway/c/common/sentry",


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
* Build Libtins with Bazel directly. This will generate a static library that will be included into the binary, reducing additional runtime dependencies.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
* unit tests
* pending manual testing with traffic to ensure there is no regression (Thanks @ymasmoudi for helping verify the packet sniffing still works with this build)
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
