### PR TITLE
test(mme): Add final set of EMM encoding decoding messages unit tests

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/ies/ShortMac.h
+++ b/lte/gateway/c/core/oai/tasks/nas/ies/ShortMac.h
@@ -20,7 +20,7 @@
 
 #include <stdint.h>
 
-#define SHORT_MAC_MINIMUM_LENGTH 3
+#define SHORT_MAC_MINIMUM_LENGTH 1
 #define SHORT_MAC_MAXIMUM_LENGTH 3
 
 typedef uint16_t short_mac_t;


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adds following test cases:
```
TestEncodeDecodeServiceRequest
TestEncodeDecodeAuthenticationResponse
TestEncodeDecodeAttachRequest2 
``` 
- Fixes shortmac param minimum length based on AuthenticationResponse encoding and decoding 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make test_oai

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
