### PR TITLE
test(mme): remove redundant calls and waits, add missing steps

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -730,10 +730,12 @@ void mme_remove_ue_context(
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
 
+#if !MME_UNIT_TEST
   // First, notify directoryd of removal
   directoryd_remove_location_a(
       ue_context_p->emm_context._imsi64,
       ue_context_p->emm_context._imsi.length);
+#endif
 
   // Release emm and esm context
   delete_mme_ue_state(ue_context_p->emm_context._imsi64);
@@ -1211,10 +1213,12 @@ void mme_ue_context_update_ue_emm_state(
       (new_mm_state == UE_REGISTERED)) {
     ue_context_p->mm_state = new_mm_state;
 
+#if !MME_UNIT_TEST
     // Report directoryd UE record
     directoryd_report_location_a(
         ue_context_p->emm_context._imsi64,
         ue_context_p->emm_context._imsi.length);
+#endif
 
     // Update Stats
     update_mme_app_stats_attached_ue_add();

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -1330,7 +1330,6 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleDetach) {
   // Check MME state after context release request is processed
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
@@ -1459,7 +1458,6 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleServiceReqDetach) {
   // Check MME state after context release request is processed
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
@@ -1609,7 +1607,6 @@ TEST_F(MmeAppProcedureTest, TestPagingMaxRetx) {
   // Check MME state after context release request is processed
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
@@ -2060,7 +2057,6 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithActiveFlag) {
   // Check MME state after context release request is processed
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
@@ -2212,7 +2208,6 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithoutActiveFlag) {
   // Check MME state after context release request is processed
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
@@ -2224,12 +2219,13 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithoutActiveFlag) {
       nas_msg_periodic_tau_req_without_actv_flag,
       sizeof(nas_msg_periodic_tau_req_without_actv_flag), plmn, guti, 1);
 
+  // Wait for UE context release cmd and DL NAS Transport
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
-
-  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_ue_ctx_release_complete();
+
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
@@ -2248,9 +2244,11 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithoutActiveFlag) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp();
 
-  // Wait for detach completion
+  // Wait for context release request
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
 
   // Check MME state after detach complete
   send_activate_message_to_mme_app();
@@ -2360,7 +2358,6 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithActiveFlag) {
   // Check MME state after context release request is processed
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
@@ -2512,7 +2509,6 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithoutActiveFlag) {
   // Check MME state after context release request is processed
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
@@ -2524,7 +2520,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithoutActiveFlag) {
       nas_msg_normal_tau_req_without_actv_flag,
       sizeof(nas_msg_normal_tau_req_without_actv_flag), plmn, guti, 1);
 
-  // Wait for UE context release cmd
+  // Wait for UE context release cmd and DL NAS Transport
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
@@ -2548,9 +2544,11 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithoutActiveFlag) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp();
 
-  // Wait for detach completion
+  // Wait for context release request
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
 
   // Check MME state after detach complete
   send_activate_message_to_mme_app();
@@ -2660,7 +2658,6 @@ TEST_F(MmeAppProcedureTest, TestTauRejDueToInvalidTac) {
   // Check MME state after context release request is processed
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
@@ -2676,6 +2673,8 @@ TEST_F(MmeAppProcedureTest, TestTauRejDueToInvalidTac) {
       nas_msg_normal_tau_req_with_actv_flag,
       sizeof(nas_msg_normal_tau_req_with_actv_flag), plmn, guti, 2);
 
+  // Waiting for context release request & DL NAS TRANSPORT
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2684,8 +2683,6 @@ TEST_F(MmeAppProcedureTest, TestTauRejDueToInvalidTac) {
   // Check MME state after context release request is processed
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  mme_state_p = magma::lte::MmeNasStateManager::getInstance().get_state(false);
   EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
@@ -2702,12 +2699,15 @@ TEST_F(MmeAppProcedureTest, TestTauRejDueToInvalidTac) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp();
 
-  // Wait for detach completion
+  // Wait for context release request
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  // Check MME state after detach complete
   EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Removed unnecessary calls to fetch the pointer to mme app state.
- Removed unnecessary waits.
- Added missing steps in detach requests in test cases added by [PR #10665](https://github.com/magma/magma/pull/10665)
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
`make test_oai`
`make coverage_oai`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
