### PR TITLE
chore(sctpd): Remove signal mask for SEGV

### DIFF
--- a/lte/gateway/c/sctpd/src/sctpd.cpp
+++ b/lte/gateway/c/sctpd/src/sctpd.cpp
@@ -41,7 +41,6 @@ using magma::sctpd::SctpdUplinkClient;
 int signalMask(void) {
   sigset_t set;
   sigemptyset(&set);
-  sigaddset(&set, SIGSEGV);
   sigaddset(&set, SIGINT);
   sigaddset(&set, SIGTERM);
 
@@ -58,14 +57,8 @@ int signalHandler(int* end, std::unique_ptr<Server>& server,
   sigset_t set;
 
   sigemptyset(&set);
-  sigaddset(&set, SIGSEGV);
   sigaddset(&set, SIGINT);
   sigaddset(&set, SIGTERM);
-
-  if (sigprocmask(SIG_BLOCK, &set, NULL) < 0) {
-    perror("sigprocmask");
-    return -1;
-  }
 
   /*
    * Block till a signal is received.
@@ -154,5 +147,6 @@ int main() {
   while (end == 0) {
     signalHandler(&end, sctpd_dl_server, service);
   }
+  shutdown_sentry();
   return 0;
 }


### PR DESCRIPTION
## Summary

Now that SCTPd supports Sentry, the mask should be removed in order to catch segfaults (see #9509).

## Additional Information

- [ ] This change is backwards-breaking