### PR TITLE
fix(mme): Fix the semantics and bug in timer management

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -677,7 +677,7 @@ static int registration_accept_t3550_handler(
   ue_m5gmm_context_s* ue_amf_context             = NULL;
   nas_amf_registration_proc_t* registration_proc = NULL;
   amf_ue_ngap_id_t ue_id                         = 0;
-  if (!amf_app_get_timer_arg(timer_id, &ue_id)) {
+  if (!amf_pop_timer_arg(timer_id, &ue_id)) {
     OAILOG_WARNING(
         LOG_AMF_APP, "T3550: Invalid Timer Id expiration, Timer Id: %u\n",
         timer_id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -1150,7 +1150,7 @@ static int paging_t3513_handler(zloop_t* loop, int timer_id, void* arg) {
   MessageDef* message_p                          = nullptr;
   itti_ngap_paging_request_t* ngap_paging_notify = nullptr;
 
-  if (!amf_app_get_timer_arg(timer_id, &ue_id)) {
+  if (!amf_pop_timer_arg(timer_id, &ue_id)) {
     OAILOG_WARNING(
         LOG_AMF_APP, "T3513: Invalid Timer Id expiration, Timer Id: %u\n",
         timer_id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.cpp
@@ -41,8 +41,8 @@ void amf_app_stop_timer(int timer_id) {
 }
 
 //------------------------------------------------------------------------------
-bool amf_app_get_timer_arg(int timer_id, timer_arg_t* arg) {
-  return magma5g::AmfUeContext::Instance().GetTimerArg(timer_id, arg);
+bool amf_pop_timer_arg(int timer_id, timer_arg_t* arg) {
+  return magma5g::AmfUeContext::Instance().PopTimerArgById(timer_id, arg);
 }
 
 //------------------------------------------------------------------------------
@@ -62,9 +62,10 @@ void AmfUeContext::StopTimer(int timer_id) {
   amf_app_timers.erase(timer_id);
 }
 //------------------------------------------------------------------------------
-bool AmfUeContext::GetTimerArg(const int timer_id, timer_arg_t* arg) const {
+bool AmfUeContext::PopTimerArgById(const int timer_id, timer_arg_t* arg) {
   try {
     *arg = amf_app_timers.at(timer_id);
+    amf_app_timers.erase(timer_id);
     return true;
   } catch (std::out_of_range& e) {
     return false;
@@ -85,8 +86,8 @@ void amf_pdu_stop_timer(int timer_id) {
 }
 
 //------------------------------------------------------------------------------
-bool amf_pdu_get_timer_arg(int timer_id, ue_pdu_id_t* arg) {
-  return magma5g::AmfUeContext::Instance().GetPduTimerArg(timer_id, arg);
+bool amf_pop_pdu_timer_arg(int timer_id, ue_pdu_id_t* arg) {
+  return magma5g::AmfUeContext::Instance().PopPduTimerArgById(timer_id, arg);
 }
 
 //------------------------------------------------------------------------------
@@ -107,9 +108,10 @@ void AmfUeContext::StopPduTimer(int timer_id) {
   amf_pdu_timers.erase(it);
 }
 //------------------------------------------------------------------------------
-bool AmfUeContext::GetPduTimerArg(const int timer_id, ue_pdu_id_t* arg) const {
+bool AmfUeContext::PopPduTimerArgById(const int timer_id, ue_pdu_id_t* arg) {
   try {
     *arg = amf_pdu_timers.at(timer_id);
+    amf_pdu_timers.erase(timer_id);
     return true;
   } catch (std::out_of_range& e) {
     return false;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.h
@@ -53,8 +53,10 @@ void amf_pdu_stop_timer(int timer_id);
     char* timer_name);
 */
 
-bool amf_app_get_timer_arg(int timer_id, timer_arg_t* arg);
-bool amf_pdu_get_timer_arg(int timer_id, ue_pdu_id_t* arg);
+// The *_pop*timer_* functions also removes the timer_id from the map.
+// These functions are supposed to be used only by expired timers.
+bool amf_pop_timer_arg(int timer_id, timer_arg_t* arg);
+bool amf_pop_pdu_timer_arg(int timer_id, ue_pdu_id_t* arg);
 
 class AmfUeContext {
  private:
@@ -76,14 +78,20 @@ class AmfUeContext {
       timer_arg_t id);
   void StopTimer(int timer_id);
 
-  bool GetTimerArg(const int timer_id, timer_arg_t* arg) const;
-
   int StartPduTimer(
       size_t msec, timer_repeat_t repeat, zloop_timer_fn handler,
       ue_pdu_id_t id);
   void StopPduTimer(int timer_id);
 
-  bool GetPduTimerArg(const int timer_id, ue_pdu_id_t* arg) const;
+  /**
+   * Pop timer, save arguments and return existence.
+   *
+   * @param timer_id Unique timer id for active timers
+   * @param arg Timer arguments to be stored in this parameter
+   * @return True if timer_id exists, False otherwise.
+   */
+  bool PopTimerArgById(const int timer_id, timer_arg_t* arg);
+  bool PopPduTimerArgById(const int timer_id, ue_pdu_id_t* arg);
 };
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -968,7 +968,7 @@ static int authenthication_t3560_handler(
   amf_context_t* amf_ctx = NULL;
   amf_ue_ngap_id_t ue_id = 0;
 
-  if (!amf_app_get_timer_arg(timer_id, &ue_id)) {
+  if (!amf_pop_timer_arg(timer_id, &ue_id)) {
     OAILOG_WARNING(
         LOG_AMF_APP, "T3560: Invalid Timer Id expiration, Timer Id: %u\n",
         timer_id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
@@ -185,7 +185,7 @@ static int security_mode_t3560_handler(zloop_t* loop, int timer_id, void* arg) {
   amf_context_t* amf_ctx = NULL;
   amf_ue_ngap_id_t ue_id = 0;
 
-  if (!amf_app_get_timer_arg(timer_id, &ue_id)) {
+  if (!amf_pop_timer_arg(timer_id, &ue_id)) {
     OAILOG_WARNING(
         LOG_AMF_APP,
         "T3560: Invalid Timer Id expiration, Timer Id: %d and for UE "

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -292,7 +292,7 @@ static int pdu_session_resource_release_t3592_handler(
   char imsi[IMSI_BCD_DIGITS_MAX + 1];
   int rc = 0;
 
-  if (!amf_pdu_get_timer_arg(timer_id, &uepdu_id)) {
+  if (!amf_pop_pdu_timer_arg(timer_id, &uepdu_id)) {
     OAILOG_WARNING(
         LOG_AMF_APP, "T3550: Invalid Timer Id expiration, Timer Id: %u\n",
         timer_id);

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -272,7 +272,7 @@ static int identification_t3570_handler(
   amf_context_t* amf_ctx = NULL;
   OAILOG_FUNC_IN(LOG_NAS_AMF);
 
-  if (!amf_app_get_timer_arg(timer_id, &ue_id)) {
+  if (!amf_pop_timer_arg(timer_id, &ue_id)) {
     OAILOG_WARNING(
         LOG_AMF_APP, "T3570: Invalid Timer Id expiration, timer Id: %u\n",
         timer_id);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -1884,7 +1884,7 @@ status_code_e mme_app_handle_mobile_reachability_timer_expiry(
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -1931,7 +1931,7 @@ status_code_e mme_app_handle_implicit_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -1958,7 +1958,7 @@ status_code_e mme_app_handle_initial_context_setup_rsp_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_ERROR(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -2333,7 +2333,7 @@ status_code_e mme_app_handle_paging_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -2409,7 +2409,7 @@ status_code_e mme_app_handle_ulr_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -2722,7 +2722,7 @@ status_code_e mme_app_handle_ue_context_modification_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
@@ -148,7 +148,7 @@ status_code_e mme_app_handle_sgs_eps_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -208,7 +208,7 @@ status_code_e mme_app_handle_sgs_implicit_eps_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -348,7 +348,7 @@ status_code_e mme_app_handle_sgs_imsi_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
@@ -431,7 +431,7 @@ status_code_e mme_app_handle_sgs_implicit_imsi_detach_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
@@ -940,7 +940,7 @@ status_code_e mme_app_handle_ts6_1_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer.h
@@ -40,8 +40,10 @@ void mme_app_resume_timer(
     struct ue_mm_context_s* const ue_mm_context_pP, time_t start_time,
     nas_timer_t* timer, zloop_timer_fn timer_expiry_handler, char* timer_name);
 
-bool mme_app_get_timer_arg(int timer_id, timer_arg_t* arg);
-bool mme_app_get_timer_arg_ue_id(int timer_id, mme_ue_s1ap_id_t* ue_id);
+// The *_pop_timer_* functions also removes the timer_id from the map.
+// These functions are supposed to be used only by expired timers.
+bool mme_pop_timer_arg(int timer_id, timer_arg_t* arg);
+bool mme_pop_timer_arg_ue_id(int timer_id, mme_ue_s1ap_id_t* ue_id);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
@@ -93,14 +93,14 @@ void mme_app_resume_timer(
   OAILOG_FUNC_OUT(LOG_MME_APP);
 }
 //------------------------------------------------------------------------------
-bool mme_app_get_timer_arg(int timer_id, timer_arg_t* arg) {
-  return magma::lte::MmeUeContext::Instance().GetTimerArg(timer_id, arg);
+bool mme_pop_timer_arg(int timer_id, timer_arg_t* arg) {
+  return magma::lte::MmeUeContext::Instance().PopTimerById(timer_id, arg);
 }
 
-bool mme_app_get_timer_arg_ue_id(int timer_id, mme_ue_s1ap_id_t* ue_id) {
+bool mme_pop_timer_arg_ue_id(int timer_id, mme_ue_s1ap_id_t* ue_id) {
   timer_arg_t arg;
   bool result =
-      magma::lte::MmeUeContext::Instance().GetTimerArg(timer_id, &arg);
+      magma::lte::MmeUeContext::Instance().PopTimerById(timer_id, &arg);
   *ue_id = arg.ue_id;
   return result;
 }
@@ -124,9 +124,10 @@ void MmeUeContext::StopTimer(int timer_id) {
   mme_app_timers.erase(timer_id);
 }
 //------------------------------------------------------------------------------
-bool MmeUeContext::GetTimerArg(const int timer_id, TimerArgType* arg) const {
+bool MmeUeContext::PopTimerById(const int timer_id, TimerArgType* arg) {
   try {
     *arg = mme_app_timers.at(timer_id);
+    mme_app_timers.erase(timer_id);
     return true;
   } catch (std::out_of_range& e) {
     return false;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.h
@@ -50,7 +50,14 @@ class MmeUeContext {
       const TimerArgType& arg);
   void StopTimer(int timer_id);
 
-  bool GetTimerArg(const int timer_id, TimerArgType* arg) const;
+  /**
+   * Pop timer, save arguments and return existence.
+   *
+   * @param timer_id Unique timer id for active timers
+   * @param arg Timer arguments to be stored in this parameter
+   * @return True if timer_id exists, False otherwise.
+   */
+  bool PopTimerById(const int timer_id, TimerArgType* arg);
 };
 
 }  // namespace lte

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -930,7 +930,7 @@ status_code_e mme_app_handle_emm_attach_t3450_expiry(
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.c
@@ -1061,7 +1061,7 @@ status_code_e mme_app_handle_auth_t3460_expiry(
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);
@@ -1576,7 +1576,7 @@ status_code_e mme_app_handle_air_timer_expiry(
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
@@ -102,7 +102,7 @@ status_code_e mme_app_handle_detach_t3422_expiry(
     mme_ue_s1ap_id = data->ue_id;
     emm_ctx        = emm_context_get(&_emm_data, mme_ue_s1ap_id);
   } else {
-    if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+    if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
       OAILOG_WARNING(
           LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.c
@@ -392,7 +392,7 @@ status_code_e mme_app_handle_identification_t3470_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.c
@@ -747,7 +747,7 @@ status_code_e mme_app_handle_security_t3460_expiry(
   OAILOG_FUNC_IN(LOG_NAS_EMM);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.c
@@ -470,7 +470,7 @@ status_code_e mme_app_handle_tau_t3450_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
@@ -417,7 +417,7 @@ status_code_e dedicated_eps_bearer_activate_t3485_handler(
   timer_arg_t timer_args;
   if (args) {
     timer_args = *((timer_arg_t*) args);
-  } else if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+  } else if (!mme_pop_timer_arg(timer_id, &timer_args)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
@@ -603,7 +603,7 @@ status_code_e erab_setup_rsp_tmr_exp_ded_bearer_handler(
   OAILOG_FUNC_IN(LOG_NAS_ESM);
 
   timer_arg_t timer_args;
-  if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+  if (!mme_pop_timer_arg(timer_id, &timer_args)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
@@ -487,7 +487,7 @@ status_code_e default_eps_bearer_activate_t3485_handler(
   timer_arg_t timer_args;
   if (args) {
     timer_args = *((timer_arg_t*) args);
-  } else if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+  } else if (!mme_pop_timer_arg(timer_id, &timer_args)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/EpsBearerContextDeactivation.c
@@ -412,7 +412,7 @@ status_code_e eps_bearer_deactivate_t3495_handler(
   timer_arg_t timer_args;
   if (args) {
     timer_args = *((timer_arg_t*) args);
-  } else if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+  } else if (!mme_pop_timer_arg(timer_id, &timer_args)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_ebr.c
@@ -324,7 +324,7 @@ status_code_e esm_ebr_start_timer(
     OAILOG_INFO_UE(
         LOG_NAS_ESM, emm_context->_imsi64,
         "ESM-FSM   - Retransmission timer %ld expires in "
-        "%d seconds for ue id " MME_UE_S1AP_ID_FMT "\n",
+        "%d milliseconds for ue id " MME_UE_S1AP_ID_FMT "\n",
         ebr_ctx->timer.id, ebr_ctx->timer.msec, esm_ebr_timer_data->ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);
   } else {

--- a/lte/gateway/c/core/oai/tasks/nas/esm/esm_information.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/esm_information.c
@@ -175,7 +175,7 @@ status_code_e mme_app_handle_esm_information_t3489_expiry(
   OAILOG_FUNC_IN(LOG_NAS_ESM);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_app_get_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);

--- a/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_recv.c
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_recv.c
@@ -639,7 +639,7 @@ status_code_e erab_setup_rsp_tmr_exp_handler(
   OAILOG_FUNC_IN(LOG_NAS_ESM);
 
   timer_arg_t timer_args;
-  if (!mme_app_get_timer_arg(timer_id, &timer_args)) {
+  if (!mme_pop_timer_arg(timer_id, &timer_args)) {
     OAILOG_WARNING(
         LOG_NAS_EMM, "Invalid Timer Id expiration, Timer Id: %u\n", timer_id);
     OAILOG_FUNC_RETURN(LOG_NAS_ESM, RETURNok);

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -168,6 +168,8 @@ void send_s6a_ula(const std::string& imsi, bool success) {
     apnconfig.set_pdn(magma::feg::UpdateLocationAnswer::APNConfiguration::IPV4);
     auto apns = ula.mutable_apn();
     apns->Add()->CopyFrom(apnconfig);
+    apnconfig.set_service_selection("ims");
+    apns->Add()->CopyFrom(apnconfig);
     magma::convert_proto_msg_to_itti_s6a_update_location_ans(ula, itti_msg);
   } else {
     itti_msg->result.choice.base = DIAMETER_UNABLE_TO_COMPLY;


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fix the bug in timer management where expired timers were not removed from the map. Since expired timer ids can be circulated by ZMQ for new timer events, this would lead to silent insertion failures and fetching timer arguments for an expired timer.
- To clarify the semantics, replaced all gets by pops.
- Added a unit test (which originally helped to catch this bug) for t3485 and t3495 timers.

To Do:
- having separate timer management for AMF is simply wrong. Move mme and amf timers to a common library.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Unit tests and s1ap integ tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
