### PR TITLE
docs: Remove CSFB Reference 1.6.X

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.6.0/nms/federation.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.0/nms/federation.md
@@ -38,7 +38,7 @@ In the **Federated LTE** **Network**’s NMS page, the Federation config should 
 Federation network can be managed like any other network in NMS. We can navigate to the newly created federation network by clicking on the appropriate network name in the network selector. Following image shows the top level view of a federation network. Here we display the currently configured federation gateways.
 
 ![feg](assets/nms/userguide/federation/feg_overview1.png)
-Federation Gateway configuration page enables the operator to configure the server addresses for Gx, Gy, Swx, S6A and CSFB as shown below.
+Federation Gateway configuration page enables the operator to configure the server addresses for Gx, Gy, Swx, and S6A as shown below.
 ![feg](assets/nms/userguide/federation/feg_configure1.png)
 
 ### Configuring Omnipresent/Network-Wide Policies on Federated LTE network


### PR DESCRIPTION
Signed-off-by: Jared Mullane <jmullane@fb.com>

## Summary

CSFB is not supported on 1.6.X. Removing reference to it within the documentation. 

## Test Plan
![Screen Shot 2021-12-21 at 10 21 56 AM](https://user-images.githubusercontent.com/61836831/146980378-f8d3650c-3d89-4065-9c0f-2576d78e7163.png)

