### PR TITLE
fix(agw): Fix websocket-client pydep version mismatch

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -111,7 +111,7 @@ setup(
         'chardet==3.0.4',
         'docker==4.0.2',
         'urllib3>=1.25.3',
-        'websocket-client==1.2.2',
+        'websocket-client',
         'requests>=2.22.0',
         'certifi>=2019.6.16',
         'idna==2.8',


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fixes `websocket-client` python package mismatch version between magma and magma_test VMs due to difference on installed python versions.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- `make` on magma VM
- `make` on magma_test VM

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
