### PR TITLE
feat(agw): Adding UEID and RejectionCause in Attach events

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_events.h
+++ b/lte/gateway/c/core/oai/include/mme_events.h
@@ -22,7 +22,8 @@ extern "C" {
 #endif
 
 #include "lte/gateway/c/core/oai/common/common_types.h"
-
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_36.401.h"
+#include "lte/gateway/c/core/oai/tasks/nas/ies/EmmCause.h"
 /**
  * Helper function to initiate AsyncEventdClient in its own thread
  */
@@ -31,9 +32,19 @@ void event_client_init(void);
 /**
  * Logs Attach successful event
  * @param imsi
+ * @param ue_id
  * @return response code
  */
-int attach_success_event(imsi64_t imsi64);
+int attach_success_event(imsi64_t imsi64, mme_ue_s1ap_id_t ue_id);
+
+/**
+ * Logs Attach reject event
+ * @param ue_id
+ * @param cause
+ * @param imsi
+ * @return response code
+ */
+int attach_reject_event(mme_ue_s1ap_id_t ue_id, emm_cause_t cause, imsi64_t imsi64);
 
 /**
  * Logs Detach successful event

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -818,7 +818,7 @@ status_code_e emm_proc_attach_complete(
           ue_id);
       emm_proc_emm_information(ue_mm_context);
       increment_counter("ue_attach", 1, 1, "result", "attach_proc_successful");
-      attach_success_event(ue_mm_context->emm_context._imsi64);
+      attach_success_event(ue_mm_context->emm_context._imsi64, ue_id);
     }
   } else if (esm_sap.err != ESM_SAP_DISCARDED) {
     /*
@@ -1068,6 +1068,7 @@ status_code_e _emm_attach_reject(
     emm_as_set_security_data(
         &emm_sap.u.emm_as.u.establish.sctx, &emm_context->_security, false,
         false);
+    attach_reject_event(attach_proc->ue_id, attach_proc->emm_cause, emm_context->_imsi64);
   } else {
     emm_as_set_security_data(
         &emm_sap.u.emm_as.u.establish.sctx, NULL, false, false);

--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -54,6 +54,9 @@ event_registry:
   attach_success:
     module: lte
     filename: mme_events.v1.yml
+  attach_reject:
+    module: lte
+    filename: mme_events.v1.yml
   detach_success:
     module: lte
     filename: mme_events.v1.yml

--- a/lte/swagger/mme_events.v1.yml
+++ b/lte/swagger/mme_events.v1.yml
@@ -14,6 +14,18 @@ definitions:
     properties:
       imsi:
         type: string
+      ue_id:
+        type: integer
+  attach_reject:
+    type: object
+    description: Used to track when UE does not attach successfully
+    properties:
+      ue_id:
+        type: integer
+      cause:
+        type: integer
+      imsi:
+        type: string
   detach_success:
     type: object
     description: Used to track when UE detaches successfully


### PR DESCRIPTION
buSigned-off-by: avamagma <avatehrani@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Adding UE ID in Attach Success event.Creating the Attach Reject event and adding IMSI, UE ID and Reject cause in Attach Reject Event

## Test Plan


Testing Attach Success with test_attach_detach.py test
Results:
`sudo tail -f /var/log/syslog | grep eventd
`
`Dec 15 03:50:30 magma-dev-focal td-agent-bit[110391]: [2] eventd: [1639540228.748627755, {"stream_name"=>"mme", "event_type"=>"attach_success", "event_tag"=>"001010000000001", "value"=>"{"ue_id":7,"imsi":"001010000000001"}",` 

Testing Attach Reject with test_attach_auth_mac_failure.py test
Results:
`sudo tail -f /var/log/syslog | grep eventd`

`Dec 15 03:51:35 magma-dev-focal td-agent-bit[110391]: [1] eventd: [1639540295.000587289, {"stream_name"=>"mme", "event_type"=>"attach_reject", "event_tag"=>"001010000000001", "value"=>"{"imsi":"001010000000001","cause":255,"ue_id":9}", `


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
