### PR TITLE
fix(agw): move lld install step to magma vm only

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -222,15 +222,6 @@
     state: link
     force: yes
 
-- name: Install lld
-  retries: 5
-  # TODO: Make this preburn
-  apt:
-    state: present
-    update_cache: no
-    pkg:
-      - lld
-
 ########################################
 # Install common Magma dev dependencies
 ########################################

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -438,6 +438,7 @@
     state: latest
     pkg:
       - clangd-12
+      - lld
 
 # TODO: preburn this
 - name: Install clang-format-11 c/c++ formatting tooling


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
magma VM and magma_test VM have different underlying base image. LLD is not availble in the one used for magma_test VM.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
provision both magma vm and magma_test vm locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
