### PR TITLE
fix: bump orc8r helm chart

### DIFF
--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -490,7 +490,7 @@ service:
     Required: false
     ConfigApps:
       - tf
-    Default: 1.5.24
+    Default: 1.5.25
   orc8r_controller_replicas:
     Description: Replica count for Orchestrator controller pods.
     Type: number

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -176,7 +176,7 @@ variable "orc8r_deployment_type" {
 variable "orc8r_chart_version" {
   description = "Version of the core orchestrator Helm chart to install."
   type        = string
-  default     = "1.5.24"
+  default     = "1.5.25"
 }
 
 variable "cwf_orc8r_chart_version" {

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Helm chart for the Magma Orchestrator
 name: orc8r
-version: 1.5.24
+version: 1.5.25
 home: https://www.magmacore.org
 sources:
   - https://github.com/magma/magma


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

When updating staging we are getting errors like the one below. 

The chart failing is [or8cr](https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Amagma%2Fmagma.git&branch=master&file=orc8r%2Fcloud%2Fdeploy%2Fterraform%2Forc8r-helm-aws%2Fmain.tf&editor=JetBrains&version=v1.2.1&utm_product_name=IntelliJ+IDEA&utm_product_version=2021.2.2&start_row=205&start_col=5&end_row=205&end_col=5) chart. And curiously that chart was modified byt #10551 on dec 15th (around same time when we stopped being able to update staging). 

I am not sure if this PR is the fix, but we can give it a try





error we are getting 
```
│ Error: cannot patch "orc8r-cwf" with kind Deployment: Deployment.apps "orc8r-cwf" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/component":"cwf", "app.kubernetes.io/instance":"cwf-orc8r", "app.kubernetes.io/name":"cwf-orc8r", "image-version":"206a67a6"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
│
│   with module.orc8r-app.helm_release.cwf-orc8r[0],
│   on .terraform/modules/orc8r-app/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf line 92, in resource "helm_release" "cwf-orc8r":
│   92: resource "helm_release" "cwf-orc8r" {
│
╵
╷
```
## Test Plan
<img src="https://media4.giphy.com/media/g0QET2Iejaa4EQ0eBV/giphy.gif"/>
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
