### PR TITLE
fix(amf): Correct SubscriberID set as "IMSI +number" in amf

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
@@ -43,7 +43,7 @@ using namespace magma::lte;
 namespace magma5g {
 
 SetSMSessionContext create_sm_pdu_session_v4(
-    char* imsi, uint8_t* apn, uint32_t pdu_session_id,
+    std::string& imsi, uint8_t* apn, uint32_t pdu_session_id,
     uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
     uint8_t* gnb_gtp_teid_ip_addr, char* ipv4_addr, uint32_t version,
     const ambr_t& state_ambr) {
@@ -52,7 +52,7 @@ SetSMSessionContext create_sm_pdu_session_v4(
   auto* req_common = req.mutable_common_context();
 
   // Encode IMSI
-  req_common->mutable_sid()->mutable_id()->assign(imsi);
+  req_common->mutable_sid()->set_id("IMSI" + imsi);
 
   // Encode TYPE IMSI
   req_common->mutable_sid()->set_type(
@@ -117,8 +117,10 @@ int AsyncSmfServiceClient::amf_smf_create_pdu_session_ipv4(
     uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
     uint8_t* gnb_gtp_teid_ip_addr, char* ipv4_addr, uint32_t version,
     const ambr_t& state_ambr) {
+  auto imsi_str = std::string(imsi);
+
   magma::lte::SetSMSessionContext req = create_sm_pdu_session_v4(
-      imsi, apn, pdu_session_id, pdu_session_type, gnb_gtp_teid, pti,
+      imsi_str, apn, pdu_session_id, pdu_session_type, gnb_gtp_teid, pti,
       gnb_gtp_teid_ip_addr, ipv4_addr, version, state_ambr);
 
   AsyncSmfServiceClient::getInstance().set_smf_session(req);

--- a/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.h
+++ b/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.h
@@ -31,7 +31,7 @@ using magma::lte::SmContextVoid;
 namespace magma5g {
 
 SetSMSessionContext create_sm_pdu_session_v4(
-    char* imsi, uint8_t* apn, uint32_t pdu_session_id,
+    std::string& imsi, uint8_t* apn, uint32_t pdu_session_id,
     uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
     uint8_t* gnb_gtp_teid_ip_addr, char* ipv4_addr, uint32_t version,
     const ambr_t& state_ambr);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -744,8 +744,12 @@ int amf_smf_notification_send(
   auto* req_rat_specific = notify_req.mutable_rat_specific_notification();
   char imsi[IMSI_BCD_DIGITS_MAX + 1];
   IMSI64_TO_STRING(ue_context->amf_context.imsi64, imsi, 15);
+  auto imsi_str = std::string(imsi);
 
-  req_common->mutable_sid()->mutable_id()->assign(imsi);
+  req_common->mutable_sid()->set_id("IMSI" + imsi_str);
+  req_common->mutable_sid()->set_type(
+      magma::lte::SubscriberID_IDType::SubscriberID_IDType_IMSI);
+
   if (notify_event_type == UE_IDLE_MODE_NOTIFY) {
     req_rat_specific->set_notify_ue_event(
         magma::lte::NotifyUeEvents::UE_IDLE_MODE_NOTIFY);

--- a/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
@@ -67,13 +67,16 @@ int create_session_grpc_req_on_gnb_setup_rsp(
   int rc = RETURNerror;
   magma::lte::SetSMSessionContext req;
 
+  auto imsi_str    = std::string(imsi);
   auto* req_common = req.mutable_common_context();
   auto* req_rat_specific =
       req.mutable_rat_specific_context()->mutable_m5gsm_session_context();
+
   // IMSI retrieved from amf context
-  req_common->mutable_sid()->mutable_id()->assign(imsi);  // string id
   req_common->mutable_sid()->set_type(
       magma::lte::SubscriberID_IDType::SubscriberID_IDType_IMSI);
+  req_common->mutable_sid()->set_id("IMSI" + imsi_str);
+
   req_common->set_rat_type(magma::lte::RATType::TGPP_NR);
   // PDU session state to CREATING
   req_common->set_sm_session_state(magma::lte::SMSessionFSMState::CREATING_0);
@@ -189,10 +192,14 @@ int amf_smf_create_pdu_session(
 ***************************************************************************/
 int release_session_gprc_req(amf_smf_release_t* message, char* imsi) {
   magma::lte::SetSMSessionContext req;
+  auto imsi_str    = std::string(imsi);
   auto* req_common = req.mutable_common_context();
-  req_common->mutable_sid()->mutable_id()->assign(imsi);
+
+  // Encode subscriber as IMSI
   req_common->mutable_sid()->set_type(
       magma::lte::SubscriberID_IDType::SubscriberID_IDType_IMSI);
+  req_common->mutable_sid()->set_id("IMSI" + imsi_str);
+
   req_common->set_sm_session_state(magma::lte::SMSessionFSMState::RELEASED_4);
   req_common->set_sm_session_version(1);  // uint32
   auto* req_rat_specific =

--- a/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -46,6 +46,20 @@ using namespace lte;
 
 AmfServiceImpl::AmfServiceImpl() {}
 
+// Remove the Leading IMSI string if present
+inline void get_subscriber_id(const std::string& subscriber_id, char* imsi) {
+  // No parameter check as these should always be filled up
+  uint8_t imsi_len = 0;
+
+  // Check if the subscriber information received contains IMSI
+  if (subscriber_id.compare(0, 4, "IMSI") == 0) {
+    // If yes then remove the same
+    imsi_len = strlen("IMSI");
+  }
+
+  strcpy(imsi, subscriber_id.c_str() + imsi_len);
+}
+
 Status AmfServiceImpl::SetAmfNotification(
     ServerContext* context, const SetSmNotificationContext* notif,
     SmContextVoid* response) {
@@ -57,7 +71,8 @@ Status AmfServiceImpl::SetAmfNotification(
   auto& req_m5g       = notif->rat_specific_notification();
 
   // CommonSessionContext
-  strcpy(itti_msg.imsi, notify_common.sid().id().c_str());
+  get_subscriber_id(notify_common.sid().id(), itti_msg.imsi);
+
   itti_msg.sm_session_fsm_state =
       (SMSessionFSMState_response) notify_common.sm_session_state();
   itti_msg.sm_session_version = notify_common.sm_session_version();
@@ -93,7 +108,8 @@ Status AmfServiceImpl::SetSmfSessionContext(
   auto& req_m5g    = request->rat_specific_context().m5g_session_context_rsp();
 
   // CommonSessionContext
-  strcpy(itti_msg.imsi, req_common.sid().id().c_str());
+  get_subscriber_id(req_common.sid().id(), itti_msg.imsi);
+
   itti_msg.sm_session_fsm_state =
       (sm_session_fsm_state_t) req_common.sm_session_state();
   itti_msg.sm_session_version = req_common.sm_session_version();

--- a/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
+++ b/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
@@ -27,7 +27,7 @@ namespace lte {
 TEST(test_create_sm_pdu_session_v4, create_sm_pdu_session_v4) {
   SetSMSessionContext request;
 
-  std::string imsi("IMSI901700000000001");
+  std::string imsi("901700000000001");
   std::string apn("magmacore.com");
   uint32_t pdu_session_id         = 0x5;
   uint32_t pdu_session_type       = 3;
@@ -52,15 +52,15 @@ TEST(test_create_sm_pdu_session_v4, create_sm_pdu_session_v4) {
   ambr_t default_ambr;
 
   request = magma5g::create_sm_pdu_session_v4(
-      (char*) imsi.c_str(), (uint8_t*) apn.c_str(), pdu_session_id,
-      pdu_session_type, gnb_gtp_teid, pti, gnb_gtp_teid_ip_addr,
-      (char*) ue_ipv4_addr.c_str(), version, default_ambr);
+      imsi, (uint8_t*) apn.c_str(), pdu_session_id, pdu_session_type,
+      gnb_gtp_teid, pti, gnb_gtp_teid_ip_addr, (char*) ue_ipv4_addr.c_str(),
+      version, default_ambr);
 
   auto* rat_req =
       request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
   auto* req_cmn = request.mutable_common_context();
 
-  EXPECT_TRUE(imsi == req_cmn->sid().id());
+  EXPECT_TRUE(imsi == req_cmn->sid().id().substr(4));
   EXPECT_TRUE(
       magma::lte::SubscriberID_IDType::SubscriberID_IDType_IMSI ==
       req_cmn->sid().type());


### PR DESCRIPTION
Signed-off-by: Rajeshs23 <rajesh.sure@wavelabs.ai>
Fix:
Set all requests as a same pattern for IMSI value

## Summary
 Issue:
For 5G, requests are coming from AMF as a “number” without IMSI keyword and from UPF, coming as a “IMSI + number” So in SMF searching the session info from SessionStore getting failed.
fix:
Set all requests as a same pattern for IMSI value and in line with 4G.
## Test Plan
1.Unit Testing
2.Verified with Ueransim 
## Additional Information
Associated zenhub ticket is #10434 
![ueransim_capture](https://user-images.githubusercontent.com/91061578/147122627-7f6fccec-247e-400d-8c12-e75442adde51.PNG)
![unittest_results](https://user-images.githubusercontent.com/91061578/147122636-4a82f4b1-4d1a-4f34-9ac7-59941c1575e2.PNG)

