### PR TITLE
chore: Turn off codecov annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
 comment: false
+github_checks:
+    annotations: false
 coverage:
   status:
     project:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

I am struggling to turn off github annotations (the `a` key hidden feature seems to not be working), which causes code review on large PRs to be painfully slow. Also, these annotations are unnecessary as we can achieve much better using Chrome plugins: https://magma.github.io/magma/docs/next/contributing/contribute_workflow#productivity-tools

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->