### PR TITLE
fix(dp): handle logging when cbsd does not exist

### DIFF
--- a/dp/cloud/python/magma/configuration_controller/response_processor/response_db_processor.py
+++ b/dp/cloud/python/magma/configuration_controller/response_processor/response_db_processor.py
@@ -135,9 +135,16 @@ class ResponseDBProcessor(object):
         request.state = self.request_states_map[RequestStates.PROCESSED.value]
 
     def _log_response(self, session: Session, response: DBResponse):
-        network_id = response.request.cbsd.network_id or ''
-        fcc_id = response.request.cbsd.fcc_id or ''
-        serial_number = response.request.cbsd.cbsd_serial_number
+        network_id = ''
+        fcc_id = ''
+        cbsd_serial_number = ''
+        cbsd = response.request.cbsd
+        if cbsd and cbsd.network_id:
+            network_id = cbsd.network_id
+        if cbsd and cbsd.fcc_id:
+            fcc_id = cbsd.fcc_id
+        if cbsd and cbsd.cbsd_serial_number:
+            cbsd_serial_number = cbsd.cbsd_serial_number
         log_name = request_response[response.request.type.name]
         response_code = response.payload.get(
             'response', {},
@@ -147,7 +154,7 @@ class ResponseDBProcessor(object):
             log_to='DP',
             log_name=f'{log_name}',
             log_message=f'{response.payload}',
-            cbsd_serial_number=f'{serial_number}',
+            cbsd_serial_number=f'{cbsd_serial_number}',
             network_id=f'{network_id}',
             fcc_id=f'{fcc_id}',
             response_code=response_code,

--- a/dp/cloud/python/magma/configuration_controller/run.py
+++ b/dp/cloud/python/magma/configuration_controller/run.py
@@ -180,15 +180,22 @@ def _log_requests_map(session_manager, requests_map):
 
 
 def _log_request(session, request):
-    network_id = request.cbsd.network_id or ''
-    fcc_id = request.cbsd.fcc_id or ''
-    serial_number = request.cbsd.cbsd_serial_number
+    network_id = ''
+    fcc_id = ''
+    cbsd_serial_number = ''
+    cbsd = request.cbsd
+    if cbsd and cbsd.network_id:
+        network_id = cbsd.network_id
+    if cbsd and cbsd.fcc_id:
+        fcc_id = cbsd.fcc_id
+    if cbsd and cbsd.cbsd_serial_number:
+        cbsd_serial_number = cbsd.cbsd_serial_number
     log = DBLog(
         log_from='DP',
         log_to='SAS',
         log_name=request.type.name,
         log_message=f'{request.payload}',
-        cbsd_serial_number=f'{serial_number}',
+        cbsd_serial_number=f'{cbsd_serial_number}',
         network_id=f'{network_id}',
         fcc_id=f'{fcc_id}',
     )


### PR DESCRIPTION
Fixed an exception when trying to log requests/responses that belong to
a cbsd which does not exist in the db.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

* Added check for cbsd entity when logging requests and responses
* if cbsd does not exist, log empty fields into log table