### PR TITLE
feat(amf): AMF context Basic parameters Serialize & Deserialize

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.h
@@ -17,6 +17,7 @@
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_defs.h"
 #include "lte/gateway/c/core/oai/include/map.h"
 #include "lte/protos/oai/mme_nas_state.pb.h"
+#include "lte/protos/oai/nas_state.pb.h"
 
 /******************************************************************************
  * This is a helper class to encapsulate all functions for converting in-memory
@@ -27,6 +28,7 @@
  * the caller class AmfNasStateManager
  ******************************************************************************/
 
+using magma::lte::oai::EmmContext;
 using magma::lte::oai::MmeNasState;
 using magma::lte::oai::UeContext;
 namespace magma5g {
@@ -80,5 +82,44 @@ class AmfNasStateConverter : public magma::lte::StateConverter {
   static void proto_to_guti_map(
       const google::protobuf::Map<std::string, uint64_t>& proto_map,
       map_guti_m5_uint64_t* guti_map);
+
+  /**
+   * Serialize struct amf_context_t to oai::EmmContext proto message, the memory
+   * for AMF procedures in AMF context is dynamically allocated by AMF task and
+   * AmfStateConvertor, and freed by AmfStateManager
+   */
+  static void amf_context_to_proto(
+      const amf_context_t* amf_ctx, EmmContext* emm_context_proto);
+
+  /**
+   * Deserialize oai::EmmContext proto message to struct amf_context_t, the
+   * memory for EMM procedures in AMF context is allocated by AmfStateConvertor,
+   * and freed by AmfStateManager
+   */
+  static void proto_to_amf_context(
+      const EmmContext& emm_context_proto, amf_context_t* amf_ctx);
+
+  template<typename NodeType>
+  static void identity_tuple_to_proto(
+      const NodeType* state_identity,
+      magma::lte::oai::IdentityTuple* identity_proto, int size) {
+    identity_proto->set_value(state_identity->u.value, size);
+    identity_proto->set_num_digits(state_identity->length);
+  }
+  template<typename NodeType>
+  static void proto_to_identity_tuple(
+      const magma::lte::oai::IdentityTuple& identity_proto,
+      NodeType* state_identity, int size) {
+    memcpy(
+        reinterpret_cast<void*>(&state_identity->u.value),
+        identity_proto.value().data(), size);
+    state_identity->length = identity_proto.num_digits();
+  }
+
+  static void tai_to_proto(
+      const tai_t* state_tai, magma::lte::oai::Tai* tai_proto);
+
+  static void proto_to_tai(
+      const magma::lte::oai::Tai& tai_proto, tai_t* state_tai);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -355,4 +355,122 @@ TEST(ue_m5gmm_context_to_proto, ue_m5gmm_context_to_proto) {
       ue_m5gmm_context1.paging_context.paging_retx_count,
       ue_m5gmm_context2.paging_context.paging_retx_count);
 }
+
+TEST(test_amf_context_to_proto, test_amf_context_state_to_proto) {
+#define AMF_CAUSE_SUCCESS 1
+  amf_context_t amf_ctx1 = {}, amf_ctx2 = {};
+  magma::lte::oai::EmmContext emm_context_proto = magma::lte::oai::EmmContext();
+
+  amf_ctx1.imsi64             = 222456000000101;
+  amf_ctx1.imsi.u.num.digit1  = 3;
+  amf_ctx1.imsi.u.num.digit2  = 1;
+  amf_ctx1.imsi.u.num.digit3  = 0;
+  amf_ctx1.imsi.u.num.digit4  = 1;
+  amf_ctx1.imsi.u.num.digit5  = 5;
+  amf_ctx1.imsi.u.num.digit6  = 0;
+  amf_ctx1.imsi.u.num.digit7  = 1;
+  amf_ctx1.imsi.u.num.digit8  = 2;
+  amf_ctx1.imsi.u.num.digit9  = 3;
+  amf_ctx1.imsi.u.num.digit10 = 4;
+  amf_ctx1.imsi.u.num.digit11 = 5;
+  amf_ctx1.imsi.u.num.digit12 = 6;
+  amf_ctx1.imsi.u.num.digit13 = 7;
+  amf_ctx1.imsi.u.num.digit14 = 8;
+  amf_ctx1.imsi.u.num.digit15 = 9;
+  amf_ctx1.saved_imsi64       = 310150123456789;
+
+  // imei
+  amf_ctx1.imei.length       = 10;
+  amf_ctx1.imei.u.num.tac2   = 2;
+  amf_ctx1.imei.u.num.tac1   = 1;
+  amf_ctx1.imei.u.num.tac3   = 3;
+  amf_ctx1.imei.u.num.tac4   = 4;
+  amf_ctx1.imei.u.num.tac5   = 5;
+  amf_ctx1.imei.u.num.tac6   = 6;
+  amf_ctx1.imei.u.num.tac7   = 7;
+  amf_ctx1.imei.u.num.tac8   = 8;
+  amf_ctx1.imei.u.num.snr1   = 1;
+  amf_ctx1.imei.u.num.snr2   = 2;
+  amf_ctx1.imei.u.num.snr3   = 3;
+  amf_ctx1.imei.u.num.snr4   = 4;
+  amf_ctx1.imei.u.num.snr5   = 5;
+  amf_ctx1.imei.u.num.snr6   = 6;
+  amf_ctx1.imei.u.num.parity = 1;
+  amf_ctx1.imei.u.num.cdsd   = 8;
+  for (int i = 0; i < IMEI_BCD8_SIZE; i++) {
+    amf_ctx1.imei.u.value[i] = i;
+  }
+
+  // imeisv
+  amf_ctx1.imeisv.length       = 10;
+  amf_ctx1.imeisv.u.num.tac2   = 2;
+  amf_ctx1.imeisv.u.num.tac1   = 1;
+  amf_ctx1.imeisv.u.num.tac3   = 3;
+  amf_ctx1.imeisv.u.num.tac4   = 4;
+  amf_ctx1.imeisv.u.num.tac5   = 5;
+  amf_ctx1.imeisv.u.num.tac6   = 6;
+  amf_ctx1.imeisv.u.num.tac7   = 7;
+  amf_ctx1.imeisv.u.num.tac8   = 8;
+  amf_ctx1.imeisv.u.num.snr1   = 1;
+  amf_ctx1.imeisv.u.num.snr2   = 2;
+  amf_ctx1.imeisv.u.num.snr3   = 3;
+  amf_ctx1.imeisv.u.num.snr4   = 4;
+  amf_ctx1.imeisv.u.num.snr5   = 5;
+  amf_ctx1.imeisv.u.num.snr6   = 6;
+  amf_ctx1.imeisv.u.num.parity = 1;
+  for (int i = 0; i < IMEISV_BCD8_SIZE; i++) {
+    amf_ctx1.imeisv.u.value[i] = i;
+  }
+  amf_ctx1.amf_cause     = AMF_CAUSE_SUCCESS;
+  amf_ctx1.amf_fsm_state = AMF_DEREGISTERED;
+
+  amf_ctx1.m5gsregistrationtype = AMF_REGISTRATION_TYPE_INITIAL;
+  amf_ctx1.member_present_mask |= AMF_CTXT_MEMBER_SECURITY;
+  amf_ctx1.member_valid_mask |= AMF_CTXT_MEMBER_SECURITY;
+  amf_ctx1.is_dynamic               = true;
+  amf_ctx1.is_registered            = true;
+  amf_ctx1.is_initial_identity_imsi = true;
+  amf_ctx1.is_guti_based_registered = true;
+  amf_ctx1.is_imsi_only_detach      = false;
+
+  // originating_tai
+  amf_ctx1.originating_tai.plmn.mcc_digit1 = 2;
+  amf_ctx1.originating_tai.plmn.mcc_digit2 = 2;
+  amf_ctx1.originating_tai.plmn.mcc_digit3 = 2;
+  amf_ctx1.originating_tai.plmn.mnc_digit3 = 6;
+  amf_ctx1.originating_tai.plmn.mnc_digit2 = 5;
+  amf_ctx1.originating_tai.plmn.mnc_digit1 = 4;
+  amf_ctx1.originating_tai.tac             = 1;
+
+  amf_ctx1.ksi = 0x06;
+
+  AmfNasStateConverter::amf_context_to_proto(&amf_ctx1, &emm_context_proto);
+  AmfNasStateConverter::proto_to_amf_context(emm_context_proto, &amf_ctx2);
+
+  EXPECT_EQ(amf_ctx1.imsi64, amf_ctx2.imsi64);
+  EXPECT_EQ(amf_ctx1.saved_imsi64, amf_ctx2.saved_imsi64);
+  EXPECT_EQ(amf_ctx1.amf_cause, amf_ctx2.amf_cause);
+  EXPECT_EQ(amf_ctx1.m5gsregistrationtype, amf_ctx2.m5gsregistrationtype);
+  EXPECT_EQ(amf_ctx1.member_present_mask, amf_ctx2.member_present_mask);
+  EXPECT_EQ(amf_ctx1.member_valid_mask, amf_ctx2.member_valid_mask);
+  EXPECT_EQ(amf_ctx1.is_dynamic, amf_ctx2.is_dynamic);
+  EXPECT_EQ(amf_ctx1.is_registered, amf_ctx2.is_registered);
+  EXPECT_EQ(
+      amf_ctx1.is_initial_identity_imsi, amf_ctx2.is_initial_identity_imsi);
+  EXPECT_EQ(
+      amf_ctx1.is_guti_based_registered, amf_ctx2.is_guti_based_registered);
+  EXPECT_EQ(amf_ctx1.is_imsi_only_detach, amf_ctx2.is_imsi_only_detach);
+  EXPECT_EQ(memcmp(&amf_ctx1.imsi, &amf_ctx2.imsi, sizeof(amf_ctx1.imsi)), 0);
+  EXPECT_EQ(amf_ctx1.imsi.u.num.digit1, amf_ctx2.imsi.u.num.digit1);
+  EXPECT_EQ(amf_ctx1.amf_fsm_state, amf_ctx2.amf_fsm_state);
+  EXPECT_EQ(memcmp(&amf_ctx1.imei, &amf_ctx2.imei, sizeof(amf_ctx1.imei)), 0);
+  EXPECT_EQ(
+      memcmp(&amf_ctx1.imeisv, &amf_ctx2.imeisv, sizeof(amf_ctx1.imeisv)), 0);
+  EXPECT_EQ(amf_ctx1.ksi, amf_ctx2.ksi);
+  EXPECT_EQ(
+      memcmp(
+          &amf_ctx1.originating_tai, &amf_ctx2.originating_tai,
+          sizeof(amf_ctx1.originating_tai)),
+      0);
+}
 }  // namespace magma5g


### PR DESCRIPTION
Signed-off-by: aniket021997 <aniket.sonawane@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Serializing and De serializing amf_context_t to support stateless feature.

## Test Plan

- Verified basic sanity with ueransim
- Verified using Functional UT
- Please find attached logs and pcap for basic registration

mme log: 
[mme.log](https://github.com/magma/magma/files/7727387/mme.log)

pcap:
![packet_amf_to_proto](https://user-images.githubusercontent.com/95931489/146375530-4a226c09-ce16-454e-8f0f-fd660c4fb4a5.PNG)

test cases:
![make_test_oai](https://user-images.githubusercontent.com/95931489/146375608-2b89ae77-0ed0-43dd-85ea-40229c2fbeef.PNG)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
