### PR TITLE
feat(agw): Mock out the gateway.mconfig dependency while running update test for ConfigManager

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -105,9 +105,6 @@ jobs:
             wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O ${{ env.SWAGGER_CODEGEN_JAR }}
       - name: Execute test_all
         run: |
-            sudo mkdir /etc/magma
-            sudo -E chmod a+rx /etc/magma
-            sudo cp ${{ env.MAGMA_ROOT }}/lte/gateway/configs/gateway.mconfig /etc/magma/
             make -C ${{ env.MAGMA_ROOT }}/lte/gateway/python test_all
       - name: Upload Test Results
         if: always()

--- a/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
@@ -86,10 +86,17 @@ class ConfigManagerTest(TestCase):
         )
         processed_updates_mock = patch('magma.magmad.events.processed_updates')
 
+        class service_mconfig_mock:
+            def __init__(self, service, mconfig_struct):
+                pass
+            dynamic_services = []
+        mock_mcfg = patch('magma.magmad.config_manager.load_service_mconfig', MagicMock(wraps=service_mconfig_mock))
+
         with load_mock as loader,\
                 update_mock as updater, \
                 restart_service_mock as restarter,\
                 update_dynamic_services_mock as dynamic_services,\
+                mock_mcfg as mock_c,\
                 processed_updates_mock as processed_updates:
             loop = asyncio.new_event_loop()
             config_manager = ConfigManager(
@@ -148,6 +155,7 @@ class ConfigManagerTest(TestCase):
             updater.assert_called_once_with(update_str)
             dynamic_services.assert_called_once_with([])
             processed_updates.assert_called_once_with(configs_by_service)
+            self.assertEqual(mock_c.call_count, 1)
 
             restarter.reset_mock()
             updater.reset_mock()

--- a/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
@@ -86,11 +86,11 @@ class ConfigManagerTest(TestCase):
         )
         processed_updates_mock = patch('magma.magmad.events.processed_updates')
 
-        class service_mconfig_mock:
+        class ServiceMconfigMock:
             def __init__(self, service, mconfig_struct):
                 pass
             dynamic_services = []
-        mock_mcfg = patch('magma.magmad.config_manager.load_service_mconfig', MagicMock(wraps=service_mconfig_mock))
+        mock_mcfg = patch('magma.magmad.config_manager.load_service_mconfig', MagicMock(wraps=ServiceMconfigMock))
 
         with load_mock as loader,\
                 update_mock as updater, \


### PR DESCRIPTION

Signed-off-by: Ankit Bhadoria <abhadoria@fb.com>

feat(agw): Mock out the gateway.mconfig dependency while running update test for ConfigManager

## Summary

mocked the dependency on gateway.mconfig file and changed the build pipeline to not copy the gateway file

## Test Plan

ran unit tests
