### PR TITLE
fix(policydb): Re-enable BaseNamesStreamerCallback

### DIFF
--- a/lte/gateway/python/magma/policydb/basename_store.py
+++ b/lte/gateway/python/magma/policydb/basename_store.py
@@ -40,8 +40,8 @@ class BaseNameDict(RedisHashDict):
 
     def send_update_notification(self):
         """
-        Use Redis pub/sub channels to send notifications. Subscribers can listen
-        to this channel to know when an update is done
+        Use Redis pub/sub channels to send notifications. Subscribers can
+        listen to this channel to know when an update is done
         """
         self.redis.publish(self._NOTIFY_CHANNEL, "Stream Update")
 

--- a/lte/gateway/python/magma/policydb/main.py
+++ b/lte/gateway/python/magma/policydb/main.py
@@ -32,6 +32,7 @@ from magma.policydb.servicers.policy_servicer import PolicyRpcServicer
 from magma.policydb.servicers.session_servicer import SessionRpcServicer
 from magma.policydb.streamer_callback import (
     ApnRuleMappingsStreamerCallback,
+    BaseNamesStreamerCallback,
     PolicyDBStreamerCallback,
     RatingGroupsStreamerCallback,
 )
@@ -41,7 +42,10 @@ def main():
     service = MagmaService('policydb', mconfigs_pb2.PolicyDB())
 
     # Optionally pipe errors to Sentry
-    sentry_init(service_name=service.name, sentry_mconfig=service.shared_mconfig.sentry_config)
+    sentry_init(
+        service_name=service.name,
+        sentry_mconfig=service.shared_mconfig.sentry_config,
+    )
 
     apn_rules_dict = ApnRuleAssignmentsDict()
     assignments_dict = RuleAssignmentsDict()
@@ -80,6 +84,7 @@ def main():
         stream = StreamerClient(
             {
                 'policydb': PolicyDBStreamerCallback(),
+                'base_names': BaseNamesStreamerCallback(basenames_dict),
                 'apn_rule_mappings': ApnRuleMappingsStreamerCallback(
                     session_mgr_stub,
                     basenames_dict,

--- a/lte/gateway/python/magma/policydb/rating_group_store.py
+++ b/lte/gateway/python/magma/policydb/rating_group_store.py
@@ -40,8 +40,9 @@ class RatingGroupsDict(RedisHashDict):
 
     def send_update_notification(self):
         """
-        Use Redis pub/sub channels to send notifications. Subscribers can listen
-        to this channel to know when an update is done to the policy store
+        Use Redis pub/sub channels to send notifications. Subscribers can
+        listen to this channel to know when an update is done to the policy
+        store
         """
         self.redis.publish(self._NOTIFY_CHANNEL, "Stream Update")
 

--- a/lte/gateway/python/magma/policydb/rule_store.py
+++ b/lte/gateway/python/magma/policydb/rule_store.py
@@ -22,9 +22,9 @@ from magma.common.redis.serializers import (
 
 class PolicyRuleDict(RedisHashDict):
     """
-    PolicyRuleDict uses the RedisHashDict collection to store a mapping of policy
-    rule ids to PolicyRules. Setting and deleting items in the dictionary syncs
-    with Redis automatically
+    PolicyRuleDict uses the RedisHashDict collection to store a mapping of
+    policy rule ids to PolicyRules.
+    Setting and deleting items in the dictionary syncs with Redis automatically
     """
     _DICT_HASH = "policydb:rules"
     _NOTIFY_CHANNEL = "policydb:rules:stream_update"
@@ -40,8 +40,9 @@ class PolicyRuleDict(RedisHashDict):
 
     def send_update_notification(self):
         """
-        Use Redis pub/sub channels to send notifications. Subscribers can listen
-        to this channel to know when an update is done to the policy store
+        Use Redis pub/sub channels to send notifications. Subscribers can
+        listen to this channel to know when an update is done to the policy
+        store
         """
         self.redis.publish(self._NOTIFY_CHANNEL, "Stream Update")
 

--- a/lte/gateway/python/magma/policydb/streamer_callback.py
+++ b/lte/gateway/python/magma/policydb/streamer_callback.py
@@ -165,10 +165,14 @@ class ApnRuleMappingsStreamerCallback(StreamerClient.Callback):
         try:
             self._session_mgr_stub.SetSessionRules(update, timeout=5)
         except grpc.RpcError as e:
+            error_extra = (
+                EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(e)
+                else None
+            )
             logging.error(
                 "Unable to apply apn->policy updates %s",
                 str(e),
-                extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(e) else None,
+                extra=error_extra,
             )
 
     def _are_sub_policies_updated(

--- a/lte/gateway/python/magma/policydb/tests/mock_stubs.py
+++ b/lte/gateway/python/magma/policydb/tests/mock_stubs.py
@@ -74,6 +74,8 @@ class MockSessionProxyResponderStub3:
         return PolicyReAuthAnswer(
             result=ReAuthResult.Value('UPDATE_INITIATED'),
             failed_rules={
-                "p2": PolicyReAuthAnswer.FailureCode.Value("UNKNOWN_RULE_NAME"),
+                "p2": PolicyReAuthAnswer.FailureCode.Value(
+                    "UNKNOWN_RULE_NAME",
+                ),
             },
         )


### PR DESCRIPTION
## Summary

Noticed that the Redis table `policydb:basenames` was not being populated on the AGW by `policydb` service. This is a fix that re-enables `BaseNamesStreamerCallback`.

## Test Plan

Used the output of `policydb_cli.py dump_data` to check that base names were being populated in Redis after the fix:

Example output:
```
(python) vagrant@magma-dev-focal:~$ policydb_cli.py dump_data
********************************************************************************
*                              policydb:installed                              *
********************************************************************************


********************************************************************************
*                            policydb:apn_installed                            *
********************************************************************************
IMSI1234567890:
    global_base_names: "base_1"
    global_policies: "policy_1"



********************************************************************************
*                              policydb:basenames                              *
********************************************************************************
base_1:
    RuleNames: "policy_1"



********************************************************************************
*                            policydb:rating_groups                            *
********************************************************************************
1:
    id: 1
    limit_type: INFINITE_UNMETERED



********************************************************************************
*                                policydb:rules                                *
********************************************************************************
policy_nw:
    id: "policy_nw"
    priority: 1
    flow_list {
      match {
        ipv4_src: "192.168.0.1/24"
        ip_src {
          address: "192.168.0.1/24"
        }
      }
      action: DENY
    }

policy_1:
    id: "policy_1"
    priority: 1
    qos {
      max_req_bw_ul: 9
      max_req_bw_dl: 9
      qci: QCI_2
    }
```

## Additional Information

- [ ] This change is backwards-breaking
