### PR TITLE
fix(agw): s1ap_test: handle missing static ip config.

### DIFF
--- a/lte/gateway/python/integ_tests/common/subscriber_db_client.py
+++ b/lte/gateway/python/integ_tests/common/subscriber_db_client.py
@@ -162,7 +162,7 @@ class SubscriberDbGrpc(SubscriberDbClient):
             apn_config.ambr.max_bandwidth_ul = apn["mbr_ul"]
             apn_config.ambr.max_bandwidth_dl = apn["mbr_dl"]
             apn_config.pdn = apn["pdn_type"] if "pdn_type" in apn else 0
-            if apn["static_ip"]:
+            if apn.get("static_ip", None):
                 apn_config.assigned_static_ip = apn["static_ip"]
         return update
 


### PR DESCRIPTION
in some cases the apn-list is passed from test itself where the static_ip
could be missing. Following PR handles it.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
