### PR TITLE
fix(s8_proxy): inject u_agw_teid to create session response

### DIFF
--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
@@ -88,6 +88,9 @@ func TestS8proxyCreateAndDeleteSession(t *testing.T) {
 	// check Agw control Plane TEID on the response
 	assert.Equal(t, AGWTeidC, csRes.CAgwTeid)
 
+	// check Agw user Plane TEID on the response
+	assert.Equal(t, csReq.BearerContext.UserPlaneFteid.Teid, csRes.UAgwTeid)
+
 	// check Pgw Control Plane TEID
 	assert.NotEmpty(t, csRes.CPgwFteid)
 	assert.Equal(t, PgwTEIDc, csRes.CPgwFteid.Teid)

--- a/feg/gateway/services/s8_proxy/servicers/senders.go
+++ b/feg/gateway/services/s8_proxy/servicers/senders.go
@@ -51,6 +51,8 @@ func (s *S8Proxy) sendAndReceiveCreateSession(
 		s.gtpClient.RemoveSessionByIMSI(csReq.Imsi)
 		return nil, fmt.Errorf("Wrong response type (no CreateSessionResponse), maybe received out of order response message: %s", err)
 	}
+	// inject user plane AGW
+	csRes.UAgwTeid = csReq.BearerContext.UserPlaneFteid.Teid
 	glog.V(2).Infof("Create Session Response (grpc):\n%s", csRes.String())
 	return csRes, nil
 }


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Added missing User plane teid from AGW.
This teid is given by FEG_RELAY so it needs to be included in the Create Session Response so the AGW knows its own user plane teid

## Test Plan
Teravm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
