### PR TITLE
test(mme): Normal TAU in connected mode

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
@@ -1499,7 +1499,7 @@ static int emm_as_data_req(
        * message. After receiving TAU Complete, we should trigger UE context
        * release
        */
-      if ((msg->nas_info == EMM_AS_NAS_DATA_TAU) &&
+      if ((msg->nas_info == EMM_AS_NAS_DATA_TAU) && (ue_mm_context->ecm_state != ECM_CONNECTED) &&
           !(emm_ctx->csfbparams.newTmsiAllocated) &&
           !(emm_ctx->csfbparams.tau_active_flag)) {
         as_msg->err_code = AS_TERMINATED_NAS;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_as.c
@@ -1499,7 +1499,8 @@ static int emm_as_data_req(
        * message. After receiving TAU Complete, we should trigger UE context
        * release
        */
-      if ((msg->nas_info == EMM_AS_NAS_DATA_TAU) && (ue_mm_context->ecm_state != ECM_CONNECTED) &&
+      if ((msg->nas_info == EMM_AS_NAS_DATA_TAU) &&
+          (ue_mm_context->ecm_state != ECM_CONNECTED) &&
           !(emm_ctx->csfbparams.newTmsiAllocated) &&
           !(emm_ctx->csfbparams.tau_active_flag)) {
         as_msg->err_code = AS_TERMINATED_NAS;

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -2801,6 +2801,120 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithoutActiveFlag) {
   EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
 }
 
+// Normal TAU sent in connected mode with active flag set to false
+TEST_F(MmeAppProcedureTest, TestAttachNormalTauReqInConnectedState) {
+  mme_app_desc_t* mme_state_p =
+      magma::lte::MmeNasStateManager::getInstance().get_state(false);
+  std::condition_variable cv;
+  std::mutex mx;
+  std::unique_lock<std::mutex> lock(mx);
+
+  MME_APP_EXPECT_CALLS(4, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
+
+  // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
+  send_mme_app_initial_ue_msg(
+      nas_msg_imsi_attach_req, sizeof(nas_msg_imsi_attach_req), plmn, guti, 1);
+
+  // Sending AIA to mme_app mimicing successful S6A response for AIR
+  send_authentication_info_resp(imsi, true);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(msg_nas_dl_data.mme_ue_s1ap_id, 1);
+  // Constructing and sending Authentication Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_auth_resp, sizeof(nas_msg_auth_resp), plmn);
+
+  // Wait for DL NAS Transport for once
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending SMC Response to mme_app mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_smc_resp, sizeof(nas_msg_smc_resp), plmn);
+
+  // Sending ULA to mme_app mimicing successful S6A response for ULR
+  send_s6a_ula(imsi, true);
+
+  // Constructing and sending Create Session Response to mme_app mimicing SPGW
+  send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
+
+  // Constructing and sending ICS Response to mme_app mimicing S1AP
+  send_ics_response();
+
+  // Constructing UE Capability Indication message to mme_app
+  // mimicing S1AP with dummy radio capabilities
+  send_ue_capabilities_ind();
+
+  // Constructing and sending Attach Complete to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_attach_comp, sizeof(nas_msg_attach_comp), plmn);
+
+  // Wait for DL NAS Transport for EMM Information
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
+  nas_message_t nas_msg_decoded = {0};
+  emm_security_context_t emm_security_context;
+  nas_message_decode_status_t decode_status;
+  status_code_e decoder_rc;
+  decoder_rc = nas_message_decode(
+      nas_msg->data, &nas_msg_decoded, nas_msg->slen,
+      (void*) &emm_security_context, &decode_status);
+  EXPECT_EQ(nas_msg->slen, 67);
+  EXPECT_EQ(decoder_rc, nas_msg->slen);
+  guti = nas_msg_decoded.plain.emm.attach_accept.guti.guti;
+  bdestroy_wrapper(
+      &nas_msg_decoded.plain.emm.attach_accept.esmmessagecontainer);
+  // Destruction at tear down is not sufficient as ICS occurs
+  // twice in this test case.
+  bdestroy_wrapper(&nas_msg);
+
+  // Constructing and sending Modify Bearer Response to mme_app
+  // mimicing SPGW
+  std::vector<int> b_modify = {5};
+  std::vector<int> b_rm     = {};
+  send_modify_bearer_resp(b_modify, b_rm);
+
+  // Check MME state after Modify Bearer Response
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
+  // Constructing and sending TAU Request without active flag
+  send_mme_app_uplink_data_ind(
+      nas_msg_normal_tau_req_without_actv_flag,
+      sizeof(nas_msg_normal_tau_req_without_actv_flag), plmn);
+  // Wait for MME to send TAU accept
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending Detach Request to mme_app
+  // mimicing S1AP
+  send_mme_app_uplink_data_ind(
+      nas_msg_detach_req, sizeof(nas_msg_detach_req), plmn);
+
+  // Constructing and sending Delete Session Response to mme_app
+  // mimicing SPGW task
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  send_delete_session_resp(DEFAULT_LBI);
+
+  // Wait for context release command
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  // Constructing and sending CONTEXT RELEASE COMPLETE to mme_app
+  // mimicing S1AP task
+  send_ue_ctx_release_complete();
+
+  // Check MME state after detach complete
+  send_activate_message_to_mme_app();
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 0);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 0);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
+}
+
 // TAU reject due to service area restriction
 TEST_F(MmeAppProcedureTest, TestTauRejDueToInvalidTac) {
   mme_app_desc_t* mme_state_p =

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -2889,6 +2889,12 @@ TEST_F(MmeAppProcedureTest, TestAttachNormalTauReqInConnectedState) {
       sizeof(nas_msg_normal_tau_req_without_actv_flag), plmn);
   // Wait for MME to send TAU accept
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+  EXPECT_EQ(mme_state_p->nb_ue_attached, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_connected, 1);
+  EXPECT_EQ(mme_state_p->nb_default_eps_bearers, 1);
+  EXPECT_EQ(mme_state_p->nb_ue_idle, 0);
+  EXPECT_EQ(mme_state_p->nb_s1u_bearers, 1);
+
   // Constructing and sending Detach Request to mme_app
   // mimicing S1AP
   send_mme_app_uplink_data_ind(

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -2858,7 +2858,7 @@ TEST_F(MmeAppProcedureTest, TestAttachNormalTauReqInConnectedState) {
   status_code_e decoder_rc;
   decoder_rc = nas_message_decode(
       nas_msg->data, &nas_msg_decoded, nas_msg->slen,
-      (void*) &emm_security_context, &decode_status);
+      reinterpret_cast<void*>(&emm_security_context), &decode_status);
   EXPECT_EQ(nas_msg->slen, 67);
   EXPECT_EQ(decoder_rc, nas_msg->slen);
   guti = nas_msg_decoded.plain.emm.attach_accept.guti.guti;

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -36,6 +36,7 @@ s1aptests/test_no_auth_response.py \
 s1aptests/test_no_security_mode_complete.py \
 s1aptests/test_tau_periodic_inactive.py \
 s1aptests/test_tau_periodic_active.py \
+s1aptests/test_tau_ta_updating_connected_mode.py \
 s1aptests/test_attach_service.py \
 s1aptests/test_attach_detach_service.py \
 s1aptests/test_attach_service_ue_radio_capability.py \

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating_connected_mode.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating_connected_mode.py
@@ -1,0 +1,106 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import time
+import unittest
+
+import s1ap_types
+import s1ap_wrapper
+
+
+class TestTauTaUpdatingConnectedMode(unittest.TestCase):
+    """Test TAU with TA updating in connected mode"""
+
+    def setUp(self):
+        """Initialize"""
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        """Cleanup"""
+        self._s1ap_wrapper.cleanup()
+
+    def test_tau_ta_updating_connected_mode(self):
+        """Attach 2 UEs.
+        1. For the 1st UE, send tracking area update(TAU) request
+        in UL NAS transport with EPS Update Type=TA Updating and
+        active flag set to false
+        2. For the 2nd UE, send tracking area update(TAU) request
+        in UL NAS transport with EPS Update Type=TA Updating and
+        active flag set to true
+        """
+        num_ues = 2
+        wait_for_s1_context_rel = False
+        self._s1ap_wrapper.configUEDevice(num_ues)
+        ue_ids = []
+        # Attach
+        for _ in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            ue_id = req.ue_id
+            self._s1ap_wrapper.s1_util.attach(
+                ue_id,
+                s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t,
+                id_type=s1ap_types.TFW_MID_TYPE_GUTI,
+            )
+            ue_ids.append(req.ue_id)
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        # Add delay to ensure that S1APTester sends Attach Complete
+        time.sleep(0.5)
+
+        active_flag = [False, True]
+        for i in range(num_ues):
+            print(
+                "************************* Sending Tracking Area Update ",
+                "request for UE id ",
+                ue_ids[i],
+            )
+            tau_req = s1ap_types.ueTauReq_t()
+            tau_req.ue_Id = ue_ids[i]
+            tau_req.type = s1ap_types.Eps_Updt_Type.TFW_TA_UPDATING.value
+            tau_req.Actv_flag = active_flag[i]
+            tau_req.ueMtmsi.pres = False
+            self._s1ap_wrapper.s1_util.issue_cmd(
+                s1ap_types.tfwCmd.UE_TAU_REQ, tau_req,
+            )
+
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertEquals(
+                response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
+            )
+            tau_acc = response.cast(s1ap_types.ueTauAccept_t)
+            print(
+                "************************* Received Tracking Area Update ",
+                "accept for UE id ",
+                tau_acc.ue_Id,
+            )
+
+        # Detach
+        for ue in ue_ids:
+            print(
+                "************************* Running UE detach (switch-off) for ",
+                "UE id ",
+                ue,
+            )
+            # Now detach the UE
+            self._s1ap_wrapper.s1_util.detach(
+                ue,
+                s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+                wait_for_s1_context_rel,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
test(mme): TAU in connected mode

## Summary

Added UT and s1ap test for normal TAU in connected mode. MME should not release S1 connection if normal TAU request is received in connected state. But MME was releasing the S1 connection after completion of TAU procedure. Fixed the issue.

## Test Plan

- Test UT and the new TC multiple times
- Verified s1ap tester sanity suite

