### PR TITLE
refactor(feg): Segregation of S6proxy servicer as southbound

### DIFF
--- a/feg/cloud/go/services/feg_relay/feg_relay/main.go
+++ b/feg/cloud/go/services/feg_relay/feg_relay/main.go
@@ -23,6 +23,7 @@ import (
 	"magma/feg/cloud/go/services/feg_relay"
 	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay"
 	nh_servicers "magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers"
+	s6a_relay_servicers "magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound"
 	"magma/feg/cloud/go/services/feg_relay/servicers"
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/orc8r/cloud/go/service"
@@ -55,7 +56,8 @@ func main() {
 
 	// Register Neutral Host Routing services
 	nhServicer := nh_servicers.NewRelayRouter()
-	protos.RegisterS6AProxyServer(srv.GrpcServer, nhServicer)
+	s6aRelay_servicers := s6a_relay_servicers.NewRelayRouter()
+	protos.RegisterS6AProxyServer(srv.GrpcServer, s6aRelay_servicers)
 	protos.RegisterSwxProxyServer(srv.GrpcServer, nhServicer)
 	protos.RegisterHelloServer(srv.GrpcServer, nhServicer)
 	lteprotos.RegisterCentralSessionControllerServer(srv.GrpcServer, nhServicer)

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/relay_router.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/relay_router.go
@@ -25,7 +25,6 @@ const (
 	DiamUnableToDeliverErr = 3002
 
 	// FeG Relay Services
-	FegS6aProxy     gateway_registry.GwServiceType = "s6a_proxy"
 	FegSessionProxy gateway_registry.GwServiceType = "session_proxy"
 	FegHello        gateway_registry.GwServiceType = "feg_hello"
 	FegSwxProxy     gateway_registry.GwServiceType = "swx_proxy"

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound/s6a_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound/s6a_relay.go
@@ -17,7 +17,19 @@ import (
 	"context"
 
 	"magma/feg/cloud/go/protos"
+	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay"
+	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
 )
+
+const FegS6aProxy gateway_registry.GwServiceType = "s6a_proxy"
+
+type RelayRouter struct {
+	gw_to_feg_relay.Router
+}
+
+func NewRelayRouter() *RelayRouter {
+	return &RelayRouter{Router: *gw_to_feg_relay.NewRouter()}
+}
 
 // S6AProxyServer implementation
 //

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/relay_test.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/relay_test.go
@@ -30,6 +30,7 @@ import (
 	models2 "magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay"
 	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers"
+	s6a_relay_servicers "magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/southbound"
 	healthTestUtils "magma/feg/cloud/go/services/health/test_utils"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
@@ -126,7 +127,8 @@ func TestNHRouting(t *testing.T) {
 	t.Logf("Relay S6a Proxy Address: %s", relayLis.Addr())
 
 	relayRouter := servicers.NewRelayRouter()
-	feg_protos.RegisterS6AProxyServer(relaySrv.GrpcServer, relayRouter)
+	s6a_relay_routers := s6a_relay_servicers.NewRelayRouter()
+	feg_protos.RegisterS6AProxyServer(relaySrv.GrpcServer, s6a_relay_routers)
 	feg_protos.RegisterHelloServer(relaySrv.GrpcServer, relayRouter)
 	go relaySrv.RunTest(relayLis)
 


### PR DESCRIPTION
Signed-off-by: shivesh <shivesh.ojha@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR deals with the segregation of  s6proxy.proto external gRPC servicers implementation.
These changes are part of the ongoing work which details the distinction between Orc8r-internal gRPC endpoints vs. external, gateway-oriented gRPC endpoints.

Verified existing UT cases.

This PR was done as part of discussion by @hcgatewood [RemoveGatewayAccess toOrc8r-InternalEndpoints](https://drive.google.com/file/d/1NO6Qd6rU80xPh0Sb0mKWlSfDt0JbeVIT/view)

## Test Plan

All Test Complete
All UT Complete
