### PR TITLE
fix(orc8r): bump RDS to 12.8 and add var to upgrade RDS immediately

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-aws/db.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/db.tf
@@ -30,6 +30,8 @@ resource "aws_db_instance" "default" {
   backup_window           = var.orc8r_db_backup_window
 
   allow_major_version_upgrade = true
+  apply_immediately = var.orc8r_db_apply_immediately
+
   skip_final_snapshot = true
   # we only need this as a placeholder value for `terraform destroy` to work,
   # this won't actually create a final snapshot on destroy

--- a/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
@@ -276,7 +276,7 @@ variable "orc8r_db_password" {
 variable "orc8r_db_engine_version" {
   description = "Postgres engine version for Orchestrator DB."
   type        = string
-  default     = "12.6"
+  default     = "12.8"
 }
 
 variable "orc8r_db_dialect" {
@@ -301,6 +301,12 @@ variable "orc8r_db_event_subscription" {
   description = "Database event subscription"
   type        = string
   default     = "orc8r-rds-events"
+}
+
+variable "orc8r_db_apply_immediately"{
+  description = "Flag to immediately upgrade RDS without waiting for a maintenance window"
+  type = bool
+  default = false
 }
 
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This PR bumps the RDS version to 12.8 and adds the necessary variable to upgrade the RDS instance in-place. This PR helps close issue #10112. The `apply_immediately` flag is set to `false` by default and only enabled when a major version upgrade is necessary for the orc8r db. 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
[Tested](https://gist.github.com/sudhikan/8e42985bc0db13512c9cd602d8acab3a) on the ENS orc8r. 9.6.22 -> 9.6.23 -> 12.8. The above link is for the terraform logs. 

