### PR TITLE
test(mme): unit test for duplicate attach in idle mode

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -3994,7 +3994,7 @@ TEST_F(MmeAppProcedureTest, TestDuplicateAttach) {
   send_s6a_ula(imsi, true);
 
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
-  send_create_session_resp(REQUEST_ACCEPTED);
+  send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
 
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
@@ -4062,7 +4062,7 @@ TEST_F(MmeAppProcedureTest, TestDuplicateAttach) {
   // Constructing and sending Delete Session Response to mme_app
   // mimicing SPGW task
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  send_delete_session_resp();
+  send_delete_session_resp(DEFAULT_LBI);
 
   // Now the new attach request should proceed
   // Sending AIA to mme_app mimicing successful S6A response for AIR
@@ -4084,7 +4084,7 @@ TEST_F(MmeAppProcedureTest, TestDuplicateAttach) {
   send_s6a_ula(imsi, true);
 
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
-  send_create_session_resp(REQUEST_ACCEPTED);
+  send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
 
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
@@ -4122,7 +4122,7 @@ TEST_F(MmeAppProcedureTest, TestDuplicateAttach) {
   // Constructing and sending Delete Session Response to mme_app
   // mimicing SPGW task
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
-  send_delete_session_resp();
+  send_delete_session_resp(DEFAULT_LBI);
 
   // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -362,7 +362,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyDetach) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -456,7 +456,7 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachEpsOnlyDetach) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -487,7 +487,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAirFailure) {
   // Sending AIA to mme_app mimicing negative S6A response for AIR
   send_authentication_info_resp(imsi, false);
 
-  // Wait for context release request; MME should be sending attach reject
+  // Wait for context release command; MME should be sending attach reject
   // as well as context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
@@ -522,7 +522,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAirTimeout) {
   send_mme_app_initial_ue_msg(
       nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
 
-  // Wait for context release request; MME should be sending attach reject
+  // Wait for context release command; MME should be sending attach reject
   // as well as context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
@@ -577,13 +577,13 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAuthMacFailure) {
   // Wait for DL NAS Transport for Auth Reject
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Wait for DL NAS Transport for Attach Reject
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
@@ -635,13 +635,13 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAuthSynchFailure) {
   // Wait for DL NAS Transport for Auth Reject
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Wait for DL NAS Transport for Attach Reject
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
@@ -688,7 +688,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyUlaFailure) {
   // Sending ULA to mme_app mimicing negative S6A response for ULR
   send_s6a_ula(imsi, false);
 
-  // Wait for context release request; MME should be sending attach reject
+  // Wait for context release command; MME should be sending attach reject
   // as well as context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
@@ -792,7 +792,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachExpiredNasTimers) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -828,7 +828,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectAuthRetxFailure) {
     cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   }
 
-  // Wait for context release request; MME should be sending attach reject
+  // Wait for context release command; MME should be sending attach reject
   // as well as context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
@@ -871,7 +871,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectSmcRetxFailure) {
     cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   }
 
-  // Wait for context release request; MME should be performing
+  // Wait for context release command; MME should be performing
   // implicit detach
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
@@ -968,7 +968,7 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachExpiredIdentity) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1004,7 +1004,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectIdentRetxFailure) {
     cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   }
 
-  // Wait for context release request; MME should be sending attach reject
+  // Wait for context release command; MME should be sending attach reject
   // as well as context release command.
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
@@ -1062,7 +1062,7 @@ TEST_F(MmeAppProcedureTest, TestIcsRequestTimeout) {
   // mimicing SPGW task
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1120,7 +1120,7 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachIcsFailure) {
   // mimicing SPGW task
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1171,7 +1171,7 @@ TEST_F(MmeAppProcedureTest, TestCreateSessionFailure) {
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
   send_create_session_resp(M_PDN_APN_NOT_ALLOWED, DEFAULT_LBI);
 
-  // Wait for context release request; MME should be sending attach reject
+  // Wait for context release command; MME should be sending attach reject
   // as well as context release command.
   // This should be unnecessary but a delete session request is also
   // triggered in the current code and need to wait for that event at
@@ -1281,7 +1281,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedDetach) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1379,7 +1379,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedExpiredDetach) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1475,7 +1475,7 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedDetachRetxFailure) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1561,7 +1561,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleDetach) {
   // mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1586,7 +1586,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleDetach) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1690,7 +1690,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleServiceReqDetach) {
   // mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1735,7 +1735,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleServiceReqDetach) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1839,7 +1839,7 @@ TEST_F(MmeAppProcedureTest, TestPagingMaxRetx) {
   // mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -1894,7 +1894,7 @@ TEST_F(MmeAppProcedureTest, TestPagingMaxRetx) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2033,7 +2033,7 @@ TEST_F(
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2185,7 +2185,7 @@ TEST_F(
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2289,7 +2289,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithActiveFlag) {
   // mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2335,7 +2335,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithActiveFlag) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2440,7 +2440,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithoutActiveFlag) {
   // mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2485,7 +2485,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithoutActiveFlag) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2590,7 +2590,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithActiveFlag) {
   // mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2636,7 +2636,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithActiveFlag) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2741,7 +2741,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithoutActiveFlag) {
   // mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2785,7 +2785,7 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithoutActiveFlag) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2890,7 +2890,7 @@ TEST_F(MmeAppProcedureTest, TestTauRejDueToInvalidTac) {
   // mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -2940,7 +2940,7 @@ TEST_F(MmeAppProcedureTest, TestTauRejDueToInvalidTac) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -3027,7 +3027,7 @@ TEST_F(MmeAppProcedureTest, TestFailedPagingForPendingBearers) {
   // mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -3076,7 +3076,7 @@ TEST_F(MmeAppProcedureTest, TestFailedPagingForPendingBearers) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -3162,7 +3162,7 @@ TEST_F(MmeAppProcedureTest, TestMobileReachabilityTimer) {
   // mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -3183,7 +3183,7 @@ TEST_F(MmeAppProcedureTest, TestMobileReachabilityTimer) {
   // mimicing SPGW task
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Check MME state after implicit detach complete
@@ -3298,7 +3298,7 @@ TEST_F(MmeAppProcedureTest, TestX2HandoverPathSwitchSuccess) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -3810,7 +3810,7 @@ TEST_F(
   send_delete_session_resp(DEFAULT_LBI);
   send_delete_session_resp(6);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -3947,7 +3947,7 @@ TEST_F(MmeAppProcedureTest, TestS1HandoverSuccess) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -3960,6 +3960,184 @@ TEST_F(MmeAppProcedureTest, TestS1HandoverSuccess) {
   EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
   EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
   EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+}
+
+TEST_F(MmeAppProcedureTest, TestDuplicateAttach) {
+  mme_app_desc_t* mme_state_p =
+      magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  std::condition_variable cv;
+  std::mutex mx;
+  std::unique_lock<std::mutex> lock(mx);
+
+  MME_APP_EXPECT_CALLS(6, 2, 2, 2, 2, 1, 2, 2, 1, 2, 4);
+
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
+  send_mme_app_initial_ue_msg(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
+
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp(REQUEST_ACCEPTED);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Destruction at tear down is not sufficient as ICS occurs
+  // twice in this test case.
+  bdestroy_wrapper(&nas_msg);
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
+  /* Move UE to ECM_IDLE mode */
+  // Send context release request mimicing S1AP
+  send_context_release_req(S1AP_RADIO_EUTRAN_GENERATED_REASON, TASK_S1AP);
+
+  // Constructing and sending Release Access Bearer Response to mme_app
+  // mimicing SPGW
+  sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
+
+  // Wait for context release command
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after context release request is processed
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 1);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+
+  /* Duplicate Attach Request */
+  // Constructing and sending Duplicate Attach Request to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn);
+
+  // An implicit detach event should occur leading to Delete Session Request
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp();
+
+  // Now the new attach request should proceed
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp(REQUEST_ACCEPTED);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
+  // Constructing and sending Detach Request to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_detach_req, sizeof(nas_msg_detach_req), plmn);
+
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp();
+
+  // Wait for context release command
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
 }
 
 }  // namespace lte

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -3417,7 +3417,7 @@ TEST_F(MmeAppProcedureTest, TestX2HandoverPathSwitchFailure) {
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -3559,7 +3559,7 @@ TEST_F(
   // to mme_app mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -3609,7 +3609,7 @@ TEST_F(
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task
@@ -3752,7 +3752,7 @@ TEST_F(
   // to mme_app mimicing SPGW
   sgw_send_release_access_bearer_response(REQUEST_ACCEPTED);
 
-  // Wait for context release request
+  // Wait for context release command
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
   // mimicing S1AP task


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Added unit test coverage for duplicate attach request when UE is in idle mode.
- Fixed comment

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
`make test_oai`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
