### PR TITLE
fix(pipelined): ip_solicitation: Use link local address for RA

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -124,7 +124,7 @@ bridge_ip_address: 192.168.128.1
 # For CWF internal redirection, same subnet as the ovs bridge ip address
 internal_ip_subnet: '192.168.0.0/16'
 # For ipv6 router solicitation app
-ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
+# ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
 
 # QoS parameters
 qos:

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -119,7 +119,7 @@ bridge_name: gtp_br0
 # Bridge ip comes from magma_ifaces_gtp
 bridge_ip_address: 192.168.128.1
 # For ipv6 router solicitation app
-ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
+# ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
 
 # QoS parameters
 qos:

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -111,8 +111,8 @@ dp_router_enabled: true
 bridge_name: gtp_br0
 # Bridge ip comes from magma_ifaces_gtp
 bridge_ip_address: 192.168.128.1
-# For ipv6 router solicitation app
-ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
+# For ipv6 router solicitation app, default is to use S1 link local address.
+# ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
 
 # QoS parameters
 qos:

--- a/orc8r/gateway/python/magma/common/misc_utils.py
+++ b/orc8r/gateway/python/magma/common/misc_utils.py
@@ -159,7 +159,7 @@ def get_ip_from_if(iface_name, preference=IpPreference.IPV4_PREFERRED):
 def get_ipv6_from_if(iface_name):
     """
     Get ipv6 address from interface name and return as string.
-    Extract only ipv6 address from (ipv6, netmask)
+    Extract only ipv6 address
     """
     ip6_addresses = netifaces.ifaddresses(iface_name)[netifaces.AF_INET6]
     ret = None
@@ -173,6 +173,21 @@ def get_ipv6_from_if(iface_name):
     if ret:
         return ret["addr"].split("%")[0]
     return "::"
+
+
+def get_link_local_ipv6_from_if(iface_name):
+    """
+    Get Link local ipv6 address from interface name and return as string.
+    """
+    ip6_addresses = netifaces.ifaddresses(iface_name)[netifaces.AF_INET6]
+    for ip_rec in ip6_addresses:
+        if "addr" in ip_rec:
+            ip = ip_rec["addr"].split("%")[0]
+            # lower priority of link local address.
+            if ip.startswith('fe80'):
+                return ip
+
+    return None
 
 
 def get_all_ips_from_if(iface_name, preference=IpPreference.IPV4_PREFERRED):

--- a/xwf/gateway/configs/pipelined.yml
+++ b/xwf/gateway/configs/pipelined.yml
@@ -111,7 +111,7 @@ bridge_name: cwag_br0
 # Bridge ip comes from 99-ovscfg.yaml
 bridge_ip_address: 192.168.128.1
 # For ipv6 router solicitation app
-ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
+# ipv6_router_addr: 'd88d:aba4:472f:fc95:7e7d:8457:5301:ebce'
 
 # QoS parameters
 qos:


### PR DESCRIPTION
Per RFC4861 (section-4.2) this must to be the link-local address
of the interface that is sending the RA message.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
