### PR TITLE
chore(ci): update devcontainer image in CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 		"augustocdias.tasks-shell-input",
 		"ryuta46.multi-command",
 	],
-	"image": "ghcr.io/magma/devcontainer:sha-3c02c72",
+	"image": "ghcr.io/magma/magma/devcontainer:sha-2f4586b",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"files.watcherExclude": {

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-3c02c72"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:sha-2f4586b"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -14,14 +14,14 @@ env:
   BAZEL_CACHE: .bazel-cache
   BAZEL_CACHE_MAGMA_VM_TAR: bazel-cache-magma-vm.tar.gz
   BAZEL_CACHE_DEVCONTAINER_TAR: bazel-cache-devcontainer.tar.gz
-  
+
   BAZEL_CACHE_REPO: .bazel-cache-repo
   BAZEL_CACHE_REPO_MAGMA_VM_TAR: bazel-cache-repo-magma-vm.tar.gz
   BAZEL_CACHE_REPO_DEVCONTAINER_TAR: bazel-cache-repo-devcontainer.tar.gz
-  
+
   S3_BUCKET_PATH: s3://magma-cache
 
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-3c02c72"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:sha-2f4586b"
 
 jobs:
   bazel-build-magma-vm-and-push-cache:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
     # Run four times a day to build bazel cache
     - cron: '0 0,6,12,18 * * *'
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-3c02c72"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:sha-2f4586b"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -22,7 +22,7 @@ on:
       - reopened
       - synchronize
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/devcontainer:sha-3c02c72"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:sha-2f4586b"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
Signed-off-by: Alexander zur Bonsen <alexander.zur.bonsen@tngtech.com>

## Summary

Update the devcontainer image in CI and devcontainer.json

The image stream change is due to parametrisation and the use of Github variables within the Github composite actions.
A list of available imagestreams can be found under [packages](https://github.com/orgs/magma/packages?repo_name=magma).

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking
