### PR TITLE
fix: s6a_proxy fix bug on VisitedPLMNID type

### DIFF
--- a/feg/gateway/services/s6a_proxy/servicers/s6a_definitions.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_definitions.go
@@ -367,7 +367,7 @@ type AIR struct {
 	OriginRealm                 datatype.DiameterIdentity `avp:"Origin-Realm"`
 	AuthSessionState            datatype.UTF8String       `avp:"Auth-Session-State"`
 	UserName                    string                    `avp:"User-Name"`
-	VisitedPLMNID               datatype.Unsigned32       `avp:"Visited-PLMN-Id"`
+	VisitedPLMNID               datatype.OctetString      `avp:"Visited-PLMN-Id"`
 	RequestedEUTRANAuthInfo     RequestedEUTRANAuthInfo   `avp:"Requested-EUTRAN-Authentication-Info"`
 	RequestedUtranGeranAuthInfo RequestedEUTRANAuthInfo   `avp:"Requested-UTRAN-GERAN-Authentication-Info"`
 }
@@ -379,7 +379,7 @@ type ULR struct {
 	OriginRealm       datatype.DiameterIdentity `avp:"Origin-Realm"`
 	AuthSessionState  datatype.Unsigned32       `avp:"Auth-Session-State"`
 	UserName          datatype.UTF8String       `avp:"User-Name"`
-	VisitedPLMNID     datatype.Unsigned32       `avp:"Visited-PLMN-Id"`
+	VisitedPLMNID     datatype.OctetString      `avp:"Visited-PLMN-Id"`
 	RATType           datatype.Unsigned32       `avp:"RAT-Type"`
 	ULRFlags          datatype.Unsigned32       `avp:"ULR-Flags"`
 	SupportedFeatures []SupportedFeatures       `avp:"Supported-Features"`

--- a/feg/gateway/services/testcore/hss/servicers/ai.go
+++ b/feg/gateway/services/testcore/hss/servicers/ai.go
@@ -72,8 +72,7 @@ func NewAIA(srv *HomeSubscriberServer, msg *diam.Message) (*diam.Message, error)
 		return ConvertAuthErrorToFailureMessage(err, msg, air.SessionID, srv.Config.Server), err
 	}
 
-	const plmnOffsetBytes = 1
-	plmn := air.VisitedPLMNID.Serialize()[plmnOffsetBytes:]
+	plmn := air.VisitedPLMNID.Serialize()
 
 	vectors, utranVectors, lteAuthNextSeq, err := GenerateLteAuthVectors(
 		uint32(air.RequestedEUTRANAuthInfo.NumVectors),

--- a/feg/gateway/services/testcore/hss/servicers/ai_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/ai_test.go
@@ -33,6 +33,10 @@ import (
 	lteprotos "magma/lte/cloud/go/protos"
 )
 
+const (
+	TEST_PLMN_ID = "\x00\x00\x00"
+)
+
 func TestNewAIA_MissingSessionID(t *testing.T) {
 	m := diameter.NewProxiableRequest(diam.AuthenticationInformation, diam.TGPP_S6A_APP_ID, dict.Default)
 	server := test_utils.NewTestHomeSubscriberServer(t)
@@ -139,7 +143,7 @@ func TestNewAIA_MissingAuthKey(t *testing.T) {
 func TestValidateAIR_MissingUserName(t *testing.T) {
 	m := createBaseAIR()
 	m.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String("magma;123_1234"))
-	m.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
+	m.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(TEST_PLMN_ID))
 	authInfo := &diam.GroupedAVP{
 		AVP: []*diam.AVP{
 			diam.NewAVP(
@@ -180,7 +184,7 @@ func TestValidateAIR_MissingEUTRANInfo(t *testing.T) {
 	m := createBaseAIR()
 	m.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String("magma;123_1234"))
 	m.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String("magma"))
-	m.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
+	m.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(TEST_PLMN_ID))
 
 	assert.EqualError(t, hss.ValidateAIR(m), "Missing requested E-UTRAN and UTRAN/GERAN authentication info in message")
 }
@@ -188,7 +192,7 @@ func TestValidateAIR_MissingEUTRANInfo(t *testing.T) {
 func TestValidateAIR_MissingSessionId(t *testing.T) {
 	m := createBaseAIR()
 	m.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String("magma"))
-	m.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
+	m.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(TEST_PLMN_ID))
 	authInfo := &diam.GroupedAVP{
 		AVP: []*diam.AVP{
 			diam.NewAVP(
@@ -235,7 +239,7 @@ func createAIRExtended(userName string, numRequestedVectors, numRequestedUtranVe
 	m := createBaseAIR()
 	m.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String("magma;123_1234"))
 	m.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String(userName))
-	m.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
+	m.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(TEST_PLMN_ID))
 	authInfo := &diam.GroupedAVP{
 		AVP: []*diam.AVP{
 			diam.NewAVP(

--- a/feg/gateway/services/testcore/hss/servicers/ul_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/ul_test.go
@@ -118,7 +118,7 @@ func TestNewULA_NewSuccessfulULA(t *testing.T) {
 func TestValidateULR_MissingUserName(t *testing.T) {
 	ulr := createBaseULR()
 	ulr.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String("magma;123_1234"))
-	ulr.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
+	ulr.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(TEST_PLMN_ID))
 	ulr.NewAVP(avp.ULRFlags, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
 	ulr.NewAVP(avp.RATType, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
 
@@ -141,7 +141,7 @@ func TestValidateULR_MissingULRFlags(t *testing.T) {
 	ulr := createBaseULR()
 	ulr.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String("magma;123_1234"))
 	ulr.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String("sub1"))
-	ulr.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
+	ulr.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(TEST_PLMN_ID))
 	ulr.NewAVP(avp.RATType, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
 
 	err := hss.ValidateULR(ulr)
@@ -152,7 +152,7 @@ func TestValidateULR_MissingRATType(t *testing.T) {
 	ulr := createBaseULR()
 	ulr.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String("magma;123_1234"))
 	ulr.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String("sub1"))
-	ulr.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
+	ulr.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(TEST_PLMN_ID))
 	ulr.NewAVP(avp.ULRFlags, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
 
 	err := hss.ValidateULR(ulr)
@@ -162,7 +162,7 @@ func TestValidateULR_MissingRATType(t *testing.T) {
 func TestValidateULR_MissingSessionID(t *testing.T) {
 	ulr := createBaseULR()
 	ulr.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String("sub1"))
-	ulr.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
+	ulr.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(TEST_PLMN_ID))
 	ulr.NewAVP(avp.ULRFlags, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
 	ulr.NewAVP(avp.RATType, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
 
@@ -201,7 +201,7 @@ func createULRExtended(userName string, ratType uint32) *diam.Message {
 	ulr := createBaseULR()
 	ulr.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String("magma;123_1234"))
 	ulr.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String(userName))
-	ulr.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
+	ulr.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(TEST_PLMN_ID))
 	ulr.NewAVP(avp.ULRFlags, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
 	ulr.NewAVP(avp.RATType, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(ratType))
 	return ulr


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

While trying to run `federated integ test` we were unable to authenticate same way we do it on lte_integ test. After some debugging we found out that PLMNID our mock HSS was reading was always 0. 

The cause for this to be 0 is that there is a bug on go-diameter where they use type as `Unsigned32` instead of `OctetString` for VisitedPLMNID. Since the AVP is in fact an OctetString,  this causes go-diameter marshall function to fail  (in fact it does not fail, it just return 0, without error).

This PR fixes that  on our s6a_proxy. That change also trigger lots of changes on mock HSS test.

Note we also raised a PR for go-diameter
https://github.com/fiorix/go-diameter/pull/167
## Test Plan

This PR adds a check to make sure received PLMN is proper on an existing test case

./build.py -c at feg
And  New federated integ test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
