### PR TITLE
fix(sessiond): Default AMBR value support in Sessiond and Pipelined.

### DIFF
--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -906,6 +906,14 @@ void SessionStateEnforcer::set_pdr_attributes(
       config.common_context.ue_ipv4());
   rule->mutable_activate_flow_req()->set_ipv6_addr(
       config.common_context.ue_ipv6());
+  rule->mutable_activate_flow_req()->mutable_apn_ambr()->set_max_bandwidth_ul(
+      config.rat_specific_context.m5gsm_session_context()
+          .default_ambr()
+          .max_bandwidth_ul());
+  rule->mutable_activate_flow_req()->mutable_apn_ambr()->set_max_bandwidth_dl(
+      config.rat_specific_context.m5gsm_session_context()
+          .default_ambr()
+          .max_bandwidth_dl());
   rule->mutable_deactivate_flow_req()->set_ip_addr(
       config.common_context.ue_ipv4());
   rule->mutable_deactivate_flow_req()->set_ipv6_addr(

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -791,10 +791,10 @@ TEST_F(SessionManagerHandlerTest, test_SetAmfSessionAmbr) {
       ->set_br_unit(AggregatedMaximumBitrate::KBPS);
   cfg.rat_specific_context.mutable_m5gsm_session_context()
       ->mutable_default_ambr()
-      ->set_max_bandwidth_ul(1024);
+      ->set_max_bandwidth_ul(10000);
   cfg.rat_specific_context.mutable_m5gsm_session_context()
       ->mutable_default_ambr()
-      ->set_max_bandwidth_dl(1024);
+      ->set_max_bandwidth_dl(20000);
 
   SessionUpdate session_update =
       SessionStore::get_default_session_update(session_map);
@@ -814,8 +814,8 @@ TEST_F(SessionManagerHandlerTest, test_SetAmfSessionAmbr) {
                   ->mutable_m5g_session_context_rsp();
 
   rsp->mutable_session_ambr()->set_br_unit(AggregatedMaximumBitrate::KBPS);
-  rsp->mutable_session_ambr()->set_max_bandwidth_ul(1024);
-  rsp->mutable_session_ambr()->set_max_bandwidth_dl(1024);
+  rsp->mutable_session_ambr()->set_max_bandwidth_ul(10000);
+  rsp->mutable_session_ambr()->set_max_bandwidth_dl(20000);
 
   EXPECT_CALL(*amf_srv_client,
               handle_response_to_access(CheckSrvResponse(&expected_response)))

--- a/lte/gateway/python/scripts/smf_upf_integration_cli.py
+++ b/lte/gateway/python/scripts/smf_upf_integration_cli.py
@@ -15,6 +15,7 @@ limitations under the License.
 
 import argparse
 
+from lte.protos.apn_pb2 import AggregatedMaximumBitrate
 from lte.protos.session_manager_pb2 import (
     CommonSessionContext,
     M5GSMSessionContext,
@@ -58,6 +59,10 @@ class CreateAmfSession(object):
                     ),
                     pdu_session_type=PduSessionType.Name(0),
                     ssc_mode=SscMode.Name(2),
+                    default_ambr=AggregatedMaximumBitrate(
+                        max_bandwidth_ul=750000,
+                        max_bandwidth_dl=1000000,
+                    ),
                 ),
             ),
         )


### PR DESCRIPTION
Signed-off-by: khansiddiquekc <khan.siddique@wavelabs.in>
## Summary

Previous Sessiond was not sending default AMBR values to pipelined. Now it is being set correctly as can be seen below in table-13 output, `pkt_mark` is being set as per AMBR value received from Sessiond.
```
Output of table=13:
vagrant@magma-dev-focal:~$ sudo ovs-ofctl -O OpenFlow13 dump-flows gtp_br0 table=13
cookie=0x2, duration=2406.092s, table=13, n_packets=0, n_bytes=0, priority=65533,ip,reg1=0x1,metadata=0x181c9,nw_src=192.168.128.11 actions=note:61.6c.6c.6f.77.6c.69.73.74.5f.73.69.64.2d.49.4d.53.49.31.32.33.34.35.2d.42.4c.52.00.00.00,set_field:0x3->pkt_mark,set_field:0x2->reg2,set_field:0x1->reg4,set_field:0x7fffffff->reg11,resubmit(,14),resubmit(,20)
cookie=0x2, duration=2406.085s, table=13, n_packets=0, n_bytes=0, priority=65533,ip,reg1=0x10,metadata=0x181c9,nw_dst=192.168.128.11 actions=note:61.6c.6c.6f.77.6c.69.73.74.5f.73.69.64.2d.49.4d.53.49.31.32.33.34.35.2d.42.4c.52.00.00.00,set_field:0x5->pkt_mark,set_field:0x2->reg2,set_field:0x1->reg4,set_field:0x7fffffff->reg11,resubmit(,14),resubmit(,20)
cookie=0xfffffffffffffffe, duration=45675.056s, table=13, n_packets=39, n_bytes=2730, priority=0 actions=resubmit(,14),set_field:0->reg0,set_field:0->reg3
```

## Test Plan

Tested with stub cli  `lte/gateway/python/scripts/smf_upf_integration_cli.py`

## Additional Information

Corresponding Zenhub task #10704 
For complete logs, please refer to the following comment.