### PR TITLE
fix(agw): handle GTP echo response edge case.

### DIFF
--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
@@ -1,4 +1,4 @@
-From ce7836e422fd0167ef2315cc8d5d0f83b2b2d879 Mon Sep 17 00:00:00 2001
+From 4a6dc157b2370697407b41730932fce42d132239 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 28 Jun 2020 21:49:40 +0000
 Subject: [PATCH 01/22] of-match: expand NXM_NX_TUN_FLAGS to include all tunnel
@@ -22,7 +22,7 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  8 files changed, 66 insertions(+), 6 deletions(-)
 
 diff --git a/include/openvswitch/meta-flow.h b/include/openvswitch/meta-flow.h
-index 95e52e358..e88a401f9 100644
+index 045dce8f5..8371d73c0 100644
 --- a/include/openvswitch/meta-flow.h
 +++ b/include/openvswitch/meta-flow.h
 @@ -380,7 +380,7 @@ enum OVS_PACKED_ENUM mf_field_id {
@@ -104,7 +104,7 @@ index 3455ed233..42a458bbd 100644
          flow->pkt_mark = cfg->egress_pkt_mark;
          wc->masks.pkt_mark = UINT32_MAX;
 diff --git a/tests/tunnel-push-pop-ipv6.at b/tests/tunnel-push-pop-ipv6.at
-index 59723e63b..4a0eeaeb3 100644
+index c7665a1ae..2b4247a60 100644
 --- a/tests/tunnel-push-pop-ipv6.at
 +++ b/tests/tunnel-push-pop-ipv6.at
 @@ -421,7 +421,7 @@ OVS_WAIT_UNTIL([test `wc -l < ofctl_monitor.log` -ge 2])
@@ -117,7 +117,7 @@ index 59723e63b..4a0eeaeb3 100644
  ])
  
 diff --git a/tests/tunnel-push-pop.at b/tests/tunnel-push-pop.at
-index 12fc1ef91..f297a0222 100644
+index 6a597488e..d628ce6ac 100644
 --- a/tests/tunnel-push-pop.at
 +++ b/tests/tunnel-push-pop.at
 @@ -511,7 +511,7 @@ OVS_WAIT_UNTIL([test `wc -l < ofctl_monitor.log` -ge 2])

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
@@ -1,4 +1,4 @@
-From 97a9156a46b26d55fc0b9215f220fe032c230122 Mon Sep 17 00:00:00 2001
+From 71e80cf136045a3d58aa3a9d05ac97f7488dc8b3 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 24 Feb 2020 04:29:56 +0000
 Subject: [PATCH 02/22] userspace: IPFIX: Add tunnel type GTP
@@ -181,7 +181,7 @@ index 864c136b5..4bb8f0b59 100644
          ipproto = IPPROTO_UDP;
  
 diff --git a/tests/tunnel-push-pop.at b/tests/tunnel-push-pop.at
-index f297a0222..4883807d1 100644
+index d628ce6ac..ef8784cfa 100644
 --- a/tests/tunnel-push-pop.at
 +++ b/tests/tunnel-push-pop.at
 @@ -442,7 +442,7 @@ AT_CHECK([ovs-ofctl add-flow int-br "actions=9"])

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
@@ -1,4 +1,4 @@
-From cc935c38e3f674bc69b9e7f7faf3610d44647def Mon Sep 17 00:00:00 2001
+From 830413402d1b48cd1ae2c8d0e52409de8ea64b16 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 00:55:30 -0800
 Subject: [PATCH 03/22] datapath: add vport-gtp for GPRS Tunneling Protocol

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0004-ovs-Add-support-to-set-GTP-header-fields.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0004-ovs-Add-support-to-set-GTP-header-fields.patch
@@ -1,4 +1,4 @@
-From e22363a9d318240200a23732577561957718dc1e Mon Sep 17 00:00:00 2001
+From 5ce03f7a9d4cf5c076a4756ec517b93c5265f522 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 00:58:18 -0800
 Subject: [PATCH 04/22] ovs: Add support to set GTP header fields.
@@ -430,7 +430,7 @@ index bc9574015..d7352b644 100644
  	return 0;
  }
 diff --git a/include/openvswitch/meta-flow.h b/include/openvswitch/meta-flow.h
-index e88a401f9..17548f548 100644
+index 8371d73c0..fc1808482 100644
 --- a/include/openvswitch/meta-flow.h
 +++ b/include/openvswitch/meta-flow.h
 @@ -514,7 +514,7 @@ enum OVS_PACKED_ENUM mf_field_id {
@@ -544,7 +544,7 @@ index 50f95e637..ea0896456 100644
      }
      ovs_mutex_unlock(&dev->mutex);
 diff --git a/lib/odp-util.c b/lib/odp-util.c
-index e1199d1da..43f81876d 100644
+index ec25976d6..9264c85b1 100644
 --- a/lib/odp-util.c
 +++ b/lib/odp-util.c
 @@ -765,7 +765,7 @@ format_odp_tnl_push_header(struct ds *ds, struct ovs_action_push_tnl *data)

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0005-OVS-gtp-echo-handling.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0005-OVS-gtp-echo-handling.patch
@@ -1,4 +1,4 @@
-From 720d5e54161777e47f8dec570d622ee490903f4a Mon Sep 17 00:00:00 2001
+From 9067df03eef48cdce93be4582a3ba396d61cba8c Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 13 Aug 2021 07:15:40 +0000
 Subject: [PATCH 05/22] OVS: gtp echo handling
@@ -9,7 +9,7 @@ testing done using ./tests/test-gtp 1.11.1.1 3201000a0000000000010000ff0003000a0
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
- include/openvswitch/packets.h  |  16 ++
+ include/openvswitch/packets.h  |  17 ++
  lib/bfd.c                      |  98 +++++++++--
  lib/bfd.h                      |   4 +-
  lib/netdev-provider.h          |   8 +
@@ -25,14 +25,14 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  tests/system-common-macros.at  |  19 +++
  tests/system-layer3-tunnels.at | 297 +++++++++++++++++++++++++++------
  tests/test-gtp.c               | 111 ++++++++++++
- 16 files changed, 773 insertions(+), 84 deletions(-)
+ 16 files changed, 774 insertions(+), 84 deletions(-)
  create mode 100644 tests/test-gtp.c
 
 diff --git a/include/openvswitch/packets.h b/include/openvswitch/packets.h
-index 236ae26cc..2f3fa3191 100644
+index 236ae26cc..e1f3c17b5 100644
 --- a/include/openvswitch/packets.h
 +++ b/include/openvswitch/packets.h
-@@ -93,6 +93,22 @@ struct ovs_key_nsh {
+@@ -93,6 +93,23 @@ struct ovs_key_nsh {
  
  #define FLOW_NSH_F_MASK ((1 << 2) - 1)
  
@@ -49,6 +49,7 @@ index 236ae26cc..2f3fa3191 100644
 +
 +struct gtp1_cntr_echo_rsp_header {
 +    ovs_be16	        seq;
++    struct gtpv1_tlv    unused;
 +    struct gtpv1_tlv    recovery;
 +} __attribute__ ((packed));
 +
@@ -656,10 +657,10 @@ index bb0e49091..42bf211e9 100644
                  MSEC_TO_PRIO(next_wake_time));
  }
 diff --git a/ofproto/ofproto-dpif-xlate.c b/ofproto/ofproto-dpif-xlate.c
-index 7108c8a30..6c882b9f7 100644
+index bd7693bf0..a5c8b5f0b 100644
 --- a/ofproto/ofproto-dpif-xlate.c
 +++ b/ofproto/ofproto-dpif-xlate.c
-@@ -7955,17 +7955,14 @@ xlate_resume(struct ofproto_dpif *ofproto,
+@@ -7993,17 +7993,14 @@ xlate_resume(struct ofproto_dpif *ofproto,
   * May modify 'packet'.
   * Returns 0 if successful, otherwise a positive errno value. */
  int
@@ -680,7 +681,7 @@ index 7108c8a30..6c882b9f7 100644
      flow_extract(packet, &flow);
      flow.in_port.ofp_port = OFPP_NONE;
  
-@@ -7974,19 +7971,31 @@ xlate_send_packet(const struct ofport_dpif *ofport, bool oam,
+@@ -8012,19 +8009,31 @@ xlate_send_packet(const struct ofport_dpif *ofport, bool oam,
          return EINVAL;
      }
  

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0006-ovs-test-add-gtp-marker-test.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0006-ovs-test-add-gtp-marker-test.patch
@@ -1,4 +1,4 @@
-From 1d9797d5f1e8a12127c5fb8c133384c803c31f01 Mon Sep 17 00:00:00 2001
+From 2b0ee819cea841c92f082cd258a16e627380efd5 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 06:54:04 +0000
 Subject: [PATCH 06/22] ovs: test: add gtp marker test

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0007-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0007-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
@@ -1,4 +1,4 @@
-From 5a1b78f3e8020df32ce3e793bc4b2f255e512d39 Mon Sep 17 00:00:00 2001
+From ef6fbd9c38c8a6ec4285263c72237340c6e3179e Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 27 Sep 2020 19:46:24 +0000
 Subject: [PATCH 07/22] native-tnl: routing: tunnel lookup with pkt-mark

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0008-fixes-for-2.14.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0008-fixes-for-2.14.patch
@@ -1,4 +1,4 @@
-From 6a33542d33955b9c9b7debf61ff68ac6e3456b3b Mon Sep 17 00:00:00 2001
+From 6c08bfbaaa63eef1239e6993759ee2e07406e5e5 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sat, 28 Nov 2020 23:09:50 -0800
 Subject: [PATCH 08/22] fixes for 2.14
@@ -148,7 +148,7 @@ index 08d576913..4cfaa50c8 100644
  #define TUNNEL_GTPU_OPT          __cpu_to_be16(0x8000)
  #endif
 diff --git a/lib/odp-util.c b/lib/odp-util.c
-index 43f81876d..cce43d9a4 100644
+index 9264c85b1..f773f106d 100644
 --- a/lib/odp-util.c
 +++ b/lib/odp-util.c
 @@ -5223,10 +5223,24 @@ scan_gtpu_metadata(const char *s,

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0009-Add-custom-IPDR-fields-for-IPFIX-export.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0009-Add-custom-IPDR-fields-for-IPFIX-export.patch
@@ -1,4 +1,4 @@
-From c4a2d8cd0ea3addea90ef6c7064af59146feb4b5 Mon Sep 17 00:00:00 2001
+From 529c88d17270eff42f1ffea58717a47038a0b712 Mon Sep 17 00:00:00 2001
 From: Nick Yurchenko <koolzz@fb.com>
 Date: Mon, 1 Feb 2021 21:25:00 -0500
 Subject: [PATCH 09/22] Add custom IPDR fields for IPFIX export
@@ -273,10 +273,10 @@ index ed0a4ace0..dda89f409 100644
      }
      ovs_mutex_unlock(&mutex);
 diff --git a/ofproto/ofproto-dpif-xlate.c b/ofproto/ofproto-dpif-xlate.c
-index 6c882b9f7..7bfcccc93 100644
+index a5c8b5f0b..f9699439b 100644
 --- a/ofproto/ofproto-dpif-xlate.c
 +++ b/ofproto/ofproto-dpif-xlate.c
-@@ -5643,6 +5643,11 @@ xlate_sample_action(struct xlate_ctx *ctx,
+@@ -5657,6 +5657,11 @@ xlate_sample_action(struct xlate_ctx *ctx,
      cookie.flow_sample.obs_point_id = os->obs_point_id;
      cookie.flow_sample.output_odp_port = output_odp_port;
      cookie.flow_sample.direction = os->direction;

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0010-ovs-Handle-spaces-in-ovs-arguments.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0010-ovs-Handle-spaces-in-ovs-arguments.patch
@@ -1,4 +1,4 @@
-From 26f890320580efce6c6acfb142c0fcc7a902ec9b Mon Sep 17 00:00:00 2001
+From 99b4ffa18190d4e311a5b4576b5f53a124a9bbe6 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 13 Mar 2020 19:18:40 +0000
 Subject: [PATCH 10/22] ovs: Handle spaces in ovs arguments

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0011-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0011-Add-pdp_start_epoch-custom-field-to-IPFIX-export.patch
@@ -1,4 +1,4 @@
-From 866f50fe33880d98640f7891aacfaded4a9a667d Mon Sep 17 00:00:00 2001
+From cff75ea91db26d7db4ea04fb6384a550a60660b5 Mon Sep 17 00:00:00 2001
 From: Nick Yurchenko <koolzz@fb.com>
 Date: Mon, 1 Feb 2021 21:46:32 -0500
 Subject: [PATCH 11/22] Add pdp_start_epoch custom field to IPFIX export
@@ -193,10 +193,10 @@ index dda89f409..1639bf683 100644
      }
      ovs_mutex_unlock(&mutex);
 diff --git a/ofproto/ofproto-dpif-xlate.c b/ofproto/ofproto-dpif-xlate.c
-index 7bfcccc93..ff9225304 100644
+index f9699439b..063d1c429 100644
 --- a/ofproto/ofproto-dpif-xlate.c
 +++ b/ofproto/ofproto-dpif-xlate.c
-@@ -5645,6 +5645,7 @@ xlate_sample_action(struct xlate_ctx *ctx,
+@@ -5659,6 +5659,7 @@ xlate_sample_action(struct xlate_ctx *ctx,
      cookie.flow_sample.direction = os->direction;
      cookie.flow_sample.flow_metadata = ctx->xin->flow.metadata;
      cookie.flow_sample.app_name = ctx->xin->flow.regs[10];

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0012-GTP-Extension-header-support-in-ovs2.14.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0012-GTP-Extension-header-support-in-ovs2.14.patch
@@ -1,4 +1,4 @@
-From f1c0e129252423dced8928203f68e35e427dc5fa Mon Sep 17 00:00:00 2001
+From ef40476ef80607d162b255e678e949fa161cec26 Mon Sep 17 00:00:00 2001
 From: YOGESH PANDEY <yogesh@wavelabs.ai>
 Date: Thu, 25 Mar 2021 16:48:07 +0530
 Subject: [PATCH 12/22] GTP Extension header support in ovs2.14

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0013-ODP-action-Fix-L3-port-to-L3-port-traffic.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0013-ODP-action-Fix-L3-port-to-L3-port-traffic.patch
@@ -1,4 +1,4 @@
-From 48cddbf7e235e71ffa72f595ee88daccc95b8418 Mon Sep 17 00:00:00 2001
+From bee231325676cc2613694695b77db6654033811f Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 18 Apr 2021 17:17:56 +0000
 Subject: [PATCH 13/22] ODP-action: Fix L3 port to L3 port traffic.
@@ -9,7 +9,7 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  1 file changed, 25 insertions(+), 2 deletions(-)
 
 diff --git a/lib/odp-util.c b/lib/odp-util.c
-index cce43d9a4..5693f0836 100644
+index f773f106d..f2c077827 100644
 --- a/lib/odp-util.c
 +++ b/lib/odp-util.c
 @@ -8605,6 +8605,27 @@ odp_put_push_nsh_action(struct ofpbuf *odp_actions,

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0014-datapath-GTP-cleanup.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0014-datapath-GTP-cleanup.patch
@@ -1,4 +1,4 @@
-From 0e0113efbbc79d739ed5915da4dbc519182c1a4b Mon Sep 17 00:00:00 2001
+From d78d2b17108e2d0fd79abea733349f48a3f19a4b Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 9 May 2021 06:11:10 +0000
 Subject: [PATCH 14/22] datapath: GTP: cleanup

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0015-GTP-handle-seq-number-in-HDR.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0015-GTP-handle-seq-number-in-HDR.patch
@@ -1,4 +1,4 @@
-From e9fccd67641cf3c614b2cad33cd7c42530c384d5 Mon Sep 17 00:00:00 2001
+From 5a0ad28209c2f264116107122b2826280f4039a7 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 28 May 2021 16:06:54 +0000
 Subject: [PATCH 15/22] GTP: handle seq number in HDR

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0016-datapath-gtp-add-segmentation-offloads.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0016-datapath-gtp-add-segmentation-offloads.patch
@@ -1,4 +1,4 @@
-From 952699ac1cce6919208a1c7b9db077e13f953c40 Mon Sep 17 00:00:00 2001
+From bb0d5d4b0af53829c83a7dcc9e1a8e69b8019c3d Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 8 Jun 2021 01:44:33 +0000
 Subject: [PATCH 16/22] datapath: gtp: add segmentation offloads

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0017-net-Fix-zero-copy-head-len-calculation.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0017-net-Fix-zero-copy-head-len-calculation.patch
@@ -1,4 +1,4 @@
-From ea2453d9b516486fe4f8bf0c7e585b4455ef835b Mon Sep 17 00:00:00 2001
+From 8454ad2413165f449a81bf60b1a62388db68a942 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 4 Jul 2021 19:31:58 +0000
 Subject: [PATCH 17/22] net: Fix zero-copy head len calculation.

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0018-gtp-Fix-for-sequence-number-length-calculation.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0018-gtp-Fix-for-sequence-number-length-calculation.patch
@@ -1,4 +1,4 @@
-From 9b622ee7475cfc1d1c13d94a3cad9ed5c4ef32d4 Mon Sep 17 00:00:00 2001
+From 99364efc65d01050a695f8733f9928e0f17c705d Mon Sep 17 00:00:00 2001
 From: Yogesh Pandey <yogesh@wavelabs.ai>
 Date: Sat, 21 Aug 2021 09:58:46 +0000
 Subject: [PATCH 18/22] gtp: Fix for sequence number length calculation

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0019-AGW-OVS-handle-gtp-tunnel-type.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0019-AGW-OVS-handle-gtp-tunnel-type.patch
@@ -1,4 +1,4 @@
-From 407cf24012bc486879e063a23b1a37b237aea3e7 Mon Sep 17 00:00:00 2001
+From 312476bbf2de6fcbf5ba0806ab73a7062f9ff333 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Wed, 23 Sep 2020 04:01:59 +0000
 Subject: [PATCH 19/22] AGW: OVS: handle gtp tunnel type

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0020-datapath-fix-gso-length.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0020-datapath-fix-gso-length.patch
@@ -1,4 +1,4 @@
-From 7b4b38b176a86346784ae286a879c44283057b25 Mon Sep 17 00:00:00 2001
+From 21818da9db7ab7644f8e169cc21db4552fdf21f4 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 21 Sep 2021 22:26:20 +0000
 Subject: [PATCH 20/22] datapath: fix gso length

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0021-datapath-update-version.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0021-datapath-update-version.patch
@@ -1,4 +1,4 @@
-From 58602e7c0d73bf5e35c96295afd30ca631cbccb1 Mon Sep 17 00:00:00 2001
+From bcdfb8d8ea9e239eff725455157e67d5f743f596 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 21 Sep 2021 22:39:41 +0000
 Subject: [PATCH 21/22] datapath: update version
@@ -8,15 +8,15 @@ Subject: [PATCH 21/22] datapath: update version
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/debian/changelog b/debian/changelog
-index ed5b127e5..d48ede187 100644
+index 83eec2410..0ed655123 100644
 --- a/debian/changelog
 +++ b/debian/changelog
 @@ -1,4 +1,4 @@
--openvswitch (2.15.2-1) unstable; urgency=low
-+openvswitch (2.15.2-6) unstable; urgency=low
+-openvswitch (2.15.4-1) unstable; urgency=low
++openvswitch (2.15.4-7) unstable; urgency=low
     [ Open vSwitch team ]
     * New upstream version
-
---
+ 
+-- 
 2.25.1
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0022-Add-GTP-IPv6-support.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0022-Add-GTP-IPv6-support.patch
@@ -1,4 +1,4 @@
-From 09d0524030d563d29c657a46de7943ad7d27a346 Mon Sep 17 00:00:00 2001
+From 98e875b18456608a1668e7a9ffeaf88f266e0a86 Mon Sep 17 00:00:00 2001
 From: Nick Yurchenko <urchennko@gmail.com>
 Date: Mon, 13 Sep 2021 18:44:22 +0000
 Subject: [PATCH 22/22] Add GTP IPv6 support

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/build.sh
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/build.sh
@@ -14,7 +14,7 @@ cd ~/$DIR
 
 git clone  https://github.com/openvswitch/ovs
 cd ovs/
-git checkout v2.15.2
+git checkout 31288dc725be6bc8eaa4e8641ee28895c9d0fd7a
 git apply "$MAGMA_ROOT/third_party/gtp_ovs/ovs-gtp-patches/$OVS_VER"/00*
 DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary
 cd ..


### PR DESCRIPTION
Few eNB returns error in case of missing zero
word in GTP extention header. Following PR fixes this.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
