### PR TITLE
fix(ci): Check out full history in build for Sentry release tag

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -106,6 +106,8 @@ jobs:
       artifacts: ${{ steps.publish_packages.outputs.artifacts }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@v8"
         with:


### PR DESCRIPTION
## Summary

Changes the GHA checkout of the repository to fetch all commits.

The Magma version in the new Sentry release tag needs to calculate the number of commits for the current release (see #10827). To do this it has to check the history and cannot work with a shallow clone of the repository.

## Test Plan

I did a shallow clone of the repository locally via:

```
git clone --depth 1 git@github.com:magma/magma.git
```

This reproduces the error we see in Sentry where the commit hash is correct but the commit count is 1.

## Additional Information

- [ ] This change is backwards-breaking