### PR TITLE
chore(agw): use version scheme that is understood by sentry

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Build AGW
         run: |
           cd lte/gateway
-          fab release package:vcs=git,destroy_vm=True
+          fab release package:destroy_vm=True
           mkdir magma-packages
           vagrant ssh -c "cp -r magma-packages /vagrant"
       - name: Publish debian packages

--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -355,7 +355,7 @@ def _run_remote_lte_package(
     vagrant_cp = '/home/vagrant/magma/fb/control_proxy.yml'
 
     with cd(f'{repo_name}/{magma_root}/lte/gateway'):
-        fab_args = f'vcs=git,all_deps=False,' \
+        fab_args = f'all_deps=False,' \
                    f'cert_file={vagrant_cert},' \
                    f'proxy_config={vagrant_cp},' \
                    f'destroy_vm={destroy_vm}'

--- a/docs/readmes/lte/build_install_magma_pkg_in_agw.md
+++ b/docs/readmes/lte/build_install_magma_pkg_in_agw.md
@@ -27,13 +27,13 @@ hide_title: true
     To create a package for production, run
 
     ```bash
-    fab release package:vcs=git
+    fab release package
     ```
 
     To create a package for development or testing, run
 
     ```bash
-    fab dev package:vcs=git
+    fab dev package
     ```
 
     The `dev` flag will compile all C++ services with `Debug` compiler flags and enable ASAN. This is recommended for testing only as it will impact performance. In contrast, the production package has C++ services built with `RelWithDebInfo` compiler flags.

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -79,7 +79,7 @@ def release():
 
 
 def package(
-    vcs='git', all_deps="False",
+    all_deps="False",
     cert_file=DEFAULT_CERT, proxy_config=DEFAULT_PROXY,
     destroy_vm='False',
     vm='magma', os="ubuntu",
@@ -99,7 +99,8 @@ def package(
         )
         exit(1)
 
-    hash = pkg.get_commit_hash(vcs)
+    hash = pkg.get_commit_hash()
+    commit_count = pkg.get_commit_count()
 
     with cd('~/magma/lte/gateway'):
         # Generate magma dependency packages
@@ -121,8 +122,8 @@ def package(
         build_type = "Debug" if env.debug_mode else "RelWithDebInfo"
 
         run(
-            './release/build-magma.sh -h "%s" -t %s --cert %s --proxy %s --os %s' %
-            (hash, build_type, cert_file, proxy_config, os),
+            './release/build-magma.sh -h %s --commit-count %s -t %s --cert %s --proxy %s --os %s' %
+            (hash, commit_count, build_type, cert_file, proxy_config, os),
         )
 
         run('rm -rf ~/magma-packages')

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -27,7 +27,8 @@ SCTPD_MIN_VERSION=1.6.0 # earliest version of sctpd with which this version is c
 BUILD_TYPE=RelWithDebInfo
 
 # Cmdline options that overwrite the version configs above
-COMMIT_HASH=""  # hash of top magma commit (hg log $MAGMA_PATH)
+COMMIT_HASH=""  # hash of top magma commit
+COMMIT_COUNT="" # count of commits on git main
 CERT_FILE="$MAGMA_ROOT/.cache/test_certs/rootCA.pem"
 CONTROL_PROXY_FILE="$MAGMA_ROOT/lte/gateway/configs/control_proxy.yml"
 OS="ubuntu"
@@ -42,6 +43,10 @@ case $key in
     ;;
     -h|--hash)
     COMMIT_HASH="$2"
+    shift
+    ;;
+    --commit-count)
+    COMMIT_COUNT="$2"
     shift
     ;;
     -t|--type)
@@ -260,7 +265,7 @@ if [ -d ${PY_TMP_BUILD} ]; then
 fi
 
 FULL_VERSION=${VERSION}-$(date +%s)-${COMMIT_HASH}
-COMMIT_HASH_WITH_VERSION=${VERSION}-${COMMIT_HASH}
+COMMIT_HASH_WITH_VERSION="magma@${VERSION}.${COMMIT_COUNT}-${COMMIT_HASH}"
 
 # first do python protos and then build the python packages.
 # library will be dropped in $PY_TMP_BUILD/usr/lib/python3/dist-packages

--- a/orc8r/tools/fab/pkg.py
+++ b/orc8r/tools/fab/pkg.py
@@ -62,19 +62,12 @@ def check_commit_changes():
             return False
 
 
-def get_commit_hash(vcs='hg'):
-    with hide('running', 'warnings', 'output'), settings(warn_only=True):
-        if vcs == 'hg':
-            local_commit_hash = local(
-                'hg identify -i',
-                capture=True,
-            ).replace('+', '').split()[0]
-        elif vcs == 'git':
-            local_commit_hash = local('git rev-parse HEAD', capture=True)
-        else:
-            print('Unknown vcs: %s' % vcs)
-            exit(1)
-    return local_commit_hash[0:8]
+def get_commit_hash():
+    return local('git rev-parse HEAD', capture=True)[0:8]
+
+
+def get_commit_count():
+    return local('git rev-list --count HEAD', capture=True)
 
 
 def download_all_pkgs():


### PR DESCRIPTION
## Summary

Sentry cannot understand the current version format that it is given. Thus, the format is changed to "magma@major.minor.bugfix.revision-commithash" where commit count (number of commits on master) is used as revision.

Note, that only the version reported to Sentry is affected here. No other version format is changed.

The intention is to back port this change to 1.6. as well, to allow for Sentry's resolve mechanism to work properly. 

Relates to #10827.

## Test Plan

Built package with build-magma.sh (via `fab release package`) and checked that the version can be found in the respective `COMMIT_HASH_FILE`.

Tested locally that Sentry version is understood correctly and enables usage of Sentry's resolve-mechanism for issues.  


## Additional Information

- [ ] This change is backwards-breaking
