### PR TITLE
docs: enhance the CI checks doc with guidelines on adding a new check

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -468,6 +468,9 @@
       "proposals/p022_enodebd_enhancements": {
         "title": "proposals/p022_enodebd_enhancements"
       },
+      "proposals/p023_magma_gtp_gateway": {
+        "title": "proposals/p023_magma_gtp_gateway"
+      },
       "proposals/qos_enforcement": {
         "title": "proposals/qos_enforcement"
       },

--- a/docs/readmes/contributing/contribute_ci_checks.md
+++ b/docs/readmes/contributing/contribute_ci_checks.md
@@ -18,7 +18,7 @@ Below are some resources for finding who to contact:
 - [List of Magma maintainers](https://github.com/orgs/magma/teams/repo-magma-maintain/members)
 - [List of `approvers-*` teams and their members](https://github.com/orgs/magma/teams/?query=approvers)
 
-## Blocking Checks
+## Blocking checks
 
 Merge blocking CI checks are listed below.
 
@@ -51,7 +51,7 @@ Merge blocking CI checks are listed below.
 | markdown-lint          | Ensure documentation changes are formatted    | approvers-docs         | [Docs precommit](../docs/docs_overview.md#precommit)|
 | C/C++ unit tests with Bazel | Run all C/C++ tests covered with Bazel   | approvers-agw          | [AGW tests](../lte/dev_unit_testing)                |
 
-## Non-blocking Checks
+## Non-blocking checks
 
 The CI checks listed below do not block merging on failure.
 
@@ -63,3 +63,15 @@ The CI checks listed below do not block merging on failure.
 | GCC Warnings & Errors / build_session_manager | Annotate PRs with any GCC Warnings or Errors for session_manager | electronjoe        | N/A                                                  |
 | Jenkins CWAG Libvirt                          | Run CWF integration tests                                        | themarwhal mattymo | TODO                                                 |
 | C / C++ code coverage                         | Upload AGW C/C++ code coverage                                   | electronjoe        | N/A                                                  |
+
+## How to add a new CI check to Magma
+
+To add a non-blocking check,
+
+1. [The table of non-blocking checks](#Non-blocking-checks) must be updated to include the new check with at least the Purpose and PoC filled out
+
+To add a blocking check,
+
+1. [The table of blocking checks](#Blocking-checks) must be updated to include the new check with all columns filled out
+2. File a proposal to outline the motivation and any relevant timelines and assign to a relevant codeowner or TSC ([An example propsal](https://github.com/magma/magma/issues/7774))
+3. Once the proposal is accepted, announce the plan in [#dev](https://magmacore.slack.com/archives/C018J8UMGMR) and coordinate with one of the [repo admins](https://github.com/orgs/magma/teams/repo-magma-admin/members) to make the switch


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
While going through old GitHub issues, I realized I never updated the CI docs to reflect the process proposal described in https://github.com/magma/magma/issues/8271 . This PR adds some guidelines for how to add a new check in the checks page.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_fix for doc
brought up docusaurus locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
