### PR TITLE
fix(sessiond): Refactor sessiond code that manages session state enum Se...

### DIFF
--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -89,12 +89,10 @@ std::string grant_type_to_str(GrantTrackingType grant_type) {
 std::string session_fsm_state_to_str(SessionFsmState state) {
   switch (state) {
     case SESSION_ACTIVE:
-    case ACTIVE:
       return "SESSION_ACTIVE";
     case SESSION_TERMINATED:
       return "SESSION_TERMINATED";
     case SESSION_RELEASED:
-    case RELEASE:
       return "SESSION_RELEASED";
     case CREATING:
       return "SESSION_CREATING";

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -311,10 +311,10 @@ magma::lte::Fsm_state_FsmState SessionState::get_proto_fsm_state() {
     case CREATED:
       return magma::lte::Fsm_state_FsmState_CREATED;
       break;
-    case ACTIVE:
+    case SESSION_ACTIVE:
       return magma::lte::Fsm_state_FsmState_ACTIVE;
       break;
-    case RELEASE:
+    case SESSION_RELEASED:
       return magma::lte::Fsm_state_FsmState_RELEASE;
       break;
     case INACTIVE:
@@ -774,8 +774,7 @@ bool SessionState::active_monitored_rules_exist() {
 }
 
 bool SessionState::is_terminating() {
-  if (curr_state_ == SESSION_RELEASED || curr_state_ == SESSION_TERMINATED ||
-      curr_state_ == RELEASE) {
+  if (curr_state_ == SESSION_RELEASED || curr_state_ == SESSION_TERMINATED) {
     return true;
   }
   return false;
@@ -857,7 +856,7 @@ void SessionState::get_updates(
     UpdateSessionRequest* update_request_out,
     std::vector<std::unique_ptr<ServiceAction>>* actions_out,
     SessionStateUpdateCriteria* session_uc) {
-  if (curr_state_ == SESSION_ACTIVE || curr_state_ == ACTIVE) {
+  if (curr_state_ == SESSION_ACTIVE) {
     get_charging_updates(update_request_out, actions_out, session_uc);
     get_monitor_updates(update_request_out, session_uc);
     get_event_trigger_updates(update_request_out, session_uc);

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -308,7 +308,7 @@ void SessionStateEnforcer::m5g_start_session_termination(
   /* update respective session's state and return from here before timeout
    * to update session store with state and version
    */
-  session->set_fsm_state(RELEASE, session_uc);
+  session->set_fsm_state(SESSION_RELEASED, session_uc);
   uint32_t cur_version = session->get_current_version();
   session->set_current_version(++cur_version, session_uc);
   MLOG(MDEBUG) << "During release state of session changed to "
@@ -553,14 +553,14 @@ void SessionStateEnforcer::m5g_process_response_from_upf(
   }
   switch (session->get_state()) {
     case CREATED:
-      session->set_fsm_state(ACTIVE, &session_uc);
+      session->set_fsm_state(SESSION_ACTIVE, &session_uc);
       /* As there is no config change, just state change as we
        * got response from UPF, so we dont bump up the session version
        * number here
        */
       amf_update_pending = true;
       break;
-    case RELEASE:
+    case SESSION_RELEASED:
       m5g_complete_termination(session_map, imsi, session_id, session_update);
     default:
       break;

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -426,7 +426,7 @@ void SetMessageManagerHandler::pdu_session_inactive(
     response_callback(status, SmContextVoid());
     return;
   }
-  if (session->get_state() == RELEASE) {
+  if (session->get_state() == SESSION_RELEASED) {
     // Nothing to be done;
     MLOG(MINFO) << " No sessions to move to Idle state : " << imsi;
     response_callback(Status::OK, SmContextVoid());
@@ -460,7 +460,7 @@ void SetMessageManagerHandler::idle_mode_change_sessions_handle(
   int count = 0;
   auto session_update = SessionStore::get_default_session_update(session_map);
   for (auto& session : session_map[imsi]) {
-    if (session->get_state() != RELEASE) {
+    if (session->get_state() != SESSION_RELEASED) {
       auto session_id = session->get_session_id();
       SessionStateUpdateCriteria& session_uc = session_update[imsi][session_id];
       m5g_enforcer_->m5g_move_to_inactive_state(imsi, session, notif,

--- a/lte/gateway/c/session_manager/Types.h
+++ b/lte/gateway/c/session_manager/Types.h
@@ -144,9 +144,7 @@ enum SessionFsmState {
   SESSION_RELEASED = 6,
   CREATING = 7,
   CREATED = 8,
-  ACTIVE = 9,
   INACTIVE = 10,
-  RELEASE = 11,
 };
 
 struct RuleLifetime {


### PR DESCRIPTION


Signed-off-by: khansiddiquekc <khan.siddique@wavelabs.in>

## Summary
Refactor sessiond code that manages session state enum SessionFsmState

1. Currently 4G and 5G are using two different sessions state values for active and release case.
2. Use common enum value for 4G and 5G in case of session state active and release by removing ACTIVE, RELEASE enum 
    values from SessionFsmState enum.
3. These enum changes are sessiond specific code. These changes do not impact AMF side code, also no need to change any 
    proto files for N11 interface.

## Test Plan
1. Tested with sessiond stub cli `magma/lte/gateway/python/scripts/smf_upf_integration_cli.py`
2. Tested on TeraVM setup.

## Additional Information
1. Corresponding Zenhub task is #10999 
2. For log please refer comment section.