### PR TITLE
chore(agw): consolidate sentry-cli and sentry_sdk releases

### DIFF
--- a/orc8r/tools/fab/pkg.py
+++ b/orc8r/tools/fab/pkg.py
@@ -141,11 +141,10 @@ def upload_pkgs_to_aws():
 
 def get_magma_version():
     return run(
-        'ls ~/magma-packages'
-        ' | grep "^magma_[0-9].*"'
-        ' | xargs -I "%" dpkg -I ~/magma-packages/%'
-        ' | grep "Version"'
-        ' | awk \'{print $2}\'',
+        'directory=$(mktemp -d) &&'
+        'dpkg-deb --extract ~/magma-packages/magma_[0-9]*.deb $directory &&'
+        'source $directory/usr/local/share/magma/commit_hash &&'
+        'echo $COMMIT_HASH',
     )
 
 


### PR DESCRIPTION
## Summary

Currently the schema of the release names created with `sentry-cli` is
`<semver>-<timestamp>-<commit_hash>` while the schema of the release names created ad-hoc by the `sentry_sdk` is `<semver>-<commit_hash>` (the latter is about to change in #10831) This PR reads the release name used by `sentry-cli` from the `/usr/local/share/magma/commit_hash` file of the Magma Debian package, which is also what is passed to `sentry_sdk.init`.

## Test Plan

Tested the new command in a local bash shell

## Additional Information

- [ ] This change is backwards-breaking
