### PR TITLE
test(agw): Add non-nat datapath integ test

### DIFF
--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -1,118 +1,121 @@
 {
   "configs_by_key": {
-    "mobilityd": {
-      "@type": "type.googleapis.com/magma.mconfig.MobilityD",
-      "logLevel": "INFO",
-      "ipBlock": "192.168.128.0/24",
-      "ipv6Block": "fdee:5:6c::/48",
-      "ipv6PrefixAllocationType": "RANDOM",
-      "ip_allocator_type": "IP_POOL",
-      "static_ip_enabled": true,
-      "multi_apn_ip_alloc": true
-    },
-    "mme": {
-      "@type": "type.googleapis.com/magma.mconfig.MME",
-      "mmeCode": 1,
-      "mmeGid": 1,
-      "mmeRelativeCapacity": 11,
-      "logLevel": "INFO",
-      "mcc": "001",
-      "mnc": "01",
-      "tac": 1,
-      "enableDnsCaching": false,
-      "relayEnabled": false,
-      "hssRelayEnabled": false,
-      "cloudSubscriberdbEnabled": false,
-      "nonEpsServiceControl": 0,
-      "csfbMcc": "001",
-      "csfbMnc": "01",
-      "lac": 1,
-      "amfName": "MAGMAAMF1",
-      "amfRegionId": "1",
-      "amfSetId": "1",
-      "amfPointer": "0",
-      "attachedEnodebTacs": [],
-      "dnsPrimary": "8.8.8.8",
-      "dnsSecondary": "8.8.4.4",
-      "ipv4PCscfAddress": "172.27.23.150",
-      "ipv6PCscfAddress": "2a12:577:9941:f99c:0002:0001:c731:f114",
-      "ipv6DnsAddress": "2001:4860:4860:0:0:0:0:8888",
-      "natEnabled": true,
-      "congestionControlEnabled": true,
-      "enable5gFeatures": false,
-      "amfDefaultSliceServiceType": 1,
-      "amfDefaultSliceDifferentiator" : "ffffff"
-    },
-    "enodebd": {
-      "@type": "type.googleapis.com/magma.mconfig.EnodebD",
-      "bandwidthMhz": 20,
-      "specialSubframePattern": 7,
-      "earfcndl": 44490,
-      "logLevel": "INFO",
-      "plmnidList": "00101",
-      "pci": 260,
-      "allowEnodebTransmit": false,
-      "subframeAssignment": 2,
-      "tac": 1
+    "connectiond": {
+      "@type": "type.googleapis.com/magma.mconfig.ConnectionD",
+      "logLevel": "INFO"
     },
     "control_proxy": {
       "@type": "type.googleapis.com/magma.mconfig.ControlProxy",
       "logLevel": "INFO"
     },
-    "magmad": {
-      "@type": "type.googleapis.com/magma.mconfig.MagmaD",
-      "logLevel": "INFO",
-      "checkinInterval": 60,
-      "checkinTimeout": 10,
-      "autoupgradeEnabled": false,
-      "autoupgradePollInterval": 300,
-      "package_version": "0.0.0-0",
-      "dynamic_services": []
+    "ctraced": {
+      "@type": "type.googleapis.com/magma.mconfig.CtraceD",
+      "logLevel": "INFO"
     },
-    "pipelined": {
-      "@type": "type.googleapis.com/magma.mconfig.PipelineD",
-      "logLevel": "INFO",
-      "ueIpBlock": "192.168.128.0/24",
-      "natEnabled": true,
-      "apps": [],
-      "services": [
-        "DPI",
-        "ENFORCEMENT"
-       ],
-      "allowedGrePeers": [
-       ],
-      "enable5gFeatures": false,
-      "upfNodeIdentifier": "192.168.60.142",
-      "liUes": {}
-    },
-    "subscriberdb": {
-      "@type": "type.googleapis.com/magma.mconfig.SubscriberDB",
-      "logLevel": "INFO",
-      "lteAuthOp": "EREREREREREREREREREREQ==",
-      "lteAuthAmf": "gAA=",
-      "enable5gFeatures": false,
-      "sync_interval": 300
-    },
-    "state":{
-      "@type": "type.googleapis.com/magma.mconfig.State",
-      "logLevel": "INFO",
-      "sync_interval": 60
+    "directoryd": {
+      "@type": "type.googleapis.com/magma.mconfig.DirectoryD",
+      "logLevel": "INFO"
     },
     "dnsd": {
       "@type": "type.googleapis.com/magma.mconfig.DnsD",
-      "logLevel": "INFO",
+      "dhcpServerEnabled": true,
       "enableCaching": false,
       "localTTL": 0,
-      "dhcpServerEnabled": true
+      "logLevel": "INFO"
+    },
+    "dpid": {
+      "@type": "type.googleapis.com/magma.mconfig.DPID",
+      "logLevel": "INFO"
+    },
+    "enodebd": {
+      "@type": "type.googleapis.com/magma.mconfig.EnodebD",
+      "allowEnodebTransmit": false,
+      "bandwidthMhz": 20,
+      "earfcndl": 44490,
+      "logLevel": "INFO",
+      "pci": 260,
+      "plmnidList": "00101",
+      "specialSubframePattern": 7,
+      "subframeAssignment": 2,
+      "tac": 1
     },
     "lighttpd": {
       "@type": "type.googleapis.com/magma.mconfig.LighttpD",
       "enableCaching": false,
       "logLevel": "INFO"
     },
-    "directoryd": {
-      "@type": "type.googleapis.com/magma.mconfig.DirectoryD",
-      "logLevel": "INFO"
+    "magmad": {
+      "@type": "type.googleapis.com/magma.mconfig.MagmaD",
+      "autoupgradeEnabled": false,
+      "autoupgradePollInterval": 300,
+      "checkinInterval": 60,
+      "checkinTimeout": 10,
+      "dynamic_services": [],
+      "logLevel": "INFO",
+      "package_version": "0.0.0-0"
+    },
+    "mme": {
+      "@type": "type.googleapis.com/magma.mconfig.MME",
+      "amfDefaultSliceDifferentiator": "ffffff",
+      "amfDefaultSliceServiceType": 1,
+      "amfName": "MAGMAAMF1",
+      "amfPointer": "0",
+      "amfRegionId": "1",
+      "amfSetId": "1",
+      "attachedEnodebTacs": [],
+      "cloudSubscriberdbEnabled": false,
+      "congestionControlEnabled": true,
+      "csfbMcc": "001",
+      "csfbMnc": "01",
+      "dnsPrimary": "8.8.8.8",
+      "dnsSecondary": "8.8.4.4",
+      "enable5gFeatures": false,
+      "enableDnsCaching": false,
+      "hssRelayEnabled": false,
+      "ipv4PCscfAddress": "172.27.23.150",
+      "ipv6DnsAddress": "2001:4860:4860:0:0:0:0:8888",
+      "ipv6PCscfAddress": "2a12:577:9941:f99c:0002:0001:c731:f114",
+      "lac": 1,
+      "logLevel": "INFO",
+      "mcc": "001",
+      "mmeCode": 1,
+      "mmeGid": 1,
+      "mmeRelativeCapacity": 11,
+      "mnc": "01",
+      "natEnabled": true,
+      "nonEpsServiceControl": 0,
+      "relayEnabled": false,
+      "tac": 1
+    },
+    "mobilityd": {
+      "@type": "type.googleapis.com/magma.mconfig.MobilityD",
+      "ipBlock": "192.168.128.0/24",
+      "ip_allocator_type": "IP_POOL",
+      "ipv6Block": "fdee:5:6c::/48",
+      "ipv6PrefixAllocationType": "RANDOM",
+      "logLevel": "INFO",
+      "multi_apn_ip_alloc": true,
+      "static_ip_enabled": true
+    },
+    "monitord": {
+      "@type": "type.googleapis.com/magma.mconfig.MonitorD",
+      "logLevel": "INFO",
+      "pollingInterval": 60
+    },
+    "pipelined": {
+      "@type": "type.googleapis.com/magma.mconfig.PipelineD",
+      "allowedGrePeers": [],
+      "apps": [],
+      "enable5gFeatures": false,
+      "liUes": {},
+      "logLevel": "INFO",
+      "natEnabled": true,
+      "services": [
+        "DPI",
+        "ENFORCEMENT"
+      ],
+      "ueIpBlock": "192.168.128.0/24",
+      "upfNodeIdentifier": "192.168.60.142"
     },
     "policydb": {
       "@type": "type.googleapis.com/magma.mconfig.PolicyDB",
@@ -124,43 +127,39 @@
     },
     "sessiond": {
       "@type": "type.googleapis.com/magma.mconfig.SessionD",
-      "logLevel": "INFO",
-      "relayEnabled": false,
+      "enable5gFeatures": false,
       "gxGyRelayEnabled": false,
-      "enable5gFeatures": false
-    },
-    "td-agent-bit": {
-      "@type": "type.googleapis.com/magma.mconfig.FluentBit",
-      "extraTags": {},
-      "throttleRate": 1000,
-      "throttleWindow": 5,
-      "throttleInterval": "1m"
-    },
-     "monitord": {
-      "@type": "type.googleapis.com/magma.mconfig.MonitorD",
       "logLevel": "INFO",
-      "pollingInterval": 60
-    },
-    "dpid": {
-      "@type": "type.googleapis.com/magma.mconfig.DPID",
-      "logLevel": "INFO"
-    },
-    "ctraced": {
-      "@type": "type.googleapis.com/magma.mconfig.CtraceD",
-      "logLevel": "INFO"
-    },
-    "connectiond": {
-      "@type": "type.googleapis.com/magma.mconfig.ConnectionD",
-      "logLevel": "INFO"
+      "relayEnabled": false
     },
     "shared_mconfig": {
       "@type": "type.googleapis.com/magma.mconfig.SharedMconfig",
       "sentry_config": {
-        "dsn_python": "",
         "dsn_native": "",
-        "upload_mme_log": false,
-        "sample_rate": 1.0
+        "dsn_python": "",
+        "sample_rate": 1.0,
+        "upload_mme_log": false
       }
+    },
+    "state": {
+      "@type": "type.googleapis.com/magma.mconfig.State",
+      "logLevel": "INFO",
+      "sync_interval": 60
+    },
+    "subscriberdb": {
+      "@type": "type.googleapis.com/magma.mconfig.SubscriberDB",
+      "enable5gFeatures": false,
+      "logLevel": "INFO",
+      "lteAuthAmf": "gAA=",
+      "lteAuthOp": "EREREREREREREREREREREQ==",
+      "sync_interval": 300
+    },
+    "td-agent-bit": {
+      "@type": "type.googleapis.com/magma.mconfig.FluentBit",
+      "extraTags": {},
+      "throttleInterval": "1m",
+      "throttleRate": 1000,
+      "throttleWindow": 5
     }
   }
 }

--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -17,8 +17,6 @@ print_grpc_payload: false
 
 ipv6_prefixlen: 58
 
-static_ip: true
-
 # [Experimental] Enable Sentry for this service
 # Allowed values: send_all_errors, send_selected_errors, disabled
 sentry: send_all_errors

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -171,9 +171,10 @@ non_nat_gw_probe_frequency: 20
 ovs_uplink_port_name: patch-up
 # virtual_mac: '02:ff:bb:cc:dd:ee'
 uplink_bridge: uplink_br0
-uplink_eth_port_name: uplink_p0
+uplink_eth_port_name: eth2
 uplink_gw_mac: 'ff:ff:ff:ff:ff:ff'
 dp_router_enabled: true
+sgi_management_iface_ip_addr: '192.168.129.1/24'
 
 ovs_gtp_stats_polling_interval: 180
 

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1174,6 +1174,45 @@ class MagmadUtil(object):
             mme_ueip_imsi_map_entries,
         )
 
+    def enable_nat(self):
+        self._set_agw_nat(True)
+        self._validate_nated_datapath()
+        self.exec_command("sudo ip route del default via 192.168.129.42")
+        self.exec_command("sudo ip route add default via 10.0.2.2 dev eth0")
+
+    def disable_nat(self):
+        self.exec_command("sudo ip route del default via 10.0.2.2 dev eth0")
+        self.exec_command("sudo ip addr replace 192.168.129.1/24 dev uplink_br0")
+        self.exec_command("sudo ip route add default via 192.168.129.42 dev uplink_br0")
+        self._set_agw_nat(False)
+        self._validate_non_nat_datapath()
+
+    def _set_agw_nat(self, enable: bool):
+        mconfig_conf = "/home/vagrant/magma/lte/gateway/configs/gateway.mconfig"
+        with open(mconfig_conf, "r") as jsonFile:
+            data = json.load(jsonFile)
+
+        data['configs_by_key']['mme']['natEnabled'] = enable
+        data['configs_by_key']['pipelined']['natEnabled'] = enable
+
+        with open(mconfig_conf, "w") as jsonFile:
+            json.dump(data, jsonFile, sort_keys=True, indent=2)
+
+        self.restart_sctpd()
+        self.restart_all_services()
+
+    def _validate_non_nat_datapath(self):
+        # validate SGi interface is part of uplink-bridge.
+        out1 = self.exec_command_output("sudo ovs-vsctl list-ports uplink_br0")
+        assert("eth2" in str(out1))
+        print("NAT is disabled")
+
+    def _validate_nated_datapath(self):
+        # validate SGi interface is not part of uplink-bridge.
+        out1 = self.exec_command_output("sudo ovs-vsctl list-ports uplink_br0")
+        assert("eth2" not in str(out1))
+        print("NAT is enabled")
+
 
 class MobilityUtil(object):
     """ Utility wrapper for interacting with mobilityd """

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_non_nat_dp_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_non_nat_dp_ul_tcp.py
@@ -1,0 +1,89 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import ipaddress
+import unittest
+
+import s1ap_types
+from integ_tests.s1aptests import s1ap_wrapper
+from s1ap_utils import MagmadUtil
+
+
+class TestAttachDetachNonNatDatapath(unittest.TestCase):
+    def __init__(self, methodName: str = ...) -> None:
+        super().__init__(methodName=methodName)
+        self.magma_utils = MagmadUtil(None)
+
+    def setUp(self):
+        self.magma_utils.disable_nat()
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+        self.magma_utils.enable_nat()
+
+    def test_attach_detach_nonnat_datapath(self):
+        """ Basic attach/detach test with a single UE """
+        num_ues = 1
+
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
+        wait_for_s1 = [True, True, False]
+        # third IP validates handling of invalid IP address.
+        ue_ips = ['192.168.129.100']
+        self._s1ap_wrapper.configUEDevice(num_ues, [], ue_ips)
+
+        for i in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ", req.ue_id,
+            )
+
+            # Now actually complete the attach
+            attach = self._s1ap_wrapper._s1_util.attach(
+                req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t,
+            )
+
+            # Validate assigned IP address.
+            addr = attach.esmInfo.pAddr.addrInfo
+            ue_ipv4 = ipaddress.ip_address(bytes(addr[:4]))
+            self.assertEqual(ue_ipv4, ipaddress.IPv4Address(ue_ips[i]))
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+
+            print(
+                "************************* Running UE uplink (TCP) for UE id ",
+                req.ue_id,
+            )
+            with self._s1ap_wrapper.configUplinkTest(req, duration=1) as test:
+                test.verify()
+
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id,
+            )
+            # Now detach the UE
+            self._s1ap_wrapper.s1_util.detach(
+                req.ue_id, detach_type[i], wait_for_s1[i],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Following PR adds non-NAT datapath test, it uses mconfig
to disable NAT and runs traffic test.
gateway mconfig is sorted using python to avoid changes
to the file while toggling the NAT related flags.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
