### PR TITLE
test(mme): Expand unit test for Nas state converter

### DIFF
--- a/lte/gateway/c/core/oai/common/state_converter.cpp
+++ b/lte/gateway/c/core/oai/common/state_converter.cpp
@@ -40,13 +40,13 @@ void StateConverter::plmn_to_chars(const plmn_t& state_plmn, char* plmn_array) {
   plmn_array[5] = (char) (state_plmn.mnc_digit3 + ASCII_ZERO);
 }
 
-void StateConverter::chars_to_plmn(const char* plmn_array, plmn_t& state_plmn) {
-  state_plmn.mcc_digit1 = (int) (plmn_array[0]) - ASCII_ZERO;
-  state_plmn.mcc_digit2 = (int) (plmn_array[1]) - ASCII_ZERO;
-  state_plmn.mcc_digit3 = (int) (plmn_array[2]) - ASCII_ZERO;
-  state_plmn.mnc_digit1 = (int) (plmn_array[3]) - ASCII_ZERO;
-  state_plmn.mnc_digit2 = (int) (plmn_array[4]) - ASCII_ZERO;
-  state_plmn.mnc_digit3 = (int) (plmn_array[5]) - ASCII_ZERO;
+void StateConverter::chars_to_plmn(const char* plmn_array, plmn_t* state_plmn) {
+  state_plmn->mcc_digit1 = static_cast<int>(plmn_array[0]) - ASCII_ZERO;
+  state_plmn->mcc_digit2 = static_cast<int>(plmn_array[1]) - ASCII_ZERO;
+  state_plmn->mcc_digit3 = static_cast<int>(plmn_array[2]) - ASCII_ZERO;
+  state_plmn->mnc_digit1 = static_cast<int>(plmn_array[3]) - ASCII_ZERO;
+  state_plmn->mnc_digit2 = static_cast<int>(plmn_array[4]) - ASCII_ZERO;
+  state_plmn->mnc_digit3 = static_cast<int>(plmn_array[5]) - ASCII_ZERO;
 }
 
 void StateConverter::guti_to_proto(
@@ -63,7 +63,7 @@ void StateConverter::guti_to_proto(
 
 void StateConverter::proto_to_guti(
     const oai::Guti& guti_proto, guti_t* state_guti) {
-  chars_to_plmn(guti_proto.plmn().c_str(), state_guti->gummei.plmn);
+  chars_to_plmn(guti_proto.plmn().c_str(), &state_guti->gummei.plmn);
 
   state_guti->gummei.mme_gid  = guti_proto.mme_gid();
   state_guti->gummei.mme_code = guti_proto.mme_code();
@@ -84,7 +84,7 @@ void StateConverter::ecgi_to_proto(
 
 void StateConverter::proto_to_ecgi(
     const oai::Ecgi& ecgi_proto, ecgi_t* state_ecgi) {
-  chars_to_plmn(ecgi_proto.plmn().c_str(), state_ecgi->plmn);
+  chars_to_plmn(ecgi_proto.plmn().c_str(), &state_ecgi->plmn);
   strncpy((char*) &state_ecgi->plmn, ecgi_proto.plmn().c_str(), PLMN_BYTES);
 
   state_ecgi->cell_identity.enb_id  = ecgi_proto.enb_id();

--- a/lte/gateway/c/core/oai/include/state_converter.h
+++ b/lte/gateway/c/core/oai/include/state_converter.h
@@ -186,7 +186,7 @@ class StateConverter {
 
  private:
   static void plmn_to_chars(const plmn_t& state_plmn, char* plmn_array);
-  static void chars_to_plmn(const char* plmn_array, plmn_t& state_plmn);
+  static void chars_to_plmn(const char* plmn_array, plmn_t* state_plmn);
 };
 
 }  // namespace lte

--- a/lte/gateway/c/core/oai/lib/bstr/bstrlib.c
+++ b/lte/gateway/c/core/oai/lib/bstr/bstrlib.c
@@ -207,7 +207,7 @@ bstring bfromcstr_with_str_len(const char* str, int len) {
   int i;
   int j;
 
-  if (str == NULL) return NULL;
+  if ((str == NULL) || (len == 0)) return NULL;
   j = len;
   i = snapUpSize((int) (j + (2 - (j != 0))));
   if (i <= (int) j) return NULL;

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
@@ -316,8 +316,7 @@ static void nas_delete_child_procedures(
 
 //-----------------------------------------------------------------------------
 static void nas_delete_con_mngt_procedure(nas_emm_con_mngt_proc_t** proc) {
-  if (*proc) {
-    Fatal("TODO Implement nas_delete_con_mngt_procedure");
+  if (proc) {
     free_wrapper((void**) proc);
   }
 }
@@ -563,7 +562,8 @@ void nas_delete_all_emm_procedures(struct emm_context_s* const emm_context) {
   if (emm_context->emm_procedures) {
     nas_delete_cn_procedures(emm_context);
     nas_delete_common_procedures(emm_context);
-    // TODO nas_delete_con_mngt_procedure(emm_context);
+    nas_delete_con_mngt_procedure(
+        &emm_context->emm_procedures->emm_con_mngt_proc);
     nas_delete_attach_procedure(emm_context);
     nas_delete_detach_procedure(emm_context);
     nas_delete_tau_procedure(emm_context);

--- a/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_procedures.c
@@ -562,8 +562,12 @@ void nas_delete_all_emm_procedures(struct emm_context_s* const emm_context) {
   if (emm_context->emm_procedures) {
     nas_delete_cn_procedures(emm_context);
     nas_delete_common_procedures(emm_context);
-    nas_delete_con_mngt_procedure(
-        &emm_context->emm_procedures->emm_con_mngt_proc);
+    // Check if emm_procedures are non-null after previous delete procedures
+    if (emm_context->emm_procedures &&
+        emm_context->emm_procedures->emm_con_mngt_proc) {
+      nas_delete_con_mngt_procedure(
+          &emm_context->emm_procedures->emm_con_mngt_proc);
+    }
     nas_delete_attach_procedure(emm_context);
     nas_delete_detach_procedure(emm_context);
     nas_delete_tau_procedure(emm_context);

--- a/lte/gateway/c/core/oai/tasks/nas/nas_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_state_converter.cpp
@@ -811,16 +811,18 @@ void NasStateConverter::proto_to_nas_emm_attach_proc(
       attach_proc_proto.attach_complete_received();
   StateConverter::proto_to_guti(
       attach_proc_proto.guti(), &state_nas_emm_attach_proc->guti);
-  if (attach_proc_proto.esm_msg_out().length() > 0) {
-    state_nas_emm_attach_proc->esm_msg_out = bfromcstr_with_str_len(
-        attach_proc_proto.esm_msg_out().c_str(),
-        attach_proc_proto.esm_msg_out().length());
-  }
+
+  state_nas_emm_attach_proc->esm_msg_out = bfromcstr_with_str_len(
+      attach_proc_proto.esm_msg_out().c_str(),
+      attach_proc_proto.esm_msg_out().length());
+
   if (attach_proc_proto.has_ies()) {
     state_nas_emm_attach_proc->ies = (emm_attach_request_ies_t*) calloc(
         1, sizeof(*(state_nas_emm_attach_proc->ies)));
     proto_to_emm_attach_request_ies(
         attach_proc_proto.ies(), state_nas_emm_attach_proc->ies);
+  } else {
+    state_nas_emm_attach_proc->ies = nullptr;
   }
   state_nas_emm_attach_proc->ue_id      = attach_proc_proto.ue_id();
   state_nas_emm_attach_proc->ksi        = attach_proc_proto.ksi();

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp
@@ -137,7 +137,7 @@ void SpgwStateConverter::proto_to_spgw_bearer_context(
       sgw_eps_bearer_context_proto.msisdn().length());
   sgw_eps_bearer_context_state->imsi_unauthenticated_indicator =
       sgw_eps_bearer_context_proto.imsi_unauth_indicator();
-  proto_to_ecgi(
+  StateConverter::proto_to_ecgi(
       sgw_eps_bearer_context_proto.last_known_cell_id(),
       &sgw_eps_bearer_context_state->last_known_cell_Id);
 


### PR DESCRIPTION
## Summary

This change adds EMM procedures in the sample EMM context for Nas state converter test.

It also fixes:
- Cpp-lint warnings in state converter base class
- Fixes implementation of delete EMM procedures function
- Add checks in bstring initialization function

## Test Plan

`make test_oai OAI_TESTS="test_nas.*"`