### PR TITLE
refactor(orc8r): Segregation of AnalyticsController servicer as internal

### DIFF
--- a/cwf/cloud/go/services/cwf/cwf/main.go
+++ b/cwf/cloud/go/services/cwf/cwf/main.go
@@ -28,6 +28,7 @@ import (
 	"magma/orc8r/cloud/go/services/analytics"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/protos"
+	analytics_servicer "magma/orc8r/cloud/go/services/analytics/servicers/protected"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
 	"magma/orc8r/lib/go/service/config"
 )
@@ -53,7 +54,7 @@ func main() {
 	promQLClient := analytics.GetPrometheusClient()
 	calcs := cwf_analytics.GetAnalyticsCalculations(&serviceConfig.Analytics)
 	userStateManager := calculations.NewUserStateManager(promQLClient, "active_sessions")
-	collectorServicer := analytics.NewCollectorServicer(&serviceConfig.Analytics, promQLClient, calcs, userStateManager)
+	collectorServicer := analytics_servicer.NewCollectorServicer(&serviceConfig.Analytics, promQLClient, calcs, userStateManager)
 	protos.RegisterAnalyticsCollectorServer(srv.GrpcServer, collectorServicer)
 
 	err = srv.Run()

--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -31,6 +31,7 @@ import (
 	"magma/orc8r/cloud/go/services/analytics"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/protos"
+	analytics_servicer "magma/orc8r/cloud/go/services/analytics/servicers/protected"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
 	state_protos "magma/orc8r/cloud/go/services/state/protos"
 	provider_protos "magma/orc8r/cloud/go/services/streamer/protos"
@@ -72,7 +73,7 @@ func main() {
 	promQLClient := analytics.GetPrometheusClient()
 	userStateManager := calculations.NewUserStateManager(promQLClient, "ue_connected")
 	calcs := lte_analytics.GetAnalyticsCalculations(&serviceConfig.Analytics)
-	collectorServicer := analytics.NewCollectorServicer(&serviceConfig.Analytics, promQLClient, calcs, userStateManager)
+	collectorServicer := analytics_servicer.NewCollectorServicer(&serviceConfig.Analytics, promQLClient, calcs, userStateManager)
 	protos.RegisterAnalyticsCollectorServer(srv.GrpcServer, collectorServicer)
 
 	err = srv.Run()

--- a/orc8r/cloud/go/services/analytics/servicers/protected/collector_servicer.go
+++ b/orc8r/cloud/go/services/analytics/servicers/protected/collector_servicer.go
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package analytics
+package servicers
 
 import (
 	"context"

--- a/orc8r/cloud/go/services/analytics/servicers/protected/collector_servicer_test.go
+++ b/orc8r/cloud/go/services/analytics/servicers/protected/collector_servicer_test.go
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package analytics_test
+package servicers_test
 
 import (
 	"context"
@@ -23,10 +23,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 
-	"magma/orc8r/cloud/go/services/analytics"
 	"magma/orc8r/cloud/go/services/analytics/calculations"
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
+	analytics_servicers "magma/orc8r/cloud/go/services/analytics/servicers/protected"
 	"magma/orc8r/lib/go/metrics"
 )
 
@@ -65,7 +65,7 @@ func TestUserThresholdEnforcement(t *testing.T) {
 	calcs := []calculations.Calculation{
 		&TestUserCalculations{calculations.BaseCalculation{}},
 	}
-	collectorServicer := analytics.NewCollectorServicer(&analyticsConfig, nil, calcs, &userStateMgr)
+	collectorServicer := analytics_servicers.NewCollectorServicer(&analyticsConfig, nil, calcs, &userStateMgr)
 	resp, err := collectorServicer.Collect(context.Background(), &protos.CollectRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, len(resp.GetResults()), 0)
@@ -122,7 +122,7 @@ func TestExportEnforcement(t *testing.T) {
 		&TestNetworkCalculations{calculations.BaseCalculation{}},
 	}
 
-	collectorServicer := analytics.NewCollectorServicer(&analyticsConfig, nil, calcs, &userStateMgr)
+	collectorServicer := analytics_servicers.NewCollectorServicer(&analyticsConfig, nil, calcs, &userStateMgr)
 	resp, err := collectorServicer.Collect(context.Background(), &protos.CollectRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, len(resp.GetResults()), 0)
@@ -161,7 +161,7 @@ func TestRegisterEnforcement(t *testing.T) {
 		}},
 	}
 
-	collectorServicer := analytics.NewCollectorServicer(&analyticsConfig, nil, calcs, &userStateMgr)
+	collectorServicer := analytics_servicers.NewCollectorServicer(&analyticsConfig, nil, calcs, &userStateMgr)
 	resp, err := collectorServicer.Collect(context.Background(), &protos.CollectRequest{})
 	results := resp.GetResults()
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/services/certifier/certifier/main.go
+++ b/orc8r/cloud/go/services/certifier/certifier/main.go
@@ -29,6 +29,7 @@ import (
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
 	analytics_protos "magma/orc8r/cloud/go/services/analytics/protos"
+	analytics_servicers "magma/orc8r/cloud/go/services/analytics/servicers/protected"
 	"magma/orc8r/cloud/go/services/certifier"
 	analytics_service "magma/orc8r/cloud/go/services/certifier/analytics"
 	"magma/orc8r/cloud/go/services/certifier/obsidian/handlers"
@@ -96,7 +97,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("err %v failed parsing the config file: skipping CollectorServicer creation ", err)
 	}
-	collectorServicer := analytics.NewCollectorServicer(
+	collectorServicer := analytics_servicers.NewCollectorServicer(
 		&serviceConfig.Analytics,
 		analytics.GetPrometheusClient(),
 		analytics_service.GetAnalyticsCalculations(&serviceConfig),

--- a/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
+++ b/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
@@ -24,6 +24,7 @@ import (
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/analytics"
 	analytics_protos "magma/orc8r/cloud/go/services/analytics/protos"
+	analytics_servicers "magma/orc8r/cloud/go/services/analytics/servicers/protected"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
 	exporter_protos "magma/orc8r/cloud/go/services/metricsd/protos"
 	"magma/orc8r/cloud/go/services/orchestrator"
@@ -76,7 +77,7 @@ func main() {
 
 	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(orchestrator.ServiceName))
 
-	collectorServicer := analytics.NewCollectorServicer(
+	collectorServicer := analytics_servicers.NewCollectorServicer(
 		&serviceConfig.Analytics,
 		analytics.GetPrometheusClient(),
 		analytics_service.GetAnalyticsCalculations(&serviceConfig.Analytics),


### PR DESCRIPTION
Signed-off-by: sabithaatla <sabitha.atla@wavelabs.ai>


## Summary

This PR deals with the segregation of Collector's internal gRPC servicers implementation.
These changes are part of the ongoing work which details the distinction between Orc8r-internal gRPC endpoints vs. external, gateway-oriented gRPC endpoints.
Moved AnalyticsCollector implementation from orc8r/cloud/go/services/analytics/servicers/ to orc8r/cloud/go/services/analytics/servicers/protected
Verified existing UT cases.

This PR was done as part of discussion by @hcgatewood [Remove gateway access to Orc8r-internal endpoints.pdf](https://drive.google.com/file/d/1NO6Qd6rU80xPh0Sb0mKWlSfDt0JbeVIT/view)

## Test Plan

All UT's passed

