### PR TITLE
chore(sessiond): add DISABLE_ASAN flag to cmake

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -20,11 +20,17 @@ include(FindClangFormat)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 
-# Add AddressSanitizer (asan) support for debug builds of SessionD
-set (CMAKE_CXX_FLAGS_DEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-set (CMAKE_LINKER_FLAGS_DEBUG
-    "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+# Add AddressSanitizer (asan) support for debug builds of SessionD. Disable adding
+# DISABLE_ASAN flag
+if (DISABLE_ASAN)
+  message("-- ASAN DISABLED")
+else()
+  message("++ ASAN ENABLED")
+  set (CMAKE_CXX_FLAGS_DEBUG
+          "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+  set (CMAKE_LINKER_FLAGS_DEBUG
+          "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+endif ()
 
 if (NOT BUILD_TESTS)
   # Add LeakSanitizer (lsan) support to the release build of SessionD so that


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

By default, if the we build the debug version and run test, the build will have asaan enable. This `DISABLE_ASAN` flag adds the option to explicitly disable ASAN during debug build

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

build through `make precommit_sm` without adding any flag
![image](https://user-images.githubusercontent.com/16157139/144355797-92089572-7ad5-459a-8bd1-7c8b70ca7e46.png)



build through CLION with enabled flag
![image](https://user-images.githubusercontent.com/16157139/144352654-921d5aef-62b2-4280-993d-db325853657a.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
