### PR TITLE
fix(agw): migrate orc8r/gateway/c to clang-11 google style

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -474,27 +474,16 @@ jobs:
       - uses: actions/checkout@v2
       - uses: DoozyX/clang-format-lint-action@v0.12
         with:
-          source: 'orc8r/gateway/c lte/gateway/c'
+          source: 'orc8r/gateway/c'
+          extensions: 'h,hpp,c,cpp'
+          clangFormatVersion: 11
+          style: '{BasedOnStyle: Google, IncludeBlocks: Preserve, SortIncludes: false}'
+      - uses: DoozyX/clang-format-lint-action@v0.12
+        with:
+          source: 'lte/gateway/c'
           extensions: 'h,hpp,c,cpp'
           clangFormatVersion: 7
           style: file
-      - name: Extract commit title
-        id: commit
-        if: failure() && github.event_name == 'push'
-        run: |
-          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
-          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "lint-clang-format check failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: "Feg workflow"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
 
   session_manager_test:
     needs: path_filter

--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -148,7 +148,7 @@ build_oai_clang: ## Build OAI with Clang, store compiler outputs to log
 
 format_all:
 	find $(MAGMA_ROOT)/orc8r/gateway/c/ \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" \) -exec \
-	clang-format --style=file -i {} \;
+	/usr/bin/clang-format-11 --style='{BasedOnStyle: Google, IncludeBlocks: Preserve, SortIncludes: false}' -i {} \;
 	find $(MAGMA_ROOT)/lte/gateway/c/ \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" \) -exec \
 	clang-format --style=file -i {} \;
 

--- a/orc8r/gateway/c/common/async_grpc/includes/GRPCReceiver.h
+++ b/orc8r/gateway/c/common/async_grpc/includes/GRPCReceiver.h
@@ -21,7 +21,7 @@
 #include <functional>                              // for function
 #include <memory>                                  // for unique_ptr
 namespace grpc {
-template<class R>
+template <class R>
 class ClientAsyncResponseReader;
 }
 
@@ -73,15 +73,14 @@ class AsyncResponse {
  * This class is implemented here because non-specialized templates
  * must be visible to a translation unit
  */
-template<typename ResponseType>
+template <typename ResponseType>
 class AsyncGRPCResponse : public AsyncResponse {
  public:
-  AsyncGRPCResponse(
-      std::function<void(grpc::Status, ResponseType)> callback,
-      uint32_t timeout_sec)
+  AsyncGRPCResponse(std::function<void(grpc::Status, ResponseType)> callback,
+                    uint32_t timeout_sec)
       : callback_(callback) {
-    context_.set_deadline(
-        std::chrono::system_clock::now() + std::chrono::seconds(timeout_sec));
+    context_.set_deadline(std::chrono::system_clock::now() +
+                          std::chrono::seconds(timeout_sec));
   }
   virtual ~AsyncGRPCResponse() = default;
 
@@ -124,12 +123,11 @@ class AsyncGRPCResponse : public AsyncResponse {
  *   local_response->get_context(), request_val, &completion_queue);
  * local_response->set_response_reader(std::move(response_reader));
  */
-template<typename ResponseType>
+template <typename ResponseType>
 class AsyncLocalResponse : public AsyncGRPCResponse<ResponseType> {
  public:
-  AsyncLocalResponse(
-      std::function<void(grpc::Status, ResponseType)> callback,
-      uint32_t timeout_sec)
+  AsyncLocalResponse(std::function<void(grpc::Status, ResponseType)> callback,
+                     uint32_t timeout_sec)
       : AsyncGRPCResponse<ResponseType>(callback, timeout_sec) {}
 
   void handle_response() {

--- a/orc8r/gateway/c/common/config/MConfigLoader.cpp
+++ b/orc8r/gateway/c/common/config/MConfigLoader.cpp
@@ -31,7 +31,7 @@ class Message;
 namespace {
 static constexpr const char* DYNAMIC_MCONFIG_PATH =
     "/var/opt/magma/configs/gateway.mconfig";
-static constexpr const char* CONFIG_DIR        = "/etc/magma";
+static constexpr const char* CONFIG_DIR = "/etc/magma";
 static constexpr const char* MCONFIG_FILE_NAME = "gateway.mconfig";
 
 bool check_file_exists(const std::string filename) {
@@ -60,8 +60,8 @@ namespace magma {
 
 using json = nlohmann::json;
 
-bool load_service_mconfig_from_file(
-    const std::string& service_name, google::protobuf::Message* message) {
+bool load_service_mconfig_from_file(const std::string& service_name,
+                                    google::protobuf::Message* message) {
   // TODO(smoeller): Should use deffered file.close() here, e.g. absl::Cleanup
   std::ifstream file;
   open_mconfig_file(&file);
@@ -74,9 +74,9 @@ bool load_service_mconfig_from_file(
   return success;
 }
 
-bool load_service_mconfig(
-    const std::string& service_name, std::istream* config_stream,
-    google::protobuf::Message* message) {
+bool load_service_mconfig(const std::string& service_name,
+                          std::istream* config_stream,
+                          google::protobuf::Message* message) {
   json mconfig_json;
   try {
     *config_stream >> mconfig_json;

--- a/orc8r/gateway/c/common/config/ServiceConfigLoader.cpp
+++ b/orc8r/gateway/c/common/config/ServiceConfigLoader.cpp
@@ -23,7 +23,7 @@ namespace magma {
 
 YAML::Node ServiceConfigLoader::load_service_config(
     const std::string& service_name) {
-  auto file_path         = std::string(CONFIG_DIR) + service_name + ".yml";
+  auto file_path = std::string(CONFIG_DIR) + service_name + ".yml";
   YAML::Node base_config = YAML::LoadFile(file_path);
 
   // Try to override original file, if an override exists

--- a/orc8r/gateway/c/common/config/YAMLUtils.cpp
+++ b/orc8r/gateway/c/common/config/YAMLUtils.cpp
@@ -18,12 +18,10 @@
 
 namespace magma {
 
-static const YAML::Node& cnode(const YAML::Node& node) {
-  return node;
-}
+static const YAML::Node& cnode(const YAML::Node& node) { return node; }
 
-static void fill_in_new_fields(
-    const YAML::Node& override_node, YAML::Node* merged_map) {
+static void fill_in_new_fields(const YAML::Node& override_node,
+                               YAML::Node* merged_map) {
   for (auto new_node : override_node) {
     if (!new_node.first.IsScalar() ||
         !cnode(*merged_map)[new_node.first.Scalar()]) {
@@ -32,13 +30,13 @@ static void fill_in_new_fields(
   }
 }
 
-static YAML::Node merge_maps(
-    const YAML::Node& default_node, const YAML::Node& override_node) {
+static YAML::Node merge_maps(const YAML::Node& default_node,
+                             const YAML::Node& override_node) {
   auto merged_map = YAML::Node(YAML::NodeType::Map);
   for (auto base_child : default_node) {
     if (base_child.first.IsScalar()) {
       const std::string& key = base_child.first.Scalar();
-      auto override_child    = YAML::Node(cnode(override_node)[key]);
+      auto override_child = YAML::Node(cnode(override_node)[key]);
       if (override_child) {
         merged_map[base_child.first] =
             YAMLUtils::merge_nodes(base_child.second, override_child);
@@ -64,8 +62,8 @@ static YAML::Node merge_maps(
  * default_node
  * Otherwise, merge the two maps
  */
-YAML::Node YAMLUtils::merge_nodes(
-    const YAML::Node& default_node, const YAML::Node& override_node) {
+YAML::Node YAMLUtils::merge_nodes(const YAML::Node& default_node,
+                                  const YAML::Node& override_node) {
   if (!override_node.IsMap()) {
     return override_node.IsNull() ? default_node : override_node;
   }

--- a/orc8r/gateway/c/common/config/YAMLUtils.h
+++ b/orc8r/gateway/c/common/config/YAMLUtils.h
@@ -27,8 +27,8 @@ class YAMLUtils final {
    * override any parameters it defines, and keep any existing parameters in
    * default_node that it doesn't define
    */
-  static YAML::Node merge_nodes(
-      const YAML::Node& default_node, const YAML::Node& override_node);
+  static YAML::Node merge_nodes(const YAML::Node& default_node,
+                                const YAML::Node& override_node);
 };
 
 }  // namespace magma

--- a/orc8r/gateway/c/common/config/includes/MConfigLoader.h
+++ b/orc8r/gateway/c/common/config/includes/MConfigLoader.h
@@ -34,12 +34,12 @@ namespace magma {
  *          passed is not the right type
  */
 // TODO(#6151): migrate to an absl::Status return type.
-bool load_service_mconfig_from_file(
-    const std::string& service_name, google::protobuf::Message* message);
+bool load_service_mconfig_from_file(const std::string& service_name,
+                                    google::protobuf::Message* message);
 
-bool load_service_mconfig(
-    const std::string& service_name, std::istream* config_stream,
-    google::protobuf::Message* message);
+bool load_service_mconfig(const std::string& service_name,
+                          std::istream* config_stream,
+                          google::protobuf::Message* message);
 
 void get_mconfig_file(std::ifstream* file);
 }  // namespace magma

--- a/orc8r/gateway/c/common/config/includes/ServiceConfigLoader.h
+++ b/orc8r/gateway/c/common/config/includes/ServiceConfigLoader.h
@@ -32,7 +32,7 @@ class ServiceConfigLoader final {
   YAML::Node load_service_config(const std::string& service_name);
 
  private:
-  static constexpr const char* CONFIG_DIR   = "/etc/magma/";
+  static constexpr const char* CONFIG_DIR = "/etc/magma/";
   static constexpr const char* OVERRIDE_DIR = "/var/opt/magma/configs/";
 };
 

--- a/orc8r/gateway/c/common/config/test/test_mconfig_loader.cpp
+++ b/orc8r/gateway/c/common/config/test/test_mconfig_loader.cpp
@@ -71,15 +71,15 @@ TEST(MConfigLoader, HealthyConfigLoads) {
   EXPECT_TRUE(
       magma::load_service_mconfig(SERVICE_NAME_MME, &config_stream, &mconfig));
   EXPECT_EQ(mconfig.tac(), 1);
-  EXPECT_EQ(
-      mconfig.ipv6_p_cscf_address(), "2a12:577:9941:f99c:0002:0001:c731:f114");
+  EXPECT_EQ(mconfig.ipv6_p_cscf_address(),
+            "2a12:577:9941:f99c:0002:0001:c731:f114");
 }
 
 TEST(MConfigLoader, MissingServiceNameFails) {
   magma::mconfig::MME mconfig;
   std::istringstream config_stream(healthy_mconfig);
-  EXPECT_FALSE(magma::load_service_mconfig(
-      "MISSING_SERVICE_NAME", &config_stream, &mconfig));
+  EXPECT_FALSE(magma::load_service_mconfig("MISSING_SERVICE_NAME",
+                                           &config_stream, &mconfig));
 }
 
 }  // namespace

--- a/orc8r/gateway/c/common/config/test/test_yaml_utils.cpp
+++ b/orc8r/gateway/c/common/config/test/test_yaml_utils.cpp
@@ -22,11 +22,11 @@ namespace magma {
 
 TEST(test_simple_field_overrides, test_yaml_utils) {
   Node default_node;
-  default_node["foo"]     = "bar";
+  default_node["foo"] = "bar";
   default_node["default"] = "default";
 
   Node override_node;
-  override_node["foo"]      = "barbar";
+  override_node["foo"] = "barbar";
   override_node["override"] = "override";
 
   auto merge = YAMLUtils::merge_nodes(default_node, override_node);
@@ -47,17 +47,17 @@ TEST(test_nested_overrides, test_yaml_utils) {
   Node default_node;
   default_node["foo"] = "bar";
   Node nested_node;
-  nested_node["a"]     = "b";
-  nested_node["c"]     = "d";
+  nested_node["a"] = "b";
+  nested_node["c"] = "d";
   default_node["nest"] = nested_node;
 
   Node override_node;
   Node nest_override;
   Node new_nest;
-  nest_override["a"]    = "e";
-  new_nest["new_nest"]  = "other";
+  nest_override["a"] = "e";
+  new_nest["new_nest"] = "other";
   override_node["nest"] = nest_override;
-  override_node["foo"]  = new_nest;
+  override_node["foo"] = new_nest;
 
   auto merge = YAMLUtils::merge_nodes(default_node, override_node);
   EXPECT_TRUE(merge["foo"].IsMap());

--- a/orc8r/gateway/c/common/eventd/includes/EventdClient.h
+++ b/orc8r/gateway/c/common/eventd/includes/EventdClient.h
@@ -57,9 +57,8 @@ class AsyncEventdClient : public GRPCReceiver, public EventdClient {
 
   static AsyncEventdClient& getInstance();
 
-  void log_event(
-      const orc8r::Event& request,
-      std::function<void(Status status, orc8r::Void)> callback);
+  void log_event(const orc8r::Event& request,
+                 std::function<void(Status status, orc8r::Void)> callback);
 
  private:
   AsyncEventdClient();

--- a/orc8r/gateway/c/common/logging/magma_logging.h
+++ b/orc8r/gateway/c/common/logging/magma_logging.h
@@ -35,7 +35,7 @@
 struct _MLOG_NEWLINE {
   ~_MLOG_NEWLINE() { std::cout << std::endl; }
 };
-#define MLOG(VERBOSITY)                                                        \
+#define MLOG(VERBOSITY) \
   (_MLOG_NEWLINE(), std::cout << "[" << __FILE__ << ":" << __LINE__ << "] ")
 
 #endif

--- a/orc8r/gateway/c/common/logging/magma_logging_init.h
+++ b/orc8r/gateway/c/common/logging/magma_logging_init.h
@@ -31,7 +31,7 @@ static void set_verbosity(uint32_t verbosity) {
 
 // get_verbosity gets the the global logging verbosity
 static google::int32 get_verbosity() {
-  (void) get_verbosity;  // casting to void to suppress unused reference warning
+  (void)get_verbosity;  // casting to void to suppress unused reference warning
   return FLAGS_v;
 }
 
@@ -51,15 +51,15 @@ static void init_logging(const char* service_name) {
 
 namespace magma {
 static void set_verbosity(__attribute__((unused)) uint32_t verbosity) {
-  (void) set_verbosity;  // casting to void to suppress unused reference warning
+  (void)set_verbosity;  // casting to void to suppress unused reference warning
 }
 // get_verbosity gets the the global logging verbosity
 static uint32_t get_verbosity() {
-  (void) get_verbosity;  // casting to void to suppress unused reference warning
+  (void)get_verbosity;  // casting to void to suppress unused reference warning
   return 0;
 }
 static void init_logging(__attribute__((unused)) const char* service_name) {
-  (void) init_logging;  // casting to void to suppress unused reference warning
+  (void)init_logging;  // casting to void to suppress unused reference warning
 }
 
 }  // namespace magma

--- a/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
+++ b/orc8r/gateway/c/common/sentry/SentryWrapper.cpp
@@ -43,16 +43,16 @@
 
 using std::experimental::optional;
 
-bool should_upload_mme_log(
-    bool sentry_upload_mme_log, YAML::Node control_proxy_config) {
+bool should_upload_mme_log(bool sentry_upload_mme_log,
+                           YAML::Node control_proxy_config) {
   if (control_proxy_config[SHOULD_UPLOAD_MME_LOG].IsDefined()) {
     return control_proxy_config[SHOULD_UPLOAD_MME_LOG].as<bool>();
   }
   return sentry_upload_mme_log;
 }
 
-optional<std::string> get_sentry_url(
-    const char* sentry_url_native, YAML::Node control_proxy_config) {
+optional<std::string> get_sentry_url(const char* sentry_url_native,
+                                     YAML::Node control_proxy_config) {
   if (control_proxy_config[SENTRY_NATIVE_URL].IsDefined()) {
     const std::string dns_override =
         control_proxy_config[SENTRY_NATIVE_URL].as<std::string>();
@@ -78,8 +78,8 @@ optional<std::string> get_cloud_address(YAML::Node control_proxy_config) {
   return {};
 }
 
-float get_sentry_sample_rate(
-    float sentry_sample_rate, YAML::Node control_proxy_config) {
+float get_sentry_sample_rate(float sentry_sample_rate,
+                             YAML::Node control_proxy_config) {
   if (control_proxy_config[SENTRY_SAMPLE_RATE].IsDefined()) {
     const auto sample_rate_override =
         control_proxy_config[SENTRY_SAMPLE_RATE].as<float>();
@@ -100,8 +100,8 @@ std::string get_snowflake() {
   return buffer.str();
 }
 
-void initialize_sentry(
-    const char* service_tag, const sentry_config_t* sentry_config) {
+void initialize_sentry(const char* service_tag,
+                       const sentry_config_t* sentry_config) {
   auto control_proxy_config = magma::ServiceConfigLoader{}.load_service_config(
       CONTROL_PROXY_SERVICE_NAME);
   auto op_sentry_url =
@@ -119,8 +119,8 @@ void initialize_sentry(
     sentry_options_set_release(options, commit_hash_p);
   }
   if (strncmp(service_tag, SENTRY_TAG_MME, SENTRY_TAG_LEN) == 0 &&
-      should_upload_mme_log(
-          sentry_config->upload_mme_log, control_proxy_config)) {
+      should_upload_mme_log(sentry_config->upload_mme_log,
+                            control_proxy_config)) {
     sentry_options_add_attachment(options, MME_LOG_PATH);
   }
   if (sentry_config->add_debug_logging) {
@@ -144,13 +144,9 @@ void initialize_sentry(
   sentry_set_tag(HWID, get_snowflake().c_str());
 }
 
-void shutdown_sentry(void) {
-  sentry_shutdown();
-}
+void shutdown_sentry(void) { sentry_shutdown(); }
 
-void set_sentry_transaction(const char* name) {
-  sentry_set_transaction(name);
-}
+void set_sentry_transaction(const char* name) { sentry_set_transaction(name); }
 
 void sentry_log_error(const char* message) {
   sentry_value_t event =
@@ -161,9 +157,9 @@ void sentry_log_error(const char* message) {
 
 #else
 
-void initialize_sentry(
-    __attribute__((unused)) const char* service_tag,
-    __attribute__((unused)) const sentry_config_t* sentry_config) {}
+void initialize_sentry(__attribute__((unused)) const char* service_tag,
+                       __attribute__((unused))
+                       const sentry_config_t* sentry_config) {}
 
 void shutdown_sentry(void) {}
 

--- a/orc8r/gateway/c/common/sentry/includes/SentryWrapper.h
+++ b/orc8r/gateway/c/common/sentry/includes/SentryWrapper.h
@@ -39,8 +39,8 @@ typedef struct sentry_config {
  * @brief Initialize sentry if SENTRY_ENABLED flag is set and project slug is
  * configured in control_proxy.yml
  */
-void initialize_sentry(
-    const char* service_tag, const sentry_config_t* sentry_config);
+void initialize_sentry(const char* service_tag,
+                       const sentry_config_t* sentry_config);
 
 /**
  * @brief Shutdown sentry if SENTRY_ENABLED flag is set

--- a/orc8r/gateway/c/common/service303/MagmaService.cpp
+++ b/orc8r/gateway/c/common/service303/MagmaService.cpp
@@ -88,9 +88,7 @@ void MagmaService::WaitForShutdown() {
   server_->Wait();  // Blocking call
 }
 
-void MagmaService::Stop() {
-  server_->Shutdown();
-}
+void MagmaService::Stop() { server_->Shutdown(); }
 
 void MagmaService::SetServiceInfoCallback(ServiceInfoCallback callback) {
   service_info_callback_ = callback;
@@ -117,15 +115,16 @@ void MagmaService::ClearOperationalStatesCallback() {
   operational_states_callback_ = nullptr;
 }
 
-Status MagmaService::GetServiceInfo(
-    __attribute__((unused)) ServerContext* context,
-    __attribute__((unused)) const Void* request, ServiceInfo* response) {
+Status MagmaService::GetServiceInfo(__attribute__((unused))
+                                    ServerContext* context,
+                                    __attribute__((unused)) const Void* request,
+                                    ServiceInfo* response) {
   auto start_time_secs =
       time_point_cast<seconds>(wall_start_time_).time_since_epoch().count();
 
-  auto meta = (service_info_callback_ != nullptr) ?
-                  service_info_callback_() :
-                  std::map<std::string, std::string>();
+  auto meta = (service_info_callback_ != nullptr)
+                  ? service_info_callback_()
+                  : std::map<std::string, std::string>();
 
   response->set_name(name_);
   response->set_version(version_);
@@ -137,21 +136,20 @@ Status MagmaService::GetServiceInfo(
   return Status::OK;
 }
 
-Status MagmaService::StopService(
-    __attribute__((unused)) ServerContext* context,
-    __attribute__((unused)) const Void* request,
-    __attribute__((unused)) Void* response) {
+Status MagmaService::StopService(__attribute__((unused)) ServerContext* context,
+                                 __attribute__((unused)) const Void* request,
+                                 __attribute__((unused)) Void* response) {
   std::raise(SIGTERM);
   return Status::OK;
 }
 
-Status MagmaService::GetMetrics(
-    __attribute__((unused)) ServerContext* context,
-    __attribute__((unused)) const Void* request, MetricsContainer* response) {
+Status MagmaService::GetMetrics(__attribute__((unused)) ServerContext* context,
+                                __attribute__((unused)) const Void* request,
+                                MetricsContainer* response) {
   // Set all common metrics
   setSharedMetrics();
 
-  MetricsSingleton& instance                 = MetricsSingleton::Instance();
+  MetricsSingleton& instance = MetricsSingleton::Instance();
   const std::vector<MetricFamily>& collected = instance.registry_->Collect();
   for (auto it = collected.begin(); it != collected.end(); it++) {
     MetricFamily* family = response->add_family();
@@ -160,19 +158,20 @@ Status MagmaService::GetMetrics(
   return Status::OK;
 }
 
-Status MagmaService::SetLogLevel(
-    __attribute__((unused)) ServerContext* context,
-    const LogLevelMessage* request, __attribute__((unused)) Void* response) {
+Status MagmaService::SetLogLevel(__attribute__((unused)) ServerContext* context,
+                                 const LogLevelMessage* request,
+                                 __attribute__((unused)) Void* response) {
   // log level FATAL is minimum verbosity and maximum level
   auto verbosity = LogLevel::FATAL - request->level();
   set_verbosity(verbosity);
   return Status::OK;
 }
 
-Status MagmaService::ReloadServiceConfig(
-    __attribute__((unused)) ServerContext* context,
-    __attribute__((unused)) const Void* request,
-    ReloadConfigResponse* response) {
+Status MagmaService::ReloadServiceConfig(__attribute__((unused))
+                                         ServerContext* context,
+                                         __attribute__((unused))
+                                         const Void* request,
+                                         ReloadConfigResponse* response) {
   if (config_reload_callback_ != nullptr) {
     if (config_reload_callback_()) {
       response->set_result(ReloadConfigResponse::RELOAD_SUCCESS);
@@ -190,9 +189,9 @@ Status MagmaService::GetOperationalStates(
     __attribute__((unused)) ServerContext* context,
     __attribute__((unused)) const Void* request,
     GetOperationalStatesResponse* response) {
-  auto op_states = (operational_states_callback_ != nullptr) ?
-                       operational_states_callback_() :
-                       std::list<std::map<std::string, std::string>>();
+  auto op_states = (operational_states_callback_ != nullptr)
+                       ? operational_states_callback_()
+                       : std::list<std::map<std::string, std::string>>();
 
   for (auto op_state : op_states) {
     State* state = response->add_states();
@@ -218,8 +217,8 @@ void MagmaService::setApplicationHealth(
 void MagmaService::setMetricsStartTime() {
   va_list ap;
   // Use standard time to get start time
-  MetricsSingleton::Instance().SetGauge(
-      "process_start_time_seconds", (double) std::time(nullptr), 0, ap);
+  MetricsSingleton::Instance().SetGauge("process_start_time_seconds",
+                                        (double)std::time(nullptr), 0, ap);
 }
 
 void MagmaService::setMetricsUptime() {
@@ -229,15 +228,15 @@ void MagmaService::setMetricsUptime() {
   duration<double> time_span =
       duration_cast<duration<double>>(t2 - start_time_);
   double uptime = time_span.count();
-  MetricsSingleton::Instance().SetGauge(
-      "process_cpu_seconds_total", uptime, 0, ap);
+  MetricsSingleton::Instance().SetGauge("process_cpu_seconds_total", uptime, 0,
+                                        ap);
 }
 
 void MagmaService::setMemoryUsage() {
   va_list ap;
   const ProcFileUtils::memory_info_t mem_info = ProcFileUtils::getMemoryInfo();
-  MetricsSingleton::Instance().SetGauge(
-      "process_virtual_memory_bytes", mem_info.virtual_mem, 0, ap);
-  MetricsSingleton::Instance().SetGauge(
-      "process_resident_memory_bytes", mem_info.physical_mem, 0, ap);
+  MetricsSingleton::Instance().SetGauge("process_virtual_memory_bytes",
+                                        mem_info.virtual_mem, 0, ap);
+  MetricsSingleton::Instance().SetGauge("process_resident_memory_bytes",
+                                        mem_info.physical_mem, 0, ap);
 }

--- a/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
@@ -24,8 +24,8 @@ void remove_counter(const char* name, size_t n_labels, ...) {
   va_end(ap);
 }
 
-void increment_counter(
-    const char* name, double increment, size_t n_labels, ...) {
+void increment_counter(const char* name, double increment, size_t n_labels,
+                       ...) {
   va_list ap;
   va_start(ap, n_labels);
   MetricsSingleton::Instance().IncrementCounter(name, increment, n_labels, ap);
@@ -67,11 +67,11 @@ void set_gauge(const char* name, double value, size_t n_labels, ...) {
   va_end(ap);
 }
 
-void observe_histogram(
-    const char* name, double observation, size_t n_labels, ...) {
+void observe_histogram(const char* name, double observation, size_t n_labels,
+                       ...) {
   va_list ap;
   va_start(ap, n_labels);
-  MetricsSingleton::Instance().ObserveHistogram(
-      name, observation, n_labels, ap);
+  MetricsSingleton::Instance().ObserveHistogram(name, observation, n_labels,
+                                                ap);
   va_end(ap);
 }

--- a/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
@@ -52,65 +52,64 @@ MetricsSingleton::MetricsSingleton()
       gauges_(registry_, BuildGauge),
       histograms_(registry_, BuildHistogram) {}
 
-void MetricsSingleton::args_to_map(
-    std::map<std::string, std::string>& labels, size_t label_count,
-    va_list& args) {
+void MetricsSingleton::args_to_map(std::map<std::string, std::string>& labels,
+                                   size_t label_count, va_list& args) {
   for (size_t i = 0; i < label_count; i++) {
     labels.insert({{va_arg(args, const char*), va_arg(args, const char*)}});
   }
 }
 
-void MetricsSingleton::RemoveCounter(
-    const char* name, size_t label_count, va_list& args) {
+void MetricsSingleton::RemoveCounter(const char* name, size_t label_count,
+                                     va_list& args) {
   std::map<std::string, std::string> labels;
   args_to_map(labels, label_count, args);
   counters_.Remove(name, labels);
 }
 
-void MetricsSingleton::IncrementCounter(
-    const char* name, double increment, size_t label_count, va_list& args) {
+void MetricsSingleton::IncrementCounter(const char* name, double increment,
+                                        size_t label_count, va_list& args) {
   std::map<std::string, std::string> labels;
   args_to_map(labels, label_count, args);
   counters_.Get(name, labels).Increment(increment);
 }
 
-void MetricsSingleton::RemoveGauge(
-    const char* name, size_t label_count, va_list& args) {
+void MetricsSingleton::RemoveGauge(const char* name, size_t label_count,
+                                   va_list& args) {
   std::map<std::string, std::string> labels;
   args_to_map(labels, label_count, args);
   gauges_.Remove(name, labels);
 }
 
-void MetricsSingleton::IncrementGauge(
-    const char* name, double increment, size_t label_count, va_list& args) {
+void MetricsSingleton::IncrementGauge(const char* name, double increment,
+                                      size_t label_count, va_list& args) {
   std::map<std::string, std::string> labels;
   args_to_map(labels, label_count, args);
   gauges_.Get(name, labels).Increment(increment);
 }
 
-void MetricsSingleton::DecrementGauge(
-    const char* name, double decrement, size_t label_count, va_list& args) {
+void MetricsSingleton::DecrementGauge(const char* name, double decrement,
+                                      size_t label_count, va_list& args) {
   std::map<std::string, std::string> labels;
   args_to_map(labels, label_count, args);
   gauges_.Get(name, labels).Decrement(decrement);
 }
 
-void MetricsSingleton::SetGauge(
-    const char* name, double value, size_t label_count, va_list& args) {
+void MetricsSingleton::SetGauge(const char* name, double value,
+                                size_t label_count, va_list& args) {
   std::map<std::string, std::string> labels;
   args_to_map(labels, label_count, args);
   gauges_.Get(name, labels).Set(value);
 }
 
-double MetricsSingleton::GetGauge(
-    const char* name, size_t label_count, va_list& args) {
+double MetricsSingleton::GetGauge(const char* name, size_t label_count,
+                                  va_list& args) {
   std::map<std::string, std::string> labels;
   args_to_map(labels, label_count, args);
   return gauges_.Get(name, labels).Value();
 }
 
-void MetricsSingleton::ObserveHistogram(
-    const char* name, double observation, size_t label_count, va_list& args) {
+void MetricsSingleton::ObserveHistogram(const char* name, double observation,
+                                        size_t label_count, va_list& args) {
   std::map<std::string, std::string> labels;
   args_to_map(labels, label_count, args);
 

--- a/orc8r/gateway/c/common/service303/ProcFileUtils.cpp
+++ b/orc8r/gateway/c/common/service303/ProcFileUtils.cpp
@@ -19,13 +19,13 @@
 namespace magma {
 namespace service303 {
 
-const std::string ProcFileUtils::STATUS_FILE         = "/proc/self/status";
-const std::string ProcFileUtils::VIRTUAL_MEM_PREFIX  = "VmSize:";
+const std::string ProcFileUtils::STATUS_FILE = "/proc/self/status";
+const std::string ProcFileUtils::VIRTUAL_MEM_PREFIX = "VmSize:";
 const std::string ProcFileUtils::PHYSICAL_MEM_PREFIX = "VmRSS:";
 
-double ProcFileUtils::parseForPrefix(
-    std::ifstream& infile, const std::string& to_compare,
-    const std::string& prefix_name) {
+double ProcFileUtils::parseForPrefix(std::ifstream& infile,
+                                     const std::string& to_compare,
+                                     const std::string& prefix_name) {
   if (to_compare.compare(prefix_name) == 0) {
     std::string value_string;
     infile >> value_string;
@@ -43,14 +43,14 @@ const ProcFileUtils::memory_info_t ProcFileUtils::getMemoryInfo() {
   while (infile >> content) {
     double value;
     // look for and set virtual_mem
-    value = ProcFileUtils::parseForPrefix(
-        infile, content, ProcFileUtils::VIRTUAL_MEM_PREFIX);
+    value = ProcFileUtils::parseForPrefix(infile, content,
+                                          ProcFileUtils::VIRTUAL_MEM_PREFIX);
     if (value >= 0) {
       info.virtual_mem = value;
     }
     // look for and set physical_mem
-    value = ProcFileUtils::parseForPrefix(
-        infile, content, ProcFileUtils::PHYSICAL_MEM_PREFIX);
+    value = ProcFileUtils::parseForPrefix(infile, content,
+                                          ProcFileUtils::PHYSICAL_MEM_PREFIX);
     if (value >= 0) {
       info.physical_mem = value;
     }

--- a/orc8r/gateway/c/common/service303/ProcFileUtils.h
+++ b/orc8r/gateway/c/common/service303/ProcFileUtils.h
@@ -28,7 +28,7 @@ class ProcFileUtils final {
    */
   typedef struct memory_info_s {
     double physical_mem = -1;
-    double virtual_mem  = -1;
+    double virtual_mem = -1;
   } memory_info_t;
 
  public:
@@ -47,9 +47,9 @@ class ProcFileUtils final {
    * @return -1 if the string isn't the prefix we're looking for, otherwise
    *    return the actual value
    */
-  static double parseForPrefix(
-      std::ifstream& infile, const std::string& to_compare,
-      const std::string& prefix_name);
+  static double parseForPrefix(std::ifstream& infile,
+                               const std::string& to_compare,
+                               const std::string& prefix_name);
 
  private:
   static const std::string STATUS_FILE;

--- a/orc8r/gateway/c/common/service303/includes/MagmaService.h
+++ b/orc8r/gateway/c/common/service303/includes/MagmaService.h
@@ -58,10 +58,10 @@ using magma::service303::MetricsSingleton;
 namespace magma {
 namespace service303 {
 
-using ServiceInfoMeta           = std::map<std::string, std::string>;
-using States                    = std::list<std::map<std::string, std::string>>;
-using ServiceInfoCallback       = std::function<ServiceInfoMeta()>;
-using ConfigReloadCallback      = std::function<bool()>;
+using ServiceInfoMeta = std::map<std::string, std::string>;
+using States = std::list<std::map<std::string, std::string>>;
+using ServiceInfoCallback = std::function<ServiceInfoMeta()>;
+using ConfigReloadCallback = std::function<bool()>;
 using OperationalStatesCallback = std::function<States()>;
 
 /**
@@ -138,9 +138,8 @@ class MagmaService final : public Service303::Service {
    * @param response (out): the ServiceInfo response
    * @return grpc Status instance
    */
-  Status GetServiceInfo(
-      ServerContext* context, const Void* request,
-      ServiceInfo* response) override;
+  Status GetServiceInfo(ServerContext* context, const Void* request,
+                        ServiceInfo* response) override;
 
   /*
    * Handles request to stop the service
@@ -150,8 +149,8 @@ class MagmaService final : public Service303::Service {
    * @param response (out): void response param
    * @return grpc Status instance
    */
-  Status StopService(
-      ServerContext* context, const Void* request, Void* response) override;
+  Status StopService(ServerContext* context, const Void* request,
+                     Void* response) override;
 
   /*
    * Collects timeseries samples from prometheus client interface on this
@@ -162,9 +161,8 @@ class MagmaService final : public Service303::Service {
    * @param response (out): container of all collected metrics
    * @return grpc Status instance
    */
-  Status GetMetrics(
-      ServerContext* context, const Void* request,
-      MetricsContainer* response) override;
+  Status GetMetrics(ServerContext* context, const Void* request,
+                    MetricsContainer* response) override;
 
   /*
    * Sets the log verbosity to print to syslog at runtime
@@ -174,9 +172,8 @@ class MagmaService final : public Service303::Service {
    * @param response (out): Void
    * @return grpc Status instance
    */
-  Status SetLogLevel(
-      ServerContext* context, const LogLevelMessage* request,
-      Void* response) override;
+  Status SetLogLevel(ServerContext* context, const LogLevelMessage* request,
+                     Void* response) override;
 
   /*
    * Handles request to reload the service config file
@@ -186,9 +183,8 @@ class MagmaService final : public Service303::Service {
    * @param response (out): reload config result (SUCCESS/FAILURE/UNSUPPORTED)
    * @return grpc Status instance
    */
-  Status ReloadServiceConfig(
-      ServerContext* context, const Void* request,
-      ReloadConfigResponse* response) override;
+  Status ReloadServiceConfig(ServerContext* context, const Void* request,
+                             ReloadConfigResponse* response) override;
 
   /*
    * Returns the  operational states of devices managed by this service.
@@ -198,9 +194,8 @@ class MagmaService final : public Service303::Service {
    * @param response (out): a list of states
    * @return grpc Status instance
    */
-  Status GetOperationalStates(
-      ServerContext* context, const Void* request,
-      GetOperationalStatesResponse* response) override;
+  Status GetOperationalStates(ServerContext* context, const Void* request,
+                              GetOperationalStatesResponse* response) override;
 
   /*
    * Simple setter function to set the new application health

--- a/orc8r/gateway/c/common/service303/includes/MetricsHelpers.h
+++ b/orc8r/gateway/c/common/service303/includes/MetricsHelpers.h
@@ -34,8 +34,8 @@ void remove_counter(const char* name, size_t n_labels, ...);
  * @param n_labels number of labels
  * @param ... label args (name, value)
  */
-void increment_counter(
-    const char* name, double increment, size_t n_labels, ...);
+void increment_counter(const char* name, double increment, size_t n_labels,
+                       ...);
 
 /**
  * Remove the gauge metric that matches name+labels given
@@ -87,8 +87,8 @@ double get_gauge(const char* name, size_t n_labels, ...);
  * @param n_labels number of labels
  * @param ... label args (name, value)
  */
-void observe_histogram(
-    const char* name, double observation, size_t n_labels, ...);
+void observe_histogram(const char* name, double observation, size_t n_labels,
+                       ...);
 
 #ifdef __cplusplus
 }

--- a/orc8r/gateway/c/common/service303/includes/MetricsRegistry.h
+++ b/orc8r/gateway/c/common/service303/includes/MetricsRegistry.h
@@ -29,7 +29,7 @@
 
 namespace prometheus {
 class Registry;
-template<typename T>
+template <typename T>
 class Family;
 }  // namespace prometheus
 
@@ -45,12 +45,11 @@ using namespace orc8r;
  * constuct a single instance of a metric family per name and a single
  * instance for each label set in that family.
  */
-template<typename T, typename MetricFamilyFactory>
+template <typename T, typename MetricFamilyFactory>
 class MetricsRegistry {
  public:
-  MetricsRegistry(
-      const std::shared_ptr<prometheus::Registry>& registry,
-      const MetricFamilyFactory& factory);
+  MetricsRegistry(const std::shared_ptr<prometheus::Registry>& registry,
+                  const MetricFamilyFactory& factory);
 
   /**
    * Get or create a metric instance matching this name and label set
@@ -60,19 +59,17 @@ class MetricsRegistry {
    * @param args...: other arguments the Metric constructor may need
    * @return prometheus T instance
    */
-  template<typename... Args>
-  T& Get(
-      const std::string& name, const std::map<std::string, std::string>& labels,
-      Args&&... args);
+  template <typename... Args>
+  T& Get(const std::string& name,
+         const std::map<std::string, std::string>& labels, Args&&... args);
 
   /**
    * Remove a metric instance specified by name/labels
    * @param name
    * @param labels
    */
-  void Remove(
-      const std::string& name,
-      const std::map<std::string, std::string>& labels);
+  void Remove(const std::string& name,
+              const std::map<std::string, std::string>& labels);
 
   const std::size_t SizeFamilies() { return families_.size(); }
 
@@ -83,30 +80,29 @@ class MetricsRegistry {
       const std::string& name,
       const std::map<std::string, std::string>& labels);
   // Convert labels to enums if applicable
-  static void parse_labels(
-      const std::map<std::string, std::string>& labels,
-      std::map<std::string, std::string>& parsed_labels);
+  static void parse_labels(const std::map<std::string, std::string>& labels,
+                           std::map<std::string, std::string>& parsed_labels);
   std::unordered_map<std::size_t, Family<T>*> families_;
   std::unordered_map<std::size_t, T*> metrics_;
   const std::shared_ptr<prometheus::Registry>& registry_;
   const MetricFamilyFactory& factory_;
 };
 
-template<typename T, typename MetricFamilyFactory>
+template <typename T, typename MetricFamilyFactory>
 MetricsRegistry<T, MetricFamilyFactory>::MetricsRegistry(
     const std::shared_ptr<prometheus::Registry>& registry,
     const MetricFamilyFactory& factory)
     : registry_(registry), factory_(factory) {}
 
-template<typename T, typename MetricFamilyFactory>
-template<typename... Args>
+template <typename T, typename MetricFamilyFactory>
+template <typename... Args>
 T& MetricsRegistry<T, MetricFamilyFactory>::Get(
     const std::string& name, const std::map<std::string, std::string>& labels,
     Args&&... args) {
   // Create the family if we haven't seen it before
   Family<T>* family;
   size_t name_hash = std::hash<std::string>{}(name);
-  auto family_it   = families_.find(name_hash);
+  auto family_it = families_.find(name_hash);
   if (family_it != families_.end()) {
     family = family_it->second;
   } else {
@@ -122,7 +118,7 @@ T& MetricsRegistry<T, MetricFamilyFactory>::Get(
   // Create the metric if we haven't seen it before
   T* metric;
   size_t metric_hash = hash_name_and_labels(name, labels);
-  auto metric_it     = metrics_.find(metric_hash);
+  auto metric_it = metrics_.find(metric_hash);
   if (metric_it != metrics_.end()) {
     metric = metric_it->second;
   } else {
@@ -134,12 +130,12 @@ T& MetricsRegistry<T, MetricFamilyFactory>::Get(
   return *metric;
 }
 
-template<typename T, typename MetricFamilyFactory>
+template <typename T, typename MetricFamilyFactory>
 void MetricsRegistry<T, MetricFamilyFactory>::Remove(
     const std::string& name, const std::map<std::string, std::string>& labels) {
   Family<T>* family;
   size_t name_hash = std::hash<std::string>{}(name);
-  auto family_it   = families_.find(name_hash);
+  auto family_it = families_.find(name_hash);
   if (family_it == families_.end()) {
     return;
   }
@@ -147,7 +143,7 @@ void MetricsRegistry<T, MetricFamilyFactory>::Remove(
 
   T* metric;
   size_t metric_hash = hash_name_and_labels(name, labels);
-  auto metric_it     = metrics_.find(metric_hash);
+  auto metric_it = metrics_.find(metric_hash);
   if (metric_it == metrics_.end()) {
     return;
   }
@@ -156,7 +152,7 @@ void MetricsRegistry<T, MetricFamilyFactory>::Remove(
   metrics_.erase(metric_hash);
 }
 
-template<typename T, typename MetricFamilyFactory>
+template <typename T, typename MetricFamilyFactory>
 std::size_t MetricsRegistry<T, MetricFamilyFactory>::hash_name_and_labels(
     const std::string& name, const std::map<std::string, std::string>& labels) {
   auto combined = std::accumulate(
@@ -168,7 +164,7 @@ std::size_t MetricsRegistry<T, MetricFamilyFactory>::hash_name_and_labels(
   return std::hash<std::string>{}(combined);
 }
 
-template<typename T, typename MetricFamilyFactory>
+template <typename T, typename MetricFamilyFactory>
 void MetricsRegistry<T, MetricFamilyFactory>::parse_labels(
     const std::map<std::string, std::string>& labels,
     std::map<std::string, std::string>& parsed_labels) {
@@ -176,9 +172,9 @@ void MetricsRegistry<T, MetricFamilyFactory>::parse_labels(
     // convert label name
     MetricLabelName label_name_enum;
     const std::string& label_name =
-        MetricLabelName_Parse(label_pair.first, &label_name_enum) ?
-            std::to_string(label_name_enum) :
-            label_pair.first;
+        MetricLabelName_Parse(label_pair.first, &label_name_enum)
+            ? std::to_string(label_name_enum)
+            : label_pair.first;
     // insert into new map
     parsed_labels.insert({{label_name, label_pair.second}});
   }

--- a/orc8r/gateway/c/common/service303/includes/MetricsSingleton.h
+++ b/orc8r/gateway/c/common/service303/includes/MetricsSingleton.h
@@ -92,26 +92,26 @@ class MetricsSingleton {
   static MetricsSingleton& Instance();
   static void flush();  // destroy instance
   void RemoveCounter(const char* name, size_t label_count, va_list& args);
-  void IncrementCounter(
-      const char* name, double increment, size_t label_count, va_list& args);
+  void IncrementCounter(const char* name, double increment, size_t label_count,
+                        va_list& args);
   void RemoveGauge(const char* name, size_t label_count, va_list& args);
-  void IncrementGauge(
-      const char* name, double increment, size_t label_count, va_list& args);
-  void DecrementGauge(
-      const char* name, double decrement, size_t label_count, va_list& args);
-  void SetGauge(
-      const char* name, double value, size_t label_count, va_list& args);
-  void ObserveHistogram(
-      const char* name, double observation, size_t label_count, va_list& args);
+  void IncrementGauge(const char* name, double increment, size_t label_count,
+                      va_list& args);
+  void DecrementGauge(const char* name, double decrement, size_t label_count,
+                      va_list& args);
+  void SetGauge(const char* name, double value, size_t label_count,
+                va_list& args);
+  void ObserveHistogram(const char* name, double observation,
+                        size_t label_count, va_list& args);
   double GetGauge(const char* name, size_t label_count, va_list& args);
 
  private:
   MetricsSingleton();                         // Prevent construction
   MetricsSingleton(const MetricsSingleton&);  // Prevent construction by copying
   MetricsSingleton& operator=(const MetricsSingleton&);  // Prevent assignment
-  void args_to_map(
-      std::map<std::string, std::string>& labels, size_t label_count,
-      va_list& args);  // Helper to convert variadic labels to map
+  void args_to_map(std::map<std::string, std::string>& labels,
+                   size_t label_count,
+                   va_list& args);  // Helper to convert variadic labels to map
   // Shared registry to store all our metrics
   std::shared_ptr<prometheus::Registry> registry_;
   // Dictionaries to store instances of our metrics and intialize new ones

--- a/orc8r/gateway/c/common/service303/test/test_magma_service.cpp
+++ b/orc8r/gateway/c/common/service303/test/test_magma_service.cpp
@@ -19,10 +19,10 @@ using ::testing::Test;
 namespace magma {
 namespace service303 {
 
-const std::string SERVICE_NAME    = "test_service";
+const std::string SERVICE_NAME = "test_service";
 const std::string SERVICE_VERSION = "0.0.0";
-const std::string META_KEY        = "key";
-const std::string META_VALUE      = "value";
+const std::string META_KEY = "key";
+const std::string META_VALUE = "value";
 
 TEST(test_magma_service, test_GetServiceInfo) {
   MagmaService magma_service(SERVICE_NAME, SERVICE_VERSION);
@@ -77,13 +77,9 @@ TEST(test_magma_service, test_GetServiceInfo_with_callback) {
   EXPECT_TRUE(response.status().meta().empty());
 }
 
-bool reload_succeeded() {
-  return true;
-}
+bool reload_succeeded() { return true; }
 
-bool reload_failed() {
-  return false;
-}
+bool reload_failed() { return false; }
 
 TEST(test_magma_service, test_ReloadServiceConfig) {
   MagmaService magma_service(SERVICE_NAME, SERVICE_VERSION);

--- a/orc8r/gateway/c/common/service303/test/test_service303.cpp
+++ b/orc8r/gateway/c/common/service303/test/test_service303.cpp
@@ -102,8 +102,8 @@ class Service303Test : public ::testing::Test {
     delete service303_client;
   }
 
-  static const MetricFamily& findFamily(
-      const MetricsContainer& container, const std::string& match) {
+  static const MetricFamily& findFamily(const MetricsContainer& container,
+                                        const std::string& match) {
     for (auto const& fam : container.family()) {
       if (fam.name().compare(match) == 0) {
         return fam;
@@ -112,15 +112,15 @@ class Service303Test : public ::testing::Test {
     assert(false);
   }
 
-  static const double findGauge(
-      const MetricsContainer& container, const std::string& match) {
+  static const double findGauge(const MetricsContainer& container,
+                                const std::string& match) {
     const MetricFamily& fam = findFamily(container, match);
     return fam.metric().Get(0).gauge().value();
   }
 
  protected:
   const std::string service_name = "test_service";
-  const std::string version      = "magma@1.2.3";
+  const std::string version = "magma@1.2.3";
   std::thread magma_server_thread;
   std::shared_ptr<MagmaService> magma_service = nullptr;
   Service303Client* service303_client;
@@ -133,7 +133,7 @@ class Service303Test : public ::testing::Test {
         magma::ServiceRegistrySingleton::Instance()->GetServiceAddrString(
             service_name);
     const std::shared_ptr<Channel> channel = CreateChannel(service_addr, cred);
-    service303_client                      = new Service303Client(channel);
+    service303_client = new Service303Client(channel);
   }
 };
 
@@ -213,9 +213,8 @@ TEST_F(Service303Test, test_histograms) {
   EXPECT_EQ(histogram->sample_sum(), 3);
   EXPECT_EQ(histogram->bucket().size(), 1);
   EXPECT_EQ(histogram->bucket().Get(0).cumulative_count(), 1);
-  EXPECT_EQ(
-      histogram->bucket().Get(0).upper_bound(),
-      std::numeric_limits<double>::infinity());
+  EXPECT_EQ(histogram->bucket().Get(0).upper_bound(),
+            std::numeric_limits<double>::infinity());
 
   // Adding another observation with buckets won't add another metric or
   // more buckets but it will add another observation to the metric
@@ -229,9 +228,8 @@ TEST_F(Service303Test, test_histograms) {
   EXPECT_EQ(histogram->sample_sum(), 10);
   EXPECT_EQ(histogram->bucket().size(), 1);
   EXPECT_EQ(histogram->bucket().Get(0).cumulative_count(), 2);
-  EXPECT_EQ(
-      histogram->bucket().Get(0).upper_bound(),
-      std::numeric_limits<double>::infinity());
+  EXPECT_EQ(histogram->bucket().Get(0).upper_bound(),
+            std::numeric_limits<double>::infinity());
 
   // Since we define a new metric using labels, it should construct with the
   // boundary definitions
@@ -251,9 +249,8 @@ TEST_F(Service303Test, test_histograms) {
   EXPECT_EQ(histogram->bucket().Get(2).cumulative_count(), 1);
   EXPECT_EQ(histogram->bucket().Get(2).upper_bound(), 100);
   EXPECT_EQ(histogram->bucket().Get(3).cumulative_count(), 0);
-  EXPECT_EQ(
-      histogram->bucket().Get(3).upper_bound(),
-      std::numeric_limits<double>::infinity());
+  EXPECT_EQ(histogram->bucket().Get(3).upper_bound(),
+            std::numeric_limits<double>::infinity());
 }
 
 TEST_F(Service303Test, test_timing_metrics) {
@@ -301,8 +298,8 @@ TEST_F(Service303Test, test_memory_metrics) {
 TEST_F(Service303Test, test_enum_conversions) {
   // enum values (from metricsd.proto):
   // s1_setup => 500, result => 0
-  increment_counter(
-      "mme_new_association", 3, 2, "result", "success", "gateway", "1234");
+  increment_counter("mme_new_association", 3, 2, "result", "success", "gateway",
+                    "1234");
 
   MetricsContainer metrics_container;
   EXPECT_EQ(0, service303_client->GetMetrics(&metrics_container));

--- a/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.cpp
+++ b/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.cpp
@@ -65,13 +65,13 @@ ServiceRegistrySingleton::ServiceRegistrySingleton() {
 ip_port_pair_t ServiceRegistrySingleton::GetServiceAddr(
     const std::string& service) {
   YAML::Node registry = *(this->registry_);
-  YAML::Node node     = registry["services"];
+  YAML::Node node = registry["services"];
   assert(node.IsMap());
   if (node[service]) {
     YAML::Node serviceNode = node[service];
     assert(serviceNode.IsMap());
     ip_port_pair_t ip_port_pair;
-    ip_port_pair.ip   = serviceNode["ip_address"].as<std::string>();
+    ip_port_pair.ip = serviceNode["ip_address"].as<std::string>();
     ip_port_pair.port = serviceNode["port"].as<std::string>();
     return ip_port_pair;
   } else {
@@ -131,16 +131,16 @@ ServiceRegistrySingleton::GetCreateGrpcChannelArgs(
   if (destination.compare(ServiceRegistrySingleton::LOCAL) == 0) {
     // connect to local service
     ip_port_pair_t pair = ServiceRegistrySingleton::GetServiceAddr(service);
-    args.ip             = pair.ip;
-    args.port           = pair.port;
+    args.ip = pair.ip;
+    args.port = pair.port;
   } else if (proxyConfig["proxy_cloud_connections"].as<bool>()) {
     // connect to the cloud via local control proxy
-    args.ip   = "127.0.0.1";
+    args.ip = "127.0.0.1";
     args.port = proxyConfig["local_port"].as<std::string>();
   } else {
     // connect to the cloud directly
-    args.ip    = cloud_address;
-    args.port  = proxyConfig["cloud_port"].as<std::string>();
+    args.ip = cloud_address;
+    args.port = proxyConfig["cloud_port"].as<std::string>();
     args.creds = GetSslCredentials();
   }
 
@@ -165,9 +165,9 @@ const std::shared_ptr<Channel> ServiceRegistrySingleton::CreateGrpcChannel(
 const std::shared_ptr<Channel>
 ServiceRegistrySingleton::GetBootstrapperGrpcChannel() {
   YAML::Node proxyConfig = *(this->proxy_config_);
-  auto ip                = proxyConfig["bootstrap_address"].as<std::string>();
-  auto port              = proxyConfig["bootstrap_port"].as<std::string>();
-  auto authority         = ip;
+  auto ip = proxyConfig["bootstrap_address"].as<std::string>();
+  auto port = proxyConfig["bootstrap_port"].as<std::string>();
+  auto authority = ip;
 
   SslCredentialsOptions options;
   options.pem_root_certs =

--- a/orc8r/gateway/c/common/service_registry/includes/ServiceRegistrySingleton.h
+++ b/orc8r/gateway/c/common/service_registry/includes/ServiceRegistrySingleton.h
@@ -48,8 +48,8 @@ typedef struct {
  */
 class ServiceRegistrySingleton {
  public:
-  static constexpr char* CLOUD = (char*) "cloud";
-  static constexpr char* LOCAL = (char*) "local";
+  static constexpr char* CLOUD = (char*)"cloud";
+  static constexpr char* LOCAL = (char*)"local";
 
  public:
   static ServiceRegistrySingleton* Instance();
@@ -95,8 +95,8 @@ class ServiceRegistrySingleton {
    * @return grpc::Channel to the given service. If a connection to cloud
    * service is requested, a connection to the control_proxy will be returned.
    */
-  const std::shared_ptr<Channel> GetGrpcChannel(
-      const std::string& service, const std::string& destination);
+  const std::shared_ptr<Channel> GetGrpcChannel(const std::string& service,
+                                                const std::string& destination);
 
   /*
    * Returns a grpc connection to the bootstrapper service


### PR DESCRIPTION
Work to accomplish #6187.  This will be applied on a per-directory basis, with the `oai/mme` sub-directory reserved for reformatting until last (after community notification in ~early January).  This PR atomically does the following:

- Re-formats all of `/orc8r/gateway/` with `clang-format-11` and `Google` style
- Updates GH Workflow for CI to match this migration
- Updates the `lte/gateway/Makefile` target for `format_all` to support this migration

Should outstanding PRs have issues with the new CI phase / rebasing on this PR, it is advised they re-format their modified files (from within either the Magma Developer VM or the Devcontainer) with:

```bash
/usr/bin/clang-format-11 --style='{BasedOnStyle: Google, IncludeBlocks: Preserve, SortIncludes: false}' -i path/to/file1.cpp path/to/file2.h ...
```

## Test Plan

To confirm that the CI phases are working, this PR was test-modified with formatting non-compliant changes to c++ files in either `orc8r/gateway` and `lte/gateway` to confirm clang-format differences are caught per sub-directory (see #10712).

Signed-off-by: Scott Moeller <electronjoe@gmail.com>