### PR TITLE
refactor(orc8r): Swagger service security changes

### DIFF
--- a/cwf/cloud/go/services/cwf/cwf/main.go
+++ b/cwf/cloud/go/services/cwf/cwf/main.go
@@ -22,8 +22,8 @@ import (
 	"magma/cwf/cloud/go/services/cwf/obsidian/handlers"
 	"magma/cwf/cloud/go/services/cwf/servicers"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
@@ -42,7 +42,7 @@ func main() {
 
 	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, servicers.NewBuilderServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(cwf_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(cwf_service.ServiceName))
 
 	var serviceConfig cwf_service.Config
 	_, _, err = config.GetStructuredServiceConfig(cwf.ModuleName, cwf_service.ServiceName, &serviceConfig)

--- a/cwf/cloud/go/services/cwf/cwf/main.go
+++ b/cwf/cloud/go/services/cwf/cwf/main.go
@@ -23,7 +23,7 @@ import (
 	"magma/cwf/cloud/go/services/cwf/servicers"
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
@@ -42,7 +42,7 @@ func main() {
 
 	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, servicers.NewBuilderServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(cwf_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(cwf_service.ServiceName))
 
 	var serviceConfig cwf_service.Config
 	_, _, err = config.GetStructuredServiceConfig(cwf.ModuleName, cwf_service.ServiceName, &serviceConfig)

--- a/fbinternal/cloud/go/services/fbinternal/fbinternal/main.go
+++ b/fbinternal/cloud/go/services/fbinternal/fbinternal/main.go
@@ -22,8 +22,8 @@ import (
 	"magma/fbinternal/cloud/go/fbinternal"
 	fbinternal_service "magma/fbinternal/cloud/go/services/fbinternal"
 	"magma/fbinternal/cloud/go/services/fbinternal/servicers"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/metricsd/protos"
 	"magma/orc8r/lib/go/definitions"
@@ -56,7 +56,7 @@ func main() {
 	)
 	protos.RegisterMetricsExporterServer(srv.GrpcServer, exporterServicer)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(fbinternal_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(fbinternal_service.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/fbinternal/cloud/go/services/fbinternal/fbinternal/main.go
+++ b/fbinternal/cloud/go/services/fbinternal/fbinternal/main.go
@@ -23,7 +23,7 @@ import (
 	fbinternal_service "magma/fbinternal/cloud/go/services/fbinternal"
 	"magma/fbinternal/cloud/go/services/fbinternal/servicers"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/metricsd/protos"
 	"magma/orc8r/lib/go/definitions"
@@ -56,7 +56,7 @@ func main() {
 	)
 	protos.RegisterMetricsExporterServer(srv.GrpcServer, exporterServicer)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(fbinternal_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(fbinternal_service.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/fbinternal/cloud/go/services/testcontroller/testcontroller/main.go
+++ b/fbinternal/cloud/go/services/testcontroller/testcontroller/main.go
@@ -29,7 +29,7 @@ import (
 	"magma/fbinternal/cloud/go/services/testcontroller/storage"
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/sqorc"
 	storage2 "magma/orc8r/cloud/go/storage"
@@ -65,7 +65,7 @@ func main() {
 	e2eServicer := servicers.NewTestControllerServicer(e2eStore)
 	protos.RegisterTestControllerServer(srv.GrpcServer, e2eServicer)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(testcontroller.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(testcontroller.ServiceName))
 
 	// Instantiate state machines, start test execution loop
 	go func() {

--- a/fbinternal/cloud/go/services/testcontroller/testcontroller/main.go
+++ b/fbinternal/cloud/go/services/testcontroller/testcontroller/main.go
@@ -28,8 +28,8 @@ import (
 	"magma/fbinternal/cloud/go/services/testcontroller/statemachines"
 	"magma/fbinternal/cloud/go/services/testcontroller/storage"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/sqorc"
 	storage2 "magma/orc8r/cloud/go/storage"
@@ -65,7 +65,7 @@ func main() {
 	e2eServicer := servicers.NewTestControllerServicer(e2eStore)
 	protos.RegisterTestControllerServer(srv.GrpcServer, e2eServicer)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(testcontroller.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(testcontroller.ServiceName))
 
 	// Instantiate state machines, start test execution loop
 	go func() {

--- a/feg/cloud/go/services/feg/feg/main.go
+++ b/feg/cloud/go/services/feg/feg/main.go
@@ -21,8 +21,8 @@ import (
 	"magma/feg/cloud/go/services/feg/obsidian/handlers"
 	"magma/feg/cloud/go/services/feg/servicers"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
 )
@@ -37,7 +37,7 @@ func main() {
 
 	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, servicers.NewBuilderServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(feg_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(feg_service.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/feg/cloud/go/services/feg/feg/main.go
+++ b/feg/cloud/go/services/feg/feg/main.go
@@ -22,7 +22,7 @@ import (
 	"magma/feg/cloud/go/services/feg/servicers"
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
 )
@@ -37,7 +37,7 @@ func main() {
 
 	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, servicers.NewBuilderServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(feg_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(feg_service.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -25,7 +25,7 @@ import (
 	lte_storage "magma/lte/cloud/go/services/lte/storage"
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
@@ -53,7 +53,7 @@ func main() {
 	provider_protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewProviderServicer())
 	state_protos.RegisterIndexerServer(srv.GrpcServer, servicers.NewIndexerServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(lte_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(lte_service.ServiceName))
 
 	// Init storage
 	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())

--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -24,8 +24,8 @@ import (
 	"magma/lte/cloud/go/services/lte/servicers"
 	lte_storage "magma/lte/cloud/go/services/lte/storage"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
@@ -53,7 +53,7 @@ func main() {
 	provider_protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewProviderServicer())
 	state_protos.RegisterIndexerServer(srv.GrpcServer, servicers.NewIndexerServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(lte_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(lte_service.ServiceName))
 
 	// Init storage
 	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())

--- a/lte/cloud/go/services/nprobe/nprobe/main.go
+++ b/lte/cloud/go/services/nprobe/nprobe/main.go
@@ -26,8 +26,8 @@ import (
 	np_storage "magma/lte/cloud/go/services/nprobe/storage"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	"magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/storage"
@@ -58,7 +58,7 @@ func main() {
 
 	// Attach handlers
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers(nprobeBlobstore))
-	protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(nprobe.ServiceName))
+	protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(nprobe.ServiceName))
 
 	serviceConfig := nprobe.GetServiceConfig()
 	nProbeManager, err := manager.NewNProbeManager(serviceConfig, nprobeBlobstore)

--- a/lte/cloud/go/services/nprobe/nprobe/main.go
+++ b/lte/cloud/go/services/nprobe/nprobe/main.go
@@ -27,7 +27,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/storage"
@@ -58,7 +58,7 @@ func main() {
 
 	// Attach handlers
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers(nprobeBlobstore))
-	protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(nprobe.ServiceName))
+	protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(nprobe.ServiceName))
 
 	serviceConfig := nprobe.GetServiceConfig()
 	nProbeManager, err := manager.NewNProbeManager(serviceConfig, nprobeBlobstore)

--- a/lte/cloud/go/services/policydb/policydb/main.go
+++ b/lte/cloud/go/services/policydb/policydb/main.go
@@ -22,8 +22,8 @@ import (
 	"magma/lte/cloud/go/services/policydb/obsidian/handlers"
 	"magma/lte/cloud/go/services/policydb/servicers"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 )
 
@@ -36,7 +36,7 @@ func main() {
 	assignmentServicer := servicers.NewPolicyAssignmentServer()
 	protos.RegisterPolicyAssignmentControllerServer(srv.GrpcServer, assignmentServicer)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(policydb.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(policydb.ServiceName))
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	err = srv.Run()

--- a/lte/cloud/go/services/policydb/policydb/main.go
+++ b/lte/cloud/go/services/policydb/policydb/main.go
@@ -23,7 +23,7 @@ import (
 	"magma/lte/cloud/go/services/policydb/servicers"
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 )
 
@@ -36,7 +36,7 @@ func main() {
 	assignmentServicer := servicers.NewPolicyAssignmentServer()
 	protos.RegisterPolicyAssignmentControllerServer(srv.GrpcServer, assignmentServicer)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(policydb.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(policydb.ServiceName))
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	err = srv.Run()

--- a/lte/cloud/go/services/smsd/smsd/main.go
+++ b/lte/cloud/go/services/smsd/smsd/main.go
@@ -23,8 +23,8 @@ import (
 	storage2 "magma/lte/cloud/go/services/smsd/storage"
 	"magma/lte/cloud/go/sms_ll"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/storage"
@@ -51,7 +51,7 @@ func main() {
 	obsidian.AttachHandlers(srv.EchoServer, restServicer.GetHandlers())
 	protos.RegisterSmsDServer(srv.GrpcServer, servicers.NewSMSDServicer(store, &sms_ll.DefaultSMSSerde{}))
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(smsd.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(smsd.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/lte/cloud/go/services/smsd/smsd/main.go
+++ b/lte/cloud/go/services/smsd/smsd/main.go
@@ -24,7 +24,7 @@ import (
 	"magma/lte/cloud/go/sms_ll"
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/storage"
@@ -51,7 +51,7 @@ func main() {
 	obsidian.AttachHandlers(srv.EchoServer, restServicer.GetHandlers())
 	protos.RegisterSmsDServer(srv.GrpcServer, servicers.NewSMSDServicer(store, &sms_ll.DefaultSMSSerde{}))
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(smsd.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(smsd.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -25,8 +25,8 @@ import (
 	subscriberdb_storage "magma/lte/cloud/go/services/subscriberdb/storage"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	state_protos "magma/orc8r/cloud/go/services/state/protos"
 	"magma/orc8r/cloud/go/sqorc"
@@ -78,7 +78,7 @@ func main() {
 	state_protos.RegisterIndexerServer(srv.GrpcServer, servicers.NewIndexerServicer())
 	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, servicers.NewSubscriberdbServicer(serviceConfig, subscriberStore))
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(subscriberdb.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(subscriberdb.ServiceName))
 
 	// Run service
 	err = srv.Run()

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -26,7 +26,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/service"
 	state_protos "magma/orc8r/cloud/go/services/state/protos"
 	"magma/orc8r/cloud/go/sqorc"
@@ -78,7 +78,7 @@ func main() {
 	state_protos.RegisterIndexerServer(srv.GrpcServer, servicers.NewIndexerServicer())
 	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, servicers.NewSubscriberdbServicer(serviceConfig, subscriberStore))
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(subscriberdb.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(subscriberdb.ServiceName))
 
 	// Run service
 	err = srv.Run()

--- a/orc8r/cloud/go/obsidian/swagger/handlers/handlers_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/handlers/handlers_test.go
@@ -22,7 +22,7 @@ import (
 
 	"magma/orc8r/cloud/go/obsidian/swagger/handlers"
 	"magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/orc8r"
 	spec "magma/orc8r/cloud/go/swagger"
@@ -191,7 +191,7 @@ func registerServicer(
 
 	partialYamlSpec := marshalToYAML(t, partialSpec)
 	standaloneYamlSpec := marshalToYAML(t, standaloneSpec)
-	protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
+	protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
 
 	go srv.RunTest(lis)
 }

--- a/orc8r/cloud/go/obsidian/swagger/handlers/handlers_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/handlers/handlers_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
 
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	"magma/orc8r/cloud/go/obsidian/swagger/handlers"
 	"magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/orc8r"
 	spec "magma/orc8r/cloud/go/swagger"
@@ -191,7 +191,7 @@ func registerServicer(
 
 	partialYamlSpec := marshalToYAML(t, partialSpec)
 	standaloneYamlSpec := marshalToYAML(t, standaloneSpec)
-	protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
+	protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
 
 	go srv.RunTest(lis)
 }

--- a/orc8r/cloud/go/obsidian/swagger/poll_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/poll_test.go
@@ -20,6 +20,7 @@ import (
 
 	"magma/orc8r/cloud/go/obsidian/swagger"
 	"magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	spec "magma/orc8r/cloud/go/swagger"
 	"magma/orc8r/cloud/go/test_utils"
@@ -120,7 +121,7 @@ func registerServicer(
 
 	partialYamlSpec := marshalToYAML(t, partialSpec)
 	standaloneYamlSpec := marshalToYAML(t, standaloneSpec)
-	protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
+	protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
 
 	go srv.RunTest(lis)
 }

--- a/orc8r/cloud/go/obsidian/swagger/poll_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/poll_test.go
@@ -20,7 +20,7 @@ import (
 
 	"magma/orc8r/cloud/go/obsidian/swagger"
 	"magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	servicers "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	spec "magma/orc8r/cloud/go/swagger"
 	"magma/orc8r/cloud/go/test_utils"
@@ -121,7 +121,7 @@ func registerServicer(
 
 	partialYamlSpec := marshalToYAML(t, partialSpec)
 	standaloneYamlSpec := marshalToYAML(t, standaloneSpec)
-	protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
+	protos.RegisterSwaggerSpecServer(srv.GrpcServer, servicers.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
 
 	go srv.RunTest(lis)
 }

--- a/orc8r/cloud/go/obsidian/swagger/servicers/protected/spec_servicer.go
+++ b/orc8r/cloud/go/obsidian/swagger/servicers/protected/spec_servicer.go
@@ -11,7 +11,7 @@
  limitations under the License.
 */
 
-package swagger
+package servicers
 
 import (
 	"context"

--- a/orc8r/cloud/go/obsidian/swagger/servicers/protected/spec_servicer_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/servicers/protected/spec_servicer_test.go
@@ -11,7 +11,7 @@
  limitations under the License.
 */
 
-package swagger_test
+package servicers_test
 
 import (
 	"context"
@@ -23,15 +23,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	"magma/orc8r/cloud/go/obsidian/swagger/protos"
+	servicers "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/obsidian/swagger/spec"
 	"magma/orc8r/cloud/go/obsidian/swagger/spec/mocks"
 )
 
 func TestSpecServicer_NewSpecServicerFromFile(t *testing.T) {
 	// Missing default dir / spec files should not panic.
-	servicer := swagger.NewSpecServicerFromFile("foo")
+	servicer := servicers.NewSpecServicerFromFile("foo")
 	assert.NotNil(t, servicer)
 }
 
@@ -60,7 +60,7 @@ func TestSpecServicer_NewSpecServicerFromSpecs(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Success
-	servicer := swagger.NewSpecServicerWithLoader(spec.NewFSLoader(d), "test_spec_servicer")
+	servicer := servicers.NewSpecServicerWithLoader(spec.NewFSLoader(d), "test_spec_servicer")
 
 	partialReq := &protos.PartialSpecRequest{}
 	partialRes, err := servicer.GetPartialSpec(context.Background(), partialReq)
@@ -83,7 +83,7 @@ func TestSpecServicer_NewSpecServicerFromSpecsPartialErr(t *testing.T) {
 	standaloneSpec := "standalone spec"
 	partialErrMock.On("GetStandaloneSpec", service).Return(standaloneSpec, nil)
 
-	servicer := swagger.NewSpecServicerWithLoader(partialErrMock, service)
+	servicer := servicers.NewSpecServicerWithLoader(partialErrMock, service)
 	assert.NotNil(t, servicer)
 
 	partialRes, err := servicer.GetPartialSpec(context.Background(), &protos.PartialSpecRequest{})
@@ -103,7 +103,7 @@ func TestSpecServicer_NewSpecServicerFromSpecsStandaloneErr(t *testing.T) {
 	standaloneErrMock.On("GetPartialSpec", service).Return(partialSpec, errors.New("partial err"))
 	standaloneErrMock.On("GetStandaloneSpec", service).Return("", nil)
 
-	servicer := swagger.NewSpecServicerWithLoader(standaloneErrMock, service)
+	servicer := servicers.NewSpecServicerWithLoader(standaloneErrMock, service)
 	assert.NotNil(t, servicer)
 
 	partialRes, err := servicer.GetPartialSpec(context.Background(), &protos.PartialSpecRequest{})
@@ -119,7 +119,7 @@ func TestSpecServicer_GetPartialSpec(t *testing.T) {
 	testFileContents := "test partial yaml spec"
 
 	// Success
-	servicer := swagger.NewSpecServicer(testFileContents, "")
+	servicer := servicers.NewSpecServicer(testFileContents, "")
 
 	req := &protos.PartialSpecRequest{}
 	res, err := servicer.GetPartialSpec(context.Background(), req)
@@ -132,7 +132,7 @@ func TestSpecServicer_GetStandaloneSpec(t *testing.T) {
 	testFileContents := "test standalone yaml spec"
 
 	// Success
-	servicer := swagger.NewSpecServicer("", testFileContents)
+	servicer := servicers.NewSpecServicer("", testFileContents)
 
 	req := &protos.StandaloneSpecRequest{}
 	res, err := servicer.GetStandaloneSpec(context.Background(), req)

--- a/orc8r/cloud/go/services/certifier/certifier/main.go
+++ b/orc8r/cloud/go/services/certifier/certifier/main.go
@@ -23,8 +23,8 @@ import (
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
@@ -112,7 +112,7 @@ func main() {
 	certprotos.RegisterCertifierServer(srv.GrpcServer, servicer)
 
 	// Add handlers that manages users to Swagger
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(certifier.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(certifier.ServiceName))
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 
 	// Start Garbage Collector Ticker

--- a/orc8r/cloud/go/services/certifier/certifier/main.go
+++ b/orc8r/cloud/go/services/certifier/certifier/main.go
@@ -24,7 +24,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
@@ -112,7 +112,7 @@ func main() {
 	certprotos.RegisterCertifierServer(srv.GrpcServer, servicer)
 
 	// Add handlers that manages users to Swagger
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(certifier.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(certifier.ServiceName))
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 
 	// Start Garbage Collector Ticker

--- a/orc8r/cloud/go/services/ctraced/ctraced/main.go
+++ b/orc8r/cloud/go/services/ctraced/ctraced/main.go
@@ -19,7 +19,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/ctraced"
@@ -52,7 +52,7 @@ func main() {
 
 	// Init gRPC servicer
 	protos.RegisterCallTraceControllerServer(srv.GrpcServer, servicers.NewCallTraceServicer(ctracedBlobstore))
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(ctraced.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(ctraced.ServiceName))
 
 	gwClient := handlers.NewGwCtracedClient()
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers(gwClient, ctracedBlobstore))

--- a/orc8r/cloud/go/services/ctraced/ctraced/main.go
+++ b/orc8r/cloud/go/services/ctraced/ctraced/main.go
@@ -18,8 +18,8 @@ import (
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/ctraced"
@@ -52,7 +52,7 @@ func main() {
 
 	// Init gRPC servicer
 	protos.RegisterCallTraceControllerServer(srv.GrpcServer, servicers.NewCallTraceServicer(ctracedBlobstore))
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(ctraced.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(ctraced.ServiceName))
 
 	gwClient := handlers.NewGwCtracedClient()
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers(gwClient, ctracedBlobstore))

--- a/orc8r/cloud/go/services/eventd/eventd/main.go
+++ b/orc8r/cloud/go/services/eventd/eventd/main.go
@@ -18,7 +18,7 @@ import (
 
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/eventd"
@@ -33,7 +33,7 @@ func main() {
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(eventd.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(eventd.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/orc8r/cloud/go/services/eventd/eventd/main.go
+++ b/orc8r/cloud/go/services/eventd/eventd/main.go
@@ -17,8 +17,8 @@ import (
 	"github.com/golang/glog"
 
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/eventd"
@@ -33,7 +33,7 @@ func main() {
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(eventd.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(eventd.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/orc8r/cloud/go/services/metricsd/metricsd/main.go
+++ b/orc8r/cloud/go/services/metricsd/metricsd/main.go
@@ -21,8 +21,8 @@ import (
 	"google.golang.org/grpc"
 
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/metricsd"
@@ -50,7 +50,7 @@ func main() {
 	controllerServicer := servicers.NewMetricsControllerServer()
 	protos.RegisterMetricsControllerServer(srv.GrpcServer, controllerServicer)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(metricsd.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(metricsd.ServiceName))
 
 	// Initialize gatherers
 	additionalCollectors := []collection.MetricCollector{

--- a/orc8r/cloud/go/services/metricsd/metricsd/main.go
+++ b/orc8r/cloud/go/services/metricsd/metricsd/main.go
@@ -22,7 +22,7 @@ import (
 
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/metricsd"
@@ -50,7 +50,7 @@ func main() {
 	controllerServicer := servicers.NewMetricsControllerServer()
 	protos.RegisterMetricsControllerServer(srv.GrpcServer, controllerServicer)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(metricsd.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(metricsd.ServiceName))
 
 	// Initialize gatherers
 	additionalCollectors := []collection.MetricCollector{

--- a/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
+++ b/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
@@ -18,8 +18,8 @@ import (
 	"google.golang.org/grpc"
 
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
@@ -73,7 +73,7 @@ func main() {
 	indexer_protos.RegisterIndexerServer(srv.GrpcServer, servicers.NewIndexerServicer())
 	streamer_protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewProviderServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(orchestrator.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(orchestrator.ServiceName))
 
 	collectorServicer := analytics.NewCollectorServicer(
 		&serviceConfig.Analytics,

--- a/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
+++ b/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
@@ -19,7 +19,7 @@ import (
 
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
@@ -73,7 +73,7 @@ func main() {
 	indexer_protos.RegisterIndexerServer(srv.GrpcServer, servicers.NewIndexerServicer())
 	streamer_protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewProviderServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(orchestrator.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(orchestrator.ServiceName))
 
 	collectorServicer := analytics.NewCollectorServicer(
 		&serviceConfig.Analytics,

--- a/orc8r/cloud/go/services/tenants/tenants/main.go
+++ b/orc8r/cloud/go/services/tenants/tenants/main.go
@@ -18,8 +18,8 @@ import (
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/obsidian/swagger"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
+	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/tenants"
@@ -53,7 +53,7 @@ func main() {
 	}
 	protos.RegisterTenantsServiceServer(srv.GrpcServer, server)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(tenants.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(tenants.ServiceName))
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers())
 

--- a/orc8r/cloud/go/services/tenants/tenants/main.go
+++ b/orc8r/cloud/go/services/tenants/tenants/main.go
@@ -19,7 +19,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/obsidian"
 	swagger_protos "magma/orc8r/cloud/go/obsidian/swagger/protos"
-	internal_swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
+	swagger "magma/orc8r/cloud/go/obsidian/swagger/servicers/protected"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/tenants"
@@ -53,7 +53,7 @@ func main() {
 	}
 	protos.RegisterTenantsServiceServer(srv.GrpcServer, server)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, internal_swagger.NewSpecServicerFromFile(tenants.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(tenants.ServiceName))
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers())
 


### PR DESCRIPTION
## Summary
This PR deals with the segregation of indexer.proto internal gRPC servicers implementation.
This changes are part of the ongoing work which details the distinction between Orc8r-internal gRPC endpoints vs. external, gateway-oriented gRPC endpoints.
Moved Indexer implementation from magma/orc8r/cloud/go/obsidian/swagger/spec_servicer.go to magma/orc8r/cloud/go/obsidian/swagger/protected/spec_servicer.go
Verified existing UT cases.

## Test Plan

All unit tests passed
No UTs added or removed
