### PR TITLE
fix(agw): Fix magma_test VM coverage pydep version mismatch

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -135,7 +135,7 @@ setup(
             # update it in lte/gateway/python/Makefile
             'grpcio-tools>=1.16.1',
             'nose==1.3.7',
-            'coverage>=6.1.2',
+            'coverage',
             'iperf3',
         ],
     },


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fixes a version dependency issue on magma_test VM while running `make` due to the discrepancy of python versions between magma and magma_test


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
```
(python) vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make
make -C .. buildenv
make[1]: Entering directory '/home/vagrant/magma/lte/gateway/python'
Initializing virtualenv with python version 3.5
virtualenv --system-site-packages --python=/usr/bin/python3.5 /home/vagrant/build/python
Running virtualenv with interpreter /usr/bin/python3.5
Using base prefix '/usr'
New python executable in /home/vagrant/build/python/bin/python3.5
Not overwriting existing python script /home/vagrant/build/python/bin/python (you must use /home/vagrant/build/python/bin/python3.5)
Installing setuptools, pkg_resources, pip, wheel...done.
. /home/vagrant/build/python/bin/activate;
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache "pip>=20.3.2"
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache "setuptools==49.6.0"  # newer than 41.0.1
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache "grpcio-tools>=1.16.1"
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
Generating python code for orc8r .proto files
/home/vagrant/build/python/bin/python /home/vagrant/magma/protos/gen_protos.py /home/vagrant/magma/orc8r/protos/ /home/vagrant/magma,/home/vagrant/magma/orc8r/protos/prometheus /home/vagrant/magma /home/vagrant/build/python/gen/
Writing mypy to orc8r/protos/magmad_pb2.pyi
Writing mypy to orc8r/protos/service303_pb2.pyi
Writing mypy to orc8r/protos/service_registry_pb2.pyi
Writing mypy to orc8r/protos/sync_rpc_service_pb2.pyi
Writing mypy to orc8r/protos/metricsd_pb2.pyi
Writing mypy to orc8r/protos/identity_pb2.pyi
Writing mypy to orc8r/protos/streamer_pb2.pyi
Writing mypy to orc8r/protos/digest_pb2.pyi
Writing mypy to orc8r/protos/redis_pb2.pyi
Writing mypy to orc8r/protos/bootstrapper_pb2.pyi
Writing mypy to orc8r/protos/eventd_pb2.pyi
Writing mypy to orc8r/protos/directoryd_pb2.pyi
Writing mypy to orc8r/protos/service_status_pb2.pyi
Writing mypy to orc8r/protos/mconfig_pb2.pyi
Writing mypy to orc8r/protos/tenants_pb2.pyi
Writing mypy to orc8r/protos/certifier_pb2.pyi
Writing mypy to orc8r/protos/state_pb2.pyi
Writing mypy to orc8r/protos/common_pb2.pyi
Writing mypy to orc8r/protos/ctraced_pb2.pyi
Writing mypy to orc8r/protos/mconfig/mconfigs_pb2.pyi
Generating python code for lte .proto files
/home/vagrant/build/python/bin/python /home/vagrant/magma/protos/gen_protos.py /home/vagrant/magma/lte/protos/ /home/vagrant/magma,/home/vagrant/magma/orc8r/protos/prometheus /home/vagrant/magma /home/vagrant/build/python/gen/
lte/protos/oai/sgw_state.proto:17:1: warning: Import lte/protos/oai/std_3gpp_types.proto is unused.
Writing mypy to lte/protos/subscriberdb_pb2.pyi
Writing mypy to lte/protos/spgw_service_pb2.pyi
Writing mypy to lte/protos/oai/std_3gpp_types_pb2.pyi
Writing mypy to lte/protos/s1ap_service_pb2.pyi
Writing mypy to lte/protos/oai/sgw_state_pb2.pyi
Writing mypy to lte/protos/policydb_pb2.pyi
Writing mypy to lte/protos/ha_service_pb2.pyi
Writing mypy to lte/protos/apn_pb2.pyi
Writing mypy to lte/protos/mobilityd_pb2.pyi
Writing mypy to lte/protos/sctpd_pb2.pyi
Writing mypy to lte/protos/oai/ngap_state_pb2.pyi
Writing mypy to lte/protos/ha_orc8r_pb2.pyi
Writing mypy to lte/protos/abort_session_pb2.pyi
Writing mypy to lte/protos/oai/common_types_pb2.pyi
Writing mypy to lte/protos/enodebd_pb2.pyi
Writing mypy to lte/protos/pipelined_pb2.pyi
Writing mypy to lte/protos/subscriberauth_pb2.pyi
Writing mypy to lte/protos/session_manager_pb2.pyi
Writing mypy to lte/protos/s6a_service_pb2.pyi
Writing mypy to lte/protos/oai/s1ap_state_pb2.pyi
Writing mypy to lte/protos/mconfig/mconfigs_pb2.pyi
Writing mypy to lte/protos/oai/nas_state_pb2.pyi
Writing mypy to lte/protos/oai/spgw_state_pb2.pyi
Writing mypy to lte/protos/sms_orc8r_pb2.pyi
Writing mypy to lte/protos/keyval_pb2.pyi
Writing mypy to lte/protos/oai/mme_nas_state_pb2.pyi
Generating python code for feg .proto files
/home/vagrant/build/python/bin/python /home/vagrant/magma/protos/gen_protos.py /home/vagrant/magma/feg/protos/ /home/vagrant/magma,/home/vagrant/magma/orc8r/protos/prometheus /home/vagrant/magma /home/vagrant/build/python/gen/
Writing mypy to feg/protos/s8_proxy_pb2.pyi
Writing mypy to feg/protos/csfb_pb2.pyi
Writing mypy to feg/protos/service_health_pb2.pyi
Writing mypy to feg/protos/envoy_controller_pb2.pyi
Writing mypy to feg/protos/s6a_proxy_pb2.pyi
Writing mypy to feg/protos/mconfig/mconfigs_pb2.pyi
Writing mypy to feg/protos/basic_acct_pb2.pyi
Writing mypy to feg/protos/mock_core_pb2.pyi
Writing mypy to feg/protos/hlr/hlr_proxy_pb2.pyi
Writing mypy to feg/protos/hss_service_pb2.pyi
Writing mypy to feg/protos/health_pb2.pyi
Writing mypy to feg/protos/swx_proxy_pb2.pyi
Writing mypy to feg/protos/hello_pb2.pyi
/home/vagrant/build/python/bin/python /home/vagrant/magma/protos/gen_prometheus_proto.py /home/vagrant/magma /home/vagrant/build/python/gen
test -f /usr/bin/java # Java exists
test -n "/var/tmp/codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar" # SWAGGER_CODEGEN_JAR set
test -f /var/tmp/codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar # swagger-codegen exists
Generating python code for lte swagger*.yml files
cp /home/vagrant/magma/lte/swagger/*.yml /home/vagrant/build/python/gen/lte/swagger/specs
ls /home/vagrant/build/python/gen/lte/swagger/specs \
	| grep -e ".*\.yml" \
	| xargs -t -I% /usr/bin/java -jar "/var/tmp/codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar" generate \
		-i /home/vagrant/build/python/gen/lte/swagger/specs/% \
		-o /home/vagrant/build/python/gen/lte/swagger \
		-l python \
		-Dmodels
/usr/bin/java -jar /var/tmp/codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i /home/vagrant/build/python/gen/lte/swagger/specs/mme_events.v1.yml -o /home/vagrant/build/python/gen/lte/swagger -l python -Dmodels
[main] INFO io.swagger.parser.Swagger20Parser - reading from /home/vagrant/build/python/gen/lte/swagger/specs/mme_events.v1.yml
[main] INFO io.swagger.codegen.ignore.CodegenIgnoreProcessor - No .swagger-codegen-ignore file found.
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/swagger_client/models/attach_success.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/test/test_attach_success.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/docs/AttachSuccess.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/swagger_client/models/detach_success.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/test/test_detach_success.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/docs/DetachSuccess.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/swagger_client/models/s1_setup_success.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/test/test_s1_setup_success.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/docs/S1SetupSuccess.md
/usr/bin/java -jar /var/tmp/codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i /home/vagrant/build/python/gen/lte/swagger/specs/session_manager_events.v1.yml -o /home/vagrant/build/python/gen/lte/swagger -l python -Dmodels
[main] INFO io.swagger.parser.Swagger20Parser - reading from /home/vagrant/build/python/gen/lte/swagger/specs/session_manager_events.v1.yml
[main] INFO io.swagger.codegen.ignore.CodegenIgnoreProcessor - No .swagger-codegen-ignore file found.
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/swagger_client/models/session_create_failure.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/test/test_session_create_failure.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/docs/SessionCreateFailure.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/swagger_client/models/session_created.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/test/test_session_created.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/docs/SessionCreated.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/swagger_client/models/session_terminated.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/test/test_session_terminated.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/docs/SessionTerminated.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/swagger_client/models/session_terminated_list_of_service_data.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/test/test_session_terminated_list_of_service_data.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/docs/SessionTerminatedListOfServiceData.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/swagger_client/models/session_update_failure.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/test/test_session_update_failure.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/docs/SessionUpdateFailure.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/swagger_client/models/session_updated.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/test/test_session_updated.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/lte/swagger/docs/SessionUpdated.md
Generating python code for orc8r swagger*.yml files
cp /home/vagrant/magma/orc8r/swagger/*.yml /home/vagrant/build/python/gen/orc8r/swagger/specs
ls /home/vagrant/build/python/gen/orc8r/swagger/specs \
	| grep -e ".*\.yml" \
	| xargs -t -I% /usr/bin/java -jar "/var/tmp/codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar" generate \
		-i /home/vagrant/build/python/gen/orc8r/swagger/specs/% \
		-o /home/vagrant/build/python/gen/orc8r/swagger \
		-l python \
		-Dmodels
/usr/bin/java -jar /var/tmp/codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i /home/vagrant/build/python/gen/orc8r/swagger/specs/magmad_events.v1.yml -o /home/vagrant/build/python/gen/orc8r/swagger -l python -Dmodels
[main] INFO io.swagger.parser.Swagger20Parser - reading from /home/vagrant/build/python/gen/orc8r/swagger/specs/magmad_events.v1.yml
[main] INFO io.swagger.codegen.ignore.CodegenIgnoreProcessor - No .swagger-codegen-ignore file found.
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/deleted_stored_mconfig.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_deleted_stored_mconfig.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/DeletedStoredMconfig.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/disconnected_sync_rpc_stream.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_disconnected_sync_rpc_stream.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/DisconnectedSyncRpcStream.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/established_sync_rpc_stream.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_established_sync_rpc_stream.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/EstablishedSyncRpcStream.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/processed_updates.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_processed_updates.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/ProcessedUpdates.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/processed_updates_updates.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_processed_updates_updates.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/ProcessedUpdatesUpdates.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/restarted_services.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_restarted_services.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/RestartedServices.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/updated_stored_mconfig.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_updated_stored_mconfig.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/UpdatedStoredMconfig.md
/usr/bin/java -jar /var/tmp/codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i /home/vagrant/build/python/gen/orc8r/swagger/specs/mock_event_definitions.v1.yml -o /home/vagrant/build/python/gen/orc8r/swagger -l python -Dmodels
[main] INFO io.swagger.parser.Swagger20Parser - reading from /home/vagrant/build/python/gen/orc8r/swagger/specs/mock_event_definitions.v1.yml
[main] INFO io.swagger.codegen.ignore.CodegenIgnoreProcessor - No .swagger-codegen-ignore file found.
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/mock_subscriber_event.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_mock_subscriber_event.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/MockSubscriberEvent.md
/usr/bin/java -jar /var/tmp/codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i /home/vagrant/build/python/gen/orc8r/swagger/specs/test_event_definitions.yml -o /home/vagrant/build/python/gen/orc8r/swagger -l python -Dmodels
[main] INFO io.swagger.parser.Swagger20Parser - reading from /home/vagrant/build/python/gen/orc8r/swagger/specs/test_event_definitions.yml
[main] INFO io.swagger.codegen.ignore.CodegenIgnoreProcessor - No .swagger-codegen-ignore file found.
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/array_and_object_event.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_array_and_object_event.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/ArrayAndObjectEvent.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/null_event.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_null_event.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/NullEvent.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/swagger_client/models/simple_event.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/test/test_simple_event.py
[main] INFO io.swagger.codegen.AbstractGenerator - writing file /home/vagrant/build/python/gen/orc8r/swagger/docs/SimpleEvent.md
make -C /home/vagrant/magma/lte/gateway/python install_egg
make[2]: Entering directory '/home/vagrant/magma/lte/gateway/python'
Initializing virtualenv with python version 3.5
virtualenv --system-site-packages --python=/usr/bin/python3.5 /home/vagrant/build/python
Running virtualenv with interpreter /usr/bin/python3.5
Using base prefix '/usr'
New python executable in /home/vagrant/build/python/bin/python3.5
Not overwriting existing python script /home/vagrant/build/python/bin/python (you must use /home/vagrant/build/python/bin/python3.5)
Installing setuptools, pkg_resources, pip, wheel...done.
. /home/vagrant/build/python/bin/activate;
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache "pip>=20.3.2"
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
Installing egg link for lte
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache --no-build-isolation -e .[dev]
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
make[2]: Leaving directory '/home/vagrant/magma/lte/gateway/python'
make -C /home/vagrant/magma/orc8r/gateway/python install_egg
make[2]: Entering directory '/home/vagrant/magma/orc8r/gateway/python'
Initializing virtualenv with python version 3.5
virtualenv --system-site-packages --python=/usr/bin/python3.5 /home/vagrant/build/python
Running virtualenv with interpreter /usr/bin/python3.5
Using base prefix '/usr'
New python executable in /home/vagrant/build/python/bin/python3.5
Not overwriting existing python script /home/vagrant/build/python/bin/python (you must use /home/vagrant/build/python/bin/python3.5)
Installing setuptools, pkg_resources, pip, wheel...done.
. /home/vagrant/build/python/bin/activate;
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache "pip>=20.3.2"
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
Installing egg link for orc8r
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache --no-build-isolation -e .[dev]
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
make[2]: Leaving directory '/home/vagrant/magma/orc8r/gateway/python'
patch --dry-run -N -s -f /home/vagrant/build/python/lib/python3.5/site-packages/aioeventlet.py </home/vagrant/magma/lte/gateway/deploy/roles/magma/files/patches/aioeventlet.py38.patch 2>/dev/null \
&&  (patch -N -s -f /home/vagrant/build/python/lib/python3.5/site-packages/aioeventlet.py </home/vagrant/magma/lte/gateway/deploy/roles/magma/files/patches/aioeventlet.py38.patch && echo "aioeventlet was patched" ) \
|| ( true && echo "skipping aioeventlet patch since it was already applied")
3 out of 3 hunks FAILED
skipping aioeventlet patch since it was already applied
patch --dry-run -N -s -f /home/vagrant/build/python/lib/python3.5/site-packages/ryu/ofproto/nx_actions.py </home/vagrant/magma/lte/gateway/deploy/roles/magma/files/patches/ryu_ipfix_args.patch 2>/dev/null \
&&  (patch -N -s -f /home/vagrant/build/python/lib/python3.5/site-packages/ryu/ofproto/nx_actions.py </home/vagrant/magma/lte/gateway/deploy/roles/magma/files/patches/ryu_ipfix_args.patch && echo "ryu was patched" ) \
|| ( true && echo "skipping ryu patch since it was already applied")
ryu was patched
patch --dry-run -N -s -f /home/vagrant/build/python/lib/python3.5/site-packages/ryu/ofproto/nx_actions.py </home/vagrant/magma/lte/gateway/deploy/roles/magma/files/patches/0001-Set-unknown-dpid-ofctl-log-to-debug.patch 2>/dev/null \
&&  (patch -N -s -f /home/vagrant/build/python/lib/python3.5/site-packages/ryu/ofproto/nx_actions.py </home/vagrant/magma/lte/gateway/deploy/roles/magma/files/patches/0001-Set-unknown-dpid-ofctl-log-to-debug.patch && echo "ryu was patched" ) \
|| ( true && echo "skipping ryu patch since it was already applied")
1 out of 1 hunk FAILED
skipping ryu patch since it was already applied
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache --force-reinstall git+https://github.com/URenko/aioh2.git
/usr/lib/python3/dist-packages/secretstorage/dhcrypto.py:15: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
  from cryptography.utils import int_from_bytes
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
make[1]: Leaving directory '/home/vagrant/magma/lte/gateway/python'
#@echo "Installing swagger-codegen requirements"
#/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache -r /home/vagrant/api-bindings/requirements.txt
Copying s1aptester config files
cp /home/vagrant/magma/lte/gateway/python/integ_tests/data/s1ap_tester_cfg/* /home/vagrant/s1ap-tester
Install MySQL for upstreaming
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache mysqlclient==1.3.12
/usr/lib/python3/dist-packages/secretstorage/dhcrypto.py:15: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
  from cryptography.utils import int_from_bytes
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
touch /home/vagrant/build/python/setupinteg_env
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
