### PR TITLE
feg(session_proxy): fix HOST-IP-ADDRESS on CER

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
@@ -112,7 +112,7 @@ func NewGxClient(
 	cloudRegistry service_registry.GatewayRegistry,
 	globalConfig *GxGlobalConfig,
 ) *GxClient {
-	diamClient := diameter.NewClient(clientCfg)
+	diamClient := diameter.NewClient(clientCfg, serverCfg.LocalAddr)
 	diamClient.BeginConnection(serverCfg)
 	return NewConnectedGxClient(diamClient, serverCfg, reAuthHandler, cloudRegistry, globalConfig)
 }

--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
@@ -108,7 +108,7 @@ func NewGyClient(
 	cloudRegistry service_registry.GatewayRegistry,
 	globalConfig *GyGlobalConfig,
 ) *GyClient {
-	diamClient := diameter.NewClient(clientCfg)
+	diamClient := diameter.NewClient(clientCfg, serverCfg.LocalAddr)
 	diamClient.BeginConnection(serverCfg)
 	return NewConnectedGyClient(diamClient, serverCfg, reAuthHandler, cloudRegistry, globalConfig)
 }

--- a/feg/gateway/services/session_proxy/session_proxy/main.go
+++ b/feg/gateway/services/session_proxy/session_proxy/main.go
@@ -136,7 +136,7 @@ func generateClientsConfsAndDiameterConnection() (
 			OCSConfsCopy[i] != PCRFConfsCopy[i] {
 			var clientCfg = *gxCliConfs[i]
 			clientCfg.AuthAppID = gyCLiConfs[i].AppID
-			diamClient := diameter.NewClient(&clientCfg)
+			diamClient := diameter.NewClient(&clientCfg, OCSConfs[i].LocalAddr)
 			diamClient.BeginConnection(OCSConfsCopy[i])
 			if gyGlobalConf.DisableGy {
 				glog.Info("Gy Disabled by configuration, not connecting to OCS")


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Host-IP-Address AVP on session proxy was always defaulted to 127.0.0.1. That was causing issues with CER reported here https://github.com/magma/magma/issues/8752 and https://github.com/magma/magma/issues/10001

This PR uses the field defined in server/local_address to set this AVP. If that field just consist on a port, it will then use the default value `127.0.0.1`

![image](https://user-images.githubusercontent.com/16157139/150582998-d95a9b18-01c1-46ee-a43a-980966bb0197.png)


## Test Plan
TeraVM

pcap here 
[cer.pcap.zip](https://github.com/magma/magma/files/7915943/cer.pcap.zip)


![image](https://user-images.githubusercontent.com/16157139/150583129-22e6a95c-bdaa-4ac9-97cb-b2330a6831a9.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
