### PR TITLE
chore(pipelined): remove tunnel-id-map

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/ipv6_solicitation.py
+++ b/lte/gateway/python/magma/pipelined/app/ipv6_solicitation.py
@@ -68,7 +68,6 @@ class IPV6SolicitationController(MagmaController):
         )
         self.config = self._get_config(kwargs['config'])
         self._prefix_mapper = kwargs['interface_to_prefix_mapper']
-        self._tunnel_id_mapper = kwargs['tunnel_id_mapper']
         self._datapath = None
         self.logger.info(
             "IPv6 Router using ll_addr %s, and src ip %s",
@@ -315,7 +314,8 @@ class IPV6SolicitationController(MagmaController):
 
             tun_id_dst = ev.msg.match.get(TUN_PORT_REG, None)
             if not tun_id_dst:
-                tun_id_dst = self._tunnel_id_mapper.get_tunnel(tun_id)
+                self.logger.error("Packet missing tun_id_dst (in-port %d tun-id %s) reg, can't reply", in_port, tun_id)
+                return
 
         pkt = packet.Packet(msg.data)
         self.logger.debug("Received PKT -> on port %d tun_id: %s tun_id_dst: %s", in_port, tun_id, tun_id_dst)

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -252,15 +252,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             interface, prefix,
         )
 
-    def _update_tunnel_map_store(
-        self, uplink_tunnel: int,
-        downlink_tunnel: int,
-    ):
-        self._service_manager.tunnel_id_mapper.save_tunnels(
-            uplink_tunnel,
-            downlink_tunnel,
-        )
-
     def _update_version(self, request: ActivateFlowsRequest, ipv4: IPAddress):
         """
         Update version for a given subscriber and rule.
@@ -317,11 +308,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             else:
                 ret_ipv6 = self._install_flows_gy(request, ipv6)
             ret.policy_results.extend(ret_ipv6.policy_results)
-        if request.uplink_tunnel and request.downlink_tunnel:
-            self._update_tunnel_map_store(
-                request.uplink_tunnel,
-                request.downlink_tunnel,
-            )
 
         fut.set_result(ret)
 

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -84,7 +84,6 @@ from magma.pipelined.rule_mappers import (
     RuleIDToNumMapper,
     SessionRuleToVersionMapper,
 )
-from magma.pipelined.tunnel_id_store import TunnelToTunnelMapper
 from ryu.base.app_manager import AppManager
 
 # Type is either Physical or Logical, highest order_priority is at zero
@@ -530,7 +529,6 @@ class ServiceManager:
         self.rule_id_mapper = RuleIDToNumMapper()
         self.session_rule_version_mapper = SessionRuleToVersionMapper()
         self.interface_to_prefix_mapper = InterfaceIDToPrefixMapper()
-        self.tunnel_id_mapper = TunnelToTunnelMapper()
         self.restart_info_store = RestartInfoStore()
 
         apps = self._get_static_apps()
@@ -614,7 +612,6 @@ class ServiceManager:
                 time.sleep(1)
             self.rule_id_mapper.setup_redis()
             self.interface_to_prefix_mapper.setup_redis()
-            self.tunnel_id_mapper.setup_redis()
 
         manager = AppManager.get_instance()
         manager.load_apps([app.module for app in self._apps])
@@ -624,7 +621,6 @@ class ServiceManager:
             'session_rule_version_mapper'
         ] = self.session_rule_version_mapper
         contexts['interface_to_prefix_mapper'] = self.interface_to_prefix_mapper
-        contexts['tunnel_id_mapper'] = self.tunnel_id_mapper
         contexts['restart_info_store'] = self.restart_info_store
         contexts['app_futures'] = {app.name: Future() for app in self._apps}
         contexts['internal_ip_allocator'] = \

--- a/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
@@ -210,8 +210,6 @@ class StartThread(object):
             self._test_setup.service_manager.session_rule_version_mapper
         contexts['interface_to_prefix_mapper'] = \
             self._test_setup.service_manager.interface_to_prefix_mapper
-        contexts['tunnel_id_mapper'] = \
-            self._test_setup.service_manager.tunnel_id_mapper
         contexts['restart_info_store'] = \
             self._test_setup.service_manager.restart_info_store
         contexts['app_futures'] = app_futures

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -429,7 +429,6 @@ def create_service_manager(
     service_manager.rule_id_mapper._rules_by_rule_num = {}
     service_manager.session_rule_version_mapper._version_by_imsi_and_rule = {}
     service_manager.interface_to_prefix_mapper._prefix_by_interface = {}
-    service_manager.tunnel_id_mapper._tunnel_map = {}
 
     return service_manager
 


### PR DESCRIPTION
IPv6 solicitation does not use tunnel-ip map, following
PR removes it and avoids updating the map in flow activation.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
