### PR TITLE
fix(subscriberdb): handle 'check subscribers' errors with known solution separately

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/client.py
+++ b/lte/gateway/python/magma/subscriberdb/client.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import asyncio
 import datetime
+import inspect
 import logging
 from typing import List, NamedTuple, Optional
 
@@ -136,10 +137,7 @@ class SubscriberDBCloudClient(SDWatchdogTask):
                 self._loop,
             )
         except grpc.RpcError as err:
-            logging.error(
-                "Check subscribers in sync request error! [%s] %s", err.code(),
-                err.details(),
-            )
+            _log_grpc_error(err)
             return False
         return res.in_sync
 
@@ -164,10 +162,7 @@ class SubscriberDBCloudClient(SDWatchdogTask):
                 self._loop,
             )
         except grpc.RpcError as err:
-            logging.error(
-                "Sync subscribers request error! [%s] %s", err.code(),
-                err.details(),
-            )
+            _log_grpc_error(err)
             return True
 
         if not res.resync:
@@ -374,3 +369,18 @@ class SubscriberDBCloudClient(SDWatchdogTask):
                 "Detach Deleted Subscribers Error! [%s] %s",
                 err.code(), err.details(),
             )
+
+
+def _log_grpc_error(err: grpc.RpcError) -> None:
+    if err.code() == grpc.StatusCode.INTERNAL or err.code() == grpc.StatusCode.UNIMPLEMENTED:
+        logging.error(
+            'Internal Error in subscriberdb-Orc8r communication. '
+            'If AGW and Orc8r are deployed at a commit hash, '
+            'upgrade AGW and Orc8r to latest commit hash.',
+        )
+    else:
+        logging.error(
+            # inspect.stack() indices: [1] -> frame record of penultimate caller; [3] -> function name
+            "%s request error! [%s] %s", inspect.stack(context=0)[1][3], err.code(),
+            err.details(),
+        )


### PR DESCRIPTION
## Summary

Translates discussion in #10387 into a proposal: differentiate grpc error with known solution from other grpc errors.

## Test Plan

Tested the introduced logging function `_log_grpc_error` locally.

For StatusCode INTERNAL the following message is logged:

`ERROR:root:Internal Error in subscriberdb-Orc8r communication. If AGW and Orc8r are deployed at a commit hash, upgrade AGW and Orc8r to latest commit hash.`

For StatusCode UNAVAILABLE (or all other StatusCodes != INTERNAL) the following message would be logged:

`ERROR:root:_sync_subscribers request error! [StatusCode.UNAVAILABLE] Received http2 header with status: 502
`

(The first part of the message depends on the caller. An error message starting with `_check_subscribers_in_sync request error! ...` is also possible.)

Without the proposed changes the error message always is `Check subscribers in sync request error! ...` or `Sync subscribers request error! ...`