### PR TITLE
fix(sessiond): prevent to un-suspend if we receive several transient errors

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -56,7 +56,7 @@ StoredChargingGrant ChargingGrant::marshal() {
   return marshaled;
 }
 
-CreditValidity ChargingGrant::is_valid_credit_response(
+CreditValidity ChargingGrant::get_credit_response_validity_type(
     const CreditUpdateResponse& update) {
   const uint32_t key             = update.charging_key();
   const std::string session_id   = update.session_id();

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -76,7 +76,7 @@ struct ChargingGrant {
 
   // Returns true if the credit returned from the Policy component is valid and
   // good to be installed.
-  static CreditValidity is_valid_credit_response(
+  static CreditValidity get_credit_response_validity_type(
       const CreditUpdateResponse& update);
 
   // Returns a SessionCreditUpdateCriteria that reflects the current state

--- a/lte/gateway/c/session_manager/EnumToString.h
+++ b/lte/gateway/c/session_manager/EnumToString.h
@@ -43,6 +43,8 @@ std::string wallet_state_to_str(SubscriberQuotaUpdate_Type state);
 
 std::string service_action_type_to_str(ServiceActionType action);
 
+std::string credit_validity_to_str(CreditValidity validity);
+
 std::string event_trigger_to_str(EventTrigger event_trigger);
 
 std::string request_origin_type_to_str(

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1474,8 +1474,13 @@ void LocalEnforcer::update_charging_credits(
         session->receive_charging_credit(credit_update_resp, &uc);
     session->set_tgpp_context(credit_update_resp.tgpp_ctx(), &uc);
 
-    bool should_activate = session->is_credit_ready_to_be_activated(credit_key);
-    if (!should_activate) {
+    // Here we will decide if credit should be activated/un-suspended
+    bool credit_ready_to_be_activated =
+        session->is_credit_ready_to_be_activated(credit_key);
+    auto credit_validity_type =
+        ChargingGrant::get_credit_response_validity_type(credit_update_resp);
+    if (credit_validity_type == TRANSIENT_ERROR ||
+        !credit_ready_to_be_activated) {
       continue;
     }
     // This credit is now out of quota and need to be acted on


### PR DESCRIPTION

Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

When we receive two a transient error, we set session into suspended stage. But if we receive another transient error, the session is un-suspended. This PR prevents this situation to happen

## Test Plan

extended test case `test_update_with_transient_error_suspendand_unsuspend` to capture suspension, send of a transient error while suspended and unsuspend using valid quota

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
