### PR TITLE
feat: pull down Bazel build cache to run agw-build and lte-integ-test…

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -12,6 +12,11 @@ on:  # yamllint disable-line rule:truthy
       - v1.*
     types: [opened, reopened, synchronize]
 
+env:
+  S3_BUCKET: "magma-cache"
+  CACHE_REPO_TAR: "bazel-cache-repo-magma-vm.tar.gz"
+  CACHE_TAR: "bazel-cache-magma-vm.tar.gz"
+
 jobs:
   build_publish_helm_charts:
     env:
@@ -122,6 +127,10 @@ jobs:
           sudo mkdir -p /etc/vbox/
           sudo touch /etc/vbox/networks.conf
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
+      - name: Download Magma VM Bazel build cache from S3
+        run: |
+          wget -qO- https://${{ env.S3_BUCKET }}.s3.amazonaws.com/${{ env.CACHE_REPO_TAR }} | tar xvfz - 
+          wget -qO- https://${{ env.S3_BUCKET }}.s3.amazonaws.com/${{ env.CACHE_TAR }} | tar xvfz - 
       - name: Build AGW
         run: |
           cd lte/gateway

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -10,6 +10,11 @@ on:  # yamllint disable-line rule:truthy
     types:
       - completed
 
+env:
+  S3_BUCKET: "magma-cache"
+  CACHE_REPO_TAR: "bazel-cache-repo-magma-vm.tar.gz"
+  CACHE_TAR: "bazel-cache-magma-vm.tar.gz"
+
 jobs:
   lte-integ-test:
     runs-on: macos-10.15
@@ -35,6 +40,10 @@ jobs:
           sudo mkdir -p /etc/vbox/
           sudo touch /etc/vbox/networks.conf
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
+      - name: Download Magma VM Bazel build cache from S3
+        run: |
+          wget -qO- https://${{ env.S3_BUCKET }}.s3.amazonaws.com/${{ env.CACHE_REPO_TAR }} | tar xvfz - 
+          wget -qO- https://${{ env.S3_BUCKET }}.s3.amazonaws.com/${{ env.CACHE_TAR }} | tar xvfz - 
       - name: Run the integ test
         run: |
           cd lte/gateway


### PR DESCRIPTION
… jobs

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Soon, I will be flipping the default build system for sessiond/sctpd/liagentd/connectiond to Bazel from CMake. As the Bazel build system will build more dependencies from scratch, the build time will increase. To manage the impact in CI, we will pull down a prebuilt cache that is refreshed daily.

Tested with this PR: https://github.com/magma/magma/pull/10513
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
