### PR TITLE
fix(amf): As part of handling PDU session release complete, added logic to invoke PDU_Release gRPC handler towards SMF, when UE context is REGISTERED_CONNECTED and related PDU session state is INACTIVE

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
@@ -157,6 +157,10 @@ void create_state_matrix() {
   Update_ue_state_matrix(
       DEREGISTERED, STATE_PDU_SESSION_RELEASE_COMPLETE, SESSION_NULL,
       DEREGISTERED, SESSION_NULL, "PDU_Release");
+
+  Update_ue_state_matrix(
+      REGISTERED_CONNECTED, STATE_PDU_SESSION_RELEASE_COMPLETE, INACTIVE,
+      REGISTERED_CONNECTED, RELEASED, "PDU_Release");
 }
 
 /*


### PR DESCRIPTION
fix(amf): As part of handling PDU session release complete, added logic to invoke PDU_Release gRPC handler towards SMF, when UE context is REGISTERED_CONNECTED and related PDU session state is INACTIVE

Signed-off-by: Moinuddin Khan <moinuddin.khan@wavelabs.ai>

fix(amf): As part of handling PDU session release complete, added logic to invoke PDU_Release gRPC handler towards SMF, when UE context is REGISTERED_CONNECTED and related PDU session state is INACTIVE

## Summary

During the processing of PDU session release complete at AMF, if UE context is in REGISTERED_CONNECTED state and related PDU session state is INACTIVE no PDU_Release gRPC was triggered towards SMF.
Added logic in AMF to handle the scenario described above.

## Test Plan

Executed TC9a followed by TC9b on TVM setup successfully
Tested PDU session setup and release using UERANSIM setup.

## Additional Information

Corresponding zenhub task id #10968
Attaching mme logs, sys logs and packet captures from TVM testing.
