### PR TITLE
chore(agw): implement shared mconfig and use it for Sentry config

### DIFF
--- a/docs/readmes/contributing/contribute_id_mappings.md
+++ b/docs/readmes/contributing/contribute_id_mappings.md
@@ -77,4 +77,3 @@ In order to receive a nomination, the project requests the following qualities i
 - Demonstrated technical leadership of particular component (example: driving component design/evolution during code review, and/or through writing 1+ design docs)
 
 Please note that this set of qualities is not an exact requirement -- if you're interested in supporting the project as a codeowner, please reach out! We'd love to work with you, and work on a path toward you becoming a Magma codeowner.
-

--- a/docs/readmes/lte/configure_sentry.md
+++ b/docs/readmes/lte/configure_sentry.md
@@ -18,7 +18,7 @@ There are two main ways to deploy the platform: [self-hosting](https://develop.s
 
 Reporting for Python services, MME, and SessionD will *only* be enabled if the corresponding URL fields are non-empty.
 
-The URL fields can be set in a network-wide configuration through the Orc8r's Swagger endpoint at `/networks/{network_id}`. You can also set or override Sentry configuration for specific gateways through the Orc8r's `/networks/{network_id}/gateways/{gateway_id}` endpoint. Finally, you can set them locally on a gateway in the `control_proxy.yml` file by filling out the following fields.
+The URL fields can be set in a network-wide configuration through the Orc8r's Swagger endpoint at `/networks/{network_id}` or `/networks/{network_id}/sentry`. You can also set or override Sentry configuration for specific gateways through the Orc8r's `/networks/{network_id}/gateways/{gateway_id}` endpoint. Finally, you can set them locally on a gateway in the `control_proxy.yml` file by filling out the following fields.
 
 ```yaml
 # [Experimental] Sentry related configs

--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -152,6 +152,15 @@
     "connectiond": {
       "@type": "type.googleapis.com/magma.mconfig.ConnectionD",
       "logLevel": "INFO"
+    },
+    "shared_mconfig": {
+      "@type": "type.googleapis.com/magma.mconfig.SharedMconfig",
+      "sentry_config": {
+        "dsn_python": "",
+        "dsn_native": "",
+        "upload_mme_log": false,
+        "sample_rate": 1.0
+      }
     }
   }
 }

--- a/lte/gateway/python/magma/enodebd/main.py
+++ b/lte/gateway/python/magma/enodebd/main.py
@@ -48,7 +48,7 @@ def main():
     logger.init()
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     # State machine manager for tracking multiple connected eNB devices.
     state_machine_manager = StateMachineManager(service)

--- a/lte/gateway/python/magma/health/main.py
+++ b/lte/gateway/python/magma/health/main.py
@@ -25,7 +25,7 @@ def main():
     service = MagmaService('health', None)
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     # Service state wrapper obj
     service_state = ServiceStateWrapper()

--- a/lte/gateway/python/magma/kernsnoopd/main.py
+++ b/lte/gateway/python/magma/kernsnoopd/main.py
@@ -29,7 +29,7 @@ def main():
     service = MagmaService('kernsnoopd', None)
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     # Initialize and run the Snooper job
     Snooper(

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -145,12 +145,12 @@ def main():
     """Start mobilityd"""
     service = MagmaService('mobilityd', mconfigs_pb2.MobilityD())
 
-    # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
-
     # Load service configs and mconfig
     config = service.config
     mconfig = service.mconfig
+
+    # Optionally pipe errors to Sentry
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     multi_apn = config.get('multi_apn', mconfig.multi_apn_ip_alloc)
     static_ip_enabled = config.get('static_ip', mconfig.static_ip_enabled)

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -37,7 +37,7 @@ def main():
     service = MagmaService('monitord', mconfigs_pb2.MonitorD())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     # Monitoring thread loop
     mtr_interface = load_service_config("monitord")["mtr_interface"]

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -61,7 +61,7 @@ def main():
     service = MagmaService('pipelined', mconfigs_pb2.PipelineD())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     service_config = service.config
 

--- a/lte/gateway/python/magma/policydb/main.py
+++ b/lte/gateway/python/magma/policydb/main.py
@@ -42,7 +42,7 @@ def main():
     service = MagmaService('policydb', mconfigs_pb2.PolicyDB())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     apn_rules_dict = ApnRuleAssignmentsDict()
     assignments_dict = RuleAssignmentsDict()

--- a/lte/gateway/python/magma/redirectd/main.py
+++ b/lte/gateway/python/magma/redirectd/main.py
@@ -28,7 +28,7 @@ def main():
     service = MagmaService('redirectd', mconfigs_pb2.RedirectD())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     redirect_ip = get_service_config_value(
         'pipelined',

--- a/lte/gateway/python/magma/smsd/main.py
+++ b/lte/gateway/python/magma/smsd/main.py
@@ -24,7 +24,7 @@ def main():
     service = MagmaService('smsd', None)
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     directoryd_chan = ServiceRegistry.get_rpc_channel(
         'directoryd',

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -34,7 +34,7 @@ def main():
     service = MagmaService('subscriberdb', mconfigs_pb2.SubscriberDB())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     # Initialize a store to keep all subscriber data.
     store = SqliteStore(

--- a/orc8r/gateway/python/magma/configuration/mconfigs.py
+++ b/orc8r/gateway/python/magma/configuration/mconfigs.py
@@ -18,12 +18,16 @@ from google.protobuf.internal.well_known_types import Any
 from magma.configuration import service_configs
 from magma.configuration.exceptions import LoadConfigError
 
+SHARED_MCONFIG = 'shared_mconfig'
+
 
 def filter_configs_by_key(configs_by_key: Dict[str, TAny]) -> Dict[str, TAny]:
     """
     Given a JSON-deserialized map of mconfig protobuf Any's keyed by service
-    name, filter out any entires without a corresponding service or which have
+    name, filter out any entries without a corresponding service or which have
     values that aren't registered in the protobuf symbol database yet.
+    In addition to the service mconfigs there is also a shared mconfig with
+    key `SHARED_MCONFIG`.
 
     Args:
         configs_by_key:
@@ -36,11 +40,11 @@ def filter_configs_by_key(configs_by_key: Dict[str, TAny]) -> Dict[str, TAny]:
     services = magmad_cfg.get('magma_services', [])
     services.append('magmad')
     services += magmad_cfg.get('registered_dynamic_services', [])
-    services = set(services)
+    expected_keys = set(services + [SHARED_MCONFIG])
 
     filtered_configs_by_key = {}
     for srv, cfg in configs_by_key.items():
-        if srv not in services:
+        if srv not in expected_keys:
             continue
         filtered_configs_by_key[srv] = cfg
     return filtered_configs_by_key

--- a/orc8r/gateway/python/magma/configuration/tests/mconfigs_tests.py
+++ b/orc8r/gateway/python/magma/configuration/tests/mconfigs_tests.py
@@ -70,6 +70,19 @@ class MconfigsTest(unittest.TestCase):
         }
         self.assertEqual(expected, actual)
 
+        # Including 'shared_mconfig'
+        configs_by_key['shared_mconfig'] = {
+            '@type': 'type.googleapis.com/magma.mconfig.SharedMconfig',
+            'value': 'shared'.encode(),
+        }
+        actual = mconfigs.filter_configs_by_key(configs_by_key)
+        expected = {
+            'magmad': configs_by_key['magmad'],
+            'directoryd': configs_by_key['directoryd'],
+            'shared_mconfig': configs_by_key['shared_mconfig'],
+        }
+        self.assertEqual(expected, actual)
+
     def test_unpack_mconfig_any(self):
         magmad_mconfig = mconfigs_pb2.MagmaD(
             checkin_interval=10,

--- a/orc8r/gateway/python/magma/ctraced/main.py
+++ b/orc8r/gateway/python/magma/ctraced/main.py
@@ -25,7 +25,7 @@ def main():
     service = MagmaService('ctraced', CtraceD())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     orc8r_chan = ServiceRegistry.get_rpc_channel(
         'ctraced',

--- a/orc8r/gateway/python/magma/directoryd/main.py
+++ b/orc8r/gateway/python/magma/directoryd/main.py
@@ -22,7 +22,7 @@ def main():
     service = MagmaService('directoryd', mconfigs_pb2.DirectoryD())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     service_config = service.config
 

--- a/orc8r/gateway/python/magma/eventd/main.py
+++ b/orc8r/gateway/python/magma/eventd/main.py
@@ -23,7 +23,7 @@ def main():
     service = MagmaService('eventd', EventD())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     event_validator = EventValidator(service.config)
     eventd_servicer = EventDRpcServicer(service.config, event_validator)

--- a/orc8r/gateway/python/magma/magmad/config_manager.py
+++ b/orc8r/gateway/python/magma/magmad/config_manager.py
@@ -118,6 +118,7 @@ class ConfigManager(StreamerClient.Callback):
                 ),
             )
 
+        # TODO adapt service restart logic to include changes in shared_mconfig
         services_to_restart = [
             srv for srv in self._services if did_mconfig_change(srv)
         ]

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -56,7 +56,7 @@ def main():
     service = MagmaService('magmad', mconfigs_pb2.MagmaD())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     logging.info('Starting magmad for UUID: %s', snowflake.make_snowflake())
 

--- a/orc8r/gateway/python/magma/state/main.py
+++ b/orc8r/gateway/python/magma/state/main.py
@@ -27,7 +27,7 @@ def main():
     service = MagmaService('state', mconfigs_pb2.State())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name)
+    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
 
     # _grpc_client_manager to manage grpc client recycling
     grpc_client_manager = GRPCClientManager(


### PR DESCRIPTION
## Summary

As part of #9508 all the Sentry config for Python services should be migrated to shared mconfig.
- implement loading of shared mconfig (follow up to #9964)
- use it to initialize Sentry SDK
- remove Sentry config from control_proxy.yml

## Test Plan

Locally tested that config can be read.
Included shared_mconfig in respective unit test.