### PR TITLE
feat(ci): more tags on images makes destinction easier

### DIFF
--- a/.github/workflows/composite/docker-builder/action.yml
+++ b/.github/workflows/composite/docker-builder/action.yml
@@ -10,7 +10,12 @@ inputs:
     required: true
   IMAGE_TAGS:
     required: true
-    default: type=sha
+    default: |
+      type=sha
+      type=schedule
+      type=ref,event=branch
+      type=ref,event=tag
+      type=ref,event=pr
   DOCKERFILE:
     required: true
 
@@ -27,6 +32,7 @@ runs:
         images: ${{ inputs.REGISTRY }}/${{ inputs.IMAGE_STREAM }}
         # defines the image tags added to the image
         tags: ${{ inputs.IMAGE_TAGS }}
+        flavor: latest=true
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Signed-off-by: Fritz Lehnert <Fritz.Lehnert@tngtech.com>

## Summary

When developing the devcontainer image, it makes like much easier to have more speaking tags on the images to select from. So for one change, the default tagging was not replaced by the `sha`, but the `sha` was added in addition to [the default tagging](https://github.com/marketplace/actions/docker-metadata-action#tags-input) (`type=ref` and `type=schedule`).
On the other hand it is seen value in using the latest tag as well, to shorten feedback cycles and get to know issues with any new version of devcontainer much faster. I personally would also see this as a prerequisite for more steps towards a continuous delivery workflow for the devcontainer.

## Test Plan

As this are CI changes, I think the CI is the way to test it.

## Additional Information

As far as I am concerned, additional tags on images never hurt, as they provide additional useful information at nearly no cost. However, this is a more general view, which would exceed the scope of this specific use case.