### PR TITLE
fix(agw): use pipe instead of redirect

### DIFF
--- a/lte/gateway/release/magma-postinst
+++ b/lte/gateway/release/magma-postinst
@@ -17,11 +17,11 @@ sed -i "s/.*OVS_CTL_OPTS.*/OVS_CTL_OPTS='--delete-bridges'/" /etc/default/openvs
 mkdir -p /var/core
 
 value=`cat /usr/local/share/magma/commit_hash`
-if sudo grep -q "COMMIT_HASH" /etc/environment
+if grep -q "COMMIT_HASH" /etc/environment
 then
     sudo sed -i -e "s/^COMMIT_HASH.*/$value/" /etc/environment
 else
-    sudo echo "$value" >> /etc/environment
+    echo "$value" | sudo tee -a /etc/environment
 fi
 
 # Set magmad service to start on boot


### PR DESCRIPTION
Signed-off-by: Alexander zur Bonsen <alexander.zur.bonsen@tngtech.com>

## Summary

In `else` path: write `COMMIT_HASH` to /etc/environment with pipe instead of redirect (why? sudo is not passed to redirect operator)

## Test Plan

Tested locally.

## Additional Information

- [ ] This change is backwards-breaking
