### PR TITLE
fix(agw): Handle failed IP allocation

### DIFF
--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -233,13 +233,17 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
                 composite_sid + ",ipv6", IPAddress.IPV6,
                 context, request,
             )
-            ipv4_addr = ipv4_response.ip_list[0]
-            ipv6_addr = ipv6_response.ip_list[0]
-            # Get vlan from IPv4 Allocate response
-            resp = AllocateIPAddressResponse(
-                ip_list=[ipv4_addr, ipv6_addr],
-                vlan=ipv4_response.vlan,
-            )
+            try:
+                ipv4_address = ipv4_response.ip_list[0]
+                ipv6_address = ipv6_response.ip_list[0]
+            except IndexError:
+                logging.warning("IPv4/IPv6 IP address allocation not successful")
+                resp = AllocateIPAddressResponse()
+            else:
+                resp = AllocateIPAddressResponse(
+                    ip_list=[ipv4_address, ipv6_address],
+                    vlan=ipv4_response.vlan,
+                )
         else:
             resp = AllocateIPAddressResponse()
 


### PR DESCRIPTION
fixes #11097

Signed-off-by: Jan Heidbrink <jan.heidbrink@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Currently when either IPv4 or IPv6 allocation fails, we raise an IndexError. Now we only log a warning here, as the caller of the `AllocateIPAddress` endpoint will receive meaningful context about the failure.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
