### PR TITLE
feat(feg): SBI print HTTP request and response logs

### DIFF
--- a/feg/gateway/sbi/mocks/mock_pcf.go
+++ b/feg/gateway/sbi/mocks/mock_pcf.go
@@ -24,7 +24,7 @@ func NewMockPcf(localAddr string) (*MockPcf, error) {
 		policies:   make(map[string]sbi_NpcfSMPolicyControlServer.SmPolicyControl),
 	}
 	sbi_NpcfSMPolicyControlServer.RegisterHandlers(mockPcf, mockPcf)
-	err := mockPcf.StartWithhWait(localAddr)
+	err := mockPcf.StartWithWait(localAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/feg/gateway/sbi/sbi_log_middleware.go
+++ b/feg/gateway/sbi/sbi_log_middleware.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sbi
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// LoggingTransport implements the http.RoundTripper interface and logs the
+// HTTP request and response information
+type LoggingTransport struct {
+	Transport http.RoundTripper
+	Logger    SbiLogger
+}
+
+type responseGrabber struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func NewLoggingTransport() LoggingTransport {
+	return LoggingTransport{
+		Transport: http.DefaultTransport,
+		Logger:    SbiLogger{},
+	}
+}
+
+func NewLoggingHttpClient() *http.Client {
+	return &http.Client{
+		Transport: NewLoggingTransport(),
+	}
+}
+
+// RoundTrip overrides the http.DefaultTransport RoundTrip behavior and logs the HTTP request and response.
+func (lt LoggingTransport) RoundTrip(req *http.Request) (res *http.Response, err error) {
+	// Before sending
+	var reqBody []byte
+
+	if req.Body != nil {
+		reqBody, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			return
+		}
+		// reset the req.Body back to original
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBody))
+	}
+	lt.Logger.LogRequest(req.Method, req.URL, reqBody, req.Header)
+
+	// Make the actual request
+	start := time.Now()
+	res, err = lt.Transport.RoundTrip(req)
+	took := time.Since(start)
+	if err != nil {
+		// error responses shall be logged by caller
+		return
+	}
+
+	// After sending
+	var resBody []byte
+	if res.Body != nil {
+		resBody, err = ioutil.ReadAll(res.Body)
+		if err != nil {
+			return
+		}
+		// reset the res.Body back to original
+		res.Body = ioutil.NopCloser(bytes.NewBuffer(resBody))
+	}
+	lt.Logger.LogResponse(req.URL, res.Status, resBody, res.Header, took)
+	return
+}
+
+func (w *responseGrabber) WriteHeader(code int) {
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *responseGrabber) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+func (w *responseGrabber) Flush() {
+	w.ResponseWriter.(http.Flusher).Flush()
+}
+
+func (w *responseGrabber) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+// ServerLoggingMiddleware logs HTTP request and response whenever a request is received.
+// When logger is nil, the messages are logged to default glog verbose level 2 logger.
+func ServerLoggingMiddleware() echo.MiddlewareFunc {
+	logger := SbiLogger{}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) (err error) {
+			// Request
+			var reqBody []byte
+			if c.Request().Body != nil { // Read
+				reqBody, _ = ioutil.ReadAll(c.Request().Body)
+				c.Request().Body = ioutil.NopCloser(bytes.NewBuffer(reqBody)) // Reset
+			}
+			logger.LogRequest(c.Request().Method, c.Request().URL, reqBody, c.Request().Header)
+
+			// Setting up for grabbing response
+			resBody := new(bytes.Buffer)
+			mw := io.MultiWriter(c.Response().Writer, resBody)
+			writer := &responseGrabber{Writer: mw, ResponseWriter: c.Response().Writer}
+			c.Response().Writer = writer
+
+			start := time.Now()
+			// invoke request handler
+			if err = next(c); err != nil {
+				c.Error(err)
+			}
+			latency := time.Since(start)
+			status := fmt.Sprintf("%d %s", c.Response().Status, http.StatusText(c.Response().Status))
+			logger.LogResponse(c.Request().URL, status, resBody.Bytes(), c.Response().Header(), latency)
+
+			return
+		}
+	}
+}

--- a/feg/gateway/sbi/sbi_logger.go
+++ b/feg/gateway/sbi/sbi_logger.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sbi
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// SbiLogger logs to glog when verbose level is set to 2
+type SbiLogger struct{}
+
+// LogRequest logs http request relateed info before making the client request
+func (logger *SbiLogger) LogRequest(method string, url *url.URL, reqBody []byte, header http.Header) {
+	var extraReqInfo string
+	if len(reqBody) != 0 {
+		extraReqInfo = fmt.Sprintf("\nBody = %s", string(reqBody))
+	}
+	glog.V(2).Infof("Request %s %v %s\n", method, url.Path, extraReqInfo)
+}
+
+// LogResponse logs http response related info after receiving the response from the server
+func (logger *SbiLogger) LogResponse(url *url.URL, status string, resBody []byte, header http.Header, latency time.Duration) {
+	var extraResInfo string
+	location, found := header["Location"]
+	if found {
+		extraResInfo = fmt.Sprintf("\nLocation = %s", location[0])
+	}
+	if len(resBody) != 0 {
+		extraResInfo = fmt.Sprintf("%s\nBody = %s", extraResInfo, string(resBody))
+	}
+	glog.V(2).Infof("Response %v for %v took %dms %s\n", status, url.Path, latency.Milliseconds(), extraResInfo)
+}

--- a/feg/gateway/sbi/sbi_test.go
+++ b/feg/gateway/sbi/sbi_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"magma/feg/gateway/sbi"
 	"magma/feg/gateway/sbi/mocks"
 	sbi_NpcfSMPolicyControl "magma/feg/gateway/sbi/specs/TS29512NpcfSMPolicyControl"
 	sbi_CommonData "magma/feg/gateway/sbi/specs/TS29571CommonData"
@@ -44,7 +45,8 @@ func TestCreateSMPolicy(t *testing.T) {
 
 	// Create new N7 client object
 	client, err := sbi_NpcfSMPolicyControl.NewClientWithResponses(
-		fmt.Sprintf("http://%s", pcfAddr.String()))
+		fmt.Sprintf("http://%s", pcfAddr.String()),
+		sbi_NpcfSMPolicyControl.WithHTTPClient(sbi.NewLoggingHttpClient()))
 
 	require.NoError(t, err, "BaseClientWithNotifier creation failed")
 


### PR DESCRIPTION
Signed-off-by: GANESH IRRINKI <ganesh.irrinki@wavelabs.ai>

## Summary
Generic logging mechanism for all SBI based requests, responses, notifications and notifcation responses.

- Client Requests and Responses are logged by using a HTTP logging client
- Notification requests and responses are logged by setting a logging middleware to the echo server

This is a PR for https://github.com/magma/magma/issues/10598

