### PR TITLE
fix(agw): logging is formatted for sentry usage

### DIFF
--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -97,10 +97,9 @@ class SubscriberDbClient:
             raise SubscriberDBStaticIPValueError(sid)
 
         except grpc.RpcError as err:
-            msg = "GetSubscriberData: while reading vlan-id error[%s] %s" % \
-                  (err.code(), err.details())
-            logging.error(msg)
-            raise SubscriberDBConnectionError(msg)
+            msg_template = "GetSubscriberData: while reading vlan-id error[%s] %s"
+            logging.error(msg_template, err.code(), err.details())
+            raise SubscriberDBConnectionError(msg_template % (err.code(), err.details()))
         return None
 
     def get_subscriber_apn_network_info(self, sid: str) -> NetworkInfo:
@@ -128,10 +127,9 @@ class SubscriberDbClient:
                 raise SubscriberDBMultiAPNValueError(sid)
 
             except grpc.RpcError as err:
-                msg = "GetSubscriberData while reading vlan-id error[%s] %s" % \
-                    (err.code(), err.details())
-                logging.error(msg)
-                raise SubscriberDBConnectionError(msg)
+                msg_template = "GetSubscriberData: while reading vlan-id error[%s] %s"
+                logging.error(msg_template, err.code(), err.details())
+                raise SubscriberDBConnectionError(msg_template % (err.code(), err.details()))
 
         return NetworkInfo()
 


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Current: Sentry groups affected log message by complete message. Here: split log string so that sentry is able to aggregate among log arguments. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
local test against private sentry -> messages are aggregated

## Additional Information

Analogously to https://github.com/magma/magma/pull/9751 (might not have been found by linter because log message was created as variable).

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
