### PR TITLE
fix(orc8r): Log entries created from user input

### DIFF
--- a/orc8r/cloud/go/obsidian/handler.go
+++ b/orc8r/cloud/go/obsidian/handler.go
@@ -16,8 +16,10 @@ package obsidian
 import (
 	"crypto/x509"
 	"fmt"
+	"html"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/labstack/echo"
@@ -227,7 +229,16 @@ func GetNetworkId(c echo.Context) (string, *echo.HTTPError) {
 	if nid == "" {
 		return nid, NetworkIdHttpErr()
 	}
-	return nid, CheckNetworkAccess(c, nid)
+	sanNid := sanitizeString(nid)
+	return sanNid, CheckNetworkAccess(c, sanNid)
+}
+
+func sanitizeString(strString string) string {
+	strSanitizedString := html.EscapeString(strString)                    //escape special charatchters in HTML text
+	strSanitizedString = strings.ReplaceAll(strSanitizedString, "\r", "") //remove line breaks
+	strSanitizedString = strings.ReplaceAll(strSanitizedString, "\n", "")
+	strSanitizedString = strings.Join(strings.Fields(strSanitizedString), " ") //remove extra whitespace
+	return strSanitizedString
 }
 
 func GetTenantID(c echo.Context) (int64, *echo.HTTPError) {


### PR DESCRIPTION
fix(orc8r): Log entries created from user input

## Summary

Added function for string sanitizing before it is written to a log entry.
function works as follows:
it escape special characters in HTML text,
it remove line breaks,
it remove extra whitespace


## Test Plan
ran /magma/orc8r/cloud/docker/  ./build.py -c

## Additional Information
This is for alert: https://github.com/magma/magma/security/code-scanning/39?query=ref%3Arefs%2Fheads%2Fmaster
