### PR TITLE
fix: Magma domain proxy helm chart default version

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -212,7 +212,7 @@ variable "wifi_orc8r_chart_version" {
 variable "dp_orc8r_chart_version" {
   description = "Version of the orchestrator domain proxy module Helm chart to install."
   type        = string
-  default     = "0.1.1"
+  default     = "0.1.0"
 }
 
 variable "orc8r_tag" {


### PR DESCRIPTION
Signed-off-by: Marcin Trojanowski <marcin.trojanowski@freedomfi.com>


## Summary

This PR fixes default value for domain-proxy helm chart version in terraform code.

## Test Plan

All tests should pass


