### PR TITLE
fix(ci): Avoid triggering build-all in forked repo

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,11 +4,11 @@ name: build-all
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
-      - magma/magma:master
+      - magma:master
       - v1.*
   pull_request:
     branches:
-      - magma/magma:master
+      - magma:master
       - v1.*
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo
-            if (github.event.repository.full_name != "magma/magma") {
+            if ("${{github.event.repository.full_name}}" != "magma/magma") {
               console.log('Cancelling ...');
               const run_id = "${{ github.run_id }}";
               await github.actions.cancelWorkflowRun({ owner, repo, run_id });

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -13,12 +13,6 @@ on:  # yamllint disable-line rule:truthy
     types: [opened, reopened, synchronize]
 
 jobs:
-  check_if:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancelling
-        uses: andymckay/cancel-action@0.2
-        if: ${{ github.event.repository.full_name != "magma/magma" }}
   build_publish_helm_charts:
     env:
       HELM_CHART_ARTIFACTORY_URL: "https://artifactory.magmacore.org:443/artifactory/"
@@ -30,6 +24,9 @@ jobs:
       ISSUE_NUMBER: "${{ github.event.number }}"
     runs-on: ubuntu-latest
     steps:
+      - name: Cancelling
+        uses: andymckay/cancel-action@0.2
+        if: ${{ github.event.repository.full_name != "magma/magma" }}
       - uses: actions/checkout@v2
       # Version is github job run number when running on master
       # Or is branch name when on release branch

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -24,6 +24,8 @@ jobs:
       ISSUE_NUMBER: "${{ github.event.number }}"
     runs-on: ubuntu-latest
     steps:
+      - name: Debug Infos
+        uses: hmarr/debug-action@v2
       - uses: actions/checkout@v2
       # Version is github job run number when running on master
       # Or is branch name when on release branch

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -13,6 +13,11 @@ on:  # yamllint disable-line rule:truthy
     types: [opened, reopened, synchronize]
 
 jobs:
+  checkIf:
+    steps:
+      - name: cancelling
+        uses: andymckay/cancel-action@0.2
+        if: "${{ github.event.pull_request.base.repo.full_name !="magma/magma" }}"
   build_publish_helm_charts:
     env:
       HELM_CHART_ARTIFACTORY_URL: "https://artifactory.magmacore.org:443/artifactory/"

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -14,6 +14,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   check_if:
+    runs-on: ubuntu-latest
     steps:
       - name: cancelling
         uses: andymckay/cancel-action@0.2

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancelling
-        uses: andymckay/cancel-action@0.2
-        if: "${{ github.event.repository.full_name != "magma/magma" }}"
+        uses: hmarr/debug-action@v2
+        if: ${{ github.event.repository.full_name != "magma/magma" }}
   build_publish_helm_charts:
     env:
       HELM_CHART_ARTIFACTORY_URL: "https://artifactory.magmacore.org:443/artifactory/"
@@ -30,8 +30,6 @@ jobs:
       ISSUE_NUMBER: "${{ github.event.number }}"
     runs-on: ubuntu-latest
     steps:
-      - name: Debug Infos
-        uses: hmarr/debug-action@v2
       - uses: actions/checkout@v2
       # Version is github job run number when running on master
       # Or is branch name when on release branch

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -13,8 +13,8 @@ on:  # yamllint disable-line rule:truthy
     types: [opened, reopened, synchronize]
 
 jobs:
-  if : "${{github.event.repository.full_name}}" != "magma/magma" 
   build_publish_helm_charts:
+    if: github.repository_owner == 'magma'
     env:
       HELM_CHART_ARTIFACTORY_URL: "https://artifactory.magmacore.org:443/artifactory/"
       HELM_CHART_MUSEUM_REPO: helm-test
@@ -100,7 +100,7 @@ jobs:
           pip install artifactory
           python ci-scripts/helm_repo_rotation.py
   agw-build:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository_owner == 'magma'
     runs-on: macos-10.15
     outputs:
       artifacts: ${{ steps.publish_packages.outputs.artifacts }}
@@ -193,6 +193,7 @@ jobs:
         with:
           args: "AGW  build succeeded on [${{github.sha}}](${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}): ${{ steps.commit.outputs.title}}"
   orc8r-build:
+    if: github.repository_owner == 'magma'
     name: orc8r build job
     runs-on: ubuntu-latest
     outputs:
@@ -274,6 +275,7 @@ jobs:
           SLACK_COLOR: "#00FF00"
           SLACK_FOOTER: ' '
   agw-container-build:
+    if: github.repository_owner == 'magma'
     name: agw container build
     runs-on: ubuntu-latest
     env:
@@ -373,7 +375,7 @@ jobs:
   cloud-upload:
     name: cloud upload job
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push'  }}
+    if: github.event_name == 'push' && github.repository_owner == 'magma'
     steps:
       - uses: actions/checkout@v2
       - name: Install SwaggerHub CLI
@@ -416,6 +418,7 @@ jobs:
           SLACK_COLOR: "#00FF00"
           SLACK_FOOTER: ' '
   cwag-deploy:
+    if: github.repository_owner == 'magma'
     name: cwag deploy job
     runs-on: ubuntu-latest
     outputs:
@@ -562,6 +565,7 @@ jobs:
           SLACK_COLOR: "#00FF00"
           SLACK_FOOTER: ' '
   cwf-operator-build:
+    if: github.repository_owner == 'magma'
     name: cwf operator build job
     runs-on: ubuntu-latest
     env:
@@ -647,6 +651,7 @@ jobs:
           SLACK_COLOR: "#00FF00"
           SLACK_FOOTER: ''
   feg-build:
+    if: github.repository_owner == 'magma'
     name: feg-build
     runs-on: ubuntu-latest
     outputs:
@@ -747,6 +752,7 @@ jobs:
           SLACK_COLOR: "#00FF00"
           SLACK_FOOTER: ' '
   nms-build:
+    if: github.repository_owner == 'magma'
     name: nms-build job
     runs-on: ubuntu-latest
     outputs:
@@ -829,7 +835,7 @@ jobs:
           SLACK_FOOTER: ' '
   Publish_to_firebase:
     name: Publish to firebase
-    if: always() && github.event_name == 'push'
+    if: always() && github.event_name == 'push' && github.repository_owner == 'magma'
     runs-on: ubuntu-latest
     needs: [agw-build, feg-build, orc8r-build, cwag-deploy, nms-build]
     steps:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -16,7 +16,7 @@ jobs:
   check_if:
     runs-on: ubuntu-latest
     steps:
-      - name: cancelling
+      - name: Cancelling
         uses: andymckay/cancel-action@0.2
         if: "${{ github.event.repository.full_name != "magma/magma" }}"
   build_publish_helm_charts:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancelling
-        uses: hmarr/debug-action@v2
+        uses: andymckay/cancel-action@0.2
         if: ${{ github.event.repository.full_name != "magma/magma" }}
   build_publish_helm_charts:
     env:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -13,11 +13,11 @@ on:  # yamllint disable-line rule:truthy
     types: [opened, reopened, synchronize]
 
 jobs:
-  checkIf:
+  check_if:
     steps:
       - name: cancelling
         uses: andymckay/cancel-action@0.2
-        if: "${{ github.event.pull_request.base.repo.full_name !="magma/magma" }}"
+        if: "${{ github.event.repository.full_name != "magma/magma" }}"
   build_publish_helm_charts:
     env:
       HELM_CHART_ARTIFACTORY_URL: "https://artifactory.magmacore.org:443/artifactory/"

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -24,9 +24,25 @@ jobs:
       ISSUE_NUMBER: "${{ github.event.number }}"
     runs-on: ubuntu-latest
     steps:
-      - name: Cancelling
-        uses: andymckay/cancel-action@0.2
-        if: ${{ github.event.repository.full_name != "magma/magma" }}
+    - uses: actions/github-script@v2
+      id: check
+      with:
+        script: |
+          const { owner, repo } = context.repo
+          if (github.event.repository.full_name != "magma/magma") {
+            console.log('Cancelling ...');
+            const run_id = "${{ github.run_id }}";
+            await github.actions.cancelWorkflowRun({ owner, repo, run_id });
+            return 'stop'
+          } else {
+            return 'build'
+          }
+        result-encoding: string
+      - name: Waiting for cancellation
+        run: sleep 60
+        if: steps.check.outputs.result == 'stop'
+      - name: Should build?
+        run: test "${{ steps.check.outputs.result }}" = "build"
       - uses: actions/checkout@v2
       # Version is github job run number when running on master
       # Or is branch name when on release branch

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -13,6 +13,7 @@ on:  # yamllint disable-line rule:truthy
     types: [opened, reopened, synchronize]
 
 jobs:
+  if : "${{github.event.repository.full_name}}" != "magma/magma" 
   build_publish_helm_charts:
     env:
       HELM_CHART_ARTIFACTORY_URL: "https://artifactory.magmacore.org:443/artifactory/"
@@ -24,25 +25,6 @@ jobs:
       ISSUE_NUMBER: "${{ github.event.number }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v2
-        id: check
-        with:
-          script: |
-            const { owner, repo } = context.repo
-            if ("${{github.event.repository.full_name}}" != "magma/magma") {
-              console.log('Cancelling ...');
-              const run_id = "${{ github.run_id }}";
-              await github.actions.cancelWorkflowRun({ owner, repo, run_id });
-              return 'stop'
-            } else {
-              return 'build'
-            }
-          result-encoding: string
-      - name: Waiting for cancellation
-        run: sleep 60
-        if: steps.check.outputs.result == 'stop'
-      - name: Should build?
-        run: test "${{ steps.check.outputs.result }}" = "build"
       - uses: actions/checkout@v2
       # Version is github job run number when running on master
       # Or is branch name when on release branch

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,11 +4,11 @@ name: build-all
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
-      - magma:master
+      - master
       - v1.*
   pull_request:
     branches:
-      - magma:master
+      - master
       - v1.*
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -4,11 +4,11 @@ name: build-all
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
-      - master
+      - magma/magma:master
       - v1.*
   pull_request:
     branches:
-      - master
+      - magma/magma:master
       - v1.*
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -24,20 +24,20 @@ jobs:
       ISSUE_NUMBER: "${{ github.event.number }}"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@v2
-      id: check
-      with:
-        script: |
-          const { owner, repo } = context.repo
-          if (github.event.repository.full_name != "magma/magma") {
-            console.log('Cancelling ...');
-            const run_id = "${{ github.run_id }}";
-            await github.actions.cancelWorkflowRun({ owner, repo, run_id });
-            return 'stop'
-          } else {
-            return 'build'
-          }
-        result-encoding: string
+      - uses: actions/github-script@v2
+        id: check
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            if (github.event.repository.full_name != "magma/magma") {
+              console.log('Cancelling ...');
+              const run_id = "${{ github.run_id }}";
+              await github.actions.cancelWorkflowRun({ owner, repo, run_id });
+              return 'stop'
+            } else {
+              return 'build'
+            }
+          result-encoding: string
       - name: Waiting for cancellation
         run: sleep 60
         if: steps.check.outputs.result == 'stop'

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   docker-build:
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -57,6 +58,7 @@ jobs:
         with:
           args: 'CWF integration test: docker build step failed on [${{ env.SHA }}](${{github.event.repository.owner.html_url}}/magma/commits/${{ env.SHA }}): ${{ steps.commit.outputs.title}}'
   cwf-integ-test:
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: macos-10.15
     needs: docker-build
     steps:

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -15,6 +15,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   lte-integ-test:
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: macos-10.15
     env:
       SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}


### PR DESCRIPTION
Signed-off-by: JeanPec <andremarie67450@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Skipped jobs from build-all,cwf-integ-test and lte-integ-test on forked repo but accepted jobs from cwf-integ-test and lte-integ-test on workflow_dispatch.
To do it I added if statement on each jobs:
- on build_all I tested if the repo owner is magma
- on cwf-integ-test and lte-integ-test  I tested if the repo owner is magma or the event is workflow_dispatch

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
To test it I checked that the jobs were skipped on a PR on my forked repo and on magma repo.
To test that the jobs from cwf-integ-test and lte-integ-test were skipped I accepted a PR on my forked repo.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
