### PR TITLE
fix(amf): amf is not set RATType in PDU Session Release

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
@@ -199,6 +199,7 @@ int release_session_gprc_req(amf_smf_release_t* message, char* imsi) {
   req_rat_specific->set_pdu_session_id(message->pdu_session_id);
   req_rat_specific->set_procedure_trans_identity(
       (const char*) (&(message->pti)));
+  req_common->set_rat_type(magma::lte::RATType::TGPP_NR);
 
   OAILOG_INFO(
       LOG_AMF_APP,


### PR DESCRIPTION
test cases:
   - verified PDU Session and release with UERANSIM
     triggered multiple PDU Session Establishment & Release,
     Observed subsequent PDU is successful.
Repro:
![image](https://user-images.githubusercontent.com/83060027/144094226-b818c790-0e73-4fe0-ab7c-89a1e300814a.png)
logs & pcap after resolution:
![image](https://user-images.githubusercontent.com/83060027/144094582-f8a6f12e-560b-403d-bb42-d5ddd0eaf12d.png)


[mme_reg_pdu_release_dreg_30_nov_21.log](https://github.com/magma/magma/files/7627486/mme_reg_pdu_release_dreg_30_nov_21.log)
Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

 AMF is not sending RATtype to SMF, SMF is failing to delete Session.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
