### PR TITLE
feat(agw): restart services on shared config changes

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -105,6 +105,9 @@ jobs:
             wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O ${{ env.SWAGGER_CODEGEN_JAR }}
       - name: Execute test_all
         run: |
+            sudo mkdir /etc/magma
+            sudo -E chmod a+rx /etc/magma
+            sudo cp ${{ env.MAGMA_ROOT }}/lte/gateway/configs/gateway.mconfig /etc/magma/
             make -C ${{ env.MAGMA_ROOT }}/lte/gateway/python test_all
       - name: Upload Test Results
         if: always()

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/thoas/go-funk v0.7.0
 	github.com/wmnsk/go-gtp v0.8.0
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.27.1
 	layeh.com/radius v0.0.0-20201203135236-838e26d0c9be

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -416,6 +416,7 @@ github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -532,6 +533,7 @@ github.com/modern-go/reflect2 v0.0.0-20180320133207-05fbef0ca5da/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39 h1:diqTAr+wSpYUQHsyj80KOYO+TUf9RqjnKsARAsDDxaE=
@@ -1021,6 +1023,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=

--- a/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
@@ -57,7 +57,12 @@ class ConfigManagerTest(TestCase):
         }
 
         @asyncio.coroutine
-        def _mock_restart_services(): return "blah"
+        def _mock_restart_services():
+            return "blah"
+
+        @asyncio.coroutine
+        def _mock_update_dynamic_services():
+            return "mockResponse"
 
         service_manager_mock = MagicMock()
         magmad_service_mock = MagicMock()
@@ -75,11 +80,16 @@ class ConfigManagerTest(TestCase):
             service_manager_mock,
             'restart_services', MagicMock(wraps=_mock_restart_services),
         )
+        update_dynamic_services_mock = patch.object(
+            service_manager_mock,
+            'update_dynamic_services', MagicMock(wraps=_mock_update_dynamic_services),
+        )
         processed_updates_mock = patch('magma.magmad.events.processed_updates')
 
         with load_mock as loader,\
                 update_mock as updater, \
                 restart_service_mock as restarter,\
+                update_dynamic_services_mock as dynamic_services,\
                 processed_updates_mock as processed_updates:
             loop = asyncio.new_event_loop()
             config_manager = ConfigManager(
@@ -109,7 +119,7 @@ class ConfigManagerTest(TestCase):
             config_manager.process_update(CONFIG_STREAM_NAME, updates, False)
 
             # Only metricsd config was updated, hence should be restarted
-            loader.assert_called_once_with()
+            self.assertEqual(loader.call_count, 1)
             restarter.assert_called_once_with(['metricsd'])
             updater.assert_called_once_with(update_str)
 
@@ -118,3 +128,28 @@ class ConfigManagerTest(TestCase):
                 'metricsd': updated_mconfig.configs_by_key['metricsd'],
             }
             processed_updates.assert_called_once_with(configs_by_service)
+
+            restarter.reset_mock()
+            updater.reset_mock()
+            processed_updates.reset_mock()
+
+            updated_mconfig.configs_by_key['shared_mconfig'].CopyFrom(some_any)
+            update_str = MessageToJson(updated_mconfig)
+            updates = [
+                DataUpdate(
+                    value=update_str.encode('utf-8'),
+                    key='last key',
+                ),
+            ]
+            config_manager.process_update(CONFIG_STREAM_NAME, updates, False)
+
+            # shared config update should restart all services
+            restarter.assert_called_once_with(['magmad', 'metricsd'])
+            updater.assert_called_once_with(update_str)
+            dynamic_services.assert_called_once_with([])
+            processed_updates.assert_called_once_with(configs_by_service)
+
+            restarter.reset_mock()
+            updater.reset_mock()
+            processed_updates.reset_mock()
+            dynamic_services.reset_mock()


### PR DESCRIPTION
Signed-off-by: Ankit Bhadoria <abhadoria@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

while processing updates to gateway.mconfig, we check if shared_mconfig changes, if yes, add all the services to restart list.

## Test Plan

added unit test, and ran various scenarios on local vm.

![Screen Shot 2021-12-10 at 1 47 56 PM](https://user-images.githubusercontent.com/12483853/145904952-6fef7685-e645-43e1-970b-44c65327934d.png)
<img width="990" alt="Screen Shot 2021-12-10 at 1 49 09 PM" src="https://user-images.githubusercontent.com/12483853/145904953-198d6b98-364f-4134-b496-274504db7214.png">
<img width="1145" alt="Screen Shot 2021-12-10 at 1 47 46 PM" src="https://user-images.githubusercontent.com/12483853/145904954-12f12176-7e3f-40f7-84da-940915585029.png">

