### PR TITLE
chore(agw): Backport use version scheme that is understood by sentry

### DIFF
--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -307,7 +307,7 @@ def _run_remote_lte_package(repo: str, magma_root: str,
     vagrant_cp = '/home/vagrant/magma/fb/control_proxy.yml'
 
     with cd(f'{repo_name}/{magma_root}/lte/gateway'):
-        fab_args = f'vcs=git,all_deps=False,' \
+        fab_args = 'all_deps=False,' \
                    f'cert_file={vagrant_cert},' \
                    f'proxy_config={vagrant_cp},' \
                    f'destroy_vm={destroy_vm}'

--- a/docs/readmes/howtos/README_package.md
+++ b/docs/readmes/howtos/README_package.md
@@ -6,11 +6,11 @@ hide_title: true
 # Packaging
 TL;DR
 -----
-1. Running `fab test package:git` on the host creates the package inside the
+1. Running `fab test package` on the host creates the package inside the
 gateway VM
 2. Commit changes to build-magma.sh and magma.lockfile.debian.
 3. To build packages for Ubuntu, bring up magma_focal VM. Run
-`fab dev package:vcs=git,vm=magma_focal,os=ubuntu` to build packages.
+`fab dev package:vm=magma_focal,os=ubuntu` to build packages.
 
 
 Creating a production release package.
@@ -31,8 +31,8 @@ you can also increment the iteration number.
 Creating a development package.
 ---------------------------
 To create an AGW package with debug compiler flags (`Debug`),
-For Debian run `fab dev package:git`
-For Ubuntu run `fab test package:vcs=git,vm=magma_focal,os=ubuntu`
+For Debian run `fab dev package`
+For Ubuntu run `fab test package:vm=magma_focal,os=ubuntu`
 
 Testing a release package before you push it.
 ---------------------------------------------

--- a/docs/readmes/lte/build_install_magma_pkg_in_agw.md
+++ b/docs/readmes/lte/build_install_magma_pkg_in_agw.md
@@ -20,7 +20,7 @@ git checkout v1.1
 
 2. **Install prerequisites**. Make sure you have installed all the tools specified in the prerequisites https://magma.github.io/magma/docs/basics/prerequisites#prerequisites
 
-3. **Build and create deb package**. In your local magma repo, go to the path `magma/lte/gateway` and run the command `fab dev package:vcs=git`
+3. **Build and create deb package**. In your local magma repo, go to the path `magma/lte/gateway` and run the command `fab dev package`
 
 This command will create a vagrant magma machine, then build and create a deb package.
 

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -71,7 +71,7 @@ def test():
     env.debug_mode = False
 
 
-def package(vcs='git', all_deps="False",
+def package(all_deps="False",
             cert_file=DEFAULT_CERT, proxy_config=DEFAULT_PROXY,
             destroy_vm='False',
             vm='magma', os="ubuntu"):
@@ -88,7 +88,8 @@ def package(vcs='git', all_deps="False",
               "\tfab [dev|test] package")
         exit(1)
 
-    hash = pkg.get_commit_hash(vcs)
+    hash = pkg.get_commit_hash()
+    commit_count = pkg.get_commit_count()
 
     with cd('~/magma/lte/gateway'):
         # Generate magma dependency packages
@@ -106,8 +107,8 @@ def package(vcs='git', all_deps="False",
         run('make clean')
         build_type = "Debug" if env.debug_mode else "RelWithDebInfo"
 
-        run('./release/build-magma.sh -h "%s" -t %s --cert %s --proxy %s --os %s' %
-            (hash, build_type, cert_file, proxy_config, os))
+        run('./release/build-magma.sh -h %s --commit-count %s -t %s --cert %s --proxy %s --os %s' %  # noqa: E501
+            (hash, commit_count, build_type, cert_file, proxy_config, os))
 
         run('rm -rf ~/magma-packages')
         run('mkdir -p ~/magma-packages')

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -27,7 +27,8 @@ SCTPD_MIN_VERSION=1.6.1 # earliest version of sctpd with which this version is c
 BUILD_TYPE=Debug
 
 # Cmdline options that overwrite the version configs above
-COMMIT_HASH=""  # hash of top magma commit (hg log $MAGMA_PATH)
+COMMIT_HASH=""  # hash of top magma commit
+COMMIT_COUNT="" # count of commits on git main
 CERT_FILE="$MAGMA_ROOT/.cache/test_certs/rootCA.pem"
 CONTROL_PROXY_FILE="$MAGMA_ROOT/lte/gateway/configs/control_proxy.yml"
 OS="ubuntu"
@@ -42,6 +43,10 @@ case $key in
     ;;
     -h|--hash)
     COMMIT_HASH="$2"
+    shift
+    ;;
+    --commit-count)
+    COMMIT_COUNT="$2"
     shift
     ;;
     -t|--type)
@@ -290,7 +295,7 @@ if [ -d ${PY_TMP_BUILD} ]; then
 fi
 
 FULL_VERSION=${VERSION}-$(date +%s)-${COMMIT_HASH}
-COMMIT_HASH_WITH_VERSION=${VERSION}-${COMMIT_HASH}
+COMMIT_HASH_WITH_VERSION="magma@${VERSION}.${COMMIT_COUNT}-${COMMIT_HASH}"
 
 # first do python protos and then build the python packages.
 # library will be dropped in $PY_TMP_BUILD/usr/lib/python3/dist-packages

--- a/lte/gateway/release/magma-postinst
+++ b/lte/gateway/release/magma-postinst
@@ -17,11 +17,11 @@ sed -i "s/.*OVS_CTL_OPTS.*/OVS_CTL_OPTS='--delete-bridges'/" /etc/default/openvs
 mkdir -p /var/core
 
 value=`cat /usr/local/share/magma/commit_hash`
-if sudo grep -q "COMMIT_HASH" /etc/environment
+if grep -q "COMMIT_HASH" /etc/environment
 then
     sudo sed -i -e "s/^COMMIT_HASH.*/$value/" /etc/environment
 else
-    sudo echo "$value" >> /etc/environment
+    echo "$value" | sudo tee -a /etc/environment
 fi
 
 # Set magmad service to start on boot

--- a/orc8r/tools/fab/pkg.py
+++ b/orc8r/tools/fab/pkg.py
@@ -54,17 +54,12 @@ def check_commit_changes():
             return False
 
 
-def get_commit_hash(vcs='hg'):
-    with hide('running', 'warnings', 'output'), settings(warn_only=True):
-        if vcs == 'hg':
-            local_commit_hash = local('hg identify -i',
-                                      capture=True).replace('+', '').split()[0]
-        elif vcs == 'git':
-            local_commit_hash = local('git rev-parse HEAD', capture=True)
-        else:
-            print('Unknown vcs: %s' % vcs)
-            exit(1)
-    return local_commit_hash[0:8]
+def get_commit_hash():
+    return local('git rev-parse HEAD', capture=True)[0:8]
+
+
+def get_commit_count():
+    return local('git rev-list --count HEAD', capture=True)
 
 
 def download_all_pkgs():


### PR DESCRIPTION
## Summary

This PR backports #10831.

(Additionally it includes fix #10951 for the postinstall script.)

## Test Plan

Built package with `fab test package` and checked that version can be found correctly in respective `COMMIT_HASH_FILE` (e.g. `magma@1.6.1.8690-40d4017f` from my branch)

## Additional Information

- [x] This change is backwards-breaking