### PR TITLE
chore: migrate Docker.ubuntu18/rhel8 file to build SCTPD with Bazel

### DIFF
--- a/ci-scripts/docker/Dockerfile.mme.ci.rhel8
+++ b/ci-scripts/docker/Dockerfile.mme.ci.rhel8
@@ -7,9 +7,10 @@ ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV BUILD_TYPE=Debug
 ENV C_BUILD=/build/c
+ENV BAZEL_BIN=/magma/bazel-bin
 
 # Remove any old CI artifact
-RUN rm -Rf $MAGMA_ROOT $C_BUILD && mkdir -p $C_BUILD
+RUN rm -Rf $MAGMA_ROOT $C_BUILD /tmp/bazel && mkdir -p $C_BUILD
 
 # Copy Code to Test
 COPY ./ $MAGMA_ROOT
@@ -19,7 +20,7 @@ RUN export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig/ && \
     cd $MAGMA_ROOT/lte/gateway && \
     echo $FEATURES && \
     make build_oai && \
-    make build_sctpd
+    bazel build //lte/gateway/c/sctpd/src:sctpd --config=production --define=disable_sentry_native=1
 
 # Prepare config file
 RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
@@ -54,6 +55,7 @@ RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
 FROM registry.access.redhat.com/ubi8/ubi:latest as magma-mme
 ENV MAGMA_ROOT=/magma
 ENV C_BUILD=/build/c
+ENV BAZEL_BIN=/magma/bazel-bin
 
 # Install a few tools (may not be necessary later on)
 ENV TZ=Europe/Paris
@@ -118,7 +120,7 @@ RUN ldconfig
 # Copy pre-built binaries for MME and SCTPD
 WORKDIR /magma-mme/bin
 COPY --from=magma-mme-builder $C_BUILD/core/oai/oai_mme/mme oai_mme
-COPY --from=magma-mme-builder $C_BUILD/sctpd/src/sctpd .
+COPY --from=magma-mme-builder $BAZEL_BIN/lte/gateway/c/sctpd/src/sctpd .
 
 # Create running dirs
 WORKDIR /var/opt/magma/configs

--- a/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
+++ b/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
@@ -7,9 +7,10 @@ ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c
+ENV BAZEL_BIN=/magma/bazel-bin
 
 # Remove any old CI artifact
-RUN rm -Rf $MAGMA_ROOT $C_BUILD && mkdir -p $C_BUILD
+RUN rm -Rf $MAGMA_ROOT $C_BUILD /tmp/bazel && mkdir -p $C_BUILD
 
 # Copy Code to Test
 COPY ./ $MAGMA_ROOT
@@ -18,7 +19,7 @@ COPY ./ $MAGMA_ROOT
 RUN cd $MAGMA_ROOT/lte/gateway && \
     echo $FEATURES && \
     make build_oai && \
-    make build_sctpd
+    bazel build //lte/gateway/c/sctpd/src:sctpd --config=production --define=disable_sentry_native=1
 
 # Prepare config file
 RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
@@ -54,6 +55,7 @@ FROM ubuntu:bionic as magma-mme
 
 ENV MAGMA_ROOT=/magma
 ENV C_BUILD=/build/c
+ENV BAZEL_BIN=/magma/bazel-bin
 
 # Install a few tools (may not be necessary later on)
 ENV DEBIAN_FRONTEND=noninteractive
@@ -123,7 +125,7 @@ RUN ldconfig
 # Copy pre-built binaries for MME and SCTPD
 WORKDIR /magma-mme/bin
 COPY --from=magma-mme-builder $C_BUILD/core/oai/oai_mme/mme oai_mme
-COPY --from=magma-mme-builder $C_BUILD/sctpd/src/sctpd .
+COPY --from=magma-mme-builder $BAZEL_BIN/lte/gateway/c/sctpd/src/sctpd .
 
 # For the moment, we are not putting any etc/*.conf files
 # We will mount volumes from docker-compose

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -8,6 +8,7 @@ ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV BUILD_TYPE=Debug
 ENV C_BUILD=/build/c
+ENV BAZEL_BIN=/magma/bazel-bin
 ENV TZ=Europe/Paris
 # Copy RHEL certificates for builder image
 COPY tmp/entitlement/*.pem /etc/pki/entitlement
@@ -104,6 +105,10 @@ RUN yum install -y \
     xz \
     # Install czmq requirements
     uuid-devel \
+# Install Bazel
+  && wget -P /usr/local/bin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 \
+  && chmod +x /usr/local/bin/bazelisk-linux-amd64 \
+  && ln -s /usr/local/bin/bazelisk-linux-amd64 /usr/local/bin/bazel \
   && ln -s /usr/bin/python2.7 /usr/local/bin/python
 
 RUN yum install -y \
@@ -282,7 +287,7 @@ RUN echo "Install fmtlib required by Folly" && \
     # Moved git clone https://github.com/fmtlib/fmt.git && \
     cd fmt && \
     mkdir _build && cd _build && \
-    cmake3 .. && \
+    cmake3 .. -DFMT_TEST=0 && \
     make -j`nproc` && \
     make install && \
     ldconfig && \
@@ -381,7 +386,7 @@ RUN ldconfig --verbose && \
     cd $MAGMA_ROOT/lte/gateway && \
     echo $FEATURES && \
     make build_oai && \
-    make build_sctpd
+    bazel build //lte/gateway/c/sctpd/src:sctpd --config=production --define=disable_sentry_native=1
 
 # Prepare config file
 RUN yum install -y python3-pip && \
@@ -416,7 +421,7 @@ RUN yum install -y python3-pip && \
 # Copy the configuration file templates and mean to modify/generate certificates
 WORKDIR /magma-mme/bin
 RUN cp $C_BUILD/core/oai/oai_mme/mme oai_mme
-RUN cp $C_BUILD/sctpd/src/sctpd .
+RUN cp $BAZEL_BIN/lte/gateway/c/sctpd/src/sctpd .
 WORKDIR /magma-mme/etc
 RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme.conf .
 RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme_fd.conf .
@@ -448,6 +453,7 @@ RUN openssl rand -out /root/.rnd 128
 FROM registry.access.redhat.com/ubi8/ubi:latest as magma-mme
 ENV MAGMA_ROOT=/magma
 ENV C_BUILD=/build/c
+ENV BAZEL_BIN=/magma/bazel-bin
 
 # Install a few tools (may not be necessary later on)
 ENV TZ=Europe/Paris
@@ -512,7 +518,7 @@ RUN ldconfig
 # Copy pre-built binaries for MME and SCTPD
 WORKDIR /magma-mme/bin
 COPY --from=magma-mme-builder $C_BUILD/core/oai/oai_mme/mme oai_mme
-COPY --from=magma-mme-builder $C_BUILD/sctpd/src/sctpd .
+COPY --from=magma-mme-builder $BAZEL_BIN/lte/gateway/c/sctpd/src/sctpd .
 
 # Copy the configuration file templates and mean to modify/generate certificates
 WORKDIR /magma-mme/etc

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -8,6 +8,7 @@ ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c
+ENV BAZEL_BIN=/magma/bazel-bin
 ENV TZ=Europe/Paris
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -56,6 +57,11 @@ RUN echo "Install 3rd party dependencies" && \
     ln -s /usr/bin/python2.7 /usr/local/bin/python
 
 RUN ["/bin/bash", "-c", "if [[ -v GIT_PROXY ]]; then git config --global http.proxy $GIT_PROXY; fi"]
+
+# Install Bazel
+RUN wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
+    chmod +x /usr/sbin/bazelisk-linux-amd64 && \
+    ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
 
 ##### NETTLE
 RUN wget --quiet https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
@@ -179,7 +185,7 @@ WORKDIR /
 RUN echo "Install fmtlib required by Folly" && \
     git clone https://github.com/fmtlib/fmt.git && cd fmt && \
     mkdir _build && cd _build && \
-    cmake .. && \
+    cmake .. -DFMT_TEST=0 && \
     make -j`nproc` && \
     make install && \
     cd / && \
@@ -213,7 +219,7 @@ RUN ldconfig && \
     cd $MAGMA_ROOT/lte/gateway && \
     echo $FEATURES && \
     make build_oai && \
-    make build_sctpd
+    bazel build //lte/gateway/c/sctpd/src:sctpd --config=production --define=disable_sentry_native=1
 
 # Prepare config file
 RUN apt-get install -y python3-pip && \
@@ -248,7 +254,7 @@ RUN apt-get install -y python3-pip && \
 # Copy the configuration file templates and mean to modify/generate certificates
 WORKDIR /magma-mme/bin
 RUN cp $C_BUILD/core/oai/oai_mme/mme oai_mme
-RUN cp $C_BUILD/sctpd/src/sctpd .
+RUN cp $BAZEL_BIN/lte/gateway/c/sctpd/src/sctpd .
 WORKDIR /magma-mme/etc
 RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme.conf .
 RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme_fd.conf .
@@ -281,6 +287,7 @@ FROM ubuntu:bionic as magma-mme
 
 ENV MAGMA_ROOT=/magma
 ENV C_BUILD=/build/c
+ENV BAZEL_BIN=/magma/bazel-bin
 
 # Install a few tools (may not be necessary later on)
 ENV DEBIAN_FRONTEND=noninteractive
@@ -350,7 +357,7 @@ RUN ldconfig
 # Copy pre-built binaries for MME and SCTPD
 WORKDIR /magma-mme/bin
 COPY --from=magma-mme-builder $C_BUILD/core/oai/oai_mme/mme oai_mme
-COPY --from=magma-mme-builder $C_BUILD/sctpd/src/sctpd .
+COPY --from=magma-mme-builder $BAZEL_BIN/lte/gateway/c/sctpd/src/sctpd .
 
 # Copy the configuration file templates and mean to modify/generate certificates
 WORKDIR /magma-mme/etc


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Modify Jenkins Dockerfiles to use Bazel to build Sctpd. Thanks @rdefosse for helping me figure out what files to change. :) 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
