### PR TITLE
fix(orc8r): Fix mconfig sync panic due to nil NGC ptr

### DIFF
--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
-	feg "magma/feg/cloud/go/feg"
+	"magma/feg/cloud/go/feg"
 	feg_serdes "magma/feg/cloud/go/serdes"
 	feg_models "magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/lte/cloud/go/lte"
@@ -107,7 +107,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 
 	gwRan := cellularGwConfig.Ran
 	gwEpc := cellularGwConfig.Epc
-	gwNgc := cellularGwConfig.Ngc
+	gwNgc := getGwConfigNgc(cellularGwConfig)
 	gwNonEpsService := cellularGwConfig.NonEpsService
 	nwRan := cellularNwConfig.Ran
 	nwEpc := cellularNwConfig.Epc
@@ -324,6 +324,16 @@ func getPipelineDServicesConfig(networkServices []string) ([]lte_mconfig.Pipelin
 		apps = append(apps, mc)
 	}
 	return apps, nil
+}
+
+// getGwConfigNgc returns the NGC part of a cellular gateway config, or a
+// default value if none exists.
+func getGwConfigNgc(configs *lte_models.GatewayCellularConfigs) *lte_models.GatewayNgcConfigs {
+	ngc := configs.Ngc
+	if ngc == nil {
+		ngc = &lte_models.GatewayNgcConfigs{}
+	}
+	return ngc
 }
 
 func getFddConfig(fddConfig *lte_models.NetworkRanConfigsFddConfig) *lte_mconfig.EnodebD_FDDConfig {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fix this err observed on staging

```
panic(0xf74180, 0x1c452b0)
    /usr/local/go/src/runtime/panic.go:679 +0x1b2
magma/lte/cloud/go/services/lte/servicers.(*builderServicer).Build(0xc0002bfc00, 0x129fe00, 0xc000ad7170, 0xc00084b740, 0xc0002bfc00, 0x1cf1718, 0xc00014cdc0)
    /src/magma/lte/cloud/go/services/lte/servicers/builder_servicer.go:187 +0x14a2
magma/orc8r/cloud/go/services/configurator/mconfig/protos._MconfigBuilder_Build_Handler.func1(0x129fe00, 0xc000ad7170, 0x1086120, 0xc00084b740, 0xc0003de380, 0x0, 0x0, 0x0)
    /src/magma/orc8r/cloud/go/services/configurator/mconfig/protos/builder.pb.go:232 +0x86
magma/orc8r/cloud/go/service/middleware/unary.blockUnregisteredGatewaysInterceptor(0x129fe00, 0xc000ad7170, 0x1086120, 0xc00084b740, 0xc0003de380, 0xc0003de3a0, 0xc0003de3a0, 0x38, 0x38, 0xc00084ba80)
```

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->