### PR TITLE
fix(amf): Support for dotted dnn encoding and decoding

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GDNN.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GDNN.cpp
@@ -53,13 +53,11 @@ int DNNMsg::DecodeDNNMsg(
     memcpy(dnn_message->dnn + dnn_length, ".", 1);
     DECODE_U8(buffer + decoded, dnn_len, decoded);
     dnn_length = dnn_length + 1;
-    MLOG(MDEBUG) << "dnn_len : " << static_cast<int>(dnn_len);
 
     memcpy(dnn_message->dnn + dnn_length, buffer + decoded, dnn_len);
 
     decoded = decoded + dnn_len;
     dnn_length += dnn_len;
-    MLOG(MDEBUG) << "dnn: " << dnn_message->dnn;
   }
   MLOG(MDEBUG) << "dnn str : " << dnn_message->dnn;
   return decoded;
@@ -81,7 +79,6 @@ int DNNMsg::EncodeDNNMsg(
   }
 
   ENCODE_U8(buffer + encoded, dnn_message->len, encoded);
-  MLOG(MDEBUG) << "len : " << static_cast<int>(dnn_message->len);
   uint8_t dnn_length = 0;
   while (dnn_length < dnn_message->len - 1) {
     uint8_t dnn_len = 0;
@@ -91,7 +88,6 @@ int DNNMsg::EncodeDNNMsg(
       ++dnn_len;
     }
     ENCODE_U8(buffer + encoded, dnn_len, encoded);
-    MLOG(MDEBUG) << "dnn len : " << dnn_len;
 
     memcpy(buffer + encoded, dnn_message->dnn + dnn_length, dnn_len);
     if (dnn_len + dnn_length < dnn_message->len - 1) {
@@ -101,7 +97,6 @@ int DNNMsg::EncodeDNNMsg(
     dnn_length = dnn_length + dnn_len;
 
     BUFFER_PRINT_LOG(buffer + encoded, dnn_len);
-    MLOG(MDEBUG) << "dnn str : " << dnn_message->dnn;
     encoded = encoded + dnn_len;
   }
   return encoded;

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -928,6 +928,56 @@ TEST(test_optional_dnn_pdu, test_pdu_session_establish_optional) {
   bdestroy(buffer);
 }
 
+TEST(test_optional_dnn_dotted_pdu, test_pdu_session_establish_optional) {
+  uint32_t bytes         = 0;
+  uint32_t container_len = 0;
+  bstring buffer;
+  amf_nas_message_t msg = {};
+
+  // build uplinknastransport
+  // uplink nas transport(pdu session request)
+
+  uint8_t pdu[44] = {0x7e, 0x00, 0x67, 0x01, 0x00, 0x15, 0x2e, 0x01, 0x01,
+                     0xc1, 0xff, 0xff, 0x91, 0xa1, 0x28, 0x01, 0x00, 0x7b,
+                     0x00, 0x07, 0x80, 0x00, 0x0a, 0x00, 0x00, 0x0d, 0x00,
+                     0x12, 0x01, 0x81, 0x22, 0x01, 0x01, 0x25, 0x09, 0x03,
+                     0x6f, 0x61, 0x69, 0x04, 0x69, 0x70, 0x76, 0x34};
+
+  uint32_t len = sizeof(pdu) / sizeof(uint8_t);
+
+  NAS5GPktSnapShot nas5g_pkt_snap;
+  ULNASTransportMsg pdu_sess_est_req;
+  bool decode_res = false;
+  memset(&pdu_sess_est_req, 0, sizeof(ULNASTransportMsg));
+
+  decode_res = decode_ul_nas_transport_msg(&pdu_sess_est_req, pdu, len);
+
+  EXPECT_EQ(decode_res, true);
+  EXPECT_EQ(
+      pdu_sess_est_req.payload_container.smf_msg.msg.pdu_session_estab_request
+          .ssc_mode.mode_val,
+      1);
+  EXPECT_EQ(pdu_sess_est_req.nssai.sst, 1);
+  uint8_t dnn[9] = "oai.ipv4";
+  EXPECT_EQ(memcmp(pdu_sess_est_req.dnn.dnn, dnn, pdu_sess_est_req.dnn.len), 0);
+
+  buffer = bfromcstralloc(len, "\0");
+  bytes  = pdu_sess_est_req.EncodeULNASTransportMsg(
+      &pdu_sess_est_req, buffer->data, len);
+  EXPECT_GT(bytes, 0);
+  ULNASTransportMsg decode_pdu_sess_est_req = {};
+  decode_res = decode_ul_nas_transport_msg(&decode_pdu_sess_est_req, pdu, len);
+  EXPECT_EQ(decode_res, true);
+  // SSC mode Check
+  EXPECT_EQ(
+      decode_pdu_sess_est_req.payload_container.smf_msg.msg
+          .pdu_session_estab_request.ssc_mode.mode_val,
+      1);
+  EXPECT_EQ(decode_pdu_sess_est_req.nssai.sst, 1);
+  EXPECT_EQ(memcmp(pdu_sess_est_req.dnn.dnn, dnn, pdu_sess_est_req.dnn.len), 0);
+  bdestroy(buffer);
+}
+
 TEST(test_dnn, test_amf_handle_s6a_update_location_ans) {
   // creating ue_context
   ue_m5gmm_context_s* ue_context = amf_create_new_ue_context();

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -929,13 +929,8 @@ TEST(test_optional_dnn_pdu, test_pdu_session_establish_optional) {
 }
 
 TEST(test_optional_dnn_dotted_pdu, test_pdu_session_establish_optional) {
-  uint32_t bytes         = 0;
-  uint32_t container_len = 0;
+  uint32_t bytes = 0;
   bstring buffer;
-  amf_nas_message_t msg = {};
-
-  // build uplinknastransport
-  // uplink nas transport(pdu session request)
 
   uint8_t pdu[44] = {0x7e, 0x00, 0x67, 0x01, 0x00, 0x15, 0x2e, 0x01, 0x01,
                      0xc1, 0xff, 0xff, 0x91, 0xa1, 0x28, 0x01, 0x00, 0x7b,


### PR DESCRIPTION
Signed-off-by: Sathyaj27 <sathya.jayadev@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Dotted DNN support is added.
Decoding and encoding added and UT added for the same.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
1) Tested positive case for dotted dnn
![MicrosoftTeams-image](https://user-images.githubusercontent.com/94469973/147565121-840ca28d-80ac-49ae-b035-93b61e86c570.png)
2) Tested negative  case of dotted dnn
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/94469973/147565203-3c72e745-b9d8-4594-9c8b-2b972608ddad.png)
3) Maximum DNN length 100 
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/94469973/147565288-377c6b30-9140-40ae-8b8a-e048a3cd57ff.png)
<img width="890" alt="lengthmore" src="https://user-images.githubusercontent.com/94469973/147565370-256f6082-f502-4d6d-8d22-4674b28623b3.PNG">

4)Tested existing cases.
## Additional Information

- [ ] This change is backwards-breaking
Corresponding zenhub task id #10603 

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
