### PR TITLE
chore: address compilation warning in MetricsHelpers

### DIFF
--- a/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
@@ -56,8 +56,9 @@ void decrement_gauge(const char* name, double decrement, size_t n_labels, ...) {
 double get_gauge(const char* name, size_t n_labels, ...) {
   va_list ap;
   va_start(ap, n_labels);
-  return MetricsSingleton::Instance().GetGauge(name, n_labels, ap);
+  double gauge = MetricsSingleton::Instance().GetGauge(name, n_labels, ap);
   va_end(ap);
+  return gauge;
 }
 
 void set_gauge(const char* name, double value, size_t n_labels, ...) {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Noticed this warning on master
```
INFO: From Compiling orc8r/gateway/c/common/service303/MetricsHelpers.cpp:
orc8r/gateway/c/common/service303/MetricsHelpers.cpp: In function 'double get_gauge(const char*, size_t, ...)':
orc8r/gateway/c/common/service303/MetricsHelpers.cpp:61:1: warning: control reaches end of non-void function [-Wreturn-type]
   61 | }
      | ^
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
