### PR TITLE
chore: remove unused boost dependency

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -119,10 +119,6 @@ load("//bazel:cpp_repositories.bzl", "cpp_repositories")
 
 cpp_repositories()
 
-load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
-
-boost_deps()
-
 # To get Folly to build reliably, we're going to pull it from the underlying system
 # This assumes that the build is done in the Docker container or VBox VM
 new_local_repository(

--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -30,16 +30,6 @@ def cpp_repositories():
         urls = ["https://github.com/google/glog/archive/v0.4.0.tar.gz"],
     )
 
-    rules_boost_commit = "fb9f3c9a6011f966200027843d894923ebc9cd0b"
-    http_archive(
-        name = "com_github_nelhage_rules_boost",
-        sha256 = "046f774b185436d506efeef8be6979f2c22f1971bfebd0979bafa28088bf28d0",
-        strip_prefix = "rules_boost-{}".format(rules_boost_commit),
-        urls = [
-            "https://github.com/nelhage/rules_boost/archive/{}.tar.gz".format(rules_boost_commit),
-        ],
-    )
-
     http_archive(
         name = "yaml-cpp",
         strip_prefix = "yaml-cpp-yaml-cpp-0.7.0",

--- a/cwf/gateway/docker/c/Dockerfile
+++ b/cwf/gateway/docker/c/Dockerfile
@@ -73,7 +73,6 @@ RUN bazel build \
   @protobuf//:protobuf \
   @prometheus_cpp//:prometheus-cpp \
   @yaml-cpp//:yaml-cpp \
-  @boost//:iterator \
   @github_nlohmann_json//:json
 
 # Copy proto files

--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -115,7 +115,6 @@ RUN bazel build \
   @protobuf//:protobuf \
   @prometheus_cpp//:prometheus-cpp \
   @yaml-cpp//:yaml-cpp \
-  @boost//:iterator \
   @github_nlohmann_json//:json \
   @sentry_native//:sentry
 

--- a/orc8r/gateway/c/common/config/BUILD.bazel
+++ b/orc8r/gateway/c/common/config/BUILD.bazel
@@ -20,7 +20,6 @@ cc_library(
     # TODO(@themarwhal): Migrate to using full path for includes - GH8299
     strip_include_prefix = "/orc8r/gateway/c/common/config",
     deps = [
-        "@boost//:iterator",
         "@yaml-cpp//:yaml-cpp",
     ],
 )


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
The boost dependency is not used anywhere anymore. (I will try to look around for a better analysis tool to detect these types of unused external deps).

I seemed to have removed the boost dependency when I cleaned up all the includes with the Include-What-You-Need tool. (https://github.com/magma/magma/pull/9930)
<img width="1245" alt="Screen Shot 2021-12-06 at 10 17 23 AM" src="https://user-images.githubusercontent.com/37634144/144871908-445779e0-8ba5-4f1f-b98c-6caa800b7f95.png">
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Build everything in CI + build containerzed SessionD for AGW manually as we don't have a CI check for that yet
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
