### PR TITLE
feat(policydb): Add dump_data command to policydb_cli.py

### DIFF
--- a/lte/gateway/python/magma/policydb/apn_rule_map_store.py
+++ b/lte/gateway/python/magma/policydb/apn_rule_map_store.py
@@ -31,7 +31,7 @@ class ApnRuleAssignmentsDict(RedisHashDict):
     """
     _DICT_HASH = "policydb:apn_installed"
 
-    def __init__(self):
+    def __init__(self, clear_data: bool = True):
         client = get_default_client()
         super().__init__(
             client,
@@ -39,4 +39,5 @@ class ApnRuleAssignmentsDict(RedisHashDict):
             get_proto_serializer(),
             get_proto_deserializer(SubscriberPolicySet),
         )
-        self._clear()
+        if (clear_data):
+            self._clear()

--- a/lte/gateway/python/magma/policydb/rule_map_store.py
+++ b/lte/gateway/python/magma/policydb/rule_map_store.py
@@ -28,7 +28,7 @@ class RuleAssignmentsDict(RedisHashDict):
     """
     _DICT_HASH = "policydb:installed"
 
-    def __init__(self):
+    def __init__(self, clear_data: bool = True):
         client = get_default_client()
         super().__init__(
             client,
@@ -37,4 +37,5 @@ class RuleAssignmentsDict(RedisHashDict):
             get_proto_deserializer(InstalledPolicies),
         )
         # TODO: Remove when sessiond becomes stateless
-        self._clear()
+        if clear_data:
+            self._clear()


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Adds the `dump_data` command to `policydb_cli.py`. This new command is intended for troubleshooting purposes, to quickly verify what contents are in the Redis tables maintained by `policydb` service.

Example output:
```
(python) vagrant@magma-dev-focal:~$ policydb_cli.py dump_data
********************************************************************************
*                              policydb:installed                              *
********************************************************************************


********************************************************************************
*                            policydb:apn_installed                            *
********************************************************************************
IMSI1234567890:
    global_base_names: "base_1"
    global_policies: "policy_1"



********************************************************************************
*                              policydb:basenames                              *
********************************************************************************


********************************************************************************
*                            policydb:rating_groups                            *
********************************************************************************
1:
    id: 1
    limit_type: INFINITE_UNMETERED



********************************************************************************
*                                policydb:rules                                *
********************************************************************************
policy_nw:
    id: "policy_nw"
    priority: 1
    flow_list {
      match {
        ipv4_src: "192.168.0.1/24"
        ip_src {
          address: "192.168.0.1/24"
        }
      }
      action: DENY
    }

policy_1:
    id: "policy_1"
    priority: 1
    qos {
      max_req_bw_ul: 9
      max_req_bw_dl: 9
      qci: QCI_2
    }
```

## Test Plan

Set up some rules, base names, subscribers, APNs, etc. on a test NMS + Orc8r + AGW setup.

Then, ran `policydb_cli.py dump_data` on the AGW as a sanity check that it was working.

## Additional Information

- [ ] This change is backwards-breaking
