### PR TITLE
test(mme): Add new esm message encode and decode unit tests

### DIFF
--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_sm_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_sm_ies.c
@@ -930,7 +930,7 @@ int decode_traffic_flow_template_ie(
   if (iei_present) {
     CHECK_PDU_POINTER_AND_LENGTH_DECODER(
         buffer, TRAFFIC_FLOW_TEMPLATE_MINIMUM_LENGTH, len);
-    CHECK_IEI_DECODER(SM_PROTOCOL_CONFIGURATION_OPTIONS_IEI, *buffer);
+    CHECK_IEI_DECODER(SM_TRAFFIC_FLOW_TEMPLATE_IEI, *buffer);
     decoded++;
   } else {
     CHECK_PDU_POINTER_AND_LENGTH_DECODER(

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_esm_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_esm_encode_decode.cpp
@@ -23,6 +23,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/common/TLVEncoder.h"
 #include "lte/gateway/c/core/oai/common/TLVDecoder.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextAccept.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextAccept.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextReject.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextRequest.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextRequest.h"
@@ -69,6 +70,24 @@ namespace lte {
     bdestroy_wrapper(                                                          \
         &decoded_msg.protocolconfigurationoptions.protocol_or_container_ids[1] \
              .contents);                                                       \
+  } while (0)
+
+#define EXPECT_EQ_PCO()                                                        \
+  do {                                                                         \
+    EXPECT_EQ(                                                                 \
+        std::string((const char*) original_msg.protocolconfigurationoptions    \
+                        .protocol_or_container_ids[0]                          \
+                        .contents->data),                                      \
+        std::string((const char*) decoded_msg.protocolconfigurationoptions     \
+                        .protocol_or_container_ids[0]                          \
+                        .contents->data));                                     \
+    EXPECT_EQ(                                                                 \
+        std::string((const char*) original_msg.protocolconfigurationoptions    \
+                        .protocol_or_container_ids[1]                          \
+                        .contents->data),                                      \
+        std::string((const char*) decoded_msg.protocolconfigurationoptions     \
+                        .protocol_or_container_ids[1]                          \
+                        .contents->data));                                     \
   } while (0)
 
 class ESMEncodeDecodeTest : public ::testing::Test {
@@ -187,20 +206,7 @@ TEST_F(ESMEncodeDecodeTest, TestActivateDedicatedEpsBearerContextAccept) {
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
   EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
-  EXPECT_EQ(
-      std::string((const char*) original_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[0]
-                      .contents->data),
-      std::string((const char*) decoded_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[0]
-                      .contents->data));
-  EXPECT_EQ(
-      std::string((const char*) original_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[1]
-                      .contents->data),
-      std::string((const char*) decoded_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[1]
-                      .contents->data));
+  EXPECT_EQ_PCO();
 
   DESTROY_PCO();
 }
@@ -225,20 +231,7 @@ TEST_F(ESMEncodeDecodeTest, TestActivateDedicatedEpsBearerContextReject) {
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
   EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
   EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
-  EXPECT_EQ(
-      std::string((const char*) original_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[0]
-                      .contents->data),
-      std::string((const char*) decoded_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[0]
-                      .contents->data));
-  EXPECT_EQ(
-      std::string((const char*) original_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[1]
-                      .contents->data),
-      std::string((const char*) decoded_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[1]
-                      .contents->data));
+  EXPECT_EQ_PCO();
 
   DESTROY_PCO();
 }
@@ -314,20 +307,7 @@ TEST_F(ESMEncodeDecodeTest, TestActivateDefaultEpsBearerContextRequest) {
       sizeof(original_msg.apnambr)));
 
   EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
-  EXPECT_EQ(
-      std::string((const char*) original_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[0]
-                      .contents->data),
-      std::string((const char*) decoded_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[0]
-                      .contents->data));
-  EXPECT_EQ(
-      std::string((const char*) original_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[1]
-                      .contents->data),
-      std::string((const char*) decoded_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[1]
-                      .contents->data));
+  EXPECT_EQ_PCO();
 
   DESTROY_PCO();
   bdestroy_wrapper(&original_msg.accesspointname);
@@ -388,20 +368,30 @@ TEST_F(ESMEncodeDecodeTest, TestActivateDedicatedEpsBearerContextRequest) {
   EXPECT_EQ(original_msg.radiopriority, decoded_msg.radiopriority);
   EXPECT_EQ(
       original_msg.packetflowidentifier, decoded_msg.packetflowidentifier);
-  EXPECT_EQ(
-      std::string((const char*) original_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[0]
-                      .contents->data),
-      std::string((const char*) decoded_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[0]
-                      .contents->data));
-  EXPECT_EQ(
-      std::string((const char*) original_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[1]
-                      .contents->data),
-      std::string((const char*) decoded_msg.protocolconfigurationoptions
-                      .protocol_or_container_ids[1]
-                      .contents->data));
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestActivateDefaultEpsBearerContextAccept) {
+  activate_default_eps_bearer_context_accept_msg original_msg = {0};
+  activate_default_eps_bearer_context_accept_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+  original_msg.presencemask =
+      ACTIVATE_DEFAULT_EPS_BEARER_CONTEXT_ACCEPT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_activate_default_eps_bearer_context_accept(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_activate_default_eps_bearer_context_accept(
+      &decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ_PCO();
 
   DESTROY_PCO();
 }

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_esm_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_esm_encode_decode.cpp
@@ -32,6 +32,8 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/BearerResourceAllocationRequest.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/BearerResourceModificationReject.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/BearerResourceModificationRequest.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextAccept.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextRequest.h"
 #include "lte/gateway/c/core/oai/common/common_defs.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h"
 }
@@ -552,6 +554,57 @@ TEST_F(ESMEncodeDecodeTest, TestBearerResourceModificationReject) {
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
   EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestDeactivateEpsBearerContextRequest) {
+  deactivate_eps_bearer_context_request_msg original_msg = {0};
+  deactivate_eps_bearer_context_request_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.esmcause = 102;
+
+  original_msg.presencemask =
+      DEACTIVATE_EPS_BEARER_CONTEXT_REQUEST_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_deactivate_eps_bearer_context_request(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_deactivate_eps_bearer_context_request(
+      &decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestDeactivateEpsBearerContextAccept) {
+  deactivate_eps_bearer_context_accept_msg original_msg = {0};
+  deactivate_eps_bearer_context_accept_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.presencemask =
+      DEACTIVATE_EPS_BEARER_CONTEXT_ACCEPT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_deactivate_eps_bearer_context_accept(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_deactivate_eps_bearer_context_accept(
+      &decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
   EXPECT_EQ_PCO();
 
   DESTROY_PCO();

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_esm_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_esm_encode_decode.cpp
@@ -34,6 +34,10 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/BearerResourceModificationRequest.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextAccept.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextRequest.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/EsmInformationRequest.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/EsmInformationResponse.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/EsmStatus.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ModifyEpsBearerContextRequest.h"
 #include "lte/gateway/c/core/oai/common/common_defs.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h"
 }
@@ -605,6 +609,130 @@ TEST_F(ESMEncodeDecodeTest, TestDeactivateEpsBearerContextAccept) {
   // TODO(@ulaskozat): Header will be decoded separately; then the following
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestEsmInformationRequest) {
+  esm_information_request_msg original_msg = {0};
+  esm_information_request_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  int encoded =
+      encode_esm_information_request(&original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_esm_information_request(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // Currently encoding/decoding functions are dummy with no actual
+  // encoding/decoding As they are the same as message header fields.
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestEsmInformationResponse) {
+  esm_information_response_msg original_msg = {0};
+  esm_information_response_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.presencemask =
+      ESM_INFORMATION_RESPONSE_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT |
+      ESM_INFORMATION_RESPONSE_ACCESS_POINT_NAME_PRESENT;
+
+  original_msg.accesspointname = bfromcstr("magma.ipv4");
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded =
+      encode_esm_information_response(&original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_esm_information_response(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(
+      std::string((const char*) original_msg.accesspointname->data),
+      std::string((const char*) decoded_msg.accesspointname->data));
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+  bdestroy_wrapper(&original_msg.accesspointname);
+  bdestroy_wrapper(&decoded_msg.accesspointname);
+}
+
+TEST_F(ESMEncodeDecodeTest, TestEsmStatus) {
+  esm_status_msg original_msg = {0};
+  esm_status_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.esmcause = 102;
+
+  int encoded = encode_esm_status(&original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_esm_status(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
+  EXPECT_EQ(encoded, decoded);
+}
+
+TEST_F(ESMEncodeDecodeTest, TestModifyEpsBearerContextRequest) {
+  modify_eps_bearer_context_request_msg original_msg = {0};
+  modify_eps_bearer_context_request_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.presencemask =
+      MODIFY_EPS_BEARER_CONTEXT_REQUEST_NEW_EPS_QOS_PRESENT |
+      MODIFY_EPS_BEARER_CONTEXT_REQUEST_TFT_PRESENT |
+      MODIFY_EPS_BEARER_CONTEXT_REQUEST_NEW_QOS_PRESENT |
+      MODIFY_EPS_BEARER_CONTEXT_REQUEST_NEGOTIATED_LLC_SAPI_PRESENT |
+      MODIFY_EPS_BEARER_CONTEXT_REQUEST_RADIO_PRIORITY_PRESENT |
+      MODIFY_EPS_BEARER_CONTEXT_REQUEST_PACKET_FLOW_IDENTIFIER_PRESENT |
+      MODIFY_EPS_BEARER_CONTEXT_REQUEST_APNAMBR_PRESENT |
+      MODIFY_EPS_BEARER_CONTEXT_REQUEST_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_epsqos(&original_msg.newepsqos);
+
+  fill_tft(&original_msg.tft);
+
+  fill_negotiated_qos(&original_msg.newqos);
+
+  original_msg.negotiatedllcsapi    = 10;
+  original_msg.radiopriority        = 5;
+  original_msg.packetflowidentifier = 118;
+
+  fill_apnambr(&original_msg.apnambr);
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_modify_eps_bearer_context_request(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded =
+      decode_modify_eps_bearer_context_request(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
+  EXPECT_TRUE(!memcmp(
+      &original_msg.newepsqos, &decoded_msg.newepsqos,
+      sizeof(original_msg.newepsqos)));
+  EXPECT_TRUE(
+      !memcmp(&original_msg.tft, &decoded_msg.tft, sizeof(original_msg.tft)));
+  EXPECT_TRUE(!memcmp(
+      &original_msg.newqos, &decoded_msg.newqos, sizeof(original_msg.newqos)));
+  EXPECT_EQ(original_msg.negotiatedllcsapi, decoded_msg.negotiatedllcsapi);
+  EXPECT_EQ(original_msg.radiopriority, decoded_msg.radiopriority);
+  EXPECT_EQ(
+      original_msg.packetflowidentifier, decoded_msg.packetflowidentifier);
+  EXPECT_TRUE(!memcmp(
+      &original_msg.apnambr, &decoded_msg.apnambr,
+      sizeof(original_msg.apnambr)));
   EXPECT_EQ_PCO();
 
   DESTROY_PCO();

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_esm_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_esm_encode_decode.cpp
@@ -25,8 +25,13 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextAccept.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextAccept.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextReject.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextReject.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextRequest.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextRequest.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/BearerResourceAllocationReject.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/BearerResourceAllocationRequest.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/BearerResourceModificationReject.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/BearerResourceModificationRequest.h"
 #include "lte/gateway/c/core/oai/common/common_defs.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h"
 }
@@ -188,54 +193,6 @@ class ESMEncodeDecodeTest : public ::testing::Test {
   uint8_t buffer[BUFFER_LEN];
 };
 
-TEST_F(ESMEncodeDecodeTest, TestActivateDedicatedEpsBearerContextAccept) {
-  activate_dedicated_eps_bearer_context_accept_msg original_msg = {0};
-  activate_dedicated_eps_bearer_context_accept_msg decoded_msg  = {0};
-  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
-  original_msg.presencemask =
-      ACTIVATE_DEDICATED_EPS_BEARER_CONTEXT_ACCEPT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
-  fill_pco(&original_msg.protocolconfigurationoptions);
-
-  int encoded = encode_activate_dedicated_eps_bearer_context_accept(
-      &original_msg, buffer, BUFFER_LEN);
-  int decoded = decode_activate_dedicated_eps_bearer_context_accept(
-      &decoded_msg, buffer, encoded);
-
-  EXPECT_EQ(encoded, decoded);
-  // TODO(@ulaskozat): Header will be decoded separately; then the following
-  // line can be uncommented.
-  // COMPARE_COMMON_MANDATORY_DEFAULTS();
-  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
-  EXPECT_EQ_PCO();
-
-  DESTROY_PCO();
-}
-
-TEST_F(ESMEncodeDecodeTest, TestActivateDedicatedEpsBearerContextReject) {
-  activate_dedicated_eps_bearer_context_reject_msg original_msg = {0};
-  activate_dedicated_eps_bearer_context_reject_msg decoded_msg  = {0};
-  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
-  original_msg.esmcause = 255;
-  original_msg.presencemask =
-      ACTIVATE_DEDICATED_EPS_BEARER_CONTEXT_REJECT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
-  fill_pco(&original_msg.protocolconfigurationoptions);
-
-  int encoded = encode_activate_dedicated_eps_bearer_context_reject(
-      &original_msg, buffer, BUFFER_LEN);
-  int decoded = decode_activate_dedicated_eps_bearer_context_reject(
-      &decoded_msg, buffer, encoded);
-
-  EXPECT_EQ(encoded, decoded);
-  // TODO(@ulaskozat): Header will be decoded separately; then the following
-  // line can be uncommented.
-  // COMPARE_COMMON_MANDATORY_DEFAULTS();
-  EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
-  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
-  EXPECT_EQ_PCO();
-
-  DESTROY_PCO();
-}
-
 TEST_F(ESMEncodeDecodeTest, TestActivateDefaultEpsBearerContextRequest) {
   activate_default_eps_bearer_context_request_msg original_msg = {0};
   activate_default_eps_bearer_context_request_msg decoded_msg  = {0};
@@ -316,6 +273,52 @@ TEST_F(ESMEncodeDecodeTest, TestActivateDefaultEpsBearerContextRequest) {
   bdestroy_wrapper(&decoded_msg.pdnaddress.pdnaddressinformation);
 }
 
+TEST_F(ESMEncodeDecodeTest, TestActivateDefaultEpsBearerContextAccept) {
+  activate_default_eps_bearer_context_accept_msg original_msg = {0};
+  activate_default_eps_bearer_context_accept_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+  original_msg.presencemask =
+      ACTIVATE_DEFAULT_EPS_BEARER_CONTEXT_ACCEPT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_activate_default_eps_bearer_context_accept(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_activate_default_eps_bearer_context_accept(
+      &decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestActivateDefaultEpsBearerContextReject) {
+  activate_default_eps_bearer_context_reject_msg original_msg = {0};
+  activate_default_eps_bearer_context_reject_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+  original_msg.presencemask =
+      ACTIVATE_DEFAULT_EPS_BEARER_CONTEXT_REJECT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_activate_default_eps_bearer_context_reject(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_activate_default_eps_bearer_context_reject(
+      &decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
 TEST_F(ESMEncodeDecodeTest, TestActivateDedicatedEpsBearerContextRequest) {
   activate_dedicated_eps_bearer_context_request_msg original_msg = {0};
   activate_dedicated_eps_bearer_context_request_msg decoded_msg  = {0};
@@ -373,24 +376,182 @@ TEST_F(ESMEncodeDecodeTest, TestActivateDedicatedEpsBearerContextRequest) {
   DESTROY_PCO();
 }
 
-TEST_F(ESMEncodeDecodeTest, TestActivateDefaultEpsBearerContextAccept) {
-  activate_default_eps_bearer_context_accept_msg original_msg = {0};
-  activate_default_eps_bearer_context_accept_msg decoded_msg  = {0};
+TEST_F(ESMEncodeDecodeTest, TestActivateDedicatedEpsBearerContextAccept) {
+  activate_dedicated_eps_bearer_context_accept_msg original_msg = {0};
+  activate_dedicated_eps_bearer_context_accept_msg decoded_msg  = {0};
   FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
   original_msg.presencemask =
-      ACTIVATE_DEFAULT_EPS_BEARER_CONTEXT_ACCEPT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
-
+      ACTIVATE_DEDICATED_EPS_BEARER_CONTEXT_ACCEPT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
   fill_pco(&original_msg.protocolconfigurationoptions);
 
-  int encoded = encode_activate_default_eps_bearer_context_accept(
+  int encoded = encode_activate_dedicated_eps_bearer_context_accept(
       &original_msg, buffer, BUFFER_LEN);
-  int decoded = decode_activate_default_eps_bearer_context_accept(
+  int decoded = decode_activate_dedicated_eps_bearer_context_accept(
       &decoded_msg, buffer, encoded);
 
   EXPECT_EQ(encoded, decoded);
   // TODO(@ulaskozat): Header will be decoded separately; then the following
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestActivateDedicatedEpsBearerContextReject) {
+  activate_dedicated_eps_bearer_context_reject_msg original_msg = {0};
+  activate_dedicated_eps_bearer_context_reject_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+  original_msg.esmcause = 255;
+  original_msg.presencemask =
+      ACTIVATE_DEDICATED_EPS_BEARER_CONTEXT_REJECT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_activate_dedicated_eps_bearer_context_reject(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_activate_dedicated_eps_bearer_context_reject(
+      &decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestBearerResourceAllocationRequest) {
+  bearer_resource_allocation_request_msg original_msg = {0};
+  bearer_resource_allocation_request_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.linkedepsbeareridentity = 5;
+
+  fill_epsqos(&original_msg.requiredtrafficflowqos);
+
+  fill_tft(&original_msg.trafficflowaggregate);
+
+  original_msg.presencemask =
+      BEARER_RESOURCE_ALLOCATION_REQUEST_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_bearer_resource_allocation_request(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded =
+      decode_bearer_resource_allocation_request(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(
+      original_msg.linkedepsbeareridentity,
+      decoded_msg.linkedepsbeareridentity);
+  EXPECT_TRUE(!memcmp(
+      &original_msg.requiredtrafficflowqos, &decoded_msg.requiredtrafficflowqos,
+      sizeof(original_msg.requiredtrafficflowqos)));
+  EXPECT_TRUE(!memcmp(
+      &original_msg.trafficflowaggregate, &decoded_msg.trafficflowaggregate,
+      sizeof(original_msg.trafficflowaggregate)));
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestBearerResourceAllocationReject) {
+  bearer_resource_allocation_reject_msg original_msg = {0};
+  bearer_resource_allocation_reject_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+  original_msg.presencemask =
+      BEARER_RESOURCE_ALLOCATION_REJECT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_bearer_resource_allocation_reject(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded =
+      decode_bearer_resource_allocation_reject(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestBearerResourceModificationRequest) {
+  bearer_resource_modification_request_msg original_msg = {0};
+  bearer_resource_modification_request_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.epsbeareridentityforpacketfilter = 8;
+
+  fill_epsqos(&original_msg.requiredtrafficflowqos);
+
+  fill_tft(&original_msg.trafficflowaggregate);
+
+  original_msg.presencemask =
+      BEARER_RESOURCE_MODIFICATION_REQUEST_REQUIRED_TRAFFIC_FLOW_QOS_PRESENT |
+      BEARER_RESOURCE_MODIFICATION_REQUEST_ESM_CAUSE_PRESENT |
+      BEARER_RESOURCE_MODIFICATION_REQUEST_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  original_msg.esmcause = 102;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_bearer_resource_modification_request(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_bearer_resource_modification_request(
+      &decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(
+      original_msg.epsbeareridentityforpacketfilter,
+      decoded_msg.epsbeareridentityforpacketfilter);
+  EXPECT_TRUE(!memcmp(
+      &original_msg.requiredtrafficflowqos, &decoded_msg.requiredtrafficflowqos,
+      sizeof(original_msg.requiredtrafficflowqos)));
+  EXPECT_TRUE(!memcmp(
+      &original_msg.trafficflowaggregate, &decoded_msg.trafficflowaggregate,
+      sizeof(original_msg.trafficflowaggregate)));
+  EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestBearerResourceModificationReject) {
+  bearer_resource_modification_reject_msg original_msg = {0};
+  bearer_resource_modification_reject_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.esmcause = 102;
+
+  original_msg.presencemask =
+      BEARER_RESOURCE_MODIFICATION_REJECT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_bearer_resource_modification_reject(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded =
+      decode_bearer_resource_modification_reject(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
   EXPECT_EQ_PCO();
 
   DESTROY_PCO();

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_esm_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_esm_encode_decode.cpp
@@ -38,6 +38,12 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/EsmInformationResponse.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/EsmStatus.h"
 #include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ModifyEpsBearerContextRequest.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ModifyEpsBearerContextAccept.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/ModifyEpsBearerContextReject.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/PdnConnectivityRequest.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/PdnConnectivityReject.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/PdnDisconnectRequest.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/msg/PdnDisconnectReject.h"
 #include "lte/gateway/c/core/oai/common/common_defs.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h"
 }
@@ -297,6 +303,7 @@ TEST_F(ESMEncodeDecodeTest, TestActivateDefaultEpsBearerContextAccept) {
   // TODO(@ulaskozat): Header will be decoded separately; then the following
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
   EXPECT_EQ_PCO();
 
   DESTROY_PCO();
@@ -320,6 +327,7 @@ TEST_F(ESMEncodeDecodeTest, TestActivateDefaultEpsBearerContextReject) {
   // TODO(@ulaskozat): Header will be decoded separately; then the following
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
   EXPECT_EQ_PCO();
 
   DESTROY_PCO();
@@ -455,6 +463,7 @@ TEST_F(ESMEncodeDecodeTest, TestBearerResourceAllocationRequest) {
   // TODO(@ulaskozat): Header will be decoded separately; then the following
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
   EXPECT_EQ(
       original_msg.linkedepsbeareridentity,
       decoded_msg.linkedepsbeareridentity);
@@ -487,6 +496,7 @@ TEST_F(ESMEncodeDecodeTest, TestBearerResourceAllocationReject) {
   // TODO(@ulaskozat): Header will be decoded separately; then the following
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
   EXPECT_EQ_PCO();
 
   DESTROY_PCO();
@@ -521,6 +531,7 @@ TEST_F(ESMEncodeDecodeTest, TestBearerResourceModificationRequest) {
   // TODO(@ulaskozat): Header will be decoded separately; then the following
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
   EXPECT_EQ(
       original_msg.epsbeareridentityforpacketfilter,
       decoded_msg.epsbeareridentityforpacketfilter);
@@ -558,6 +569,7 @@ TEST_F(ESMEncodeDecodeTest, TestBearerResourceModificationReject) {
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
   EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
   EXPECT_EQ_PCO();
 
   DESTROY_PCO();
@@ -584,6 +596,7 @@ TEST_F(ESMEncodeDecodeTest, TestDeactivateEpsBearerContextRequest) {
   // TODO(@ulaskozat): Header will be decoded separately; then the following
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
   EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
   EXPECT_EQ_PCO();
 
@@ -609,6 +622,7 @@ TEST_F(ESMEncodeDecodeTest, TestDeactivateEpsBearerContextAccept) {
   // TODO(@ulaskozat): Header will be decoded separately; then the following
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
   EXPECT_EQ_PCO();
 
   DESTROY_PCO();
@@ -652,6 +666,7 @@ TEST_F(ESMEncodeDecodeTest, TestEsmInformationResponse) {
   // TODO(@ulaskozat): Header will be decoded separately; then the following
   // line can be uncommented.
   // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
   EXPECT_EQ(
       std::string((const char*) original_msg.accesspointname->data),
       std::string((const char*) decoded_msg.accesspointname->data));
@@ -733,6 +748,176 @@ TEST_F(ESMEncodeDecodeTest, TestModifyEpsBearerContextRequest) {
   EXPECT_TRUE(!memcmp(
       &original_msg.apnambr, &decoded_msg.apnambr,
       sizeof(original_msg.apnambr)));
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestModifyEpsBearerContextAccept) {
+  modify_eps_bearer_context_accept_msg original_msg = {0};
+  modify_eps_bearer_context_accept_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.presencemask =
+      MODIFY_EPS_BEARER_CONTEXT_ACCEPT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_modify_eps_bearer_context_accept(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded =
+      decode_modify_eps_bearer_context_accept(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestModifyEpsBearerContextReject) {
+  modify_eps_bearer_context_reject_msg original_msg = {0};
+  modify_eps_bearer_context_reject_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.esmcause = 102;
+
+  original_msg.presencemask =
+      BEARER_RESOURCE_MODIFICATION_REJECT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_modify_eps_bearer_context_reject(
+      &original_msg, buffer, BUFFER_LEN);
+  int decoded =
+      decode_modify_eps_bearer_context_reject(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestPdnConnectivityRequest) {
+  pdn_connectivity_request_msg original_msg = {0};
+  pdn_connectivity_request_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.requesttype = 3;
+  original_msg.pdntype     = 2;
+
+  original_msg.presencemask =
+      PDN_CONNECTIVITY_REQUEST_ESM_INFORMATION_TRANSFER_FLAG_PRESENT |
+      PDN_CONNECTIVITY_REQUEST_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  original_msg.esminformationtransferflag = 1;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded =
+      encode_pdn_connectivity_request(&original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_pdn_connectivity_request(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.requesttype, decoded_msg.requesttype);
+  EXPECT_EQ(original_msg.pdntype, decoded_msg.pdntype);
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
+  EXPECT_EQ(
+      original_msg.esminformationtransferflag,
+      decoded_msg.esminformationtransferflag);
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestPdnConnectivityReject) {
+  pdn_connectivity_reject_msg original_msg = {0};
+  pdn_connectivity_reject_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.esmcause = 102;
+
+  original_msg.presencemask =
+      PDN_CONNECTIVITY_REJECT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded =
+      encode_pdn_connectivity_reject(&original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_pdn_connectivity_reject(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestPdnDisconnectRequest) {
+  pdn_disconnect_request_msg original_msg = {0};
+  pdn_disconnect_request_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.linkedepsbeareridentity = 5;
+
+  original_msg.presencemask =
+      PDN_DISCONNECT_REQUEST_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded =
+      encode_pdn_disconnect_request(&original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_pdn_disconnect_request(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(
+      original_msg.linkedepsbeareridentity,
+      decoded_msg.linkedepsbeareridentity);
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
+  EXPECT_EQ_PCO();
+
+  DESTROY_PCO();
+}
+
+TEST_F(ESMEncodeDecodeTest, TestPdnDisconnectReject) {
+  pdn_disconnect_reject_msg original_msg = {0};
+  pdn_disconnect_reject_msg decoded_msg  = {0};
+  FILL_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  original_msg.esmcause = 102;
+
+  original_msg.presencemask =
+      PDN_DISCONNECT_REJECT_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
+
+  fill_pco(&original_msg.protocolconfigurationoptions);
+
+  int encoded = encode_pdn_disconnect_reject(&original_msg, buffer, BUFFER_LEN);
+  int decoded = decode_pdn_disconnect_reject(&decoded_msg, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  // TODO(@ulaskozat): Header will be decoded separately; then the following
+  // line can be uncommented.
+  // COMPARE_COMMON_MANDATORY_DEFAULTS();
+  EXPECT_EQ(original_msg.esmcause, decoded_msg.esmcause);
+  EXPECT_EQ(original_msg.presencemask, decoded_msg.presencemask);
   EXPECT_EQ_PCO();
 
   DESTROY_PCO();


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fix bug in TFT decoding when IEI is present.
- Refactor common PCO checks.
- Regroup test cases in a logical order.
- Add unit tests for bearer resource allocation request/reject and resource modification request/reject.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
run `make test_oai` in magma vm.
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
