### PR TITLE
fix(ci): Fix issue 8765 make autolabel gha workflow read from codeowner file

### DIFF
--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -42,7 +42,6 @@ jobs:
       - uses: actions/github-script@v3
         with:
           script: |
-g
             var fs = require('fs');
             var codeownersBuf = fs.readFileSync(process.env.MAGMA_ROOT + '/CODEOWNERS', {encoding: 'utf8'});
 

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -59,7 +59,6 @@ jobs:
                 if(token.startsWith("@magma/approvers-"))  {
                   comp = token.split('-')[1];
                 }
-                // console.log("PathX=" + path + " CompX=" + comp);
                 if( path && comp ) {
                   codeownersDict[path] = comp;
                 }

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -43,8 +43,9 @@ jobs:
         with:
           script: |
             var fs = require('fs');
+
             console.log("PWD:" + process.cwd());
-            var codeownersBuf = fs.readFileSync(process.env.MAGMA_ROOT_DIR + 'CODEOWNERS', {encoding: 'utf8'});
+            var codeownersBuf = fs.readFileSync(process.env.MAGMA_ROOT_DIR + '/CODEOWNERS', {encoding: 'utf8'});
             console.log("CODEOWNERS file contents:" + codeownersBuf);
 
             let newCompLbls = new Set(); // Set of new label strings

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -60,7 +60,7 @@ jobs:
                 if(token.startsWith("@magma/approvers-"))  {
                   comp = token.split('-')[1];
                 }
-                if( (path !== "") && (comp !== "") ) {
+                if( path && comp ) {
                   codeownersDict[path] = comp;
                 }
               } // End of for loop on tokens on each record of CODEOWNERS file

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -39,13 +39,14 @@ jobs:
     env:
       MAGMA_ROOT_DIR: "${{ github.workspace }}"
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/github-script@v3
         with:
           script: |
             var fs = require('fs');
 
             console.log("PWD:" + process.cwd());
-            var codeownersBuf = fs.readFileSync(process.env.MAGMA_ROOT_DIR + '/CODEOWNERS', {encoding: 'utf8'});
+            var codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
             console.log("CODEOWNERS file contents:" + codeownersBuf);
 
             let newCompLbls = new Set(); // Set of new label strings

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           script: |
             var fs = require('fs');
-            var codeownersBuf = fs.readFileSync(process.env.MAGMA_ROOT + '/CODEOWNERS', {encoding: 'utf8'});
+            var codeownersBuf = fs.readFileSync('CODEOWNERS', {encoding: 'utf8'});
 
             console.log("CODEOWNERS file contents:" + codeownersBuf);
 

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -42,23 +42,27 @@ jobs:
         with:
           script: |
             let fs = require('fs');
+            let path = "";
+            let comp = "";
             console.log("PWD:" + process.cwd());
             let codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
             console.log("CODEOWNERS file contents:" + codeownersBuf);
             const records = codeownersBuf.split(/[\r\n]+/);
-            for( const rec of records ) {
+            for( const rec of records )
+            {
               if (! rec.startsWith("/")) { continue; }
               const tokens = rec.split(" ");
-              for( const token of tokens ) {
-                if(token.startsWith("/"))  {
-                  let path = token.substring(1);
+              for( const token of tokens )
+              {
+                if(token.startsWith("/")) {
+                  path = token.substring(1);
                 }
                 if(token.startsWith("@magma/approvers-"))  {
-                  let comp = token.substring(17);
+                  comp = token.substring(17);
                 }
                 console.log("Path=" + path + " Comp=" + comp);
-              }
-            }
+              } // End of for loop on tokens on each record of CODEOWNERS file
+            } // End of for loop on record of CODEOWNERS file
 
             let newCompLbls = new Set(); // Set of new label strings
 

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -36,13 +36,14 @@ concurrency:
 jobs:
   AutoLabelPR:
     runs-on: ubuntu-latest
+    MAGMA_ROOT: "${{ github.workspace }}"
     steps:
       - uses: actions/github-script@v3
         with:
           script: |
 
             var fs = require('fs');
-            var codeownersBuf = fs.readFileSync(process.env.WORKFLOW_NAME + '/CODEOWNERS', {encoding: 'utf8'});
+            var codeownersBuf = fs.readFileSync(process.env.MAGMA_ROOT + '/CODEOWNERS', {encoding: 'utf8'});
 
             console.log("CODEOWNERS file contents:" + codeownersBuf);
 

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -45,7 +45,7 @@ jobs:
             console.log("PWD:" + process.cwd());
             let codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
             console.log("CODEOWNERS file contents:" + codeownersBuf);
-            const records = codeOwnersBuf.split(/[\r\n]+/);
+            const records = codeownersBuf.split(/[\r\n]+/);
             for( const rec of records ) {
               if (! rec.startsWith("/")) { continue; }
               const tokens = rec.split(" ");

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -28,6 +28,7 @@ on:  # yamllint disable-line rule:truthy
       - 'third_party/**'
       - 'wifi/**'
       - 'xwf/**'
+      - 'CODEOWNERS'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -43,7 +43,9 @@ jobs:
           script: |
             let fs = require('fs');
             let codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
-            var codeownersDict = {};
+            let path = "";
+            let comp = "";
+            let codeownersDict = {};
             const records = codeownersBuf.split(/[\r\n]+/);
             for( const rec of records )
             {
@@ -51,9 +53,6 @@ jobs:
               const tokens = rec.split(" ");
               for( const token of tokens )
               {
-                var path = "";
-                var comp = "";
-
                 if(token.startsWith("/")) {
                   path = token.substring(1);
                 }

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -58,14 +58,14 @@ jobs:
                 }
                 if(token.startsWith("@magma/approvers-"))  {
                   comp = token.split('-')[1];
+                  codeownersDict[path] = comp;
                 }
-                console.log("Path=" + path + " Comp=" + comp);
-                codeownersDict[path] = comp;
+                //console.log("Path=" + path + " Comp=" + comp);
               } // End of for loop on tokens on each record of CODEOWNERS file
             } // End of for loop on record of CODEOWNERS file
 
             for(var key in codeownersDict) {
-              console.log("Key=" + key + " Value=" + codeownersDict[key]);
+              console.log("Path=" + key + " Comp=" + codeownersDict[key]);
               // do something with "key" and "value" variables
             }
 

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           script: |
 
+            var fs = require('fs');
+            var codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
+            console.log("CODEOWNERS file contents:" + codeownersBuf);
+
             let newCompLbls = new Set(); // Set of new label strings
 
             // Fetch files modified in the PR

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -42,7 +42,8 @@ jobs:
           script: |
 
             var fs = require('fs');
-            var codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
+            var codeownersBuf = fs.readFileSync(process.env.WORKFLOW_NAME + '/CODEOWNERS', {encoding: 'utf8'});
+
             console.log("CODEOWNERS file contents:" + codeownersBuf);
 
             let newCompLbls = new Set(); // Set of new label strings

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -36,18 +36,30 @@ concurrency:
 jobs:
   AutoLabelPR:
     runs-on: ubuntu-latest
-    env:
-      MAGMA_ROOT_DIR: "${{ github.workspace }}"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/github-script@v3
         with:
           script: |
-            var fs = require('fs');
+            let fs = require('fs');
 
             console.log("PWD:" + process.cwd());
-            var codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
+            let codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
             console.log("CODEOWNERS file contents:" + codeownersBuf);
+            const records = codeOwnersBuf.split(/[\r\n]+/);
+            for( const rec of records ) {
+              if (not rec.startsWith("/")) { continue; }
+              const tokens = rec.split(" ");
+              for( const token of tokens ) {
+                if(token.startsWith("/"))  {
+                  let path = token.substring(1);
+                }
+                if(token.startsWith("@magma/approvers-"))  {
+                  let comp = token.substring(17);
+                }
+                console.log("Path=" + path + " Comp=" + comp);
+              }
+            }
 
             let newCompLbls = new Set(); // Set of new label strings
 

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -42,13 +42,12 @@ jobs:
         with:
           script: |
             let fs = require('fs');
-
             console.log("PWD:" + process.cwd());
             let codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
             console.log("CODEOWNERS file contents:" + codeownersBuf);
             const records = codeOwnersBuf.split(/[\r\n]+/);
             for( const rec of records ) {
-              if (not rec.startsWith("/")) { continue; }
+              if (! rec.startsWith("/")) { continue; }
               const tokens = rec.split(" ");
               for( const token of tokens ) {
                 if(token.startsWith("/"))  {

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -37,14 +37,14 @@ jobs:
   AutoLabelPR:
     runs-on: ubuntu-latest
     env:
-      MAGMA_ROOT: "${{ github.workspace }}"
+      MAGMA_ROOT_DIR: "${{ github.workspace }}"
     steps:
       - uses: actions/github-script@v3
         with:
           script: |
             var fs = require('fs');
-            var codeownersBuf = fs.readFileSync('CODEOWNERS', {encoding: 'utf8'});
-
+            console.log("PWD:" + process.cwd());
+            var codeownersBuf = fs.readFileSync(process.env.MAGMA_ROOT_DIR + 'CODEOWNERS', {encoding: 'utf8'});
             console.log("CODEOWNERS file contents:" + codeownersBuf);
 
             let newCompLbls = new Set(); // Set of new label strings

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -36,12 +36,13 @@ concurrency:
 jobs:
   AutoLabelPR:
     runs-on: ubuntu-latest
-    MAGMA_ROOT: "${{ github.workspace }}"
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
     steps:
       - uses: actions/github-script@v3
         with:
           script: |
-
+g
             var fs = require('fs');
             var codeownersBuf = fs.readFileSync(process.env.MAGMA_ROOT + '/CODEOWNERS', {encoding: 'utf8'});
 

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -42,8 +42,6 @@ jobs:
         with:
           script: |
             let fs = require('fs');
-            let path = "";
-            let comp = "";
             let codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
             var codeownersDict = {};
             const records = codeownersBuf.split(/[\r\n]+/);
@@ -53,18 +51,22 @@ jobs:
               const tokens = rec.split(" ");
               for( const token of tokens )
               {
+                let path = "";
+                let comp = "";
+
                 if(token.startsWith("/")) {
                   path = token.substring(1);
                 }
                 if(token.startsWith("@magma/approvers-"))  {
                   comp = token.split('-')[1];
+                }
+                if( (path !== "") && (comp !== "") ) {
                   codeownersDict[path] = comp;
                 }
-                //console.log("Path=" + path + " Comp=" + comp);
               } // End of for loop on tokens on each record of CODEOWNERS file
             } // End of for loop on record of CODEOWNERS file
 
-            for(var key in codeownersDict) {
+            for(let path in codeownersDict) {
               console.log("Path=" + key + " Comp=" + codeownersDict[key]);
               // do something with "key" and "value" variables
             }

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -44,9 +44,8 @@ jobs:
             let fs = require('fs');
             let path = "";
             let comp = "";
-            console.log("PWD:" + process.cwd());
             let codeownersBuf = fs.readFileSync('./CODEOWNERS', {encoding: 'utf8'});
-            console.log("CODEOWNERS file contents:" + codeownersBuf);
+            var codeownersDict = {};
             const records = codeownersBuf.split(/[\r\n]+/);
             for( const rec of records )
             {
@@ -58,11 +57,17 @@ jobs:
                   path = token.substring(1);
                 }
                 if(token.startsWith("@magma/approvers-"))  {
-                  comp = token.substring(17);
+                  comp = token.split('-')[1];
                 }
                 console.log("Path=" + path + " Comp=" + comp);
+                codeownersDict[path] = comp;
               } // End of for loop on tokens on each record of CODEOWNERS file
             } // End of for loop on record of CODEOWNERS file
+
+            for(var key in codeownersDict) {
+              console.log("Key=" + key + " Value=" + codeownersDict[key]);
+              // do something with "key" and "value" variables
+            }
 
             let newCompLbls = new Set(); // Set of new label strings
 

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -83,68 +83,8 @@ jobs:
                   console.log("File=" + fullPath + " startsWith=" + k + " component=" + codeownersDict[k]);
                   newCompLbls.add("component: " + codeownersDict[k]);
                 }
-              }
-             switch (true) {
-              case /^ci-scripts\/.*/.test(f.filename):
-              case /^\.circleci\/.*/.test(f.filename):
-              case /^circleci\/.*/.test(f.filename):
-              case /^\.github\/workflows\/.*/.test(f.filename):
-              case /^third_party\/build\/.*/.test(f.filename):
-              case /^orc8r\/tools\/packer\/.*/.test(f.filename):
-              case /^orc8r\/cloud\/deploy\/bare-metal\/.*/.test(f.filename):
-              case /^orc8r\/cloud\/deploy\/bare-metal-ansible\/.*/.test(f.filename):
-              case /^lte\/gateway\/docker\/.*/.test(f.filename):
-              case /^lte\/gateway\/release\/.*/.test(f.filename):
-              case /^lte\/gateway\/Vagrantfile/.test(f.filename):
-              case /^cwf\/gateway\/Vagrantfile/.test(f.filename):
-                console.log("file changed under CI component : " + f['filename']);
-                //newCompLbls.add("component: ci");
-                break;
-              case /^nms\/.*/.test(f.filename):
-                console.log("file changed under NMS component : " + f['filename']);
-                //newCompLbls.add("component: nms");
-                break;
-              case /^cwf\/.*/.test(f.filename):
-              case /^feg\/radius\/.*/.test(f.filename):
-                console.log("file changed under CWF component : " + f['filename']);
-                //newCompLbls.add("component: cwf");
-                break;
-              case /^feg\/.*/.test(f.filename):
-                console.log("file changed under FEG component : " + f['filename']);
-                //newCompLbls.add("component: feg");
-                break;
-              case /^openwrt\/.*/.test(f.filename):
-                console.log("file changed under OPENWRT component : " + f['filename']);
-                //newCompLbls.add("component: openwrt");
-                break;
-              case /^lte\/gateway\/.*/.test(f.filename):
-              case /^lte\/protos\/.*/.test(f.filename):
-              case /^orc8r\/gateway\/c\/.*/.test(f.filename):
-              case /^third_party\/gtp_ovs\/.*/.test(f.filename):
-                console.log("file changed under AGW component : " + f['filename']);
-                //newCompLbls.add("component: agw");
-                break;
-              case /.*\/cloud\/.*/.test(f.filename):
-              case /^\.golangci\.yml/.test(f.filename):
-              case /^orc8r\/.*/.test(f.filename):
-                console.log("file changed under ORC8R component : " + f['filename']);
-                //newCompLbls.add("component: orc8r");
-                break;
-              case /^xwf\/.*/.test(f.filename):
-                console.log("file changed under XWF component : " + f['filename']);
-                //newCompLbls.add("component: xwf");
-                break;
-              case /^show-tech\/.*/.test(f.filename):
-                console.log("file changed under SHOW-TECH component : " + f['filename']);
-                //newCompLbls.add("component: show-tech");
-                break;
-              case /^docs\/.*/.test(f.filename):
-                console.log("file changed under DOCS: " + f['filename']);
-                //newCompLbls.add("component: docs");
-                break;
-             } // end of switch case
-            } // end of for loop
-
+              } //end of for loop on codeowners dictionary object
+            } // end of for loop on PR files
 
             const curLblObjs = await github.issues.listLabelsOnIssue({
               issue_number: context.issue.number,

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -61,7 +61,7 @@ jobs:
                 }
                 console.log("PathX=" + path + " CompX=" + comp);
                 if( path && comp ) {
-                  codeownersDict[p] = c;
+                  codeownersDict[path] = comp;
                 }
               } // End of for loop on tokens on each record of CODEOWNERS file
             } // End of for loop on record of CODEOWNERS file

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -61,13 +61,13 @@ jobs:
                 }
                 console.log("PathX=" + path + " CompX=" + comp);
                 if( path && comp ) {
-                  codeownersDict[path] = comp;
+                  codeownersDict[p] = c;
                 }
               } // End of for loop on tokens on each record of CODEOWNERS file
             } // End of for loop on record of CODEOWNERS file
 
-            for(var path in codeownersDict) {
-              console.log("Path=" + path + " Comp=" + codeownersDict[path]);
+            for(var k in codeownersDict) {
+              console.log("Path=" + k + " Comp=" + codeownersDict[k]);
             }
 
             let newCompLbls = new Set(); // Set of new label strings
@@ -81,6 +81,12 @@ jobs:
 
             // Identify new component labels based on the files modified in the PR
             for (const f of pulledFiles['data']) {
+              var fullPath = f.filename;
+              for(var k in codeownersDict) {
+                if( fullPath.startsWith(k) )  {
+                  console.log("File=" + fullPath + " startsWith=" + k + " component=" + codeownersDict[k]);
+                }
+              }
              switch (true) {
               case /^ci-scripts\/.*/.test(f.filename):
               case /^\.circleci\/.*/.test(f.filename):

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -51,8 +51,8 @@ jobs:
               const tokens = rec.split(" ");
               for( const token of tokens )
               {
-                let path = "";
-                let comp = "";
+                var path = "";
+                var comp = "";
 
                 if(token.startsWith("/")) {
                   path = token.substring(1);
@@ -60,15 +60,15 @@ jobs:
                 if(token.startsWith("@magma/approvers-"))  {
                   comp = token.split('-')[1];
                 }
+                console.log("PathX=" + path + " CompX=" + comp);
                 if( path && comp ) {
                   codeownersDict[path] = comp;
                 }
               } // End of for loop on tokens on each record of CODEOWNERS file
             } // End of for loop on record of CODEOWNERS file
 
-            for(let path in codeownersDict) {
-              console.log("Path=" + key + " Comp=" + codeownersDict[key]);
-              // do something with "key" and "value" variables
+            for(var path in codeownersDict) {
+              console.log("Path=" + path + " Comp=" + codeownersDict[path]);
             }
 
             let newCompLbls = new Set(); // Set of new label strings

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -59,16 +59,12 @@ jobs:
                 if(token.startsWith("@magma/approvers-"))  {
                   comp = token.split('-')[1];
                 }
-                console.log("PathX=" + path + " CompX=" + comp);
+                // console.log("PathX=" + path + " CompX=" + comp);
                 if( path && comp ) {
                   codeownersDict[path] = comp;
                 }
               } // End of for loop on tokens on each record of CODEOWNERS file
             } // End of for loop on record of CODEOWNERS file
-
-            for(var k in codeownersDict) {
-              console.log("Path=" + k + " Comp=" + codeownersDict[k]);
-            }
 
             let newCompLbls = new Set(); // Set of new label strings
 
@@ -85,6 +81,7 @@ jobs:
               for(var k in codeownersDict) {
                 if( fullPath.startsWith(k) )  {
                   console.log("File=" + fullPath + " startsWith=" + k + " component=" + codeownersDict[k]);
+                  newCompLbls.add("component: " + codeownersDict[k]);
                 }
               }
              switch (true) {
@@ -101,49 +98,49 @@ jobs:
               case /^lte\/gateway\/Vagrantfile/.test(f.filename):
               case /^cwf\/gateway\/Vagrantfile/.test(f.filename):
                 console.log("file changed under CI component : " + f['filename']);
-                newCompLbls.add("component: ci");
+                //newCompLbls.add("component: ci");
                 break;
               case /^nms\/.*/.test(f.filename):
                 console.log("file changed under NMS component : " + f['filename']);
-                newCompLbls.add("component: nms");
+                //newCompLbls.add("component: nms");
                 break;
               case /^cwf\/.*/.test(f.filename):
               case /^feg\/radius\/.*/.test(f.filename):
                 console.log("file changed under CWF component : " + f['filename']);
-                newCompLbls.add("component: cwf");
+                //newCompLbls.add("component: cwf");
                 break;
               case /^feg\/.*/.test(f.filename):
                 console.log("file changed under FEG component : " + f['filename']);
-                newCompLbls.add("component: feg");
+                //newCompLbls.add("component: feg");
                 break;
               case /^openwrt\/.*/.test(f.filename):
                 console.log("file changed under OPENWRT component : " + f['filename']);
-                newCompLbls.add("component: openwrt");
+                //newCompLbls.add("component: openwrt");
                 break;
               case /^lte\/gateway\/.*/.test(f.filename):
               case /^lte\/protos\/.*/.test(f.filename):
               case /^orc8r\/gateway\/c\/.*/.test(f.filename):
               case /^third_party\/gtp_ovs\/.*/.test(f.filename):
                 console.log("file changed under AGW component : " + f['filename']);
-                newCompLbls.add("component: agw");
+                //newCompLbls.add("component: agw");
                 break;
               case /.*\/cloud\/.*/.test(f.filename):
               case /^\.golangci\.yml/.test(f.filename):
               case /^orc8r\/.*/.test(f.filename):
                 console.log("file changed under ORC8R component : " + f['filename']);
-                newCompLbls.add("component: orc8r");
+                //newCompLbls.add("component: orc8r");
                 break;
               case /^xwf\/.*/.test(f.filename):
                 console.log("file changed under XWF component : " + f['filename']);
-                newCompLbls.add("component: xwf");
+                //newCompLbls.add("component: xwf");
                 break;
               case /^show-tech\/.*/.test(f.filename):
                 console.log("file changed under SHOW-TECH component : " + f['filename']);
-                newCompLbls.add("component: show-tech");
+                //newCompLbls.add("component: show-tech");
                 break;
               case /^docs\/.*/.test(f.filename):
                 console.log("file changed under DOCS: " + f['filename']);
-                newCompLbls.add("component: docs");
+                //newCompLbls.add("component: docs");
                 break;
              } // end of switch case
             } // end of for loop


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Fix issue [8765](https://github.com/magma/magma/issues/8765) - make autolabel gha workflow read from codeowner file
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Testing is done in forked repo under branch test-issue-8765. Tested on [PR](https://github.com/ranj8work/magma/pull/1). workflow action log is [here](https://github.com/ranj8work/magma/runs/4477387978?check_suite_focus=true). Full logs are [here](https://pipelines.actions.githubusercontent.com/jZ8fnY0IO29UAvj9Y4uXZQfFHOkmqyS3D4wnLzGrQoL3isvxfw/_apis/pipelines/1/runs/1237/signedlogcontent/2?urlExpires=2021-12-09T23%3A34%3A09.9958170Z&urlSigningMethod=HMACV1&urlSignature=uIe8WiuRjbL%2B147CaY7G5rimrImOkrW7h7shmdAd6rM%3D).
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [NO] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
