### PR TITLE
fix(amf): Send the concerned PDU sessions to be released info to SMF upon t3592…

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -866,10 +866,10 @@ ue_m5gmm_context_s* ue_context_loopkup_by_guti(tmsi_t tmsi_rcv);
 void ue_context_update_ue_id(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t ue_id);
 ue_m5gmm_context_s* ue_context_lookup_by_gnb_ue_id(
-    gnb_ue_ngap_id_t gnb_ue_ngap_id);    
+    gnb_ue_ngap_id_t gnb_ue_ngap_id);
 int t3592_abort_handler(
-     ue_m5gmm_context_t*  ue_context,
-    std::shared_ptr<smf_context_t> smf_ctx,  uint8_t pdu_session_id);
+    ue_m5gmm_context_t* ue_context, std::shared_ptr<smf_context_t> smf_ctx,
+    uint8_t pdu_session_id);
 
 /* Fetch tmsi from ue id */
 tmsi_t amf_lookup_guti_by_ueid(amf_ue_ngap_id_t ue_id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h
@@ -866,7 +866,10 @@ ue_m5gmm_context_s* ue_context_loopkup_by_guti(tmsi_t tmsi_rcv);
 void ue_context_update_ue_id(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t ue_id);
 ue_m5gmm_context_s* ue_context_lookup_by_gnb_ue_id(
-    gnb_ue_ngap_id_t gnb_ue_ngap_id);
+    gnb_ue_ngap_id_t gnb_ue_ngap_id);    
+int t3592_abort_handler(
+     ue_m5gmm_context_t*  ue_context,
+    std::shared_ptr<smf_context_t> smf_ctx,  uint8_t pdu_session_id);
 
 /* Fetch tmsi from ue id */
 tmsi_t amf_lookup_guti_by_ueid(amf_ue_ngap_id_t ue_id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -260,8 +260,8 @@ int pdu_session_resource_release_complete(
 }
 
 int t3592_abort_handler(
-     ue_m5gmm_context_t*  ue_context,
-    std::shared_ptr<smf_context_t> smf_ctx,  uint8_t pdu_session_id) {
+    ue_m5gmm_context_t* ue_context, std::shared_ptr<smf_context_t> smf_ctx,
+    uint8_t pdu_session_id) {
   int rc                               = RETURNerror;
   amf_smf_t amf_smf_msg                = {};
   amf_smf_msg.pdu_session_id           = pdu_session_id;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -259,6 +259,18 @@ int pdu_session_resource_release_complete(
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 
+int t3592_abort_handler(
+     ue_m5gmm_context_t*  ue_context,
+    std::shared_ptr<smf_context_t> smf_ctx,  uint8_t pdu_session_id) {
+  int rc                               = RETURNerror;
+  amf_smf_t amf_smf_msg                = {};
+  amf_smf_msg.pdu_session_id           = pdu_session_id;
+  amf_smf_msg.u.release.pti            = smf_ctx->smf_proc_data.pti.pti;
+  amf_smf_msg.u.release.pdu_session_id = pdu_session_id;
+  amf_smf_msg.u.release.cause_value    = SMF_CAUSE_SUCCESS;
+  rc = pdu_session_resource_release_complete(ue_context, amf_smf_msg, smf_ctx);
+  return rc;
+}
 static int pdu_session_resource_release_t3592_handler(
     zloop_t* loop, int timer_id, void* arg) {
   OAILOG_INFO(
@@ -270,7 +282,6 @@ static int pdu_session_resource_release_t3592_handler(
   std::shared_ptr<smf_context_t> smf_ctx;
   char imsi[IMSI_BCD_DIGITS_MAX + 1];
   int rc = 0;
-
   if (!amf_pop_pdu_timer_arg(timer_id, &uepdu_id)) {
     OAILOG_WARNING(
         LOG_AMF_APP, "T3550: Invalid Timer Id expiration, Timer Id: %u\n",
@@ -325,7 +336,7 @@ static int pdu_session_resource_release_t3592_handler(
         pdu_session_resource_release_t3592_handler, id);
 
   } else {
-    /* Abort the registration procedure */
+    /* Abort the pdu session procedure */
     OAILOG_ERROR(
         LOG_AMF_APP,
         "T3592: Maximum retires:%d, for PDU_SESSION_RELEASE_COMPELETE done "
@@ -333,6 +344,7 @@ static int pdu_session_resource_release_t3592_handler(
         "the pdu sesssion release "
         "procedure\n",
         smf_ctx->retransmission_count);
+    t3592_abort_handler(ue_context, smf_ctx, pdu_session_id);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
 }

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -31,6 +31,7 @@ using ::testing::Test;
 namespace magma5g {
 
 extern task_zmq_ctx_s amf_app_task_zmq_ctx;
+extern std::unordered_map<amf_ue_ngap_id_t, ue_m5gmm_context_s*> ue_context_map;
 
 class AMFAppProcedureTest : public ::testing::Test {
   virtual void SetUp() {
@@ -820,4 +821,26 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
   amf_app_handle_deregistration_req(ue_id);
 }
 
+TEST(test_t3592abort, test_pdu_session_release_notify_smf)
+{
+  amf_ue_ngap_id_t ue_id = 1;
+  uint8_t pdu_session_id = 1;
+  int rc                 = RETURNerror;
+  // creating ue_context
+  ue_m5gmm_context_s* ue_context = amf_create_new_ue_context();
+  ue_context_map.insert(
+      std::pair<amf_ue_ngap_id_t, ue_m5gmm_context_s*>(ue_id, ue_context));
+  std::shared_ptr<smf_context_t> smf_ctx =
+      amf_insert_smf_context(ue_context, pdu_session_id);
+    smf_ctx->pdu_session_state = ACTIVE;
+    ue_context->mm_state = REGISTERED_CONNECTED;
+    smf_ctx->n_active_pdus=1;
+    EXPECT_NE(ue_context, nullptr);
+    EXPECT_NE(ue_context->amf_context.smf_ctxt_map.size(), 0);
+    rc = t3592_abort_handler(ue_context, smf_ctx, pdu_session_id);
+    EXPECT_TRUE(rc == RETURNok);
+    EXPECT_EQ(ue_context->amf_context.smf_ctxt_map.size(), 0);
+    ue_context_map.clear();
+    delete ue_context;
+}
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -821,8 +821,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
   amf_app_handle_deregistration_req(ue_id);
 }
 
-TEST(test_t3592abort, test_pdu_session_release_notify_smf)
-{
+TEST(test_t3592abort, test_pdu_session_release_notify_smf) {
   amf_ue_ngap_id_t ue_id = 1;
   uint8_t pdu_session_id = 1;
   int rc                 = RETURNerror;
@@ -832,15 +831,15 @@ TEST(test_t3592abort, test_pdu_session_release_notify_smf)
       std::pair<amf_ue_ngap_id_t, ue_m5gmm_context_s*>(ue_id, ue_context));
   std::shared_ptr<smf_context_t> smf_ctx =
       amf_insert_smf_context(ue_context, pdu_session_id);
-    smf_ctx->pdu_session_state = ACTIVE;
-    ue_context->mm_state = REGISTERED_CONNECTED;
-    smf_ctx->n_active_pdus=1;
-    EXPECT_NE(ue_context, nullptr);
-    EXPECT_NE(ue_context->amf_context.smf_ctxt_map.size(), 0);
-    rc = t3592_abort_handler(ue_context, smf_ctx, pdu_session_id);
-    EXPECT_TRUE(rc == RETURNok);
-    EXPECT_EQ(ue_context->amf_context.smf_ctxt_map.size(), 0);
-    ue_context_map.clear();
-    delete ue_context;
+  smf_ctx->pdu_session_state = ACTIVE;
+  ue_context->mm_state       = REGISTERED_CONNECTED;
+  smf_ctx->n_active_pdus     = 1;
+  EXPECT_NE(ue_context, nullptr);
+  EXPECT_NE(ue_context->amf_context.smf_ctxt_map.size(), 0);
+  rc = t3592_abort_handler(ue_context, smf_ctx, pdu_session_id);
+  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(ue_context->amf_context.smf_ctxt_map.size(), 0);
+  ue_context_map.clear();
+  delete ue_context;
 }
 }  // namespace magma5g


### PR DESCRIPTION


Signed-off-by: RahulKalsangra <rahul.kalsangra@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The T3592 timer is aborted after maximum "PDU session release command" retry.
And there is no way for the SMF to know what need to be done with the PDU session under consideration.
As the PDU session is already out of the AMF context, it will become a stale one from the SMF perspective as well.
Hence, it need to be intimated to the SMF for removal from it's context.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
ueransim test 
![testpduretry](https://user-images.githubusercontent.com/51331971/146574869-f603401d-1eb4-4748-9b38-c6589729c9ea.png)


packet captured :
![packettimer](https://user-images.githubusercontent.com/51331971/146574947-b23a887c-104f-46e3-8f28-7c28ce816fa3.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
