### PR TITLE
test(pipelined): skip stats check in ipv6 solicitation

### DIFF
--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_ipv6_solicitation.IPV6RouterSolicitationTableTest.test_ipv6_flows.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_ipv6_solicitation.IPV6RouterSolicitationTableTest.test_ipv6_flows.snapshot
@@ -1,5 +1,5 @@
- cookie=0x0, table=mme(main_table), n_packets=2, n_bytes=156, priority=65535,dl_src=5e:cc:cc:b1:49:4b,dl_dst=0a:00:27:00:00:02 actions=load:0x1->NXM_NX_REG1[],resubmit(,ipv6_solicitation(main_table))
- cookie=0x0, table=ipv6_solicitation(main_table), n_packets=1, n_bytes=70, priority=10,icmp6,reg1=0x1,ipv6_src=fe80::/10,icmp_type=133 actions=CONTROLLER:65535
- cookie=0x0, table=ipv6_solicitation(main_table), n_packets=1, n_bytes=86, priority=10,icmp6,reg1=0x1,ipv6_src=fe80::/10,icmp_type=135 actions=CONTROLLER:65535
- cookie=0x0, table=ipv6_solicitation(main_table), n_packets=0, n_bytes=0, priority=10,icmp6,reg1=0x10,ipv6_dst=ff02::1:ff00:0/104,icmp_type=135 actions=CONTROLLER:65535
- cookie=0x0, table=ipv6_solicitation(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ priority=65535,dl_src=5e:cc:cc:b1:49:4b,dl_dst=0a:00:27:00:00:02 actions=load:0x1->NXM_NX_REG1[],resubmit(,ipv6_solicitation(main_table))
+ table=ipv6_solicitation(main_table), priority=10,icmp6,reg1=0x1,ipv6_src=fe80::/10,icmp_type=133 actions=CONTROLLER:65535
+ table=ipv6_solicitation(main_table), priority=10,icmp6,reg1=0x1,ipv6_src=fe80::/10,icmp_type=135 actions=CONTROLLER:65535
+ table=ipv6_solicitation(main_table), priority=10,icmp6,reg1=0x10,ipv6_dst=ff02::1:ff00:0/104,icmp_type=135 actions=CONTROLLER:65535
+ table=ipv6_solicitation(main_table), priority=0 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/test_ipv6_solicitation.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ipv6_solicitation.py
@@ -170,6 +170,7 @@ class IPV6RouterSolicitationTableTest(unittest.TestCase):
         snapshot_verifier = SnapshotVerifier(
             self, self.BRIDGE,
             self.service_manager,
+            include_stats=False,
         )
 
         with isolator, snapshot_verifier:


### PR DESCRIPTION
We dont need to validate OVS flow match logic, so stats check is not
needed. Lets skip it to improve stability of the test.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
`make test`
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
