### PR TITLE
chore: make SessionD unit tests runnable with Clang

### DIFF
--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -980,22 +980,10 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
       session_store->get_default_session_update(session_map_2);
   EXPECT_EQ(session_map_2[IMSI1].size(), 1);
 
-  RuleLifetime lifetime1 = {
-      .activation_time = std::time_t(0),
-      .deactivation_time = std::time_t(5),
-  };
-  RuleLifetime lifetime2 = {
-      .activation_time = std::time_t(5),
-      .deactivation_time = std::time_t(10),
-  };
-  RuleLifetime lifetime3 = {
-      .activation_time = std::time_t(10),
-      .deactivation_time = std::time_t(15),
-  };
-  RuleLifetime lifetime4 = {
-      .activation_time = std::time_t(15),
-      .deactivation_time = std::time_t(20),
-  };
+  RuleLifetime lifetime1(std::time_t(0), std::time_t(5));
+  RuleLifetime lifetime2(std::time_t(5), std::time_t(10));
+  RuleLifetime lifetime3(std::time_t(10), std::time_t(15));
+  RuleLifetime lifetime4(std::time_t(15), std::time_t(20));
   auto& uc = session_update[IMSI1][SESSION_ID_1];
   uint32_t v1 = session_map_2[IMSI1]
                     .front()
@@ -3473,4 +3461,4 @@ int main(int argc, char** argv) {
   return RUN_ALL_TESTS();
 }
 
-}  // namespace magma
+};  // namespace magma


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I have an unrelated work where I'm trying to test out toolchain configurations for Bazel. For testing I wanted to make sure I can go back and forth between building with clang and gcc/g++ easily, but it turns out sessiond unit tests on master cannot be run with clang due to simple compilaiton errors. 

Ex
```
/workspaces/magma/lte/gateway/c/session_manager/Types.h:159:12: note: candidate constructor not viable: requires single argument 'rule_install', but 2 arguments were provided
  explicit RuleLifetime(const DynamicRuleInstall& rule_install);
           ^
/workspaces/magma/lte/gateway/c/session_manager/Types.h:152:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
struct RuleLifetime {
       ^
/workspaces/magma/lte/gateway/c/session_manager/Types.h:152:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided
/workspaces/magma/lte/gateway/c/session_manager/Types.h:155:3: note: candidate constructor not viable: requires 0 arguments, but 2 were provided
  RuleLifetime() : activation_time(0), deactivation_time(0) {}
  ^
/workspaces/magma/lte/gateway/c/session_manager/test/test_local_enforcer.cpp:995:16: error: no matching constructor for initialization of 'magma::RuleLifetime'
  RuleLifetime lifetime4 = {
               ^           ~
/workspaces/magma/lte/gateway/c/session_manager/Types.h:156:3: note: candidate constructor not viable: cannot convert argument of incomplete type 'void' to 'const time_t' (aka 'const long') for 1st argument
  RuleLifetime(const time_t activation, const time_t deactivation)
  ^
/workspaces/magma/lte/gateway/c/session_manager/Types.h:158:12: note: candidate constructor not viable: requires single argument 'rule_install', but 2 arguments were provided
  explicit RuleLifetime(const StaticRuleInstall& rule_install);
           ^
/workspaces/magma/lte/gateway/c/session_manager/Types.h:159:12: note: candidate constructor not viable: requires single argument 'rule_install', but 2 arguments were provided
  explicit RuleLifetime(const DynamicRuleInstall& rule_install);
           ^
/workspaces/magma/lte/gateway/c/session_manager/Types.h:152:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
struct RuleLifetime {
       ^
/workspaces/magma/lte/gateway/c/session_manager/Types.h:152:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided
/workspaces/magma/lte/gateway/c/session_manager/Types.h:155:3: note: candidate constructor not viable: requires 0 arguments, but 2 were provided
  RuleLifetime() : activation_time(0), deactivation_time(0) {}
  ^
In file included from /workspaces/magma/lte/gateway/c/session_manager/test/test_local_enforcer.cpp:13:
```

This PR addresses those errors so that they can be run with clang.

To repro, patch the lte/gateway/Make file with the following
```
diff --git a/lte/gateway/Makefile b/lte/gateway/Makefile
index beb4f3843..73f75f76c 100644
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -143,7 +143,7 @@ endef
 
 # run_ctest BUILD_DIRECTORY, TEST_BUILD_DIRECTORY, FILE_DIRECTORY, FLAGS, LIST OF TESTS
 define run_ctest
-$(call run_cmake, $(1), $(3), $(4) $(TEST_FLAG))
+$(call run_cmake, $(1), $(3), $(4) $(TEST_FLAG), CC="clang" CXX="clang++")
 cd $(2) && ctest --output-on-failure -R $(5)
 endef
```
and then run `make test_session_manager`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI and the clang run both pass
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
