### PR TITLE
fix(feg): Log entries created from user input

### DIFF
--- a/feg/gateway/sbi/sbi_logger.go
+++ b/feg/gateway/sbi/sbi_logger.go
@@ -15,8 +15,10 @@ package sbi
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -31,7 +33,7 @@ func (logger *SbiLogger) LogRequest(method string, url *url.URL, reqBody []byte,
 	if len(reqBody) != 0 {
 		extraReqInfo = fmt.Sprintf("\nBody = %s", string(reqBody))
 	}
-	glog.V(2).Infof("Request %s %v %s\n", method, url.Path, extraReqInfo)
+	glog.V(2).Infof("Request %s %v %s\n", method, sanitizeUrlPath(url.Path), sanitizeString(extraReqInfo))
 }
 
 // LogResponse logs http response related info after receiving the response from the server
@@ -44,5 +46,16 @@ func (logger *SbiLogger) LogResponse(url *url.URL, status string, resBody []byte
 	if len(resBody) != 0 {
 		extraResInfo = fmt.Sprintf("%s\nBody = %s", extraResInfo, string(resBody))
 	}
-	glog.V(2).Infof("Response %v for %v took %dms %s\n", status, url.Path, latency.Milliseconds(), extraResInfo)
+	glog.V(2).Infof("Response %v for %v took %dms %s\n", status, sanitizeUrlPath(url.Path), latency.Milliseconds(), sanitizeString(extraResInfo))
+}
+
+func sanitizeUrlPath(strString string) string {
+	return html.EscapeString(strString)
+}
+
+func sanitizeString(strString string) string {
+	strSanitizedString := strings.ReplaceAll(strString, "\r", " ") //remove line breaks
+	strSanitizedString = strings.ReplaceAll(strSanitizedString, "\n", " ")
+	strSanitizedString = strings.Join(strings.Fields(strSanitizedString), " ") //remove extra whitespace
+	return strSanitizedString
 }


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

fix(feg): Log entries created from user input

## Summary

   If unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries. I added functions for url and response body sanitizing before they are written to a log entry.


## Test Plan

ran /magma/feg/gateway/docker/ ./build.py -c and /magma/feg/gateway/sbi/sbi_test.go
all test passed

## Additional Information

PR is for security alerts:
https://github.com/magma/magma/security/code-scanning/59?query=ref%3Arefs%2Fheads%2Fmaster
https://github.com/magma/magma/security/code-scanning/58?query=ref%3Arefs%2Fheads%2Fmaster
https://github.com/magma/magma/security/code-scanning/57?query=ref%3Arefs%2Fheads%2Fmaster

