### PR TITLE
feat(feg_relay): move session proxy to NH implementation

### DIFF
--- a/feg/cloud/configs/service_registry.yml
+++ b/feg/cloud/configs/service_registry.yml
@@ -35,7 +35,7 @@ services:
       s8_proxy:
         port: 9103
       session_proxy:
-        port: 9079
+        port: 9103
       n7_n40_proxy:
         port: 9103
       swx_proxy:

--- a/feg/cloud/helm/feg-orc8r/templates/session_proxy.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/session_proxy.service.yaml
@@ -30,5 +30,5 @@ spec:
   ports:
     - name: grpc
       port: 9180
-      targetPort: 9079
+      targetPort: 9103
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR moves session_proxy services from the default implementation on feg relay into the nh implementation. That implementation is the one that runs in this [file](https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Amagma%2Fmagma.git&branch=master&file=feg%2Fcloud%2Fgo%2Fservices%2Ffeg_relay%2Fgw_to_feg_relay%2Fservicers%2Fsession_proxy_relay.go&editor=JetBrains&version=v1.2.1&utm_product_name=IntelliJ+IDEA&utm_product_version=2021.2.2&start_row=27&start_col=25&end_row=27&end_col=25) 
<!-- Enumerate changes you made and why you made them -->

## Test Plan

TBD

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
