### PR TITLE
test(mme): Add mobile reachability and implicit detach timer test

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_config.h
+++ b/lte/gateway/c/core/oai/include/mme_config.h
@@ -307,6 +307,8 @@ typedef struct nas_config_s {
   uint8_t prefered_ciphering_algorithm[8];
   uint32_t t3402_min;
   uint32_t t3412_min;
+  uint32_t t3412_msec;  // keeping t3412_min as it is used to communicate to UE
+                        // and to prevent back and forth conversions
   uint32_t t3422_msec;
   uint32_t t3450_msec;
   uint32_t t3460_msec;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -867,7 +867,7 @@ void mme_ue_context_update_ue_sig_connection_state(
         ue_context_p->mme_ue_s1ap_id);
 
     if (mme_config.nas_config.t3412_min > 0) {
-      // Start Mobile reachability timer only if peroidic TAU timer is not
+      // Start Mobile reachability timer only if periodic TAU timer is not
       // disabled
       if (ue_context_p->mobile_reachability_timer.id ==
           MME_APP_TIMER_INACTIVE_ID) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
@@ -366,14 +366,20 @@ status_code_e mme_app_handle_s6a_update_location_ans(
    * Mobile Reachability timer
    */
   ue_mm_context->mobile_reachability_timer.id = MME_APP_TIMER_INACTIVE_ID;
+  ue_mm_context->implicit_detach_timer.id     = MME_APP_TIMER_INACTIVE_ID;
+#if !MME_UNIT_TEST
   ue_mm_context->mobile_reachability_timer.msec =
       ((mme_config.nas_config.t3412_min) +
        MME_APP_DELTA_T3412_REACHABILITY_TIMER) *
       60000;
-  ue_mm_context->implicit_detach_timer.id = MME_APP_TIMER_INACTIVE_ID;
   ue_mm_context->implicit_detach_timer.msec =
       (ue_mm_context->mobile_reachability_timer.msec) +
       MME_APP_DELTA_REACHABILITY_IMPLICIT_DETACH_TIMER * 60000;
+#else  /* !MME_UNIT_TEST */
+  ue_mm_context->mobile_reachability_timer.msec =
+      mme_config.nas_config.t3412_msec;
+  ue_mm_context->implicit_detach_timer.msec = mme_config.nas_config.t3412_msec;
+#endif /* !MME_UNIT_TEST */
 
   /*
    * Set the flag: send_ue_purge_request to indicate that

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -190,6 +190,7 @@ void apn_map_config_init(apn_map_config_t* apn_map_config) {
 void nas_config_init(nas_config_t* nas_conf) {
   nas_conf->t3402_min    = T3402_DEFAULT_VALUE;
   nas_conf->t3412_min    = T3412_DEFAULT_VALUE;
+  nas_conf->t3412_msec   = 60000 * T3412_DEFAULT_VALUE;
   nas_conf->t3422_msec   = 1000 * T3422_DEFAULT_VALUE;
   nas_conf->t3450_msec   = 1000 * T3450_DEFAULT_VALUE;
   nas_conf->t3460_msec   = 1000 * T3460_DEFAULT_VALUE;
@@ -1630,6 +1631,8 @@ int mme_config_parse_string(
       if ((config_setting_lookup_int(
               setting, MME_CONFIG_STRING_NAS_T3412_TIMER, &aint))) {
         config_pP->nas_config.t3412_min = (uint32_t) aint;
+        config_pP->nas_config.t3412_msec =
+            60000 * config_pP->nas_config.t3412_min;
       }
       if ((config_setting_lookup_int(
               setting, MME_CONFIG_STRING_NAS_T3422_TIMER, &aint))) {

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -36,8 +36,10 @@ extern task_zmq_ctx_t task_zmq_ctx_main;
 #define DEFAULT_UE_IPv4 1000
 
 void nas_config_timer_reinit(nas_config_t* nas_conf, uint32_t timeout_msec) {
-  nas_conf->t3402_min    = 1;
-  nas_conf->t3412_min    = 1;
+  nas_conf->t3402_min = 1;
+  nas_conf->t3412_min = 1;
+  nas_conf->t3412_msec =
+      50 * timeout_msec;  // implicit detach after 2x of this value
   nas_conf->t3422_msec   = timeout_msec;
   nas_conf->t3450_msec   = timeout_msec;
   nas_conf->t3460_msec   = timeout_msec;


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Add millisecond granularity for mobile reachability and implicit detach timers for testing purposes.
- Add unit test to cover both timers.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
run `make test_oai` multiple times with no failures.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
