### PR TITLE
feat(sessiond): Adding UE IPv6 and IPv4v6 address support in sessiond

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -333,16 +333,25 @@ void SessionState::sess_infocopy(struct SessionInfo* info) {
   // Static SessionInfo vlaue till UPF node value implementation
   // gets stablized.
   // TODO we cud eventually  migrate to SMF-UPF proto enum directly.
+  if (info == nullptr) {
+    return;
+  }
   info->state = get_proto_fsm_state();
   info->subscriber_id.assign(imsi_);
-  info->ver_no              = get_current_version();
-  info->local_f_teid        = get_upf_local_teid();
-  info->nodeId.node_id_type = SessionInfo::IPv4;
-  info->pdr_rules           = get_all_pdr_rules();
+  info->ver_no       = get_current_version();
+  info->local_f_teid = get_upf_local_teid();
+  info->pdr_rules    = get_all_pdr_rules();
   if (!info->pdr_rules.empty()) {
     // Get the UE ip address from first rule
-    auto& rule    = info->pdr_rules.front();
-    info->ip_addr = rule.pdi().ue_ipv4();
+    auto& rule = info->pdr_rules.front();
+    if (!rule.pdi().ue_ipv4().empty()) {
+      info->nodeId.node_id_type = SessionInfo::IPv4;
+      info->ip_addr             = rule.pdi().ue_ipv4();
+    }
+    if (!rule.pdi().ue_ipv6().empty()) {
+      info->nodeId.node_id_type = SessionInfo::IPv6;
+      info->ipv6_addr           = rule.pdi().ue_ipv6();
+    }
   }
 }
 

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -688,7 +688,12 @@ void SessionStateEnforcer::prepare_response_to_access(
           .end_ipv4_addr());
 
   rsp_cmn->mutable_sid()->CopyFrom(config.common_context.sid());  // imsi
-  rsp_cmn->set_ue_ipv4(config.common_context.ue_ipv4());
+  if (!config.common_context.ue_ipv4().empty()) {
+    rsp_cmn->set_ue_ipv4(config.common_context.ue_ipv4());
+  }
+  if (!config.common_context.ue_ipv6().empty()) {
+    rsp_cmn->set_ue_ipv6(config.common_context.ue_ipv6());
+  }
   rsp_cmn->set_apn(config.common_context.apn());
   rsp_cmn->set_sm_session_state(config.common_context.sm_session_state());
   rsp_cmn->set_sm_session_version(config.common_context.sm_session_version());
@@ -896,14 +901,20 @@ void SessionStateEnforcer::set_pdr_attributes(
     SetGroupPDR* rule) {
   const auto& config = session_state->get_config();
   auto ue_ipv4       = config.common_context.ue_ipv4();
+  auto ue_ipv6       = config.common_context.ue_ipv6();
 
   rule->mutable_pdi()->set_ue_ipv4(ue_ipv4);
+  rule->mutable_pdi()->set_ue_ipv6(ue_ipv6);
   rule->mutable_activate_flow_req()->mutable_sid()->set_id(imsi);
   rule->mutable_deactivate_flow_req()->mutable_sid()->set_id(imsi);
   rule->mutable_activate_flow_req()->set_ip_addr(
       config.common_context.ue_ipv4());
+  rule->mutable_activate_flow_req()->set_ipv6_addr(
+      config.common_context.ue_ipv6());
   rule->mutable_deactivate_flow_req()->set_ip_addr(
       config.common_context.ue_ipv4());
+  rule->mutable_deactivate_flow_req()->set_ipv6_addr(
+      config.common_context.ue_ipv6());
 }
 
 std::vector<StaticRuleInstall> SessionStateEnforcer::to_vec(

--- a/lte/gateway/c/session_manager/test/Consts.h
+++ b/lte/gateway/c/session_manager/test/Consts.h
@@ -28,10 +28,12 @@
 #define IP3 "127.0.0.3"
 #define IP4 "127.0.0.4"
 #define APN1 "03-21-00-02-00-20:Magma"
+#define IPv4_1 "10.20.30.40"
 #define IPv6_1 "2001:0db8:0a0b:12f0:0000:0000:0000:0001"
 #define IPv6_2 "2001:0db8:0a0b:12f0:0000:0000:0000:0002"
 #define IPv6_3 "2001:0db8:0a0b:12f0:0000:0000:0000:0003"
 #define IPv6_4 "2001:0db8:0a0b:12f0:0000:0000:0000:0004"
+#define IPv6_5 "2001:0db8:0000:0000:0000:0000:0000:0001"
 #define TEID_1_UL 11
 #define TEID_1_DL 12
 #define TEID_2_UL 21

--- a/lte/gateway/python/scripts/smf_upf_integration_cli.py
+++ b/lte/gateway/python/scripts/smf_upf_integration_cli.py
@@ -22,7 +22,6 @@ from lte.protos.session_manager_pb2 import (
     RatSpecificContext,
     RatSpecificNotification,
     RATType,
-    RedirectServer,
     RequestType,
     SetSmNotificationContext,
     SetSMSessionContext,
@@ -58,6 +57,71 @@ class CreateAmfSession(object):
                         end_ipv4_addr="192.168.60.141",
                     ),
                     pdu_session_type=PduSessionType.Name(0),
+                    ssc_mode=SscMode.Name(2),
+                ),
+            ),
+        )
+
+
+class CreateAmfSessionIPv6(object):
+    """
+    Creates IPv6 PDU session
+    """
+
+    def __init__(self):
+        self._set_session = SetSMSessionContext(
+            common_context=CommonSessionContext(
+                sid=SubscriberID(id="IMSI12345"),
+                apn=bytes("BLR", 'utf-8'),
+                ue_ipv6="2001:db8::1",
+                rat_type=RATType.Name(2),
+                sm_session_state=SMSessionFSMState.Name(0),
+                sm_session_version=0,
+            ),
+            rat_specific_context=RatSpecificContext(
+                m5gsm_session_context=M5GSMSessionContext(
+                    pdu_session_id=1,
+                    request_type=RequestType.Name(
+                        0,
+                    ),
+                    gnode_endpoint=TeidSet(
+                        teid=10000,
+                        end_ipv4_addr="192.168.60.141",
+                    ),
+                    pdu_session_type=PduSessionType.Name(1),
+                    ssc_mode=SscMode.Name(2),
+                ),
+            ),
+        )
+
+
+class CreateAmfSessionIPv4v6(object):
+    """
+    Creates IPv4v6 PDU session
+    """
+
+    def __init__(self):
+        self._set_session = SetSMSessionContext(
+            common_context=CommonSessionContext(
+                sid=SubscriberID(id="IMSI12345"),
+                apn=bytes("BLR", 'utf-8'),
+                ue_ipv4="192.168.128.11",
+                ue_ipv6="2001:db8::1",
+                rat_type=RATType.Name(2),
+                sm_session_state=SMSessionFSMState.Name(0),
+                sm_session_version=0,
+            ),
+            rat_specific_context=RatSpecificContext(
+                m5gsm_session_context=M5GSMSessionContext(
+                    pdu_session_id=1,
+                    request_type=RequestType.Name(
+                        0,
+                    ),
+                    gnode_endpoint=TeidSet(
+                        teid=10000,
+                        end_ipv4_addr="192.168.60.141",
+                    ),
+                    pdu_session_type=PduSessionType.Name(2),
                     ssc_mode=SscMode.Name(2),
                 ),
             ),
@@ -114,6 +178,63 @@ class ReleaseAmfSession(object):
                             1,
                         ),
                         pdu_session_type=PduSessionType.IPV4,
+                    ),
+                ),
+            )
+
+
+class ReleaseAmfSessionIPv6(object):
+    """
+    Releases IPv6 PDU session.
+    """
+
+    def __init__(self):
+        self._set_session =\
+            SetSMSessionContext(
+                common_context=CommonSessionContext(
+                    sid=SubscriberID(id="IMSI12345"),
+                    ue_ipv6="2001:db8::1",
+                    apn=bytes("BLR", 'utf-8'),
+                    rat_type=RATType.Name(2),
+                    sm_session_state=SMSessionFSMState.Name(4),
+                    sm_session_version=6,
+                ),
+                rat_specific_context=RatSpecificContext(
+                    m5gsm_session_context=M5GSMSessionContext(
+                        pdu_session_id=1,
+                        request_type=RequestType.Name(
+                            1,
+                        ),
+                        pdu_session_type=PduSessionType.IPV6,
+                    ),
+                ),
+            )
+
+
+class ReleaseAmfSessionIPv4v6(object):
+    """
+    Releases IPv4v6 PDU session.
+    """
+
+    def __init__(self):
+        self._set_session =\
+            SetSMSessionContext(
+                common_context=CommonSessionContext(
+                    sid=SubscriberID(id="IMSI12345"),
+                    ue_ipv4="192.168.128.11",
+                    ue_ipv6="2001:db8::1",
+                    apn=bytes("BLR", 'utf-8'),
+                    rat_type=RATType.Name(2),
+                    sm_session_state=SMSessionFSMState.Name(4),
+                    sm_session_version=6,
+                ),
+                rat_specific_context=RatSpecificContext(
+                    m5gsm_session_context=M5GSMSessionContext(
+                        pdu_session_id=1,
+                        request_type=RequestType.Name(
+                            1,
+                        ),
+                        pdu_session_type=PduSessionType.IPV4IPV6,
                     ),
                 ),
             )
@@ -430,9 +551,77 @@ def set_amf_session_tc8(client, args):
     print(response)
 
 
+@grpc_wrapper
+def set_amf_session_tc11(client, args):
+    """
+    Create an object for CreateAmfSessionIPv6 and fill CommonSessionContext,
+    RatSpecificContext and call grpc SetAmfSessionContext towards sessiond
+
+    Args:
+        client: self
+        args: command line arguments, sid and apn
+    """
+    print("=========TEST CASE-11 IPv6 PDU SESSION ESTABLISHMENT===========")
+    cls_sess = CreateAmfSessionIPv6()
+    print(cls_sess._set_session)
+    response = client.SetAmfSessionContext(cls_sess._set_session)
+    print(response)
+
+
+@grpc_wrapper
+def set_amf_session_tc12(client, args):
+    """
+    Create an object for ReleaseAmfSessionIPv6 and fill CommonSessionContext,
+    RatSpecificContext and call grpc SetAmfSessionContext towards sessiond
+
+    Args:
+        client: self
+        args: command line arguments, sid and apn
+    """
+    print("=========TEST CASE-12 IPv6 PDU SESSION RELEASE============")
+    cls_sess = ReleaseAmfSessionIPv6()
+    print(cls_sess._set_session)
+    response = client.SetAmfSessionContext(cls_sess._set_session)
+    print(response)
+
+
+@grpc_wrapper
+def set_amf_session_tc13(client, args):
+    """
+    Create an object for CreateAmfSessionIPv4v6 and fill CommonSessionContext,
+    RatSpecificContext and call grpc SetAmfSessionContext towards sessiond
+
+    Args:
+        client: self
+        args: command line arguments, sid and apn
+    """
+    print("=========TEST CASE-13 IPv4IPV6 PDU SESSION ESTABLISHMENT===========")
+    cls_sess = CreateAmfSessionIPv4v6()
+    print(cls_sess._set_session)
+    response = client.SetAmfSessionContext(cls_sess._set_session)
+    print(response)
+
+
+@grpc_wrapper
+def set_amf_session_tc14(client, args):
+    """
+    Create an object for ReleaseAmfSessionIPv4v6 and fill CommonSessionContext,
+    RatSpecificContext and call grpc SetAmfSessionContext towards sessiond
+
+    Args:
+        client: self
+        args: command line arguments, sid and apn
+    """
+    print("=========TEST CASE-14 IPV4IPV6 PDU SESSION RELEASE============")
+    cls_sess = ReleaseAmfSessionIPv4v6()
+    print(cls_sess._set_session)
+    response = client.SetAmfSessionContext(cls_sess._set_session)
+    print(response)
+
+
 def create_amf_parser(apps):
     """
-    Creates the argparse subparser for the ng_services app
+    Create the argparse subparser for the ng_services app
     """
 
     app = apps.add_parser('amf_context')
@@ -569,6 +758,54 @@ def create_amf_parser(apps):
     )
     subcmd.add_argument('--apn', help='APN', default='12345')
     subcmd.set_defaults(func=set_amf_session_tc8)
+
+    subcmd = subparsers.add_parser(
+        'set_amf_session_tc11',
+        help='AMF Set Session for UE IPv6',
+    )
+    subcmd.add_argument(
+        '--sid',
+        help='Subscriber_ID',
+        default="imsi00000000001",
+    )
+    subcmd.add_argument('--apn', help='APN', default='12345')
+    subcmd.set_defaults(func=set_amf_session_tc11)
+
+    subcmd = subparsers.add_parser(
+        'set_amf_session_tc12',
+        help='AMF Release Session for UE IPv6',
+    )
+    subcmd.add_argument(
+        '--sid',
+        help='Subscriber_ID',
+        default="imsi00000000001",
+    )
+    subcmd.add_argument('--apn', help='APN', default='12345')
+    subcmd.set_defaults(func=set_amf_session_tc12)
+
+    subcmd = subparsers.add_parser(
+        'set_amf_session_tc13',
+        help='AMF Set Session for UE IPv4v6',
+    )
+    subcmd.add_argument(
+        '--sid',
+        help='Subscriber_ID',
+        default="imsi00000000001",
+    )
+    subcmd.add_argument('--apn', help='APN', default='12345')
+    subcmd.set_defaults(func=set_amf_session_tc13)
+
+    subcmd = subparsers.add_parser(
+        'set_amf_session_tc14',
+        help='AMF Release Session for UE IPv4v6',
+    )
+    subcmd.add_argument(
+        '--sid',
+        help='Subscriber_ID',
+        default="imsi00000000001",
+    )
+    subcmd.add_argument('--apn', help='APN', default='12345')
+    subcmd.set_defaults(func=set_amf_session_tc14)
 
 
 def create_parser():


### PR DESCRIPTION
Signed-off-by: mehul jindal <mehul.jindal@wavelabs.ai>

## Summary

1. Adding UE IPv6 and IPv4v6 address support in sessiond
2. PDU session establishment , release and Paging features are supported for UE IPv6
3. This IPv6 address is only for UE, not for gNB.

## Test Plan
1. Tested with stub CLI `magma/lte/gateway/python/scripts/smf_upf_integration_cli.py`
2. UT code changes are added for IPv6 support

## Additional Information

1. Corresponding zenhub task id is #9102 
2. For complete logs please refer following comment.
