### PR TITLE
chore: update SSL related dependencies to be taken from the system

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -92,6 +92,15 @@ load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
 rules_cc_dependencies()
 
 ### PROTO / GRPC DEPENDENCIES ###
+# boringssl is pulled in as GRPC's SSL library if we don't specify it here manually
+# we want to opt to use the system SSL library for now. This will make it easier to make sure
+# all SSL references across our multiple external dependencies are consistent. (GRPC and Sentry, for example)
+new_local_repository(
+    name = "boringssl",
+    build_file = "//bazel/external:system_ssl.BUILD",
+    path = "/",
+)
+
 protobuf()
 
 load("@protobuf//:protobuf_deps.bzl", "protobuf_deps")

--- a/bazel/external/system_ssl.BUILD
+++ b/bazel/external/system_ssl.BUILD
@@ -1,0 +1,27 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "crypto",
+    linkopts = ["-lcrypto"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ssl",
+    linkopts = ["-lssl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":crypto",
+    ],
+)

--- a/cwf/gateway/docker/c/Dockerfile
+++ b/cwf/gateway/docker/c/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get -y update && apt-get -y install \
   gcc \
   g++ \
   build-essential \
+  libssl-dev \
   # folly deps
   libfolly-dev \
   libgoogle-glog-dev \


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This change makes it so that we use the system SSL library instead of pulling in boringssl (Google's implementation).

This is a workaround for now as one of Sentry's dependency (libcurl/ssl) can crash if the underlying 
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
