### PR TITLE
fix(agw): fixed containerized agw docker build over macOS

### DIFF
--- a/lte/gateway/docker/services/python/Dockerfile
+++ b/lte/gateway/docker/services/python/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update && apt-get install -y \
   redis-server \
   wget \
   ethtool \
-  linux-headers-`uname -r` \
+  linux-headers-generic \
   iptables \
   iproute2
 


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

This PR fix linux headers installation issue for gateway_python image

## Test Plan
```
=> [gateway_c 21/50] COPY --from=builder /usr/lib/x86_64-linux-gnu/libnorm* /usr/lib/x86_64-linux-gnu/                                                                                        0.1s
 => [gateway_c 22/50] COPY --from=builder /usr/lib/x86_64-linux-gnu/libgflags* /usr/lib/x86_64-linux-gnu/                                                                                      0.0s
 => [gateway_c 23/50] COPY --from=builder /usr/lib/x86_64-linux-gnu/libgssapi_krb5* /usr/lib/x86_64-linux-gnu/                                                                                 0.0s
 => [gateway_c 24/50] COPY --from=builder /usr/lib/x86_64-linux-gnu/libkrb5* /usr/lib/x86_64-linux-gnu/                                                                                        0.0s
 => [gateway_c 25/50] COPY --from=builder /usr/lib/x86_64-linux-gnu/libk5crypto* /usr/lib/x86_64-linux-gnu/                                                                                    0.0s
 => [gateway_c 26/50] COPY --from=builder /usr/lib/x86_64-linux-gnu/libkeyutils* /usr/lib/x86_64-linux-gnu/                                                                                    0.0s
 => [gateway_c 27/50] COPY --from=builder /usr/lib/x86_64-linux-gnu/libcurl.so.* /usr/lib/x86_64-linux-gnu/                                                                                    0.0s
 => [gateway_c 28/50] COPY --from=builder /usr/lib/x86_64-linux-gnu/librtmp.so.* /usr/lib/x86_64-linux-gnu/                                                                                    0.0s
 => [gateway_c 29/50] COPY --from=builder /usr/lib/x86_64-linux-gnu/libssh.so.* /usr/lib/x86_64-linux-gnu/                                                                                     0.0s
 => [gateway_c 30/50] COPY --from=builder /usr/local/lib/liblfds710.so /usr/local/lib/                                                                                                         0.0s
 => [gateway_c 31/50] COPY --from=builder /usr/local/lib/libgrpc++.so /usr/local/lib/                                                                                                          0.0s
 => [gateway_c 32/50] COPY --from=builder /usr/local/lib/libfolly.so /usr/local/lib/                                                                                                           0.0s
 => [gateway_c 33/50] COPY --from=builder /usr/local/lib/libgrpc.so /usr/local/lib/                                                                                                            0.0s
 => [gateway_c 34/50] COPY --from=builder /usr/local/lib/libgpr.so /usr/local/lib/                                                                                                             0.0s
 => [gateway_c 35/50] COPY --from=builder /usr/lib/libnettle.so  /usr/local/lib/                                                                                                               0.0s
 => [gateway_c 36/50] COPY --from=builder /usr/lib/libfluid* /usr/local/lib/                                                                                                                   0.1s
 => [gateway_c 37/50] COPY --from=builder /usr/lib/libgnutls.so.* /usr/local/lib/                                                                                                              0.1s
 => [gateway_c 38/50] COPY --from=builder /usr/lib/libhogweed.so.2 /usr/local/lib/                                                                                                             0.0s
 => [gateway_c 39/50] COPY --from=builder /usr/local/lib/libfdproto.so.6 /usr/local/lib/                                                                                                       0.0s
 => [gateway_c 40/50] COPY --from=builder /usr/local/lib/libfdcore.so.6 /usr/local/lib/                                                                                                        0.0s
 => [gateway_c 41/50] COPY --from=builder /usr/local/lib/libaddress_sorting.so /usr/local/lib/                                                                                                 0.0s
 => [gateway_c 42/50] COPY --from=builder /magma/bazel-bin/lte/gateway/c/session_manager/sessiond /usr/local/bin/sessiond                                                                      0.1s
 => [gateway_c 43/50] COPY --from=builder /magma/bazel-bin/lte/gateway/c/sctpd/src/sctpd /usr/local/bin/sctpd                                                                                  0.1s
 => [gateway_c 44/50] COPY --from=builder /magma/bazel-bin/lte/gateway/c/connection_tracker/src/connectiond /usr/local/bin/connectiond                                                         0.1s
 => [gateway_c 45/50] COPY --from=builder /magma/bazel-bin/lte/gateway/c/li_agent/src/liagentd /usr/local/bin/liagentd                                                                         0.1s
 => [gateway_c 46/50] COPY --from=builder /build/c/core/oai/oai_mme/mme /usr/local/bin/oai_mme                                                                                                 0.2s
 => [gateway_c 47/50] RUN ldconfig 2> /dev/null                                                                                                                                                0.3s
 => [gateway_c 48/50] COPY lte/gateway/configs /etc/magma                                                                                                                                      0.0s
 => [gateway_c 49/50] COPY orc8r/gateway/configs/templates /etc/magma/templates                                                                                                                0.0s
 => [gateway_c 50/50] COPY lte/gateway/deploy/roles/magma/files/magma-create-gtp-port.sh /usr/local/bin/                                                                                       0.0s
 => exporting to image                                                                                                                                                                         7.8s
 => => exporting layers                                                                                                                                                                        7.8s
 => => writing image sha256:d0c395403373476999ee86f079f738df8396f21b60db6cbaf6818aa53fadc016                                                                                                   0.0s
 => => naming to docker.io/library/agw_gateway_c                                                                                                                                               0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
```