### PR TITLE
fix(amf): criticality of different IE's changed for spirent related optimization.

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -625,7 +625,7 @@ void ngap_handle_conn_est_cnf(
       Ngap_ProcedureCode_id_InitialContextSetup;
   pdu.choice.initiatingMessage.value.present =
       Ngap_InitiatingMessage__value_PR_InitialContextSetupRequest;
-  pdu.choice.initiatingMessage.criticality = Ngap_Criticality_ignore;
+  pdu.choice.initiatingMessage.criticality = Ngap_Criticality_reject;
   out = &pdu.choice.initiatingMessage.value.choice.InitialContextSetupRequest;
 
   /* mandatory */
@@ -886,7 +886,7 @@ void ngap_handle_conn_est_cnf(
     ie = CALLOC(1, sizeof(Ngap_InitialContextSetupRequestIEs_t));
 
     ie->id          = Ngap_ProtocolIE_ID_id_UEAggregateMaximumBitRate;
-    ie->criticality = Ngap_Criticality_reject;
+    ie->criticality = Ngap_Criticality_ignore;
     ie->value.present =
         Ngap_InitialContextSetupRequestIEs__value_PR_UEAggregateMaximumBitRate;
 
@@ -908,7 +908,7 @@ void ngap_handle_conn_est_cnf(
     ie = (Ngap_InitialContextSetupRequestIEs_t*) calloc(
         1, sizeof(Ngap_InitialContextSetupRequestIEs_t));
     ie->id            = Ngap_ProtocolIE_ID_id_NAS_PDU;
-    ie->criticality   = Ngap_Criticality_reject;
+    ie->criticality   = Ngap_Criticality_ignore;
     ie->value.present = Ngap_InitialContextSetupRequestIEs__value_PR_NAS_PDU;
     ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
 
@@ -1315,7 +1315,7 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
   ie = CALLOC(1, sizeof(Ngap_PDUSessionResourceSetupRequestIEs_t));
 
   ie->id          = Ngap_ProtocolIE_ID_id_UEAggregateMaximumBitRate;
-  ie->criticality = Ngap_Criticality_reject;
+  ie->criticality = Ngap_Criticality_ignore;
   ie->value.present =
       Ngap_PDUSessionResourceSetupRequestIEs__value_PR_UEAggregateMaximumBitRate;
 


### PR DESCRIPTION
Signed-off-by: LKishor123 <laawanya.kishor@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Criticality of different IE's changed for spirent related optimization, as spirent was not replying for PDU session establishment accept packet.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
1. Unit Test
![sit_1](https://user-images.githubusercontent.com/52399057/145725090-d4603f2b-0958-465c-9c4b-559d7617c556.png)

2. Spirent


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
