### PR TITLE
feat(amf): Stateless feature integration for AMF

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_main.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_main.cpp
@@ -96,12 +96,14 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       amf_nas_proc_authentication_info_answer(
           &AMF_APP_AUTH_RESPONSE_DATA(received_message_p));
       is_task_state_same = true;
+      force_ue_write     = true;
       break;
 
     case AMF_APP_DECRYPT_IMSI_INFO_RESP:
       amf_decrypt_imsi_info_answer(
           &AMF_APP_DECRYPT_IMSI_RESPONSE_DATA(received_message_p));
       is_task_state_same = true;
+      force_ue_write     = true;
       break;
 
     case AMF_IP_ALLOCATION_RESPONSE:
@@ -109,6 +111,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
       response_p = &(received_message_p->ittiMsg.amf_ip_allocation_response);
       amf_smf_handle_ip_address_response(response_p);
       is_task_state_same = true;
+      force_ue_write     = true;
       break;
 
     case S6A_UPDATE_LOCATION_ANS: {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.cpp
@@ -111,13 +111,14 @@ int AmfNasStateManager::initialize_state(const amf_config_t* amf_config_p) {
 
   // Allocate the local AMF state and create respective single object
   create_state();
-// TODO: This is a temporary check and will be removed in upcoming PR
-#if MME_UNIT_TEST
+#if !MME_UNIT_TEST
+  redis_client =
+      std::make_unique<magma::lte::RedisClient>(persist_state_enabled);
+#endif
   read_state_from_db();
   read_ue_state_from_db();
   // TODO(panyogesh): This should be removed as part of fixing global tables
   amf_sync_app_maps_from_db();
-#endif
   is_initialized = true;
   return rc;
 }


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
**PR consists of application code changes to integrate the stateless feature with AMF.**

**Approach:**
The stateless feature allows decoupling of state data and state functions. This is achieved by syncing(storing) **amf_nas_state** (state_chache) and **amf_ue_state** (ue_context) with Redis DB.

**Implementation:**
The amf_nas_state sync is controlled by is_task_state_same flag. If is_task_state_same flag is false, it is synced.
The amf_ue_state is synced if UE is in REGISTERED_CONNECTED state, or if force_ue_write flag is set to True.

The following snapshot lists the triggers for amf_nas_state and amf_ue_state:
![trigger_snap](https://user-images.githubusercontent.com/89975652/148541633-69bd40e3-8ade-4eac-a6cb-9c6206b829ae.png)


<!-- Enumerate changes you made and why you made them -->

### **Test Plan**
## 1. Verified basic sanity with ueransim and verified with the Unit test.(Stateless: Disabled)
mme log:
[amf_integration_basic_sanity.log](https://github.com/magma/magma/files/7828721/amf_integration_basic_sanity.log)

    
 pcap:
 ![amf_integration_basic_sanity_pcap](https://user-images.githubusercontent.com/89975652/148542592-d9185916-cca2-405a-997f-cd9dd2ee8672.png)


   Unit test snap:
   ![integration_pr_ut](https://user-images.githubusercontent.com/89975652/148542493-2ee1849f-0509-4379-b1e8-ee7e870fa413.png)

## 2. Verified Stateless feature using UERANSIM (Stateless: Enabled)
**Environment setup:**
This test was performed by including both AMF stateless feature changes and NGAP stateless feature changes.
The following PRs were taken as a base to perform this integration test using ueransim.
AMF PRs: #10605 #10805 #10903 #10853 #10885 #10906 #10908 #10958 #11034 
NGAP PRs: #11014 #11005 #11032 #11070

**Test Plan:**
1. Bring up mme. Add subscriber. Connect GNB(ueransim). Connect UE(ueransim).                  
    UE registration and PDU session is up.
2. Do a make restart. This mimics a mme crash and the state data is lost.**(1)**
3. Trigger a ps-release from the ueransim's ue-cli.
     **Expected behavior:** The PDU session release should take place successfully. This verifies that mme has fetched 
       the data from Redis DB and is successfully able to continue with the ps-release flow.
     **Observed**: Successfully continuation.
4. Do a make restart. This mimics a mme crash and the state data is lost.**(2)**
5. Trigger deregister normal from the ueransim's ue-cli.
    **Expected behavior:**  The deregister normal should take place successfully. We receive a Guti-based registration Request.
     **Observed**: Successfully continuation and Guti-based registration is successful and PDU session is established.
6. Do a make restart. This mimics a mme crash and the state data is lost.**(3)**
7. Trigger deregister switch-off from the ueransim's ue-cli.
    **Expected behavior:** The deregister switch-off should take place successfully
     **Observed**: De-register switch-off is successful.

The following is a snapshot of the Redis DB entries after Registration and PDU session establishment.
This verifies the state data being written to Redis DB.
![MicrosoftTeams-image (9)](https://user-images.githubusercontent.com/89975652/148546923-f8e32d23-7faa-422d-bdb8-394d952d3e9b.png)

**MME LOGS:**
- After PDU session establisment :  [pdusession.log](https://github.com/magma/magma/files/7828906/pdusession.log)
- After ps-release: [ps-release.log](https://github.com/magma/magma/files/7828925/ps-release.log)
- After deregister normal: [dereg_normal.log](https://github.com/magma/magma/files/7828931/dereg_normal.log)
- After deregister switch-off: [dereg_switchoff.log](https://github.com/magma/magma/files/7828932/dereg_switchoff.log)

**PCAP SNAP:**
![integration_amf_ngap](https://user-images.githubusercontent.com/89975652/148547739-70831b60-159b-4231-95d1-2105477a9222.png)

**Attached are complete PCAP and logs:**
[pcap_and_logs.zip](https://github.com/magma/magma/files/7828959/pcap_and_logs.zip)



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
