### PR TITLE
chore(orc8r): add feature to remove verbose protos from orc8r service…

### DIFF
--- a/orc8r/lib/go/service/logcodec.go
+++ b/orc8r/lib/go/service/logcodec.go
@@ -16,6 +16,9 @@ package service
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/jsonpb"
@@ -24,15 +27,62 @@ import (
 	grpc_proto "google.golang.org/grpc/encoding/proto"
 )
 
+// logModes
+type grpcLogVerbosityLevel int
+
+const (
+	GRPCLOG_DISABLED    = grpcLogVerbosityLevel(iota) // Default value
+	GRPCLOG_FULL                                      // Prints all protos
+	GRPCLOG_HIDEVERBOSE                               // Prints all except verboseProtos
+	grpclog_end
+)
+
+var (
+	// Default list of verbose protos
+	verboseProtos = map[string]grpcLogVerbosityLevel{
+		"protos.Void":                  GRPCLOG_HIDEVERBOSE,
+		"protos.ServiceInfo":           GRPCLOG_HIDEVERBOSE,
+		"protos.HealthStatus":          GRPCLOG_HIDEVERBOSE,
+		"protos.MetricsContainer":      GRPCLOG_HIDEVERBOSE,
+		"protos.SubmitMetricsRequest":  GRPCLOG_HIDEVERBOSE,
+		"protos.SubmitMetricsResponse": GRPCLOG_HIDEVERBOSE,
+		"grpc.MetricFamilies":          GRPCLOG_HIDEVERBOSE,
+		"grpc.Void":                    GRPCLOG_HIDEVERBOSE,
+	}
+)
+
 // logCodec is a debugging Codec implementation for protobuf.
 // It'll be used if debug GRPC printout is enabled
 type logCodec struct {
-	protoCodec encoding.Codec
+	protoCodec     encoding.Codec
+	verbosityLevel grpcLogVerbosityLevel
 }
 
-func printMessage(prefix string, v interface{}) {
+// Marshal of GRPC Codec interface
+func (lc logCodec) Marshal(v interface{}) ([]byte, error) {
+	printMessage("Sending: ", v, lc.verbosityLevel)
+	return lc.protoCodec.Marshal(v)
+}
+
+// Unmarshal of GRPC Codec interface
+func (lc logCodec) Unmarshal(data []byte, v interface{}) error {
+	err := lc.protoCodec.Unmarshal(data, v)
+	printMessage("Received: ", v, lc.verbosityLevel)
+	return err
+}
+
+// Name of GRPC Codec interface
+func (logCodec) Name() string {
+	return grpc_proto.Name
+}
+
+func printMessage(prefix string, v interface{}, verboseLevel grpcLogVerbosityLevel) {
 	var payload string
 	if pm, ok := v.(proto.Message); ok {
+		if verboseLevel == GRPCLOG_HIDEVERBOSE && isProtoHidden(pm) {
+			// do not print verbose proto
+			return
+		}
 		var buf bytes.Buffer
 		err := (&jsonpb.Marshaler{EmitDefaults: true, Indent: "\t", OrigName: true}).Marshal(&buf, pm)
 		if err == nil {
@@ -46,20 +96,52 @@ func printMessage(prefix string, v interface{}) {
 	glog.Infof("%s%T: %s", prefix, v, payload)
 }
 
-// Marshal of GRPC Codec interface
-func (lc logCodec) Marshal(v interface{}) ([]byte, error) {
-	printMessage("Sending: ", v)
-	return lc.protoCodec.Marshal(v)
+func isProtoHidden(pm proto.Message) bool {
+	vType := strings.Replace(fmt.Sprintf("%T", pm), "*", "", 1) // remove possible * from proto name
+	if val, ok := verboseProtos[vType]; ok && val == GRPCLOG_HIDEVERBOSE {
+		return true
+	}
+	return false
 }
 
-// Unmarshal of GRPC Codec interface
-func (lc logCodec) Unmarshal(data []byte, v interface{}) error {
-	err := lc.protoCodec.Unmarshal(data, v)
-	printMessage("Received: ", v)
-	return err
+// registerPrintGrpcPayloadLogCodecIfRequired will get MAGMA_PRINT_GRPC_PAYLOAD from flags or
+// from EnvVar and register a new logger to print GRPC message content
+func registerPrintGrpcPayloadLogCodecIfRequired() {
+	verbosityLevel := getVerbosityLevelFromFlagOrEnvVar()
+	if verbosityLevel == GRPCLOG_DISABLED {
+		return
+	}
+	ls := logCodec{
+		protoCodec:     encoding.GetCodec(grpc_proto.Name),
+		verbosityLevel: verbosityLevel,
+	}
+	encoding.RegisterCodec(ls)
 }
 
-// Name of GRPC Codec interface
-func (logCodec) Name() string {
-	return grpc_proto.Name
+// getLogVerbosityFromFlagOrEnvVar parses verbosityLevel either from flags or Env var and converts it'
+// into one of grpcLogVerbosityLevel valid values. Flag value will have priority
+// It returns DISABLED in case value is not right
+func getVerbosityLevelFromFlagOrEnvVar() grpcLogVerbosityLevel {
+	if printGrpcPayload != 0 {
+		return parseVerbosityLevel(printGrpcPayload)
+	}
+	logModeStr := strings.TrimSpace(os.Getenv(PrintGrpcPayloadEnv))
+	if logModeStr == "" {
+		return GRPCLOG_DISABLED
+	}
+	logModeInt, err := strconv.Atoi(logModeStr)
+	if err != nil {
+		return GRPCLOG_DISABLED
+	}
+	return parseVerbosityLevel(logModeInt)
+}
+
+func parseVerbosityLevel(logMode int) grpcLogVerbosityLevel {
+	if logMode < 0 || logMode >= int(grpclog_end) {
+		glog.Errorf(
+			"could not parse PrintGrpcPayload properly. Value %d is not validDefaulting. Setting to 0 (DISABLED)",
+			logMode)
+		return GRPCLOG_DISABLED
+	}
+	return grpcLogVerbosityLevel(logMode)
 }

--- a/orc8r/lib/go/service/service.go
+++ b/orc8r/lib/go/service/service.go
@@ -25,14 +25,11 @@ import (
 
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/encoding"
-	grpc_proto "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/keepalive"
 
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
 	"magma/orc8r/lib/go/service/config"
-	"magma/orc8r/lib/go/util"
 )
 
 const (
@@ -41,7 +38,7 @@ const (
 )
 
 var (
-	printGrpcPayload           bool
+	printGrpcPayload           int
 	currentlyRunningServices   = make(map[string]*Service)
 	currentlyRunningServicesMu sync.RWMutex
 )
@@ -59,7 +56,8 @@ var defaultKeepaliveParams = keepalive.ServerParameters{
 }
 
 func init() {
-	flag.BoolVar(&printGrpcPayload, PrintGrpcPayloadFlag, false, "Enable GRPC Payload Printout")
+	flag.IntVar(&printGrpcPayload, PrintGrpcPayloadFlag, int(GRPCLOG_DISABLED),
+		"Enable GRPC Payload Printout (0: disabled 1: enabled 2: hide verbose")
 }
 
 type Service struct {
@@ -104,14 +102,8 @@ func NewServiceWithOptionsImpl(moduleName string, serviceName string, serverOpti
 		configMap = nil
 	}
 
-	// Check if service was started with print-grpc-payload flag or MAGMA_PRINT_GRPC_PAYLOAD env is set
-	if printGrpcPayload || util.IsTruthyEnv(PrintGrpcPayloadEnv) {
-		ls := logCodec{encoding.GetCodec(grpc_proto.Name)}
-		if ls.protoCodec != nil {
-			glog.Errorf("Adding Debug Codec for service %s", serviceName)
-			encoding.RegisterCodec(ls)
-		}
-	}
+	// Registers new logger in case print-grpc-payload flag or MAGMA_PRINT_GRPC_PAYLOAD env is set
+	registerPrintGrpcPayloadLogCodecIfRequired()
 
 	// Use keepalive options to proactively reinit http2 connections and
 	// mitigate flow control issues


### PR DESCRIPTION
…s log

Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Visualizing protos in go services is key feature for troubleshooting. However, since we are printing any kind of proto, sometimes we get spammed by protos that are too verbose and do not provide any insight (like metrics periodic update)

This PR adds a new option to reduce the amount of protons to be displayed. 

The list of protos to be hidden is right now hardcoded. If necessary in the future we can move that list to the config file and add some regex style syntax to make this feature more powerful if. For now we will test this way.

## Test Plan

`./build.py -c`
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
