### PR TITLE
chore(deps): Upgrade aiohttp from 3.6.2 to 3.8.0

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -125,7 +125,7 @@ setup(
         'freezegun>=0.3.15',
         'pycryptodome>=3.9.9',
         'pyroute2==0.5.14',
-        'aiohttp==3.6.2',
+        'aiohttp==3.8.0',
         'jsonpointer>=1.14',
         'ovs>=2.13',
         'prometheus-client>=0.3.1',

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -125,7 +125,7 @@ setup(
         'freezegun>=0.3.15',
         'pycryptodome>=3.9.9',
         'pyroute2==0.5.14',
-        'aiohttp==3.8.0',
+        'aiohttp',
         'jsonpointer>=1.14',
         'ovs>=2.13',
         'prometheus-client>=0.3.1',


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

chore(deps): Upgrade aiohttp from 3.6.2 to 3.8.0

## Summary

There is  an open redirect vulnerability in python aiohttp v3.6.2 lib. A maliciously crafted link to an aiohttp-based web-server could redirect the browser to a different website. This security problem has been fixed in v3.7.4. but in that version there is a bug that causes some unit test to failing. There is a new version 3.8.0 that we shuld try.

## Test Plan

ran magma/lte/gateway make test_python


PR is for security alert: https://github.com/magma/magma/security/dependabot/lte/gateway/python/setup.py/aiohttp/open
