### PR TITLE
fix(orc8r): Revert additonal labels from k8s services to avoid incompatibilities with deployed objects

### DIFF
--- a/lte/gateway/deploy/agwc-helm-charts/templates/_helpers.tpl
+++ b/lte/gateway/deploy/agwc-helm-charts/templates/_helpers.tpl
@@ -27,5 +27,4 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Generate selector labels */}}
 {{- define "image-version-label" -}}
-image-version: {{ .Values.image.tag}}
 {{- end -}}

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -490,7 +490,7 @@ service:
     Required: false
     ConfigApps:
       - tf
-    Default: 1.5.25
+    Default: 1.5.26
   orc8r_controller_replicas:
     Description: Replica count for Orchestrator controller pods.
     Type: number

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -176,7 +176,7 @@ variable "orc8r_deployment_type" {
 variable "orc8r_chart_version" {
   description = "Version of the core orchestrator Helm chart to install."
   type        = string
-  default     = "1.5.25"
+  default     = "1.5.26"
 }
 
 variable "cwf_orc8r_chart_version" {

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Helm chart for the Magma Orchestrator
 name: orc8r
-version: 1.5.25
+version: 1.5.26
 home: https://www.magmacore.org
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/helpers/labels.tpl
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/helpers/labels.tpl
@@ -36,12 +36,8 @@ app.kubernetes.io/instance: {{ $envAll.Release.Name }}
 
 {{/* Generate selector labels */}}
 {{- define "magmalte-image-version-label" -}}
-image-version: {{ .Values.magmalte.image.tag}}
-chart-version: {{ .Chart.Version }}
 {{- end -}}
 
 {{/* Generate selector labels */}}
 {{- define "nginx-image-version-label" -}}
-image-version: {{ .Values.nginx.image.tag}}
-chart-version: {{ .Chart.Version }}
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/_helpers.tpl
+++ b/orc8r/cloud/helm/orc8r/templates/_helpers.tpl
@@ -36,6 +36,4 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Generate selector labels */}}
 {{- define "nginx-image-version-label" -}}
-image-version: {{ .Values.nginx.image.tag}}
-chart-version: {{ .Chart.Version }}
 {{- end -}}

--- a/orc8r/cloud/helm/orc8rlib/templates/_helpers.tpl
+++ b/orc8r/cloud/helm/orc8rlib/templates/_helpers.tpl
@@ -28,7 +28,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Generate selector labels */}}
 {{- define "controller-image-version-label" -}}
-image-version: {{ .Values.controller.image.tag}}
 {{- end -}}
 
 {{/* Generate image version tag labels */}}


### PR DESCRIPTION

An existing service has imutable selectors, the additonal labels included in PR10085 creates an incompatibility with existing services.

Signed-off-by: Joary Paulo Wanzeler Fortuna <joarypl@fb.com>

## Summary

Disable the labels added to k8s services objects from PR10085

## Test Plan


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
