### PR TITLE
chore: add update multiple fegs to TeraVM fabfile

### DIFF
--- a/ci-scripts/teravm/fabfile_teravm_conf.json
+++ b/ci-scripts/teravm/fabfile_teravm_conf.json
@@ -16,17 +16,15 @@
     "setups" :{
         "setup_1": {
             "_description": "<description one>",
-            "controller":"192.0.0.1",
             "proxy": "192.0.0.1",
-            "feg": "192.0.0.1",
+            "feg": ["192.0.0.1","192.0.0.2"],
             "gateway": "192.0.0.1",
             "ng40": "192.0.0.1"
         },
         "setup_2": {
             "_description": "<description two>",
-            "controller": "192.0.0.1",
             "proxy": "192.0.0.1",
-            "feg": "192.0.0.1,",
+            "feg": ["192.0.0.1"],
             "gateway": "192.0.0.1",
             "ng40": "192.0.0.1"
         }


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Added support to update multiple fegs.

Note fab configuration file needs to be updated to use an array `[ ` on feg description. 

Remember that in order to have passwordless ssh access to all your fegs, you need to execute this command on your driver
```
ssh-copy-id magma@your_fegs_ip
```

Also, note you will need to add magma user to sudoers so it can do sudo commands without password



## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
