### PR TITLE
docs: commenting on untested OS will lead to frustration

### DIFF
--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -166,14 +166,9 @@ git checkout v1.6
 git tag -l
 ```
 
-## Build/Deploy Tooling
+## Deployment Tooling
 
-We support building the AGW and Orchestrator on macOS and Linux host operating
-systems. Doing so on a Windows environment should be possible but has not been
-tested. You may prefer to use a Linux virtual machine if you are on a Windows
-host.
-
-First, follow the previous section on developer tools. Then, install some
+First, follow the previous section on [developer tools](#development-tools). Then, install some
 additional prerequisite tools.
 
 ### macOS


### PR DESCRIPTION
... especially when seen with respect to https://github.com/magma/magma/issues/10116.

Of course this can be different for the cloud deployment tooling in contrast to the developer tooling, however, it should be tested, made clear that the scope is different, and given the restrictions or requirements for it to work.
