### PR TITLE
fix(amf): set default slice service type if ue doen't send slice service type.

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.h
@@ -51,6 +51,7 @@ int amf_handle_deregistration_ue_origin_req(
 int amf_validate_dnn(
     const amf_context_s* amf_ctxt_p, std::string dnn_string, int* index,
     bool ue_sent_dnn);
+void amf_get_default_sst_config(uint8_t* sst);
 void smf_dnn_ambr_select(
     const std::shared_ptr<smf_context_t>& smf_ctx,
     ue_m5gmm_context_s* ue_context, int index_dnn);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -453,7 +453,12 @@ int amf_smf_process_pdu_session_packet(
         return rc;
       }
 
-      smf_ctx->sst = msg->nssai.sst;
+      // NSSAI
+      if (msg->nssai.sst) {
+        smf_ctx->sst = msg->nssai.sst;
+      } else {
+        amf_get_default_sst_config(&(smf_ctx->sst));
+      }
       if (msg->nssai.sd[0]) {
         memcpy(smf_ctx->sd, msg->nssai.sd, SD_LENGTH);
       }
@@ -551,6 +556,20 @@ int amf_smf_process_pdu_session_packet(
       break;
   }
   return rc;
+}
+/***************************************************************************
+**                                                                        **
+** Name:    amf_get_default_sst_config()                                  **
+**                                                                        **
+** Description: Get default sst value from amf config                     **
+**                                                                        **
+**                                                                        **
+***************************************************************************/
+void amf_get_default_sst_config(uint8_t* sst) {
+  amf_config_read_lock(&amf_config);
+  *sst = static_cast<uint8_t>(
+      amf_config.plmn_support_list.plmn_support[0].s_nssai.sst);
+  amf_config_unlock(&amf_config);
 }
 /***************************************************************************
 **                                                                        **


### PR DESCRIPTION
Signed-off-by: LKishor123 <laawanya.kishor@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Right now amf returns empty snssai field, if ue doesn't send a snssai. This fix will set a default slice service type if ue doen't send slice service type.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
1. Unit Test
![sit_2](https://user-images.githubusercontent.com/52399057/145725146-fd7ed419-48ed-4394-acc3-855a92799b78.png)

2. Spirent
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
