### PR TITLE
test(mme): Add MME_APP unit tests for path switch request

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -15,7 +15,6 @@
 #include <chrono>
 #include <gtest/gtest.h>
 #include <cstdint>
-#include <cstdlib>
 #include <thread>
 
 #include "feg/protos/s6a_proxy.pb.h"
@@ -472,7 +471,7 @@ void send_s1ap_path_switch_req(
 
   erab_to_switch_dl_list->no_of_items      = 1;
   erab_to_switch_dl_list->item[0].e_rab_id = 5;  // default bearer id
-  erab_to_switch_dl_list->item[0].gtp_teid = rand();
+  erab_to_switch_dl_list->item[0].gtp_teid = 2;
   uint32_t enb_transport_addr              = 0xc0a83c8d;  // 192.168.60.141
   erab_to_switch_dl_list->item[0].transport_layer_address =
       blk2bstr(&enb_transport_addr, 4);

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -31,6 +31,10 @@ namespace lte {
 #define STATE_MAX_WAIT_MS 2000
 #define NAS_RETX_LIMIT 5
 
+#define DEFAULT_eNB_S1AP_UE_ID 0
+#define DEFAULT_SCTP_ASSOC_ID 0
+#define DEFAULT_ENB_ID 0
+
 #define MME_APP_EXPECT_CALLS(                                                  \
     dlNas, connEstConf, ctxRel, air, ulr, purgeReq, csr, mbr, relBearer, dsr,  \
     setAppHealth)                                                              \
@@ -115,6 +119,10 @@ void send_erab_setup_rsp();
 void send_erab_release_rsp();
 
 void send_paging_request();
+
+void send_s1ap_path_switch_req(
+    const uint32_t sctp_assoc_id, const uint32_t enb_id,
+    const uint32_t enb_ue_s1ap_id, const plmn_t& plmn);
 
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -12,6 +12,8 @@
  */
 #include <chrono>
 #include <gtest/gtest.h>
+#include <cstdint>
+#include <cstdlib>
 #include <thread>
 #include <mutex>
 #include <condition_variable>
@@ -32,6 +34,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_extern.h"
 #include "lte/gateway/c/core/oai/include/mme_app_state.h"
 #include "lte/gateway/c/core/oai/tasks/nas/api/network/nas_message.h"
+#include "lte/gateway/c/core/oai/include/s1ap_messages_types.h"
 }
 
 using ::testing::_;
@@ -59,6 +62,30 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   itti_free_msg_content(received_message_p);
   free(received_message_p);
   return 0;
+}
+
+MATCHER_P2(
+    check_params_in_path_switch_req_ack, new_enb_ue_s1ap_id, new_sctp_assoc_id,
+    "") {
+  auto path_switch_ack_recv =
+      static_cast<itti_s1ap_path_switch_request_ack_t>(arg);
+  if ((path_switch_ack_recv.enb_ue_s1ap_id == new_enb_ue_s1ap_id) &&
+      (path_switch_ack_recv.sctp_assoc_id == new_sctp_assoc_id)) {
+    return true;
+  }
+  return false;
+}
+
+MATCHER_P2(
+    check_params_in_path_switch_req_failure, new_enb_ue_s1ap_id,
+    new_sctp_assoc_id, "") {
+  auto path_switch_ack_recv =
+      static_cast<itti_s1ap_path_switch_request_failure_t>(arg);
+  if ((path_switch_ack_recv.enb_ue_s1ap_id == new_enb_ue_s1ap_id) &&
+      (path_switch_ack_recv.sctp_assoc_id == new_sctp_assoc_id)) {
+    return true;
+  }
+  return false;
 }
 
 class MmeAppProcedureTest : public ::testing::Test {

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -13,7 +13,6 @@
 #include <chrono>
 #include <gtest/gtest.h>
 #include <cstdint>
-#include <cstdlib>
 #include <thread>
 #include <mutex>
 #include <condition_variable>
@@ -3145,6 +3144,243 @@ TEST_F(MmeAppProcedureTest, TestMobileReachabilityTimer) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Check MME state after implicit detach complete
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+}
+
+TEST_F(MmeAppProcedureTest, TestX2HandoverPathSwitchSuccess) {
+  mme_app_desc_t* mme_state_p =
+      magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  std::condition_variable cv;
+  std::mutex mx;
+  std::unique_lock<std::mutex> lock(mx);
+
+  MME_APP_EXPECT_CALLS(3, 1, 1, 1, 1, 1, 1, 2, 0, 1, 3);
+
+  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  send_mme_app_initial_ue_msg(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
+
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp(REQUEST_ACCEPTED);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+
+  // Send path switch request to mme_app mimicing S1AP, use 1 for all new ids,
+  // since Initial UE message is using 0
+  uint32_t new_enb_ue_s1ap_id = DEFAULT_eNB_S1AP_UE_ID + 1;
+  uint32_t new_sctp_assoc_id  = DEFAULT_SCTP_ASSOC_ID + 1;
+  uint32_t new_enb_id         = DEFAULT_ENB_ID + 1;
+  send_s1ap_path_switch_req(
+      new_sctp_assoc_id, new_enb_id, new_enb_ue_s1ap_id, plmn);
+
+  // Expect that Path Switch ACK is sent to S1AP from mme_app after modify
+  // bearer response is received
+  EXPECT_CALL(
+      *s1ap_handler,
+      s1ap_handle_path_switch_req_ack(check_params_in_path_switch_req_ack(
+          new_enb_ue_s1ap_id, new_sctp_assoc_id)))
+      .Times(1);
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW, with same parameters as last one
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
+  // Constructing and sending Detach Request to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_detach_req, sizeof(nas_msg_detach_req), plmn);
+
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp();
+
+  // Wait for context release request
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+}
+
+TEST_F(MmeAppProcedureTest, TestX2HandoverPathSwitchFailure) {
+  mme_app_desc_t* mme_state_p =
+      magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  std::condition_variable cv;
+  std::mutex mx;
+  std::unique_lock<std::mutex> lock(mx);
+
+  MME_APP_EXPECT_CALLS(3, 1, 1, 1, 1, 1, 1, 2, 0, 1, 3);
+
+  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  send_mme_app_initial_ue_msg(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
+
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp(REQUEST_ACCEPTED);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
+  // Send path switch request to mme_app mimicing S1AP, use 1 for all new ids,
+  // since Initial UE message is using 0
+  uint32_t new_enb_ue_s1ap_id = DEFAULT_eNB_S1AP_UE_ID + 1;
+  uint32_t new_sctp_assoc_id  = DEFAULT_SCTP_ASSOC_ID + 1;
+  uint32_t new_enb_id         = DEFAULT_ENB_ID + 1;
+  send_s1ap_path_switch_req(
+      new_sctp_assoc_id, new_enb_id, new_enb_ue_s1ap_id, plmn);
+
+  // Expect that Path Switch Failure is sent to S1AP from mme_app after modify
+  // bearer response is received
+  EXPECT_CALL(
+      *s1ap_handler, s1ap_handle_path_switch_req_failure(
+                         check_params_in_path_switch_req_failure(
+                             new_enb_ue_s1ap_id, new_sctp_assoc_id)))
+      .Times(1);
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW, with empty modify bearer list to trigger failure
+  b_modify = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
+  // Constructing and sending Detach Request to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_detach_req, sizeof(nas_msg_detach_req), plmn);
+
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp();
+
+  // Wait for context release request
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
   send_activate_message_to_mme_app();
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   EXPECT_EQ(mme_state_p->nb_ue_attached, 0);

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -22,6 +22,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
 #include "lte/gateway/c/core/oai/common/itti_free_defined_msg.h"
 #include "lte/gateway/c/core/oai/include/s11_messages_types.h"
+#include "lte/gateway/c/core/oai/include/s1ap_messages_types.h"
 }
 
 const task_info_t tasks_info[] = {
@@ -53,6 +54,12 @@ class MockS1apHandler {
   MOCK_METHOD0(s1ap_generate_s1ap_e_rab_setup_req, void());
   MOCK_METHOD0(s1ap_generate_s1ap_e_rab_rel_cmd, void());
   MOCK_METHOD0(s1ap_handle_paging_request, void());
+  MOCK_METHOD1(
+      s1ap_handle_path_switch_req_ack,
+      bool(itti_s1ap_path_switch_request_ack_t path_switch_ack));
+  MOCK_METHOD1(
+      s1ap_handle_path_switch_req_failure,
+      bool(itti_s1ap_path_switch_request_failure_t path_switch_fail));
 };
 
 class MockMmeAppHandler {

--- a/lte/gateway/c/core/oai/test/mock_tasks/s1ap_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/s1ap_mock.cpp
@@ -78,9 +78,13 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case S1AP_PATH_SWITCH_REQUEST_ACK: {
+      s1ap_handler_->s1ap_handle_path_switch_req_ack(
+          received_message_p->ittiMsg.s1ap_path_switch_request_ack);
     } break;
 
     case S1AP_PATH_SWITCH_REQUEST_FAILURE: {
+      s1ap_handler_->s1ap_handle_path_switch_req_failure(
+          received_message_p->ittiMsg.s1ap_path_switch_request_failure);
     } break;
 
     case MME_APP_HANDOVER_REQUEST: {


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

This change adds success and failure test case for MME_APP handlers for Path Switch Request. 

## Test Plan

make test_oai

