### PR TITLE
chore(agw): Dont opt-in logs that are filtered by Sentry

### DIFF
--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -20,7 +20,6 @@ import metrics_pb2
 import prometheus_client.core
 import requests
 import snowflake
-from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos import metricsd_pb2
 from orc8r.protos.common_pb2 import Void
@@ -139,7 +138,6 @@ class MetricsCollector(object):
                 "Metrics upload error for service %s (chunk %d)! "
                 "[%s] %s", service_name, chunk, err.code(),
                 err.details(),
-                extra=SEND_TO_ERROR_MONITORING,
             )
         else:
             logging.debug(
@@ -299,7 +297,6 @@ class MetricsCollector(object):
             logging.error(
                 "Prometheus Target Metrics upload error! [%s] %s",
                 err.code(), err.details(),
-                extra=SEND_TO_ERROR_MONITORING,
             )
         else:
             logging.debug(

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -264,7 +264,6 @@ class StateReplicator(SDWatchdogTask):
             logging.error(
                 "GRPC call failed for state replication: %s",
                 err,
-                extra=SEND_TO_ERROR_MONITORING,
             )
         else:
             unreplicated_states = set()


### PR DESCRIPTION
Signed-off-by: Jan Heidbrink <jan.heidbrink@tngtech.com>

## Summary

This stops sending some logs to Sentry that are discarded by a server-side filter anyway.

## Test Plan

None

## Additional Information

- [ ] This change is backwards-breaking
