### PR TITLE
test(mme): add unit test for paging failure for dedicated bearer

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -28,7 +28,7 @@ namespace magma {
 namespace lte {
 
 #define MME_APP_TIMER_TO_MSEC 10
-#define STATE_MAX_WAIT_MS 10000
+#define STATE_MAX_WAIT_MS 2000
 #define NAS_RETX_LIMIT 5
 
 #define MME_APP_EXPECT_CALLS(                                                  \

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -198,7 +198,7 @@ TEST_F(MmeAppProcedureTest, TestInitialUeMessageFaultyNasMsg) {
 
   MME_APP_EXPECT_CALLS(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   // The following buffer just includes an attach request
   uint8_t nas_msg_faulty[29] = {0x72, 0x08, 0x09, 0x10, 0x10, 0x00, 0x00, 0x00,
                                 0x00, 0x10, 0x02, 0xe0, 0xe0, 0x00, 0x04, 0x02,
@@ -229,7 +229,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyDetach) {
 
   MME_APP_EXPECT_CALLS(3, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -317,7 +317,7 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachEpsOnlyDetach) {
 
   MME_APP_EXPECT_CALLS(4, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_guti_attach_req, sizeof(nas_msg_guti_attach_req), plmn, guti, 1);
 
@@ -411,7 +411,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAirFailure) {
 
   MME_APP_EXPECT_CALLS(1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -449,7 +449,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAirTimeout) {
 
   MME_APP_EXPECT_CALLS(1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -484,7 +484,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAuthMacFailure) {
 
   MME_APP_EXPECT_CALLS(3, 0, 2, 1, 0, 0, 0, 0, 0, 0, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -539,7 +539,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAuthSynchFailure) {
 
   MME_APP_EXPECT_CALLS(3, 0, 2, 2, 0, 0, 0, 0, 0, 0, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -597,7 +597,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyUlaFailure) {
 
   MME_APP_EXPECT_CALLS(3, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -650,7 +650,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachExpiredNasTimers) {
 
   MME_APP_EXPECT_CALLS(15, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -747,7 +747,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectAuthRetxFailure) {
 
   MME_APP_EXPECT_CALLS(6, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -785,7 +785,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectSmcRetxFailure) {
 
   MME_APP_EXPECT_CALLS(6, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -827,7 +827,7 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachExpiredIdentity) {
 
   MME_APP_EXPECT_CALLS(8, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_guti_attach_req, sizeof(nas_msg_guti_attach_req), plmn, guti, 1);
 
@@ -923,7 +923,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectIdentRetxFailure) {
 
   MME_APP_EXPECT_CALLS(6, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -961,7 +961,7 @@ TEST_F(MmeAppProcedureTest, TestIcsRequestTimeout) {
 
   MME_APP_EXPECT_CALLS(2, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -1017,7 +1017,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachIcsFailure) {
 
   MME_APP_EXPECT_CALLS(2, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -1077,7 +1077,7 @@ TEST_F(MmeAppProcedureTest, TestCreateSessionFailure) {
   // and once during processing the response for Delete Session Request
   MME_APP_EXPECT_CALLS(3, 0, 2, 1, 1, 1, 1, 0, 0, 1, 1);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -1140,7 +1140,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedDetach) {
 
   MME_APP_EXPECT_CALLS(4, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -1236,7 +1236,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedExpiredDetach) {
 
   MME_APP_EXPECT_CALLS(8, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -1334,7 +1334,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedDetachRetxFailure) {
 
   MME_APP_EXPECT_CALLS(8, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -1430,7 +1430,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleDetach) {
 
   MME_APP_EXPECT_CALLS(3, 1, 2, 1, 1, 1, 1, 1, 1, 1, 3);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -1506,6 +1506,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleDetach) {
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
   EXPECT_EQ(mme_state_p->nb_ue_idle, 1);
   EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+
   // Constructing and sending Detach Request to mme_app
   // mimicing S1AP
   send_mme_app_uplink_data_ind(
@@ -1541,7 +1542,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleServiceReqDetach) {
 
   MME_APP_EXPECT_CALLS(3, 2, 2, 1, 1, 1, 1, 2, 1, 1, 4);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -1690,7 +1691,7 @@ TEST_F(MmeAppProcedureTest, TestPagingMaxRetx) {
 
   MME_APP_EXPECT_CALLS(3, 2, 2, 1, 1, 1, 1, 2, 1, 1, 4);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -1851,7 +1852,7 @@ TEST_F(
 
   MME_APP_EXPECT_CALLS(3, 1, 1, 1, 1, 1, 1, 1, 0, 1, 4);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -1989,7 +1990,7 @@ TEST_F(
 
   MME_APP_EXPECT_CALLS(7, 1, 1, 1, 1, 1, 1, 1, 0, 1, 4);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -2140,7 +2141,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithActiveFlag) {
 
   MME_APP_EXPECT_CALLS(3, 2, 2, 1, 1, 1, 1, 2, 1, 1, 4);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -2291,7 +2292,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithoutActiveFlag) {
 
   MME_APP_EXPECT_CALLS(4, 1, 3, 1, 1, 1, 1, 1, 1, 1, 4);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -2441,7 +2442,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithActiveFlag) {
 
   MME_APP_EXPECT_CALLS(3, 2, 2, 1, 1, 1, 1, 2, 1, 1, 4);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -2592,7 +2593,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithoutActiveFlag) {
 
   MME_APP_EXPECT_CALLS(4, 1, 3, 1, 1, 1, 1, 1, 1, 1, 4);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -2741,7 +2742,7 @@ TEST_F(MmeAppProcedureTest, TestTauRejDueToInvalidTac) {
 
   MME_APP_EXPECT_CALLS(4, 1, 3, 1, 1, 1, 1, 1, 1, 1, 4);
 
-  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
@@ -2884,6 +2885,141 @@ TEST_F(MmeAppProcedureTest, TestTauRejDueToInvalidTac) {
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
   EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
   EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+}
+
+TEST_F(MmeAppProcedureTest, TestFailedPagingForPendingBearers) {
+  mme_app_desc_t* mme_state_p =
+      magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  std::condition_variable cv;
+  std::mutex mx;
+  std::unique_lock<std::mutex> lock(mx);
+
+  MME_APP_EXPECT_CALLS(3, 1, 2, 1, 1, 1, 1, 1, 1, 1, 4);
+
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
+  send_mme_app_initial_ue_msg(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
+
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp(REQUEST_ACCEPTED);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+
+  // Force switching to IDLE Mode
+  // Send context release request mimicing S1AP
+  send_context_release_req(S1AP_RADIO_EUTRAN_GENERATED_REASON, TASK_S1AP);
+
+  // Constructing and sending Release Access Bearer Response to mme_app
+  // mimicing SPGW
+  sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
+
+  // Wait for context release request
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after context release request is processed
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 1);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+
+  // Trigger paging via bearer request in control plane
+  // Send activate dedicated bearer request mimicing SPGW
+  send_s11_create_bearer_req();
+  EXPECT_CALL(*s1ap_handler, s1ap_handle_paging_request())
+      .Times(2)
+      .WillRepeatedly(ReturnFromAsyncTask(&cv));
+  // Force paging failure via ignoring paging requests
+  for (int i = 0; i <= MAX_PAGING_RETRY_COUNT; ++i) {
+    cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  }
+  EXPECT_CALL(*spgw_handler, sgw_handle_nw_initiated_actv_bearer_rsp())
+      .Times(1)
+      .WillOnce(ReturnFromAsyncTask(&cv));
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Check expected MME state after failure
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 1);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+
+  // Constructing and sending Detach Request to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_detach_req, sizeof(nas_msg_detach_req), plmn);
+
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp();
+
+  // Wait for context release request
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
 }
 
 }  // namespace lte

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -2977,7 +2977,7 @@ TEST_F(MmeAppProcedureTest, TestFailedPagingForPendingBearers) {
   // Send activate dedicated bearer request mimicing SPGW
   send_s11_create_bearer_req();
   EXPECT_CALL(*s1ap_handler, s1ap_handle_paging_request())
-      .Times(2)
+      .Times(MAX_PAGING_RETRY_COUNT + 1)
       .WillRepeatedly(ReturnFromAsyncTask(&cv));
   // Force paging failure via ignoring paging requests
   for (int i = 0; i <= MAX_PAGING_RETRY_COUNT; ++i) {


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Add unit test for paging failure for dedicated bearer
- Fix grammer in comment
- Reduce wait_for timer to 2 seconds that looks like a good balance between no-flakiness and run time. With a lot of test cases, occasionally itti latency goes over 1 second but it is not observed to be as high as 2 seconds.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Run `make test_oai OAI_TESTS='.*mme_app.*'` in magma VM 100 times.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
