### PR TITLE
feat(orc8r): `CloudRegistration` and `client_api.go`

### DIFF
--- a/orc8r/cloud/go/services/bootstrapper/client_api.go
+++ b/orc8r/cloud/go/services/bootstrapper/client_api.go
@@ -16,14 +16,13 @@ package bootstrapper
 import (
 	"context"
 
-	"magma/orc8r/lib/go/protos"
-
-	merrors "magma/orc8r/lib/go/errors"
-	"magma/orc8r/lib/go/registry"
-
 	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/protos"
+	"magma/orc8r/lib/go/registry"
 )
 
 func GetToken(ctx context.Context, networkID string, logicalID string, refresh bool) (string, error) {

--- a/orc8r/cloud/go/services/bootstrapper/client_api.go
+++ b/orc8r/cloud/go/services/bootstrapper/client_api.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrapper
+
+import (
+	"context"
+
+	"magma/orc8r/lib/go/protos"
+
+	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/registry"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func GetToken(ctx context.Context, networkID string, logicalID string, refresh bool) (string, error) {
+	client, err := getCloudRegistrationClient()
+	if err != nil {
+		return "", err
+	}
+
+	req := &protos.GetTokenRequest{
+		GatewayDeviceInfo: &protos.GatewayDeviceInfo{
+			NetworkId: networkID,
+			LogicalId: logicalID,
+		},
+		Refresh: refresh,
+	}
+
+	res, err := client.GetToken(ctx, req)
+	return res.Token, err
+}
+
+func GetGatewayRegistrationInfo(ctx context.Context, token string) (*protos.GetGatewayRegistrationInfoResponse, error) {
+	client, err := getCloudRegistrationClient()
+	if err != nil {
+		return nil, err
+	}
+
+	req := &protos.GetGatewayRegistrationInfoRequest{}
+
+	res, err := client.GetGatewayRegistrationInfo(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func GetGatewayDeviceInfo(ctx context.Context, token string) (*protos.GatewayDeviceInfo, error) {
+	client, err := getCloudRegistrationClient()
+	if err != nil {
+		return nil, err
+	}
+
+	req := &protos.GetGatewayDeviceInfoRequest{
+		Token: token,
+	}
+
+	res, err := client.GetGatewayDeviceInfo(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch res.Response.(type) {
+	case *protos.GetGatewayDeviceInfoResponse_GatewayDeviceInfo:
+		gatewayInfo := res.Response.(*protos.GetGatewayDeviceInfoResponse_GatewayDeviceInfo)
+		return gatewayInfo.GatewayDeviceInfo, nil
+	default:
+		return nil, status.Error(codes.Unauthenticated, res.Response.(*protos.GetGatewayDeviceInfoResponse_Error).Error)
+	}
+}
+
+func getCloudRegistrationClient() (protos.CloudRegistrationClient, error) {
+	conn, err := registry.GetConnection(ServiceName)
+	if err != nil {
+		initErr := merrors.NewInitError(err, ServiceName)
+		glog.Error(initErr)
+		return nil, initErr
+	}
+	return protos.NewCloudRegistrationClient(conn), err
+}

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/cloud_registration.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/cloud_registration.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/lib/go/protos"
+)
+
+// NotImplementedWarning is pulled out of getDomainName for ease of testing
+const NotImplementedWarning = "warning: not implemented"
+
+type cloudRegistrationServicer struct {
+	store   Store
+	rootCA  string
+	timeout time.Duration
+}
+
+func NewCloudRegistrationServicer(store Store, rootCA string, timeout time.Duration) (protos.CloudRegistrationServer, error) {
+	if store == nil {
+		return nil, fmt.Errorf("storage store is nil")
+	}
+	return &cloudRegistrationServicer{store: store, rootCA: rootCA, timeout: timeout}, nil
+}
+
+func (c *cloudRegistrationServicer) GetToken(ctx context.Context, request *protos.GetTokenRequest) (*protos.GetTokenResponse, error) {
+	networkId := request.GatewayDeviceInfo.NetworkId
+	logicalId := request.GatewayDeviceInfo.LogicalId
+
+	tokenInfo, err := c.store.GetTokenInfoFromLogicalID(networkId, logicalId)
+	if err != nil {
+		// Error is not bubbled up since the tokenInfo is only important if the token exists and is expired
+		// If GetTokenInfoFromLogicalID fails, we can just ignore and continue
+		glog.V(2).Infof("could not get tokenInfo for networkID %v and logicalID %v: %v", networkId, logicalId, err)
+	}
+
+	refresh := request.Refresh || tokenInfo == nil || IsExpired(tokenInfo)
+	if refresh {
+		tokenInfo, err = c.generateAndSaveTokenInfo(networkId, logicalId)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "could not generate and save tokenInfo for networkID %v and logicalID %v: %v", networkId, logicalId, err)
+		}
+		glog.V(2).Infof("generated new token for networkID %v and logicalID %v: %v", networkId, logicalId, err)
+	}
+
+	res := &protos.GetTokenResponse{Timeout: tokenInfo.Timeout, Token: NonceToToken(tokenInfo.Nonce)}
+	return res, nil
+}
+
+func (c *cloudRegistrationServicer) GetGatewayRegistrationInfo(ctx context.Context, request *protos.GetGatewayRegistrationInfoRequest) (*protos.GetGatewayRegistrationInfoResponse, error) {
+	domainName := getDomainName()
+	res := &protos.GetGatewayRegistrationInfoResponse{
+		RootCa:     c.rootCA,
+		DomainName: domainName,
+	}
+	return res, nil
+}
+
+func (c *cloudRegistrationServicer) GetGatewayDeviceInfo(ctx context.Context, request *protos.GetGatewayDeviceInfoRequest) (*protos.GetGatewayDeviceInfoResponse, error) {
+	nonce, err := NonceFromToken(request.Token)
+	if err != nil {
+		res := &protos.GetGatewayDeviceInfoResponse{
+			Response: &protos.GetGatewayDeviceInfoResponse_Error{
+				Error: err.Error(),
+			},
+		}
+		return res, nil
+	}
+
+	tokenInfo, err := c.store.GetTokenInfoFromNonce(nonce)
+	if err != nil {
+		res := &protos.GetGatewayDeviceInfoResponse{
+			Response: &protos.GetGatewayDeviceInfoResponse_Error{
+				Error: fmt.Sprintf("could not get token info from token %v: %v", request.Token, err),
+			},
+		}
+		return res, nil
+	}
+	if IsExpired(tokenInfo) {
+		res := &protos.GetGatewayDeviceInfoResponse{
+			Response: &protos.GetGatewayDeviceInfoResponse_Error{
+				Error: fmt.Sprintf("token %v has expired", request.Token),
+			},
+		}
+		return res, nil
+	}
+
+	res := &protos.GetGatewayDeviceInfoResponse{
+		Response: &protos.GetGatewayDeviceInfoResponse_GatewayDeviceInfo{
+			GatewayDeviceInfo: &protos.GatewayDeviceInfo{
+				NetworkId: tokenInfo.GatewayDeviceInfo.NetworkId,
+				LogicalId: tokenInfo.GatewayDeviceInfo.LogicalId,
+			},
+		},
+	}
+	return res, nil
+}
+
+func (c *cloudRegistrationServicer) generateAndSaveTokenInfo(networkID string, logicalID string) (*protos.TokenInfo, error) {
+	nonce := GenerateNonce(NonceLength)
+	timeout := clock.Now().Add(c.timeout)
+
+	tokenInfo := &protos.TokenInfo{
+		GatewayDeviceInfo: &protos.GatewayDeviceInfo{
+			NetworkId: networkID,
+			LogicalId: logicalID,
+		},
+		Nonce:   nonce,
+		Timeout: GetTimestamp(timeout),
+	}
+
+	err := c.store.SetTokenInfo(tokenInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return tokenInfo, nil
+}
+
+// TODO(#10437)
+func getDomainName() string {
+	return NotImplementedWarning
+}

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/cloud_registration_test.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/cloud_registration_test.go
@@ -38,8 +38,8 @@ func TestCloudRegistrationServicer_GetGatewayRegistrationInfo(t *testing.T) {
 
 	getGatewayRegistrationInfoRes, err := cloudRegistration.GetGatewayRegistrationInfo(ctx, &protos.GetGatewayRegistrationInfoRequest{})
 	expectedRes := &protos.GetGatewayRegistrationInfoResponse{
-		RootCa:               rootCA,
-		DomainName:           registration.NotImplementedWarning,
+		RootCa:     rootCA,
+		DomainName: registration.NotImplementedWarning,
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, expectedRes, getGatewayRegistrationInfoRes)

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/cloud_registration_test.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/cloud_registration_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registration_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/services/bootstrapper"
+	"magma/orc8r/cloud/go/services/bootstrapper/servicers/registration"
+	"magma/orc8r/cloud/go/test_utils"
+	"magma/orc8r/lib/go/protos"
+)
+
+var (
+	rootCA          = "rootCA"
+	timeoutDuration = 30 * time.Minute
+)
+
+func TestCloudRegistrationServicer_GetGatewayRegistrationInfo(t *testing.T) {
+	ctx, cloudRegistration := cloudRegistrationTestSetup(t)
+
+	getGatewayRegistrationInfoRes, err := cloudRegistration.GetGatewayRegistrationInfo(ctx, &protos.GetGatewayRegistrationInfoRequest{})
+	expectedRes := &protos.GetGatewayRegistrationInfoResponse{
+		RootCa:               rootCA,
+		DomainName:           registration.NotImplementedWarning,
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, expectedRes, getGatewayRegistrationInfoRes)
+}
+
+// TestCloudRegistrationServicer_Registration tests GetGatewayDeviceInfo and GetToken
+// Tests that the functions interplay together with expected behavior
+func TestCloudRegistrationServicer_Registration(t *testing.T) {
+	var (
+		networkID = "networkID"
+		logicalID = "logicalID"
+
+		gatewayDeviceInfo = &protos.GatewayDeviceInfo{
+			NetworkId: networkID,
+			LogicalId: logicalID,
+		}
+	)
+	ctx, cloudRegistration := cloudRegistrationTestSetup(t)
+
+	nonce := registration.GenerateNonce(registration.NonceLength)
+	assert.Equal(t, registration.NonceLength, len(nonce))
+	token := registration.NonceToToken(nonce)
+
+	// Try getting device info when token is invalid
+	getGatewayDeviceInfoRes, err := cloudRegistration.GetGatewayDeviceInfo(ctx, &protos.GetGatewayDeviceInfoRequest{Token: token})
+	expectedErrorRes := &protos.GetGatewayDeviceInfoResponse_Error{
+		Error: fmt.Sprintf("could not get token info from token %v: %v", token, "Not found"),
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, expectedErrorRes, getGatewayDeviceInfoRes.Response)
+
+	// Register some device info
+	getTokenRes, err := cloudRegistration.GetToken(ctx, &protos.GetTokenRequest{
+		GatewayDeviceInfo: gatewayDeviceInfo,
+		Refresh:           false,
+	})
+	assert.NoError(t, err)
+	assert.True(t, clock.Now().Before(registration.GetTime(getTokenRes.Timeout)))
+	token = getTokenRes.Token
+	timeout := getTokenRes.Timeout
+
+	// Get device info
+	getGatewayDeviceInfoRes, err = cloudRegistration.GetGatewayDeviceInfo(ctx, &protos.GetGatewayDeviceInfoRequest{Token: token})
+	assert.NoError(t, err)
+	assert.Equal(t, &protos.GetGatewayDeviceInfoResponse_GatewayDeviceInfo{GatewayDeviceInfo: gatewayDeviceInfo}, getGatewayDeviceInfoRes.Response)
+
+	// Refresh device info
+	getTokenRes, err = cloudRegistration.GetToken(ctx, &protos.GetTokenRequest{
+		GatewayDeviceInfo: gatewayDeviceInfo,
+		Refresh:           true,
+	})
+	newToken := getTokenRes.Token
+	assert.NoError(t, err)
+	assert.True(t, registration.GetTime(timeout).Before(registration.GetTime(getTokenRes.Timeout)))
+	assert.NotEqual(t, token, newToken)
+
+	// Get device info with new token
+	getGatewayDeviceInfoRes, err = cloudRegistration.GetGatewayDeviceInfo(ctx, &protos.GetGatewayDeviceInfoRequest{Token: newToken})
+	assert.NoError(t, err)
+	assert.Equal(t, &protos.GetGatewayDeviceInfoResponse_GatewayDeviceInfo{GatewayDeviceInfo: gatewayDeviceInfo}, getGatewayDeviceInfoRes.Response)
+
+	// Old token should still work
+	getGatewayDeviceInfoRes, err = cloudRegistration.GetGatewayDeviceInfo(ctx, &protos.GetGatewayDeviceInfoRequest{Token: token})
+	assert.NoError(t, err)
+	assert.Equal(t, &protos.GetGatewayDeviceInfoResponse_GatewayDeviceInfo{GatewayDeviceInfo: gatewayDeviceInfo}, getGatewayDeviceInfoRes.Response)
+
+	// Test that token expires properly
+	clock.SetAndFreezeClock(t, time.Now().Add(timeoutDuration))
+	getGatewayDeviceInfoRes, err = cloudRegistration.GetGatewayDeviceInfo(ctx, &protos.GetGatewayDeviceInfoRequest{Token: token})
+	expectedErrorRes = &protos.GetGatewayDeviceInfoResponse_Error{
+		Error: fmt.Sprintf("token %v has expired", token),
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, expectedErrorRes, getGatewayDeviceInfoRes.Response)
+}
+
+func cloudRegistrationTestSetup(t *testing.T) (context.Context, protos.CloudRegistrationServer) {
+	factory := test_utils.NewSQLBlobstore(t, bootstrapper.BlobstoreTableName)
+	store := registration.NewBlobstoreStore(factory)
+
+	cloudRegistration, err := registration.NewCloudRegistrationServicer(store, rootCA, timeoutDuration)
+	assert.NoError(t, err)
+
+	return context.Background(), cloudRegistration
+}

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/nonce.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/nonce.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registration
+
+import (
+	"fmt"
+	"math/rand"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/services/bootstrapper"
+	"magma/orc8r/lib/go/protos"
+)
+
+// NonceLength is the number of characters that the nonce will have
+const NonceLength = 30
+
+func IsExpired(t *protos.TokenInfo) bool {
+	expirationTime := GetTime(t.Timeout)
+	return clock.Now().After(expirationTime)
+}
+
+func NonceToToken(nonce string) string {
+	return bootstrapper.TokenPrefix + nonce
+}
+
+func NonceFromToken(token string) (string, error) {
+	if token[:len(bootstrapper.TokenPrefix)] != bootstrapper.TokenPrefix {
+		return "", fmt.Errorf("token %v does not have tokenPrefix %v", token, bootstrapper.TokenPrefix)
+	}
+
+	return token[len(bootstrapper.TokenPrefix):], nil
+}
+
+// GenerateNonce is sourced from https://stackoverflow.com/a/31832326
+func GenerateNonce(n int) string {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/nonce_test.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/nonce_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"magma/orc8r/cloud/go/services/bootstrapper"
+	"magma/orc8r/cloud/go/services/bootstrapper/servicers/registration"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeneratedNonce(t *testing.T) {
+	nonce := registration.GenerateNonce(registration.NonceLength)
+	assert.Equal(t, registration.NonceLength, len(nonce))
+
+	testNonce(t, nonce)
+}
+
+func TestBadToken(t *testing.T) {
+	token := "tokenWithoutNoncePrefix"
+	revertedNonce, err := registration.NonceFromToken(token)
+	assert.Equal(t, fmt.Errorf("token %v does not have tokenPrefix %v", token, bootstrapper.TokenPrefix), err)
+	assert.Equal(t, "", revertedNonce)
+
+	testNonce(t, token)
+}
+
+func testNonce(t *testing.T, nonce string) {
+	token := registration.NonceToToken(nonce)
+	revertedNonce, err := registration.NonceFromToken(token)
+	assert.NoError(t, err)
+	assert.Equal(t, nonce, revertedNonce)
+}

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/nonce_test.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/nonce_test.go
@@ -17,10 +17,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"magma/orc8r/cloud/go/services/bootstrapper"
 	"magma/orc8r/cloud/go/services/bootstrapper/servicers/registration"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGeneratedNonce(t *testing.T) {

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/time.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/time.go
@@ -1,0 +1,20 @@
+package registration
+
+import (
+	"time"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+)
+
+// GetTime turns Timestamp into Time
+func GetTime(timestamp *timestamp.Timestamp) time.Time {
+	return time.Unix(timestamp.Seconds, int64(timestamp.Nanos))
+}
+
+// GetTimestamp turns Time into Timestamp
+func GetTimestamp(time time.Time) *timestamp.Timestamp {
+	return &timestamp.Timestamp{
+		Seconds: time.Unix(),
+		Nanos:   int32(time.Nanosecond()),
+	}
+}


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
- Add `CloudRegistration`, which hosts RPC endpoints for registering a gateway preliminarily and returning registration tokens.
- Also add the `client_api.go` so that services within orc8r can access useful `CloudRegistration` methods.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Added tests and ran all tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
Part of some Stacked PRs
1. [Last PR](https://github.com/magma/magma/pull/10495)
2. **[Part of this PR]** [CloudRegistration PR](https://github.com/reginawang3495/magma/pull/4)
   - on a fork and has some comments about this change
3.  **[Part of this PR]**[Add registration client_api.go PR](https://github.com/reginawang3495/magma/pull/12)
     - on a fork and has some comments about this change
4. [Registration PR](https://github.com/reginawang3495/magma/pull/11)
   - on a fork
5. [Add Servicers to Bootstrapper Service PR](https://github.com/reginawang3495/magma/pull/7)
   - on a fork
   
<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
