### PR TITLE
refactor(orc8r): Service303 security changes

### DIFF
--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -33,6 +33,7 @@ import (
 	"magma/orc8r/cloud/go/service/middleware/unary"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
+	platform_service_servicers "magma/orc8r/lib/go/service/servicers/protected"
 	platform_service "magma/orc8r/lib/go/service"
 	"magma/orc8r/lib/go/service/config"
 )
@@ -52,7 +53,7 @@ func init() {
 // OrchestratorService defines a service which extends the generic platform
 // service with an optional HTTP server.
 type OrchestratorService struct {
-	*platform_service.Service
+	*platform_service_servicers.Service
 
 	// EchoServer runs on the echo_port specified in the registry.
 	// This field will be nil for services that don't specify the

--- a/orc8r/cloud/go/service/test_utils.go
+++ b/orc8r/cloud/go/service/test_utils.go
@@ -18,12 +18,13 @@ import (
 
 	"magma/orc8r/cloud/go/service/middleware/unary"
 	platform_service "magma/orc8r/lib/go/service"
+	platform_service_servicers "magma/orc8r/lib/go/service/servicers/protected"
 )
 
 // NewTestService returns a new gRPC orchestrator service without
 // loading Orchestrator plugins from disk. This should only be used in test
 // contexts, where plugins are registered manually.
-func NewTestService(t *testing.T, moduleName string, serviceType string) (*platform_service.Service, error) {
+func NewTestService(t *testing.T, moduleName string, serviceType string) (*platform_service_servicers.Service, error) {
 	if t == nil {
 		panic("for tests only")
 	}

--- a/orc8r/cloud/go/test_utils/service.go
+++ b/orc8r/cloud/go/test_utils/service.go
@@ -25,7 +25,7 @@ import (
 	"magma/gateway/config"
 	cloud_service "magma/orc8r/cloud/go/service"
 	"magma/orc8r/lib/go/registry"
-	platform_service "magma/orc8r/lib/go/service"
+	platform_service_servicers "magma/orc8r/lib/go/service/servicers/protected"
 	platform_cfg "magma/orc8r/lib/go/service/config"
 )
 
@@ -49,7 +49,7 @@ allow_http_proxy: True`
 // NewTestService creates and registers a basic test Magma service on a
 // dynamically selected available local port.
 // Returns the newly created service and listener it was registered with.
-func NewTestService(t *testing.T, moduleName string, serviceType string) (*platform_service.Service, net.Listener) {
+func NewTestService(t *testing.T, moduleName string, serviceType string) (*platform_service_servicers.Service, net.Listener) {
 	srvPort, lis, err := getOpenPort()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Signed-off-by: Tej <tej.prakash@wavelabs.ai>

## Summary

This PR deals with the segregation of Service303 internal gRPC servicers implementation.

These changes are part of the ongoing work which details the distinction between Orc8r-internal gRPC endpoints vs. external, gateway-oriented gRPC endpoints.


- Moved `service303` servicer from  `orc8r/lib/go/service/servicers/service303_servicer.go` to `orc8r/lib/go/service/servicers/protected/service303_servicer.go`
- Moved `service.Service` type to `orc8r/lib/go/service/servicers/protected/service303_servicer.go`

This PR was done as part of requirement by @hcgatewood [RemoveGatewayAccess toOrc8r-InternalEndpoints](https://drive.google.com/file/d/1NO6Qd6rU80xPh0Sb0mKWlSfDt0JbeVIT/view)

## Test Plan

All existing UTs passed
No new UTs added or removed

