### PR TITLE
test(mme): Add further enc/decoding tests for emm messages

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -1072,8 +1072,8 @@ status_code_e _emm_attach_reject(
     emm_as_set_security_data(
         &emm_sap.u.emm_as.u.establish.sctx, NULL, false, false);
   }
-  rc = emm_sap_send(&emm_sap);
-  attach_proc->attach_reject_sent++;
+  rc                              = emm_sap_send(&emm_sap);
+  attach_proc->attach_reject_sent = true;
   increment_counter("ue_attach", 1, 1, "action", "attach_reject_sent");
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/ExtendedServiceRequest.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/ExtendedServiceRequest.c
@@ -42,7 +42,7 @@ int decode_extended_service_request(
 
   if ((decoded_result = decode_u8_nas_key_set_identifier(
            &extended_service_request->naskeysetidentifier, 0,
-           *(buffer + decoded) & 0x0f, len - decoded)) < 0)
+           *(buffer + decoded) >> 4, len - decoded)) < 0)
     return decoded_result;
 
   decoded++;
@@ -83,11 +83,11 @@ int encode_extended_service_request(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, EXTENDED_SERVICE_REQUEST_MINIMUM_LENGTH, len);
   *(buffer + encoded) =
-      ((encode_u8_service_type(&extended_service_request->servicetype) & 0x0f)
+      ((encode_u8_nas_key_set_identifier(
+            &extended_service_request->naskeysetidentifier) &
+        0x0f)
        << 4) |
-      (encode_u8_nas_key_set_identifier(
-           &extended_service_request->naskeysetidentifier) &
-       0x0f);
+      (encode_u8_service_type(&extended_service_request->servicetype) & 0x0f);
   encoded++;
 
   if ((encode_result = encode_mobile_identity_ie(

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/TrackingAreaUpdateAccept.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/TrackingAreaUpdateAccept.c
@@ -39,7 +39,7 @@ int decode_tracking_area_update_accept(
    */
   if ((decoded_result = decode_u8_eps_update_result(
            &tracking_area_update_accept->epsupdateresult, 0,
-           *(buffer + decoded) >> 4, len - decoded)) < 0)
+           *(buffer + decoded), len - decoded)) < 0)
     return decoded_result;
 
   decoded++;

--- a/lte/gateway/c/core/oai/tasks/nas/ies/TrackingAreaIdentityList.c
+++ b/lte/gateway/c/core/oai/tasks/nas/ies/TrackingAreaIdentityList.c
@@ -156,6 +156,7 @@ int decode_tracking_area_identity_list(
     }
     partial_item++;
   }
+  trackingareaidentitylist->numberoflists = partial_item;
   return decoded;
 }
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_emm_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_emm_encode_decode.cpp
@@ -14,8 +14,15 @@
 
 extern "C" {
 #include "lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.h"
+#include "lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachAccept.h"
+#include "lte/gateway/c/core/oai/tasks/nas/emm/msg/CsServiceNotification.h"
 #include "lte/gateway/c/core/oai/tasks/nas/emm/msg/EmmInformation.h"
+#include "lte/gateway/c/core/oai/tasks/nas/emm/msg/ExtendedServiceRequest.h"
 #include "lte/gateway/c/core/oai/tasks/nas/emm/msg/TrackingAreaUpdateRequest.h"
+#include "lte/gateway/c/core/oai/tasks/nas/emm/msg/TrackingAreaUpdateReject.h"
+#include "lte/gateway/c/core/oai/tasks/nas/emm/msg/TrackingAreaUpdateAccept.h"
+#include "lte/gateway/c/core/oai/tasks/nas/emm/msg/NASSecurityModeCommand.h"
+#include "lte/gateway/c/core/oai/tasks/nas/emm/msg/NASSecurityModeComplete.h"
 #include "lte/gateway/c/core/oai/tasks/nas/emm/msg/UplinkNasTransport.h"
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/common/log.h"
@@ -33,6 +40,21 @@ namespace lte {
     msg.protocoldiscriminator = EPS_SESSION_MANAGEMENT_MESSAGE;                \
     msg.securityheadertype    = 0x0001;                                        \
     msg.messagetype           = 33;                                            \
+  } while (0)
+
+#define FILL_EMM_GUTI(msg_guti)                                                \
+  do {                                                                         \
+    msg_guti.guti.typeofidentity = EPS_MOBILE_IDENTITY_GUTI;                   \
+    msg_guti.guti.mcc_digit1     = 0;                                          \
+    msg_guti.guti.mcc_digit2     = 0;                                          \
+    msg_guti.guti.mcc_digit3     = 1;                                          \
+    msg_guti.guti.mnc_digit1     = 0;                                          \
+    msg_guti.guti.mnc_digit2     = 1;                                          \
+    msg_guti.guti.mnc_digit3     = 0x0f;                                       \
+    msg_guti.guti.mme_group_id   = 1;                                          \
+    msg_guti.guti.mme_code       = 1;                                          \
+    msg_guti.guti.m_tmsi         = 0x2bfb815f;                                 \
+    msg_guti.guti.spare          = 0xf;                                        \
   } while (0)
 
 class EMMEncodeDecodeTest : public ::testing::Test {
@@ -155,17 +177,7 @@ TEST_F(EMMEncodeDecodeTest, TestEncodeDecodeTAURequest) {
       NAS_KEY_SET_IDENTIFIER_NATIVE;
   original_msg.naskeysetidentifier.tsc = 0;
 
-  original_msg.oldguti.guti.typeofidentity = EPS_MOBILE_IDENTITY_GUTI;
-  original_msg.oldguti.guti.mcc_digit1     = 0;
-  original_msg.oldguti.guti.mcc_digit2     = 0;
-  original_msg.oldguti.guti.mcc_digit3     = 1;
-  original_msg.oldguti.guti.mnc_digit1     = 0;
-  original_msg.oldguti.guti.mnc_digit2     = 1;
-  original_msg.oldguti.guti.mnc_digit3     = 0x0f;
-  original_msg.oldguti.guti.mme_group_id   = 1;
-  original_msg.oldguti.guti.mme_code       = 1;
-  original_msg.oldguti.guti.m_tmsi         = 0x2bfb815f;
-  original_msg.oldguti.guti.spare          = 0xf;
+  FILL_EMM_GUTI(original_msg.oldguti);
 
   // Set optional IEs
   original_msg.noncurrentnativenaskeysetidentifier.naskeysetidentifier =
@@ -174,17 +186,7 @@ TEST_F(EMMEncodeDecodeTest, TestEncodeDecodeTAURequest) {
   original_msg.gprscipheringkeysequencenumber          = 1;
   original_msg.oldptmsisignature                       = 2;
 
-  original_msg.additionalguti.guti.typeofidentity = EPS_MOBILE_IDENTITY_GUTI;
-  original_msg.additionalguti.guti.mcc_digit1     = 0;
-  original_msg.additionalguti.guti.mcc_digit2     = 1;
-  original_msg.additionalguti.guti.mcc_digit3     = 1;
-  original_msg.additionalguti.guti.mnc_digit1     = 0;
-  original_msg.additionalguti.guti.mnc_digit2     = 1;
-  original_msg.additionalguti.guti.mnc_digit3     = 0x0f;
-  original_msg.additionalguti.guti.mme_group_id   = 1;
-  original_msg.additionalguti.guti.mme_code       = 1;
-  original_msg.additionalguti.guti.m_tmsi         = 0x2bfb816f;
-  original_msg.additionalguti.guti.spare          = 0xf;
+  FILL_EMM_GUTI(original_msg.additionalguti);
 
   original_msg.nonceue = 3;
 
@@ -264,6 +266,386 @@ TEST_F(EMMEncodeDecodeTest, TestEncodeDecodeTAURequest) {
 
   bdestroy_wrapper(&original_msg.supportedcodecs);
   bdestroy_wrapper(&decoded_msg.supportedcodecs);
+}
+
+TEST_F(EMMEncodeDecodeTest, TestEncodeDecodeTAUAccept) {
+  tracking_area_update_accept_msg original_msg = {0};
+  tracking_area_update_accept_msg decoded_msg  = {0};
+
+  FILL_EMM_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  // Set mandatory IEs
+  original_msg.epsupdateresult = EPS_UPDATE_RESULT_COMBINED_TA_LA_UPDATED;
+
+  // Set optional IEs
+  original_msg.t3412value.unit       = GPRS_TIMER_UNIT_2S;
+  original_msg.t3412value.timervalue = 1;
+
+  FILL_EMM_GUTI(original_msg.guti);
+
+  original_msg.epsbearercontextstatus = 1;
+
+  original_msg.locationareaidentification.mccdigit1 = 0;
+  original_msg.locationareaidentification.mccdigit2 = 0;
+  original_msg.locationareaidentification.mccdigit3 = 1;
+  original_msg.locationareaidentification.mncdigit1 = 0;
+  original_msg.locationareaidentification.mncdigit2 = 1;
+  original_msg.locationareaidentification.mncdigit3 = 1;
+  original_msg.locationareaidentification.lac       = 0x01;
+
+  original_msg.emmcause = 1;
+
+  original_msg.epsnetworkfeaturesupport.b1 = 1;
+  original_msg.epsnetworkfeaturesupport.b2 = 0;
+
+  original_msg.additionalupdateresult = 0;
+
+  original_msg.presencemask =
+      TRACKING_AREA_UPDATE_ACCEPT_T3412_VALUE_PRESENT |
+      TRACKING_AREA_UPDATE_ACCEPT_GUTI_PRESENT |
+      TRACKING_AREA_UPDATE_ACCEPT_EPS_BEARER_CONTEXT_STATUS_PRESENT |
+      TRACKING_AREA_UPDATE_ACCEPT_LOCATION_AREA_IDENTIFICATION_PRESENT |
+      TRACKING_AREA_UPDATE_ACCEPT_EMM_CAUSE_PRESENT |
+      TRACKING_AREA_UPDATE_ACCEPT_EPS_NETWORK_FEATURE_SUPPORT_PRESENT |
+      TRACKING_AREA_UPDATE_ACCEPT_ADDITIONAL_UPDATE_RESULT_PRESENT;
+
+  // Encode and decode back message
+  int encoded = encode_tracking_area_update_accept(
+      &original_msg, temp_buffer, BUFFER_LEN);
+  int decoded =
+      decode_tracking_area_update_accept(&decoded_msg, temp_buffer, encoded);
+
+  ASSERT_EQ(decoded, encoded);
+  ASSERT_EQ(original_msg.epsupdateresult, decoded_msg.epsupdateresult);
+  ASSERT_EQ(original_msg.t3412value.unit, decoded_msg.t3412value.unit);
+  ASSERT_EQ(
+      original_msg.t3412value.timervalue, decoded_msg.t3412value.timervalue);
+
+  ASSERT_TRUE(!memcmp(
+      &original_msg.guti, &decoded_msg.guti, sizeof(original_msg.guti)));
+  ASSERT_EQ(
+      original_msg.epsbearercontextstatus, decoded_msg.epsbearercontextstatus);
+  ASSERT_TRUE(!memcmp(
+      &original_msg.locationareaidentification,
+      &decoded_msg.locationareaidentification,
+      sizeof(original_msg.locationareaidentification)));
+  ASSERT_EQ(original_msg.emmcause, decoded_msg.emmcause);
+  ASSERT_EQ(
+      original_msg.epsnetworkfeaturesupport.b1,
+      decoded_msg.epsnetworkfeaturesupport.b1);
+  ASSERT_EQ(
+      original_msg.epsnetworkfeaturesupport.b2,
+      decoded_msg.epsnetworkfeaturesupport.b2);
+  ASSERT_EQ(
+      original_msg.additionalupdateresult, decoded_msg.additionalupdateresult);
+}
+
+TEST_F(EMMEncodeDecodeTest, TestEncodeDecodeTAUReject) {
+  tracking_area_update_reject_msg original_msg = {0};
+  tracking_area_update_reject_msg decoded_msg  = {0};
+
+  FILL_EMM_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  // Set mandatory IEs
+  original_msg.emmcause = 1;
+
+  // Encode and decode back message
+  int encoded = encode_tracking_area_update_reject(
+      &original_msg, temp_buffer, BUFFER_LEN);
+  int decoded =
+      decode_tracking_area_update_reject(&decoded_msg, temp_buffer, encoded);
+
+  ASSERT_EQ(encoded, decoded);
+  ASSERT_EQ(original_msg.emmcause, decoded_msg.emmcause);
+}
+
+TEST_F(EMMEncodeDecodeTest, TestEncodeDecodeCSServiceNotification) {
+  cs_service_notification_msg original_msg = {0};
+  cs_service_notification_msg decoded_msg  = {0};
+
+  FILL_EMM_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  // Set mandatory IEs
+  original_msg.pagingidentity = 1;
+
+  // Set optional IEs
+  original_msg.cli               = bfromcstr("TEST_CLI");
+  original_msg.sscode            = 2;
+  original_msg.lcsindicator      = 1;
+  original_msg.lcsclientidentity = bfromcstr("TEST_LCS");
+
+  original_msg.presencemask =
+      CS_SERVICE_NOTIFICATION_CLI_PRESENT |
+      CS_SERVICE_NOTIFICATION_SS_CODE_PRESENT |
+      CS_SERVICE_NOTIFICATION_LCS_INDICATOR_PRESENT |
+      CS_SERVICE_NOTIFICATION_LCS_CLIENT_IDENTITY_PRESENT;
+
+  // Encode and decode back message
+  int encoded =
+      encode_cs_service_notification(&original_msg, temp_buffer, BUFFER_LEN);
+  int decoded =
+      decode_cs_service_notification(&decoded_msg, temp_buffer, encoded);
+
+  ASSERT_EQ(encoded, decoded);
+  ASSERT_EQ(original_msg.pagingidentity, decoded_msg.pagingidentity);
+  ASSERT_EQ(original_msg.lcsindicator, decoded_msg.lcsindicator);
+  ASSERT_EQ(original_msg.sscode, decoded_msg.sscode);
+  ASSERT_EQ(
+      std::string(bdata(original_msg.cli)),
+      std::string(bdata(decoded_msg.cli)));
+  ASSERT_EQ(
+      std::string(bdata(original_msg.lcsclientidentity)),
+      std::string(bdata(decoded_msg.lcsclientidentity)));
+
+  bdestroy_wrapper(&original_msg.cli);
+  bdestroy_wrapper(&decoded_msg.cli);
+
+  bdestroy_wrapper(&original_msg.lcsclientidentity);
+  bdestroy_wrapper(&decoded_msg.lcsclientidentity);
+}
+
+TEST_F(EMMEncodeDecodeTest, TestEncodeDecodeAttachAcceptConsecutiveTACs) {
+  attach_accept_msg original_msg = {0};
+  attach_accept_msg decoded_msg  = {0};
+
+  FILL_EMM_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  // Set mandatory IEs
+  original_msg.epsattachresult = EPS_ATTACH_RESULT_EPS;
+
+  original_msg.t3412value.unit       = GPRS_TIMER_UNIT_2S;
+  original_msg.t3412value.timervalue = 1;
+
+  original_msg.esmmessagecontainer = bfromcstr("TEST_CONTAINER");
+
+  original_msg.tailist.numberoflists = 1;
+  original_msg.tailist.partial_tai_list[0].typeoflist =
+      TRACKING_AREA_IDENTITY_LIST_ONE_PLMN_CONSECUTIVE_TACS;
+  original_msg.tailist.partial_tai_list[0].numberofelements = 1;
+  original_msg.tailist.partial_tai_list[0]
+      .u.tai_one_plmn_consecutive_tacs.plmn.mcc_digit1 = 0;
+  original_msg.tailist.partial_tai_list[0]
+      .u.tai_one_plmn_consecutive_tacs.plmn.mcc_digit2 = 0;
+  original_msg.tailist.partial_tai_list[0]
+      .u.tai_one_plmn_consecutive_tacs.plmn.mcc_digit3 = 1;
+  original_msg.tailist.partial_tai_list[0]
+      .u.tai_one_plmn_consecutive_tacs.plmn.mnc_digit1 = 0;
+  original_msg.tailist.partial_tai_list[0]
+      .u.tai_one_plmn_consecutive_tacs.plmn.mnc_digit2 = 1;
+  original_msg.tailist.partial_tai_list[0]
+      .u.tai_one_plmn_consecutive_tacs.plmn.mnc_digit3 = 1;
+  original_msg.tailist.partial_tai_list[0].u.tai_one_plmn_consecutive_tacs.tac =
+      1;
+
+  // Set optional IEs
+  FILL_EMM_GUTI(original_msg.guti);
+
+  original_msg.t3402value.unit       = GPRS_TIMER_UNIT_60S;
+  original_msg.t3402value.timervalue = 1;
+
+  original_msg.locationareaidentification.mccdigit1 = 0;
+  original_msg.locationareaidentification.mccdigit2 = 0;
+  original_msg.locationareaidentification.mccdigit3 = 1;
+  original_msg.locationareaidentification.mncdigit1 = 0;
+  original_msg.locationareaidentification.mncdigit2 = 1;
+  original_msg.locationareaidentification.mncdigit3 = 1;
+  original_msg.locationareaidentification.lac       = 0x01;
+
+  original_msg.emmcause = 1;
+
+  original_msg.epsnetworkfeaturesupport.b1 = 1;
+  original_msg.epsnetworkfeaturesupport.b2 = 0;
+
+  original_msg.additionalupdateresult = 0;
+
+  original_msg.presencemask =
+      ATTACH_ACCEPT_GUTI_PRESENT |
+      ATTACH_ACCEPT_LOCATION_AREA_IDENTIFICATION_PRESENT |
+      ATTACH_ACCEPT_EMM_CAUSE_PRESENT | ATTACH_ACCEPT_T3402_VALUE_PRESENT |
+      ATTACH_ACCEPT_EPS_NETWORK_FEATURE_SUPPORT_PRESENT |
+      ATTACH_ACCEPT_ADDITIONAL_UPDATE_RESULT_PRESENT;
+
+  // Encode and decode back message
+  int encoded = encode_attach_accept(&original_msg, temp_buffer, BUFFER_LEN);
+  int decoded = decode_attach_accept(&decoded_msg, temp_buffer, encoded);
+
+  ASSERT_EQ(encoded, decoded);
+
+  ASSERT_EQ(original_msg.epsattachresult, decoded_msg.epsattachresult);
+  ASSERT_EQ(original_msg.t3412value.unit, decoded_msg.t3412value.unit);
+  ASSERT_EQ(
+      original_msg.t3412value.timervalue, decoded_msg.t3412value.timervalue);
+  ASSERT_EQ(
+      original_msg.t3402value.timervalue, decoded_msg.t3402value.timervalue);
+  ASSERT_EQ(original_msg.t3402value.unit, decoded_msg.t3402value.unit);
+  ASSERT_EQ(
+      std::string(bdata(original_msg.esmmessagecontainer)),
+      std::string(bdata(decoded_msg.esmmessagecontainer)));
+
+  ASSERT_TRUE(!memcmp(
+      &original_msg.guti, &decoded_msg.guti, sizeof(original_msg.guti)));
+  ASSERT_TRUE(!memcmp(
+      &original_msg.tailist, &decoded_msg.tailist,
+      sizeof(original_msg.tailist)));
+  ASSERT_TRUE(!memcmp(
+      &original_msg.locationareaidentification,
+      &decoded_msg.locationareaidentification,
+      sizeof(original_msg.locationareaidentification)));
+  ASSERT_EQ(original_msg.emmcause, decoded_msg.emmcause);
+  ASSERT_EQ(
+      original_msg.epsnetworkfeaturesupport.b1,
+      decoded_msg.epsnetworkfeaturesupport.b1);
+  ASSERT_EQ(
+      original_msg.epsnetworkfeaturesupport.b2,
+      decoded_msg.epsnetworkfeaturesupport.b2);
+  ASSERT_EQ(
+      original_msg.additionalupdateresult, decoded_msg.additionalupdateresult);
+
+  bdestroy_wrapper(&original_msg.esmmessagecontainer);
+  bdestroy_wrapper(&decoded_msg.esmmessagecontainer);
+}
+
+TEST_F(EMMEncodeDecodeTest, TestEncodeDecodeSMCCommand) {
+  security_mode_command_msg original_msg = {0};
+  security_mode_command_msg decoded_msg  = {0};
+
+  FILL_EMM_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  // Set mandatory IEs
+  original_msg.selectednassecurityalgorithms.typeofcipheringalgorithm =
+      NAS_SECURITY_ALGORITHMS_EEA2;
+  original_msg.selectednassecurityalgorithms.typeofintegrityalgorithm =
+      NAS_SECURITY_ALGORITHMS_EIA2;
+  original_msg.naskeysetidentifier.naskeysetidentifier =
+      NAS_KEY_SET_IDENTIFIER_NATIVE;
+  original_msg.naskeysetidentifier.tsc = 0;
+
+  original_msg.replayeduesecuritycapabilities.eea = UE_SECURITY_CAPABILITY_EEA1;
+  original_msg.replayeduesecuritycapabilities.eia = UE_SECURITY_CAPABILITY_EIA1;
+  original_msg.replayeduesecuritycapabilities.umts_present = 1;
+  original_msg.replayeduesecuritycapabilities.uea = UE_SECURITY_CAPABILITY_UEA1;
+  original_msg.replayeduesecuritycapabilities.uia = UE_SECURITY_CAPABILITY_UIA1;
+  original_msg.replayeduesecuritycapabilities.gprs_present = 1;
+  original_msg.replayeduesecuritycapabilities.gea = UE_SECURITY_CAPABILITY_GEA1;
+
+  // Set optional IEs
+  original_msg.imeisvrequest = IMEISV_REQUESTED;
+
+  original_msg.replayedueadditionalsecuritycapabilities._5g_ea = 1;
+  original_msg.replayedueadditionalsecuritycapabilities._5g_ia = 1;
+
+  original_msg.presencemask =
+      SECURITY_MODE_COMMAND_IMEISV_REQUEST_PRESENT |
+      SECURITY_MODE_COMMAND_REPLAYED_UE_ADDITIONAL_SECU_CAPABILITY_PRESENT;
+
+  // Encode and decode back message
+  int encoded =
+      encode_security_mode_command(&original_msg, temp_buffer, BUFFER_LEN);
+  int decoded =
+      decode_security_mode_command(&decoded_msg, temp_buffer, encoded);
+
+  ASSERT_EQ(encoded, decoded);
+
+  ASSERT_TRUE(!memcmp(
+      &original_msg.replayeduesecuritycapabilities,
+      &decoded_msg.replayeduesecuritycapabilities,
+      sizeof(original_msg.replayeduesecuritycapabilities)));
+  ASSERT_EQ(
+      original_msg.replayedueadditionalsecuritycapabilities._5g_ea,
+      decoded_msg.replayedueadditionalsecuritycapabilities._5g_ea);
+  ASSERT_EQ(
+      original_msg.replayedueadditionalsecuritycapabilities._5g_ia,
+      decoded_msg.replayedueadditionalsecuritycapabilities._5g_ia);
+  ASSERT_EQ(
+      original_msg.naskeysetidentifier.naskeysetidentifier,
+      decoded_msg.naskeysetidentifier.naskeysetidentifier);
+  ASSERT_EQ(
+      original_msg.naskeysetidentifier.tsc,
+      decoded_msg.naskeysetidentifier.tsc);
+}
+
+TEST_F(EMMEncodeDecodeTest, TestEncodeDecodeSMCComplete) {
+  security_mode_complete_msg original_msg = {0};
+  security_mode_complete_msg decoded_msg  = {0};
+
+  FILL_EMM_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  // Set optional IEs
+  original_msg.imeisv.imeisv.typeofidentity = MOBILE_IDENTITY_IMEISV;
+  original_msg.imeisv.imeisv.oddeven        = 1;
+  original_msg.imeisv.imeisv.tac1           = 1;
+  original_msg.imeisv.imeisv.tac2           = 1;
+  original_msg.imeisv.imeisv.tac3           = 0;
+  original_msg.imeisv.imeisv.tac4           = 0;
+  original_msg.imeisv.imeisv.tac5           = 0;
+  original_msg.imeisv.imeisv.tac6           = 0;
+  original_msg.imeisv.imeisv.tac7           = 0;
+  original_msg.imeisv.imeisv.tac8           = 0;
+  original_msg.imeisv.imeisv.snr1           = 1;
+  original_msg.imeisv.imeisv.snr2           = 1;
+  original_msg.imeisv.imeisv.snr3           = 0;
+  original_msg.imeisv.imeisv.snr4           = 0;
+  original_msg.imeisv.imeisv.snr5           = 0;
+  original_msg.imeisv.imeisv.snr6           = 0;
+  original_msg.imeisv.imeisv.svn1           = 0;
+  original_msg.imeisv.imeisv.svn2           = 0;
+  original_msg.imeisv.imeisv.last           = 0;
+
+  original_msg.presencemask = SECURITY_MODE_COMPLETE_IMEISV_PRESENT;
+
+  // Encode and decode back message
+  int encoded =
+      encode_security_mode_complete(&original_msg, temp_buffer, BUFFER_LEN);
+  int decoded =
+      decode_security_mode_complete(&decoded_msg, temp_buffer, encoded);
+
+  ASSERT_EQ(encoded, decoded);
+
+  ASSERT_TRUE(!memcmp(
+      &original_msg.imeisv, &decoded_msg.imeisv, sizeof(original_msg.imeisv)));
+}
+
+TEST_F(EMMEncodeDecodeTest, TestEncodeDecodeExtendedServiceRequest) {
+  extended_service_request_msg original_msg = {0};
+  extended_service_request_msg decoded_msg  = {0};
+
+  FILL_EMM_COMMON_MANDATORY_DEFAULTS(original_msg);
+
+  // Set mandatory IEs
+  original_msg.servicetype                             = MT_CS_FB;
+  original_msg.naskeysetidentifier.naskeysetidentifier = 1;
+  original_msg.naskeysetidentifier.tsc                 = 1;
+
+  original_msg.mtmsi.tmsi.typeofidentity = MOBILE_IDENTITY_TMSI;
+  original_msg.mtmsi.tmsi.tmsi[0]        = 1;
+  original_msg.mtmsi.tmsi.tmsi[1]        = 0;
+  original_msg.mtmsi.tmsi.tmsi[2]        = 1;
+  original_msg.mtmsi.tmsi.tmsi[3]        = 1;
+  original_msg.mtmsi.tmsi.oddeven        = 0;
+  original_msg.mtmsi.tmsi.f              = 0xf;
+
+  original_msg.csfbresponse = 1;
+
+  original_msg.presencemask = EMM_CSFB_RSP_PRESENT;
+
+  // Encode and decode back message
+  int encoded =
+      encode_extended_service_request(&original_msg, temp_buffer, BUFFER_LEN);
+  int decoded =
+      decode_extended_service_request(&decoded_msg, temp_buffer, encoded);
+
+  ASSERT_EQ(encoded, decoded);
+
+  ASSERT_EQ(original_msg.servicetype, decoded_msg.servicetype);
+  ASSERT_EQ(original_msg.csfbresponse, decoded_msg.csfbresponse);
+  ASSERT_EQ(
+      original_msg.naskeysetidentifier.naskeysetidentifier,
+      decoded_msg.naskeysetidentifier.naskeysetidentifier);
+  ASSERT_EQ(
+      original_msg.naskeysetidentifier.tsc,
+      decoded_msg.naskeysetidentifier.tsc);
+  ASSERT_TRUE(!memcmp(
+      &original_msg.mtmsi, &decoded_msg.mtmsi, sizeof(original_msg.mtmsi)));
 }
 
 }  // namespace lte


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adds following test cases for EMM decoding and encoding messages
```
TestEncodeDecodeExtendedServiceRequest
TestEncodeDecodeSMCComplete
TestEncodeDecodeSMCCommand
TestEncodeDecodeAttachAccept
TestEncodeDecodeCSServiceNotification
TestEncodeDecodeTAUReject
TestEncodeDecodeTAUAccept
```
- Also fixes some bugs on encoding of `naskeysetidentifier` structs
- Resolves a compiler warning due to doing `attach_proc->attach_reject_sent++` even though is used and defined as boolean 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make test_oai
- make coverage_oai

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
