### PR TITLE
fix(ci): `magma/` is already included in `$MAGMA_ROOT`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -316,6 +316,6 @@ RUN go get -v golang.org/x/tools/gopls
 #### Update shared library configuration
 RUN ldconfig -v
 
-RUN ln -s "$MAGMA_ROOT"/magma/bazel/bazelrcs/devcontainer.bazelrc /etc/bazelrc
+RUN ln -s $MAGMA_ROOT/bazel/bazelrcs/devcontainer.bazelrc /etc/bazelrc
 
 WORKDIR $MAGMA_ROOT


### PR DESCRIPTION
Signed-off-by: Fritz Lehnert <Fritz.Lehnert@tngtech.com>

## Summary

`magma/` is already included in `$MAGMA_ROOT` in [line 34](https://github.com/Neudrino/magma/blob/39bdfdc015e5d78dd82cd1e1a8f266863bf5dda2/.devcontainer/Dockerfile#L34)

## Test Plan

* CI
