### PR TITLE
feat(amf): Added few logs for sqlite3 locked issue in subscriberdb

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
@@ -68,12 +68,12 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
             "Add Subscriber Request:",
         )
         sid = SIDUtils.to_str(request.sid)
-        logging.debug("Add subscriber rpc for sid: %s", sid)
         try:
             self._store.add_subscriber(request)
         except DuplicateSubscriberError:
             context.set_details("Duplicate subscriber: %s" % sid)
             context.set_code(grpc.StatusCode.ALREADY_EXISTS)
+            logging.debug("Add subscriber rpc for sid: %s", sid)
 
     @return_void
     @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
@@ -86,8 +86,8 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
             "Delete Subscriber Request:",
         )
         sid = SIDUtils.to_str(request)
-        logging.debug("Delete subscriber rpc for sid: %s", sid)
         self._store.delete_subscriber(sid)
+        logging.debug("Delete subscriber rpc for sid: %s", sid)
 
     @return_void
     @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
@@ -111,6 +111,7 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         except SubscriberNotFoundError:
             context.set_details("Subscriber not found: %s" % sid)
             context.set_code(grpc.StatusCode.NOT_FOUND)
+            logging.debug("Update subscriber rpc for sid: %s", sid)
 
     @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetSubscriberData(self, request, context):


### PR DESCRIPTION

Signed-off-by: salman-momin07 <salman.momin@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Added few logs in subscriberdb for debugging "sqlite3.OperationalError: database table is locked: subscriberdb" error.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
For debugging and getting more logs information related to database lock issue, one need to enable
1) "print_grpc_payload " parameter as true in subscriberdb.yml
2) Change "log_level" as DEBUG

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
