### PR TITLE
chore(deps): Upgrade lxml from 4.6.3 to 4.7.1

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -101,7 +101,7 @@ setup(
         'envoy>=0.0.3',
         'glob2>=0.7',
         # lxml required by spyne.
-        'lxml==4.6.3',
+        'lxml==4.7.1',
         'ryu>=4.34',
         'spyne>=2.13.15',
         'scapy==2.4.4',


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

chore(deps): Upgrade lxml from 4.6.3 to 4.7.1

## Summary

The HTML Cleaner in lxml.html lets certain crafted script content pass through, as well as script content in SVG files embedded using data URIs. This security issue has been resolved in lxml 4.6.5 so it needs to be upgraded.

## Test Plan

ran magma/lte/gateway make test_python

## Additional Information

PR is for security alert: https://github.com/magma/magma/security/dependabot/lte/gateway/python/setup.py/lxml/open
