### PR TITLE
test(agw): Add UE static IP integ test

### DIFF
--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -17,6 +17,8 @@ print_grpc_payload: false
 
 ipv6_prefixlen: 58
 
+static_ip: true
+
 # [Experimental] Enable Sentry for this service
 # Allowed values: send_all_errors, send_selected_errors, disabled
 sentry: send_all_errors

--- a/lte/gateway/python/integ_tests/common/subscriber_db_client.py
+++ b/lte/gateway/python/integ_tests/common/subscriber_db_client.py
@@ -162,6 +162,8 @@ class SubscriberDbGrpc(SubscriberDbClient):
             apn_config.ambr.max_bandwidth_ul = apn["mbr_ul"]
             apn_config.ambr.max_bandwidth_dl = apn["mbr_dl"]
             apn_config.pdn = apn["pdn_type"] if "pdn_type" in apn else 0
+            if apn["static_ip"]:
+                apn_config.assigned_static_ip = apn["static_ip"]
         return update
 
     def _check_invariants(self):

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -14,6 +14,7 @@ PROTO_LIST:=orc8r_protos lte_protos feg_protos
 
 # Add the s1aptester integration tests
 PRECOMMIT_TESTS = s1aptests/test_attach_detach.py \
+s1aptests/test_attach_detach_static_ip.py \
 s1aptests/test_gateway_metrics_attach_detach.py \
 s1aptests/test_attach_detach_looped.py  \
 s1aptests/test_attach_emergency.py \

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -203,7 +203,9 @@ class TestWrapper(object):
         print("************************* Waiting for IP changes to propagate")
         self._mobility_util.wait_for_changes()
 
-    def configUEDevice(self, num_ues, reqData=[]):
+    def configUEDevice(self, num_ues, reqData=None, static_ips=[]):
+        if reqData is None:
+            reqData = []
         """ Configure the device on the UE side """
         reqs = self._sub_util.add_sub(num_ues=num_ues)
         for i in range(num_ues):
@@ -240,8 +242,12 @@ class TestWrapper(object):
             )
             # APN configuration below can be overwritten in the test case
             # after configuring UE device.
+            if i < len(static_ips):
+                ue_ip = static_ips[i]
+            else:
+                ue_ip = None
             self.configAPN(
-                "IMSI" + "".join([str(j) for j in reqs[i].imsi]), None,
+                imsi="IMSI" + "".join([str(j) for j in reqs[i].imsi]), apn_list=None, default=True, static_ip=ue_ip,
             )
             self._configuredUes.append(reqs[i])
 
@@ -314,7 +320,7 @@ class TestWrapper(object):
             )
             self._configuredUes.append(reqs[i])
 
-    def configAPN(self, imsi, apn_list, default=True):
+    def configAPN(self, imsi, apn_list, default=True, static_ip=None):
         """ Configure the APN """
         # add a default APN to be used in attach requests
         if default:
@@ -326,6 +332,7 @@ class TestWrapper(object):
                 "pre_vul": 0,  # preemption-vulnerability
                 "mbr_ul": 200000000,  # MBR UL
                 "mbr_dl": 100000000,  # MBR DL
+                "static_ip": static_ip,
             }
             # APN list to be configured
             if apn_list is not None:

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_static_ip.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_static_ip.py
@@ -1,0 +1,76 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import ipaddress
+import unittest
+
+import s1ap_types
+from integ_tests.s1aptests import s1ap_wrapper
+
+
+class TestAttachDetachStaticIP(unittest.TestCase):
+
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_detach_static_ip1(self):
+        """ Basic attach/detach test with a single UE """
+        num_ues = 3
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
+        wait_for_s1 = [True, True, False]
+        # third IP validates handling of invalid IP address.
+        ue_ips = ['1.1.1.1', '2.2.2.2', '888']
+        self._s1ap_wrapper.configUEDevice(num_ues, [], ue_ips)
+
+        for i in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ", req.ue_id,
+            )
+            # Now actually complete the attach
+            attach = self._s1ap_wrapper._s1_util.attach(
+                req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t,
+            )
+
+            # Validate assigned IP address.
+            addr = attach.esmInfo.pAddr.addrInfo
+            ue_ipv4 = ipaddress.ip_address(bytes(addr[:4]))
+            if i < (num_ues - 1):
+                self.assertEqual(ue_ipv4, ipaddress.IPv4Address(ue_ips[i]))
+            else:
+                self.assertIn(ue_ipv4, ipaddress.ip_network("192.168.128.0/24"))
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id,
+            )
+            # Now detach the UE
+            self._s1ap_wrapper.s1_util.detach(
+                req.ue_id, detach_type[i], wait_for_s1[i],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Following PR adds S1AP integ test for static IP allocation.
It uses subscriberDB API to configure static IP and verifies allocated IP in the test.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
