### PR TITLE
fix(ci): Fix provisioning of magma_test vm

### DIFF
--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/debian.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/debian.yml
@@ -25,6 +25,11 @@
     url: https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public
     state: present
 
+- name: Remove old magma etagecom sources
+  shell: rm -rf /etc/apt/sources.list.d/packages_magma_etagecom_io.list
+  become: yes
+  ignore_errors: yes
+
 - name: Add apt-transport-https
   apt: pkg=apt-transport-https state=present update_cache=yes
   #  when: preburn


### PR DESCRIPTION
Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Remove old reference to magma etagecom

## Test Plan
Provisioned magma_test vm successfully

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
