### PR TITLE
fix(agw): Convert log level from mconfig correctly

### DIFF
--- a/lte/gateway/c/connection_tracker/src/main.cpp
+++ b/lte/gateway/c/connection_tracker/src/main.cpp
@@ -44,10 +44,7 @@ static magma::mconfig::ConnectionD load_mconfig() {
 static uint32_t get_log_verbosity(const YAML::Node& config,
                                   magma::mconfig::ConnectionD mconfig) {
   if (!config["log_level"].IsDefined()) {
-    if (mconfig.log_level() < 0 || mconfig.log_level() > 4) {
-      return MINFO;
-    }
-    return mconfig.log_level();
+    return magma::get_log_verbosity_from_mconfig(mconfig.log_level());
   }
   std::string log_level = config["log_level"].as<std::string>();
   if (log_level == "DEBUG") {

--- a/lte/gateway/c/li_agent/src/main.cpp
+++ b/lte/gateway/c/li_agent/src/main.cpp
@@ -28,10 +28,7 @@
 static uint32_t get_log_verbosity(const YAML::Node& config,
                                   magma::mconfig::LIAgentD mconfig) {
   if (!config["log_level"].IsDefined()) {
-    if (mconfig.log_level() < 0 || mconfig.log_level() > 4) {
-      return MINFO;
-    }
-    return mconfig.log_level();
+    return magma::get_log_verbosity_from_mconfig(mconfig.log_level());
   }
   std::string log_level = config["log_level"].as<std::string>();
   if (log_level == "DEBUG") {

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -122,10 +122,7 @@ static const std::shared_ptr<grpc::Channel> get_controller_channel(
 static uint32_t get_log_verbosity(const YAML::Node& config,
                                   magma::mconfig::SessionD mconfig) {
   if (!config["log_level"].IsDefined()) {
-    if (mconfig.log_level() < 0 || mconfig.log_level() > 4) {
-      return MINFO;
-    }
-    return mconfig.log_level();
+    return magma::get_log_verbosity_from_mconfig(mconfig.log_level());
   }
   std::string log_level = config["log_level"].as<std::string>();
   if (log_level == "DEBUG") {

--- a/orc8r/gateway/c/common/config/MConfigLoader.cpp
+++ b/orc8r/gateway/c/common/config/MConfigLoader.cpp
@@ -113,4 +113,11 @@ bool load_service_mconfig(const std::string& service_name,
   return status.ok();
 }
 
+uint32_t get_log_verbosity_from_mconfig(const uint32_t mconfig_log_level) {
+  if (mconfig_log_level < 0 || mconfig_log_level > 4) {
+    return MINFO;
+  }
+  return 4 - mconfig_log_level;
+}
+
 }  // namespace magma

--- a/orc8r/gateway/c/common/config/includes/MConfigLoader.h
+++ b/orc8r/gateway/c/common/config/includes/MConfigLoader.h
@@ -42,4 +42,6 @@ bool load_service_mconfig(const std::string& service_name,
                           google::protobuf::Message* message);
 
 void get_mconfig_file(std::ifstream* file);
+
+uint32_t get_log_verbosity_from_mconfig(uint32_t mconfig_log_level);
 }  // namespace magma

--- a/orc8r/gateway/c/common/config/test/test_mconfig_loader.cpp
+++ b/orc8r/gateway/c/common/config/test/test_mconfig_loader.cpp
@@ -17,6 +17,7 @@
 #include <sstream>
 
 #include "orc8r/gateway/c/common/config/includes/MConfigLoader.h"
+#include "orc8r/gateway/c/common/logging/magma_logging.h"
 #include "lte/protos/mconfig/mconfigs.pb.h"
 
 namespace {
@@ -80,6 +81,15 @@ TEST(MConfigLoader, MissingServiceNameFails) {
   std::istringstream config_stream(healthy_mconfig);
   EXPECT_FALSE(magma::load_service_mconfig("MISSING_SERVICE_NAME",
                                            &config_stream, &mconfig));
+}
+
+TEST(MConfigLoader, ConvertingLogLevelsCorrectly) {
+  EXPECT_EQ(magma::get_log_verbosity_from_mconfig(0), MDEBUG);
+  EXPECT_EQ(magma::get_log_verbosity_from_mconfig(1), MINFO);
+  EXPECT_EQ(magma::get_log_verbosity_from_mconfig(2), MWARNING);
+  EXPECT_EQ(magma::get_log_verbosity_from_mconfig(3), MERROR);
+  EXPECT_EQ(magma::get_log_verbosity_from_mconfig(4), MFATAL);
+  EXPECT_EQ(magma::get_log_verbosity_from_mconfig(10), MINFO);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

When reading the log level from an mconfig file, it needs to be inverted before setting it as verbosity. Extract a new function MConfigLoader to do that and use it for sessiond, li_agent and connection_tracker.

Fixes #10911.

## Test Plan

Start sessiond locally with the following gateway.mconfig:
```
[...]
"sessiond": {
    "@type": "type.googleapis.com/magma.mconfig.SessionD",
    "logLevel": "INFO",
    [...]
},
[...]
```

Output before the change:
```
I1222 12:14:14.918968 150611 magma_logging_init.h:28] Setting verbosity to 1
```

Output after the change:
```
I1222 12:15:17.982623 150734 magma_logging_init.h:28] Setting verbosity to 3
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
