### PR TITLE
fix(orc8r): fixed helm if condition for replicas

### DIFF
--- a/orc8r/cloud/helm/orc8r/templates/accessd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/accessd.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "accessd.pdb") -}}
 {{- define "accessd.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/analytics.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/analytics.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "analytics.pdb") -}}
 {{- define "analytics.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/certifier.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/certifier.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "certifier.pdb") -}}
 {{- define "certifier.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/configurator.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/configurator.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "configurator.pdb") -}}
 {{- define "configurator.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/ctraced.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ctraced.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "ctraced.pdb") -}}
 {{- define "ctraced.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/device.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/device.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "device.pdb") -}}
 {{- define "device.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/directoryd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/directoryd.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "directoryd.pdb") -}}
 {{- define "directoryd.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/dispatcher.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dispatcher.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "dispatcher.pdb") -}}
 {{- define "dispatcher.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/eventd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/eventd.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "eventd.pdb") -}}
 {{- define "eventd.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/metricsd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/metricsd.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "metricsd.pdb") -}}
 {{- define "metricsd.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/obsidian.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/obsidian.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "obsidian.pdb") -}}
 {{- define "obsidian.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/orchestrator.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/orchestrator.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "orchestrator.pdb") -}}
 {{- define "orchestrator.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/service_registry.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/service_registry.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "service_registry.pdb") -}}
 {{- define "service_registry.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/state.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/state.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "state.pdb") -}}
 {{- define "state.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/streamer.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/streamer.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "streamer.pdb") -}}
 {{- define "streamer.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/tenants.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/tenants.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "tenants.pdb") -}}
 {{- define "tenants.pdb" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/orc8r/cloud/helm/orc8rlib/templates/_pdb.yaml
+++ b/orc8r/cloud/helm/orc8rlib/templates/_pdb.yaml
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- define "orc8rlib.pdb.tpl" -}}
-{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
Signed-off-by: Shubham Tatvamasi <shubhamtatvamasi@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fixed the helm install error which was coming due to replicas limit:
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [apiVersion not set, kind not set]
```

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
