### PR TITLE
fix(ci): Timeout on pushing results to load test api

### DIFF
--- a/experimental/cloudstrapper/playbooks/roles/ghz-platform/tasks/run-tests.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/ghz-platform/tasks/run-tests.yaml
@@ -41,7 +41,7 @@
     - "{{ load_tests }}"
     - test
 
-- name: push results to gHZ API
+- name: push results to gHZ API first try
   uri:
     url: "{{ GHZ_API_URL }}:{{ GHZ_API_PORT}}/api/projects/{{ item[1] }}/ingest"
     method: POST
@@ -49,3 +49,18 @@
     body_format: json
     body: "{{ item[0].stdout | from_json }}"
   loop: "{{ json_output.results | zip(test_ids) | list }}"
+  ignore_errors: true
+  timeout: 300
+  register: pushFirstTry
+
+- name: push results to gHZ API second try
+  uri:
+    url: "{{ GHZ_API_URL }}:{{ GHZ_API_PORT}}/api/projects/{{ item[1] }}/ingest"
+    method: POST
+    status_code: 201
+    body_format: json
+    body: "{{ item[0].stdout | from_json }}"
+  loop: "{{ json_output.results | zip(test_ids) | list }}"
+  timeout: 300
+  ignore_errors: true
+  when: pushFirstTry.stderr is defined and 'FAILED' in pushFirstTry.stderr


### PR DESCRIPTION
Signed-off-by: quentinDERORY <15911421+quentinDERORY@users.noreply.github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Pushing results to the load test ui can sometimes runs long. 
Adding second try with timeout as workarround

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
