### PR TITLE
fix(agw): Handle empty IP list

### DIFF
--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -233,8 +233,16 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
                 composite_sid + ",ipv6", IPAddress.IPV6,
                 context, request,
             )
-            ipv4_addr = ipv4_response.ip_list[0]
-            ipv6_addr = ipv6_response.ip_list[0]
+            ipv4_addr = None
+            ipv6_addr = None
+            if not ipv4_response.ip_list:
+                logging.warning("IPv4 IP address allocation wasn't successful")
+            else:
+                ipv4_addr = ipv4_response.ip_list[0]
+            if not ipv6_response.ip_list:
+                logging.warning("IPv6 IP address allocation wasn't successful")
+            else:
+                ipv6_addr = ipv6_response.ip_list[0]
             # Get vlan from IPv4 Allocate response
             resp = AllocateIPAddressResponse(
                 ip_list=[ipv4_addr, ipv6_addr],


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

fix(agw): Handle empty IP list

## Summary

When IPv4 or IPv6 allocation fails, we get an error because we are reading an empty list. A check has been added for ipv4_response.ip_list and ipv6_response.ip_list emptiness, and if any list is empty we log a warning to bring awareness that for the given request the allocation wasn't successful.

## Test Plan

ran magma/lte/gateway make test_python

PR for issue: https://github.com/magma/magma/issues/11097