### PR TITLE
fix(orc8r): Log entries created from user input

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,6 +66,7 @@ RUN echo "Install general purpose packages" && \
         libpcap-dev \
         libssl-dev \
         libtool \
+        lld \
         make \
         ninja-build \
         perl \

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && \
         # dependency of sctpd
         libsctp-dev \
         libssl-dev \
+        lld \
         python3 \
         python-is-python3 \
         unzip \

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -222,13 +222,14 @@
     state: link
     force: yes
 
-- name: Set up environment variables for VSCode integration
-  lineinfile:
-    # We set this variable in .profile so that VSCode can determine which build config to use 
-    path: /home/{{ ansible_user }}/.profile
-    line: "export VSCODE_BAZEL_BUILD_CONFIG=vm"
+- name: Install lld
+  retries: 5
+  # TODO: Make this preburn
+  apt:
     state: present
-  when: full_provision
+    update_cache: no
+    pkg:
+      - lld
 
 ########################################
 # Install common Magma dev dependencies

--- a/orc8r/cloud/go/obsidian/server/metrics.go
+++ b/orc8r/cloud/go/obsidian/server/metrics.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"html"
 	"strconv"
 
 	"github.com/golang/glog"
@@ -50,12 +51,18 @@ func CollectStats(next echo.HandlerFunc) echo.HandlerFunc {
 		requestCount.Inc()
 		status := strconv.Itoa(c.Response().Status)
 		respStatuses.WithLabelValues(status, c.Request().Method).Inc()
+		url := sanitizeString(c.Request().URL.String())
 		glog.V(2).Infof(
 			"REST API code: %v, method: %v, url: %v\n",
 			status,
 			c.Request().Method,
-			c.Request().URL,
+			url,
 		)
 		return nil
 	}
+}
+
+func sanitizeString(strString string) string {
+	strSanitizedString := html.EscapeString(strString)
+	return strSanitizedString
 }


### PR DESCRIPTION
## Summary

issue: https://github.com/magma/magma/issues/10986
GitHub Code scanning alerts are created because of using URL  in log directly: "If unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries."
If the log is displayed as HTML, then arbitrary HTML may be included to spoof log entries.


## Test Plan

go build and go test in  orc8r/cloud/go/obsidian

