### PR TITLE
fix(agw): Update dependency issue python3-websocket-client

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -111,7 +111,7 @@ setup(
         'chardet==3.0.4',
         'docker==4.0.2',
         'urllib3>=1.25.3',
-        'websocket-client',
+        'websocket-client==1.2.3',
         'requests>=2.22.0',
         'certifi>=2019.6.16',
         'idna==2.8',


### PR DESCRIPTION
Signed-off-by: Jared Mullane <jmullane@fb.com>

## Summary

Previously (https://github.com/magma/magma/pull/10723) the python3-websocket-client was updated to version 1.2.2, however, the error below shows 1.2.3 (latest version) to be installed. 

![image](https://user-images.githubusercontent.com/61836831/145864771-ad978d98-a7ab-4fed-8084-777f0fa63bec.png)



