### PR TITLE
fix(mobilityd): Less strict APN parsing in GetSubscriberIPTable

### DIFF
--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -380,7 +380,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         for composite_sid, ip in csid_ip_pairs:
             # handle composite sid to sid and apn mapping
             sid, _, apn_part = composite_sid.partition('.')
-            apn, _ = apn_part.split(',')
+            apn, *_ = apn_part.split(',')
             sid_pb = SIDUtils.to_pb(sid)
             version = IPAddress.IPV4 if ip.version == 4 else IPAddress.IPV6
             ip_msg = IPAddress(version=version, address=ip.packed)


### PR DESCRIPTION
## Summary

Sentry monitoring shows that parsing of the composite SID into
an APN can fail because there is no comma and ipvx appendix in
the composite string.

This change makes the parser ignore this error and simply return
the part after the period as APN if there is no comma.

Fixes #10880.