### PR TITLE
fix(amf): Sending Authenticate Request while processing SUCI based In…

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -118,7 +118,7 @@ int amf_as_send(amf_as_t* msg) {
 ***************************************************************************/
 static int amf_as_establish_req(amf_as_establish_t* msg, int* amf_cause) {
   amf_security_context_t* amf_security_context = NULL;
-  amf_nas_message_decode_status_t decode_status;
+  amf_nas_message_decode_status_t decode_status = {0};
   int decoder_rc                       = 1;
   int rc                               = RETURNerror;
   tai_t originating_tai                = {0};


### PR DESCRIPTION
fix(amf): Sending Authenticate Request while processing SUCI based Initial UE Registration request message

Signed-off-by: Moinuddin Khan <moinuddin.khan@wavelabs.ai>

## Summary
Upon receiving SUCI based Initial UE Registration request message, AMF should process it and send an Authenticate Request to UE. But, AMF was triggering Identity request toward UE.
This behavior is now rectified with this PR.

## Test Plan
Tested with TerraVM setup and UERANSIM setup.

## Additional Information
Corresponding zenhub task id #10660 
Attaching testing mme logs and packet captures 
