### PR TITLE
fix(orc8r): Incorrect conversion between integer types

### DIFF
--- a/orc8r/cloud/go/services/state/indexer/indexer.go
+++ b/orc8r/cloud/go/services/state/indexer/indexer.go
@@ -69,7 +69,7 @@ type Version uint32
 // the required integer size.
 func NewIndexerVersion(version int64) (Version, error) {
 	if version < 0 || version > 4294967295 {
-		return 0, fmt.Errorf("version %d is outside the boundaries of unit32 type", version)
+		return 0, fmt.Errorf("version value %d is outside the boundaries of unit32 type", version)
 	}
 	capped := Version(version)
 	if int64(capped) != version {

--- a/orc8r/cloud/go/services/state/indexer/indexer.go
+++ b/orc8r/cloud/go/services/state/indexer/indexer.go
@@ -68,8 +68,8 @@ type Version uint32
 // NewIndexerVersion returns a new indexer version, ensuring it fits into
 // the required integer size.
 func NewIndexerVersion(version int64) (Version, error) {
-	if version < 0 || version > 4294967295 {
-		return 0, fmt.Errorf("version value %d is outside the boundaries of unit32 type", version)
+	if version < 0 || version > math.MaxUint32 {
+		return 0, fmt.Errorf("version value %d is outside the boundaries of uint32 type", version)
 	}
 	capped := Version(version)
 	if int64(capped) != version {

--- a/orc8r/cloud/go/services/state/indexer/indexer.go
+++ b/orc8r/cloud/go/services/state/indexer/indexer.go
@@ -73,9 +73,7 @@ func NewIndexerVersion(version int64) (Version, error) {
 		return 0, fmt.Errorf("version value %d is outside the boundaries of uint32 type", version)
 	}
 	capped := Version(version)
-	if int64(capped) != version {
-		return 0, fmt.Errorf("indexer version %v too large for %T", version, Version(0))
-	}
+
 	return capped, nil
 }
 

--- a/orc8r/cloud/go/services/state/indexer/indexer.go
+++ b/orc8r/cloud/go/services/state/indexer/indexer.go
@@ -16,6 +16,7 @@ package indexer
 
 import (
 	"fmt"
+	"math"
 
 	state_types "magma/orc8r/cloud/go/services/state/types"
 )

--- a/orc8r/cloud/go/services/state/indexer/indexer.go
+++ b/orc8r/cloud/go/services/state/indexer/indexer.go
@@ -68,6 +68,9 @@ type Version uint32
 // NewIndexerVersion returns a new indexer version, ensuring it fits into
 // the required integer size.
 func NewIndexerVersion(version int64) (Version, error) {
+	if version < 0 || version > 4294967295 {
+		return 0, fmt.Errorf("version %d is outside the boundaries of unit32 type", version)
+	}
 	capped := Version(version)
 	if int64(capped) != version {
 		return 0, fmt.Errorf("indexer version %v too large for %T", version, Version(0))


### PR DESCRIPTION
fix(orc8): fix incorrect conversion between integer types

## Summary

- magma/orc8r/cloud/go/services/state/indexer/indexer.go:71

Check for lower and upper bounds for uint32 type added.

Fix for: https://github.com/magma/magma/security/code-scanning/19?query=ref%3Arefs%2Fheads%2Fmaster

## Test Plan

I ran test:  
/magma/orc8r/cloud/docker/  ./build.py -c
