### PR TITLE
feat(orc8r): FEG_RELAY update to redirect session request to N7_N40 Proxy

### DIFF
--- a/feg/cloud/configs/service_registry.yml
+++ b/feg/cloud/configs/service_registry.yml
@@ -36,6 +36,8 @@ services:
         port: 9103
       session_proxy:
         port: 9079
+      n7_n40_proxy:
+        port: 9103
       swx_proxy:
         port: 9103
       csfb:

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound/relay_router.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound/relay_router.go
@@ -29,6 +29,7 @@ const (
 	FegSessionProxy gateway_registry.GwServiceType = "session_proxy"
 	FegHello        gateway_registry.GwServiceType = "feg_hello"
 	FegSwxProxy     gateway_registry.GwServiceType = "swx_proxy"
+	FegN7N40Proxy   gateway_registry.GwServiceType = "n7_n40_proxy"
 )
 
 // RelayRouter implements generic routing logic and currently just embeds gw_to_feg_relay.Router functionality

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound/session_proxy_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound/session_proxy_relay.go
@@ -19,17 +19,18 @@ import (
 	"github.com/golang/glog"
 
 	"magma/lte/cloud/go/protos"
+	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
 )
 
 // SessionProxyServer implementation
 //
-// Notify OCS/PCRF of new session and return rules associated with subscriber
+// CreateSession Notifies OCS/PCRF of new session and return rules associated with subscriber
 // along with credits for each rule
 func (s *RelayRouter) CreateSession(
 	ctx context.Context, r *protos.CreateSessionRequest) (*protos.CreateSessionResponse, error) {
 
 	// CreateSession's SID is just IMSI with "IMSI" prefix which findServingNHFeg() should remove
-	client, ctx, cancel, err := s.getSessionProxyClient(ctx, r.GetCommonContext().GetSid().GetId())
+	client, ctx, cancel, err := s.getSessionControllerProxyClient(ctx, getSessionControllerProxyType(r.GetCommonContext().GetRatType()), r.GetCommonContext().GetSid().GetId())
 	if err != nil {
 		return nil, err
 	}
@@ -37,67 +38,89 @@ func (s *RelayRouter) CreateSession(
 	return client.CreateSession(ctx, r)
 }
 
-// Updates OCS/PCRF with used credit and terminations from gateway
+// UpdateSession Updates OCS/PCRF with used credit and terminations from gateway
 func (s *RelayRouter) UpdateSession(
 	ctx context.Context, r *protos.UpdateSessionRequest) (*protos.UpdateSessionResponse, error) {
 
-	// Group requests by PLMNID
-	// Use the longest possible PLMN ID (6), in the worst case we'll fragment requests more then needed, but the routing
-	// will still be logically correct
-	reqMap := map[string]*protos.UpdateSessionRequest{}
+	// Group requests by [PLMNID][GwServiceType]
+	// - PLMNID: Use the longest possible PLMN ID (6), in the worst case we'll fragment requests more then needed,
+	//   but the routing will still be logically correct
+	// - GwServiceType: Each request will be sent to either Session_Proxy or for N7_N40_proxy
+	reqMap := map[string]map[gateway_registry.GwServiceType]*protos.UpdateSessionRequest{}
 	for _, u := range r.GetUpdates() {
 		if u == nil {
 			continue
 		}
 		plmnid := getPlmnId6(u.GetCommonContext().GetSid().GetId())
-		req, ok := reqMap[plmnid]
-		if !ok || req == nil {
-			req = &protos.UpdateSessionRequest{Updates: []*protos.CreditUsageUpdate{u}}
-			reqMap[plmnid] = req
-		} else {
-			req.Updates = append(req.Updates, u)
+
+		// Group requests by PLMNID
+		pMap, ok := reqMap[plmnid]
+		if !ok || pMap == nil {
+			// Group requests by GwServiceType
+			addReqMapEntry(reqMap, plmnid)
 		}
+
+		// Append the Updates to the Session_Proxy or N7_N40_Proxy map request,
+		// based on the RAT Type
+		proxyType := getSessionControllerProxyType(u.GetCommonContext().GetRatType())
+		reqMap[plmnid][proxyType].Updates = append(reqMap[plmnid][proxyType].Updates, u)
 	}
 	for _, m := range r.GetUsageMonitors() {
 		if m == nil {
 			continue
 		}
 		plmnid := getPlmnId6(m.GetSid())
-		req, ok := reqMap[plmnid]
-		if !ok || req == nil {
-			req = &protos.UpdateSessionRequest{UsageMonitors: []*protos.UsageMonitoringUpdateRequest{m}}
-			reqMap[plmnid] = req
-		} else {
-			req.UsageMonitors = append(req.UsageMonitors, m)
+		pMap, ok := reqMap[plmnid]
+		if !ok || pMap == nil {
+			addReqMapEntry(reqMap, plmnid)
 		}
+
+		// Append the UsageMonitors to the Session_Proxy or N7_N40_Proxy map request,
+		// based on the RAT Type
+		proxyType := getSessionControllerProxyType(m.GetRatType())
+		reqMap[plmnid][proxyType].UsageMonitors = append(reqMap[plmnid][proxyType].UsageMonitors, m)
 	}
-	resultChan := make(chan *protos.UpdateSessionResponse, len(reqMap))
+
+	// Each request in reqMap is segregated into two requests and
+	// relays each request to respective proxies (session_proxy and n7n40_proxy).
+	// Hence length of resultChan is len(reqMap) * 2
+
+	resultChan := make(chan *protos.UpdateSessionResponse, len(reqMap)*2)
+	var numOfProxyRreq int
 
 	// send a separate Update request for each unique PLMN ID
-	for plmnid, req := range reqMap {
-		go func(plmnid string, req *protos.UpdateSessionRequest) {
-			client, ctx, cancel, err := s.getSessionProxyClient(ctx, plmnid)
-			if err != nil {
-				glog.Errorf("failed connect to Session Proxy for PLMNID '%s': %v", plmnid, err)
-				resultChan <- genUpdateErrorResp(req)
-				return
+	for plmnid, proxyMap := range reqMap {
+		for gwProxyType, req := range proxyMap {
+			if (req == nil) || ((len(req.Updates) == 0) && (len(req.UsageMonitors) == 0)) {
+				continue
 			}
-			defer cancel()
-			resp, err := client.UpdateSession(ctx, req)
-			if err != nil {
-				glog.Errorf("failed Session Proxy Update for PLMNID '%s': %v", plmnid, err)
-				resultChan <- genUpdateErrorResp(req)
-				return
-			}
-			resultChan <- resp
-		}(plmnid, req)
+			numOfProxyRreq++
+
+			go func(plmnid string, req *protos.UpdateSessionRequest, gwProxyType gateway_registry.GwServiceType) {
+				client, ctx, cancel, err := s.getSessionControllerProxyClient(ctx, gwProxyType, plmnid)
+				if err != nil {
+					glog.Errorf("failed connect to %s for PLMNID '%s': %v", gwProxyType, plmnid, err)
+					resultChan <- genUpdateErrorResp(req)
+					return
+				}
+				defer cancel()
+				resp, err := client.UpdateSession(ctx, req)
+				if err != nil {
+					glog.Errorf("failed %s Update for PLMNID '%s': %v", gwProxyType, plmnid, err)
+					resultChan <- genUpdateErrorResp(req)
+					return
+				}
+				resultChan <- resp
+			}(plmnid, req, gwProxyType)
+		}
 	}
+
 	// Combine received responses
 	resp := &protos.UpdateSessionResponse{
 		Responses:             []*protos.CreditUpdateResponse{},
 		UsageMonitorResponses: []*protos.UsageMonitoringUpdateResponse{},
 	}
-	for i := len(reqMap); i > 0; i-- {
+	for i := numOfProxyRreq; i > 0; i-- {
 		nhResp := <-resultChan
 		resp.Responses = append(resp.Responses, nhResp.GetResponses()...)
 		resp.UsageMonitorResponses = append(resp.UsageMonitorResponses, nhResp.GetUsageMonitorResponses()...)
@@ -106,12 +129,12 @@ func (s *RelayRouter) UpdateSession(
 	return resp, nil
 }
 
-// Terminates session in OCS/PCRF for a subscriber
+// TerminateSession Terminates session in OCS/PCRF for a subscriber
 func (s *RelayRouter) TerminateSession(
 	ctx context.Context, r *protos.SessionTerminateRequest) (*protos.SessionTerminateResponse, error) {
 
 	// TerminateSession's SID is just IMSI with "IMSI" prefix which findServingNHFeg() should remove
-	client, ctx, cancel, err := s.getSessionProxyClient(ctx, r.GetCommonContext().GetSid().GetId())
+	client, ctx, cancel, err := s.getSessionControllerProxyClient(ctx, getSessionControllerProxyType(r.GetCommonContext().GetRatType()), r.GetCommonContext().GetSid().GetId())
 	if err != nil {
 		return nil, err
 	}
@@ -119,10 +142,9 @@ func (s *RelayRouter) TerminateSession(
 	return client.TerminateSession(ctx, r)
 }
 
-func (s *RelayRouter) getSessionProxyClient(
-	c context.Context, imsi string) (protos.CentralSessionControllerClient, context.Context, context.CancelFunc, error) {
-
-	conn, ctx, cancel, err := s.GetFegServiceConnection(c, imsi, FegSessionProxy)
+// getSessionControllerProxyClient Get Proxy Client based on GwServiceType
+func (s *RelayRouter) getSessionControllerProxyClient(c context.Context, gwProxyType gateway_registry.GwServiceType, imsi string) (protos.CentralSessionControllerClient, context.Context, context.CancelFunc, error) {
+	conn, ctx, cancel, err := s.GetFegServiceConnection(c, imsi, gwProxyType)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -151,4 +173,29 @@ func genUpdateErrorResp(req *protos.UpdateSessionRequest) *protos.UpdateSessionR
 		})
 	}
 	return resp
+}
+
+// getSessionControllerProxyType Service selection based on the RAT Type
+func getSessionControllerProxyType(r protos.RATType) gateway_registry.GwServiceType {
+	switch r {
+	case protos.RATType_TGPP_NR:
+		return FegN7N40Proxy
+	default:
+		return FegSessionProxy
+	}
+}
+
+// addReqMapEntry Defines the map for Session_Proxy and N7_N40_Proxy per PLMN
+func addReqMapEntry(reqMap map[string]map[gateway_registry.GwServiceType]*protos.UpdateSessionRequest,
+	plmnid string) {
+
+	reqMap[plmnid] = map[gateway_registry.GwServiceType]*protos.UpdateSessionRequest{}
+	reqMap[plmnid][FegSessionProxy] = &protos.UpdateSessionRequest{
+		Updates:       []*protos.CreditUsageUpdate{},
+		UsageMonitors: []*protos.UsageMonitoringUpdateRequest{},
+	}
+	reqMap[plmnid][FegN7N40Proxy] = &protos.UpdateSessionRequest{
+		Updates:       []*protos.CreditUsageUpdate{},
+		UsageMonitors: []*protos.UsageMonitoringUpdateRequest{},
+	}
 }

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/relay_test.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/relay_test.go
@@ -31,6 +31,7 @@ import (
 	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay"
 	servicers "magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound"
 	healthTestUtils "magma/feg/cloud/go/services/health/test_utils"
+	lte_protos "magma/lte/cloud/go/protos"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/device"
@@ -91,6 +92,147 @@ func (tp *testHelloServer) SayHello(c context.Context, req *feg_protos.HelloRequ
 	}, nil
 }
 
+type testCentralSessionController struct {
+	lte_protos.UnimplementedCentralSessionControllerServer
+	resultChan chan string // Calling FeG ID string on success
+}
+
+func (tp *testCentralSessionController) UpdateSession(
+	ctx context.Context,
+	req *lte_protos.UpdateSessionRequest) (*lte_protos.UpdateSessionResponse, error) {
+
+	var res *lte_protos.UpdateSessionResponse
+	var ratType lte_protos.RATType
+
+	if tp == nil {
+		return nil, fmt.Errorf("nil test Central Session Controller")
+	}
+	if tp.resultChan == nil {
+		return nil, fmt.Errorf("nil test Central Session Controller channel")
+	}
+	var targetFegId = "<MISSING METADATA>"
+	ctxMetadata, ok := metadata.FromIncomingContext(ctx)
+	if ok && ctxMetadata != nil {
+		targetFegId = "<MISSING GW ID>"
+		values, ok := ctxMetadata[gateway_registry.GatewayIdHeaderKey]
+		if !ok {
+			values, ok = ctxMetadata[strings.ToLower(gateway_registry.GatewayIdHeaderKey)]
+		}
+		if ok && len(values) > 0 {
+			targetFegId = values[0]
+		}
+	}
+	tp.resultChan <- targetFegId
+
+	if len(req.Updates) > 0 {
+		ratType = req.Updates[0].GetCommonContext().GetRatType()
+	} else if len(req.UsageMonitors) > 0 {
+		ratType = req.UsageMonitors[0].GetRatType()
+	} else {
+		return nil, fmt.Errorf("empty data in UpdateSessionRequest")
+	}
+
+	if ratType == lte_protos.RATType_TGPP_NR {
+		res = &lte_protos.UpdateSessionResponse{
+			Responses: []*lte_protos.CreditUpdateResponse{
+				createCreditUsageResponse(nhImsi2, 2),
+			},
+			UsageMonitorResponses: []*lte_protos.UsageMonitoringUpdateResponse{
+				createUsageMonitoringResponse(nhImsi2, "mkey2"),
+				createUsageMonitoringResponse(nhImsi2, "mkey3"),
+			},
+		}
+	} else {
+		res = &lte_protos.UpdateSessionResponse{
+			Responses: []*lte_protos.CreditUpdateResponse{
+				createCreditUsageResponse(nhImsi, 1),
+			},
+			UsageMonitorResponses: []*lte_protos.UsageMonitoringUpdateResponse{
+				createUsageMonitoringResponse(nhImsi, "mkey"),
+			},
+		}
+	}
+
+	return res, nil
+}
+
+func createCreditUsageRequest(
+	imsi string,
+	chargingKey uint32,
+	requestNumber uint32,
+	requestType lte_protos.CreditUsage_UpdateType,
+	ratType lte_protos.RATType,
+) *lte_protos.CreditUsageUpdate {
+	return &lte_protos.CreditUsageUpdate{
+		Usage: &lte_protos.CreditUsage{
+			BytesTx:     1024,
+			BytesRx:     2048,
+			ChargingKey: chargingKey,
+			Type:        requestType,
+		},
+		SessionId:     imsi,
+		RequestNumber: requestNumber,
+		CommonContext: &lte_protos.CommonSessionContext{
+			Sid: &lte_protos.SubscriberID{
+				Id: imsi,
+			},
+			RatType: ratType,
+		},
+	}
+}
+
+func createCreditUsageResponse(
+	imsi string,
+	chargingKey uint32,
+) *lte_protos.CreditUpdateResponse {
+	return &lte_protos.CreditUpdateResponse{
+		Success:     true,
+		SessionId:   genSessionID(imsi),
+		Sid:         imsi,
+		ChargingKey: chargingKey,
+	}
+}
+
+func createUsageMonitoringRequest(
+	imsi string,
+	monitoringKey string,
+	requestNumber uint32,
+	monitoringLevel lte_protos.MonitoringLevel,
+	ratType lte_protos.RATType,
+) *lte_protos.UsageMonitoringUpdateRequest {
+	return &lte_protos.UsageMonitoringUpdateRequest{
+		Update: &lte_protos.UsageMonitorUpdate{
+			BytesTx:       1024,
+			BytesRx:       2048,
+			MonitoringKey: []byte(monitoringKey),
+			Level:         monitoringLevel,
+		},
+		SessionId:     genSessionID(imsi),
+		RequestNumber: requestNumber,
+		Sid:           imsi,
+		EventTrigger:  lte_protos.EventTrigger_USAGE_REPORT,
+		RatType:       ratType,
+	}
+}
+
+func createUsageMonitoringResponse(
+	imsi string,
+	monitoringKey string,
+) *lte_protos.UsageMonitoringUpdateResponse {
+	return &lte_protos.UsageMonitoringUpdateResponse{
+		Success:   true,
+		SessionId: genSessionID(imsi),
+		Sid:       imsi,
+		Credit: &lte_protos.UsageMonitoringCredit{
+			MonitoringKey: []byte(monitoringKey),
+		},
+	}
+}
+
+func genSessionID(imsi string) string {
+	return fmt.Sprintf("%s-1234", imsi)
+}
+
 func TestNHRouting(t *testing.T) {
 	testHealthServiser := setupNeutralHostNetworks(t)
 
@@ -113,6 +255,9 @@ func TestNHRouting(t *testing.T) {
 	// Register FeG's test Hello Server
 	feg_protos.RegisterHelloServer(srv.GrpcServer, &testHelloServer{})
 
+	// Register FeG's Central Session Controller Server
+	sessionProxy := &testCentralSessionController{resultChan: make(chan string, 2)}
+	lte_protos.RegisterCentralSessionControllerServer(srv.GrpcServer, sessionProxy)
 	go srv.RunTest(lis)
 
 	// Add Serving FeG Host to directoryd
@@ -128,6 +273,7 @@ func TestNHRouting(t *testing.T) {
 	relayRouter := servicers.NewRelayRouter()
 	feg_protos.RegisterS6AProxyServer(relaySrv.GrpcServer, relayRouter)
 	feg_protos.RegisterHelloServer(relaySrv.GrpcServer, relayRouter)
+	lte_protos.RegisterCentralSessionControllerServer(relaySrv.GrpcServer, relayRouter)
 	go relaySrv.RunTest(relayLis)
 
 	ctx := service_test_utils.GetContextWithCertificate(t, agwHwId)
@@ -149,6 +295,37 @@ func TestNHRouting(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("Neutral Host Routed S6a Proxy Call timed out")
 	}
+
+	// Test UpdateSession routing
+	sessProxyClient := lte_protos.NewCentralSessionControllerClient(conn)
+	toutctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	updateSessReq := &lte_protos.UpdateSessionRequest{
+		Updates: []*lte_protos.CreditUsageUpdate{
+			createCreditUsageRequest(nhImsi, 1, 1, lte_protos.CreditUsage_QUOTA_EXHAUSTED, lte_protos.RATType_TGPP_LTE),
+			createCreditUsageRequest(nhImsi2, 2, 2, lte_protos.CreditUsage_TERMINATED, lte_protos.RATType_TGPP_NR),
+		},
+		UsageMonitors: []*lte_protos.UsageMonitoringUpdateRequest{
+			createUsageMonitoringRequest(nhImsi, "mkey", 1, lte_protos.MonitoringLevel_SESSION_LEVEL, lte_protos.RATType_TGPP_LTE),
+			createUsageMonitoringRequest(nhImsi2, "mkey2", 2, lte_protos.MonitoringLevel_PCC_RULE_LEVEL, lte_protos.RATType_TGPP_NR),
+			createUsageMonitoringRequest(nhImsi2, "mkey3", 3, lte_protos.MonitoringLevel_SESSION_LEVEL, lte_protos.RATType_TGPP_NR),
+		},
+	}
+
+	res, err := sessProxyClient.UpdateSession(toutctx, updateSessReq)
+	cancel()
+	assert.NoError(t, err)
+
+	// Based on RATType, feg_relay UpdateSession splits and relays the request to session_proxy and n7_n40_proxy
+	// in serving feg. As testCentralSessionController UpdateSession is executed twice,
+	// verifying the servingFegHwId twice
+	for i := len(sessionProxy.resultChan); i > 0; i-- {
+		servingFegHwId := <-sessionProxy.resultChan
+		assert.Equal(t, fegHwId, servingFegHwId)
+	}
+
+	// Verifying the collective response from session_proxy and n7_n40_proxy of serving Feg
+	assert.Equal(t, len(updateSessReq.Updates), len(res.Responses))
+	assert.Equal(t, len(updateSessReq.UsageMonitors), len(res.UsageMonitorResponses))
 
 	// Test SayHello routing & NH argumentation regex
 	helloClient := feg_protos.NewHelloClient(conn)

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/test_setup.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/test_setup.go
@@ -44,6 +44,7 @@ var (
 	federatedLteNetworkID = "federated_lte"
 	nhImsi                = "123456000000101"
 	nhPlmnId              = nhImsi[:6]
+	nhImsi2               = "123456000000201"
 	agwHwId               = "lte_gw_hw_id"
 	agwId                 = "lte_gw_id"
 	fegHwId               = "feg_hw_id"


### PR DESCRIPTION
Signed-off-by: shivesh-wavelabs <shivesh.ojha@wavelabs.ai>

## Summary
FEG_RELAY code changes to redirect sessiond request to FegN7N40PROXY based on the RAT-TYPE

## Test Plan
All UTs passed.