### PR TITLE
chore(ci): add json linter for all gateway.mconfig files

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -529,3 +529,15 @@ jobs:
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
+
+  jsonlint-mconfig:
+    name: jsonlint-mconfig
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
+      - name: jsonlint-mconfig
+        run: find . -name gateway.mconfig -print0 | xargs --max-args=1 --null --replace='%' sh -c ">/dev/null jq . % || { echo % is not a valid json file; exit 1; } "

--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -13,7 +13,7 @@ concurrency:
 # Applies on all review jobs below
 # See Reviewdog doc provided at https://github.com/reviewdog/reviewdog
 # github-pr-check: Adds lint as annotations in the PR that can be toggled by pressing 'a'
-# github-pr-review: Adds lint as GitHub comments 
+# github-pr-review: Adds lint as GitHub comments
 
 jobs:
   pre_job_go_determinator:
@@ -136,7 +136,7 @@ jobs:
           filter_mode: added  # Any added or changed content.
           reporter: github-pr-review  # Post code review comments.
           locale: "US"
-  
+
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Validate all gateway.mconfig files via jq to prevent bugs like #11246.  

## Test Plan

Changed workflow trigger from `pull_request_target` to `pull_request` in a draft of this PR. The jsonlint job executed with the expected result.

<img width="1792" alt="Screenshot 2022-01-25 at 09 40 10" src="https://user-images.githubusercontent.com/82914459/150955182-f7bbaee8-6714-4fc0-ad9e-65a6dbf3ea64.png">

(Rebased subsequently to get rid of the json syntax error that the linter found and validate that it turns green.) 