### PR TITLE
test(mme): Add S1 Handover MME unit tests

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -124,5 +124,19 @@ void send_s1ap_path_switch_req(
     const uint32_t sctp_assoc_id, const uint32_t enb_id,
     const uint32_t enb_ue_s1ap_id, const plmn_t& plmn);
 
+void send_s1ap_handover_required(
+    const uint32_t sctp_assoc_id, const uint32_t enb_id,
+    const uint32_t enb_ue_s1ap_id, const uint32_t mme_ue_s1ap_id);
+
+void send_s1ap_handover_request_ack(
+    const uint32_t sctp_assoc_id, const uint32_t enb_id,
+    const uint32_t tgt_enb_id, const uint32_t enb_ue_s1ap_id,
+    const uint32_t tgt_enb_ue_s1ap_id, const uint32_t mme_ue_s1ap_id);
+
+void send_s1ap_handover_notify(
+    const uint32_t tgt_sctp_assoc_id, const uint32_t enb_id,
+    const uint32_t tgt_enb_id, const uint32_t enb_ue_s1ap_id,
+    const uint32_t tgt_enb_ue_s1ap_id, const uint32_t mme_ue_s1ap_id);
+
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -87,6 +87,30 @@ MATCHER_P2(
   return false;
 }
 
+MATCHER_P2(
+    check_params_in_mme_app_handover_request, mme_ue_s1ap_id, new_sctp_assoc_id,
+    "") {
+  auto mme_app_handover_request_recv =
+      static_cast<itti_mme_app_handover_request_t>(arg);
+  if ((mme_app_handover_request_recv.mme_ue_s1ap_id == mme_ue_s1ap_id) &&
+      (mme_app_handover_request_recv.target_sctp_assoc_id ==
+       new_sctp_assoc_id)) {
+    return true;
+  }
+  return false;
+}
+
+MATCHER_P2(
+    check_params_in_mme_app_handover_command, mme_ue_s1ap_id, new_enb_id, "") {
+  auto mme_app_handover_command_recv =
+      static_cast<itti_mme_app_handover_command_t>(arg);
+  if ((mme_app_handover_command_recv.target_enb_id == new_enb_id) &&
+      (mme_app_handover_command_recv.mme_ue_s1ap_id == mme_ue_s1ap_id)) {
+    return true;
+  }
+  return false;
+}
+
 class MmeAppProcedureTest : public ::testing::Test {
   virtual void SetUp() {
     mme_hss_associated = false;
@@ -3388,6 +3412,142 @@ TEST_F(MmeAppProcedureTest, TestX2HandoverPathSwitchFailure) {
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
   EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
   EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+}
+
+TEST_F(MmeAppProcedureTest, TestS1HandoverSuccess) {
+  mme_app_desc_t* mme_state_p =
+      magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  std::condition_variable cv;
+  std::mutex mx;
+  std::unique_lock<std::mutex> lock(mx);
+
+  MME_APP_EXPECT_CALLS(3, 1, 1, 1, 1, 1, 1, 2, 0, 1, 3);
+
+  // Construction and sending Initial Attach Request to mme_app mimicing S1AP
+  send_mme_app_initial_ue_msg(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
+
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp(REQUEST_ACCEPTED);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
+  uint32_t new_enb_ue_s1ap_id = DEFAULT_eNB_S1AP_UE_ID + 1;
+  uint32_t new_sctp_assoc_id  = DEFAULT_SCTP_ASSOC_ID + 1;
+  uint32_t new_enb_id         = DEFAULT_ENB_ID + 1;
+  uint32_t mme_ue_s1ap_id     = 1;
+
+  // Send Handover Required to mme_app mimicing S1AP, use 1 for all new ids,
+  // since Initial UE message is using 0
+  send_s1ap_handover_required(
+      DEFAULT_SCTP_ASSOC_ID, new_enb_id, new_enb_ue_s1ap_id, mme_ue_s1ap_id);
+
+  // Expect that MME Handover Request is sent to S1AP from mme_app
+  EXPECT_CALL(
+      *s1ap_handler,
+      s1ap_mme_handle_handover_request(check_params_in_mme_app_handover_request(
+          mme_ue_s1ap_id, DEFAULT_SCTP_ASSOC_ID)))
+      .Times(1);
+
+  // Send Handover Request Ack to mme_app mimicing S1AP
+  send_s1ap_handover_request_ack(
+      DEFAULT_SCTP_ASSOC_ID, DEFAULT_ENB_ID, new_enb_id, DEFAULT_eNB_S1AP_UE_ID,
+      new_enb_ue_s1ap_id, mme_ue_s1ap_id);
+
+  // Expect that MME Handover Command is sent to S1AP from mme_app
+  EXPECT_CALL(
+      *s1ap_handler,
+      s1ap_mme_handle_handover_command(
+          check_params_in_mme_app_handover_command(mme_ue_s1ap_id, new_enb_id)))
+      .Times(1);
+
+  // Send Handover Notify to mme_app mimicing S1AP
+  send_s1ap_handover_notify(
+      new_sctp_assoc_id, DEFAULT_ENB_ID, new_enb_id, DEFAULT_eNB_S1AP_UE_ID,
+      new_enb_ue_s1ap_id, mme_ue_s1ap_id);
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW, with same parameters as last one
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 2);
+
+  // Constructing and sending Detach Request to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_detach_req, sizeof(nas_msg_detach_req), plmn);
+
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp();
+
+  // Wait for context release request
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
 }
 
 }  // namespace lte

--- a/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
+++ b/lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h
@@ -60,6 +60,12 @@ class MockS1apHandler {
   MOCK_METHOD1(
       s1ap_handle_path_switch_req_failure,
       bool(itti_s1ap_path_switch_request_failure_t path_switch_fail));
+  MOCK_METHOD1(
+      s1ap_mme_handle_handover_request,
+      bool(itti_mme_app_handover_request_t mme_handover_request));
+  MOCK_METHOD1(
+      s1ap_mme_handle_handover_command,
+      bool(itti_mme_app_handover_command_t mme_handover_request));
 };
 
 class MockMmeAppHandler {

--- a/lte/gateway/c/core/oai/test/mock_tasks/s1ap_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/s1ap_mock.cpp
@@ -88,9 +88,13 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     case MME_APP_HANDOVER_REQUEST: {
+      s1ap_handler_->s1ap_mme_handle_handover_request(
+          received_message_p->ittiMsg.mme_app_handover_request);
     } break;
 
     case MME_APP_HANDOVER_COMMAND: {
+      s1ap_handler_->s1ap_mme_handle_handover_command(
+          received_message_p->ittiMsg.mme_app_handover_command);
     } break;
 
     case TERMINATE_MESSAGE: {


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Adding unit test for MME procedures related with S1 Handover 
- Adding them in single unit test to ensure state correctness and order of function calls

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- make test_oai

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
