### PR TITLE
fix(agw): Add missing comma to default mconfig

### DIFF
--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -138,7 +138,7 @@
         "dsn_native": "",
         "dsn_python": "",
         "sample_rate": 1.0,
-        "upload_mme_log": false
+        "upload_mme_log": false,
         "exclusion_patterns": [
           "GetServiceInfo",
           "GetOperationalStates",


### PR DESCRIPTION
## Summary

In a recent change of the mconfig json, a comma was missing. This led to errors in the lte integration test logs, starting at:
https://github.com/magma/magma/runs/4871989725

```
Jan 19 20:10:58 magma-dev-focal magmad[94288]: Traceback (most recent call last):
Jan 19 20:10:58 magma-dev-focal magmad[94288]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/configuration/mconfig_managers.py", line 177, in load_mconfig
Jan 19 20:10:58 magma-dev-focal magmad[94288]:     return self.deserialize_mconfig(mconfig_str)
Jan 19 20:10:58 magma-dev-focal magmad[94288]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/configuration/mconfig_managers.py", line 235, in deserialize_mconfig
Jan 19 20:10:58 magma-dev-focal magmad[94288]:     json_mconfig = json.loads(serialized_value)
Jan 19 20:10:58 magma-dev-focal magmad[94288]:   File "/usr/lib/python3.8/json/__init__.py", line 357, in loads
Jan 19 20:10:58 magma-dev-focal magmad[94288]:     return _default_decoder.decode(s)
Jan 19 20:10:58 magma-dev-focal magmad[94288]:   File "/usr/lib/python3.8/json/decoder.py", line 337, in decode
Jan 19 20:10:58 magma-dev-focal magmad[94288]:     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
Jan 19 20:10:58 magma-dev-focal magmad[94288]:   File "/usr/lib/python3.8/json/decoder.py", line 353, in raw_decode
Jan 19 20:10:58 magma-dev-focal magmad[94288]:     obj, end = self.scan_once(s, idx)
Jan 19 20:10:58 magma-dev-focal magmad[94288]: json.decoder.JSONDecodeError: Expecting ',' delimiter: line 142 column 9 (char 4085)
```

## Test Plan

Validate via `jq . lte/gateway/configs/gateway.mconfig`

## Additional Information

- [ ] This change is backwards-breaking