### PR TITLE
fix(magmad): Copy keys before iterating over service dictionary

### DIFF
--- a/orc8r/gateway/python/magma/magmad/service_poller.py
+++ b/orc8r/gateway/python/magma/magmad/service_poller.py
@@ -152,7 +152,7 @@ class ServicePoller(Job):
         Make RPC calls to 'GetServiceInfo' functions of other services, to
         get current status.
         """
-        for service in self._service_info:
+        for service in list(self._service_info):
             # Check whether service provides service303 interface
             if service in self._config['non_service303_services']:
                 continue


### PR DESCRIPTION
## Summary

This avoids an exception if the dictionary changes during the async iteration.

Fixes #10630.

## Test Plan

I did not reproduce the error locally but the basic idea can be easily tested interactively, e.g.:
```
> ipython

In [1]: d = {1:'a', 2:'b'}
   ...: for key in d:
   ...:     if key == 1:
   ...:         d[3] = 'c'
   ...: 
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-1-55c7f14ce775> in <module>
      1 d = {1:'a', 2:'b'}
----> 2 for key in d:
      3     if key == 1:
      4         d[3] = 'c'
      5 

RuntimeError: dictionary changed size during iteration

In [2]: d = {1:'a', 2:'b'}
   ...: for key in list(d):
   ...:     if key == 1:
   ...:         d[3] = 'c'
   ...: 

In [3]: d
Out[3]: {1: 'a', 2: 'b', 3: 'c'}
```

## Additional Information

- [ ] This change is backwards-breaking
