### PR TITLE
feat(orc8r): Added route53 letsencrypt issuer for cert-manager

### DIFF
--- a/orc8r/cloud/helm/orc8r/charts/certs/templates/aws-route53-secret-access-key.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/certs/templates/aws-route53-secret-access-key.yaml
@@ -10,19 +10,12 @@
 # limitations under the License.
 
 {{- if .Values.create }}
-{{- if .Values.preInstallChecks.enabled }}
+{{- if .Values.route53.enabled }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: {{ .Release.Name }}-pre-install-checks
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+  name: {{ .Release.Name }}-aws-route53-secret-access-key
 data:
-{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
-  cert_manager: "cert-manager is installed"
-{{- else }}
-  cert_manager: {{ required "Please install cert-manager from https://cert-manager.io/docs/installation/kubernetes/" .Values.preInstallChecks.test }}
-{{- end }}
+  secret-access-key: {{ required "route53.secretKey must be provided" .Values.route53.secretKey | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/certs/templates/route53-issuer.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/certs/templates/route53-issuer.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.create }}
+{{- if .Values.route53.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Release.Name }}-route53-issuer
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: {{ .Release.Name }}-route53-issuer-key
+    solvers:
+      - dns01:
+          route53:
+            region: {{ required "route53.region must be provided" .Values.route53.region }}
+            accessKeyID: {{ required "route53.accessKey must be provided" .Values.route53.accessKey }}
+            secretAccessKeySecretRef:
+              name: {{ .Release.Name }}-aws-route53-secret-access-key
+              key: secret-access-key
+{{- end }}
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/certs/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/certs/values.yaml
@@ -37,7 +37,7 @@ nms:
   # 10 year = 87600h
   duration: 87600h
   renewBefore: 24h
-  customIssuer:
+  customIssuer: # orc8r-route53-issuer
 
 controller:
   # 10 year = 87600h
@@ -57,3 +57,10 @@ root:
 
 preInstallChecks:
   enabled: true
+  test: # Keep this empty. It's a part of the pre-install checks.
+
+route53:
+  enabled: false
+  region:
+  accessKey:
+  secretKey:


### PR DESCRIPTION
Signed-off-by: Shubham Tatvamasi <shubhamtatvamasi@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Added route53 letsencrypt issuer for cert-manager.
This will only work when NS records are owned by Route53

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
