### PR TITLE
fix(nms): Fixed minikube deployment db host value

### DIFF
--- a/orc8r/cloud/helm/orc8r/examples/minikube.values.yaml
+++ b/orc8r/cloud/helm/orc8r/examples/minikube.values.yaml
@@ -54,7 +54,7 @@ nms:
     env:
       api_host: orc8r-nginx-proxy:443
       mapbox_access_token: ""
-      mysql_host: mysql
+      mysql_host: postgresql
       #labels:
       #node_selector_key: extraRuntime
       #node_selector_value: virtlet


### PR DESCRIPTION
Previously after deploying on minikube, the pod nms-magmalte would throw this error: 
```
yarn run v1.22.5
$ NODE_ENV=production node -r @fbcnms/babel-register scripts/server
{"name":"SequelizeHostNotFoundError","parent":{"errno":"ENOTFOUND","code":"ENOTFOUND","syscall":"getaddrinfo","hostname":"mysql","host":"mysql","port":5432},"original":{"errno":"ENOTFOUND","code":"ENOTFOUND","syscall":"getaddrinfo","hostname":"mysql","host":"mysql","port":5432},"level":"error","label":"scripts/server.js","timestamp":"2022-01-21T21:25:20.728Z"}
Unhandled rejection SequelizeHostNotFoundError: getaddrinfo ENOTFOUND mysql mysql:5432
    at Client.connection.connect.err [as _connectionCallback] (/usr/src/node_modules/sequelize/lib/dialects/postgres/connection-manager.js:173:24)
    at Client._handleErrorWhileConnecting (/usr/src/node_modules/pg/lib/client.js:305:19)
    at Client._handleErrorEvent (/usr/src/node_modules/pg/lib/client.js:315:19)
    at Connection.emit (events.js:198:13)
    at Socket.reportStreamError (/usr/src/node_modules/pg/lib/connection.js:52:12)
    at Socket.emit (events.js:198:13)
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)
Done in 5.85s.
Stream closed EOF for orc8r/nms-magmalte-68c89d6ff6-4km72 (nms-app)
```
mysql_host from mysql -> postgresql so that it is hooked up to the correct db host