### PR TITLE
fix(sessiond): Enable ASAN for SessionD unit tests 

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -20,12 +20,13 @@ include(FindClangFormat)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 
+# Add AddressSanitizer (asan) support for debug builds of SessionD
+set (CMAKE_CXX_FLAGS_DEBUG
+    "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+set (CMAKE_LINKER_FLAGS_DEBUG
+    "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
 if (NOT BUILD_TESTS)
-  # Add AddressSanitizer (asan) support for debug builds of SessionD
-  set (CMAKE_CXX_FLAGS_DEBUG
-      "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-  set (CMAKE_LINKER_FLAGS_DEBUG
-      "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
   # Add LeakSanitizer (lsan) support to the release build of SessionD so that
   # we can find memory leaks in production.
   # Disabling LSAN on Prod until we figure out how to get gcore to work

--- a/lte/gateway/c/session_manager/SessionManagerServer.cpp
+++ b/lte/gateway/c/session_manager/SessionManagerServer.cpp
@@ -42,6 +42,8 @@ void AsyncService::wait_for_requests() {
     if (!ok) {
       MLOG(MINFO)
           << "sessiond server encountered error while processing request";
+      // Free memory for the queued up item even if we couldn't process it
+      delete static_cast<CallData*>(tag);
       continue;
     }
     static_cast<CallData*>(tag)->proceed();


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
We've previously had to turn off ASAN for SessionD unit tests as there were issues. This PR fixes the issue so that we can enable ASAN for any new unit tests written. This PR also includes changes in the CMake file to enable ASAN for all debug builds. (including unit tests)

To summarize the change, when we find GRPC call items in the queue that we are unable to process due to either timeouts or cancellations, we also need to delete the calldata object. We do something similar in the success case: we process each calldata object and then once the callback functions are called, we delete the object. Before this PR, we were not deleting these objects, which led to an accumulation of unfreed objects. 

We probably were not seeing this object accumulation (even if it was happening, we wouldn't see any errors in memory leaks) in production because we have LSAN disabled for production builds. But with the sessiond integ test we hit this case consistently.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
S1AP test
SessionD unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
