### PR TITLE
test(mme): Add more test coverage for 3gpp lib folder

### DIFF
--- a/lte/gateway/c/core/oai/common/common_defs.h
+++ b/lte/gateway/c/core/oai/common/common_defs.h
@@ -168,11 +168,11 @@ typedef enum {
     size += sizeof(uint16_t);                                                  \
   } while (0)
 
-// value is 24bits, so most significant 8 bits are all zeros.
+// value is 24bits, so most significant 8 bits should be discarded.
 #define ENCODE_U24(buffer, value, size)                                        \
   do {                                                                         \
-    uint32_t n_value = htonl(value);                                           \
-    n_value          = n_value >> 8;                                           \
+    uint32_t n_value = value << 8;                                             \
+    n_value          = htonl(n_value);                                         \
     memcpy(buffer, (unsigned char*) &n_value, 3);                              \
     size += 3;                                                                 \
   } while (0)

--- a/lte/gateway/c/core/oai/common/common_defs.h
+++ b/lte/gateway/c/core/oai/common/common_defs.h
@@ -130,7 +130,7 @@ typedef enum {
   vALUE = ntohs(vALUE);                                                        \
   sIZE += sizeof(uint16_t)
 
-// vALUE is uint32_t and most significant byte will be zero
+// vALUE is uint32_t; the most significant byte after decoding will be zero
 #define DECODE_U24(bUFFER, vALUE, sIZE)                                        \
   vALUE = 0;                                                                   \
   memcpy((unsigned char*) &vALUE, bUFFER, 3);                                  \
@@ -168,7 +168,7 @@ typedef enum {
     size += sizeof(uint16_t);                                                  \
   } while (0)
 
-// value is 24bits, so most significant 8 bits should be discarded.
+// value is 24bits, so the most significant byte should be discarded.
 #define ENCODE_U24(buffer, value, size)                                        \
   do {                                                                         \
     uint32_t n_value = value << 8;                                             \

--- a/lte/gateway/c/core/oai/common/common_defs.h
+++ b/lte/gateway/c/core/oai/common/common_defs.h
@@ -130,10 +130,13 @@ typedef enum {
   vALUE = ntohs(vALUE);                                                        \
   sIZE += sizeof(uint16_t)
 
+// vALUE is uint32_t and most significant byte will be zero
 #define DECODE_U24(bUFFER, vALUE, sIZE)                                        \
-  memcpy((unsigned char*) &vALUE, bUFFER, sizeof(uint32_t));                   \
-  vALUE = ntohl(vALUE) >> 8;                                                   \
-  sIZE += sizeof(uint8_t) + sizeof(uint16_t)
+  vALUE = 0;                                                                   \
+  memcpy((unsigned char*) &vALUE, bUFFER, 3);                                  \
+  vALUE = ntohl(vALUE);                                                        \
+  vALUE = vALUE >> 8;                                                          \
+  sIZE += 3
 
 #define DECODE_U32(bUFFER, vALUE, sIZE)                                        \
   memcpy((unsigned char*) &vALUE, bUFFER, sizeof(uint32_t));                   \
@@ -165,11 +168,13 @@ typedef enum {
     size += sizeof(uint16_t);                                                  \
   } while (0)
 
+// value is 24bits, so most significant 8 bits are all zeros.
 #define ENCODE_U24(buffer, value, size)                                        \
   do {                                                                         \
     uint32_t n_value = htonl(value);                                           \
-    memcpy(buffer, (unsigned char*) &n_value, sizeof(uint32_t));               \
-    size += sizeof(uint8_t) + sizeof(uint16_t);                                \
+    n_value          = n_value >> 8;                                           \
+    memcpy(buffer, (unsigned char*) &n_value, 3);                              \
+    size += 3;                                                                 \
   } while (0)
 
 #define ENCODE_U32(buffer, value, size)                                        \

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h
@@ -254,6 +254,31 @@ int decode_mobile_identity_ie(
     mobile_identity_t* mobileidentity, const bool iei_present, uint8_t* buffer,
     const uint32_t len);
 
+int decode_imsi_mobile_identity(
+    imsi_mobile_identity_t* imsi, uint8_t* buffer, const uint32_t len);
+int decode_imei_mobile_identity(
+    imei_mobile_identity_t* imei, uint8_t* buffer, const uint32_t len);
+int decode_imeisv_mobile_identity(
+    imeisv_mobile_identity_t* imeisv, uint8_t* buffer, const uint32_t len);
+int decode_tmsi_mobile_identity(
+    tmsi_mobile_identity_t* tmsi, uint8_t* buffer, const uint32_t len);
+int decode_tmgi_mobile_identity(
+    tmgi_mobile_identity_t* tmgi, uint8_t* buffer, const uint32_t len);
+int decode_no_mobile_identity(
+    no_mobile_identity_t* no_id, uint8_t* buffer, const uint32_t len);
+int encode_imsi_mobile_identity(
+    imsi_mobile_identity_t* imsi, uint8_t* buffer, const uint32_t len);
+int encode_imei_mobile_identity(
+    imei_mobile_identity_t* imei, uint8_t* buffer, const uint32_t len);
+int encode_imeisv_mobile_identity(
+    imeisv_mobile_identity_t* imeisv, uint8_t* buffer, const uint32_t len);
+int encode_tmsi_mobile_identity(
+    tmsi_mobile_identity_t* tmsi, uint8_t* buffer, const uint32_t len);
+int encode_tmgi_mobile_identity(
+    tmgi_mobile_identity_t* tmgi, uint8_t* buffer, const uint32_t len);
+int encode_no_mobile_identity(
+    no_mobile_identity_t* no_id, uint8_t* buffer, const uint32_t len);
+
 //------------------------------------------------------------------------------
 // 10.5.1.6 Mobile Station Classmark 2
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_common_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_common_ies.c
@@ -156,34 +156,6 @@ int encode_location_area_identification_ie(
 }
 
 //------------------------------------------------------------------------------
-// 10.5.1.4 Mobile Identity
-//------------------------------------------------------------------------------
-static int decode_imsi_mobile_identity(
-    imsi_mobile_identity_t* imsi, uint8_t* buffer, const uint32_t len);
-static int decode_imei_mobile_identity(
-    imei_mobile_identity_t* imei, uint8_t* buffer, const uint32_t len);
-static int decode_imeisv_mobile_identity(
-    imeisv_mobile_identity_t* imeisv, uint8_t* buffer, const uint32_t len);
-static int decode_tmsi_mobile_identity(
-    tmsi_mobile_identity_t* tmsi, uint8_t* buffer, const uint32_t len);
-static int decode_tmgi_mobile_identity(
-    tmgi_mobile_identity_t* tmgi, uint8_t* buffer, const uint32_t len);
-static int decode_no_mobile_identity(
-    no_mobile_identity_t* no_id, uint8_t* buffer, const uint32_t len);
-static int encode_imsi_mobile_identity(
-    imsi_mobile_identity_t* imsi, uint8_t* buffer, const uint32_t len);
-static int encode_imei_mobile_identity(
-    imei_mobile_identity_t* imei, uint8_t* buffer, const uint32_t len);
-static int encode_imeisv_mobile_identity(
-    imeisv_mobile_identity_t* imeisv, uint8_t* buffer, const uint32_t len);
-static int encode_tmsi_mobile_identity(
-    tmsi_mobile_identity_t* tmsi, uint8_t* buffer, const uint32_t len);
-static int encode_tmgi_mobile_identity(
-    tmgi_mobile_identity_t* tmgi, uint8_t* buffer, const uint32_t len);
-static int encode_no_mobile_identity(
-    no_mobile_identity_t* no_id, uint8_t* buffer, const uint32_t len);
-
-//------------------------------------------------------------------------------
 int decode_mobile_identity_ie(
     mobile_identity_t* mobileidentity, const bool iei_present, uint8_t* buffer,
     const uint32_t len) {
@@ -295,7 +267,7 @@ int encode_mobile_identity_ie(
 }
 
 //------------------------------------------------------------------------------
-static int decode_imsi_mobile_identity(
+int decode_imsi_mobile_identity(
     imsi_mobile_identity_t* imsi, uint8_t* buffer, const uint32_t len) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int decoded   = 0;
@@ -391,7 +363,7 @@ static int decode_imsi_mobile_identity(
 }
 
 //------------------------------------------------------------------------------
-static int decode_imei_mobile_identity(
+int decode_imei_mobile_identity(
     imei_mobile_identity_t* imei, uint8_t* buffer, const uint32_t len) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int decoded = 0;
@@ -442,7 +414,7 @@ static int decode_imei_mobile_identity(
 }
 
 //------------------------------------------------------------------------------
-static int decode_imeisv_mobile_identity(
+int decode_imeisv_mobile_identity(
     imeisv_mobile_identity_t* imeisv, uint8_t* buffer, const uint32_t len) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int decoded = 0;
@@ -496,7 +468,7 @@ static int decode_imeisv_mobile_identity(
 }
 
 //------------------------------------------------------------------------------
-static int decode_tmsi_mobile_identity(
+int decode_tmsi_mobile_identity(
     tmsi_mobile_identity_t* tmsi, uint8_t* buffer, const uint32_t len) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int decoded = 0;
@@ -533,12 +505,12 @@ static int decode_tmsi_mobile_identity(
 }
 
 //------------------------------------------------------------------------------
-static int decode_tmgi_mobile_identity(
+int decode_tmgi_mobile_identity(
     tmgi_mobile_identity_t* tmgi, uint8_t* buffer, const uint32_t len) {
   int decoded = 0;
 
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
-      buffer, MOBILE_IDENTITY_IE_TMGI_LENGTH, len);
+      buffer, MOBILE_IDENTITY_IE_TMGI_LENGTH - 1, len);
   tmgi->spare = (*(buffer + decoded) >> 6) & 0x2;
 
   /*
@@ -558,24 +530,28 @@ static int decode_tmgi_mobile_identity(
   }
 
   decoded++;
-  // IES_DECODE_U24(tmgi->mbmsserviceid, *(buffer + decoded));
+
   IES_DECODE_U24(buffer, decoded, tmgi->mbmsserviceid);
-  tmgi->mccdigit2 = (*(buffer + decoded) >> 4) & 0xf;
-  tmgi->mccdigit1 = *(buffer + decoded) & 0xf;
-  decoded++;
-  tmgi->mncdigit3 = (*(buffer + decoded) >> 4) & 0xf;
-  tmgi->mccdigit3 = *(buffer + decoded) & 0xf;
-  decoded++;
-  tmgi->mncdigit2 = (*(buffer + decoded) >> 4) & 0xf;
-  tmgi->mncdigit1 = *(buffer + decoded) & 0xf;
-  decoded++;
-  tmgi->mbmssessionid = *(buffer + decoded);
-  decoded++;
+  if (tmgi->mccmncindication) {
+    tmgi->mccdigit2 = (*(buffer + decoded) >> 4) & 0xf;
+    tmgi->mccdigit1 = *(buffer + decoded) & 0xf;
+    decoded++;
+    tmgi->mncdigit3 = (*(buffer + decoded) >> 4) & 0xf;
+    tmgi->mccdigit3 = *(buffer + decoded) & 0xf;
+    decoded++;
+    tmgi->mncdigit2 = (*(buffer + decoded) >> 4) & 0xf;
+    tmgi->mncdigit1 = *(buffer + decoded) & 0xf;
+    decoded++;
+  }
+  if (tmgi->mbmssessionidindication) {
+    tmgi->mbmssessionid = *(buffer + decoded);
+    decoded++;
+  }
   return decoded;
 }
 
 //------------------------------------------------------------------------------
-static int decode_no_mobile_identity(
+int decode_no_mobile_identity(
     no_mobile_identity_t* no_id, uint8_t* buffer, const uint32_t len) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int decoded = 0;
@@ -604,7 +580,7 @@ static int decode_no_mobile_identity(
 }
 
 //------------------------------------------------------------------------------
-static int encode_imsi_mobile_identity(
+int encode_imsi_mobile_identity(
     imsi_mobile_identity_t* imsi, uint8_t* buffer, const uint32_t len) {
   uint32_t encoded = 0;
 
@@ -664,7 +640,7 @@ static int encode_imsi_mobile_identity(
 }
 
 //------------------------------------------------------------------------------
-static int encode_imei_mobile_identity(
+int encode_imei_mobile_identity(
     imei_mobile_identity_t* imei, uint8_t* buffer, const uint32_t len) {
   uint32_t encoded = 0;
 
@@ -697,7 +673,7 @@ static int encode_imei_mobile_identity(
 }
 
 //------------------------------------------------------------------------------
-static int encode_imeisv_mobile_identity(
+int encode_imeisv_mobile_identity(
     imeisv_mobile_identity_t* imeisv, uint8_t* buffer, const uint32_t len) {
   uint32_t encoded = 0;
 
@@ -732,7 +708,7 @@ static int encode_imeisv_mobile_identity(
 }
 
 //------------------------------------------------------------------------------
-static int encode_tmsi_mobile_identity(
+int encode_tmsi_mobile_identity(
     tmsi_mobile_identity_t* tmsi, uint8_t* buffer, const uint32_t len) {
   uint32_t encoded = 0;
 
@@ -752,7 +728,7 @@ static int encode_tmsi_mobile_identity(
 }
 
 //------------------------------------------------------------------------------
-static int encode_tmgi_mobile_identity(
+int encode_tmgi_mobile_identity(
     tmgi_mobile_identity_t* tmgi, uint8_t* buffer, const uint32_t len) {
   uint32_t encoded = 0;
 
@@ -764,28 +740,43 @@ static int encode_tmgi_mobile_identity(
                         (tmgi->typeofidentity & 0x7);
   encoded++;
   IES_ENCODE_U24(buffer, encoded, tmgi->mbmsserviceid);
-  *(buffer + encoded) =
-      ((tmgi->mccdigit2 & 0xf) << 4) | (tmgi->mccdigit1 & 0xf);
-  encoded++;
-  *(buffer + encoded) =
-      ((tmgi->mncdigit3 & 0xf) << 4) | (tmgi->mccdigit3 & 0xf);
-  encoded++;
-  *(buffer + encoded) =
-      ((tmgi->mncdigit2 & 0xf) << 4) | (tmgi->mncdigit1 & 0xf);
-  encoded++;
-  *(buffer + encoded) = tmgi->mbmssessionid;
-  encoded++;
+  if (tmgi->mccmncindication) {
+    *(buffer + encoded) =
+        ((tmgi->mccdigit2 & 0xf) << 4) | (tmgi->mccdigit1 & 0xf);
+    encoded++;
+    *(buffer + encoded) =
+        ((tmgi->mncdigit3 & 0xf) << 4) | (tmgi->mccdigit3 & 0xf);
+    encoded++;
+    *(buffer + encoded) =
+        ((tmgi->mncdigit2 & 0xf) << 4) | (tmgi->mncdigit1 & 0xf);
+    encoded++;
+  }
+  if (tmgi->mbmssessionidindication) {
+    *(buffer + encoded) = tmgi->mbmssessionid;
+    encoded++;
+  }
   return encoded;
 }
 
 //------------------------------------------------------------------------------
-static int encode_no_mobile_identity(
+int encode_no_mobile_identity(
     no_mobile_identity_t* no_id, uint8_t* buffer, const uint32_t len) {
   uint32_t encoded = 0;
 
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, 1, len);
-  *(buffer + encoded) = no_id->typeofidentity;
+  *(buffer + encoded) = (no_id->typeofidentity & 0x07) |
+                        ((no_id->oddeven << 3) & 0x0f) |
+                        ((no_id->digit1 << 4) & 0xf0);
   encoded++;
+  if (len > 1) {
+    *(buffer + encoded) = (no_id->digit2 & 0xf) | ((no_id->digit3 << 4) & 0xf0);
+    encoded++;
+    if (len > 2) {
+      *(buffer + encoded) =
+          (no_id->digit4 & 0xf) | ((no_id->digit5 << 4) & 0xf0);
+      encoded++;
+    }
+  }
   return encoded;
 }
 
@@ -906,8 +897,7 @@ int decode_mobile_station_classmark_3_ie(
 int encode_mobile_station_classmark_3_ie(
     mobile_station_classmark3_t* mobilestationclassmark3,
     const bool iei_present, uint8_t* buffer, const uint32_t len) {
-  Fatal("TODO encode_mobile_station_classmark_3_ie");
-  return -1;
+  return TLV_PROTOCOL_NOT_SUPPORTED;
 }
 
 //------------------------------------------------------------------------------
@@ -1051,6 +1041,5 @@ int decode_network_resource_identifier_container_ie(
 int encode_network_resource_identifier_container_ie(
     network_resource_identifier_container_t* networkresourceidentifiercontainer,
     const bool iei_present, uint8_t* buffer, const uint32_t len) {
-  Fatal("TODO encode_network_resource_identifier_container_ie");
-  return -1;
+  return TLV_PROTOCOL_NOT_SUPPORTED;
 }

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_common_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_common_ies.c
@@ -864,20 +864,15 @@ int decode_plmn_list_ie(
   uint8_t i     = 0;
 
   if (iei_present) {
-    CHECK_PDU_POINTER_AND_LENGTH_DECODER(
-        buffer, (plmnlist->num_plmn * 3 + 2), len);
     CHECK_IEI_DECODER(C_PLMN_LIST_IEI, *buffer);
     decoded++;
-  } else {
-    CHECK_PDU_POINTER_AND_LENGTH_DECODER(
-        buffer, (plmnlist->num_plmn * 3 + 1), len);
   }
 
   ielen = *(buffer + decoded);
   decoded++;
   CHECK_LENGTH_DECODER(len - decoded, ielen);
   plmnlist->num_plmn = 0;
-  while (decoded < len) {
+  while (decoded < ielen) {
     plmnlist->plmn[i].mcc_digit2 = (*(buffer + decoded) >> 4) & 0xf;
     plmnlist->plmn[i].mcc_digit1 = *(buffer + decoded) & 0xf;
     decoded++;

--- a/lte/gateway/c/core/oai/test/lib/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/lib/CMakeLists.txt
@@ -20,3 +20,7 @@ link_directories(/usr/src/googletest/googlemock/lib/)
 add_executable(bstr_test test_bstr.cpp)
 target_link_libraries(bstr_test LIB_BSTR gmock_main gtest gtest_main gmock pthread)
 add_test(test_bstr bstr_test)
+
+add_executable(3gpp_test test_3gpp.cpp)
+target_link_libraries(3gpp_test LIB_3GPP gmock_main gtest gtest_main gmock)
+add_test(test_3gpp 3gpp_test)

--- a/lte/gateway/c/core/oai/test/lib/test_3gpp.cpp
+++ b/lte/gateway/c/core/oai/test/lib/test_3gpp.cpp
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h"
+#include "lte/gateway/c/core/oai/common/log.h"
+#include "lte/gateway/c/core/oai/common/common_defs.h"
+#include "lte/gateway/c/core/oai/tasks/nas/ies/MobileIdentity.h"
+}
+
+namespace magma {
+namespace lte {
+
+#define BUFFER_LEN 200
+
+class m3GppTest : public ::testing::Test {
+  virtual void SetUp() {}
+
+  virtual void TearDown() {}
+
+ protected:
+  void initialize_imei() {
+    imei.typeofidentity = MOBILE_IDENTITY_IMEI;
+    imei.oddeven        = MOBILE_IDENTITY_EVEN;
+    imei.cdsd           = 0xf;
+    imei.tac1           = 1;
+    imei.tac2           = 2;
+    imei.tac3           = 7;
+    imei.tac4           = 8;
+    imei.tac5           = 9;
+    imei.tac6           = 4;
+    imei.tac7           = 5;
+    imei.tac8           = 6;
+    imei.snr1           = 3;
+    imei.snr2           = 4;
+    imei.snr3           = 5;
+    imei.snr4           = 0;
+    imei.snr5           = 6;
+    imei.snr6           = 9;
+  }
+
+  void cmp_imei(
+      const imei_mobile_identity_t* imei1,
+      const imei_mobile_identity_t* imei2) {
+    EXPECT_EQ(imei1->typeofidentity, imei2->typeofidentity);
+    EXPECT_EQ(imei1->oddeven, imei2->oddeven);
+    EXPECT_EQ(imei1->tac1, imei2->tac1);
+    EXPECT_EQ(imei1->tac2, imei2->tac2);
+    EXPECT_EQ(imei1->tac3, imei2->tac3);
+    EXPECT_EQ(imei1->tac4, imei2->tac4);
+    EXPECT_EQ(imei1->tac5, imei2->tac5);
+    EXPECT_EQ(imei1->tac6, imei2->tac6);
+    EXPECT_EQ(imei1->tac7, imei2->tac7);
+    EXPECT_EQ(imei1->tac8, imei2->tac8);
+    EXPECT_EQ(imei1->snr1, imei2->snr1);
+    EXPECT_EQ(imei1->snr2, imei2->snr2);
+    EXPECT_EQ(imei1->snr3, imei2->snr3);
+    EXPECT_EQ(imei1->snr4, imei2->snr4);
+    EXPECT_EQ(imei1->snr5, imei2->snr5);
+    EXPECT_EQ(imei1->snr6, imei2->snr6);
+    EXPECT_EQ(imei1->cdsd, imei2->cdsd);
+  }
+
+  void initialize_tmgi() {
+    tmgi.typeofidentity          = MOBILE_IDENTITY_TMGI;
+    tmgi.spare                   = 0;
+    tmgi.mbmssessionidindication = 1;
+    tmgi.mccmncindication        = 1;
+    tmgi.oddeven                 = 1;
+    tmgi.mccdigit1               = 9;
+    tmgi.mccdigit2               = 5;
+    tmgi.mccdigit3               = 3;
+    tmgi.mncdigit1               = 4;
+    tmgi.mncdigit2               = 8;
+    tmgi.mncdigit3               = 7;
+    tmgi.mbmsserviceid           = 657;
+    tmgi.mbmssessionid           = 12;
+  }
+
+  void cmp_tmgi(
+      const tmgi_mobile_identity_t* tmgi1,
+      const tmgi_mobile_identity_t* tmgi2) {
+    EXPECT_EQ(tmgi1->typeofidentity, tmgi2->typeofidentity);
+    EXPECT_EQ(tmgi1->spare, tmgi2->spare);
+    EXPECT_EQ(tmgi1->mbmssessionidindication, tmgi2->mbmssessionidindication);
+    EXPECT_EQ(tmgi1->mbmsserviceid, tmgi2->mbmsserviceid);
+    EXPECT_EQ(tmgi1->mbmssessionid, tmgi2->mbmssessionid);
+    EXPECT_EQ(tmgi1->oddeven, tmgi2->oddeven);
+    EXPECT_EQ(tmgi1->mccdigit1, tmgi2->mccdigit1);
+    EXPECT_EQ(tmgi1->mccdigit2, tmgi2->mccdigit2);
+    EXPECT_EQ(tmgi1->mccdigit3, tmgi2->mccdigit3);
+    EXPECT_EQ(tmgi1->mncdigit1, tmgi2->mncdigit1);
+    EXPECT_EQ(tmgi1->mncdigit2, tmgi2->mncdigit2);
+    EXPECT_EQ(tmgi1->mncdigit3, tmgi2->mncdigit3);
+  }
+
+  imei_mobile_identity_t imei;
+  tmgi_mobile_identity_t tmgi;
+  uint8_t buffer[BUFFER_LEN];
+};
+
+TEST_F(m3GppTest, TestImeiMobileIdentity) {
+  imei_mobile_identity_t imei_decoded = {0};
+  initialize_imei();
+
+  int encoded = encode_imei_mobile_identity(&imei, buffer, BUFFER_LEN);
+  int decoded = decode_imei_mobile_identity(&imei_decoded, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  cmp_imei(&imei, &imei_decoded);
+
+  imei.oddeven = MOBILE_IDENTITY_ODD;
+  imei.cdsd    = 9;
+
+  encoded = encode_imei_mobile_identity(&imei, buffer, BUFFER_LEN);
+  decoded = decode_imei_mobile_identity(&imei_decoded, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  cmp_imei(&imei, &imei_decoded);
+
+  // Test for TLV_VALUE_DOESNT_MATCH
+  imei.typeofidentity = 0;
+  encoded             = encode_imei_mobile_identity(&imei, buffer, BUFFER_LEN);
+  decoded = decode_imei_mobile_identity(&imei_decoded, buffer, encoded);
+
+  EXPECT_EQ(decoded, TLV_VALUE_DOESNT_MATCH);
+
+  // Test for cdsd default decoded to 0x0f then oddeven is set as even.
+  imei.typeofidentity = MOBILE_IDENTITY_IMEI;
+  imei.cdsd           = 1;
+  imei.oddeven        = MOBILE_IDENTITY_EVEN;
+  encoded             = encode_imei_mobile_identity(&imei, buffer, BUFFER_LEN);
+  decoded = decode_imei_mobile_identity(&imei_decoded, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  EXPECT_EQ(imei_decoded.cdsd, 0x0f);
+}
+
+TEST_F(m3GppTest, TestTmgiMobileIdentity) {
+  tmgi_mobile_identity_t tmgi_decoded = {0};
+  initialize_tmgi();
+
+  int encoded = encode_tmgi_mobile_identity(&tmgi, buffer, BUFFER_LEN);
+  int decoded = decode_tmgi_mobile_identity(&tmgi_decoded, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  cmp_tmgi(&tmgi, &tmgi_decoded);
+}
+
+TEST_F(m3GppTest, TestNoMobileIdentity) {
+  no_mobile_identity_t no_id         = {0};
+  no_mobile_identity_t no_id_decoded = {0};
+  no_id.typeofidentity               = MOBILE_IDENTITY_NOT_AVAILABLE;
+  no_id.oddeven                      = 1;
+  no_id.digit1                       = 9;
+  no_id.digit2                       = 0;
+  no_id.digit3                       = 0;
+  no_id.digit4                       = 0;
+  no_id.digit5                       = 0;
+
+  int encoded = encode_no_mobile_identity(
+      &no_id, buffer, MOBILE_IDENTITY_NOT_AVAILABLE_LTE_LENGTH);
+  int decoded = decode_no_mobile_identity(&no_id_decoded, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  EXPECT_EQ(no_id.typeofidentity, no_id_decoded.typeofidentity);
+  EXPECT_EQ(no_id.oddeven, no_id_decoded.oddeven);
+  EXPECT_EQ(no_id.digit1, no_id_decoded.digit1);
+  EXPECT_TRUE(!memcmp(&no_id, &no_id_decoded, sizeof(no_mobile_identity_t)));
+}
+
+}  // namespace lte
+}  // namespace magma
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  OAILOG_INIT("MME", OAILOG_LEVEL_DEBUG, MAX_LOG_PROTOS);
+  return RUN_ALL_TESTS();
+}

--- a/lte/gateway/c/core/oai/test/lib/test_3gpp.cpp
+++ b/lte/gateway/c/core/oai/test/lib/test_3gpp.cpp
@@ -157,7 +157,7 @@ class m3GppTest : public ::testing::Test {
 };
 
 TEST_F(m3GppTest, TestImeiMobileIdentity) {
-  imei_mobile_identity_t imei_decoded = {0};
+  imei_mobile_identity_t imei_decoded;
   initialize_imei();
 
   int encoded = encode_imei_mobile_identity(&imei, buffer, BUFFER_LEN);
@@ -205,15 +205,15 @@ TEST_F(m3GppTest, TestTmgiMobileIdentity) {
 }
 
 TEST_F(m3GppTest, TestNoMobileIdentity) {
-  no_mobile_identity_t no_id         = {0};
-  no_mobile_identity_t no_id_decoded = {0};
-  no_id.typeofidentity               = MOBILE_IDENTITY_NOT_AVAILABLE;
-  no_id.oddeven                      = 1;
-  no_id.digit1                       = 9;
-  no_id.digit2                       = 0;
-  no_id.digit3                       = 0;
-  no_id.digit4                       = 0;
-  no_id.digit5                       = 0;
+  no_mobile_identity_t no_id = {0};
+  no_mobile_identity_t no_id_decoded;
+  no_id.typeofidentity = MOBILE_IDENTITY_NOT_AVAILABLE;
+  no_id.oddeven        = 1;
+  no_id.digit1         = 9;
+  no_id.digit2         = 0;
+  no_id.digit3         = 0;
+  no_id.digit4         = 0;
+  no_id.digit5         = 0;
 
   int encoded = encode_no_mobile_identity(
       &no_id, buffer, MOBILE_IDENTITY_NOT_AVAILABLE_LTE_LENGTH);
@@ -231,7 +231,7 @@ TEST_F(m3GppTest, TestNoMobileIdentity) {
 }
 
 TEST_F(m3GppTest, TestImsiMobileIdentity) {
-  imsi_mobile_identity_t imsi_decoded = {0};
+  imsi_mobile_identity_t imsi_decoded;
   initialize_imsi();
 
   int encoded = encode_imsi_mobile_identity(&imsi, buffer, BUFFER_LEN);
@@ -249,8 +249,8 @@ TEST_F(m3GppTest, TestImsiMobileIdentity) {
 }
 
 TEST_F(m3GppTest, TestMobileStationClassmark2) {
-  mobile_station_classmark2_t msclassmark2         = {0};
-  mobile_station_classmark2_t msclassmark2_decoded = {0};
+  mobile_station_classmark2_t msclassmark2 = {0};
+  mobile_station_classmark2_t msclassmark2_decoded;
 
   msclassmark2.revisionlevel     = 3;
   msclassmark2.esind             = 1;
@@ -269,6 +269,7 @@ TEST_F(m3GppTest, TestMobileStationClassmark2) {
   msclassmark2.cmsp              = 1;
   msclassmark2.a52               = 1;
   msclassmark2.a53               = 1;
+
   // With iei present
   int encoded = encode_mobile_station_classmark_2_ie(
       &msclassmark2, true, buffer, BUFFER_LEN);
@@ -287,6 +288,41 @@ TEST_F(m3GppTest, TestMobileStationClassmark2) {
   EXPECT_TRUE(!(memcmp(
       (const void*) &msclassmark2, (const void*) &msclassmark2_decoded,
       sizeof(mobile_station_classmark2_t))));
+}
+
+TEST_F(m3GppTest, TestPlmnList) {
+  plmn_list_t plmn_list;
+  plmn_list_t plmn_list_decoded;
+
+  plmn_list.num_plmn = PLMN_LIST_IE_MAX_PLMN;
+  for (int i = 0; i < PLMN_LIST_IE_MAX_PLMN; ++i) {
+    plmn_list.plmn[i].mcc_digit1 = 7;
+    plmn_list.plmn[i].mcc_digit2 = 4;
+    plmn_list.plmn[i].mcc_digit3 = 3;
+    plmn_list.plmn[i].mnc_digit1 = 8;
+    plmn_list.plmn[i].mnc_digit2 = 1;
+    plmn_list.plmn[i].mnc_digit3 = 6;
+  }
+
+  // With iei present
+  int encoded = encode_plmn_list_ie(&plmn_list, true, buffer, BUFFER_LEN);
+  int decoded = decode_plmn_list_ie(&plmn_list_decoded, true, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  EXPECT_EQ(plmn_list.num_plmn, plmn_list_decoded.num_plmn);
+  EXPECT_TRUE(!(memcmp(
+      (const void*) &plmn_list, (const void*) &plmn_list_decoded,
+      sizeof(plmn_list_t))));
+
+  // Without iei present
+  encoded = encode_plmn_list_ie(&plmn_list, false, buffer, BUFFER_LEN);
+  decoded = decode_plmn_list_ie(&plmn_list_decoded, false, buffer, encoded);
+
+  EXPECT_EQ(encoded, decoded);
+  EXPECT_EQ(plmn_list.num_plmn, plmn_list_decoded.num_plmn);
+  EXPECT_TRUE(!(memcmp(
+      (const void*) &plmn_list, (const void*) &plmn_list_decoded,
+      sizeof(plmn_list_t))));
 }
 
 }  // namespace lte

--- a/lte/gateway/c/core/oai/test/lib/test_3gpp.cpp
+++ b/lte/gateway/c/core/oai/test/lib/test_3gpp.cpp
@@ -84,7 +84,7 @@ class m3GppTest : public ::testing::Test {
     tmgi.mncdigit1               = 4;
     tmgi.mncdigit2               = 8;
     tmgi.mncdigit3               = 7;
-    tmgi.mbmsserviceid           = 657;
+    tmgi.mbmsserviceid           = 0xCADB85;
     tmgi.mbmssessionid           = 12;
   }
 


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Added more test coverage for IE encoding/decoding functions that are not covered via existing tests.
- Fix few bugs in the process.
  - DECODE_U24 and ENCODE_U24 did not properly manipulate uint32_t sized integer.
  - IMSI decoding was not properly using oddeven flag. Instead of just using it for the last octet, it was used for each octet for the IMSI digit pairs. IMSI encoding had the same issue during encoding.
  - TMGI decoding was not using the presence flags properly.
  - plmn_list decoding logic was incorrect.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
`make test_oai` on magma vm.
S1AP tester.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
