### PR TITLE
fix(amf): Authentication reject for Security mode failure

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -779,6 +779,20 @@ int amf_proc_authentication_failure(
           "Sending authentication reject with cause AMF_CAUSE_MAC_FAILURE\n");
       rc = amf_auth_auth_rej(ue_id);
     } break;
+    case AMF_UE_SECURITY_CAPABILITIES_MISMATCH: {
+      OAILOG_ERROR(
+          LOG_NAS_AMF,
+          "Sending authentication reject with cause "
+          "AMF_UE_SECURITY_CAPABILITIES_MISMATCH\n");
+      rc = amf_auth_auth_rej(ue_id);
+    } break;
+    case AMF_SECURITY_MODE_REJECT: {
+      OAILOG_ERROR(
+          LOG_NAS_AMF,
+          "Sending authentication reject with cause "
+          "AMF_SECURITY_MODE_REJECT\n");
+      rc = amf_auth_auth_rej(ue_id);
+    } break;
 
     default: {
       OAILOG_DEBUG(LOG_NAS_AMF, "Unsupported 5gmm cause\n");

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -91,6 +91,12 @@ class AMFAppProcedureTest : public ::testing::Test {
       0x7e, 0x0,  0x57, 0x2d, 0x10, 0x25, 0x70, 0x6f, 0x9a, 0x5b, 0x90,
       0xb6, 0xc9, 0x57, 0x50, 0x6c, 0x88, 0x3d, 0x76, 0xcc, 0x63};
 
+  const uint8_t ue_auth_response_security_capability_mismatch_hexbuf[4] = {
+      0x7e, 0x0, 0x59, 0x17};
+
+  const uint8_t ue_auth_response_security_mode_reject_hexbuf[4] = {0x7e, 0x0,
+                                                                   0x59, 0x18};
+
   const uint8_t ue_smc_response_hexbuf[60] = {
       0x7e, 0x4,  0x54, 0xf6, 0xe1, 0x2a, 0x0,  0x7e, 0x0,  0x5e, 0x77, 0x0,
       0x9,  0x45, 0x73, 0x80, 0x61, 0x21, 0x85, 0x61, 0x51, 0xf1, 0x71, 0x0,
@@ -195,6 +201,73 @@ bool validate_smc_procedure(
   }
 
   return true;
+}
+
+TEST_F(AMFAppProcedureTest, TestRegistrationAuthSecurityModeReject) {
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
+      NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+      NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
+  };
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64          = send_initial_ue_message_no_tmsi(
+      amf_app_desc_p, 36, 1, 1, 0, plmn, initial_ue_message_hexbuf,
+      sizeof(initial_ue_message_hexbuf));
+
+  /* Check if UE Context is created with correct imsi */
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
+
+  /* Send the authentication response message from subscriberdb */
+  int rc = RETURNok;
+  rc     = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Validate if authentication procedure is initialized as expected */
+  EXPECT_TRUE(validate_auth_procedure(ue_id, 0));
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_security_mode_reject_hexbuf,
+      sizeof(ue_auth_response_security_mode_reject_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+}
+
+TEST_F(AMFAppProcedureTest, TestRegistrationAuthSecurityCapabilityMismatch) {
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
+      NGAP_NAS_DL_DATA_REQ,                 // Security Command Mode Request to
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
+      NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
+  };
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64          = send_initial_ue_message_no_tmsi(
+      amf_app_desc_p, 36, 1, 1, 0, plmn, initial_ue_message_hexbuf,
+      sizeof(initial_ue_message_hexbuf));
+
+  /* Check if UE Context is created with correct imsi */
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
+
+  /* Send the authentication response message from subscriberdb */
+  int rc = RETURNok;
+  rc     = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn,
+      ue_auth_response_security_capability_mismatch_hexbuf,
+      sizeof(ue_auth_response_security_capability_mismatch_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
 }
 
 TEST_F(AMFAppProcedureTest, TestRegistrationProcNoTMSI) {

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -205,14 +205,6 @@ bool validate_smc_procedure(
 
 TEST_F(AMFAppProcedureTest, TestRegistrationAuthSecurityModeReject) {
   amf_ue_ngap_id_t ue_id = 0;
-  std::vector<MessagesIds> expected_Ids{
-      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
-                                            // indication to ngap
-      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
-      NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
-      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
-      NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
-  };
   /* Send the initial UE message */
   imsi64_t imsi64 = 0;
   imsi64          = send_initial_ue_message_no_tmsi(
@@ -235,19 +227,15 @@ TEST_F(AMFAppProcedureTest, TestRegistrationAuthSecurityModeReject) {
       amf_app_desc_p, ue_id, plmn, ue_auth_response_security_mode_reject_hexbuf,
       sizeof(ue_auth_response_security_mode_reject_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  // ue context should not exist
+  EXPECT_TRUE(ue_context_p == nullptr);
 }
 
 TEST_F(AMFAppProcedureTest, TestRegistrationAuthSecurityCapabilityMismatch) {
   amf_ue_ngap_id_t ue_id = 0;
-  std::vector<MessagesIds> expected_Ids{
-      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
-                                            // indication to ngap
-      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
-      NGAP_NAS_DL_DATA_REQ,                 // Security Command Mode Request to
-      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
-                                       // Registration Accept
-      NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
-  };
   /* Send the initial UE message */
   imsi64_t imsi64 = 0;
   imsi64          = send_initial_ue_message_no_tmsi(
@@ -268,6 +256,11 @@ TEST_F(AMFAppProcedureTest, TestRegistrationAuthSecurityCapabilityMismatch) {
       ue_auth_response_security_capability_mismatch_hexbuf,
       sizeof(ue_auth_response_security_capability_mismatch_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  // ue context should not exist
+  EXPECT_TRUE(ue_context_p == nullptr);
 }
 
 TEST_F(AMFAppProcedureTest, TestRegistrationProcNoTMSI) {


### PR DESCRIPTION
Signed-off-by: Sathyaj27 <sathya.jayadev@wavelabs.ai>
fix(amf): Authentication reject for Security mode failure

## Summary
Added reject for case 23/24 authentication failure.

## Test Plan
1)Tested with TerraVM setup  for case 23:
<img width="951" alt="Capture1" src="https://user-images.githubusercontent.com/94469973/146121777-e08d3141-12ad-473c-a809-a5458935eb4c.PNG">

2) Tested with TeraVM for case 24 :
<img width="960" alt="Capture2" src="https://user-images.githubusercontent.com/94469973/146121928-6b6b11e3-6b19-4a69-b508-9427376f8289.PNG">

3) UT Cases validated  :
<img width="596" alt="UT cases" src="https://user-images.githubusercontent.com/94469973/146122012-49b450d3-bf85-46f2-8422-dacac6c17b1b.PNG">

4) UERANSIM Testing completed for basic call flows.

## Additional Information
Corresponding zenhub task id #10663