### PR TITLE
chore: make the gy redirect test a bit more tolerant by adding a smal…

### DIFF
--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -459,6 +459,7 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 		tr.WaitForEnforcementStatsForRule(imsi, "redirect"), time.Minute, 2*time.Second)
 
 	// Send ReAuth Request to update quota
+	fmt.Println("Sending a Gy ReAuth to trigger an update")
 	raa, err := sendChargingReAuthRequest(imsi, 1)
 	assert.NoError(t, err)
 	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
@@ -471,6 +472,9 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 
 	// Assert that a CCR-I and CCR-U were sent to the OCS
 	tr.AssertAllGyExpectationsMetNoError()
+
+	fmt.Println("Wait a few seconds for the rules to settle")
+	time.Sleep(2)
 
 	// we need to generate more traffic
 	req = &cwfprotos.GenTrafficRequest{


### PR DESCRIPTION
…l sleep

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
The `TestGyCreditExhaustionRedirect` test has been flaky due to a few reasons.
1. Traffic connections - there is not much I can do about this without a larger investigation. We try to get around this with retries and that mostly works for other tests
2. CWF integ test not seeing enough traffic and fails the test - I'm trying to improve this type of failure more details below

The test mostly does the following
1. create a session
2. put some traffic and trigger a CCR/A-U that returns a FUA-redirect
3. trigger the redirect
4. trigger a Gy RAR and remove the redirect
5. put some traffic and assert some traffic passes

We sometimes fail step 5. After I took a look at the logs, it seems to be an unfortunate timing issue. Since SessionD does not expose any endpoint to get data usage for a session, the CWF integ test uses the pipelined interface to get the data usage information. 

When redirect is removed, this happens in two steps. First the redirect rule is removed and then the Gx rule is installed again.
The problem arises (in the test), if the traffic is passed between those two actions can happen. When the Gy rule is removed, the ORIGINAL Gx rule can now pass traffic. (When we install the redirect rule in the first place, we don't remove Gx rules). Then the same Gx rule is installed again, which resets the stats inside PipelineD. Then the test check fails as it doesn't know that the value reset. I don't think this is a problem on the SessionD side as it knows how to handle versioned flat rate reports. 

The easiest fix here is to add a sleep to ensure we have enough time for  deactivate  GY and activate GX to happen before we pass traffic.


Job in question: https://github.com/magma/magma/runs/4392311920?check_suite_focus=true

## Test Plan
Test on master
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
