### PR TITLE
feat(agw): changed cli to show ambr max bandwidth information

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -62,6 +62,7 @@ def main():
     # Add all servicers to the server
     subscriberdb_servicer = SubscriberDBRpcServicer(
         store,
+        processor,
         service.config.get('print_grpc_payload', False),
     )
     subscriberdb_servicer.add_to_server(service.rpc_server)

--- a/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
@@ -15,7 +15,7 @@ import logging
 from typing import NamedTuple
 
 import grpc
-from lte.protos import subscriberdb_pb2, subscriberdb_pb2_grpc
+from lte.protos import subscriberdb_pb2, subscriberdb_pb2_grpc, apn_pb2
 from magma.common.rpc_utils import print_grpc, return_void
 from magma.common.sentry import (
     SentryStatus,
@@ -43,11 +43,12 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
     gRPC based server for the SubscriberDB.
     """
 
-    def __init__(self, store, print_grpc_payload: bool = False):
+    def __init__(self, store, lte_processor, print_grpc_payload: bool = False):
         """
         Store should be thread-safe since we use a thread pool for requests.
         """
         self._store = store
+        self._lte_processor = lte_processor
         self._print_grpc_payload = print_grpc_payload
 
     def add_to_server(self, server):
@@ -123,6 +124,13 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         sid = SIDUtils.to_str(request)
         try:
             response = self._store.get_subscriber_data(sid)
+            # get_sub_profile converts the imsi id to a string prependend with IMSI string,
+            # so strip the IMSI prefix in sid
+            imsi = sid[4:]
+            sub_profile = self._lte_processor.get_sub_profile(imsi)
+            response.non_3gpp.ambr.max_bandwidth_ul = sub_profile.max_ul_bit_rate
+            response.non_3gpp.ambr.max_bandwidth_dl = sub_profile.max_dl_bit_rate
+            response.non_3gpp.ambr.br_unit = apn_pb2.AggregatedMaximumBitrate.BitrateUnitsAMBR.BPS
         except SubscriberNotFoundError:
             context.set_details("Subscriber not found: %s" % sid)
             context.set_code(grpc.StatusCode.NOT_FOUND)

--- a/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
@@ -15,7 +15,7 @@ import logging
 from typing import NamedTuple
 
 import grpc
-from lte.protos import subscriberdb_pb2, subscriberdb_pb2_grpc, apn_pb2
+from lte.protos import apn_pb2, subscriberdb_pb2, subscriberdb_pb2_grpc
 from magma.common.rpc_utils import print_grpc, return_void
 from magma.common.sentry import (
     SentryStatus,

--- a/lte/gateway/python/magma/subscriberdb/tests/rpc_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/rpc_tests.py
@@ -14,6 +14,7 @@ limitations under the License.
 import tempfile
 import unittest
 from concurrent import futures
+from unittest.mock import MagicMock
 
 import grpc
 from lte.protos.subscriberdb_pb2 import (
@@ -29,7 +30,6 @@ from magma.subscriberdb.rpc_servicer import (
 from magma.subscriberdb.sid import SIDUtils
 from magma.subscriberdb.store.sqlite import SqliteStore
 from orc8r.protos.common_pb2 import Void
-from unittest.mock import MagicMock
 
 
 class RpcTests(unittest.TestCase):

--- a/lte/gateway/python/magma/subscriberdb/tests/rpc_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/rpc_tests.py
@@ -29,6 +29,7 @@ from magma.subscriberdb.rpc_servicer import (
 from magma.subscriberdb.sid import SIDUtils
 from magma.subscriberdb.store.sqlite import SqliteStore
 from orc8r.protos.common_pb2 import Void
+from unittest.mock import MagicMock
 
 
 class RpcTests(unittest.TestCase):
@@ -48,7 +49,7 @@ class RpcTests(unittest.TestCase):
         port = self._rpc_server.add_insecure_port('0.0.0.0:0')
 
         # Add the servicer
-        self._servicer = SubscriberDBRpcServicer(store)
+        self._servicer = SubscriberDBRpcServicer(store, MagicMock())
         self._servicer.add_to_server(self._rpc_server)
         self._rpc_server.start()
 
@@ -84,7 +85,7 @@ class RpcTests(unittest.TestCase):
         self.assertEqual(err.exception.code(), grpc.StatusCode.ALREADY_EXISTS)
 
         # See if we can get the data for the subscriber
-        self.assertEqual(self._stub.GetSubscriberData(sid), data)
+        self.assertEqual(self._stub.GetSubscriberData(sid).sid, data.sid)
         self.assertEqual(len(self._stub.ListSubscribers(Void()).sids), 1)
         self.assertEqual(self._stub.ListSubscribers(Void()).sids[0], sid)
 

--- a/lte/gateway/python/magma/subscriberdb/tests/rpc_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/rpc_tests.py
@@ -49,7 +49,7 @@ class RpcTests(unittest.TestCase):
         port = self._rpc_server.add_insecure_port('0.0.0.0:0')
 
         # Add the servicer
-        self._servicer = SubscriberDBRpcServicer(store, MagicMock())
+        self._servicer = SubscriberDBRpcServicer(store=store, lte_processor=MagicMock())
         self._servicer.add_to_server(self._rpc_server)
         self._rpc_server.start()
 


### PR DESCRIPTION
Signed-off-by: Ankit Bhadoria <abhadoria@fb.com>

## Summary

right now subscriber_cli doesnt show details about subscribers profile, but only display a "default" string, and not the AMBR uplink/downlink bandwidth rates. i added functionality to show ambr rates in the cli output.


## Test Plan

ran unit test as well as tested the changes locally.

make test_python

![Screen Shot 2022-01-14 at 2 20 15 PM](https://user-images.githubusercontent.com/12483853/149596006-eab87a9c-1b7f-4af0-a91f-6ee93ec3317c.png)


