### PR TITLE
feat(agw): Implement opt-out for Sentry, remove other options

### DIFF
--- a/lte/gateway/configs/ctraced.yml
+++ b/lte/gateway/configs/ctraced.yml
@@ -23,7 +23,3 @@ trace_interfaces:
 #   - tshark
 # tshark has more capabilities - see command_builder.py
 trace_tool: tshark
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/directoryd.yml
+++ b/lte/gateway/configs/directoryd.yml
@@ -15,7 +15,3 @@
 print_grpc_payload: false
 
 log_level: INFO
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/enodebd.yml
+++ b/lte/gateway/configs/enodebd.yml
@@ -52,7 +52,3 @@ web_ui_enable_list: []
 
 # Network interface to terminate S1
 s1_interface: eth1
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -60,7 +60,3 @@ event_registry:
   s1_setup_success:
     module: lte
     filename: mme_events.v1.yml
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/health.yml
+++ b/lte/gateway/configs/health.yml
@@ -25,7 +25,3 @@ state_recovery:
   interval_check_mins: 3
   # Destination path to save redis RDB temp snapshots
   snapshots_dir: /tmp/redis_snapshots
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/kernsnoopd.yml
+++ b/lte/gateway/configs/kernsnoopd.yml
@@ -20,7 +20,3 @@ collect_interval: 10
 ebpf_programs:
   ~
 #  - byte_count
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -172,7 +172,3 @@ services_to_restart:
 
 # How many times can grpc status check fail before restarting the services above
 restart_timeout_threshold: 15
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: send_selected_errors

--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -16,7 +16,3 @@ redis_port: 6380
 print_grpc_payload: false
 
 ipv6_prefixlen: 58
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: send_all_errors

--- a/lte/gateway/configs/monitord.yml
+++ b/lte/gateway/configs/monitord.yml
@@ -13,7 +13,3 @@
 
 # log_level is set in mconfig. it can be overridden here
 mtr_interface: mtr0
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -220,9 +220,5 @@ sgi_tunnel:
 #   gtp_tso_enable: false
 #
 
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled
-
 ebpf:
   enabled: true

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -195,9 +195,5 @@ sgi_tunnel:
 #   gtp_tso_enable: false
 #
 
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled
-
 ebpf:
   enabled: false

--- a/lte/gateway/configs/policydb.yml
+++ b/lte/gateway/configs/policydb.yml
@@ -34,7 +34,3 @@ bridge_interface: gtp_br0
 # To disable, leave empty
 # If disabled, allows all traffic from the subscribers
 redirect_rule_name:
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/redirectd.yml
+++ b/lte/gateway/configs/redirectd.yml
@@ -14,7 +14,3 @@
 # log_level is set in mconfig. it can be overridden here
 
 http_port: 8080
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/smsd.yml
+++ b/lte/gateway/configs/smsd.yml
@@ -11,7 +11,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 log_level: INFO
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/state.yml
+++ b/lte/gateway/configs/state.yml
@@ -48,7 +48,3 @@ state_protos:
 json_state:
   - redis_key: "directory_record"
     state_scope: "network"
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -55,7 +55,3 @@ s6a_over_grpc: True
 
 # Number of thread workers for the gRPC server
 grpc_workers: 10
-
-# [Experimental] Enable Sentry for this service
-# Allowed values: send_all_errors, send_selected_errors, disabled
-sentry: disabled

--- a/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
@@ -1012,6 +1012,5 @@ def get_service_config(sas_enabled: bool = True, prim_src: str = "GNSS"):
             "sas_location": "indoor",
             "sas_height_type": "AMSL",
         },
-        'sentry': 'disabled',
         'prim_src': prim_src,
     }

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -33,11 +33,6 @@ from lte.protos.mobilityd_pb2_grpc import (
 )
 from lte.protos.subscriberdb_pb2 import SubscriberID
 from magma.common.rpc_utils import return_void
-from magma.common.sentry import (
-    SentryStatus,
-    get_sentry_status,
-    send_uncaught_errors_to_monitoring,
-)
 from magma.subscriberdb.sid import SIDUtils
 
 from .ip_address_man import (
@@ -58,8 +53,6 @@ from .subscriberdb_client import (
     SubscriberDBMultiAPNValueError,
     SubscriberDBStaticIPValueError,
 )
-
-enable_sentry_wrapper = get_sentry_status("mobilityd") == SentryStatus.SEND_SELECTED_ERRORS
 
 
 class MobilityServiceRpcServicer(MobilityServiceServicer):
@@ -96,7 +89,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._ip_address_man.add_ip_block(ip_block)
 
     @return_void
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def AddIPBlock(self, request, context):
         """ Add a range of IP addresses into the free IP pool
 
@@ -121,7 +113,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         except IPVersionNotSupportedError:
             self._unimplemented_ip_version_error(context)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ListAddedIPv4Blocks(self, request, context):
         """ Return a list of IPv4 blocks assigned """
         logging.debug("Received ListAddedIPv4Blocks")
@@ -142,7 +133,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ListAddedIPv6Blocks(self, request, context):
         """ Return a list of IPv6 blocks assigned """
         self._print_grpc(request)
@@ -163,7 +153,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ListAllocatedIPs(self, request, context):
         """ Return a list of IPs allocated from a IP block
 
@@ -203,7 +192,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def AllocateIPAddress(self, request, context):
         """ Allocate an IP address from the free IP pool """
         logging.debug("Received AllocateIPAddress")
@@ -251,7 +239,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         return resp
 
     @return_void
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ReleaseIPAddress(self, request, context):
         """ Release an allocated IP address """
         logging.debug("Received ReleaseIPAddress")
@@ -286,7 +273,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
             )
             context.set_code(grpc.StatusCode.NOT_FOUND)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def RemoveIPBlock(self, request, context):
         """ Attempt to remove IP blocks and return the removed blocks """
         logging.debug("Received RemoveIPBlock")
@@ -324,7 +310,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetIPForSubscriber(self, request, context):
         logging.debug("Received GetIPForSubscriber")
         self._print_grpc(request)
@@ -352,7 +337,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetSubscriberIDFromIP(self, request, context):
         logging.debug("Received GetSubscriberIDFromIP")
         ip_addr = request
@@ -372,7 +356,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetSubscriberIPTable(self, request, context):
         """ Get the full subscriber table """
         logging.debug("Received GetSubscriberIPTable")
@@ -392,7 +375,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._print_grpc(resp)
         return resp
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ListGatewayInfo(self, request, context):
         logging.debug("Received ListGatewayInfo")
         self._print_grpc(request)
@@ -405,7 +387,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         return resp
 
     @return_void
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def SetGatewayInfo(self, request, context):
         logging.debug("Received SetGatewayInfo")
         info = request

--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -20,7 +20,6 @@ import grpc
 from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from magma.common.rpc_utils import grpc_async_wrapper
-from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from magma.magmad.check.network_check.ping import PingCommandResult
 from magma.monitord.icmp_state import ICMPMonitoringResponse
@@ -96,7 +95,6 @@ class CpeMonitoringModule:
                 "GetSubscribers Error for %s! %s",
                 err.code(),
                 err.details(),
-                extra=SEND_TO_ERROR_MONITORING,
             )
         return PingedTargets(ping_targets, ping_addresses)
 

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -47,11 +47,6 @@ from lte.protos.pipelined_pb2 import (
     VersionedPolicyID,
 )
 from lte.protos.session_manager_pb2 import RuleRecordTable
-from magma.common.sentry import (
-    SentryStatus,
-    get_sentry_status,
-    send_uncaught_errors_to_monitoring,
-)
 from magma.pipelined.app.check_quota import CheckQuotaController
 from magma.pipelined.app.classifier import Classifier
 from magma.pipelined.app.dpi import DPIController
@@ -80,8 +75,6 @@ from magma.pipelined.policy_converters import (
 
 grpc_msg_queue = queue.Queue()
 DEFAULT_CALL_TIMEOUT = 5
-
-enable_sentry_wrapper = get_sentry_status("pipelined") == SentryStatus.SEND_SELECTED_ERRORS
 
 
 class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
@@ -130,7 +123,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
     # General setup rpc
     # --------------------------
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def SetupDefaultControllers(self, request, context) -> SetupFlowsResult:
         """
         Setup default controllers, used on pipelined restarts
@@ -158,7 +150,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
     # Enforcement App
     # --------------------------
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def SetupPolicyFlows(self, request, context) -> SetupFlowsResult:
         """
         Setup flows for all subscribers, used on pipelined restarts
@@ -207,7 +198,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         self._enforcement_stats.handle_restart(gx_reqs)
         fut.set_result(enforcement_res)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ActivateFlows(self, request, context):
         """
         Activate flows for a subscriber based on the pre-defined rules
@@ -439,7 +429,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         # TODO: add metrics
         return gy_res
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def DeactivateFlows(self, request, context):
         """
         Deactivate flows for a subscriber
@@ -524,7 +513,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             rule_ids,
         )
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetPolicyUsage(self, request, context):
         """
         Get policy usage stats
@@ -552,7 +540,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
     # -------------------------
     # GRPC messages from MME
     # --------------------------
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def UpdateUEState(self, request, context):
 
         self._log_grpc_payload(request)
@@ -586,7 +573,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
     # IPFIX App
     # --------------------------
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def UpdateIPFIXFlow(self, request, context):
         """
         Update IPFIX sampling record
@@ -607,7 +593,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
     # DPI App
     # --------------------------
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def CreateFlow(self, request, context):
         """
         Add dpi flow
@@ -627,7 +612,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         )
         return resp
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def RemoveFlow(self, request, context):
         """
         Add dpi flow
@@ -646,7 +630,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         )
         return resp
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def UpdateFlowStats(self, request, context):
         """
         Update stats for a flow
@@ -665,7 +648,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
     # UE MAC App
     # --------------------------
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def SetupUEMacFlows(self, request, context) -> SetupFlowsResult:
         """
         Activate a list of attached UEs
@@ -712,7 +694,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
         fut.set_result(res)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def AddUEMacFlow(self, request, context):
         """
         Associate UE MAC address to subscriber
@@ -747,7 +728,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
         fut.set_result(res)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def DeleteUEMacFlow(self, request, context):
         """
         Delete UE MAC address to subscriber association
@@ -804,7 +784,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
     # Check Quota App
     # --------------------------
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def SetupQuotaFlows(self, request, context) -> SetupFlowsResult:
         """
         Activate a list of quota rules
@@ -841,7 +820,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         res = self._check_quota_app.handle_restart(request.requests)
         fut.set_result(res)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def UpdateSubscriberQuotaState(self, request, context):
         """
         Updates the subcsciber quota state
@@ -869,7 +847,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
     # Debugging
     # --------------------------
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetAllTableAssignments(self, request, context):
         """
         Get the flow table assignment for all apps ordered by main table number
@@ -911,7 +888,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             return
         logging.info(log_msg)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def SetSMFSessions(self, request, context):
         """
         Setup the 5G Session flows for the subscriber
@@ -1004,7 +980,6 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         response = self._enforcement_stats.get_stats(request.cookie, request.cookie_mask)
         fut.set_result(response)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetStats(self, request, context):
         """
         Invokes API that returns a RuleRecordTable filtering records based

--- a/lte/gateway/python/magma/smsd/relay.py
+++ b/lte/gateway/python/magma/smsd/relay.py
@@ -20,7 +20,6 @@ import lte.protos.sms_orc8r_pb2_grpc as sms_orc8r_pb2_grpc
 from lte.protos.mconfig.mconfigs_pb2 import MME
 from magma.common.job import Job
 from magma.common.rpc_utils import grpc_async_wrapper, return_void
-from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.configuration.mconfig_managers import load_service_mconfig
 from orc8r.protos.common_pb2 import Void
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
@@ -94,7 +93,7 @@ class SmsRelay(Job):
                 self._mme_sms.SMODownlink.future(dl, SMS_TIMEOUT_SECS),
             )
         except grpc.RpcError as err:
-            logging.error("RPC call to MME failed: %s", err, extra=SEND_TO_ERROR_MONITORING)
+            logging.error("RPC call to MME failed: %s", err)
             return
 
     @return_void

--- a/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
@@ -17,18 +17,12 @@ from typing import NamedTuple
 import grpc
 from lte.protos import apn_pb2, subscriberdb_pb2, subscriberdb_pb2_grpc
 from magma.common.rpc_utils import print_grpc, return_void
-from magma.common.sentry import (
-    SentryStatus,
-    get_sentry_status,
-    send_uncaught_errors_to_monitoring,
-)
 from magma.subscriberdb.sid import SIDUtils
 from magma.subscriberdb.store.base import (
     DuplicateSubscriberError,
     SubscriberNotFoundError,
 )
 
-enable_sentry_wrapper = get_sentry_status("subscriberdb") == SentryStatus.SEND_SELECTED_ERRORS
 suci_profile_data = NamedTuple(
     'suci_profile_data', [
         ('protection_scheme', int),
@@ -58,7 +52,6 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         subscriberdb_pb2_grpc.add_SubscriberDBServicer_to_server(self, server)
 
     @return_void
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def AddSubscriber(self, request, context):
         """
         Add a subscriber to the store
@@ -76,7 +69,6 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
             context.set_code(grpc.StatusCode.ALREADY_EXISTS)
 
     @return_void
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def DeleteSubscriber(self, request, context):
         """
         Delete a subscriber from the store
@@ -90,7 +82,6 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         self._store.delete_subscriber(sid)
 
     @return_void
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def UpdateSubscriber(self, request, context):
         """
         Update the subscription data
@@ -112,7 +103,6 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
             context.set_details("Subscriber not found: %s" % sid)
             context.set_code(grpc.StatusCode.NOT_FOUND)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetSubscriberData(self, request, context):
         """
         Return the subscription data for the subscriber
@@ -141,7 +131,6 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         )
         return response
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def ListSubscribers(self, request, context):  # pylint:disable=unused-argument
         """
         Return a list of subscribers from the store

--- a/orc8r/gateway/python/magma/ctraced/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/ctraced/rpc_servicer.py
@@ -11,11 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from magma.common.sentry import (
-    SentryStatus,
-    get_sentry_status,
-    send_uncaught_errors_to_monitoring,
-)
 from magma.ctraced.trace_manager import TraceManager
 from orc8r.protos.ctraced_pb2 import (
     EndTraceRequest,
@@ -27,8 +22,6 @@ from orc8r.protos.ctraced_pb2_grpc import (
     CallTraceServiceServicer,
     add_CallTraceServiceServicer_to_server,
 )
-
-enable_sentry_wrapper = get_sentry_status("ctraced") == SentryStatus.SEND_SELECTED_ERRORS
 
 
 class CtraceDRpcServicer(CallTraceServiceServicer):
@@ -46,7 +39,6 @@ class CtraceDRpcServicer(CallTraceServiceServicer):
         """
         add_CallTraceServiceServicer_to_server(self, server)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def StartCallTrace(
         self,
         request: StartTraceRequest,
@@ -61,7 +53,6 @@ class CtraceDRpcServicer(CallTraceServiceServicer):
         response = StartTraceResponse(success=success)
         return response
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def EndCallTrace(
         self,
         _request: EndTraceRequest,

--- a/orc8r/gateway/python/magma/directoryd/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/directoryd/rpc_servicer.py
@@ -26,11 +26,6 @@ from magma.common.redis.serializers import (
     get_json_serializer,
 )
 from magma.common.rpc_utils import return_void
-from magma.common.sentry import (
-    SentryStatus,
-    get_sentry_status,
-    send_uncaught_errors_to_monitoring,
-)
 from orc8r.protos.directoryd_pb2 import AllDirectoryRecords, DirectoryField
 from orc8r.protos.directoryd_pb2_grpc import (
     GatewayDirectoryServiceServicer,
@@ -40,8 +35,6 @@ from redis.exceptions import LockError, RedisError
 
 DIRECTORYD_REDIS_TYPE = "directory_record"
 LOCATION_MAX_LEN = 5
-
-enable_sentry_wrapper = get_sentry_status("directoryd") == SentryStatus.SEND_SELECTED_ERRORS
 
 
 class DirectoryRecord:
@@ -79,7 +72,6 @@ class GatewayDirectoryServiceRpcServicer(GatewayDirectoryServiceServicer):
         add_GatewayDirectoryServiceServicer_to_server(self, server)
 
     @return_void
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def UpdateRecord(self, request, context):
         """ Update the directory record of an object
 
@@ -122,7 +114,6 @@ class GatewayDirectoryServiceRpcServicer(GatewayDirectoryServiceServicer):
             context.set_details("Could not connect to redis: %s" % e)
 
     @return_void
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def DeleteRecord(self, request, context):
         """ Delete the directory record for an ID
 
@@ -155,7 +146,6 @@ class GatewayDirectoryServiceRpcServicer(GatewayDirectoryServiceServicer):
             context.set_code(grpc.StatusCode.UNAVAILABLE)
             context.set_details("Could not connect to redis: %s" % e)
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetDirectoryField(self, request, context):
         """ Get the directory record field for an ID and key
 
@@ -215,7 +205,6 @@ class GatewayDirectoryServiceRpcServicer(GatewayDirectoryServiceServicer):
         self._print_grpc(response)
         return response
 
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def GetAllDirectoryRecords(self, request, context):
         """ Get all directory records
 

--- a/orc8r/gateway/python/magma/eventd/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/eventd/rpc_servicer.py
@@ -20,17 +20,10 @@ from typing import Any, Dict
 import grpc
 import jsonschema
 from magma.common.rpc_utils import return_void
-from magma.common.sentry import (
-    SentryStatus,
-    get_sentry_status,
-    send_uncaught_errors_to_monitoring,
-)
 from magma.eventd.event_validator import EventValidator
 from orc8r.protos import eventd_pb2, eventd_pb2_grpc
 
 RETRY_ON_FAILURE = 'retry_on_failure'
-
-enable_sentry_wrapper = get_sentry_status("eventd") == SentryStatus.SEND_SELECTED_ERRORS
 
 
 class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
@@ -51,7 +44,6 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
         eventd_pb2_grpc.add_EventServiceServicer_to_server(self, server)
 
     @return_void
-    @send_uncaught_errors_to_monitoring(enable_sentry_wrapper)
     def LogEvent(self, request: eventd_pb2.Event, context):
         """
         Logs an event.

--- a/orc8r/gateway/python/magma/magmad/proxy_client.py
+++ b/orc8r/gateway/python/magma/magmad/proxy_client.py
@@ -15,7 +15,6 @@ import logging
 
 import aioh2
 import h2.events
-from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos.sync_rpc_service_pb2 import GatewayResponse, SyncRPCResponse
 
@@ -107,7 +106,6 @@ class ControlProxyHttpClient(object):
         except Exception as e:  # pylint: disable=broad-except
             logging.error(
                 "[SyncRPC] Exception in proxy_client: %s", e,
-                extra=SEND_TO_ERROR_MONITORING,
             )
             sync_rpc_response_queue.put(
                 SyncRPCResponse(

--- a/orc8r/gateway/python/magma/state/garbage_collector.py
+++ b/orc8r/gateway/python/magma/state/garbage_collector.py
@@ -16,7 +16,6 @@ import grpc
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.redis.containers import RedisFlatDict
 from magma.common.rpc_utils import grpc_async_wrapper, print_grpc
-from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.common.service import MagmaService
 from magma.state.keys import make_scoped_device_id
 from magma.state.redis_dicts import get_json_redis_dicts, get_proto_redis_dicts
@@ -86,7 +85,6 @@ class GarbageCollector:
             logging.error(
                 "GRPC call failed for state deletion: %s",
                 err,
-                extra=SEND_TO_ERROR_MONITORING,
             )
         else:
             for redis_dict in self._redis_dicts:

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -21,7 +21,6 @@ from google.protobuf.json_format import MessageToDict
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.rpc_utils import grpc_async_wrapper, print_grpc
 from magma.common.sdwatchdog import SDWatchdogTask
-from magma.common.sentry import SEND_TO_ERROR_MONITORING
 from magma.common.service import MagmaService
 from magma.state.garbage_collector import GarbageCollector
 from magma.state.keys import make_mem_key, make_scoped_device_id
@@ -123,7 +122,6 @@ class StateReplicator(SDWatchdogTask):
                 logging.error(
                     "GRPC call failed for initial state re-sync: %s",
                     err,
-                    extra=SEND_TO_ERROR_MONITORING,
                 )
                 return
         request = await self._collect_states_to_replicate()


### PR DESCRIPTION
## Summary

As an intermediate solution with maximum configurability, Sentry could be disabled or enabled per Python service and run in a special opt-in mode that only tracked a few error log messages. After enabling Sentry in the HIL, we got a better estimation of the logging volume and issues, and these options were only rarely needed.

To reduce complexity, we remove the Sentry options again and replace them by an opt-out tag that can be used to exclude error logs from Sentry monitoring.

See the discussion in #10027 for more details.

## Test Plan

Added unit tests and executed a manual end-to-end test with a Sentry test account.
