### PR TITLE
feat(orc8r): Create playbook to update control_proxy targets for new orc8r

### DIFF
--- a/experimental/cloudstrapper/playbooks/agw-config-update.yaml
+++ b/experimental/cloudstrapper/playbooks/agw-config-update.yaml
@@ -1,0 +1,11 @@
+---
+
+- hosts: "{{ agw }}"
+  roles:
+    - {role: agw-config-update, tags: config-update}
+  vars_files:
+    - roles/vars/defaults.yaml
+    - "{{ dirLocalInventory }}/secrets.yaml"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ awsAccessKey }}"
+    AWS_SECRET_ACCESS_KEY: "{{ awsSecretKey }}"

--- a/experimental/cloudstrapper/playbooks/roles/agw-config-update/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/agw-config-update/tasks/main.yaml
@@ -1,0 +1,87 @@
+---
+
+- name: Check if rootCA exists and is not empty
+  stat:
+    path: "{{ agwCertsPath }}/rootCA.pem"
+  become: true
+  register: has_rootca
+  failed_when:
+    - (not has_rootca.stat.exists) or (has_rootca.stat.size == 0)
+
+- name: Check if control_proxy.yml exists and is not empty
+  stat:
+    path: "{{ agwConfigPath }}/control_proxy.yml"
+  become: true
+  register: has_control_proxy
+  failed_when:
+    - (not has_control_proxy.stat.exists) or (has_control_proxy.stat.size == 0)
+
+# Reference: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/lineinfile_module.html
+- name: Check if cloud_address is correctly configured in control_proxy
+  lineinfile:
+    state: absent
+    path: "{{ agwConfigPath }}/control_proxy.yml"
+    regex: '^cloud_address:[ ]{1,}controller.{{ orc8rStagingDomainName }}'
+  check_mode: true
+  become: true
+  register: check_cloud_address
+  changed_when: false   # Do not count this as a change, it is just a check
+
+- name: Configure cloud_address in control_proxy
+  lineinfile:
+    path: "{{ agwConfigPath }}/control_proxy.yml"
+    regex: '^cloud_address:.*$'
+    line: "cloud_address: controller.{{ orc8rStagingDomainName }}"
+  become: true
+  diff: true
+  when: check_cloud_address.found == 0
+
+- name: Check if boostrap_address is correctly configured in control_proxy
+  lineinfile:
+    state: absent
+    path: "{{ agwConfigPath }}/control_proxy.yml"
+    regex: '^bootstrap_address:[ ]{1,}bootstrapper-controller.{{ orc8rStagingDomainName }}'
+  check_mode: true
+  become: true
+  register: check_bootstrap_address
+  changed_when: false   # Do not count this as a change, it is just a check
+
+- name: Configure boostrap_address in control_proxy
+  lineinfile:
+    path: "{{ agwConfigPath }}/control_proxy.yml"
+    regex: '^bootstrap_address:.*$'
+    line: "bootstrap_address: bootstrapper-controller.{{ orc8rStagingDomainName }}"
+  become: true
+  diff: true
+  when: check_bootstrap_address.found == 0
+
+- name: Check if fluentd_address is correctly configured in control_proxy
+  lineinfile:
+    state: absent
+    path: "{{ agwConfigPath }}/control_proxy.yml"
+    regex: '^fluentd_address:.[ ]{1,}fluentd.{{ orc8rStagingDomainName }}'
+  check_mode: true
+  become: true
+  register: check_fluentd_address
+  changed_when: false   # Do not count this as a change, it is just a check
+
+- name: Configure fluentd_address in control_proxy
+  lineinfile:
+    path: "{{ agwConfigPath }}/control_proxy.yml"
+    regex: '^fluentd_address:.*$'
+    line: "fluentd_address: fluentd.{{ orc8rStagingDomainName }}"
+  become: true
+  diff: true
+  when: updateFluentD and check_fluentd_address.found == 0
+
+- name: restart magma services
+  systemd:
+    state: restarted
+    name: "{{ item }}"
+  become: true
+  with_items:
+    - "{{ servicesMagma }}"
+  when: (check_cloud_address.found == 0) or
+    (check_bootstrap_address.found == 0) or
+    (updateFluentD and check_fluentd_address.found == 0 )
+

--- a/experimental/cloudstrapper/playbooks/roles/agw-config-update/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/agw-config-update/vars/main.yaml
@@ -1,0 +1,25 @@
+---
+
+servicesMagma:
+  - magma@magmad.service
+
+servicesMagmaWildCard:
+  - magma@*
+
+servicesMagmaAll:
+  - magma@control_proxy.service
+  - magma@magmad.service
+  - magma@pipelined.service
+  - magma@sessiond.service
+  - magma@dnsd.service
+  - magma@mme.service
+  - magma@redirectd.service
+  - magma@td-agent-bit.service
+  - magma@lighttpd.service
+  - magma@mobilityd.service
+  - magma@redis.service
+
+agwCertsPath: /var/opt/magma/tmp/certs/
+agwConfigPath: /var/opt/magma/configs
+
+updateFluentD: false


### PR DESCRIPTION
Signed-off-by: Joary Paulo Wanzeler Fortuna <joarypl@fb.com>

Create a playbook to check if the control_proxy has the expected address values and update if necessary.

## Summary

- Created new role & playbook to check control_proxy.
- Playbook does:
  - Check if `rootCA.pem` already exists in the expected location
  - Check if `control_proxy.yml` already exists in the expected location
  - Check if `cloud_address` & `boostrapper_address` are using the target `orc8rDomainName`, if negative update them.
  - If `updateFluentD=true` also update `fluentd_address`
  - Restart magma services if any line was changed.

## Test Plan

Configure the `/etc/ansible/hosts` to have access to all your production AGW, example:

```
[prod]
ec2-XX.ca-central-1.compute.amazonaws.com ansible_user=ubuntu ansible_ssh_private_key_file=/Users/joarypl/Magma/blue-green-orc8r/orc8r-blue-green.pem

[staging]
ec2-XX.ca-central-1.compute.amazonaws.com ansible_user=ubuntu ansible_ssh_private_key_file=/Users/joarypl/Magma/blue-green-orc8r/orc8r-blue-green.pem

[all:children]
prod
staging
```

Check if all AGWs are accessible in the groups `ansible all -a "/bin/echo Hello World"`

Update `control_proxy.yml` and restart magma services using the playbook:

```
ansible-playbook agw-config-update.yaml \
-e "orc8rDomainName=staging.bg.magmacore.click" \
-e "agw=staging" \
-e "dirLocalInventory=/Users/joarypl/Magma/blue-green-orc8r" 
```

**OBS:**
* Use existing secrets.yaml from `dirLocalInventory`
* Select which group of AGWs will be updated by setting `agw=staging`
* This will update only cloud_address and boostrapper_address, optionally you can add `-e updateFluentD=true` to update fluentd_address as well.

Expected behavior:

* Just AGWs in the target host group will be updated.
* AGW's `control_proxy` with different values than expected will be updated and magma will be restarted
* AGWs without`rootCA/control_proxy.yml` will fail, control proxy will not be update and services will not be restarted
* AGWs with `control_proxy` already configured with expected values will not be changed and magma will not be restarted.
* Changes above will be applied per AGW, ansible PLAY RECAP should be enough to list which hosts were changed, which ones failed and which ones were already in the expected configuration:

![image](https://user-images.githubusercontent.com/1166157/144857199-b30a88f1-839c-440e-b7a3-135fbc6bf45d.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
