### PR TITLE
chore: cleanup bazel build of sentry

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -3,3 +3,5 @@
 .cache
 orc8r/cloud/docker/metrics-configs/alert_rules
 nms/app/node_modules
+nms/node_modules
+orc8r/cloud/node_modules

--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -95,15 +95,11 @@ def cpp_repositories():
         urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],
     )
 
-    new_git_repository(
+    http_archive(
         name = "sentry_native",
+        sha256 = "d7fa804995124c914a3abe077a73307960bbcadfbba9021e8ccbd05c7ba45f88",
         build_file = "//bazel/external:sentry_native.BUILD",
-        # 0.4.12 tag
-        commit = "3436a29d839aa7437548be940ab62a85ca699635",
-        # This is important, we pull in get_sentry/breakpad this way
-        init_submodules = True,
-        remote = "https://github.com/getsentry/sentry-native",
-        shallow_since = "1627998929 +0000",
+        url = "https://github.com/getsentry/sentry-native/releases/download/0.4.12/sentry-native.zip",
     )
 
     http_archive(


### PR DESCRIPTION
## Summary
refer to [#10718](https://github.com/magma/magma/issues/10718) for more details

## Test Plan
`bazel build @sentry_native//:sentry`
<img width="1491" alt="1bazel-build-sentry-native" src="https://user-images.githubusercontent.com/25142344/145283676-fc09c649-388a-4d3e-822b-ce9afda5e74c.png">

`bazel build //orc8r/gateway/c/common/sentry/...:*`
<img width="1489" alt="2bazel-build-dependency" src="https://user-images.githubusercontent.com/25142344/145283849-1b5cfa86-a680-438a-8d55-fa30f411318e.png">

`bazel run //lte/gateway/c/session_manager:sessiond `
<img width="1477" alt="3bazel-build-sessiond" src="https://user-images.githubusercontent.com/25142344/145455888-328e599f-40ee-4861-ad82-6e30ccb58889.png">

`bazel test //...`
![image](https://user-images.githubusercontent.com/25142344/145455852-bfa4386c-75b4-4e13-9f23-b96823fa1a4f.png)


# before change
<img width="1770" alt="4before" src="https://user-images.githubusercontent.com/25142344/145455922-f7e767a6-d23c-4af2-82e1-c7501b989863.png">

# after change 
<img width="1789" alt="5after" src="https://user-images.githubusercontent.com/25142344/145455931-b72f84a9-5e03-4b8d-b36c-b7301eebf2f1.png">
