### PR TITLE
test(mme): Include packet filter count in unit test NW initiated bearer activation

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_app_ue_context.h
+++ b/lte/gateway/c/core/oai/include/mme_app_ue_context.h
@@ -511,12 +511,6 @@ ue_mm_context_t* mme_ue_context_exists_enb_ue_s1ap_id(
 ue_mm_context_t* mme_ue_context_exists_guti(
     mme_ue_context_t* const mme_ue_context, const guti_t* const guti);
 
-/** \brief Move the content of a context to another context
- * \param dst            The destination context
- * \param src            The source context
- **/
-void mme_app_move_context(ue_mm_context_t* dst, ue_mm_context_t* src);
-
 /** \brief Notify the MME_APP that a duplicated ue_context_t exist (both share
  * the same mme_ue_s1ap_id)
  * \param enb_key The UE id identifier used in S1AP and MME_APP (agregated with

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -373,21 +373,6 @@ ue_mm_context_t* mme_ue_context_exists_guti(
 }
 
 //------------------------------------------------------------------------------
-void mme_app_move_context(ue_mm_context_t* dst, ue_mm_context_t* src) {
-  OAILOG_FUNC_IN(LOG_MME_APP);
-  if ((dst) && (src)) {
-    enb_s1ap_id_key_t enb_s1ap_id_key = dst->enb_s1ap_id_key;
-    enb_ue_s1ap_id_t enb_ue_s1ap_id   = dst->enb_ue_s1ap_id;
-    mme_ue_s1ap_id_t mme_ue_s1ap_id   = dst->mme_ue_s1ap_id;
-    memcpy(dst, src, sizeof(*dst));
-    dst->enb_s1ap_id_key = enb_s1ap_id_key;
-    dst->enb_ue_s1ap_id  = enb_ue_s1ap_id;
-    dst->mme_ue_s1ap_id  = mme_ue_s1ap_id;
-  }
-  OAILOG_FUNC_OUT(LOG_MME_APP);
-}
-
-//------------------------------------------------------------------------------
 void mme_ue_context_update_coll_keys(
     mme_ue_context_t* const mme_ue_context_p,
     ue_mm_context_t* const ue_context_p,

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -2175,6 +2175,7 @@ static void add_tunnel_helper(
               .packetfiltercontents),
         ue_ipv4.s_addr, ue_ipv6, &dlflow);
 
+#if !MME_UNIT_TEST
     rc = gtpv1u_add_tunnel(
         ue_ipv4, ue_ipv6, vlan, enb, enb_ipv6,
         eps_bearer_ctxt_entry_p->s_gw_teid_S1u_S12_S4_up,
@@ -2195,6 +2196,7 @@ static void add_tunnel_helper(
           eps_bearer_ctxt_entry_p->enb_teid_S1u,
           eps_bearer_ctxt_entry_p->s_gw_teid_S1u_S12_S4_up);
     }
+#endif
   }
 }
 bool does_bearer_context_hold_valid_enb_ip(ip_address_t enb_ip_address_S1u) {

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.cpp
@@ -301,6 +301,7 @@ void fill_nw_initiated_activate_bearer_request(
   dl_tft->ebit = TRAFFIC_FLOW_TEMPLATE_PARAMETER_LIST_IS_NOT_INCLUDED;
 
   // create one uplink tft
+  ul_tft->numberofpacketfilters = 1;
   ul_tft->packetfilterlist.createnewtft[0].direction =
       TRAFFIC_FLOW_TEMPLATE_UPLINK_ONLY;
   ul_tft->packetfilterlist.createnewtft[0].eval_precedence = qos.pl;
@@ -308,6 +309,7 @@ void fill_nw_initiated_activate_bearer_request(
       &ul_tft->packetfilterlist.createnewtft[0].packetfiltercontents);
 
   // create one downlink tft
+  dl_tft->numberofpacketfilters = 1;
   dl_tft->packetfilterlist.createnewtft[0].direction =
       TRAFFIC_FLOW_TEMPLATE_DOWNLINK_ONLY;
   dl_tft->packetfilterlist.createnewtft[0].eval_precedence = qos.pl;


### PR DESCRIPTION
## Summary

The sample UL and DL traffic flow template in dedicated bearer activation/deactivation unit test did not specify the number of packet filters, causing it to skip add_tunnel_helper function call. This change fixes it.

This change also leans up an unused function on MME context

## Test Plan

make test_oai