### PR TITLE
feat: migrate Makefile targets to use Bazel

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -83,11 +83,11 @@ OAI_TESTS ?= ".*"
 
 all: build
 
-build: build_python build_common build_oai build_sctpd build_session_manager build_connection_tracker build_envoy_controller build_li_agent ## Build all
+build: build_python build_c build_oai build_envoy_controller ## Build all
 
 smf_build: build_session_manager  ## Build only sessionD component make smf_build
 
-test: test_python test_common test_oai test_sctpd test_session_manager ## Run all tests
+test: test_python test_c test_oai ## Run all tests
 
 clean: clean_python clean_envoy_controller ## Clean all builds
 	rm -rf $(C_BUILD)
@@ -150,9 +150,6 @@ endef
 build_python: stop ## Build Python environment
 	make -C $(MAGMA_ROOT)/lte/gateway/python buildenv
 
-build_common: ## Build shared libraries
-	$(call run_cmake, $(C_BUILD)/magma_common, $(MAGMA_ROOT)/orc8r/gateway/c/common, $(COMMON_FLAGS))
-
 define copy_bazel_c_build ## Copy Bazel build output to C_BUILD/
 # 1 - source directory, 2 - binary name
 mkdir -p $(C_BUILD)/$(1)
@@ -176,24 +173,23 @@ format_all:
 	clang-format --style=file -i {} \;
 
 build_sctpd:
-	$(call run_cmake, $(C_BUILD)/sctpd, $(GATEWAY_C_DIR)/sctpd, )
+	bazel build //lte/gateway/c/sctpd/src:sctpd
+	$(call copy_bazel_c_build,sctpd/src,sctpd)
 
-build_session_manager: build_common ## Build session manager
-	$(call run_cmake, $(C_BUILD)/session_manager, $(GATEWAY_C_DIR)/session_manager, )
+build_session_manager:
+	bazel build //lte/gateway/c/session_manager:sessiond
+	$(call copy_bazel_c_build,session_manager,sessiond)
 
 build_li_agent: ## Build li agent
-	$(call run_cmake, $(C_BUILD)/li_agent, $(GATEWAY_C_DIR)/li_agent, )
+	bazel build //lte/gateway/c/li_agent/src:liagentd
+	$(call copy_bazel_c_build,li_agent/src,liagentd)
 
 build_connection_tracker:
-	$(call run_cmake, $(C_BUILD)/connection_tracker, $(GATEWAY_C_DIR)/connection_tracker, )
+	bazel build //lte/gateway/c/connection_tracker/src:connectiond
+	$(call copy_bazel_c_build,connection_tracker/src,connectiond)
 
 build_envoy_controller: ## Build envoy controller
 	cd $(MAGMA_ROOT)/feg/gateway && $(MAKE) install_envoy_controller
-
-# Catch all for c services that don't have custom flags
-# This works with build_dpi
-build_%:
-	$(call run_cmake, $(C_BUILD)/$*, $(MAGMA_ROOT)/c/$*, $(COMMON_FLAGS))
 
 scan_oai: ## Scan OAI
 	$(call run_scanbuild, $(C_BUILD)/scan/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS))
@@ -216,24 +212,17 @@ test_c: ## Run all Bazel-ified C/C++ tests
 test_oai: ## Run all OAI-specific tests
 	$(call run_ctest, $(C_BUILD)/core, $(C_BUILD)/core/oai, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(OAI_TEST_FLAGS), $(OAI_TESTS))
 
-test_sctpd: ## Run all tests for sctpd
-	$(call run_ctest, $(C_BUILD)/sctp, $(C_BUILD)/sctp/src, $(GATEWAY_C_DIR)/sctpd, )
-
 test_common: ## Run all tests in magma_common
-	$(call run_cmake, $(C_BUILD)/magma_common, $(MAGMA_ROOT)/orc8r/gateway/c/common, $(TEST_FLAG))
-	# Run the common lib tests that exist
-	cd $(C_BUILD)/magma_common/config && ctest --output-on-failure
-	cd $(C_BUILD)/magma_common/service303 && ctest --output-on-failure
-	cd $(C_BUILD)/magma_common/service_registry && ctest --output-on-failure
+	bazel test //orc8r/gateway/c/...:*
 
-test_li_agent:
-	$(call run_ctest, $(C_BUILD)/li_agent, $(C_BUILD)/li_agent/src, $(GATEWAY_C_DIR)/li_agent, )
+test_sctpd: ## Run sctpd tests
+	bazel test //lte/gateway/c/sctpd/src/test:all
 
+test_li_agent: ## Run li_agent tests
+	bazel test //lte/gateway/c/li_agent/src/test:all
 
-# Catch all for c service tests
-# This works with test_dpi and test_session_manager
-test_%: build_common
-	$(call run_ctest, $(C_BUILD)/$*, $(C_BUILD)/$*, $(GATEWAY_C_DIR)/$*, )
+test_session_manager: ## Run session_manager tests
+	bazel test //lte/gateway/c/session_manager/test:all
 
 coverage_oai: test_oai
 	lcov --capture --directory $(C_BUILD) --output-file /tmp/coverage_oai.info.raw


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This PR is the official cutover change to make Bazel the default build system for SessionD, SCTPD, LiagentD, ConnectionD

1. Migrate each of the `make build_X` and `make test_X` targets for the services listed above so that developers can continue using the same command. However, it is recommended that the developers eventually run bazel directly as it provides more flexibility in terms of running individual tests and modifying the build configuration.


## List of things that have been migrated already
1. CI - Code coverage: all Bazel test targets are reporting code coverage as part of c-cpp-codecov job
2. CI - Unit tests: all Bazel test targets are run as part of c_cpp_unit_tests job

## Blockers before this can be merged
1. https://github.com/magma/magma/pull/10583 to enable LSAN for RELWITHDEBINFO as we do with the cmake builds
2. https://github.com/magma/magma/pull/10587 blocks the PR above
3. https://github.com/magma/magma/pull/10544 to speed up building from scratch in CI. As Bazel builds most external dependencies from scratch, builds are much slower if there is no cache. For local development, the cache lives in the host machine. For CI, we pull it from S3 that is updated daily.
4. Migrate AGW containers to be built with Bazel https://github.com/magma/magma/pull/10608
5. Remove individual unit test jobs from CI - https://github.com/magma/magma/pull/10592
6. Add basic build_c / test_c targets to specify different flags for DEBUG and RELWITHDEBINFO builds: https://github.com/magma/magma/pull/10642
7

<!-- Enumerate changes you made and why you made them -->

## Test Plan
* Produced an AGW package on top of this build as a final check. Running sanity tests overnight showed no regression.
![261732348_5140904732606195_259434626505696741_n](https://user-images.githubusercontent.com/37634144/144482892-e09fd33e-3f2a-487d-9f25-d897c0a33a2e.png)
* LTE integ test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
