### PR TITLE
fix(orc8r): Log entries created from user input

### DIFF
--- a/orc8r/cloud/go/obsidian/server/metrics.go
+++ b/orc8r/cloud/go/obsidian/server/metrics.go
@@ -50,12 +50,24 @@ func CollectStats(next echo.HandlerFunc) echo.HandlerFunc {
 		requestCount.Inc()
 		status := strconv.Itoa(c.Response().Status)
 		respStatuses.WithLabelValues(status, c.Request().Method).Inc()
+		url := sanitizeString(c.Request().URL.String())
 		glog.V(2).Infof(
 			"REST API code: %v, method: %v, url: %v\n",
 			status,
 			c.Request().Method,
-			c.Request().URL,
+			url,
 		)
 		return nil
 	}
+}
+
+func sanitizeString(strString string) string {
+	//escape special charatchters in HTML text
+	strSanitizedString := html.EscapeString(strString)
+	//remove line breaks
+	strSanitizedString = strings.Replace(strSanitizedString, "\r", "", -1)
+	strSanitizedString = strings.Replace(strSanitizedString, "\n", "", -1)
+	//remove extra whitespace
+	strSanitizedString = strings.Join(strings.Fields(strSanitizedString), " ")
+	return strSanitizedString
 }


### PR DESCRIPTION
fix(orc8r): Log entries created from user input

## Summary

Added function for string sanitizing before it is written to a log entry.
function works as follows:
it escape special characters in HTML text,
it remove line breaks,
it remove extra whitespace

## Test Plan

I ran tests /magma/orc8r/cloud/docker/  ./build.py -c

This is for alert:
https://github.com/magma/magma/security/code-scanning/40?query=ref%3Arefs%2Fheads%2Fmaster
