### PR TITLE
test(agw): Use magma-test VM for running trf server

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -120,6 +120,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # UE trfgen network
     magma_test.vm.network "private_network", ip: "192.168.128.11", nic_type: "82540EM"
     #config.ssh.private_key_path = "~/.ssh/vagrant.key"
+    magma_test.vm.network "private_network", ip: "192.168.129.43", nic_type: "82540EM"
     config.ssh.forward_agent = true
 
     magma_test.vm.provider "virtualbox" do |vb|

--- a/lte/gateway/deploy/roles/trfserver/files/traffic_server.py
+++ b/lte/gateway/deploy/roles/trfserver/files/traffic_server.py
@@ -522,8 +522,14 @@ class TrafficTestDriver(object):
     def _get_macs(self):
         ''' Retrieves the MAC addresses of the associated test servers, based
         on the information of the instances '''
+        dev = 'eth2'
         ip = pyroute2.IPRoute()
-        mac = ip.link('get', index=ip.link_lookup(ifname='eth2')[0])[0] \
+        # incase of missing eth2, use eth3.
+        # This check is done for compatibility for namespace based trf-serve
+        res = ip.link_lookup(ifname=dev)
+        if len(res) == 0:
+            dev = 'eth3'
+        mac = ip.link('get', index=ip.link_lookup(ifname=dev)[0])[0] \
             .get_attr('IFLA_ADDRESS')
 
         return (mac,) * len(self._instances)

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -250,7 +250,7 @@ def federated_integ_test(
 
 def integ_test(
     gateway_host=None, test_host=None, trf_host=None,
-    destroy_vm='True', provision_vm='True',
+    destroy_vm='True', provision_vm='True', use_trf_ns='False',
 ):
     """
     Run the integration tests. This defaults to running on local vagrant
@@ -272,6 +272,7 @@ def integ_test(
 
     destroy_vm = bool(strtobool(destroy_vm))
     provision_vm = bool(strtobool(provision_vm))
+    use_trf_ns = bool(strtobool(use_trf_ns))
 
     # Setup the gateway: use the provided gateway if given, else default to the
     # vagrant machine
@@ -297,13 +298,17 @@ def integ_test(
 
     # Setup the trfserver: use the provided trfserver if given, else default to the
     # vagrant machine
-    if not trf_host:
+    if use_trf_ns:
+        trf_host = vagrant_setup(
+            'magma_test', destroy_vm, force_provision=provision_vm,
+        )
+    elif not trf_host:
         trf_host = vagrant_setup(
             'magma_trfserver', destroy_vm, force_provision=provision_vm,
         )
     else:
         ansible_setup(trf_host, "trfserver", "magma_trfserver.yml")
-    execute(_start_trfserver)
+    execute(_start_trfserver, use_trf_ns)
 
     # Run the tests: use the provided test machine if given, else default to
     # the vagrant machine
@@ -370,6 +375,7 @@ def get_test_logs(
     test_host=None,
     trf_host=None,
     dst_path="/tmp/build_logs.tar.gz",
+    use_trf_ns='False',
 ):
     """
     Download the relevant magma logs from the given gateway and test machines.
@@ -387,6 +393,7 @@ def get_test_logs(
          defaults to the `magma_trfserver` vagrant box.
         dst_path: The path where the tarred logs will be placed on the host
     """
+    use_trf_ns = bool(strtobool(use_trf_ns))
 
     # Grab the build logs from the machines and bring them to the host
     local('rm -rf /tmp/build_logs')
@@ -419,19 +426,20 @@ def get_test_logs(
             )
 
     # Set up to enter the trfserver host
-    env.host_string = trf_host
-    if not trf_host:
-        setup_env_vagrant("magma_trfserver")
-        trf_host = env.hosts[0]
-    (env.user, _, _) = split_hoststring(trf_host)
+    if not use_trf_ns:
+        env.host_string = trf_host
+        if not trf_host:
+            setup_env_vagrant("magma_trfserver")
+            trf_host = env.hosts[0]
+        (env.user, _, _) = split_hoststring(trf_host)
 
-    # Don't fail if the logs don't exists
-    for p in trf_files:
-        with settings(warn_only=True):
-            get(
-                remote_path=p, local_path='/tmp/build_logs/trfserver/',
-                use_sudo=True,
-            )
+        # Don't fail if the logs don't exists
+        for p in trf_files:
+            with settings(warn_only=True):
+                get(
+                    remote_path=p, local_path='/tmp/build_logs/trfserver/',
+                    use_sudo=True,
+                )
 
     # Set up to enter the test host
     env.host_string = test_host
@@ -526,14 +534,19 @@ def make_integ_tests(test_host=None, destroy_vm='False', provision_vm='False'):
     execute(_make_integ_tests)
 
 
-def build_and_start_magma_trf(test_host=None, destroy_vm='False', provision_vm='False'):
+def build_and_start_magma_trf(test_host=None, destroy_vm='False', provision_vm='False', use_trf_ns='False'):
     destroy_vm = bool(strtobool(destroy_vm))
     provision_vm = bool(strtobool(provision_vm))
-    if not test_host:
+    use_trf_ns = bool(strtobool(use_trf_ns))
+
+    if use_trf_ns:
+        # do not start trf VM.
+        pass
+    elif not test_host:
         vagrant_setup('magma_trfserver', destroy_vm, force_provision=provision_vm)
     else:
         ansible_setup(test_host, "test", "magma_test.yml")
-    execute(_start_trfserver)
+    execute(_start_trfserver, use_trf_ns)
 
 
 def start_magma(test_host=None, destroy_vm='False', provision_vm='False'):
@@ -605,14 +618,23 @@ def _set_service_config_var(service, var_name, value):
     )
 
 
-def _start_trfserver():
+def _start_trfserver(use_trf_ns=False):
     """ Starts the traffic gen server"""
     # disable-tcp-checksumming
     # trfgen-server non daemon
+
     host = env.hosts[0].split(':')[0]
     port = env.hosts[0].split(':')[1]
     key = env.key_filename
     # set tty on cbreak mode as background ssh process breaks indentation
+    if use_trf_ns:
+        local(
+        'ssh -f -i %s -o UserKnownHostsFile=/dev/null'
+        ' -o StrictHostKeyChecking=no -tt %s -p %s'
+        ' nohup sudo bash -x /home/vagrant/magma/lte/gateway/python/integ_tests/script/setup-trf-ns.sh reset; '
+        % (key, host, port),
+        )
+        return
     local(
         'ssh -f -i %s -o UserKnownHostsFile=/dev/null'
         ' -o StrictHostKeyChecking=no -tt %s -p %s'

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -125,9 +125,13 @@ class TrafficUtil(object):
 
     def update_dl_route(self, ue_ip_block):
         """ Update downlink route in TRF server """
+        dev = "eth2"
+        ip = pyroute2.IPRoute()
+        if ip.link_lookup(ifname='trf1'):
+            dev = "eth3"
         ret_code = self.exec_command(
             "sudo ip route flush via 192.168.129.1 && sudo ip route "
-            "replace " + ue_ip_block + " via 192.168.129.1 dev eth2",
+            "replace " + ue_ip_block + " via 192.168.129.1 dev " + dev,
         )
         if ret_code != 0:
             return False

--- a/lte/gateway/python/integ_tests/script/setup-trf-ns.sh
+++ b/lte/gateway/python/integ_tests/script/setup-trf-ns.sh
@@ -1,0 +1,62 @@
+
+DEV="eth3"
+NS_NAME="trf_ns"
+LINK_NAME="trf"
+MAGMA_DEV=192.168.60.142
+
+function setup()
+{
+  # on magma vm: sudo ip r add 192.168.60.144 via 192.168.129.42
+
+  sshpass -p vagrant ssh vagrant@$MAGMA_DEV -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no sudo ip r r 192.168.60.144 via 192.168.129.42 dev eth2
+
+  ethtool --offload eth1 rx off tx off
+  ethtool --offload eth2 rx off tx off
+  ethtool --offload eth3 rx off tx off
+
+  echo "1" > /proc/sys/net/ipv4/ip_forward
+  ip netns add $NS_NAME
+
+  ip link add "$LINK_NAME"1  type veth peer name  "$LINK_NAME"2
+
+  ip link set dev  $DEV  netns $NS_NAME
+  ip link set dev  "$LINK_NAME"2  netns $NS_NAME
+  ifconfig "$LINK_NAME"1 up
+
+  ip link set dev  "$LINK_NAME"1 address "08:00:27:62:75:8b"
+  ip r r 192.168.60.144 dev "$LINK_NAME"1
+
+  ip netns exec $NS_NAME ifconfig lo up
+  ip netns exec $NS_NAME ifconfig "$LINK_NAME"2 0.0.0.0 up
+  ip netns exec $NS_NAME ip link set dev "$LINK_NAME"2 address "08:00:27:62:75:8b"
+  ip netns exec $NS_NAME ifconfig  $DEV up
+  ip netns exec $NS_NAME ip a add 192.168.60.144/24 dev $DEV
+  ip netns exec $NS_NAME ip a add 192.168.129.42/24 dev $DEV
+  ip netns exec $NS_NAME ip r add 10.0.2.15       dev  "$LINK_NAME"2
+  ip netns exec $NS_NAME ip r add 192.168.60.141  dev  "$LINK_NAME"2
+  ip netns exec $NS_NAME ip r add 192.168.128.11  dev  "$LINK_NAME"2
+  ip netns exec $NS_NAME ip r add default  via 192.168.129.1 dev $DEV
+
+  sleep 2
+  ip netns exec $NS_NAME /usr/sbin/sshd
+  sleep 1
+  nohup ip netns exec $NS_NAME /home/vagrant/magma/lte/gateway/deploy/roles/trfserver/files/traffic_server.py 192.168.60.144 62462 &
+}
+
+function destroy()
+{
+  ip netns exec $NS_NAME ip link set $DEV  netns 1
+  sleep 1
+  ip netns del $NS_NAME
+  ip link  del "$LINK_NAME"1
+
+  ifconfig  $DEV up
+}
+
+function reset()
+{
+  destroy
+  setup
+}
+
+$1


### PR DESCRIPTION
This creates separate namespace to run trf-server on magma-test
VM thus eliminating need of running magma-trfserver in 
separate VM.
This would further reduce requirement of running magma integ-tests.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
