### PR TITLE
fix(agw): Rendering strings is done by logging framework

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -56,6 +56,7 @@ from typing import List, Optional, Tuple
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
 from magma.mobilityd.ip_descriptor import IPState
 from magma.mobilityd.metrics import IP_ALLOCATED_TOTAL, IP_RELEASED_TOTAL
+from magma.mobilityd.utils import log_error_and_raise
 
 from .ip_allocator_base import (
     DuplicateIPAssignmentError,
@@ -337,14 +338,13 @@ class IPAddressManager:
             ip_desc = allocator.alloc_ip_address(sid, 0)
             existing_sid = self.get_sid_for_ip(ip_desc.ip)
             if existing_sid:
-                error_msg = "Dup IP: {} for SID: {}, which already is " \
-                            "assigned to SID: {}".format(
-                                ip_desc.ip,
-                                sid,
-                                existing_sid,
-                            )
-                logging.error(error_msg)
-                raise DuplicateIPAssignmentError(error_msg)
+                log_error_and_raise(
+                    DuplicateIPAssignmentError,
+                    "Dup IP: %s for SID: %s, which already is assigned to SID: %s",
+                    ip_desc.ip,
+                    sid,
+                    existing_sid,
+                )
 
             if version == IPAddress.IPV4:
                 self._store.ip_state_map.add_ip_to_state(

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -34,6 +34,7 @@ from magma.mobilityd.ip_allocator_base import (
 from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
 from magma.mobilityd.mobility_store import MobilityStore
 from magma.mobilityd.subscriberdb_client import SubscriberDbClient
+from magma.mobilityd.utils import log_error_and_raise
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 
@@ -131,11 +132,12 @@ class IPAllocatorStaticWrapper(IPAllocator):
         # Validate static IP is not in any of IP pool.
         for ip_pool in self._store.assigned_ip_blocks:
             if ip_addr_info.ip in ip_pool:
-                error_msg = "Static Ip {} Overlap with IP-POOL: {}".format(
-                    ip_addr_info.ip, ip_pool,
+                log_error_and_raise(
+                    DuplicateIPAssignmentError,
+                    "Static Ip %s Overlap with IP-POOL: %s",
+                    ip_addr_info.ip,
+                    ip_pool,
                 )
-                logging.error(error_msg)
-                raise DuplicateIPAssignmentError(error_msg)
 
         # update gw info if available.
         if ip_addr_info.net_info.gw_ip:

--- a/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
@@ -16,6 +16,8 @@ from copy import deepcopy
 from ipaddress import ip_address, ip_network
 from typing import List, Optional
 
+from magma.mobilityd.utils import log_error_and_raise
+
 from .ip_allocator_base import (
     IPAllocator,
     IPNotInUseError,
@@ -57,9 +59,7 @@ class IPv6AllocatorPool(IPAllocator):
             raise OverlappedIPBlocksError(ipblock)
 
         if ipblock.prefixlen > self._ipv6_prefixlen:
-            msg = "IPv6 block exceeds maximum allowed prefix length"
-            logging.error(msg)
-            raise InvalidIPv6NetworkError(msg)
+            log_error_and_raise(InvalidIPv6NetworkError, "IPv6 block exceeds maximum allowed prefix length")
 
         # For now only one IPv6 network is supported
         self._assigned_ip_block = ipblock

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 import grpc
 from lte.protos.apn_pb2 import APNConfiguration
+from magma.mobilityd.utils import log_error_and_raise
 from magma.subscriberdb.sid import SIDUtils
 
 
@@ -97,9 +98,12 @@ class SubscriberDbClient:
             raise SubscriberDBStaticIPValueError(sid)
 
         except grpc.RpcError as err:
-            msg_template = "GetSubscriberData: while reading vlan-id error[%s] %s"
-            logging.error(msg_template, err.code(), err.details())
-            raise SubscriberDBConnectionError(msg_template % (err.code(), err.details()))
+            log_error_and_raise(
+                SubscriberDBConnectionError,
+                "GetSubscriberData: while reading vlan-id error[%s] %s",
+                err.code(),
+                err.details(),
+            )
         return None
 
     def get_subscriber_apn_network_info(self, sid: str) -> NetworkInfo:
@@ -127,9 +131,12 @@ class SubscriberDbClient:
                 raise SubscriberDBMultiAPNValueError(sid)
 
             except grpc.RpcError as err:
-                msg_template = "GetSubscriberData: while reading vlan-id error[%s] %s"
-                logging.error(msg_template, err.code(), err.details())
-                raise SubscriberDBConnectionError(msg_template % (err.code(), err.details()))
+                log_error_and_raise(
+                    SubscriberDBConnectionError,
+                    "GetSubscriberData: while reading vlan-id error[%s] %s",
+                    err.code(),
+                    err.details(),
+                )
 
         return NetworkInfo()
 

--- a/lte/gateway/python/magma/mobilityd/utils.py
+++ b/lte/gateway/python/magma/mobilityd/utils.py
@@ -1,0 +1,32 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+
+
+def log_error_and_raise(exception_class: type, message_template: str, *args):
+    """Create an error message by rendering the message template with *args.
+    The template is passed to logging.error, and the rendered message is
+    passed to the exception constructor.
+
+    Args:
+        exception_class (type): [The exception to raise]
+        message_template (str): [The template for the log and exception message]
+        *args: Further arguments are used for rendering the message from the template
+
+    Raises:
+        exception_class: [The exception that is passed to this function]
+    """
+    logging.error(message_template, *args)
+    rendered_message = message_template % args
+    raise exception_class(rendered_message)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

[pull/11069](https://github.com/magma/magma/pull/11069) fixed Sentry event aggregation for an error log that was observed in the lab. This PR extends this to several error logs that we haven't so far seen in the wild, but that would equally fail to be correctly aggregated by Sentry.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

Tested in a local repl that the new function works

## Additional Information

Based on [pull/11069](https://github.com/magma/magma/pull/11069), so should be merged after that one

The lines changed here were found with the regex `\.error\([^'"]+` (with "full words only" checked)

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
