### PR TITLE
test(mme): Add MME_APP unit test for Auth and ICS failures

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -245,6 +245,14 @@ void send_ics_response() {
   return;
 }
 
+void send_ics_failure() {
+  MessageDef* message_p =
+      itti_alloc_new_message(TASK_S1AP, MME_APP_INITIAL_CONTEXT_SETUP_FAILURE);
+  MME_APP_INITIAL_CONTEXT_SETUP_FAILURE(message_p).mme_ue_s1ap_id = 1;
+  send_msg_to_task(&task_zmq_ctx_main, TASK_MME_APP, message_p);
+  return;
+}
+
 void send_ue_ctx_release_complete() {
   MessageDef* message_p =
       itti_alloc_new_message(TASK_S1AP, S1AP_UE_CONTEXT_RELEASE_COMPLETE);

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -90,6 +90,8 @@ void send_delete_session_resp();
 
 void send_ics_response();
 
+void send_ics_failure();
+
 void send_ue_ctx_release_complete();
 
 void send_ue_capabilities_ind();


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Add unit test for MME_APP task for:
- Authentication Failure due to MAC error
- Authentication Failure due to Synchronization error
- ICS failure

## Test Plan

make test_oai

