### PR TITLE
fix(amf): AMF is crashing when a PDU-Establishment Request came with missing DNN in the IE.

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -263,7 +263,6 @@ typedef struct smf_context_s {
   QOSRule qos_rules[1];
   teid_upf_gnb_t gtp_tunnel_id;
   paa_t pdu_address;
-  uint8_t apn[ACCESS_POINT_NAME_MAX_LENGTH + 1];
   smf_proc_data_t smf_proc_data;
   struct nas5g_timer_s T3592;  // PDU_SESSION_RELEASE command timer
   int retransmission_count;

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -249,8 +249,7 @@ void amf_smf_context_cleanup_pdu_session(ue_m5gmm_context_s* ue_context) {
 
     if (i->pdu_address.pdn_type == IPv4) {
       AsyncM5GMobilityServiceClient::getInstance().release_ipv4_address(
-          imsi, reinterpret_cast<const char*>(i->apn),
-          &(i->pdu_address.ipv4_address));
+          imsi, i->dnn.c_str(), &(i->pdu_address.ipv4_address));
     }
   }
 }

--- a/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
@@ -171,9 +171,9 @@ int amf_smf_create_pdu_session(
       LOG_AMF_APP, "Sending msg(grpc) to :[mobilityd] for ue: [%s] ip-addr\n",
       imsi);
   AMFClientServicer::getInstance().allocate_ipv4_address(
-      imsi, reinterpret_cast<char*>(smf_ctx->apn), message->pdu_session_id,
-      message->pti, AF_INET, message->gnb_gtp_teid,
-      message->gnb_gtp_teid_ip_addr, 4, amf_ctxt_p->subscribed_ue_ambr);
+      imsi, smf_ctx->dnn.c_str(), message->pdu_session_id, message->pti,
+      AF_INET, message->gnb_gtp_teid, message->gnb_gtp_teid_ip_addr, 4,
+      amf_ctxt_p->subscribed_ue_ambr);
 
   return (RETURNok);
 }


### PR DESCRIPTION
Signed-off-by: sreedharkumartn <sreedhar.kumar@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Issue handled:

- AMF is crashing when a PDU-Establishment Request came with missing DNN info in the IE. (Zenhub task ticket #10581).

1. Crash root cause:
If Subscriber db is configured with Internet, apn_2:
![subscriber_apn_config](https://user-images.githubusercontent.com/89978170/144073091-cc5e97ed-deca-4ed2-a186-21b5b4ae6879.JPG)
UE: DNN IE is not present:
![ueransim_no_dnn](https://user-images.githubusercontent.com/89978170/144072912-32fa01c7-0b41-4cde-8f56-d9e34d6ce807.JPG)
AMF is crashing at PDU Session Establishment Request.
![image](https://user-images.githubusercontent.com/89978170/144226208-3a30ab22-4178-4fbf-802f-be9b1e4e3c61.png)

2. apn is removed and replaced with dnn.
As dnn is string and apn is array. No need of extra buffer for dnn.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Fix for Issue:
Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/144066295-220800ab-3420-4904-a17d-a951d2bd5802.png)
Log:
[mme_missing_dnn_resolved.log](https://github.com/magma/magma/files/7626467/mme_missing_dnn_resolved.log)

DNN Scenarios handled:
![image](https://user-images.githubusercontent.com/89978170/144067647-aa4d8293-1d20-48c2-ae23-df7bd4970a6a.png)

Subscriber db: Not configured.
![subscriber](https://user-images.githubusercontent.com/89978170/144072849-6bb312fa-f6a5-49a3-9da3-3c35a9adcd0f.JPG)
UE: DNN IE present with empty DNN value
![ueransim_dnn_empty](https://user-images.githubusercontent.com/89978170/144072967-353ae65c-514f-421f-8c96-d935418638b7.JPG)

- Case 1a: Subscriber db: Not configured, UE: DNN IE not present
Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/144068260-f9bb9285-60d2-41af-9c8c-3bd46d2da22f.png)
Log:
[mme_dnn_case_1a.log](https://github.com/magma/magma/files/7626541/mme_dnn_case_1a.log)

- Case 1b: Subscriber db: Not configured, UE: DNN IE present with empty DNN value
Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/144068622-dba49380-a74a-4fd9-a39d-446d5ae4d837.png)
Log:
[mme_dnn_case_1b.log](https://github.com/magma/magma/files/7626558/mme_dnn_case_1b.log)

- Case 2: Subscriber db: Not configured, UE: DNN IE present with valid DNN.
Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/144069095-9ed9737b-53e2-44f4-8094-6b11fd94c7e3.png)
Log:
[mme_dnn_case_2.log](https://github.com/magma/magma/files/7626584/mme_dnn_case_2.log)

- Case 3a: Subscriber db: Internet, apn_2, mme.yml: apn_2, UE: DNN IE is not present.
Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/144070302-03ecd0aa-dc1b-46b4-af74-1760fcd38e23.png)
Log:
[mme_dnn_case_3a.log](https://github.com/magma/magma/files/7626634/mme_dnn_case_3a.log)

- Case 3b: Subscriber db: Internet, apn_2, mme.yml: nil, UE: DNN IE is not present.
Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/144071039-8696dac5-227b-4f83-9f25-ed9e107f00e0.png)
Log:
[mme_missing_dnn_resolved.log](https://github.com/magma/magma/files/7626655/mme_missing_dnn_resolved.log)

- Case 3c: Subscriber db: Internet, apn_2, mme.yml: apn_2, UE: DNN IE is present with empty DNN value.
Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/144071337-ec91af21-061d-4953-976f-2fed929a87f6.png)
Log:
[mme_dnn_case_3c.log](https://github.com/magma/magma/files/7626688/mme_dnn_case_3c.log)

- Case 3d: Subscriber db: Internet, apn_2, mme.yml: nil, UE: DNN IE is present with empty DNN value.
Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/144071709-16480907-19d8-47a7-89be-3a856c444ea1.png)
Log:
[mme_dnn_case_3d.log](https://github.com/magma/magma/files/7626702/mme_dnn_case_3d.log)

- Case 4a: Subscriber db: Internet, apn_2, UE: Internet.
Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/144072131-571e5a97-54ec-4e22-9b8f-7f47dab1366b.png)
Log:
[mme_dnn_case_4a.log](https://github.com/magma/magma/files/7626716/mme_dnn_case_4a.log)

- Case 4b: Subscriber db: Internet, apn_2, UE: apn_1.
Pcap snap:
![image](https://user-images.githubusercontent.com/89978170/144072734-f8eaf4a1-ecb7-4e6b-987b-a11368a1f12c.png)
Log:
[mme_dnn_case_4b.log](https://github.com/magma/magma/files/7626718/mme_dnn_case_4b.log)

Validated with UT Test cases:
![image](https://user-images.githubusercontent.com/89978170/144072488-09a15a14-aaf4-48f5-b933-43fba98ca706.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
