### PR TITLE
chore(agw): Backport consolidation of sentry-cli and sentry_sdk releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,7 +385,10 @@ commands:
       - run:
           name: Create a release in Sentry.io with the commit hash
           command: |
-            COMMIT_HASH_WITH_VERSION="1.6.1-${CIRCLE_SHA1:0:8}"
+            # The assumption here is that the magma version is copied out
+            # into /home/circleci/project/circleci in the magma_integ_test step
+            COMMIT_HASH_WITH_VERSION=$(cat circleci/magma_version)
+            echo ${COMMIT_HASH_WITH_VERSION}
             sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native -p radtonics_lab_native -p magma-staging-native ${COMMIT_HASH_WITH_VERSION}
             sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${COMMIT_HASH_WITH_VERSION}
             sentry-cli --log-level=info releases finalize ${COMMIT_HASH_WITH_VERSION}

--- a/orc8r/tools/fab/pkg.py
+++ b/orc8r/tools/fab/pkg.py
@@ -131,11 +131,11 @@ def upload_pkgs_to_aws():
 
 
 def get_magma_version():
-    return run('ls ~/magma-packages'
-               ' | grep "^magma_[0-9].*"'
-               ' | xargs -I "%" dpkg -I ~/magma-packages/%'
-               ' | grep "Version"'
-               ' | awk \'{print $2}\'')
+    return run('directory=$(mktemp -d) &&'
+               'dpkg-deb --extract ~/magma-packages/magma_[0-9]*.deb $directory &&'  # noqa: E501
+               'source $directory/usr/local/share/magma/commit_hash &&'
+               'echo $COMMIT_HASH',
+               )
 
 
 def copy_packages():


### PR DESCRIPTION
## Summary

Backport PR #10832.

And #9319, which is a prerequisite for #10832. 

## Test Plan

Tested the new shell commands on VM bash locally.

## Additional Information

- [ ] This change is backwards-breaking
