### PR TITLE
refactor(feg): Segregation of swx_proxy servicer as external

### DIFF
--- a/feg/cloud/go/services/feg_relay/feg_relay/main.go
+++ b/feg/cloud/go/services/feg_relay/feg_relay/main.go
@@ -23,6 +23,7 @@ import (
 	"magma/feg/cloud/go/services/feg_relay"
 	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay"
 	nh_servicers "magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers"
+	swx_proxy_servicers "magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound"
 	"magma/feg/cloud/go/services/feg_relay/servicers"
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/orc8r/cloud/go/service"
@@ -55,8 +56,9 @@ func main() {
 
 	// Register Neutral Host Routing services
 	nhServicer := nh_servicers.NewRelayRouter()
+	swxproxy_servicers := swx_proxy_servicers.NewRelayRouter()
 	protos.RegisterS6AProxyServer(srv.GrpcServer, nhServicer)
-	protos.RegisterSwxProxyServer(srv.GrpcServer, nhServicer)
+	protos.RegisterSwxProxyServer(srv.GrpcServer, swxproxy_servicers)
 	protos.RegisterHelloServer(srv.GrpcServer, nhServicer)
 	lteprotos.RegisterCentralSessionControllerServer(srv.GrpcServer, nhServicer)
 

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/relay_router.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/relay_router.go
@@ -28,7 +28,6 @@ const (
 	FegS6aProxy     gateway_registry.GwServiceType = "s6a_proxy"
 	FegSessionProxy gateway_registry.GwServiceType = "session_proxy"
 	FegHello        gateway_registry.GwServiceType = "feg_hello"
-	FegSwxProxy     gateway_registry.GwServiceType = "swx_proxy"
 )
 
 // RelayRouter implements generic routing logic and currently just embeds gw_to_feg_relay.Router functionality

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound/swx_proxy_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound/swx_proxy_relay.go
@@ -17,7 +17,20 @@ import (
 	"context"
 
 	"magma/feg/cloud/go/protos"
+	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay"
+	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
 )
+
+const FegSwxProxy gateway_registry.GwServiceType = "swx_proxy"
+
+type RelayRouter struct {
+	gw_to_feg_relay.Router
+}
+
+// NewRelayRouter creates & returns a new RelayRouter
+func NewRelayRouter() *RelayRouter {
+	return &RelayRouter{Router: *gw_to_feg_relay.NewRouter()}
+}
 
 // SwxProxyServer implementation
 //


### PR DESCRIPTION
Signed-off-by: shivesh <shivesh.ojha@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This PR deals with the segregation of  swx_proxy.proto external gRPC servicers implementation.
These changes are part of the ongoing work which details the distinction between Orc8r-internal gRPC endpoints vs. external, gateway-oriented gRPC endpoints.

Verified existing UT cases.

This PR was done as part of discussion by @hcgatewood [RemoveGatewayAccess toOrc8r-InternalEndpoints](https://drive.google.com/file/d/1NO6Qd6rU80xPh0Sb0mKWlSfDt0JbeVIT/view)


## Test Plan

All UTs passed successfully.


