### PR TITLE
fix(amf): PDU Session faiulre due to incorrect duplication PDU count

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -1365,6 +1365,7 @@ TEST(test_pdu_negative, test_pdu_invalid_pdu_identity) {
       std::pair<amf_ue_ngap_id_t, ue_m5gmm_context_s*>(ue_id, ue_context));
   std::shared_ptr<smf_context_t> smf_ctx =
       amf_insert_smf_context(ue_context, pdu_session_id);
+  smf_ctx->pdu_session_state = ACTIVE;
 
   for (int req_cnt = 0;
        req_cnt < MAX_UE_INITIAL_PDU_SESSION_ESTABLISHMENT_REQ_ALLOWED;

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -328,6 +328,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
       sizeof(pdu_sess_release_complete_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  ASSERT_NE(ue_context_p, nullptr);
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 0);
+
   rc = send_pdu_notification_response();
   EXPECT_TRUE(rc == RETURNok);
 


### PR DESCRIPTION
test cases:
   - reproduced and verified fix with UERANSIM
       triggered 5 times PDU Session create & Release
   - oai test executed

Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
   PDU Session setup is failing after the 5th time successful PDUSession Setup and Release. 

**Fix:**
 if PDU Session is already ACTIVE state then only amf will start duplicate session count of specific PDU session-id and reject after MAX duplication Session count.

## Test Plan
Repro:
![image](https://user-images.githubusercontent.com/83060027/144423164-e6ed437a-0d98-4532-80ac-c2b13dbafc2d.png)

pcap & logs after the fix:
![image](https://user-images.githubusercontent.com/83060027/144423590-6109125a-af39-44ff-915b-6e88feb4fdcd.png)

[mme_reg_02_dec_21.log](https://github.com/magma/magma/files/7641866/mme_reg_02_dec_21.log)


Test oai Results:
![image](https://user-images.githubusercontent.com/83060027/144423039-a7ffc866-3cf8-4eef-82dd-ace504f3e65b.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
