### PR TITLE
test(mme): Reduce flakes due to late ITTI messages

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -28,7 +28,7 @@ namespace magma {
 namespace lte {
 
 #define MME_APP_TIMER_TO_MSEC 10
-#define STATE_MAX_WAIT_MS 1000
+#define STATE_MAX_WAIT_MS 10000
 #define NAS_RETX_LIMIT 5
 
 #define MME_APP_EXPECT_CALLS(                                                  \


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
There were some flakes reported on some local runs and when running ` make coverage_oai`. For event waits, this PR increases the limit to 10seconds.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run `make coverage_oai` multiple times and observe no failures.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
