### PR TITLE
fix(sessiond): Correct SubscriberID set as "IMSI +number" in Sessiond

### DIFF
--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -37,6 +37,7 @@
 #include "lte/protos/session_manager.pb.h"
 #include "lte/protos/subscriberdb.pb.h"
 #include "magma_logging.h"
+#include "Utilities.h"
 
 namespace google {
 namespace protobuf {
@@ -107,7 +108,8 @@ void SetMessageManagerHandler::SetAmfSessionContext(
   m5g_enforcer_->get_event_base().runInEventBaseThread([this, response_callback,
                                                         request_cpy]() {
     // extract values from proto
-    std::string imsi = request_cpy.common_context().sid().id();
+    std::string imsi =
+        prepend_imsi_with_prefix(request_cpy.common_context().sid().id());
     const auto rat_type = request_cpy.common_context().rat_type();
     if (rat_type != TGPP_NR) {
       // We don't support outside of 5G
@@ -398,7 +400,8 @@ void SetMessageManagerHandler::pdu_session_inactive(
     std::function<void(Status, SmContextVoid)> response_callback) {
   // extract values from proto
   uint32_t pdu_id = notif.rat_specific_notification().pdu_session_id();
-  std::string imsi = notif.common_context().sid().id();
+  std::string imsi =
+      prepend_imsi_with_prefix(notif.common_context().sid().id());
   /* Read the SessionMap from global session_store */
   SessionSearchCriteria criteria(imsi, IMSI_AND_PDUID, pdu_id);
   auto session_map = session_store_.read_sessions({imsi});
@@ -455,7 +458,8 @@ void SetMessageManagerHandler::idle_mode_change_sessions_handle(
     const SetSmNotificationContext& notif,
     std::function<void(Status, SmContextVoid)> response_callback) {
   // extract IMSI value from proto
-  auto imsi = notif.common_context().sid().id();
+  std::string imsi =
+      prepend_imsi_with_prefix(notif.common_context().sid().id());
   auto session_map = session_store_.read_sessions({imsi});
   int count = 0;
   auto session_update = SessionStore::get_default_session_update(session_map);
@@ -503,7 +507,8 @@ void SetMessageManagerHandler::service_handle_request_on_paging(
     const SetSmNotificationContext& notif,
     std::function<void(Status, SmContextVoid)> response_callback) {
   // extract IMSI value from proto
-  auto imsi = notif.common_context().sid().id();
+  std::string imsi =
+      prepend_imsi_with_prefix(notif.common_context().sid().id());
   auto session_map = session_store_.read_sessions({imsi});
   int count = 0;
   auto session_update = SessionStore::get_default_session_update(session_map);

--- a/lte/gateway/c/session_manager/UpfMsgManageHandler.cpp
+++ b/lte/gateway/c/session_manager/UpfMsgManageHandler.cpp
@@ -32,6 +32,7 @@
 #include "lte/protos/session_manager.pb.h"
 #include "lte/protos/subscriberdb.pb.h"
 #include "magma_logging.h"
+#include "Utilities.h"
 
 namespace google {
 namespace protobuf {
@@ -111,8 +112,7 @@ void UpfMsgManageHandler::SetUPFSessionsConfig(
                                                          ses_config]() {
     for (auto& upf_session : ses_config.upf_session_state()) {
       // Deleting the IMSI prefix from imsi
-      std::string imsi_upf = upf_session.subscriber_id();
-      std::string imsi = imsi_upf.substr(4, imsi_upf.length() - 4);
+      const std::string imsi = upf_session.subscriber_id();
       uint32_t version = upf_session.session_version();
       uint32_t teid = upf_session.local_f_teid();
       auto session_map = session_store_.read_sessions({imsi});
@@ -182,7 +182,7 @@ void UpfMsgManageHandler::SendPagingRequest(
         if (!status.ok()) {
           MLOG(MERROR) << "Subscriber could not be found for ip ";
         }
-        const std::string& imsi = sid.id();
+        std::string imsi = prepend_imsi_with_prefix(sid.id());
         get_session_from_imsi(imsi, fte_id, response_callback);
         return;
       });

--- a/lte/gateway/c/session_manager/Utilities.cpp
+++ b/lte/gateway/c/session_manager/Utilities.cpp
@@ -63,4 +63,10 @@ std::chrono::milliseconds time_difference_from_now(
   return std::chrono::duration_cast<std::chrono::milliseconds>(sec);
 }
 
+std::string prepend_imsi_with_prefix(const std::string& imsi) {
+  if (imsi.find(IMSI_PREFIX) == std::string::npos) {
+    return IMSI_PREFIX + imsi;
+  }
+  return imsi;
+}
 }  // namespace magma

--- a/lte/gateway/c/session_manager/Utilities.h
+++ b/lte/gateway/c/session_manager/Utilities.h
@@ -19,6 +19,8 @@
 #include <chrono>
 #include <string>
 
+#define IMSI_PREFIX "IMSI"
+
 namespace google {
 namespace protobuf {
 class Timestamp;
@@ -31,4 +33,5 @@ uint64_t get_time_in_sec_since_epoch();
 std::chrono::milliseconds time_difference_from_now(
     const google::protobuf::Timestamp& timestamp);
 std::chrono::milliseconds time_difference_from_now(const std::time_t timestamp);
+std::string prepend_imsi_with_prefix(const std::string& imsi);
 }  // namespace magma

--- a/lte/gateway/python/scripts/smf_upf_integration_cli.py
+++ b/lte/gateway/python/scripts/smf_upf_integration_cli.py
@@ -40,7 +40,7 @@ class CreateAmfSession(object):
         self._set_session = SetSMSessionContext(
             common_context=CommonSessionContext(
                 sid=SubscriberID(id="IMSI12345"),
-                ue_ipv4="192.168.128.11",
+                ue_ipv4="192.168.128.12",
                 apn=bytes("BLR", 'utf-8'),
                 rat_type=RATType.Name(2),
                 sm_session_state=SMSessionFSMState.Name(0),
@@ -165,7 +165,7 @@ class ReleaseAmfSession(object):
             SetSMSessionContext(
                 common_context=CommonSessionContext(
                     sid=SubscriberID(id="IMSI12345"),
-                    ue_ipv4="192.168.128.11",
+                    ue_ipv4="192.168.128.12",
                     apn=bytes("BLR", 'utf-8'),
                     rat_type=RATType.Name(2),
                     sm_session_state=SMSessionFSMState.Name(4),


### PR DESCRIPTION
Signed-off-by: mehul jindal <mehul.jindal@wavelabs.ai>

## Summary
Issue:
For 5G, requests are coming from AMF as a “number” without IMSI keyword and from UPF, coming as a “IMSI + number”. So here, searching the session info from SessionStore getting failed.
Fix:
Set all requests as a same pattern for IMSI value and in line with 4G. 

## Test Plan

1. Verified with UERANSIM (Traffic Flow)
2. Verified with Teravm setup (basic call flow)

## Additional Information
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/88073743/145957089-e3ed0ee9-e20e-48e3-a09b-0b9faaaa5cee.png)

![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/88073743/145957181-5511f982-d2e0-46d6-b83b-6bcb36e1edb8.png)

