### PR TITLE
feat(orc8r): Disable logging and metrics in orc8r helm chart if staging is enabled

### DIFF
--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -755,3 +755,12 @@ service:
     Required: false
     ConfigApps:
       - tf
+  orc8r_is_staging_deployment:
+    Description: >-
+      Indicates if the orc8r-app being deploy is a staging environment.
+      Staging environment does not deploy Logging, Metrics and Alerts
+    Type: bool
+    Default: false
+    Required: false
+    ConfigApps:
+      - tf

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/efs.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/efs.tf
@@ -13,6 +13,8 @@
 
 # k8s requires provisioner to treat efs as a persistent volume
 resource "helm_release" "efs_provisioner" {
+  count = var.orc8r_is_staging_deployment == true ? 0 : 1
+
   name       = var.efs_provisioner_name
   repository = local.stable_helm_repo
   chart      = "efs-provisioner"

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/helm.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/helm.tf
@@ -13,7 +13,7 @@
 
 # helm tiller service account
 resource "kubernetes_service_account" "tiller" {
-  count = var.existing_tiller_service_account_name == null ? 1 : 0
+  count = var.install_tiller == true ? 1 : 0
 
   metadata {
     name      = "tiller"
@@ -25,7 +25,7 @@ resource "kubernetes_service_account" "tiller" {
 
 # helm tiller cluster role
 resource "kubernetes_cluster_role_binding" "tiller" {
-  count = var.existing_tiller_service_account_name == null ? 1 : 0
+  count = var.install_tiller == true ? 1 : 0
 
   metadata {
     name = "tiller"

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/k8s.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/k8s.tf
@@ -18,6 +18,8 @@ resource "kubernetes_namespace" "orc8r" {
 }
 
 resource "kubernetes_namespace" "monitoring" {
+  count = var.orc8r_is_staging_deployment == true ? 0 : 1
+
   metadata {
     name = var.monitoring_kubernetes_namespace
   }
@@ -25,6 +27,8 @@ resource "kubernetes_namespace" "monitoring" {
 
 # external dns maps route53 to ingress resources
 resource "helm_release" "external_dns" {
+  count = var.orc8r_is_staging_deployment == true ? 0 : 1
+
   name       = var.external_dns_deployment_name
   repository = local.stable_helm_repo
   chart      = "external-dns"

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/logging.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 resource "helm_release" "fluentd" {
-  count = var.elasticsearch_endpoint == null ? 0 : 1
+  count = var.elasticsearch_endpoint == null || var.orc8r_is_staging_deployment == true ? 0 : 1
 
   name       = var.fluentd_deployment_name
   namespace  = kubernetes_namespace.orc8r.metadata[0].name
@@ -129,12 +129,12 @@ resource "helm_release" "fluentd" {
 
 # helm chart for cleaning old indices.
 resource "helm_release" "elasticsearch_curator" {
-  count = var.elasticsearch_endpoint == null ? 0 : 1
+  count = var.elasticsearch_endpoint == null || var.orc8r_is_staging_deployment == true ? 0 : 1
 
   name       = var.elasticsearch_curator_name
   repository = local.stable_helm_repo
   chart      = "elasticsearch-curator"
-  namespace  = kubernetes_namespace.monitoring.metadata[0].name
+  namespace  = kubernetes_namespace.monitoring[0].metadata[0].name
   version    = "2.2.3"
   keyring    = ""
 

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
@@ -212,5 +212,9 @@ data "template_file" "orc8r_values" {
     thanos_store_selector   = var.thanos_store_node_selector != "" ? format("compute-type: %s", var.thanos_store_node_selector) : "{}"
 
     region = var.region
+
+    # Staging deployments does not deploy neither logging nor metrics
+    enable_logging = !var.orc8r_is_staging_deployment
+    enable_metrics = !var.orc8r_is_staging_deployment
   }
 }

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/storage.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/storage.tf
@@ -12,6 +12,7 @@
 ################################################################################
 
 resource "kubernetes_persistent_volume_claim" "storage" {
+
   for_each = {
     promcfg = {
       access_mode = "ReadWriteMany"

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -82,36 +82,36 @@ metrics:
             claimName: ${metrics_pvc_promcfg}
 
   prometheus:
-    create: true
+    create: ${enable_metrics}
     includeOrc8rAlerts: true
     prometheusCacheHostname: ${prometheus_cache_hostname}
     alertmanagerHostname: ${alertmanager_hostname}
 
   alertmanager:
-    create: true
+    create: ${enable_metrics}
 
   prometheusConfigurer:
-    create: true
+    create: ${enable_metrics}
     image:
       repository: docker.io/facebookincubator/prometheus-configurer
       tag: ${prometheus_configurer_version}
     prometheusURL: ${prometheus_url}
 
   alertmanagerConfigurer:
-    create: true
+    create: ${enable_metrics}
     image:
       repository: docker.io/facebookincubator/alertmanager-configurer
       tag: ${alertmanager_configurer_version}
     alertmanagerURL: ${alertmanager_url}
 
   prometheusCache:
-    create: true
+    create: ${enable_metrics}
     image:
       repository: docker.io/facebookincubator/prometheus-edge-hub
       tag: 1.1.0
     limit: 500000
   grafana:
-    create: false
+    create: ${enable_metrics}
 
   userGrafana:
     image:
@@ -212,4 +212,4 @@ nms:
         ssl_cert_key_name: controller.key
 
 logging:
-  enabled: false
+  enabled: ${enable_logging}

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -75,6 +75,15 @@ variable "monitoring_kubernetes_namespace" {
   default     = "monitoring"
 }
 
+variable "orc8r_is_staging_deployment" {
+  description = <<EOT
+    Indicates if the orc8r-app being deploy is a staging environment.
+    Staging environment does not deploy Logging, Metrics and Alerts
+    EOT
+  type        = bool
+  default     = false
+}
+
 ##############################################################################
 # General Orchestrator configuration
 ##############################################################################

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/yace.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/yace.tf
@@ -54,7 +54,7 @@ resource "helm_release" "yace_exporter" {
   count = var.cloudwatch_exporter_enabled ? 1 : 0
 
   name       = "yace-exporter"
-  namespace  = kubernetes_namespace.monitoring.metadata[0].name
+  namespace  = kubernetes_namespace.monitoring[0].metadata[0].name
   repository = "https://mogaal.github.io/helm-charts/"
   chart      = "prometheus-yace-exporter"
   timeout    = 600


### PR DESCRIPTION

Signed-off-by: Joary Paulo Wanzeler Fortuna <joarypl@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

Disable specific resources for a orc8r-app module deployment marked as staging (meaning the same resources already exists from main orc8r).

Changelog:
- Added variable to flag orc8r-app module is a staging one.
- On Terraform use the flag to disable resources that are already deployied in the main Orc8r:
    - EFS Provisioner
    - Tiller & its rolebindings
    - Namespace for monitoring (wich already exists)
    - External DNS helm deployment
    - Fluentd for orc8r-app logging
    - Elasticsearch-curator for orc8r-app metrics
    - Disabled logging and metrics from orc8r helm chart
- On orc8r helm chart, make logging and metrics sub-charts to be configurable instead of always deployied

## Test Plan

1. Deploy the main orc8r without any special configuration, including both modules orc8r & orc8r-helm-aws in the main.tf.

2. Create a new orc8r-helm-aws module marked as staging with variable `orc8r_is_staging_deployment=true` and with `orc8r_kubernetes_namespace = "staging"`

Expected: 
- Terraform should run without problems (not being blocked by duplicated resources)
- New namespace should be created and the orc8r & lte-orc8r pods deployed.
- Neither Logging/Monitoring/Metrics resources will be created.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
