### PR TITLE
chore(agw): Reduce loglevel of error-treating functions

### DIFF
--- a/orc8r/gateway/python/magma/common/cert_validity.py
+++ b/orc8r/gateway/python/magma/common/cert_validity.py
@@ -90,8 +90,8 @@ def cert_is_invalid(host, port, certfile, keyfile, loop):
     tcp_res, ssl_res = res
 
     if isinstance(tcp_res, Exception):
-        logging.error(
-            'Error making TCP connection: %s, %s',
+        logging.debug(
+            'Error making TCP connection: %s, %s - thus no indication of invalid SSL certificate',
             'errno==None' if tcp_res.errno is None
             else os.strerror(tcp_res.errno),
             tcp_res,
@@ -100,12 +100,13 @@ def cert_is_invalid(host, port, certfile, keyfile, loop):
 
     # Invalid cert only when tcp succeeds and ssl fails
     if isinstance(ssl_res, Exception):
-        logging.error(
-            'Error making SSL connection: %s, %s',
+        logging.debug(
+            'TCP connection succeeded but SSL connection did not: %s, %s - assuming invalid SSL certificate',
             'errno==None' if ssl_res.errno is None
             else os.strerror(ssl_res.errno),
             ssl_res,
         )
         return True
 
+    logging.debug('SSL connection succeeded - thus no indication of invalid SSL certificate')
     return False

--- a/orc8r/gateway/python/magma/magmad/state_reporter.py
+++ b/orc8r/gateway/python/magma/magmad/state_reporter.py
@@ -106,14 +106,8 @@ class StateReporterErrorHandler:
         not_valid = await \
             cert_is_invalid(host, port, cert_file, key_file, self._loop)
         if not_valid:
-            logging.error('Bootstrapping due to invalid cert')
+            logging.info('Bootstrapping due to invalid certificate')
             await self._bootstrap_manager.schedule_bootstrap_now()
-            return
-        else:
-            logging.error(
-                'StateReporting failure likely '
-                'not due to invalid cert',
-            )
 
 
 class StateReporter(SDWatchdogTask):


### PR DESCRIPTION
Fixes #10408

## Summary

As part of a larger effort to look at frequent error logs observed in monitoring (see #10507), the goal of this PR is to avoid multiple different error logs as a result of a single error. The initial error should still be logged as such but the subsequent log statements are just a reaction to the error and not errors themselves.

This reduces some loglevels from Error to Info or Debug. All log statements touched here are executed while handling a RpcError ("Checkin Error") that is already logged with loglevel Error.

## Test Plan

None

## Additional Information

- [ ] This change is backwards-breaking

