### PR TITLE
docs: add bazel docs for AGW build/test

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -137,7 +137,7 @@ jobs:
   c_cpp_unit_tests:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
-    name: Run C/C++ unit tests with Bazel
+    name: C/C++ unit tests with Bazel
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo

--- a/docs/readmes/contributing/contribute_ci_checks.md
+++ b/docs/readmes/contributing/contribute_ci_checks.md
@@ -49,6 +49,7 @@ Merge blocking CI checks are listed below.
 | Python Format Check    | Ensure Python changes are formatted           | themarwhal             | [AGW formatting](../lte/dev_unit_testing#format-agw)|
 | lint-clang-format      | Ensure C++/C changes are formatted            | approvers-agw          | [AGW formatting](../lte/dev_unit_testing#format-agw)|
 | markdown-lint          | Ensure documentation changes are formatted    | approvers-docs         | [Docs precommit](../docs/docs_overview.md#precommit)|
+| C/C++ unit tests with Bazel | Run all C/C++ tests covered with Bazel   | approvers-agw          | [AGW tests](../lte/dev_unit_testing)                |
 
 ## Non-blocking Checks
 
@@ -61,4 +62,4 @@ The CI checks listed below do not block merging on failure.
 | GCC Warnings & Errors / build_oai             | Annotate PRs with any GCC Warnings or Errors for MME             | electronjoe        | N/A                                                  |
 | GCC Warnings & Errors / build_session_manager | Annotate PRs with any GCC Warnings or Errors for session_manager | electronjoe        | N/A                                                  |
 | Jenkins CWAG Libvirt                          | Run CWF integration tests                                        | themarwhal mattymo | TODO                                                 |
-| ci/circleci: c-cpp-codecov                    | Upload AGW C/C++ code coverage                                   | electronjoe        | N/A                                                  |
+| C / C++ code coverage                         | Upload AGW C/C++ code coverage                                   | electronjoe        | N/A                                                  |

--- a/docs/readmes/lte/dev_unit_testing.md
+++ b/docs/readmes/lte/dev_unit_testing.md
@@ -73,6 +73,15 @@ To run tests for those services, run
 [VM] make test_<service_directory_name> # Ex: make test_session_manager
 ```
 
+A subset of the AGW C/C++ directories are in progress of migrating to use Bazel as the default build system. We will list out some of the useful commands here, but please refer to the [Bazel user guide](https://docs.bazel.build/versions/main/guide.html) for a complete overview.
+
+```bash
+[VM] cd magma # or any subdirectory inside magma
+[VM] bazel test //... # to test all targets
+[VM] bazel test //lte/gateway/c/session_manager/...:* # to test all targets under lte/gateway/c/session_manager 
+[VM] bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* # to test all C/C++ targets
+```
+
 ### Test Go AGW services
 
 We have several Go implementations of AGW services that live in `orc8r/gateway/go`.
@@ -116,4 +125,13 @@ To run formatting for each C/C++ services, run
 ```bash
 [VM] cd magma/lte/gateway
 [VM] make format_all
+```
+
+### Format Bazel BUILD files
+
+To format all Bazel related files, run
+
+```bash
+[VM] cd magma # or any subdirectory inside magma
+[VM] bazel run //:buildifier
 ```

--- a/docs/readmes/nms/organizations.md
+++ b/docs/readmes/nms/organizations.md
@@ -25,22 +25,25 @@ When you deploy the NMS for the first time, you'll need to create a user that
 has access to the master organization. Run the command
 
 - Docker (development environment)
+
     ```bash
     docker-compose exec magmalte yarn setAdminPassword master ADMIN_USER_EMAIL ADMIN_USER_PASSWORD
     ```
+
 - Kubernetes (production environment)
+
     ```bash
     export NMS_POD=$(kubectl get pod -l app.kubernetes.io/component=magmalte -o jsonpath='{.items[0].metadata.name}')
     kubectl exec -it ${NMS_POD} -- yarn setAdminPassword master ADMIN_USER_EMAIL ADMIN_USER_PASSWORD
     ```
-          
+
 You can then log in to the master organization at `master.nms.yourdomain.com`
 to create additional organizations and users.
 
 When creating a new organization, only enable the `NMS` tab. Also, note that
 only users with the `Super User` role can create new networks within each
 organization.
-          
+
 ## DNS Resolution
 
 We use [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) to


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I like to make the Bazel C/C++ check mandatory as we migrate the default build system for sessiond/liagentd/connectiond. I will raise a proposal to make the check mandatory soon, but wanted to have the docs in place so the transition is smoother. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_fix
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
