### PR TITLE
fix(nms): incorrect subscribers total

### DIFF
--- a/nms/app/packages/magmalte/app/components/context/SubscriberContext.js
+++ b/nms/app/packages/magmalte/app/components/context/SubscriberContext.js
@@ -41,6 +41,7 @@ export type SubscriberContextType = {
   sessionState: {[string]: subscriber_state},
   metrics?: {[string]: Metrics},
   gwSubscriberMap: {[gateway_id]: Array<subscriber_id>},
+  subscribersTotal?: number,
   setState?: (
     key: string,
     val?: mutable_subscriber | mutable_subscribers,

--- a/nms/app/packages/magmalte/app/components/lte/LteContext.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteContext.js
@@ -288,7 +288,7 @@ export function SubscriberContextProvider(props: Props) {
             newState,
             newSessionState,
           }),
-        subscribersTotal,
+        subscribersTotal: subscribersTotal,
       }}>
       {props.children}
     </SubscriberContext.Provider>

--- a/nms/app/packages/magmalte/app/components/lte/LteContext.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteContext.js
@@ -242,6 +242,7 @@ export function SubscriberContextProvider(props: Props) {
   const [subscriberMetrics, setSubscriberMetrics] = useState({});
   const [isLoading, setIsLoading] = useState(true);
   const enqueueSnackbar = useEnqueueSnackbar();
+  const [subscribersTotal, setSubscribersTotal] = useState(0);
   useEffect(() => {
     const fetchLteState = async () => {
       if (networkId == null) {
@@ -253,6 +254,7 @@ export function SubscriberContextProvider(props: Props) {
         setSubscriberMetrics,
         setSessionState,
         enqueueSnackbar,
+        setSubscribersTotal,
       }),
         setIsLoading(false);
     };
@@ -286,6 +288,7 @@ export function SubscriberContextProvider(props: Props) {
             newState,
             newSessionState,
           }),
+        subscribersTotal,
       }}>
       {props.children}
     </SubscriberContext.Provider>

--- a/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
+++ b/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
@@ -24,7 +24,7 @@ import type {
   network_id,
   subscriber,
   subscriber_state,
-  paginated_subscribers
+  paginated_subscribers,
 } from '@fbcnms/magma-api';
 
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
@@ -52,7 +52,7 @@ type InitSubscriberStateProps = {
   setSubscriberMap: ({[string]: subscriber}) => void,
   setSessionState: ({[string]: subscriber_state}) => void,
   setSubscriberMetrics?: ({[string]: Metrics}) => void,
-  setSubscribersTotal?: number,
+  setSubscribersTotal?: (subscribersTotal: number) => void,
   enqueueSnackbar?: (
     msg: string,
     cfg: EnqueueSnackbarOptions,
@@ -161,7 +161,7 @@ export default async function InitSubscriberState(
     enqueueSnackbar,
     setSubscribersTotal,
   } = props;
-  const subscriberResponse: paginated_subscribers = await FetchSubscribers({
+  const subscriberResponse: Promise<paginated_subscribers> = await FetchSubscribers({
     networkId,
     enqueueSnackbar,
   });

--- a/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
+++ b/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
@@ -51,6 +51,7 @@ type InitSubscriberStateProps = {
   setSubscriberMap: ({[string]: subscriber}) => void,
   setSessionState: ({[string]: subscriber_state}) => void,
   setSubscriberMetrics?: ({[string]: Metrics}) => void,
+  setSubscribersTotal?: number,
   enqueueSnackbar?: (
     msg: string,
     cfg: EnqueueSnackbarOptions,
@@ -157,11 +158,13 @@ export default async function InitSubscriberState(
     setSubscriberMetrics,
     setSessionState,
     enqueueSnackbar,
+    setSubscribersTotal
   } = props;
   const subscriberResponse = await FetchSubscribers({
     networkId,
     enqueueSnackbar,
   });
+  setSubscribersTotal(subscriberResponse.total_count);
   if (subscriberResponse) {
     setSubscriberMap(subscriberResponse.subscribers);
   }

--- a/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
+++ b/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
@@ -24,6 +24,7 @@ import type {
   network_id,
   subscriber,
   subscriber_state,
+  paginated_subscribers
 } from '@fbcnms/magma-api';
 
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
@@ -158,9 +159,9 @@ export default async function InitSubscriberState(
     setSubscriberMetrics,
     setSessionState,
     enqueueSnackbar,
-    setSubscribersTotal
+    setSubscribersTotal,
   } = props;
-  const subscriberResponse = await FetchSubscribers({
+  const subscriberResponse: paginated_subscribers = await FetchSubscribers({
     networkId,
     enqueueSnackbar,
   });

--- a/nms/app/packages/magmalte/app/views/network/NetworkKPIs.js
+++ b/nms/app/packages/magmalte/app/views/network/NetworkKPIs.js
@@ -52,7 +52,7 @@ export default function NetworkKPI() {
       {
         icon: PeopleIcon,
         category: 'Subscribers',
-        value: Object.keys(subscriberCtx.state).length,
+        value: subscriberCtx.subscribersTotal||0,
       },
       {
         icon: LibraryBooksIcon,

--- a/nms/app/packages/magmalte/app/views/network/NetworkKPIs.js
+++ b/nms/app/packages/magmalte/app/views/network/NetworkKPIs.js
@@ -52,7 +52,7 @@ export default function NetworkKPI() {
       {
         icon: PeopleIcon,
         category: 'Subscribers',
-        value: Object.keys(subscriberCtx.state).length,
+        value: subscriberCtx.subscribersTotal || 0,
       },
       {
         icon: LibraryBooksIcon,


### PR DESCRIPTION
## Summary
This is a fix for issue [#8211](https://github.com/magma/magma/issues/8211). This fix was made from **branch v1.6** and consist change on `NetworkKPIs` the count on subscriber items and choosing the `total_count` on subscribers request.

Files changed:

- SubscriberState.js
- SubscriberContext.js
- LteContext.js
- NetworkKPIs.js

## Test Plan
Test locally

## Additional Information

- [ ]  This change expect the attribute `total_count` on `subscribers_v2` request
