### PR TITLE
chore(agw): rename SEND_TO_MONITORING tag

### DIFF
--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -20,7 +20,7 @@ import grpc
 from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from magma.common.rpc_utils import grpc_async_wrapper
-from magma.common.sentry import SEND_TO_MONITORING
+from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from magma.magmad.check.network_check.ping import PingCommandResult
 from magma.monitord.icmp_state import ICMPMonitoringResponse
@@ -96,7 +96,7 @@ class CpeMonitoringModule:
                 "GetSubscribers Error for %s! %s",
                 err.code(),
                 err.details(),
-                extra=SEND_TO_MONITORING,
+                extra=SEND_TO_ERROR_MONITORING,
             )
         return PingedTargets(ping_targets, ping_addresses)
 

--- a/lte/gateway/python/magma/smsd/relay.py
+++ b/lte/gateway/python/magma/smsd/relay.py
@@ -20,7 +20,7 @@ import lte.protos.sms_orc8r_pb2_grpc as sms_orc8r_pb2_grpc
 from lte.protos.mconfig.mconfigs_pb2 import MME
 from magma.common.job import Job
 from magma.common.rpc_utils import grpc_async_wrapper, return_void
-from magma.common.sentry import SEND_TO_MONITORING
+from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.configuration.mconfig_managers import load_service_mconfig
 from orc8r.protos.common_pb2 import Void
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
@@ -94,7 +94,7 @@ class SmsRelay(Job):
                 self._mme_sms.SMODownlink.future(dl, SMS_TIMEOUT_SECS),
             )
         except grpc.RpcError as err:
-            logging.error("RPC call to MME failed: %s", err, extra=SEND_TO_MONITORING)
+            logging.error("RPC call to MME failed: %s", err, extra=SEND_TO_ERROR_MONITORING)
             return
 
     @return_void

--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -28,8 +28,8 @@ COMMIT_HASH = 'COMMIT_HASH'
 HWID = 'hwid'
 SERVICE_NAME = 'service_name'
 LOGGING_EXTRA = 'extra'
-SEND_TO_MONITORING_KEY = "send_to_monitoring"
-SEND_TO_MONITORING = {SEND_TO_MONITORING_KEY: True}
+SEND_TO_ERROR_MONITORING_KEY = "send_to_error_monitoring"
+SEND_TO_ERROR_MONITORING = {SEND_TO_ERROR_MONITORING_KEY: True}
 
 
 class SentryStatus(Enum):
@@ -47,7 +47,7 @@ def send_uncaught_errors_to_monitoring(enabled: bool):
             try:
                 return func(*args, **kwargs)
             except Exception as err:
-                logging.error("Uncaught error", exc_info=True, extra=SEND_TO_MONITORING)
+                logging.error("Uncaught error", exc_info=True, extra=SEND_TO_ERROR_MONITORING)
                 raise err
 
         if enabled:
@@ -61,8 +61,8 @@ def _ignore_if_not_marked(
         event: Dict[str, Any],
         hint: Dict[str, Any],  # pylint: disable=unused-argument
 ) -> Optional[Dict[str, Any]]:
-    if event.get(LOGGING_EXTRA) and event.get(LOGGING_EXTRA).get(SEND_TO_MONITORING_KEY):
-        del event[LOGGING_EXTRA][SEND_TO_MONITORING_KEY]
+    if event.get(LOGGING_EXTRA) and event.get(LOGGING_EXTRA).get(SEND_TO_ERROR_MONITORING_KEY):
+        del event[LOGGING_EXTRA][SEND_TO_ERROR_MONITORING_KEY]
         return event
     return None
 

--- a/orc8r/gateway/python/magma/common/tests/sentry_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/sentry_tests.py
@@ -31,7 +31,7 @@ class SentryTests(unittest.TestCase):
 
     def test_do_not_ignore_and_remove_tag_if_marked(self):
         """Test marked events that are sent to Sentry"""
-        returned_event = _ignore_if_not_marked({"key": "value", "extra": {"send_to_monitoring": True}}, {})
+        returned_event = _ignore_if_not_marked({"key": "value", "extra": {"send_to_error_monitoring": True}}, {})
         self.assertEqual(returned_event, {"key": "value", "extra": {}})
 
     def test_uncaught_error_wrapper(self):

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -20,7 +20,7 @@ import metrics_pb2
 import prometheus_client.core
 import requests
 import snowflake
-from magma.common.sentry import SEND_TO_MONITORING
+from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos import metricsd_pb2
 from orc8r.protos.common_pb2 import Void
@@ -139,7 +139,7 @@ class MetricsCollector(object):
                 "Metrics upload error for service %s (chunk %d)! "
                 "[%s] %s", service_name, chunk, err.code(),
                 err.details(),
-                extra=SEND_TO_MONITORING,
+                extra=SEND_TO_ERROR_MONITORING,
             )
         else:
             logging.debug(
@@ -299,7 +299,7 @@ class MetricsCollector(object):
             logging.error(
                 "Prometheus Target Metrics upload error! [%s] %s",
                 err.code(), err.details(),
-                extra=SEND_TO_MONITORING,
+                extra=SEND_TO_ERROR_MONITORING,
             )
         else:
             logging.debug(

--- a/orc8r/gateway/python/magma/magmad/proxy_client.py
+++ b/orc8r/gateway/python/magma/magmad/proxy_client.py
@@ -15,7 +15,7 @@ import logging
 
 import aioh2
 import h2.events
-from magma.common.sentry import SEND_TO_MONITORING
+from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos.sync_rpc_service_pb2 import GatewayResponse, SyncRPCResponse
 
@@ -107,7 +107,7 @@ class ControlProxyHttpClient(object):
         except Exception as e:  # pylint: disable=broad-except
             logging.error(
                 "[SyncRPC] Exception in proxy_client: %s", e,
-                extra=SEND_TO_MONITORING,
+                extra=SEND_TO_ERROR_MONITORING,
             )
             sync_rpc_response_queue.put(
                 SyncRPCResponse(

--- a/orc8r/gateway/python/magma/magmad/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/magmad/rpc_servicer.py
@@ -24,7 +24,7 @@ from google.protobuf.json_format import MessageToJson
 from google.protobuf.struct_pb2 import Struct
 from magma.common.rpc_utils import return_void, set_grpc_err
 from magma.common.sentry import (
-    SEND_TO_MONITORING,
+    SEND_TO_ERROR_MONITORING,
     SentryStatus,
     get_sentry_status,
     send_uncaught_errors_to_monitoring,
@@ -243,7 +243,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
             logging.error(
                 'Error running command %s! %s: %s',
                 request.command, e.__class__.__name__, e,
-                extra=SEND_TO_MONITORING,
+                extra=SEND_TO_ERROR_MONITORING,
             )
             set_grpc_err(
                 context,

--- a/orc8r/gateway/python/magma/state/garbage_collector.py
+++ b/orc8r/gateway/python/magma/state/garbage_collector.py
@@ -16,7 +16,7 @@ import grpc
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.redis.containers import RedisFlatDict
 from magma.common.rpc_utils import grpc_async_wrapper, print_grpc
-from magma.common.sentry import SEND_TO_MONITORING
+from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.common.service import MagmaService
 from magma.state.keys import make_scoped_device_id
 from magma.state.redis_dicts import get_json_redis_dicts, get_proto_redis_dicts
@@ -86,7 +86,7 @@ class GarbageCollector:
             logging.error(
                 "GRPC call failed for state deletion: %s",
                 err,
-                extra=SEND_TO_MONITORING,
+                extra=SEND_TO_ERROR_MONITORING,
             )
         else:
             for redis_dict in self._redis_dicts:

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -21,7 +21,7 @@ from google.protobuf.json_format import MessageToDict
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.rpc_utils import grpc_async_wrapper, print_grpc
 from magma.common.sdwatchdog import SDWatchdogTask
-from magma.common.sentry import SEND_TO_MONITORING
+from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.common.service import MagmaService
 from magma.state.garbage_collector import GarbageCollector
 from magma.state.keys import make_mem_key, make_scoped_device_id
@@ -123,7 +123,7 @@ class StateReplicator(SDWatchdogTask):
                 logging.error(
                     "GRPC call failed for initial state re-sync: %s",
                     err,
-                    extra=SEND_TO_MONITORING,
+                    extra=SEND_TO_ERROR_MONITORING,
                 )
                 return
         request = await self._collect_states_to_replicate()
@@ -264,7 +264,7 @@ class StateReplicator(SDWatchdogTask):
             logging.error(
                 "GRPC call failed for state replication: %s",
                 err,
-                extra=SEND_TO_MONITORING,
+                extra=SEND_TO_ERROR_MONITORING,
             )
         else:
             unreplicated_states = set()


### PR DESCRIPTION
## Summary

As suggested in https://github.com/magma/magma/pull/10099#discussion_r748601516 the tag SEND_TO_MONITORING is renamed to SEND_TO_ERROR_MONITORING to increase clarity.