### PR TITLE
chore: Add dev registry to VMs

### DIFF
--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/debian.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/debian.yml
@@ -29,13 +29,8 @@
   apt: pkg=apt-transport-https state=present update_cache=yes
   #  when: preburn
 
-- name: Add JFrog key
-  apt_key:
-    url: https://facebookconnectivity.jfrog.io/artifactory/api/gpg/key/public
-    state: present
-
 - name: Add JFrog repo
   apt_repository:
-    repo: 'deb https://facebookconnectivity.jfrog.io/artifactory/list/{{ repo }}/ {{ distribution }} main'
+    repo: 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main amd64'
     update_cache: yes
     mode: 0644


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

Add dev registry to VMs

## Summary

Need that for some other tasks (remove build from integ test suite)

## Test Plan

vagrant up

## Additional Information

- [ ] This change is backwards-breaking
