### PR TITLE
fix(sessiond): remove hard coding for SSC_MODE_3 in sessiond and fill…

### DIFF
--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -81,11 +81,8 @@ SessionConfig SetMessageManagerHandler::m5g_build_session_config(
   cfg.common_context = request.common_context();
   cfg.rat_specific_context = request.rat_specific_context();
 
-  /* As we dont have 5G polices defined yet, for now
-   * for all new connection we set SSC  mode as SSC_MODE_3
-   */
   cfg.rat_specific_context.mutable_m5gsm_session_context()->set_ssc_mode(
-      SSC_MODE_3);
+      request.rat_specific_context().m5gsm_session_context().ssc_mode());
 
   return cfg;
 }


### PR DESCRIPTION
remove hard coding for SSC_MODE_3 in sessiond and fill whatever AMF requested SSC_MODE

Signed-off-by: Balaji-Jatla <sai.balaji@wavelabs.ai>


## Summary
1) currently sessiond is hard coded to SSC_MODE_3 
2) This PR removed the hardcode and setting ssc_mode attribute whatever AMF is requesting


## Test Plan
Tested with stub CLI `magma/lte/gateway/python/scripts/smf_upf_integration_cli.py`

## Additional Information
1) corresponding zenhub task id is #10709 
2) For complete logs refer following comment section.


