### PR TITLE
feat: migrate containerzed sessiond for AGW to be built with Bazel

### DIFF
--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -31,13 +31,17 @@ ENV C_BUILD /build/c
 ENV OAI_BUILD $C_BUILD/oai
 ENV TZ=Europe/Paris
 
-ENV CCACHE_DIR $MAGMA_ROOT/.cache/gateway/ccache
+ENV CCACHE_DIR ${MAGMA_ROOT}/.cache/gateway/ccache
 ENV MAGMA_DEV_MODE 0
-ENV XDG_CACHE_HOME $MAGMA_ROOT/.cache
+ENV XDG_CACHE_HOME ${MAGMA_ROOT}/.cache
 
-# Add the magma apt repo
 RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg
+    # Setup necessary tools for adding the Magma repository
+    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg wget && \
+    # Download Bazel
+    wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
+    chmod +x /usr/sbin/bazelisk-linux-amd64 && \
+    ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
 
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
 RUN apt-key add /tmp/jfrog.pub && \
@@ -56,9 +60,6 @@ RUN apt-get update && apt-get install -y \
   libtool \
   pkg-config \
   libgflags-dev \
-  libgtest-dev \
-  clang-11 \
-  #clang-format-11 \
   libc++-dev \
   protobuf-compiler \
   grpc-dev \
@@ -76,7 +77,6 @@ RUN apt-get update && apt-get install -y \
   libfolly-dev \
   libsctp-dev \
   libpcap-dev \
-  libtins-dev \
   libmnl-dev \
   uuid-dev \
   libcurl4-openssl-dev \
@@ -88,9 +88,7 @@ RUN apt-get update && apt-get install -y \
   libboost-filesystem-dev \
   libboost-regex-dev \
   check \
-  libgtest-dev \
   liblfds710 \
-  google-mock \
   libssl-dev \
   libsctp-dev \
   libtspi-dev \
@@ -103,32 +101,52 @@ RUN apt-get update && apt-get install -y \
   libgmp3-dev \
   libczmq-dev
 
+ENV MAGMA_ROOT /magma
+WORKDIR /magma
+
+# Copy Bazel files at root and third_party
+COPY WORKSPACE.bazel BUILD.bazel .bazelignore .bazelrc .bazelversion ${MAGMA_ROOT}/
+COPY bazel/ ${MAGMA_ROOT}/bazel
+
+# Build external dependencies first. This will help not rebuilt all dependencies triggered by Magma changes.
+RUN bazel build \
+  @com_github_grpc_grpc//:grpc++ \
+  @com_github_google_glog//:glog \
+  @protobuf//:protobuf \
+  @prometheus_cpp//:prometheus-cpp \
+  @yaml-cpp//:yaml-cpp \
+  @boost//:iterator \
+  @github_nlohmann_json//:json \
+  @sentry_native//:sentry
+
 # Copy proto files
-COPY feg/protos $MAGMA_ROOT/feg/protos
-COPY feg/gateway/services/aaa/protos $MAGMA_ROOT/feg/gateway/services/aaa/protos
-COPY lte/protos $MAGMA_ROOT/lte/protos
-COPY orc8r/protos $MAGMA_ROOT/orc8r/protos
-COPY protos $MAGMA_ROOT/protos
+COPY feg/protos ${MAGMA_ROOT}/feg/protos
+COPY feg/gateway/services/aaa/protos ${MAGMA_ROOT}/feg/gateway/services/aaa/protos
+COPY lte/protos ${MAGMA_ROOT}/lte/protos
+COPY orc8r/protos ${MAGMA_ROOT}/orc8r/protos
+COPY protos ${MAGMA_ROOT}/protos
 
 # Build session_manager c code
-COPY lte/gateway/Makefile $MAGMA_ROOT/lte/gateway/Makefile
-COPY orc8r/gateway/c/common $MAGMA_ROOT/orc8r/gateway/c/common
-COPY lte/gateway/c $MAGMA_ROOT/lte/gateway/c
+COPY lte/gateway/Makefile ${MAGMA_ROOT}/lte/gateway/Makefile
+COPY orc8r/gateway/c/common ${MAGMA_ROOT}/orc8r/gateway/c/common
+COPY lte/gateway/c ${MAGMA_ROOT}/lte/gateway/c
 
-COPY lte/gateway/python/scripts $MAGMA_ROOT/lte/gateway/python/scripts
-COPY lte/gateway/docker $MAGMA_ROOT/lte/gateway/docker
-COPY lte/gateway/docker/mme/configs/ $MAGMA_ROOT/lte/gateway/docker/configs/
+COPY lte/gateway/python/scripts ${MAGMA_ROOT}/lte/gateway/python/scripts
+COPY lte/gateway/docker ${MAGMA_ROOT}/lte/gateway/docker
+COPY lte/gateway/docker/mme/configs/ ${MAGMA_ROOT}/lte/gateway/docker/configs/
 
 ARG BUILD_TYPE=RelWithDebInfo
 ENV BUILD_TYPE=$BUILD_TYPE
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_session_manager BUILD_TYPE="${BUILD_TYPE}"
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_sctpd BUILD_TYPE="${BUILD_TYPE}"
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_connection_tracker BUILD_TYPE="${BUILD_TYPE}"
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_li_agent BUILD_TYPE="${BUILD_TYPE}"
-RUN make -C $MAGMA_ROOT/lte/gateway/ build_oai BUILD_TYPE="${BUILD_TYPE}"
+RUN bazel build  \
+  //lte/gateway/c/sctpd/src:sctpd \
+  //lte/gateway/c/connection_tracker/src:connectiond \
+  //lte/gateway/c/li_agent/src:liagentd \
+  //lte/gateway/c/session_manager:sessiond \
+  --define=folly_so=1
+RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_oai BUILD_TYPE="${BUILD_TYPE}"
 
 # Prepare config file
-COPY lte/gateway/configs $MAGMA_ROOT/lte/gateway/configs
+COPY lte/gateway/configs ${MAGMA_ROOT}/lte/gateway/configs
 
 # -----------------------------------------------------------------------------
 # Dev/Production image
@@ -155,7 +173,6 @@ RUN apt-get update && apt-get install -y \
   libyaml-cpp-dev \
   libgoogle-glog-dev \
   libprotoc-dev \
-  libtins-dev \
   libmnl-dev \
   libsctp-dev \
   psmisc \
@@ -194,6 +211,9 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libgssapi_krb5* /usr/lib/x86_64-li
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libkrb5* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libk5crypto* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libkeyutils* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libcurl.so.* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/librtmp.so.* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libssh.so.* /usr/lib/x86_64-linux-gnu/
 
 
 COPY --from=builder /usr/local/lib/liblfds710.so /usr/local/lib/
@@ -211,10 +231,10 @@ COPY --from=builder /usr/local/lib/libfdcore.so.6 /usr/local/lib/
 COPY --from=builder /usr/local/lib/libaddress_sorting.so /usr/local/lib/
 
 # Copy the build artifacts.
-COPY --from=builder $C_BUILD/session_manager/sessiond /usr/local/bin/sessiond
-COPY --from=builder $C_BUILD/li_agent/src/liagentd /usr/local/bin/liagentd
-COPY --from=builder $C_BUILD/sctpd/src/sctpd /usr/local/bin/sctpd
-COPY --from=builder $C_BUILD/connection_tracker/src/connectiond /usr/local/bin/connectiond
+COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/session_manager/sessiond /usr/local/bin/sessiond
+COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/sctpd/src/sctpd /usr/local/bin/sctpd
+COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/connection_tracker/src/connectiond /usr/local/bin/connectiond
+COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/li_agent/src/liagentd /usr/local/bin/liagentd
 COPY --from=builder $C_BUILD/core/oai/oai_mme/mme /usr/local/bin/oai_mme
 
 RUN ldconfig 2> /dev/null


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Round 2 of this PR: https://github.com/magma/magma/pull/10505

Some additional information that was not included in the original PR.

### Increase in image size
```bash
docker images
REPOSITORY     TAG       IMAGE ID       CREATED         SIZE
agw_gateway_c  master    90a05793c414   3 minutes ago   1.25GB
agw_gateway_c  bazel     567acd94f40f   16 hours ago    1.59GB
```
There will be an increase in size due to a few factors.
1. These Bazel built binaries attempt to build dependencies statically into the binary as much as possible. This naturally makes each executable bigger.
2. Since OAI_MME service hasn't been migrated to Bazel yet, we still have to keep around a lot of the shared dependencies as runtime dependencies. Eventually, we should be able to get rid of most of these. As a data point, I stripped out unused shared libraries from the CWAG sessiond Docker image and that reduced the size to 393MB.

```bash
docker images
REPOSITORY            TAG       IMAGE ID       CREATED        SIZE
cwf_gateway_sessiond  latest    114e6f8776a4   12 days ago    393MB
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Built and brought up the containers. Note that this PR doesn't touch the Python containers, so the control_proxy failure is not related.
```bash
vagrant@magma-dev-focal:~/magma/lte/gateway/docker$ docker ps
CONTAINER ID   IMAGE                       COMMAND                  CREATED         STATUS                             PORTS     NAMES
cbc77ed4822b   agw_gateway_c:latest        "sh -c 'mkdir -p /va…"   2 minutes ago   Up 2 minutes (healthy)                       sessiond
4e1098c3d210   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 17 seconds (health: starting)             policydb
b360692bd63d   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes (healthy)                       directoryd
3ccd62a8ddf4   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes                                 state
a5700dcd8ca1   agw_gateway_c:latest        "sh -c '/usr/local/b…"   2 minutes ago   Up 2 minutes                                 oai_mme
bd22801ec9c9   agw_gateway_python:latest   "/bin/bash -c '/usr/…"   2 minutes ago   Up 21 seconds                                redis
ec843704f7b9   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes                                 monitord
2e7b466d093c   agw_gateway_python:latest   "bash -c '/usr/bin/o…"   2 minutes ago   Up 2 minutes (healthy)                       pipelined
a177a5693ecc   agw_gateway_python:latest   "/bin/bash -c '/usr/…"   2 minutes ago   Restarting (1) 21 seconds ago                td-agent-bit
bdf06da99d81   agw_gateway_python:latest   "sh -c '/usr/local/b…"   4 minutes ago   Up 10 seconds                            control_proxy
bde810f96249   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes                                 redirectd
87a6848bfd9a   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes                                 enodebd
b4e733e502d5   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes                                 magmad
b37b325f1aa6   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes                                 subscriberdb
8f6183423c2c   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes                                 ctraced
0b7c9d6e520b   agw_gateway_c:latest        "/usr/local/bin/conn…"   2 minutes ago   Up 2 minutes                                 connectiond
54006b0a100e   agw_gateway_c:latest        "/usr/local/bin/sctpd"   2 minutes ago   Up 2 minutes                                 sctpd
a8369e11372c   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes                                 eventd
791b72a87c49   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes                                 smsd
8398e4e32801   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 15 seconds                                mobilityd
bce037b33038   agw_gateway_python:latest   "/usr/bin/env python…"   2 minutes ago   Up 2 minutes                                 health
vagrant@magma-dev-focal:~/magma/lte/gateway/docker$
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
