### PR TITLE
feat(amf): AMF security context Serialize and Deserialize

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.cpp
@@ -23,6 +23,9 @@ extern "C" {
 }
 
 using magma::lte::oai::EmmContext;
+using magma::lte::oai::EmmSecurityContext;
+using magma::lte::oai::EmmSecurityContext_Count;
+using magma::lte::oai::EmmSecurityContext_SelectedAlgorithms;
 using magma::lte::oai::MmeNasState;
 namespace magma5g {
 
@@ -356,4 +359,89 @@ void AmfNasStateConverter::proto_to_amf_context(
   proto_to_tai(emm_context_proto.originating_tai(), &amf_ctx->originating_tai);
   amf_ctx->ksi = emm_context_proto.ksi();
 }
+void AmfNasStateConverter::amf_security_context_to_proto(
+    const amf_security_context_t* state_amf_security_context,
+    EmmSecurityContext* emm_security_context_proto) {
+  emm_security_context_proto->set_sc_type(state_amf_security_context->sc_type);
+  emm_security_context_proto->set_eksi(state_amf_security_context->eksi);
+  emm_security_context_proto->set_vector_index(
+      state_amf_security_context->vector_index);
+  emm_security_context_proto->set_knas_enc(
+      state_amf_security_context->knas_enc, AUTH_KNAS_ENC_SIZE);
+  emm_security_context_proto->set_knas_int(
+      state_amf_security_context->knas_int, AUTH_KNAS_INT_SIZE);
+
+  // Count values
+  EmmSecurityContext_Count* dl_count_proto =
+      emm_security_context_proto->mutable_dl_count();
+  dl_count_proto->set_overflow(state_amf_security_context->dl_count.overflow);
+  dl_count_proto->set_seq_num(state_amf_security_context->dl_count.seq_num);
+  EmmSecurityContext_Count* ul_count_proto =
+      emm_security_context_proto->mutable_ul_count();
+  ul_count_proto->set_overflow(state_amf_security_context->ul_count.overflow);
+  ul_count_proto->set_seq_num(state_amf_security_context->ul_count.seq_num);
+  EmmSecurityContext_Count* kenb_ul_count_proto =
+      emm_security_context_proto->mutable_kenb_ul_count();
+  kenb_ul_count_proto->set_overflow(
+      state_amf_security_context->kenb_ul_count.overflow);
+  kenb_ul_count_proto->set_seq_num(
+      state_amf_security_context->kenb_ul_count.seq_num);
+
+  // Security algorithm
+  EmmSecurityContext_SelectedAlgorithms* selected_algorithms_proto =
+      emm_security_context_proto->mutable_selected_algos();
+  selected_algorithms_proto->set_encryption(
+      state_amf_security_context->selected_algorithms.encryption);
+  selected_algorithms_proto->set_integrity(
+      state_amf_security_context->selected_algorithms.integrity);
+  emm_security_context_proto->set_direction_encode(
+      state_amf_security_context->direction_encode);
+  emm_security_context_proto->set_direction_decode(
+      state_amf_security_context->direction_decode);
+}
+
+void AmfNasStateConverter::proto_to_amf_security_context(
+    const EmmSecurityContext& emm_security_context_proto,
+    amf_security_context_t* state_amf_security_context) {
+  state_amf_security_context->sc_type =
+      (amf_sc_type_t) emm_security_context_proto.sc_type();
+  state_amf_security_context->eksi = emm_security_context_proto.eksi();
+  state_amf_security_context->vector_index =
+      emm_security_context_proto.vector_index();
+  memcpy(
+      state_amf_security_context->knas_enc,
+      emm_security_context_proto.knas_enc().c_str(), AUTH_KNAS_ENC_SIZE);
+  memcpy(
+      state_amf_security_context->knas_int,
+      emm_security_context_proto.knas_int().c_str(), AUTH_KNAS_INT_SIZE);
+
+  // Count values
+  const EmmSecurityContext_Count& dl_count_proto =
+      emm_security_context_proto.dl_count();
+  state_amf_security_context->dl_count.overflow = dl_count_proto.overflow();
+  state_amf_security_context->dl_count.seq_num  = dl_count_proto.seq_num();
+  const EmmSecurityContext_Count& ul_count_proto =
+      emm_security_context_proto.ul_count();
+  state_amf_security_context->ul_count.overflow = ul_count_proto.overflow();
+  state_amf_security_context->ul_count.seq_num  = ul_count_proto.seq_num();
+  const EmmSecurityContext_Count& kenb_ul_count_proto =
+      emm_security_context_proto.kenb_ul_count();
+  state_amf_security_context->kenb_ul_count.overflow =
+      kenb_ul_count_proto.overflow();
+  state_amf_security_context->kenb_ul_count.seq_num =
+      kenb_ul_count_proto.seq_num();
+
+  // Security algorithm
+  const EmmSecurityContext_SelectedAlgorithms& selected_algorithms_proto =
+      emm_security_context_proto.selected_algos();
+  state_amf_security_context->selected_algorithms.encryption =
+      selected_algorithms_proto.encryption();
+  state_amf_security_context->selected_algorithms.integrity =
+      selected_algorithms_proto.integrity();
+  state_amf_security_context->direction_encode =
+      emm_security_context_proto.direction_encode();
+  state_amf_security_context->direction_decode =
+      emm_security_context_proto.direction_decode();
+}
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.cpp
@@ -24,8 +24,6 @@ extern "C" {
 
 using magma::lte::oai::EmmContext;
 using magma::lte::oai::EmmSecurityContext;
-using magma::lte::oai::EmmSecurityContext_Count;
-using magma::lte::oai::EmmSecurityContext_SelectedAlgorithms;
 using magma::lte::oai::MmeNasState;
 namespace magma5g {
 
@@ -372,15 +370,13 @@ void AmfNasStateConverter::amf_security_context_to_proto(
       state_amf_security_context->knas_int, AUTH_KNAS_INT_SIZE);
 
   // Count values
-  EmmSecurityContext_Count* dl_count_proto =
-      emm_security_context_proto->mutable_dl_count();
+  auto* dl_count_proto = emm_security_context_proto->mutable_dl_count();
   dl_count_proto->set_overflow(state_amf_security_context->dl_count.overflow);
   dl_count_proto->set_seq_num(state_amf_security_context->dl_count.seq_num);
-  EmmSecurityContext_Count* ul_count_proto =
-      emm_security_context_proto->mutable_ul_count();
+  auto* ul_count_proto = emm_security_context_proto->mutable_ul_count();
   ul_count_proto->set_overflow(state_amf_security_context->ul_count.overflow);
   ul_count_proto->set_seq_num(state_amf_security_context->ul_count.seq_num);
-  EmmSecurityContext_Count* kenb_ul_count_proto =
+  auto* kenb_ul_count_proto =
       emm_security_context_proto->mutable_kenb_ul_count();
   kenb_ul_count_proto->set_overflow(
       state_amf_security_context->kenb_ul_count.overflow);
@@ -388,7 +384,7 @@ void AmfNasStateConverter::amf_security_context_to_proto(
       state_amf_security_context->kenb_ul_count.seq_num);
 
   // Security algorithm
-  EmmSecurityContext_SelectedAlgorithms* selected_algorithms_proto =
+  auto* selected_algorithms_proto =
       emm_security_context_proto->mutable_selected_algos();
   selected_algorithms_proto->set_encryption(
       state_amf_security_context->selected_algorithms.encryption);
@@ -416,23 +412,20 @@ void AmfNasStateConverter::proto_to_amf_security_context(
       emm_security_context_proto.knas_int().c_str(), AUTH_KNAS_INT_SIZE);
 
   // Count values
-  const EmmSecurityContext_Count& dl_count_proto =
-      emm_security_context_proto.dl_count();
+  const auto& dl_count_proto = emm_security_context_proto.dl_count();
   state_amf_security_context->dl_count.overflow = dl_count_proto.overflow();
   state_amf_security_context->dl_count.seq_num  = dl_count_proto.seq_num();
-  const EmmSecurityContext_Count& ul_count_proto =
-      emm_security_context_proto.ul_count();
+  const auto& ul_count_proto = emm_security_context_proto.ul_count();
   state_amf_security_context->ul_count.overflow = ul_count_proto.overflow();
   state_amf_security_context->ul_count.seq_num  = ul_count_proto.seq_num();
-  const EmmSecurityContext_Count& kenb_ul_count_proto =
-      emm_security_context_proto.kenb_ul_count();
+  const auto& kenb_ul_count_proto = emm_security_context_proto.kenb_ul_count();
   state_amf_security_context->kenb_ul_count.overflow =
       kenb_ul_count_proto.overflow();
   state_amf_security_context->kenb_ul_count.seq_num =
       kenb_ul_count_proto.seq_num();
 
   // Security algorithm
-  const EmmSecurityContext_SelectedAlgorithms& selected_algorithms_proto =
+  const auto& selected_algorithms_proto =
       emm_security_context_proto.selected_algos();
   state_amf_security_context->selected_algorithms.encryption =
       selected_algorithms_proto.encryption();

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.h
@@ -29,6 +29,7 @@
  ******************************************************************************/
 
 using magma::lte::oai::EmmContext;
+using magma::lte::oai::EmmSecurityContext;
 using magma::lte::oai::MmeNasState;
 using magma::lte::oai::UeContext;
 namespace magma5g {
@@ -65,6 +66,15 @@ class AmfNasStateConverter : public magma::lte::StateConverter {
   static std::string amf_app_convert_guti_m5_to_string(const guti_m5_t& guti);
   static void amf_app_convert_string_to_guti_m5(
       const std::string& guti_str, guti_m5_t* guti_m5_p);
+
+  static void amf_security_context_to_proto(
+      const amf_security_context_t* state_amf_security_context,
+      EmmSecurityContext* emm_security_context_proto);
+
+  static void proto_to_amf_security_context(
+      const EmmSecurityContext& emm_security_context_proto,
+      amf_security_context_t* state_amf_security_context);
+
   /***********************************************************
    *                 Map <-> Proto
    * Functions to serialize/deserialize in-memory maps

--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -24,6 +24,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.h"
 #include "lte/gateway/c/core/oai/test/amf/amf_app_test_util.h"
+#include "lte/gateway/c/core/oai/lib/secu/secu_defs.h"
 
 using ::testing::Test;
 
@@ -118,6 +119,68 @@ TEST(TestAMFStateConverter, TestStateToProto) {
       amf_app_desc2.amf_ue_contexts.guti_ue_context_htbl.get(guti1, &data),
       magma::MAP_OK);
   EXPECT_EQ(data, 40);
+}
+
+TEST(test_amf_security_context_to_proto, test_amf_security_context_to_proto) {
+  amf_security_context_t state_amf_security_context_1 = {};
+  amf_security_context_t state_amf_security_context_2 = {};
+  // EmmSecurityProto
+  magma::lte::oai::EmmSecurityContext emm_security_context_proto =
+      magma::lte::oai::EmmSecurityContext();
+  // amf_security_context setup
+  state_amf_security_context_1.sc_type      = SECURITY_CTX_TYPE_NOT_AVAILABLE;
+  state_amf_security_context_1.eksi         = 1;
+  state_amf_security_context_1.vector_index = 1;
+  state_amf_security_context_1.dl_count.overflow      = 2;
+  state_amf_security_context_1.dl_count.seq_num       = 1;
+  state_amf_security_context_1.ul_count.overflow      = 1;
+  state_amf_security_context_1.ul_count.seq_num       = 2;
+  state_amf_security_context_1.kenb_ul_count.overflow = 1;
+  state_amf_security_context_1.kenb_ul_count.seq_num  = 1;
+  state_amf_security_context_1.direction_decode       = SECU_DIRECTION_UPLINK;
+  state_amf_security_context_1.direction_encode       = SECU_DIRECTION_DOWNLINK;
+
+  AmfNasStateConverter::amf_security_context_to_proto(
+      &state_amf_security_context_1, &emm_security_context_proto);
+  AmfNasStateConverter::proto_to_amf_security_context(
+      emm_security_context_proto, &state_amf_security_context_2);
+
+  EXPECT_EQ(
+      state_amf_security_context_1.sc_type,
+      state_amf_security_context_2.sc_type);
+  EXPECT_EQ(
+      state_amf_security_context_1.eksi, state_amf_security_context_2.eksi);
+  EXPECT_EQ(
+      state_amf_security_context_1.vector_index,
+      state_amf_security_context_2.vector_index);
+
+  // Count values
+  EXPECT_EQ(
+      state_amf_security_context_1.dl_count.overflow,
+      state_amf_security_context_2.dl_count.overflow);
+  EXPECT_EQ(
+      state_amf_security_context_1.dl_count.seq_num,
+      state_amf_security_context_2.dl_count.seq_num);
+  EXPECT_EQ(
+      state_amf_security_context_1.ul_count.overflow,
+      state_amf_security_context_2.ul_count.overflow);
+  EXPECT_EQ(
+      state_amf_security_context_1.ul_count.seq_num,
+      state_amf_security_context_2.ul_count.seq_num);
+  EXPECT_EQ(
+      state_amf_security_context_1.kenb_ul_count.overflow,
+      state_amf_security_context_2.kenb_ul_count.overflow);
+  EXPECT_EQ(
+      state_amf_security_context_1.kenb_ul_count.seq_num,
+      state_amf_security_context_2.kenb_ul_count.seq_num);
+
+  // Security algorithm
+  EXPECT_EQ(
+      state_amf_security_context_1.direction_decode,
+      state_amf_security_context_2.direction_decode);
+  EXPECT_EQ(
+      state_amf_security_context_1.direction_encode,
+      state_amf_security_context_2.direction_encode);
 }
 
 class AMFAppStatelessTest : public ::testing::Test {

--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -121,7 +121,7 @@ TEST(TestAMFStateConverter, TestStateToProto) {
   EXPECT_EQ(data, 40);
 }
 
-TEST(test_amf_security_context_to_proto, test_amf_security_context_to_proto) {
+TEST(TestAMFStateConverter, TestAMFSecurityContextToProto) {
   amf_security_context_t state_amf_security_context_1 = {};
   amf_security_context_t state_amf_security_context_2 = {};
   // EmmSecurityProto


### PR DESCRIPTION
Signed-off-by: krishnavamsi-wavelabs <krishna.vamsi@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

**Serialising and Deserialising amf_security_context_t to support Stateless Feature.**

## Test Plan
- Verified basic sanity with ueransim
- Verified using Functional UT
- Please find attached logs and pcap for basic registration

Mme log:
[mme.log](https://github.com/magma/magma/files/7727797/mme.log)

Pcap:
![amf_sc_pcap](https://user-images.githubusercontent.com/88074557/146384796-9506d33f-bd0d-4873-8f8a-76f709b1d8e8.png)

Functional UT:
![amf_sc](https://user-images.githubusercontent.com/88074557/146384952-48a9ad7c-1ec6-4385-bfd7-b317e437ea6c.png)



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
