### PR TITLE
refactor(feg): Segregation of CentralSessionController servicer as external

### DIFF
--- a/feg/cloud/go/services/feg_relay/feg_relay/main.go
+++ b/feg/cloud/go/services/feg_relay/feg_relay/main.go
@@ -23,6 +23,7 @@ import (
 	"magma/feg/cloud/go/services/feg_relay"
 	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay"
 	nh_servicers "magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers"
+	session_servicers "magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound"
 	"magma/feg/cloud/go/services/feg_relay/servicers"
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/orc8r/cloud/go/service"
@@ -58,7 +59,9 @@ func main() {
 	protos.RegisterS6AProxyServer(srv.GrpcServer, nhServicer)
 	protos.RegisterSwxProxyServer(srv.GrpcServer, nhServicer)
 	protos.RegisterHelloServer(srv.GrpcServer, nhServicer)
-	lteprotos.RegisterCentralSessionControllerServer(srv.GrpcServer, nhServicer)
+
+	sessionServicer := session_servicers.NewSessionRelayRouter()
+	lteprotos.RegisterCentralSessionControllerServer(srv.GrpcServer, sessionServicer)
 
 	// Register S8 Proxy Neutral Host Routing services
 	s8nhServicer := nh_servicers.NewS8RelayRouter(&nhServicer.Router)

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/relay_router.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/relay_router.go
@@ -41,7 +41,7 @@ func NewRelayRouter() *RelayRouter {
 	return &RelayRouter{Router: *gw_to_feg_relay.NewRouter()}
 }
 
-func getPlmnId6(imsi string) string {
+func GetPlmnId6(imsi string) string {
 	imsi = strings.TrimPrefix(strings.TrimSpace(imsi), "IMSI")
 	if len(imsi) > gw_to_feg_relay.MaxPlmnIdLen {
 		imsi = imsi[:gw_to_feg_relay.MaxPlmnIdLen]


### PR DESCRIPTION
Signed-off-by: shivesh-wavelabs <shivesh.ojha@wavelabs.ai>

## Summary
This PR deals with the segregation of CentralSessionController's external gRPC servicers implementation.
These changes are part of the ongoing work which details the distinction between Orc8r-external gRPC endpoints vs. external, gateway-oriented gRPC endpoints.
Moved CentralSessionController implementation from  feg/gateway/services/session_proxy/servicers/ to  feg/gateway/services/session_proxy/servicers/southbound/

This PR was done as part of discussion by @hcgatewood [RemoveGatewayAccess toOrc8r-InternalEndpoints](https://drive.google.com/file/d/1NO6Qd6rU80xPh0Sb0mKWlSfDt0JbeVIT/view)

## Test Plan
Verified existing UT cases.