### PR TITLE
fix(amf): Changing the hashtable implementation of amf_state_ue_id into map

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.cpp
@@ -102,20 +102,10 @@ void AmfNasStateManager::create_state() {
       AMF_GNB_UE_ID_AMF_UE_ID_TABLE_NAME);
   state_cache_p->amf_ue_contexts.guti_ue_context_htbl.set_name(
       AMF_GUTI_UE_ID_TABLE_NAME);
-  create_hashtables();
+  state_ue_ht.set_name(AMF_UE_ID_UE_CTXT_TABLE_NAME);
 
   // Initialize the local timers, which are non-persistent
   amf_nas_state_init_local_state();
-}
-
-// Delete the hashtables for amf NAS state
-// TODO in future PR, Hash table is replaced by MAP & hash table is depricated
-void AmfNasStateManager::clear_amf_nas_hashtables() {
-  if (!state_cache_p) {
-    return;
-  }
-
-  hashtable_ts_destroy(state_ue_ht);
 }
 
 // Free the memory allocated to state pointer
@@ -123,18 +113,8 @@ void AmfNasStateManager::free_state() {
   if (!state_cache_p) {
     return;
   }
-  clear_amf_nas_hashtables();
   delete state_cache_p;
   state_cache_p = nullptr;
-}
-
-// Create the hashtables for AMF and NAS state
-void AmfNasStateManager::create_hashtables() {
-  bstring b          = bfromcstr(AMF_UE_ID_UE_CTXT_TABLE_NAME);
-  max_ue_htbl_lists_ = 2;
-  state_ue_ht        = hashtable_ts_create(
-      max_ue_htbl_lists_, nullptr, amf_app_state_free_ue_context, b);
-  bdestroy(b);
 }
 
 // Initialize state that is non-persistent, e.g. timers
@@ -154,19 +134,14 @@ void AmfNasStateManager::amf_nas_state_init_local_state() {
 amf_app_desc_t* AmfNasStateManager::get_state(bool read_from_redis) {
   state_dirty = true;
 
-  // if read_from_redis is false, no need to clear and create ht.
-  if (persist_state_enabled_ && read_from_redis) {
-    clear_amf_nas_hashtables();
-    create_hashtables();
-  }
   return state_cache_p;
 }
 
-hash_table_ts_t* AmfNasStateManager::get_ue_state_ht() {
+map_uint64_ue_context_t AmfNasStateManager::get_ue_state_ht() {
   return state_ue_ht;
 }
 
-hash_table_ts_t* get_amf_ue_state() {
+map_uint64_ue_context_t get_amf_ue_state() {
   return AmfNasStateManager::getInstance().get_ue_state_ht();
 }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.h
@@ -38,7 +38,7 @@ amf_app_desc_t* get_amf_nas_state(bool read_from_redis);
 void clear_amf_nas_state();
 
 // Retrieving respective global hash table
-hash_table_ts_t* get_amf_ue_state();
+map_uint64_ue_context_t get_amf_ue_state();
 int amf_nas_state_init(const amf_config_t* amf_config_p);
 
 /**
@@ -65,7 +65,7 @@ class AmfNasStateManager {
   amf_app_desc_t* get_state(bool read_from_redis);
 
   // Retriving respective hash table from global data
-  hash_table_ts_t* get_ue_state_ht();
+  map_uint64_ue_context_t get_ue_state_ht();
 
   /**
    * Copy constructor and assignment operator are marked as deleted functions.
@@ -83,7 +83,7 @@ class AmfNasStateManager {
   log_proto_t log_task;
   uint32_t max_ue_htbl_lists_;
   uint32_t amf_statistic_timer_;
-  hash_table_ts_t* state_ue_ht;
+  map_uint64_ue_context_t state_ue_ht;
   amf_app_desc_t* state_cache_p;
   void free_state();
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -424,7 +424,7 @@ void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p) {
   amf_app_desc_t* amf_app_desc_p     = get_amf_nas_state(false);
   amf_ue_context_t* amf_ue_context_p = &amf_app_desc_p->amf_ue_contexts;
   OAILOG_DEBUG(LOG_NAS_AMF, "amf_free_ue_context \n");
-  hash_table_ts_t* amf_state_ue_id_ht = get_amf_ue_state();
+  map_uint64_ue_context_t amf_state_ue_id_ht = get_amf_ue_state();
   if (!ue_context_p || !amf_ue_context_p) {
     return;
   }
@@ -444,10 +444,8 @@ void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p) {
   }
 
   if (ue_context_p->amf_ue_ngap_id != INVALID_AMF_UE_NGAP_ID) {
-    h_rc = hashtable_ts_remove(
-        amf_state_ue_id_ht, (const hash_key_t) ue_context_p->amf_ue_ngap_id,
-        reinterpret_cast<void**>(&ue_context_p));
-    if (h_rc != HASH_TABLE_OK)
+    m_rc = amf_state_ue_id_ht.remove(ue_context_p->amf_ue_ngap_id);
+    if (m_rc != magma::MAP_OK)
       OAILOG_TRACE(LOG_AMF_APP, "Error Could not remove this ue context \n");
     ue_context_p->amf_ue_ngap_id = INVALID_AMF_UE_NGAP_ID;
   }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -398,6 +398,9 @@ typedef struct ue_m5gmm_context_s {
   m5g_uecontextrequest_t ue_context_request;
 } ue_m5gmm_context_t;
 
+// Map- Key: uint64_t , Data: ue_m5gmm_context_s*
+typedef magma::map_s<uint64_t, ue_m5gmm_context_s*> map_uint64_ue_context_t;
+
 /* Operation on UE context structure
  */
 int amf_insert_ue_context(

--- a/lte/gateway/c/core/oai/test/amf/test_amf_map.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_map.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 #include "lte/gateway/c/core/oai/include/map.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_defs.h"
+#include "lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h"
 
 using ::testing::Test;
 
@@ -100,5 +101,22 @@ TEST(test_map, test_map) {
       magma::MAP_KEY_NOT_EXISTS);
 
   delete state_cache_p;
+}
+
+TEST(test_map, test_amf_state_ue_ht) {
+  // Initializations for Map: Key-uint64_t Data-void*
+  amf_ue_ngap_id_t ue_id         = 1;
+  ue_m5gmm_context_s* ue_context = amf_create_new_ue_context();
+  map_uint64_ue_context_t state_ue_ht;
+
+  EXPECT_EQ(state_ue_ht.get(2, &ue_context), magma::MAP_EMPTY);
+
+  EXPECT_EQ(state_ue_ht.insert(ue_id, ue_context), magma::MAP_OK);
+
+  EXPECT_EQ(state_ue_ht.get(ue_id, &ue_context), magma::MAP_OK);
+
+  EXPECT_EQ(state_ue_ht.remove(ue_id), magma::MAP_OK);
+
+  delete ue_context;
 }
 }  // namespace magma5g


### PR DESCRIPTION
Signed-off-by: sreedharkumartn <sreedhar.kumar@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
amf_state_ue_id_ht hashtable implementation were converted into map implementation.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Validated UT cases.
- Verified basic sanity with UERANSIM.
- Please find the attached PCAP snap and mme logs.

PCAP snap:
![packet_amf_state_712](https://user-images.githubusercontent.com/89978170/145000268-77931713-42ae-4268-a914-51fc9a06b648.png)

mme log:
[amf_state_mme_712.log](https://github.com/magma/magma/files/7667018/amf_state_mme_712.log)

UT cases Validated:
![amf_state_ut_712](https://user-images.githubusercontent.com/89978170/145000620-b4c3c1ce-d67b-4035-8ffd-0a7c03f693c1.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
