### PR TITLE
fix(agw): Disabled failing timer test cases

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -257,6 +257,10 @@ s1aptests/test_restore_config_after_non_sanity.py
 # s1aptests/test_attach_detach_multi_ue_looped.py \
 # s1aptests/test_attach_detach_rar_tcp_he.py \ GitHubIssue 6254
 
+# Temporarily disabled for Github issue #11237
+# s1aptests/test_mobile_reachability_timer_with_mme_restart.py \
+# s1aptests/test_implicit_detach_timer_with_mme_restart.py \
+
 CLOUD_TESTS = cloud_tests/checkin_test.py \
 cloud_tests/metrics_export_test.py \
 cloud_tests/config_test.py

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -167,8 +167,6 @@ s1aptests/test_guti_attach_with_zero_mtmsi.py \
 s1aptests/test_ics_timer_expiry_with_mme_restart.py \
 s1aptests/test_attach_mobile_reachability_timer_expiry.py \
 s1aptests/test_attach_implicit_detach_timer_expiry.py \
-s1aptests/test_mobile_reachability_timer_with_mme_restart.py \
-s1aptests/test_implicit_detach_timer_with_mme_restart.py \
 s1aptests/test_restore_mme_config_after_sanity.py
 
 NON_SANITY_TESTS = s1aptests/test_modify_config_for_non_sanity.py \


### PR DESCRIPTION
## Title
fix(agw): Disabled failing timer test cases

## Summary
Some of the timer test cases are failing on latest master codebase as per github issue #11237. This PR disables the test cases temporarily for the CI runs to pass. Once the issue is fixed, the test cases will be enabled again. Failing test cases are s1aptests/test_mobile_reachability_timer_with_mme_restart.py and s1aptests/test_implicit_detach_timer_with_mme_restart.py

## Test plan
Verified with test case execution.

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>