### PR TITLE
fix(orc8r): Updated Helm and Docker repo links for artifactory

### DIFF
--- a/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.custom
+++ b/experimental/cloudstrapper/playbooks/roles/control/templates/main.tf.j2.custom
@@ -63,7 +63,7 @@ module "orc8r-app" {
   docker_pass = ""
 
   # Note that this can be any Helm chart repo provider
-  helm_repo = "https://docker.artifactory.magmacore.org/artifactory/helm"
+  helm_repo = "https://artifactory.magmacore.org/artifactory/helm"
   helm_user = ""
   helm_pass = ""
   eks_cluster_id = module.orc8r.eks_cluster_id

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
@@ -70,7 +70,7 @@ module "orc8r-app" {
   docker_pass     = ""
 
   # Note that this can be any Helm chart repo provider
-  helm_repo       = "https://docker.artifactory.magmacore.org/artifactory/helm"
+  helm_repo       = "https://artifactory.magmacore.org/artifactory/helm"
   helm_user       = ""
   helm_pass       = ""
   eks_cluster_id = module.orc8r.eks_cluster_id

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/poc/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/poc/main.tf
@@ -81,12 +81,12 @@ module "orc8r-app" {
   orc8r_db_pass    = module.orc8r.orc8r_db_pass
 
   # Note that this can be any container registry provider
-  docker_registry = "https://docker.artifactory.magmacore.org/artifactory/docker"
+  docker_registry = "docker.artifactory.magmacore.org"
   docker_user     = ""
   docker_pass     = ""
 
   # Note that this can be any Helm chart repo provider
-  helm_repo       = "https://docker.artifactory.magmacore.org/artifactory/helm"
+  helm_repo       = "https://artifactory.magmacore.org/artifactory/helm"
   helm_user       = ""
   helm_pass       = ""
   eks_cluster_id = module.orc8r.eks_cluster_id


### PR DESCRIPTION
Signed-off-by: Shubham Tatvamasi <shubhamtatvamasi@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

fix(orc8r): Updated Helm and Docker repo links for artifactory

We don't need `docker` subdomain in helm repo URL
```bash
curl https://artifactory.magmacore.org/artifactory/helm/index.yaml
```

We already have same updated here:
https://github.com/magma/magma/blob/master/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf#L333


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
