### PR TITLE
feat(agw): Support orchestration for containerised agw

### DIFF
--- a/lte/gateway/deploy/agw_install_docker.sh
+++ b/lte/gateway/deploy/agw_install_docker.sh
@@ -14,7 +14,7 @@ MODE=$1
 WHOAMI=$(whoami)
 MAGMA_USER="ubuntu"
 MAGMA_VERSION="${MAGMA_VERSION:-master}"
-GIT_URL="${GIT_URL:-https://github.com/ymasmoudi/magma.git}"
+GIT_URL="${GIT_URL:-https://github.com/magma/magma.git}"
 DEPLOY_PATH="/opt/magma/lte/gateway/deploy"
 
 echo "Checking if the script has been executed by root user"
@@ -54,15 +54,14 @@ rm -rf /opt/magma/
 git clone "${GIT_URL}" /opt/magma
 cd /opt/magma || exit
 git checkout "$MAGMA_VERSION"
-git checkout agwc_eks_orchestration_support
 
 
 echo "Generating localhost hostfile for Ansible"
 echo "[agw_docker]
 127.0.0.1 ansible_connection=local" > $DEPLOY_PATH/agw_hosts
 
-if [ "$MODE" == "eks" ]; then
-  su - $MAGMA_USER -c "sudo ansible-playbook -e \"MAGMA_ROOT='/opt/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts --tags eks $DEPLOY_PATH/magma_docker.yml"
+if [ "$MODE" == "base" ]; then
+  su - $MAGMA_USER -c "sudo ansible-playbook -e \"MAGMA_ROOT='/opt/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts --tags base $DEPLOY_PATH/magma_docker.yml"
 else
   # install magma and its dependencies including OVS.
   su - $MAGMA_USER -c "sudo ansible-playbook -e \"MAGMA_ROOT='/opt/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts --tags agwc $DEPLOY_PATH/magma_docker.yml"

--- a/lte/gateway/deploy/roles/agw_docker/tasks/main.yml
+++ b/lte/gateway/deploy/roles/agw_docker/tasks/main.yml
@@ -15,7 +15,7 @@
     file: all.yaml
   tags:
     - agwc
-    - eks
+    - base
 
 - name: Install aptitude using apt
   apt: name=aptitude state=latest force_apt_get=yes
@@ -72,7 +72,7 @@
 - name: create directories for magma configs and files
   tags:
     - agwc
-    - eks
+    - base
   file:
     path: "{{ item }}"
     state: directory
@@ -91,13 +91,13 @@
   sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
   tags:
     - agwc
-    - eks
+    - base
 
 - name: touch snowflake
   shell: touch /etc/snowflake
   tags:
     - agwc
-    - eks
+    - base
 
 - name: start docker service
   systemd: name=docker state=started enabled=yes
@@ -116,13 +116,13 @@
   shell: cp -r  /opt/magma/lte/gateway/configs/* /etc/magma/
   tags:
     - agwc
-    - eks
+    - base
 
 - name: copy the config files for orchestrator
   shell: cp -r  /opt/magma/orc8r/gateway/configs/templates/* /etc/magma/templates/
   tags:
     - agwc
-    - eks
+    - base
 
 - name: copy docker compose config file
   shell: cp -r  /opt/magma/lte/gateway/docker/docker-compose.yaml /var/opt/magma/docker/
@@ -133,7 +133,7 @@
   shell: cp -f /etc/magma/pipelined.yml_prod /etc/magma/pipelined.yml
   tags:
     - agwc
-    - eks
+    - base
 
 - name: docker login
   shell: docker login -u {{ docker_user }} -p {{ docker_pass }}  {{ docker_registry }}

--- a/lte/gateway/deploy/roles/agw_docker/tasks/main.yml
+++ b/lte/gateway/deploy/roles/agw_docker/tasks/main.yml
@@ -15,6 +15,7 @@
     file: all.yaml
   tags:
     - agwc
+    - eks
 
 - name: Install aptitude using apt
   apt: name=aptitude state=latest force_apt_get=yes
@@ -71,6 +72,7 @@
 - name: create directories for magma configs and files
   tags:
     - agwc
+    - eks
   file:
     path: "{{ item }}"
     state: directory
@@ -89,11 +91,13 @@
   sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
   tags:
     - agwc
+    - eks
 
 - name: touch snowflake
   shell: touch /etc/snowflake
   tags:
     - agwc
+    - eks
 
 - name: start docker service
   systemd: name=docker state=started enabled=yes
@@ -112,11 +116,13 @@
   shell: cp -r  /opt/magma/lte/gateway/configs/* /etc/magma/
   tags:
     - agwc
+    - eks
 
 - name: copy the config files for orchestrator
   shell: cp -r  /opt/magma/orc8r/gateway/configs/templates/* /etc/magma/templates/
   tags:
     - agwc
+    - eks
 
 - name: copy docker compose config file
   shell: cp -r  /opt/magma/lte/gateway/docker/docker-compose.yaml /var/opt/magma/docker/
@@ -127,6 +133,7 @@
   shell: cp -f /etc/magma/pipelined.yml_prod /etc/magma/pipelined.yml
   tags:
     - agwc
+    - eks
 
 - name: docker login
   shell: docker login -u {{ docker_user }} -p {{ docker_pass }}  {{ docker_registry }}

--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -16,7 +16,7 @@
     file: all.yaml
   tags:
     - agwc
-    - eks
+    - base
 
 - name: Update ca-certs
   become: true
@@ -25,7 +25,7 @@
     update_cache: true
   tags:
     - agwc
-    - eks
+    - base
 
 - name: Forbid usage of expired Let's Encrypt CA cert
   ignore_errors: true
@@ -36,7 +36,7 @@
     line: '!mozilla/DST_Root_CA_X3.crt'
   tags:
     - agwc
-    - eks
+    - base
 
 
 - name: Trigger update of CA certs
@@ -45,7 +45,7 @@
   command: update-ca-certificates
   tags:
     - agwc
-    - eks
+    - base
 
 - name: Configuring private package manager.
   copy:
@@ -56,7 +56,7 @@
   become: true
   tags:
     - agwc
-    - eks
+    - base
 
 - name: Add unvalidated Apt signing key.
   when: magma_pkgrepo_key_fingerprint == ""
@@ -77,7 +77,7 @@
           };
   tags:
     - agwc
-    - eks
+    - base
 
 - name: Add validated Apt signing key.
   when: magma_pkgrepo_key_fingerprint != ""
@@ -88,7 +88,7 @@
     state: present
   tags:
     - agwc
-    - eks
+    - base
 
 - name: Update and upgrade apt packages
   become: true
@@ -96,7 +96,7 @@
     update_cache: true
   tags:
     - agwc
-    - eks
+    - base
 
 - name: Install runtime dependencies.
   become: true
@@ -115,7 +115,7 @@
       - ifupdown
   tags:
     - agwc
-    - eks
+    - base
 
 - name: Preconfigure wireshark (tshark) SUID property
   become: true
@@ -123,7 +123,7 @@
   shell: bash -c 'echo "wireshark-common wireshark-common/install-setuid boolean true" | debconf-set-selections'
   tags:
     - agwc
-    - eks
+    - base
 
 - name: Installing magma.
   become: true
@@ -149,7 +149,7 @@
   tags:
     - never
     - agwc
-    - eks
+    - base
 
 - name: Create interfaces.d if it does not exist
   file:
@@ -157,7 +157,7 @@
     state: directory
   tags:
     - agwc
-    - eks
+    - base
 
 # Copy these files in containerized agw only
 - name: copy necessary files for ovs
@@ -171,6 +171,7 @@
   tags:
     - never
     - agwc
+    - base
 
 - name: Start service openvswitch-switch.
   become: true
@@ -180,6 +181,7 @@
   tags:
     - skipfirstinstall
     - agwc
+    - base
 
 # Ansible's service module doesn't support wildcards so we have to use shell
 - name: Stop all magma services.
@@ -194,6 +196,7 @@
   tags:
     - skipfirstinstall
     - agwc
+    - base
 
 - name: Bring up mtr0
   shell: ifup mtr0
@@ -201,6 +204,7 @@
   tags:
     - skipfirstinstall
     - agwc
+    - base
 
 - name: Bring up uplink_br0
   shell: ifup uplink_br0
@@ -208,6 +212,7 @@
   tags:
     - skipfirstinstall
     - agwc
+    - base
 
 - name: Bring up ipfix0
   shell: ifup ipfix0
@@ -215,6 +220,7 @@
   tags:
     - skipfirstinstall
     - agwc
+    - base
 
 - name: Bring up dhcp0
   shell: ifup dhcp0
@@ -222,6 +228,7 @@
   tags:
     - skipfirstinstall
     - agwc
+    - base
 
 - name: Start service magma@magmad.
   become: true
@@ -235,4 +242,4 @@
   shell: ansible-galaxy collection install community.general
   tags:
     - agwc
-    - eks
+    - base

--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -16,6 +16,7 @@
     file: all.yaml
   tags:
     - agwc
+    - eks
 
 - name: Update ca-certs
   become: true
@@ -24,6 +25,7 @@
     update_cache: true
   tags:
     - agwc
+    - eks
 
 - name: Forbid usage of expired Let's Encrypt CA cert
   ignore_errors: true
@@ -34,6 +36,7 @@
     line: '!mozilla/DST_Root_CA_X3.crt'
   tags:
     - agwc
+    - eks
 
 
 - name: Trigger update of CA certs
@@ -42,6 +45,7 @@
   command: update-ca-certificates
   tags:
     - agwc
+    - eks
 
 - name: Configuring private package manager.
   copy:
@@ -52,6 +56,7 @@
   become: true
   tags:
     - agwc
+    - eks
 
 - name: Add unvalidated Apt signing key.
   when: magma_pkgrepo_key_fingerprint == ""
@@ -72,6 +77,7 @@
           };
   tags:
     - agwc
+    - eks
 
 - name: Add validated Apt signing key.
   when: magma_pkgrepo_key_fingerprint != ""
@@ -82,6 +88,7 @@
     state: present
   tags:
     - agwc
+    - eks
 
 - name: Update and upgrade apt packages
   become: true
@@ -89,6 +96,7 @@
     update_cache: true
   tags:
     - agwc
+    - eks
 
 - name: Install runtime dependencies.
   become: true
@@ -107,6 +115,7 @@
       - ifupdown
   tags:
     - agwc
+    - eks
 
 - name: Preconfigure wireshark (tshark) SUID property
   become: true
@@ -114,6 +123,7 @@
   shell: bash -c 'echo "wireshark-common wireshark-common/install-setuid boolean true" | debconf-set-selections'
   tags:
     - agwc
+    - eks
 
 - name: Installing magma.
   become: true
@@ -139,6 +149,7 @@
   tags:
     - never
     - agwc
+    - eks
 
 - name: Create interfaces.d if it does not exist
   file:
@@ -146,6 +157,7 @@
     state: directory
   tags:
     - agwc
+    - eks
 
 # Copy these files in containerized agw only
 - name: copy necessary files for ovs
@@ -223,3 +235,4 @@
   shell: ansible-galaxy collection install community.general
   tags:
     - agwc
+    - eks


### PR DESCRIPTION

## Summary

This PR support an additional tag "base" needed to automate the build of a customized aws ami for eks clusters.

## Test Plan

```
ymasmoudi-mbp:pods ymasmoudi$ kubectl get pods --all-namespaces 
NAMESPACE     NAME                             READY   STATUS             RESTARTS   AGE
default       connectiond-68c9c8b945-s5qz6     1/1     Running            13         106m
default       control-proxy-64d4f9dbbc-dgn98   0/1     CrashLoopBackOff   25         106m
default       ctraced-55bc84df9-wbnc4          1/1     Running            0          106m
default       directoryd-546db9b5fb-zlbl7      1/1     Running            0          106m
default       enodebd-6596c9d458-qb8c5         1/1     Running            0          106m
default       eventd-598f9b8c75-szc2d          1/1     Running            0          106m
default       health-6547556d64-gwgnn          1/1     Running            0          106m
default       magmad-7fc5fb494d-9cf8f          1/1     Running            0          106m
default       mobilityd-57f4577ff8-wj5dj       1/1     Running            0          106m
default       monitord-7595cc5549-bx6nw        1/1     Running            0          106m
default       oai-config                       0/1     Completed          0          106m
default       oai-mme-6977ddb8d9-2nw5z         1/1     Running            0          106m
default       pipelined-b45fbc888-q8bhz        1/1     Running            0          106m
default       policydb-84675d7486-wrwdd        1/1     Running            0          106m
default       redirectd-74c4959585-vhmzx       1/1     Running            0          106m
default       redis-6dbfd64d56-k25z6           1/1     Running            0          106m
default       sctpd-66c97df8f7-j7njs           1/1     Running            0          106m
default       sessiond-6cf4645d9b-c96sx        1/1     Running            0          106m
default       smsd-64f9d65c55-fctm4            1/1     Running            0          106m
default       state-7cf59bb6fd-t492d           1/1     Running            0          106m
default       subscriberdb-86db4cd6c5-6248h    1/1     Running            0          106m
default       td-agent-bit-5fc47545f6-jpgz8    1/1     Running            0          106m
kube-system   aws-node-wg442                   1/1     Running            2          23d
kube-system   coredns-54957984bd-88bdk         1/1     Running            1          23d
kube-system   coredns-54957984bd-cql5d         1/1     Running            1          23d
kube-system   kube-proxy-5vwvf                 1/1     Running            1          23d
```
