### PR TITLE
refactor(orc8r): Segregation of Certifier service as internal

### DIFF
--- a/orc8r/cloud/go/services/certifier/certifier/main.go
+++ b/orc8r/cloud/go/services/certifier/certifier/main.go
@@ -28,12 +28,13 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
+	analytics_servicers "magma/orc8r/cloud/go/services/analytics/servicers/protected"
 	analytics_protos "magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/certifier"
 	analytics_service "magma/orc8r/cloud/go/services/certifier/analytics"
 	"magma/orc8r/cloud/go/services/certifier/obsidian/handlers"
 	certprotos "magma/orc8r/cloud/go/services/certifier/protos"
-	"magma/orc8r/cloud/go/services/certifier/servicers"
+	servicers "magma/orc8r/cloud/go/services/certifier/servicers/protected"
 	"magma/orc8r/cloud/go/services/certifier/storage"
 	"magma/orc8r/cloud/go/sqorc"
 	storage2 "magma/orc8r/cloud/go/storage"
@@ -96,7 +97,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("err %v failed parsing the config file: skipping CollectorServicer creation ", err)
 	}
-	collectorServicer := analytics.NewCollectorServicer(
+	collectorServicer := analytics_servicers.NewCollectorServicer(
 		&serviceConfig.Analytics,
 		analytics.GetPrometheusClient(),
 		analytics_service.GetAnalyticsCalculations(&serviceConfig),

--- a/orc8r/cloud/go/services/certifier/client_api_test.go
+++ b/orc8r/cloud/go/services/certifier/client_api_test.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"magma/orc8r/cloud/go/services/certifier"
-	"magma/orc8r/cloud/go/services/certifier/servicers"
+	servicers "magma/orc8r/cloud/go/services/certifier/servicers/protected"
 	"magma/orc8r/cloud/go/services/certifier/test_init"
 	"magma/orc8r/lib/go/protos"
 	security_cert "magma/orc8r/lib/go/security/cert"

--- a/orc8r/cloud/go/services/certifier/servicers/protected/certifier.go
+++ b/orc8r/cloud/go/services/certifier/servicers/protected/certifier.go
@@ -1,0 +1,451 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/identity"
+	certprotos "magma/orc8r/cloud/go/services/certifier/protos"
+	"magma/orc8r/cloud/go/services/certifier/storage"
+	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/protos"
+	"magma/orc8r/lib/go/security/cert"
+	unarylib "magma/orc8r/lib/go/service/middleware/unary"
+)
+
+var (
+	NumTrialsForSn      int
+	CollectGarbageAfter time.Duration // remove cert if expired for certain amount of time
+)
+
+func init() {
+	NumTrialsForSn = 1
+	CollectGarbageAfter = time.Hour * 24
+}
+
+type CAInfo struct {
+	Cert    *x509.Certificate
+	PrivKey interface{}
+}
+
+type CertifierServer struct {
+	store storage.CertifierStorage
+	CAs   map[protos.CertType]*CAInfo
+}
+
+func NewCertifierServer(store storage.CertifierStorage, CAs map[protos.CertType]*CAInfo) (srv *CertifierServer, err error) {
+	srv = new(CertifierServer)
+	srv.store = store
+	if CAs == nil {
+		return nil, fmt.Errorf("CA info not provided to certifier")
+	}
+	if len(CAs) == 0 {
+		return nil, fmt.Errorf("No Certificates are provided to certifier")
+	}
+	srv.CAs = CAs
+	return srv, nil
+}
+
+func generateSerialNumber(store storage.CertifierStorage) (sn *big.Int, err error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+
+	for i := 0; i < NumTrialsForSn; i++ {
+		sn, err = rand.Int(rand.Reader, limit)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to generate serial number: %s", err)
+		}
+		_, err := store.GetCertInfo(cert.SerialToString(sn))
+		if err != nil {
+			return sn, nil
+		}
+	}
+	return nil, fmt.Errorf(
+		"Failed to genearte serial number after %d trials.", NumTrialsForSn)
+}
+
+func parseAndCheckCSR(csrDER []byte) (*x509.CertificateRequest, error) {
+	csr, err := x509.ParseCertificateRequest(csrDER)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse certificate request: %s", err)
+	}
+
+	err = csr.CheckSignature()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to check certificate request signature: %s", err)
+	}
+	return csr, err
+}
+
+func (srv *CertifierServer) signCSR(
+	csr *x509.CertificateRequest,
+	sn *big.Int,
+	certType protos.CertType,
+	validTime time.Duration,
+) ([]byte, time.Time, time.Time, error) {
+
+	if srv.CAs == nil {
+		return nil, time.Time{}, time.Time{}, fmt.Errorf("CAInfo not found")
+	}
+	ca, ok := srv.CAs[certType]
+	if !ok {
+		return nil, time.Time{}, time.Time{}, fmt.Errorf("No CA found for given cert type: %s", certType.String())
+	}
+	signingCert := ca.Cert
+	signingKey := ca.PrivKey
+
+	now := clock.Now().UTC()
+	// Provide a cert from an hour ago to account for clock skews
+	notBefore := now.Add(-1 * time.Hour)
+	notAfter := now.Add(validTime)
+	if notAfter.After(signingCert.NotAfter) {
+		glog.Warningln("The requested time is longer than signing certificate valid time.")
+		notAfter = signingCert.NotAfter
+	}
+	template := x509.Certificate{
+		SerialNumber:          sn,
+		Subject:               csr.Subject,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	clientCertDER, err := x509.CreateCertificate(
+		rand.Reader, &template, signingCert, csr.PublicKey, signingKey)
+	if err != nil {
+		return nil, time.Time{}, time.Time{}, fmt.Errorf("Failed to sign csr: %s", err)
+	}
+
+	return clientCertDER, notBefore, notAfter, nil
+}
+
+func checkOrOverwriteCN(csr *x509.CertificateRequest, csrMsg *protos.CSR) error {
+	id := csrMsg.Id
+	idCn := id.ToCommonName()
+	if idCn == nil {
+		return nil
+	}
+	if len(csr.Subject.CommonName) == 0 {
+		csr.Subject.CommonName = *idCn
+		return nil
+	}
+
+	if csr.Subject.CommonName != *idCn {
+		return status.Errorf(
+			codes.Aborted,
+			"CN from CSR (%s) and CN in Identity (%s) do not match", csr.Subject.CommonName, *idCn)
+	}
+
+	if csrMsg.CertType == protos.CertType_VPN && identity.IsGateway(id) {
+		// Use networkID & logicalID to identify the vpn client instead of hwID
+		gw := id.GetGateway()
+		csr.Subject.CommonName = gw.GetLogicalId()
+	}
+
+	return nil
+}
+
+func (srv *CertifierServer) getCertInfo(sn string) (*certprotos.CertificateInfo, error) {
+	certInfo, err := srv.store.GetCertInfo(sn)
+	if err != nil {
+		return &certprotos.CertificateInfo{}, status.Errorf(codes.NotFound, "Failed to load certificate: %s", err)
+	}
+	return certInfo, nil
+}
+
+// Verify that the certificate is signed by our CA
+func (srv *CertifierServer) verifyCert(clientCert *x509.Certificate, certType protos.CertType) error {
+	// Check if CAInfo / cert exists for requested cert type
+	if srv.CAs == nil {
+		return fmt.Errorf("CAInfo not found")
+	}
+	ca, ok := srv.CAs[certType]
+	if !ok {
+		return fmt.Errorf("No CA found for given cert type: %s", certType.String())
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(ca.Cert) // Use appropriate cert to check against
+	opts := x509.VerifyOptions{
+		Roots:         caPool,
+		Intermediates: x509.NewCertPool(),
+		// Make sure client cert has ExtKeyUsageClientAuth
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	if _, err := clientCert.Verify(opts); err != nil {
+		return fmt.Errorf("Certificate Verification Failure: %s", err)
+	}
+	return nil
+}
+
+func (srv *CertifierServer) GetCA(ctx context.Context, getCAReqMsg *certprotos.GetCARequest) (*protos.CACert, error) {
+	if getCAReqMsg == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid CA request")
+	}
+
+	ca, ok := srv.CAs[getCAReqMsg.CertType]
+	if !ok {
+		return nil, fmt.Errorf("no CA found for given CA type: %s", getCAReqMsg.CertType.String())
+	}
+
+	caCertMsg := &protos.CACert{Cert: ca.Cert.Raw}
+
+	return caCertMsg, nil
+}
+
+func (srv *CertifierServer) SignAddCertificate(ctx context.Context, csrMsg *protos.CSR) (*protos.Certificate, error) {
+
+	sn, err := generateSerialNumber(srv.store)
+	if err != nil {
+		return nil, status.Errorf(codes.Aborted, "Error generating serial number: %s", err)
+	}
+
+	csr, err := parseAndCheckCSR(csrMsg.CsrDer)
+	if err != nil {
+		return nil, status.Errorf(codes.Aborted, "Error parsing CSR: %s", err)
+	}
+
+	err = checkOrOverwriteCN(csr, csrMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	validTime, err := ptypes.Duration(csrMsg.ValidTime)
+	if err != nil {
+		return nil, status.Errorf(codes.Aborted, "Invalid requested certificate duration: %s", err)
+	}
+
+	certDER, notBefore, notAfter, err := srv.signCSR(csr, sn, csrMsg.CertType, validTime)
+	if err != nil {
+		return nil, status.Errorf(codes.Aborted, "Error signing CSR: %s", err)
+	}
+
+	notBeforeProto, _ := ptypes.TimestampProto(notBefore)
+	notAfterProto, _ := ptypes.TimestampProto(notAfter)
+
+	// create CertificateInfo
+	certInfo := &certprotos.CertificateInfo{
+		Id:        csrMsg.Id,
+		CertType:  csrMsg.CertType,
+		NotBefore: notBeforeProto,
+		NotAfter:  notAfterProto,
+	}
+	// add to table
+	snString := cert.SerialToString(sn)
+	// Ensure serial number is not the orc8r client reserved SN
+	if snString == unarylib.ORC8R_CLIENT_CERT_VALUE {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid Serial Number")
+	}
+	err = srv.store.PutCertInfo(snString, certInfo)
+	if err != nil {
+		return nil, status.Errorf(codes.Aborted, "Error adding CertificateInfo: %s", err)
+	}
+
+	// create Certificate
+	certMsg := protos.Certificate{
+		Sn:        &protos.Certificate_SN{Sn: snString},
+		NotBefore: notBeforeProto,
+		NotAfter:  notAfterProto,
+		CertDer:   certDER,
+	}
+	return &certMsg, nil
+}
+
+func (srv *CertifierServer) GetIdentity(
+	ctx context.Context, snMsg *protos.Certificate_SN) (*certprotos.CertificateInfo, error) {
+
+	var certSN string
+	if snMsg != nil {
+		certSN = strings.TrimLeft(snMsg.Sn, "0")
+	}
+	certInfo, err := srv.store.GetCertInfo(certSN)
+	if err != nil {
+		return &certprotos.CertificateInfo{}, status.Errorf(
+			codes.NotFound, "Certificate with serial number '%s' is not found", certSN)
+	}
+
+	// check timestamp
+	notBefore, _ := ptypes.Timestamp(certInfo.NotBefore)
+	notAfter, _ := ptypes.Timestamp(certInfo.NotAfter)
+	now := clock.Now().UTC()
+	if now.After(notAfter) {
+		return &certprotos.CertificateInfo{}, status.Errorf(codes.OutOfRange,
+			"Certificate with serial number '%s' has expired", certSN)
+	}
+	if now.Before(notBefore) {
+		return &certprotos.CertificateInfo{}, status.Errorf(codes.OutOfRange,
+			"Certificate with serial number '%s' is not yet valid", certSN)
+	}
+	return certInfo, nil
+}
+
+func (srv *CertifierServer) RevokeCertificate(
+	ctx context.Context, snMsg *protos.Certificate_SN) (*protos.Void, error) {
+
+	var certSN string
+	if snMsg != nil {
+		certSN = strings.TrimLeft(snMsg.Sn, "0")
+	}
+	_, err := srv.store.GetCertInfo(certSN)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "Cannot find certificate with SN: %s", certSN)
+	}
+	err = srv.store.DeleteCertInfo(certSN)
+	if err != nil {
+		return nil, status.Errorf(codes.Aborted, "Failed to delete certificate: %s", err)
+	}
+	return &protos.Void{}, nil
+}
+
+func (srv *CertifierServer) AddCertificate(ctx context.Context, req *certprotos.AddCertRequest) (*protos.Void, error) {
+
+	res := &protos.Void{}
+	x509Cert, err := x509.ParseCertificate(req.CertDer)
+	if err != nil {
+		return res,
+			status.Errorf(codes.InvalidArgument, "DER Parse Error: %s", err)
+	}
+	if x509Cert.SerialNumber == nil {
+		return res, status.Errorf(codes.InvalidArgument, "Invalid Serial Number")
+	}
+	snStr := cert.SerialToString(x509Cert.SerialNumber)
+	// Ensure serial number is not the orc8r client reserved SN
+	if snStr == unarylib.ORC8R_CLIENT_CERT_VALUE {
+		return res, status.Errorf(codes.InvalidArgument, "Invalid Serial Number")
+	}
+	// Verify that the certificate is signed by our CA
+	if err = srv.verifyCert(x509Cert, req.CertType); err != nil {
+		return res, status.Errorf(
+			codes.InvalidArgument, "%s for Certificate SN %s", err, snStr)
+	}
+	// Check if a certificate with the same SN is already there
+	_, err = srv.store.GetCertInfo(snStr)
+	if err == nil {
+		return res, status.Errorf(
+			codes.AlreadyExists, "Certificate SN %s already exists", snStr)
+	}
+	// create CertificateInfo
+	notBeforeProto, _ := ptypes.TimestampProto(x509Cert.NotBefore)
+	notAfterProto, _ := ptypes.TimestampProto(x509Cert.NotAfter)
+	certInfo := &certprotos.CertificateInfo{
+		Id:        req.Id,
+		CertType:  req.CertType,
+		NotBefore: notBeforeProto,
+		NotAfter:  notAfterProto,
+	}
+	// add to table
+	err = srv.store.PutCertInfo(snStr, certInfo)
+	if err != nil {
+		return res,
+			status.Errorf(codes.Internal, "Error adding CertificateInfo: %s", err)
+	}
+	return res, nil
+}
+
+// Finds & returns Serial Numbers of all Certificates associated with the
+// given Identity
+func (srv *CertifierServer) FindCertificates(ctx context.Context, id *protos.Identity) (*certprotos.SerialNumbers, error) {
+
+	res := &certprotos.SerialNumbers{}
+	if id != nil {
+		idKey := id.HashString()
+		snList, err := srv.ListCertificates(ctx, &protos.Void{})
+		if err != nil {
+			return res, err
+		}
+		for _, sn := range snList.Sns {
+			certInfo, err := srv.getCertInfo(sn)
+			if err != nil {
+				return res, err
+			}
+			if certInfo != nil && certInfo.Id.HashString() == idKey {
+				res.Sns = append(res.Sns, sn)
+			}
+		}
+	}
+	return res, nil
+}
+
+// Returns serial numbers of all certificates in the table
+func (srv *CertifierServer) ListCertificates(ctx context.Context, void *protos.Void) (*certprotos.SerialNumbers, error) {
+	res := &certprotos.SerialNumbers{}
+	snList, err := srv.store.ListSerialNumbers()
+	if err != nil {
+		return res, status.Errorf(
+			codes.Internal, "Failed to get certificate serial numbers: %s", err)
+	}
+	res.Sns = snList
+	return res, nil
+}
+
+// GetAll returns all Certificates Records
+func (srv *CertifierServer) GetAll(context.Context, *protos.Void) (*certprotos.CertificateInfoMap, error) {
+	res := &certprotos.CertificateInfoMap{Certificates: map[string]*certprotos.CertificateInfo{}}
+	certInfos, err := srv.store.GetAllCertInfo()
+	if err != nil {
+		return res, status.Errorf(codes.Internal, "Failed to get all certificates: %v", err)
+	}
+	res.Certificates = certInfos
+	return res, nil
+}
+
+func (srv *CertifierServer) CollectGarbage(ctx context.Context, void *protos.Void) (*protos.Void, error) {
+	count, err := srv.CollectGarbageImpl(ctx)
+	glog.Infof("purged %d expired certificates", count)
+	return &protos.Void{}, err
+}
+
+func (srv *CertifierServer) CollectGarbageImpl(ctx context.Context) (int, error) {
+	snList, err := srv.ListCertificates(ctx, &protos.Void{})
+	if err != nil {
+		return 0, err
+	}
+	var multiErr *errors.Multi
+	count := 0
+	for _, sn := range snList.Sns {
+		certInfo, err := srv.getCertInfo(sn)
+		if err != nil {
+			multiErr.AddFmt(err, "'%s' get info error:", sn)
+		}
+		notAfter, _ := ptypes.Timestamp(certInfo.NotAfter)
+		notAfter = notAfter.Add(CollectGarbageAfter)
+		if time.Now().UTC().After(notAfter) {
+			err = srv.store.DeleteCertInfo(sn)
+			if err != nil {
+				multiErr.AddFmt(err, "'%s' delete error:", sn)
+			} else {
+				count += 1
+			}
+		}
+	}
+	if multiErr.AsError() != nil {
+		glog.Errorf("Failed to delete certificate[s]: %v", multiErr)
+		return count, status.Error(codes.Internal, multiErr.Error())
+	}
+	return count, nil
+}

--- a/orc8r/cloud/go/services/certifier/servicers/protected/certifier_test.go
+++ b/orc8r/cloud/go/services/certifier/servicers/protected/certifier_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers_test
+
+import (
+	"context"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/cloud/go/blobstore"
+	protected_servicers "magma/orc8r/cloud/go/services/certifier/servicers/protected"
+	"magma/orc8r/cloud/go/services/certifier/storage"
+	"magma/orc8r/cloud/go/sqorc"
+	"magma/orc8r/lib/go/protos"
+	certifierTestUtils "magma/orc8r/lib/go/security/csr"
+)
+
+func TestCertifierBlobstore(t *testing.T) {
+	db, err := sqorc.Open("sqlite3", ":memory:")
+	assert.NoError(t, err)
+	fact := blobstore.NewSQLStoreFactory(storage.CertifierTableBlobstore, db, sqorc.GetSqlBuilder())
+	err = fact.InitializeFactory()
+	assert.NoError(t, err)
+	store := storage.NewCertifierBlobstore(fact)
+	testCertifierImpl(t, store)
+}
+
+func testCertifierImpl(t *testing.T, store storage.CertifierStorage) {
+	ctx := context.Background()
+
+	caCert, caKey, err := certifierTestUtils.CreateSignedCertAndPrivKey(time.Hour * 24 * 10)
+	assert.NoError(t, err)
+
+	// just test with default
+	caMap := map[protos.CertType]*protected_servicers.CAInfo{
+		protos.CertType_DEFAULT: {caCert, caKey},
+	}
+	srv, err := protected_servicers.NewCertifierServer(store, caMap)
+	assert.NoError(t, err)
+
+	// sign and add
+	csrMsg, err := certifierTestUtils.CreateCSR(time.Hour*24*10, "cn", "cn")
+	assert.NoError(t, err)
+	certMsg, err := srv.SignAddCertificate(ctx, csrMsg)
+	assert.NoError(t, err)
+
+	// get
+	certInfoMsg, err := srv.GetIdentity(ctx, certMsg.Sn)
+	assert.NoError(t, err)
+	assert.True(t, proto.Equal(certInfoMsg.Id, csrMsg.Id))
+
+	// do the same with CSN containing leading zeros (ngnix encoding)
+	for i := 0; i < 3; i++ {
+		certMsg.Sn.Sn = "0" + certMsg.Sn.Sn
+		certInfoMsg, err = srv.GetIdentity(ctx, certMsg.Sn)
+		assert.NoError(t, err)
+		assert.True(t, proto.Equal(certInfoMsg.Id, csrMsg.Id))
+	}
+
+	// revoke
+	_, err = srv.RevokeCertificate(ctx, certMsg.Sn)
+	assert.NoError(t, err)
+
+	// get should return not found error
+	_, err = srv.GetIdentity(ctx, certMsg.Sn)
+	assert.Error(t, err)
+
+	// test expiration
+	csrMsg, err = certifierTestUtils.CreateCSR(0, "cn", "cn")
+	assert.NoError(t, err)
+	certMsg, err = srv.SignAddCertificate(ctx, csrMsg)
+	assert.NoError(t, err)
+	_, err = srv.GetIdentity(ctx, certMsg.Sn)
+	assert.Error(t, err)
+	_, err = srv.RevokeCertificate(ctx, certMsg.Sn)
+	assert.NoError(t, err)
+
+	// test garbage collection
+	protected_servicers.CollectGarbageAfter = time.Duration(0)
+
+	for i := 0; i < 3; i++ {
+		csrMsg, err = certifierTestUtils.CreateCSR(0, "cn", "cn")
+		assert.NoError(t, err)
+		_, err = srv.SignAddCertificate(ctx, csrMsg)
+		assert.NoError(t, err)
+	}
+	allSns, _ := store.ListSerialNumbers()
+	assert.Equal(t, 3, len(allSns))
+	srv.CollectGarbage(ctx, nil)
+	allSns, _ = store.ListSerialNumbers()
+	assert.Equal(t, 0, len(allSns))
+
+	// test csr longer than cert
+	csrMsg, err = certifierTestUtils.CreateCSR(time.Hour*24*100, "cn", "cn")
+	assert.NoError(t, err)
+	certMsg, err = srv.SignAddCertificate(ctx, csrMsg)
+	assert.NoError(t, err)
+	certInfoMsg, err = srv.GetIdentity(ctx, certMsg.Sn)
+	assert.NoError(t, err)
+	notAfter, _ := ptypes.Timestamp(certInfoMsg.NotAfter)
+	assert.True(t, notAfter.Equal(caCert.NotAfter))
+
+	// test CN mismatch
+	csrMsg, err = certifierTestUtils.CreateCSR(time.Hour*1, "cn", "nc")
+	assert.NoError(t, err)
+	_, err = srv.SignAddCertificate(ctx, csrMsg)
+	assert.Error(t, err)
+
+	// test CN onverwrite
+	csrMsg, err = certifierTestUtils.CreateCSR(time.Hour*1, "", "cn")
+	assert.NoError(t, err)
+	certMsg, err = srv.SignAddCertificate(ctx, csrMsg)
+	assert.NoError(t, err)
+	cert, err := x509.ParseCertificate(certMsg.CertDer)
+	assert.NoError(t, err)
+	assert.Equal(t, cert.Subject.CommonName, *csrMsg.Id.ToCommonName())
+}

--- a/orc8r/cloud/go/services/certifier/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/certifier/test_init/test_service_init.go
@@ -20,7 +20,7 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/certifier"
 	certprotos "magma/orc8r/cloud/go/services/certifier/protos"
-	"magma/orc8r/cloud/go/services/certifier/servicers"
+	servicers "magma/orc8r/cloud/go/services/certifier/servicers/protected"
 	"magma/orc8r/cloud/go/services/certifier/storage"
 	"magma/orc8r/cloud/go/test_utils"
 	"magma/orc8r/lib/go/protos"


### PR DESCRIPTION
Signed-off-by: sabithaatla <sabitha.atla@wavelabs.ai>


## Summary
This PR deals with the segregation of Certifier's internal gRPC servicers implementation.
These changes are part of the ongoing work which details the distinction between Orc8r-internal gRPC endpoints vs. external, gateway-oriented gRPC endpoints.
Moved Certifier implementation from orc8r/cloud/go/services/certifier/servicers to orc8r/cloud/go/services/certifier/servicers/protected/
Verified existing UT cases.

## Test Plan
All UTs completed succesfully
