### PR TITLE
test(mme): Add SPGW unit test for suspend notification

### DIFF
--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -1497,13 +1497,14 @@ status_code_e sgw_handle_suspend_notification(
           (eps_bearer_entry_p->paa.pdn_type == IPv4_AND_v6)) {
         ue_ipv6 = &eps_bearer_entry_p->paa.ipv6_address;
       }
-
+#if !MME_UNIT_TEST
       rv = gtp_tunnel_ops->discard_data_on_tunnel(
           ue_ipv4, ue_ipv6, eps_bearer_entry_p->s_gw_teid_S1u_S12_S4_up, NULL);
       if (rv < 0) {
         OAILOG_ERROR_UE(
             LOG_SPGW_APP, imsi64, "ERROR in Disabling DL data on TUNNEL\n");
       }
+#endif
     } else {
       OAILOG_ERROR_UE(LOG_SPGW_APP, imsi64, "Bearer context not found \n");
     }

--- a/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mme_app_mock.cpp
@@ -55,6 +55,8 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S11_SUSPEND_ACKNOWLEDGE: {
+      mme_app_handler_->mme_app_handle_suspend_acknowledge(
+          received_message_p->ittiMsg.s11_suspend_acknowledge);
     } break;
 
     case S1AP_E_RAB_SETUP_RSP: {

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -21,6 +21,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
 #include "lte/gateway/c/core/oai/common/itti_free_defined_msg.h"
+#include "lte/gateway/c/core/oai/include/s11_messages_types.h"
 }
 
 const task_info_t tasks_info[] = {
@@ -71,6 +72,9 @@ class MockMmeAppHandler {
   MOCK_METHOD0(mme_app_handle_enb_reset_req, void());
   MOCK_METHOD0(mme_app_handle_e_rab_setup_rsp, void());
   MOCK_METHOD0(mme_app_handle_path_switch_request, void());
+  MOCK_METHOD1(
+      mme_app_handle_suspend_acknowledge,
+      bool(itti_s11_suspend_acknowledge_t suspend_ack));
 };
 
 class MockSctpHandler {

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.h"
 #include "lte/gateway/c/core/oai/include/s11_messages_types.h"
 #include "lte/gateway/c/core/oai/common/itti_free_defined_msg.h"
+#include "lte/gateway/c/core/oai/common/common_types.h"
 }
 
 namespace magma {
@@ -365,7 +366,8 @@ void fill_nw_initiated_deactivate_bearer_response(
   nw_deactv_bearer_resp->cause.cause_value     = cause;
 
   if (delete_default_bearer) {
-    nw_deactv_bearer_resp->lbi  = (ebi_t*) calloc(1, sizeof(ebi_t));
+    nw_deactv_bearer_resp->lbi =
+        reinterpret_cast<ebi_t*>(calloc(1, sizeof(ebi_t)));
     *nw_deactv_bearer_resp->lbi = ebi[0];
     nw_deactv_bearer_resp->bearer_contexts.bearer_contexts[0]
         .cause.cause_value = cause;
@@ -381,6 +383,17 @@ void fill_nw_initiated_deactivate_bearer_response(
       num_bearer_context;
   nw_deactv_bearer_resp->imsi             = test_imsi64;
   nw_deactv_bearer_resp->s_gw_teid_s11_s4 = sgw_s11_context_teid;
+}
+
+void fill_s11_suspend_notification(
+    itti_s11_suspend_notification_t* suspend_notif, teid_t sgw_s11_context_teid,
+    std::string imsi_str, ebi_t link_bearer_id) {
+  suspend_notif->teid        = sgw_s11_context_teid;
+  suspend_notif->lbi         = link_bearer_id;
+  suspend_notif->imsi.length = imsi_str.size();
+  strncpy(
+      (char*) suspend_notif->imsi.digit, imsi_str.c_str(),
+      suspend_notif->imsi.length);
 }
 
 }  // namespace lte

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
@@ -278,7 +278,7 @@ void fill_packet_filter_content(packet_filter_contents_t* pf_content) {
 
 void fill_nw_initiated_activate_bearer_request(
     itti_gx_nw_init_actv_bearer_request_t* gx_nw_init_actv_req_p,
-    std::string imsi_str, ebi_t lbi, bearer_qos_t qos) {
+    const std::string& imsi_str, ebi_t lbi, bearer_qos_t qos) {
   gx_nw_init_actv_req_p->imsi_length = imsi_str.size();
   strncpy(gx_nw_init_actv_req_p->imsi, imsi_str.c_str(), imsi_str.size());
   gx_nw_init_actv_req_p->lbi            = lbi;
@@ -349,7 +349,7 @@ void fill_nw_initiated_activate_bearer_response(
 
 void fill_nw_initiated_deactivate_bearer_request(
     itti_gx_nw_init_deactv_bearer_request_t* gx_nw_init_deactv_req_p,
-    std::string imsi_str, ebi_t lbi, ebi_t eps_bearer_id) {
+    const std::string& imsi_str, ebi_t lbi, ebi_t eps_bearer_id) {
   gx_nw_init_deactv_req_p->imsi_length = imsi_str.size();
   strncpy(gx_nw_init_deactv_req_p->imsi, imsi_str.c_str(), imsi_str.size());
   gx_nw_init_deactv_req_p->lbi           = lbi;
@@ -387,7 +387,7 @@ void fill_nw_initiated_deactivate_bearer_response(
 
 void fill_s11_suspend_notification(
     itti_s11_suspend_notification_t* suspend_notif, teid_t sgw_s11_context_teid,
-    std::string imsi_str, ebi_t link_bearer_id) {
+    const std::string& imsi_str, ebi_t link_bearer_id) {
   suspend_notif->teid        = sgw_s11_context_teid;
   suspend_notif->lbi         = link_bearer_id;
   suspend_notif->imsi.length = imsi_str.size();

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -97,5 +97,9 @@ void fill_nw_initiated_deactivate_bearer_response(
     gtpv2c_cause_value_t cause, ebi_t ebi[], unsigned int num_bearer_context,
     teid_t sgw_s11_context_teid);
 
+void fill_s11_suspend_notification(
+    itti_s11_suspend_notification_t* suspend_notif, teid_t sgw_s11_context_teid,
+    std::string imsi_str, ebi_t link_bearer_id);
+
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -79,7 +79,7 @@ void fill_release_access_bearer_request(
 
 void fill_nw_initiated_activate_bearer_request(
     itti_gx_nw_init_actv_bearer_request_t* gx_nw_init_actv_req_p,
-    std::string imsi_str, ebi_t lbi, bearer_qos_t qos);
+    const std::string& imsi_str, ebi_t lbi, bearer_qos_t qos);
 
 void fill_nw_initiated_activate_bearer_response(
     itti_s11_nw_init_actv_bearer_rsp_t* nw_actv_bearer_resp,
@@ -89,7 +89,7 @@ void fill_nw_initiated_activate_bearer_response(
 
 void fill_nw_initiated_deactivate_bearer_request(
     itti_gx_nw_init_deactv_bearer_request_t* gx_nw_init_deactv_req_p,
-    std::string imsi_str, ebi_t lbi, ebi_t eps_bearer_id);
+    const std::string& imsi_str, ebi_t lbi, ebi_t eps_bearer_id);
 
 void fill_nw_initiated_deactivate_bearer_response(
     itti_s11_nw_init_deactv_bearer_rsp_t* nw_deactv_bearer_resp,
@@ -99,7 +99,7 @@ void fill_nw_initiated_deactivate_bearer_response(
 
 void fill_s11_suspend_notification(
     itti_s11_suspend_notification_t* suspend_notif, teid_t sgw_s11_context_teid,
-    std::string imsi_str, ebi_t link_bearer_id);
+    const std::string& imsi_str, ebi_t link_bearer_id);
 
 }  // namespace lte
 }  // namespace magma


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

This change adds a unit test to test `sgw_handle_suspend_notification`. Most of the test case is a repeat of the Create Session Request test case, with the addition of Suspend notification once the Session is established. 

A minor lint fix is also added for casting the call to calloc.
Also marked test IMSI string as constant in the helper functions.

## Test Plan

make test_oai