### PR TITLE
fix(ci): Queue AGW load tests

### DIFF
--- a/.github/workflows/agw-docker-load-test.yaml
+++ b/.github/workflows/agw-docker-load-test.yaml
@@ -11,6 +11,8 @@ on:  # yamllint disable-line rule:truthy
     types:
       - completed
 
+concurrency: ${{ github.workflow }}-${{ github.event.workflow_run.head_commit.id }}
+
 jobs:
   docker-load-test:
     name: agw docker load tests


### PR DESCRIPTION
Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Avoid launching agw load tests in parallel. They cannot run in parallel because they use tags to identify aws instances
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
