### PR TITLE
chore: Update ghz API params on ansible

### DIFF
--- a/experimental/cloudstrapper/playbooks/roles/ghz-platform/vars/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/ghz-platform/vars/main.yaml
@@ -20,5 +20,5 @@ load_tests:
 
 MAGMA_ROOT: "{{ magmaRepo }}"
 GHZ_PATH: "{{ magmaRepo }}/lte/gateway/docker/ghz"
-GHZ_API_URL: "http://ec2-18-183-107-169.ap-northeast-1.compute.amazonaws.com"
-GHZ_API_PORT: 8000
+GHZ_API_URL: "http://35.75.138.193"
+GHZ_API_PORT: 80


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Since ghz-web is now running on port 80, updating params on `../vars/main.yaml` for running the playbook
- Also update host with provided elastic IP from bastion instance

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- pushed tests running playbook on cloudstrapper AGW

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
