### PR TITLE
feat(mme): Add Attach/Detach events

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_events.h
+++ b/lte/gateway/c/core/oai/include/mme_events.h
@@ -29,19 +29,179 @@ extern "C" {
 void event_client_init(void);
 
 /**
- * Logs Attach successful event
+ * Fire event for having received an AttachRequest message
+ *
  * @param imsi
+ * @param guti
+ * @param mme_id
+ * @param enb_id
+ * @param enb_ip
+ * @param apn
  * @return response code
  */
-int attach_success_event(imsi64_t imsi64);
+int attach_request_event(
+    imsi64_t imsi64, const guti_t guti, const char* imei, const char* mme_id,
+    const char* enb_id, const char* enb_ip, const char* apn);
 
 /**
- * Logs Detach successful event
+ * Fire event for having sent an AttachAccept message
+ *
+ * @param imsi
+ * @param guti
+ * @param mme_id
+ * @param enb_id
+ * @param enb_ip
+ * @param apn
+
+ * @return response code
+ */
+int attach_accept_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn);
+
+/**
+ * Fire event for having sent an AttachReject message
+ *
+ * @param imsi
+ * @param guti
+ * @param mme_id
+ * @param enb_id
+ * @param enb_ip
+ * @param apn
+ * @param cause
+ * @return response code
+ */
+int attach_reject_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* cause);
+
+/**
+ * Fire event for having received an AttachComplete message
+ *
+ * @param imsi
+ * @param guti
+ * @param mme_id
+ * @param enb_id
+ * @param enb_ip
+ * @param apn
+ * @return response code
+ */
+int attach_complete_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn);
+
+/**
+ * Fire event for successfully processing an AttachComplete message.
+ * Only fires if a new UE is successfully attached after processing the
+ * AttachComplete.
+ * If a duplicate AttachComplete was processed for example, and no new UE
+ * was attached, then this event should not be fired.
+ *
+ * @param imsi
+ * @param guti
+ * @param mme_id
+ * @param enb_id
+ * @param enb_ip
+ * @param apn
+ * @return response code
+ */
+int attach_success_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn);
+
+/**
+ * Fire event for when an Attach failure occurs.
+ * This should be called, for example, when an AttachRequest was received,
+ * but neither an AttachAccept or AttachReject was sent back to the UE.
+ * Or, if an AttachComplete was received, but the MME was unable to finish
+ * the Attach process.
+ *
+ * @param imsi
+ * @param guti
+ * @param mme_id
+ * @param enb_id
+ * @param enb_ip
+ * @param apn
+ * @param cause
+ * @return response code
+ */
+int attach_failure_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* cause);
+
+/**
+ * Fire event to record a DetachRequest message being sent/received
+ *
+ * @param imsi
+ * @param guti
+ * @param mme_id
+ * @param enb_id
+ * @param enb_ip
+ * @param apn
+ * @param source
+ * @return response code
+ */
+int detach_request_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* source);
+
+/**
+ * Fire event to record a DetachAccept message being sent/received
+ *
+ * @param imsi
+ * @param guti
+ * @param mme_id
+ * @param enb_id
+ * @param enb_ip
+ * @param apn
+ * @param source
+ * @return response code
+ */
+int detach_accept_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* source);
+
+/**
+ * Fire event for when an implicit Detach has occurred
+ *
+ * @param imsi
+ * @param guti
+ * @param mme_id
+ * @param enb_id
+ * @param enb_ip
+ * @param apn
+ * @return response code
+ */
+int detach_implicit_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn);
+
+/**
+ * Fire event for a successful Detach
+ *
  * @param imsi
  * @param action Indicates whether explicit detach accept action was sent to UE
  * @return response code
  */
-int detach_success_event(imsi64_t imsi64, const char* action);
+int detach_success_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* action);
+
+/**
+ * Fire event for a failed Detach
+ *
+ * @param imsi
+ * @param guti
+ * @param mme_id
+ * @param enb_id
+ * @param enb_ip
+ * @param apn
+ * @param cause
+ * @return response code
+ */
+int detach_failure_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* cause);
 
 /**
  * Logs s1 setup success event

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_events.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_events.cpp
@@ -40,8 +40,17 @@ using magma::orc8r::Void;
 
 namespace {
 constexpr char MME_STREAM_NAME[]  = "mme";
+constexpr char ATTACH_REQUEST[]   = "attach_request";
+constexpr char ATTACH_ACCEPT[]    = "attach_accept";
+constexpr char ATTACH_REJECT[]    = "attach_reject";
+constexpr char ATTACH_COMPLETE[]  = "attach_complete";
 constexpr char ATTACH_SUCCESS[]   = "attach_success";
+constexpr char ATTACH_FAILURE[]   = "attach_failure";
+constexpr char DETACH_REQUEST[]   = "detach_request";
+constexpr char DETACH_ACCEPT[]    = "detach_accept";
+constexpr char DETACH_IMPLICIT[]  = "detach_implicit";
 constexpr char DETACH_SUCCESS[]   = "detach_success";
+constexpr char DETACH_FAILURE[]   = "detach_failure";
 constexpr char S1_SETUP_SUCCESS[] = "s1_setup_success";
 }  // namespace
 
@@ -70,25 +79,197 @@ static int report_event(
   return log_event(event_request);
 }
 
-int attach_success_event(imsi64_t imsi64) {
+int attach_request_event(
+    imsi64_t imsi64, const guti_t guti, const char* imei, const char* mme_id,
+    const char* enb_id, const char* enb_ip, const char* apn) {
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
   IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
 
   folly::dynamic event_value = folly::dynamic::object;
   event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";  // TODO(andreilee): Fix this
+  event_value["imei"]        = imei;
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
+
+  return report_event(event_value, ATTACH_REQUEST, MME_STREAM_NAME, imsi_str);
+}
+
+int attach_accept_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn) {
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
+
+  return report_event(event_value, ATTACH_ACCEPT, MME_STREAM_NAME, imsi_str);
+}
+
+int attach_reject_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* cause) {
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
+  event_value["cause"]       = cause;
+
+  return report_event(event_value, ATTACH_REJECT, MME_STREAM_NAME, imsi_str);
+}
+
+int attach_complete_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn) {
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
+
+  return report_event(event_value, ATTACH_COMPLETE, MME_STREAM_NAME, imsi_str);
+}
+
+int attach_success_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn) {
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
 
   return report_event(event_value, ATTACH_SUCCESS, MME_STREAM_NAME, imsi_str);
 }
 
-int detach_success_event(imsi64_t imsi64, const char* action) {
+int attach_failure_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* cause, const char* apn) {
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
   IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
 
   folly::dynamic event_value = folly::dynamic::object;
   event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
+
+  return report_event(event_value, ATTACH_FAILURE, MME_STREAM_NAME, imsi_str);
+}
+
+int detach_request_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* source) {
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
+  event_value["source"]      = source;
+
+  return report_event(event_value, DETACH_REQUEST, MME_STREAM_NAME, imsi_str);
+}
+
+int detach_accept_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* source) {
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
+  event_value["source"]      = source;
+
+  return report_event(event_value, DETACH_ACCEPT, MME_STREAM_NAME, imsi_str);
+}
+
+int detach_implicit_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn) {
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
+
+  return report_event(event_value, DETACH_IMPLICIT, MME_STREAM_NAME, imsi_str);
+}
+
+int detach_success_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* action) {
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
   event_value["action"]      = action;
 
   return report_event(event_value, DETACH_SUCCESS, MME_STREAM_NAME, imsi_str);
+}
+
+int detach_failure_event(
+    imsi64_t imsi64, const guti_t guti, const char* mme_id, const char* enb_id,
+    const char* enb_ip, const char* apn, const char* cause) {
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+  event_value["guti"]        = "guti";
+  event_value["mme_id"]      = mme_id;
+  event_value["enb_id"]      = enb_id;
+  event_value["enb_ip"]      = enb_ip;
+  event_value["apn"]         = apn;
+  event_value["cause"]       = cause;
+
+  return report_event(event_value, DETACH_FAILURE, MME_STREAM_NAME, imsi_str);
 }
 
 int s1_setup_success_event(const char* enb_name, uint32_t enb_id) {

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
@@ -462,6 +462,7 @@ static int emm_as_recv(
         OAILOG_FUNC_RETURN(LOG_NAS_EMM, decoder_rc);
       }
 
+      // TODO(andreilee): Probably don't want to fire AttachComplete event here
       rc = emm_recv_attach_complete(
           ue_id, &emm_msg->attach_complete, emm_cause, decode_status);
       bdestroy((bstring)(emm_msg->attach_complete.esmmessagecontainer));

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
@@ -30,6 +30,7 @@
 #include "lte/gateway/c/core/oai/tasks/nas/emm/msg/emm_cause.h"
 #include "lte/gateway/c/core/oai/tasks/nas/emm/emm_proc.h"
 #include "lte/gateway/c/core/oai/include/3gpp_requirements_24.301.h"
+//#include "lte/gateway/c/core/oai/include/mme_events.h"
 #include "lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_sap.h"
 #include "orc8r/gateway/c/common/service303/includes/MetricsHelpers.h"
 #include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_itti_messaging.h"
@@ -510,6 +511,15 @@ status_code_e emm_recv_attach_complete(
       "EMMAS-SAP - Received Attach Complete message for ue_id "
       "= " MME_UE_S1AP_ID_FMT "\n",
       ue_id);
+  //  // Fire event when receiving AttachComplete
+  //  ue_mm_context_t* ue_mm_context = NULL;
+  //  ue_mm_context = mme_ue_context_exists_mme_ue_s1ap_id(ue_id);
+  //  if (ue_mm_context) {
+  //    imsi64_t imsi64 = ue_mm_context->emm_context._imsi64;
+  //    guti_t guti = ue_mm_context->emm_context._guti;
+  //    attach_complete_event(imsi64, guti, "", "", "", "");
+  //  }
+
   /*
    * Execute the attach procedure completion
    */
@@ -537,6 +547,8 @@ status_code_e emm_recv_detach_request(
     mme_ue_s1ap_id_t ue_id, const detach_request_msg* msg,
     const bool is_initial, int* emm_cause,
     const nas_message_decode_status_t* status) {
+  //  ue_mm_context_t* ue_mm_context = NULL;
+  //  struct emm_context_s* ctx    = NULL;
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNok;
 
@@ -579,6 +591,14 @@ status_code_e emm_recv_detach_request(
    * Execute the UE initiated detach procedure completion by the network
    */
   increment_counter("ue_detach", 1, 1, "cause", "ue_initiated");
+  //  ue_mm_context = mme_ue_context_exists_mme_ue_s1ap_id(ue_id);
+  //  if (ue_mm_context) {
+  //    ctx = &ue_mm_context->emm_context;
+  //    if (ctx) {
+  //      detach_request_event(ctx->_imsi64, ctx->_guti, "", "", "", "", "UE");
+  //    }
+  //  }
+
   // Send the SGS Detach indication towards MME App
   rc = emm_proc_sgs_detach_request(ue_id, params.type);
   if (rc != RETURNerror) {
@@ -1266,9 +1286,23 @@ status_code_e emm_recv_security_mode_reject(
 status_code_e emm_recv_detach_accept(mme_ue_s1ap_id_t ue_id, int* emm_cause) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   int rc = RETURNok;
+  //  ue_mm_context_t* ue_mm_context = NULL;
+  //  struct emm_context_s* ctx    = NULL;
 
   OAILOG_INFO(LOG_NAS_EMM, "EMMAS-SAP - Received Detach Accept  message\n");
-  rc         = emm_proc_detach_accept(ue_id);
+  //  ue_mm_context = mme_ue_context_exists_mme_ue_s1ap_id(ue_id);
+  //  if (ue_mm_context) {
+  //    ctx = &ue_mm_context->emm_context;
+  //    if (ctx) {
+  //      detach_accept_event(ctx->_imsi64, ctx->_guti, "", "", "", "", "UE");
+  //    }
+  //  }
+  rc = emm_proc_detach_accept(ue_id);
+  //  if (ctx) {
+  //      detach_success_event(
+  //          ctx->_imsi64, ctx->_guti, "", "", "", "",
+  //          "detach_accept_not_sent");
+  //  }
   *emm_cause = RETURNok == rc ? EMM_CAUSE_SUCCESS : EMM_CAUSE_PROTOCOL_ERROR;
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }

--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -51,7 +51,34 @@ event_registry:
   disconnected_sync_rpc_stream:
     module: orc8r
     filename: magmad_events.v1.yml
+  attach_request:
+    module: lte
+    filename: mme_events.v1.yml
+  attach_accept:
+    module: lte
+    filename: mme_events.v1.yml
+  attach_reject:
+    module: lte
+    filename: mme_events.v1.yml
+  attach_complete:
+    module: lte
+    filename: mme_events.v1.yml
   attach_success:
+    module: lte
+    filename: mme_events.v1.yml
+  attach_failure:
+    module: lte
+    filename: mme_events.v1.yml
+  detach_request:
+    module: lte
+    filename: mme_events.v1.yml
+  detach_accept:
+    module: lte
+    filename: mme_events.v1.yml
+  detach_implicit:
+    module: lte
+    filename: mme_events.v1.yml
+  detach_failure:
     module: lte
     filename: mme_events.v1.yml
   detach_success:

--- a/lte/swagger/mme_events.v1.yml
+++ b/lte/swagger/mme_events.v1.yml
@@ -8,20 +8,378 @@ info:
   version: 1.0.0
 
 definitions:
+  attach_request:
+    type: object
+    description: |
+     Indicates that an AttachRequest message has been received
+    properties:
+      imsi:
+        type: string
+      guti:
+        type: string
+      imei:
+        type string
+      mme_id:
+        type: string
+      enb_id:
+        type: string
+      enb_ip:
+        type: string
+      apn:
+        type: string
+  attach_accept:
+    type: object
+    description: |
+      Indicates that the MME has sent an AttachAccept message
+    properties:
+      imsi:
+        type: string
+      guti:
+        type: string
+      mme_id:
+        type: string
+      enb_id:
+        type: string
+      enb_ip:
+        type: string
+      apn:
+        type: string
+  attach_complete:
+    type: object
+    description: |
+      Indicates that an AttachComplete message has been received by the MME.
+      Whether or not the MME has successfully handled the AttachComplete
+      does not affect whether this event fires.
+    properties:
+      imsi:
+        type: string
+      guti:
+        type: string
+      mme_id:
+        type: string
+      enb_id:
+        type: string
+      enb_ip:
+        type: string
+      apn:
+        type: string
   attach_success:
     type: object
-    description: Used to track when UE attaches successfully
+    description: |
+      Indicates that a UE has attached successfully.
+      Fires when the AttachComplete message sent by the UE has been
+      successfully handled by the Magma MME service.
     properties:
       imsi:
         type: string
+      guti:
+        type: string
+      mme_id:
+        type: string
+      enb_id:
+        type: string
+      enb_ip:
+        type: string
+      apn:
+        type: string
+  attach_reject:
+    type: object
+    description: |
+      Indicates that a UE AttachRequest was rejected.
+      Fires when Magma MME service sends an AttachReject message to the UE.
+    properties:
+      imsi:
+        description: |
+          International Mobile Subscriber Identity
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the IMSI is not present, a GUTI will be provided.
+        type: string
+        x-nullable: true
+      guti:
+        description: |
+          Globally Unique Temporary Identifier
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the GUTI is not present, the IMSI will be provided.
+        type: string
+        x-nullable: true
+      mme_id:
+        type: string
+        x-nullable: true
+      enb_id:
+        description: ID of eNodeB through which the Attach request was received
+        type: integer
+        x-nullable: false
+      enb_ip:
+        description: IP of eNodeB through which the Attach request was received
+        type: string
+        x-nullable: true
+      apn:
+        description: Access Point Name
+        type: string
+        x-nullable: true
+        example: "inet"
+      cause:
+        description: Cause of attach rejection
+        type: string
+        x-nullable: false
+  attach_failure:
+    type: object
+    description: |
+      Indicates that the Attach procedure failed within the Magma MME.
+      Fires when Magma MME service failed to handle an AttachRequest.
+    properties:
+      imsi:
+        description: |
+          International Mobile Subscriber Identity
+          This is used to identify the UE for which the attach failure belongs to.
+          If the IMSI is not present, a GUTI will be provided.
+        type: string
+        x-nullable: true
+      guti:
+        description: |
+          Globally Unique Temporary Identifier
+          This is used to identify the UE for which the attach failure belongs to.
+          If the GUTI is not present, the IMSI will be provided.
+        type: string
+        x-nullable: true
+      mme_id:
+        type: string
+        x-nullable: true
+      enb_id:
+        description: ID of eNodeB through which the Attach request was received
+        type: integer
+        x-nullable: false
+      enb_ip:
+        description: IP of eNodeB through which the Attach request was received
+        type: string
+        x-nullable: true
+      apn:
+        description: Access Point Name
+        type: string
+        x-nullable: true
+        example: "inet"
+      cause:
+        description: Cause of attach failure
+        type: string
+        x-nullable: false
+  detach_request:
+    type: object
+    description: |
+      Indicates that a DetachRequest message was either sent or received.
+      This can be for a UE, MME, or HSS initiated DetachRequest.
+      See the property named source.
+    properties:
+      imsi:
+        description: |
+          International Mobile Subscriber Identity
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the IMSI is not present, a GUTI will be provided.
+        type: string
+        x-nullable: true
+      guti:
+        description: |
+          Globally Unique Temporary Identifier
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the GUTI is not present, the IMSI will be provided.
+        type: string
+        x-nullable: true
+      mme_id:
+        type: string
+        x-nullable: true
+      enb_id:
+        description: ID of eNodeB through which the Attach request was received
+        type: integer
+        x-nullable: false
+      enb_ip:
+        description: IP of eNodeB through which the Attach request was received
+        type: string
+        x-nullable: true
+      apn:
+        description: Access Point Name
+        type: string
+        x-nullable: true
+        example: "inet"
+      source:
+        description: >
+          DetachAccept Message Source:
+           * UE  - This event records when the DetachAccept has been received
+                   by the MME. This does not guarantee that the detach will
+                   succeed, or that it has already succeeded.
+           * MME - This event records when the DetachAccept has been sent by
+                   the MME. This does not guarantee that the UE has received
+                   the DetachAccept.
+        type: string
+        x-nullable: true
+        enum:
+          - UE
+          - MME
+  detach_accept:
+    type: object
+    description: |
+      Indicates that a DetachAccept message was either sent or received.
+      This can be for either a UE or MME initiated DetachRequest.
+      See the property named source.
+    properties:
+      imsi:
+        description: |
+          International Mobile Subscriber Identity
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the IMSI is not present, a GUTI will be provided.
+        type: string
+        x-nullable: true
+      guti:
+        description: |
+          Globally Unique Temporary Identifier
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the GUTI is not present, the IMSI will be provided.
+        type: string
+        x-nullable: true
+      mme_id:
+        type: string
+        x-nullable: true
+      enb_id:
+        description: ID of eNodeB through which the Attach request was received
+        type: integer
+        x-nullable: false
+      enb_ip:
+        description: IP of eNodeB through which the Attach request was received
+        type: string
+        x-nullable: true
+      apn:
+        description: Access Point Name
+        type: string
+        x-nullable: true
+        example: "inet"
+      source:
+        description: >
+          DetachAccept Message Source:
+           * UE  - This event records when the DetachAccept has been received
+                   by the MME. This does not guarantee that the detach will
+                   succeed, or that it has already succeeded.
+           * MME - This event records when the DetachAccept has been sent by
+                   the MME. This does not guarantee that the UE has received
+                   the DetachAccept.
+        type: string
+        x-nullable: true
+        enum:
+          - UE
+          - MME
+  detach_implicit:
+    type: object
+    description: |
+      Indicates that an implicit detach has occurred for a UE
+    properties:
+      imsi:
+        description: |
+          International Mobile Subscriber Identity
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the IMSI is not present, a GUTI will be provided.
+        type: string
+        x-nullable: true
+      guti:
+        description: |
+          Globally Unique Temporary Identifier
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the GUTI is not present, the IMSI will be provided.
+        type: string
+        x-nullable: true
+      mme_id:
+        type: string
+        x-nullable: true
+      enb_id:
+        description: ID of eNodeB through which the Attach request was received
+        type: integer
+        x-nullable: false
+      enb_ip:
+        description: IP of eNodeB through which the Attach request was received
+        type: string
+        x-nullable: true
+      apn:
+        description: Access Point Name
+        type: string
+        x-nullable: true
+        example: "inet"
+      cause:
+        description: Cause of attach rejection
+        type: string
+        x-nullable: false
   detach_success:
     type: object
-    description: Used to track when UE detaches successfully
+    description: |
+      Indicates that a UE detach has completed successfully
     properties:
       imsi:
+        description: |
+          International Mobile Subscriber Identity
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the IMSI is not present, a GUTI will be provided.
         type: string
+        x-nullable: true
+      guti:
+        description: |
+          Globally Unique Temporary Identifier
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the GUTI is not present, the IMSI will be provided.
+        type: string
+        x-nullable: true
+      mme_id:
+        type: string
+        x-nullable: true
+      enb_id:
+        description: ID of eNodeB through which the Attach request was received
+        type: integer
+        x-nullable: false
+      enb_ip:
+        description: IP of eNodeB through which the Attach request was received
+        type: string
+        x-nullable: true
+      apn:
+        description: Access Point Name
+        type: string
+        x-nullable: true
+        example: "inet"
       action:
+        description: Indicates whether a DetachAccept message was sent or not
         type: string
+  detach_failure:
+    type: object
+    description: |
+      Indicates that a UE detach has failed
+    properties:
+      imsi:
+        description: |
+          International Mobile Subscriber Identity
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the IMSI is not present, a GUTI will be provided.
+        type: string
+        x-nullable: true
+      guti:
+        description: |
+          Globally Unique Temporary Identifier
+          This is used to identify the UE for which the attach rejection belongs to.
+          If the GUTI is not present, the IMSI will be provided.
+        type: string
+        x-nullable: true
+      mme_id:
+        type: string
+        x-nullable: true
+      enb_id:
+        description: ID of eNodeB through which the Attach request was received
+        type: integer
+        x-nullable: false
+      enb_ip:
+        description: IP of eNodeB through which the Attach request was received
+        type: string
+        x-nullable: true
+      apn:
+        description: Access Point Name
+        type: string
+        x-nullable: true
+        example: "inet"
+      cause:
+        description: Cause of detach failure
+        type: string
+        x-nullable: false
   s1_setup_success:
     type: object
     description: Used to track establishment of S1 connection


### PR DESCRIPTION
## Summary

**Note: This pull request has been put up as a "request for comments", as testing still needs to be done**

This pull request is part of a larger project to add better traceability and observability of a UE in the Magma control plane, culminating in an NMS project to add more powerful event tracking interfaces.

A number of events are added, allowing for more granular monitoring of a UE in a Magma-operated network. While full details are available in seeing the files changed, the names of the events added are as follows:

- `attach_request`
- `attach_accept`
- `attach_reject`
- `attach_complete`
- `attach_success`
- `attach_failure`
- `detach_request`
- `detach_accept`
- `detach_implicit`
- `detach_success`
- `detach_implicit`

The initial motivation for adding more comprehensive event coverage is to achieve feature parity with more traditional call tracing tools, and while some event names reflect that, there are others that are added to cover gaps, or add monitoring coverage in areas where Magma's behavior differs more from a traditional packet core in traceability.

## Test Plan

Manual tests in progress

Automated testing will require some larger changes to how S1AP tests are set up, or adding unit tests to MME. Will need some collaboration there first, before a test plan is actually put here.

## Additional Information

- [ ] This change is backwards-breaking
