### PR TITLE
chore(ci): imagestream changed for python-precommit with composite actions

### DIFF
--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -24,7 +24,7 @@ LINT_DOCKER_PATH = os.path.join(
 IMAGE_NAME = 'magma/py-lint'
 ORC8R_PYTHON_PATH = 'orc8r/gateway/python/magma'
 LTE_PYTHON_PATH = 'lte/gateway/python/magma'
-GITHUB_IMAGE_NAME = 'ghcr.io/magma/python-precommit:sha-38a9341'
+GITHUB_IMAGE_NAME = 'ghcr.io/magma/magma/python-precommit:sha-b22d512'
 
 
 def main() -> None:


### PR DESCRIPTION
... introduced in https://github.com/magma/magma/pull/10378.

Afaiks, this is the only occurrence of images apart from devcontainer (according IntelliJ search), already updated in https://github.com/magma/magma/pull/10736.

Fixes https://github.com/magma/magma/issues/10828.

## Test plan

* CI
* Image is https://github.com/magma/magma/pkgs/container/magma%2Fpython-precommit/11566600?tag=sha-b22d512

