### PR TITLE
fix(orc8r): Format policy action & effect enums

### DIFF
--- a/orc8r/cloud/go/services/certifier/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/certifier/obsidian/handlers/handlers.go
@@ -17,11 +17,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/services/certifier"
@@ -122,7 +120,7 @@ func getUserTokensHandler(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to list user tokens: %v", err))
 	}
-	return c.JSON(http.StatusOK, res)
+	return c.JSON(http.StatusOK, protos.PolicyListProtoToModel(res.PolicyLists))
 }
 
 func addUserTokenHandler(c echo.Context) error {
@@ -136,7 +134,7 @@ func addUserTokenHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 
-	policiesProto, err := policiesModelToProto(policies)
+	policiesProto, err := protos.PoliciesModelToProto(policies)
 	if err != nil {
 		return err
 	}
@@ -177,72 +175,5 @@ func loginHandler(c echo.Context) error {
 	if err != nil {
 		return obsidian.MakeHTTPError(err, http.StatusInternalServerError)
 	}
-	return c.JSON(http.StatusOK, res.PolicyLists)
-}
-
-func policiesModelToProto(policies *models.Policies) ([]*protos.Policy, error) {
-	policyProtos := make([]*protos.Policy, len(*policies))
-	for i, policyModel := range *policies {
-		policyProto := &protos.Policy{
-			Effect: matchEffect(policyModel.Effect),
-			Action: matchAction(policyModel.Action),
-		}
-		if err := setResource(policyModel, policyProto); err != nil {
-			return nil, err
-		}
-		policyProtos[i] = policyProto
-	}
-	return policyProtos, nil
-}
-
-func convertTenantResourceIDs(ids []string) ([]int64, error) {
-	var intIDs []int64
-	for _, i := range ids {
-		j, err := strconv.ParseInt(i, 10, 64)
-		if err != nil {
-			return []int64{}, errors.Wrapf(err, "failed to convert tenant IDs to integers")
-		}
-		intIDs = append(intIDs, j)
-	}
-	return intIDs, nil
-}
-
-func matchEffect(rawEffect string) protos.Effect {
-	switch rawEffect {
-	case protos.Effect_DENY.String():
-		return protos.Effect_DENY
-	case protos.Effect_ALLOW.String():
-		return protos.Effect_ALLOW
-	default:
-		return protos.Effect_UNKNOWN
-	}
-}
-
-func matchAction(rawAction string) protos.Action {
-	switch rawAction {
-	case protos.Action_READ.String():
-		return protos.Action_READ
-	case protos.Action_WRITE.String():
-		return protos.Action_WRITE
-	default:
-		return protos.Action_NONE
-	}
-}
-
-// setResource uses the resource value in the policy model and sets the
-// resource based on its type in the policy proto
-func setResource(policyModel *models.Policy, policyProto *protos.Policy) error {
-	switch policyModel.ResourceType {
-	case models.PolicyResourceTypeNETWORKID:
-		policyProto.Resource = &protos.Policy_Network{Network: &protos.NetworkResource{Networks: policyModel.ResourceIDs}}
-	case models.PolicyResourceTypeTENANTID:
-		tenantIDs, err := convertTenantResourceIDs(policyModel.ResourceIDs)
-		if err != nil {
-			return err
-		}
-		policyProto.Resource = &protos.Policy_Tenant{Tenant: &protos.TenantResource{Tenants: tenantIDs}}
-	default:
-		policyProto.Resource = &protos.Policy_Path{Path: &protos.PathResource{Path: policyModel.Path}}
-	}
-	return nil
+	return c.JSON(http.StatusOK, protos.PolicyListProtoToModel(res.PolicyLists))
 }

--- a/orc8r/cloud/go/services/certifier/protos/helpers.go
+++ b/orc8r/cloud/go/services/certifier/protos/helpers.go
@@ -1,9 +1,13 @@
 package protos
 
 import (
+	"strconv"
+
 	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/blobstore"
+	"magma/orc8r/cloud/go/services/certifier/obsidian/models"
 )
 
 const (
@@ -47,4 +51,109 @@ func (p *PolicyList) PolicyToBlob(username string) (blobstore.Blob, error) {
 	}
 	policyBlob := blobstore.Blob{Type: PolicyType, Key: username, Value: marshalledPolicy}
 	return policyBlob, nil
+}
+
+func PolicyListProtoToModel(policyLists []*PolicyList) []models.PolicyList {
+	var policyListsModels []models.PolicyList
+	for _, pl := range policyLists {
+		policiesModel := policiesProtoToModel(pl.Policies)
+		policyListsModel := models.PolicyList{
+			Token:    &pl.Token,
+			Policies: policiesModel,
+		}
+		policyListsModels = append(policyListsModels, policyListsModel)
+	}
+	return policyListsModels
+}
+
+func PoliciesModelToProto(policies *models.Policies) ([]*Policy, error) {
+	policyProtos := make([]*Policy, len(*policies))
+	for i, policyModel := range *policies {
+		policyProto := &Policy{
+			Effect: matchEffect(policyModel.Effect),
+			Action: matchAction(policyModel.Action),
+		}
+		if err := setResource(policyModel, policyProto); err != nil {
+			return nil, err
+		}
+		policyProtos[i] = policyProto
+	}
+	return policyProtos, nil
+}
+
+func policiesProtoToModel(policies []*Policy) models.Policies {
+	var policiesModel models.Policies
+	for _, p := range policies {
+		policyModel := &models.Policy{
+			Action: p.Action.String(),
+			Effect: p.Effect.String(),
+		}
+		if path := p.GetPath(); path != nil {
+			policyModel.Path = path.Path
+		}
+		if nid := p.GetNetwork(); nid != nil {
+			policyModel.ResourceIDs = nid.Networks
+		}
+		if tid := p.GetTenant(); tid != nil {
+			var tidStr []string
+			for _, i := range tid.Tenants {
+				tidStr = append(tidStr, strconv.FormatInt(i, 10))
+			}
+			policyModel.ResourceIDs = tidStr
+		}
+		policiesModel = append(policiesModel, policyModel)
+	}
+	return policiesModel
+}
+
+func convertTenantResourceIDs(ids []string) ([]int64, error) {
+	var intIDs []int64
+	for _, i := range ids {
+		j, err := strconv.ParseInt(i, 10, 64)
+		if err != nil {
+			return []int64{}, errors.Wrapf(err, "failed to convert tenant IDs to integers")
+		}
+		intIDs = append(intIDs, j)
+	}
+	return intIDs, nil
+}
+
+func matchEffect(rawEffect string) Effect {
+	switch rawEffect {
+	case Effect_DENY.String():
+		return Effect_DENY
+	case Effect_ALLOW.String():
+		return Effect_ALLOW
+	default:
+		return Effect_UNKNOWN
+	}
+}
+
+func matchAction(rawAction string) Action {
+	switch rawAction {
+	case Action_READ.String():
+		return Action_READ
+	case Action_WRITE.String():
+		return Action_WRITE
+	default:
+		return Action_NONE
+	}
+}
+
+// setResource uses the resource value in the policy model and sets the
+// resource based on its type in the policy proto
+func setResource(policyModel *models.Policy, policyProto *Policy) error {
+	switch policyModel.ResourceType {
+	case models.PolicyResourceTypeNETWORKID:
+		policyProto.Resource = &Policy_Network{Network: &NetworkResource{Networks: policyModel.ResourceIDs}}
+	case models.PolicyResourceTypeTENANTID:
+		tenantIDs, err := convertTenantResourceIDs(policyModel.ResourceIDs)
+		if err != nil {
+			return err
+		}
+		policyProto.Resource = &Policy_Tenant{Tenant: &TenantResource{Tenants: tenantIDs}}
+	default:
+		policyProto.Resource = &Policy_Path{Path: &PathResource{Path: policyModel.Path}}
+	}
+	return nil
 }


### PR DESCRIPTION
The policy protos do not decode nicely, specifically the action and effect enum fields. Added a format function so that they form helpful messages

# Before
<img width="1339" alt="horrible_enums" src="https://user-images.githubusercontent.com/25142344/151222416-2cfaa669-6298-4819-9a34-c56495e64d23.png">


# After
<img width="1402" alt="Screen Shot 2022-01-26 at 1 13 25 PM" src="https://user-images.githubusercontent.com/25142344/151222440-4efcfd2f-69c2-4e31-bac1-1c819f1c5838.png">
