### PR TITLE
fix(orc8r): orc8r-obsidian pod crash fix

### DIFF
--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -216,8 +216,6 @@ certifier:
   service:
     labels:
       orc8r.io/analytics_collector: "true"
-      orc8r.io/obsidian_handlers: "true"
-      orc8r.io/swagger_spec: "true"
     annotations:
       orc8r.io/obsidian_handlers_path_prefixes: >
         /magma/v1/user,


### PR DESCRIPTION
Signed-off-by: Shubham Tatvamasi <shubhamtatvamasi@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Orc8r Helm deployment is crashing due to the **orc8r-obsidian** pod is not in healthy status and that's because **orc8r-certifier** service labels are conflicting with the obsidian pod.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
