### PR TITLE
refactor(feg): Segregation of SessionProxyResponder servicer as external

### DIFF
--- a/feg/cloud/go/services/feg_relay/feg_relay/main.go
+++ b/feg/cloud/go/services/feg_relay/feg_relay/main.go
@@ -24,6 +24,7 @@ import (
 	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay"
 	nh_servicers "magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers"
 	"magma/feg/cloud/go/services/feg_relay/servicers"
+	reauth_srv "magma/feg/cloud/go/services/feg_relay/servicers/southbound"
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/orc8r/cloud/go/service"
 )
@@ -36,6 +37,17 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating Feg Proxy service: %s", err)
 	}
+
+	// SessionProxyResponder Servicer
+	reauth_servicer, err := reauth_srv.NewFegToGwRelayServer()
+
+	if err != nil {
+		glog.Fatalf("Failed to create FegToGwRelayServer: %v", err)
+		return
+	}
+
+	lteprotos.RegisterSessionProxyResponderServer(srv.GrpcServer, reauth_servicer)
+
 	servicer, err := servicers.NewFegToGwRelayServer()
 
 	if err != nil {
@@ -44,7 +56,6 @@ func main() {
 	}
 
 	// Register responders FEG -> AGW
-	lteprotos.RegisterSessionProxyResponderServer(srv.GrpcServer, servicer)
 	lteprotos.RegisterAbortSessionResponderServer(srv.GrpcServer, servicer)
 	protos.RegisterS8ProxyResponderServer(srv.GrpcServer, servicer)
 

--- a/feg/cloud/go/services/feg_relay/servicers/abort.go
+++ b/feg/cloud/go/services/feg_relay/servicers/abort.go
@@ -25,7 +25,7 @@ func (srv *FegToGwRelayServer) ServiceAbort(
 	ctx context.Context,
 	req *fegprotos.ServiceAbortRequest,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.ServiceAbortRequestUnverified(ctx, req)

--- a/feg/cloud/go/services/feg_relay/servicers/abort_session.go
+++ b/feg/cloud/go/services/feg_relay/servicers/abort_session.go
@@ -26,7 +26,7 @@ import (
 func (srv *FegToGwRelayServer) AbortSession(
 	ctx context.Context, req *protos.AbortSessionRequest) (*protos.AbortSessionResult, error) {
 
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.AbortSessionUnverified(ctx, req)
@@ -37,7 +37,7 @@ func (srv *FegToGwRelayServer) AbortSession(
 func (srv *FegToGwRelayServer) AbortSessionUnverified(
 	ctx context.Context, req *protos.AbortSessionRequest) (*protos.AbortSessionResult, error) {
 
-	hwId, err := getHwIDFromIMSI(ctx, req.UserName)
+	hwId, err := GetHwIDFromIMSI(ctx, req.UserName)
 	if err != nil {
 		msg := fmt.Sprintf("unable to get HwID from IMSI %v. err: %v", req.GetUserName(), err)
 		log.Print(msg)

--- a/feg/cloud/go/services/feg_relay/servicers/alert.go
+++ b/feg/cloud/go/services/feg_relay/servicers/alert.go
@@ -25,7 +25,7 @@ func (srv *FegToGwRelayServer) AlertReq(
 	ctx context.Context,
 	req *fegprotos.AlertRequest,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.AlertRequestUnverified(ctx, req)

--- a/feg/cloud/go/services/feg_relay/servicers/cancel_location.go
+++ b/feg/cloud/go/services/feg_relay/servicers/cancel_location.go
@@ -29,7 +29,7 @@ func (srv *FegToGwRelayServer) CancelLocation(
 	ctx context.Context,
 	req *fegprotos.CancelLocationRequest,
 ) (*fegprotos.CancelLocationAnswer, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.CancelLocationUnverified(ctx, req)
@@ -41,7 +41,7 @@ func (srv *FegToGwRelayServer) CancelLocationUnverified(
 	ctx context.Context,
 	req *fegprotos.CancelLocationRequest,
 ) (*fegprotos.CancelLocationAnswer, error) {
-	hwId, err := getHwIDFromIMSI(ctx, req.UserName)
+	hwId, err := GetHwIDFromIMSI(ctx, req.UserName)
 	if err != nil {
 		fmt.Printf("unable to get HwID from IMSI %v. err: %v", req.UserName, err)
 		if _, ok := err.(errors.ClientInitError); ok {

--- a/feg/cloud/go/services/feg_relay/servicers/detach.go
+++ b/feg/cloud/go/services/feg_relay/servicers/detach.go
@@ -25,7 +25,7 @@ func (srv *FegToGwRelayServer) EPSDetachAc(
 	ctx context.Context,
 	req *fegprotos.EPSDetachAck,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.EPSDetachAckUnverified(ctx, req)
@@ -48,7 +48,7 @@ func (srv *FegToGwRelayServer) IMSIDetachAc(
 	ctx context.Context,
 	req *fegprotos.IMSIDetachAck,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.IMSIDetachAckUnverified(ctx, req)

--- a/feg/cloud/go/services/feg_relay/servicers/downlink.go
+++ b/feg/cloud/go/services/feg_relay/servicers/downlink.go
@@ -25,7 +25,7 @@ func (srv *FegToGwRelayServer) Downlink(
 	ctx context.Context,
 	req *fegprotos.DownlinkUnitdata,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.DownlinkUnitdataUnverified(ctx, req)

--- a/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
+++ b/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
@@ -42,7 +42,7 @@ func NewFegToGwRelayServer() (*FegToGwRelayServer, error) {
 	return &FegToGwRelayServer{}, nil
 }
 
-func getHwIDFromIMSI(ctx context.Context, imsi string) (string, error) {
+func GetHwIDFromIMSI(ctx context.Context, imsi string) (string, error) {
 	gw := protos.GetClientGateway(ctx)
 	// directoryd prefixes imsi with "IMSI" when updating the location
 	if !strings.HasPrefix(imsi, "IMSI") {
@@ -80,10 +80,10 @@ func getHwIDFromTeid(ctx context.Context, teid string) (string, error) {
 }
 
 func getGWSGSServiceConnCtx(ctx context.Context, imsi string) (*grpc.ClientConn, context.Context, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, nil, err
 	}
-	hwID, err := getHwIDFromIMSI(ctx, imsi)
+	hwID, err := GetHwIDFromIMSI(ctx, imsi)
 	if err != nil {
 		errorStr := fmt.Sprintf(
 			"unable to get HwID from IMSI %v. err: %v\n",
@@ -169,7 +169,7 @@ func getFegServedIds(ctx context.Context, networkId string) ([]string, error) {
 	return nids, nil
 }
 
-func validateFegContext(ctx context.Context) error {
+func ValidateFegContext(ctx context.Context) error {
 	fegID := protos.GetClientGateway(ctx)
 	if fegID == nil {
 		ctxMetadata, _ := metadata.FromIncomingContext(ctx)

--- a/feg/cloud/go/services/feg_relay/servicers/location.go
+++ b/feg/cloud/go/services/feg_relay/servicers/location.go
@@ -25,7 +25,7 @@ func (srv *FegToGwRelayServer) LocationUpdateAcc(
 	ctx context.Context,
 	req *fegprotos.LocationUpdateAccept,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.LocationUpdateAcceptUnverified(ctx, req)
@@ -48,7 +48,7 @@ func (srv *FegToGwRelayServer) LocationUpdateRej(
 	ctx context.Context,
 	req *fegprotos.LocationUpdateReject,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.LocationUpdateRejectUnverified(ctx, req)

--- a/feg/cloud/go/services/feg_relay/servicers/mmi_info.go
+++ b/feg/cloud/go/services/feg_relay/servicers/mmi_info.go
@@ -25,7 +25,7 @@ func (srv *FegToGwRelayServer) MMInformationReq(
 	ctx context.Context,
 	req *fegprotos.MMInformationRequest,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.MMInformationRequestUnverified(ctx, req)

--- a/feg/cloud/go/services/feg_relay/servicers/paging.go
+++ b/feg/cloud/go/services/feg_relay/servicers/paging.go
@@ -25,7 +25,7 @@ func (srv *FegToGwRelayServer) PagingReq(
 	ctx context.Context,
 	req *fegprotos.PagingRequest,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.PagingRequestUnverified(ctx, req)

--- a/feg/cloud/go/services/feg_relay/servicers/release.go
+++ b/feg/cloud/go/services/feg_relay/servicers/release.go
@@ -25,7 +25,7 @@ func (srv *FegToGwRelayServer) ReleaseReq(
 	ctx context.Context,
 	req *fegprotos.ReleaseRequest,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.ReleaseRequestUnverified(ctx, req)

--- a/feg/cloud/go/services/feg_relay/servicers/reset.go
+++ b/feg/cloud/go/services/feg_relay/servicers/reset.go
@@ -26,7 +26,7 @@ import (
 // Reset (Code 322) over diameter connection,
 // Not implemented
 func (srv *FegToGwRelayServer) Reset(ctx context.Context, in *protos.ResetRequest) (*protos.ResetAnswer, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.ResetUnverified(ctx, in)
@@ -60,7 +60,7 @@ func (srv *FegToGwRelayServer) ResetUnverified(
 		for _, uid := range req.UserId {
 			if _, ok := uidMap[uid]; !ok {
 				uidMap[uid] = struct{}{}
-				hwId, err := getHwIDFromIMSI(ctx, uid)
+				hwId, err := GetHwIDFromIMSI(ctx, uid)
 				if err != nil {
 					glog.Errorf("Reset: unable to get Hw ID for UID %s: %v.", uid, err)
 					continue

--- a/feg/cloud/go/services/feg_relay/servicers/s8_bearer_pgw.go
+++ b/feg/cloud/go/services/feg_relay/servicers/s8_bearer_pgw.go
@@ -72,7 +72,7 @@ func (srv *FegToGwRelayServer) DeleteBearerRequest(
 
 func getS8ProxyResponderClient(ctx context.Context, teid string) (
 	fegprotos.S8ProxyResponderClient, context.Context, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, ctx, err
 	}
 	hwId, err := getHwIDFromTeid(ctx, teid)

--- a/feg/cloud/go/services/feg_relay/servicers/southbound/gx_reauth.go
+++ b/feg/cloud/go/services/feg_relay/servicers/southbound/gx_reauth.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"magma/feg/cloud/go/services/feg_relay/servicers"
 	"magma/lte/cloud/go/protos"
 	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
 )
@@ -26,10 +27,10 @@ func (srv *FegToGwRelayServer) PolicyReAuth(
 	ctx context.Context,
 	req *protos.PolicyReAuthRequest,
 ) (*protos.PolicyReAuthAnswer, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := servicers.ValidateFegContext(ctx); err != nil {
 		return &protos.PolicyReAuthAnswer{Result: protos.ReAuthResult_OTHER_FAILURE}, err
 	}
-	hwID, err := getHwIDFromIMSI(ctx, req.Imsi)
+	hwID, err := servicers.GetHwIDFromIMSI(ctx, req.Imsi)
 	if err != nil {
 		return &protos.PolicyReAuthAnswer{Result: protos.ReAuthResult_SESSION_NOT_FOUND},
 			fmt.Errorf("unable to get HwID from IMSI %v. err: %v", req.Imsi, err)

--- a/feg/cloud/go/services/feg_relay/servicers/southbound/gy_reauth.go
+++ b/feg/cloud/go/services/feg_relay/servicers/southbound/gy_reauth.go
@@ -17,19 +17,29 @@ import (
 	"context"
 	"fmt"
 
+	"magma/feg/cloud/go/services/feg_relay/servicers"
 	"magma/lte/cloud/go/protos"
 	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
 )
+
+// FegToGwRelayServer is a server serving requests from FeG to Access Gateway
+type FegToGwRelayServer struct {
+}
+
+// NewFegToGwRelayServer creates a new FegToGwRelayServer
+func NewFegToGwRelayServer() (*FegToGwRelayServer, error) {
+	return &FegToGwRelayServer{}, nil
+}
 
 // ReAuth initiates a credit reauth on the gateway
 func (srv *FegToGwRelayServer) ChargingReAuth(
 	ctx context.Context,
 	req *protos.ChargingReAuthRequest,
 ) (*protos.ChargingReAuthAnswer, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := servicers.ValidateFegContext(ctx); err != nil {
 		return &protos.ChargingReAuthAnswer{Result: protos.ReAuthResult_OTHER_FAILURE}, err
 	}
-	hwID, err := getHwIDFromIMSI(ctx, req.Sid)
+	hwID, err := servicers.GetHwIDFromIMSI(ctx, req.Sid)
 	if err != nil {
 		return &protos.ChargingReAuthAnswer{Result: protos.ReAuthResult_SESSION_NOT_FOUND},
 			fmt.Errorf("unable to get HwID from IMSI %v. err: %v", req.Sid, err)

--- a/feg/cloud/go/services/feg_relay/servicers/terminate_registration.go
+++ b/feg/cloud/go/services/feg_relay/servicers/terminate_registration.go
@@ -26,7 +26,7 @@ import (
 func (srv *FegToGwRelayServer) TerminateRegistration(
 	ctx context.Context, req *protos.RegistrationTerminationRequest) (*protos.RegistrationAnswer, error) {
 
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.TerminateRegistrationUnverified(ctx, req)
@@ -37,7 +37,7 @@ func (srv *FegToGwRelayServer) TerminateRegistration(
 func (srv *FegToGwRelayServer) TerminateRegistrationUnverified(
 	ctx context.Context, req *protos.RegistrationTerminationRequest) (*protos.RegistrationAnswer, error) {
 
-	hwId, err := getHwIDFromIMSI(ctx, req.UserName)
+	hwId, err := GetHwIDFromIMSI(ctx, req.UserName)
 	if err != nil {
 		errmsg := fmt.Errorf("unable to get HwID from IMSI %v. err: %v", req.GetUserName(), err)
 		log.Print(errmsg)

--- a/feg/cloud/go/services/feg_relay/servicers/vlr.go
+++ b/feg/cloud/go/services/feg_relay/servicers/vlr.go
@@ -27,7 +27,7 @@ func (srv *FegToGwRelayServer) VLRResetAck(
 	ctx context.Context,
 	req *fegprotos.ResetAck,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.VLRResetAckUnverified(ctx, req)
@@ -59,7 +59,7 @@ func (srv *FegToGwRelayServer) VLRResetIndication(
 	ctx context.Context,
 	req *fegprotos.ResetIndication,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		glog.Errorf("Failed to validate FeG context: %s", err)
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (srv *FegToGwRelayServer) VLRStatus(
 	ctx context.Context,
 	req *fegprotos.Status,
 ) (*protos.Void, error) {
-	if err := validateFegContext(ctx); err != nil {
+	if err := ValidateFegContext(ctx); err != nil {
 		return nil, err
 	}
 	return srv.VLRStatusUnverified(ctx, req)


### PR DESCRIPTION
Signed-off-by: shivesh-wavelabs <shivesh.ojha@wavelabs.ai>

## Summary
This PR deals with the segregation of SessionProxyResponder's external gRPC servicers implementation.
These changes are part of the ongoing work which details the distinction between Orc8r-external gRPC endpoints vs. external, gateway-oriented gRPC endpoints.
Moved SessionProxyResponder implementation from  feg/cloud/go/services/feg_relay/servicers/ to feg/cloud/go/services/feg_relay/servicers/southbound/

This PR was done as part of discussion by @hcgatewood [RemoveGatewayAccess toOrc8r-InternalEndpoints](https://drive.google.com/file/d/1NO6Qd6rU80xPh0Sb0mKWlSfDt0JbeVIT/view)

## Test Plan
All UTs passed.