### PR TITLE
test(mme): Extend MME config unit tests with display

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_config.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_config.cpp
@@ -859,6 +859,13 @@ TEST(MMEConfigTest, TestParseHealthyConfig) {
   free_mme_config(&mme_config);
 }
 
+TEST(MMEConfigTest, TestParseHealthyConfigDisplay) {
+  mme_config_t mme_config = {0};
+  EXPECT_EQ(mme_config_parse_string(kHealthyConfig, &mme_config), 0);
+  mme_config_display(&mme_config);
+  free_mme_config(&mme_config);
+}
+
 TEST(MMEConfigTest, TestMissingSctpdConfig) {
   mme_config_t mme_config = {0};
   EXPECT_EQ(mme_config_parse_string(kEmptyConfig, &mme_config), 0);

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_sgw_config.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_sgw_config.cpp
@@ -81,5 +81,12 @@ TEST(SGWConfigTest, TestParseHealthyConfig) {
   free_sgw_config(&sgw_config);
 }
 
+TEST(SGWConfigTest, TestParseHealthyConfigDisplay) {
+  sgw_config_t sgw_config = {0};
+  EXPECT_EQ(sgw_config_parse_string(sHealthyConfig, &sgw_config), 0);
+  sgw_config_display(&sgw_config);
+  free_sgw_config(&sgw_config);
+}
+
 }  // namespace lte
 }  // namespace magma


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adds `mme_config_display` and `sgw_config_display` calls to MME config and SPGW config unit tests

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make test_oai

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
