### PR TITLE
fix(pipelined): Fix eBPF init logic and arg passing

### DIFF
--- a/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
@@ -24,8 +24,10 @@ from threading import Thread
 
 import netifaces
 from bcc import BPF
+from lte.protos.mobilityd_pb2 import IPAddress
 from magma.pipelined.mobilityd_client import get_mobilityd_gw_info
 from pyroute2 import IPDB, IPRoute, NetlinkError, NetNS, NSPopen
+from scapy.layers.inet6 import getmacbyip6
 from scapy.layers.l2 import getmacbyip
 
 LOG = logging.getLogger("pipelined.ebpf")
@@ -51,12 +53,17 @@ def get_ebpf_manager(config):
         enabled = False
     gw_info = get_mobilityd_gw_info()
     for gw in gw_info:
-        if gw.vlan == "":
+        if gw.ip.version != IPAddress.IPV4:
+            continue
+        if gw.vlan in {"NO_VLAN", ""}:
             bpf_man = ebpf_manager(config['nat_iface'], config['enodeb_iface'], gw.ip, enabled)
             if enabled:
                 # TODO: For Development purpose dettch and attach latest eBPF code.
                 # Remove this for production deployment
                 bpf_man.detach_ul_ebpf()
+                bpf_man.detach_dl_ebpf()
+
+                bpf_man.attach_ul_ebpf()
                 bpf_man.attach_dl_ebpf()
                 LOG.info("eBPF manager: initilized: enabled: %s", enabled)
             return bpf_man
@@ -75,7 +82,7 @@ def get_ebpf_manager(config):
 
 
 class ebpf_manager:
-    def __init__(self, sgi_if_name: str, s1_if_name: str, gw_ip: str, enabled=True, bpf_ul_file: str = BPF_UL_FILE, bpf_dl_file: str = BPF_DL_FILE):
+    def __init__(self, sgi_if_name: str, s1_if_name: str, gw_ip: IPAddress, enabled=True, bpf_ul_file: str = BPF_UL_FILE, bpf_dl_file: str = BPF_DL_FILE):
 
         self.b_ul = BPF(src_file=bpf_ul_file, cflags=[''])
         self.b_dl = BPF(src_file=bpf_dl_file, cflags=[''])
@@ -87,9 +94,13 @@ class ebpf_manager:
         self.sgi_if_name = sgi_if_name
         self.s1_if_name = s1_if_name
         self.ul_src_mac = self._get_mac_address(sgi_if_name)
-        self.ul_gw_mac = self._get_mac_address_of_ip(gw_ip)
         self.sgi_if_index = self._get_ifindex(self.sgi_if_name)
-        self.enabled = enabled
+        self.ul_gw_mac = self._get_mac_address_of_ip(gw_ip)
+
+        if self.ul_gw_mac is None:
+            self.enabled = False
+        else:
+            self.enabled = enabled
 
     """Attach eBPF Uplink traffic handler
     """
@@ -203,8 +214,10 @@ class ebpf_manager:
         )
 
         key = self.dl_map.Key(ip_addr)
-        val = self.dl_map.Leaf(self._pack_ip(remote_ipv4),
-                               socket.htonl(tunnel_id))
+        val = self.dl_map.Leaf(
+            self._pack_ip(remote_ipv4),
+            socket.htonl(tunnel_id),
+        )
         self.dl_map[key] = val
 
     """Delete uplink session entry
@@ -287,9 +300,18 @@ class ebpf_manager:
         LOG.debug("if-name: %s, mac: %s" % (if_name, addr_str))
         return self._pack_mac_addr(addr_str)
 
-    def _get_mac_address_of_ip(self, ip_addr: str):
-        addr_str = getmacbyip(ip_addr)
-        LOG.debug("IP: %s, mac: %s" % (ip_addr, addr_str))
+    def _get_mac_address_of_ip(self, ip_addr: IPAddress):
+        if ip_addr.version == IPAddress.IPV4:
+            ip_str = socket.inet_ntop(socket.AF_INET, ip_addr.address)
+            addr_str = getmacbyip(ip_str)
+        else:
+            ip_str = socket.inet_ntop(socket.AF_INET6, ip_addr.address)
+            addr_str = getmacbyip6(ip_str)
+        if not addr_str:
+            LOG.error("Coudn't find mac for IP: %s, disabling ebpf" % (ip_str))
+            return None
+        LOG.debug("IP: %s, mac: %s" % (ip_str, addr_str))
+
         return self._pack_mac_addr(addr_str)
 
     def _pack_ip(self, ip_str: str):
@@ -308,9 +330,11 @@ class ebpf_manager:
         mac_bytes = bytearray(mac_addr)
         return mac_bytes.hex(":")
 
+
 # for debugging
 if __name__ == "__main__":
-    bm = ebpf_manager("sgi0", "enb0", "10.0.2.2", bpf_ul_file=BPF_UL_FILE, bpf_dl_file=BPF_DL_FILE, enabled=True)
+    gw_ip = IPAddress(version=IPAddress.IPV4, address=socket.inet_aton("10.0.2.2"))
+    bm = ebpf_manager("sgi0", "enb0", gw_ip, bpf_ul_file=BPF_UL_FILE, bpf_dl_file=BPF_DL_FILE, enabled=True)
 
     bm.detach_ul_ebpf()
     bm.attach_ul_ebpf()


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
 - NO_VLAN is actual string recieved from mobilityd
 - IP address need to be converted to string first

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
