### PR TITLE
fix(ci): add "dp" to allowed pr semantic scope

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -85,6 +85,7 @@ jobs:
             cwg
             deps
             directoryd
+            dp
             eap
             eap_aka
             eap_sim


### PR DESCRIPTION
With recent addition of dp module to magma, extend the sematic pr check
with a new "dp" scope to allow accurate labeling of dp PRs.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

* added "dp" to the list of PR scopes