### PR TITLE
fix(amf): Send proper imsi value from subscriberDB in gRPC towards AM…

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.cpp
@@ -62,14 +62,13 @@ static void handle_subs_authentication_info_ans(
   if (!status.ok()) {
     std::cout << "get_subs_auth_info fails with code " << status.error_code()
               << ", msg: " << status.error_message() << std::endl;
-  } else {
-    strncpy(amf_app_subs_auth_info_resp_p->imsi, imsi.c_str(), imsi_length);
-    amf_app_subs_auth_info_resp_p->imsi_length = imsi_length;
-    amf_app_subs_auth_info_resp_p->ue_id       = ue_id;
-
-    magma5g::convert_proto_msg_to_itti_m5g_auth_info_ans(
-        response, amf_app_subs_auth_info_resp_p);
   }
+  strncpy(amf_app_subs_auth_info_resp_p->imsi, imsi.c_str(), imsi_length);
+  amf_app_subs_auth_info_resp_p->imsi_length = imsi_length;
+  amf_app_subs_auth_info_resp_p->ue_id       = ue_id;
+
+  magma5g::convert_proto_msg_to_itti_m5g_auth_info_ans(
+      response, amf_app_subs_auth_info_resp_p);
 
   send_msg_to_task(&grpc_service_task_zmq_ctx, TASK_AMF_APP, message_p);
 }


### PR DESCRIPTION
Signed-off-by: RahulKalsangra <rahul.kalsangra@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
<!-- Enumerate changes you made and why you made them -->
If the input parameter status is not ok, then the IMSI value is not getting populated in authentication response towards AMF.
When the authentication response is processed at AMF the IMSI value is resulting in value 0.
with the changes, the proper IMSI value is getting populated in grpc towards amf.
## Test Plan
ueransim 
![11088test](https://user-images.githubusercontent.com/51331971/148801741-f5661fff-34c8-4466-ba59-f92800a6a3b0.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

https://app.zenhub.com/workspaces/magma--5g-sa-60871e99b9326f001696b1ee/issues/magma/magma/11088
- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
