### PR TITLE
fix(orc8r): Add default tier after creating networks

### DIFF
--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers.go
@@ -53,6 +53,22 @@ func registerNetwork(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
+
+	// Creating default tier for each created network
+	for _, s := range createdNetworks {
+		defaultTier := &models.Tier{
+			ID:       "default",
+			Gateways: models.TierGateways{},
+			Images:   models.TierImages{},
+			Version:  models.TierVersion("1.0"),
+		}
+		entity := defaultTier.ToNetworkEntity()
+		_, err := configurator.CreateEntity(c.Request().Context(), s.ID, entity, serdes.Entity)
+		if err != nil {
+			// Handling error: this may not block the register workflow, instead it prints error logs
+		}
+	}
+
 	return c.JSON(http.StatusCreated, createdNetworks[0].ID)
 }
 

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers_test.go
@@ -364,6 +364,23 @@ func Test_PostNetworkHandlers(t *testing.T) {
 	}
 	assert.Equal(t, expectedNetwork1, actualNetwork1)
 
+	actualTier1, err := configurator.LoadEntity(
+		context.Background(), "n1",
+		orc8r.UpgradeTierEntityType, "default",
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: false},
+		serdes.Entity,
+	)
+	expectedTier1 := &models.Tier{
+		ID:       "default",
+		Gateways: models.TierGateways{},
+		Images:   models.TierImages{},
+		Version:  models.TierVersion("1.0"),
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, "n1", actualTier1.NetworkID)
+	assert.Equal(t, "upgrade_tier", actualTier1.Type)
+	assert.Equal(t, expectedTier1, actualTier1.Config.(*models.Tier))
+
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            fmt.Sprintf("%s/%s/", testURLRoot, "n1"),


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Create a default tier for orc8r network creation.

Issue: https://github.com/magma/magma/issues/9990


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

Unit test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
