### PR TITLE
fix(agw): refactor QoSManager

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement.py
@@ -26,7 +26,6 @@ from magma.pipelined.policy_converters import (
     get_eth_type,
     get_ue_ip_match_args,
 )
-from magma.pipelined.qos.common import QosManager
 from magma.pipelined.qos.qos_meter_impl import MeterManager
 from magma.pipelined.redirect import RedirectException, RedirectionManager
 from magma.pipelined.utils import Utils
@@ -70,7 +69,7 @@ class EnforcementController(PolicyMixin, RestartMixin, MagmaController):
             self._service_manager.allocate_scratch_tables(self.APP_NAME, 1)[0]
         self._bridge_ip_address = kwargs['config']['bridge_ip_address']
         self._redirect_manager = None
-        self._qos_mgr = None
+        self._qos_mgr = kwargs['qos_manager']
         self._clean_restart = kwargs['config']['clean_restart']
         self._redirect_manager = RedirectionManager(
             self._bridge_ip_address,
@@ -90,7 +89,7 @@ class EnforcementController(PolicyMixin, RestartMixin, MagmaController):
             datapath: ryu datapath struct
         """
         self._datapath = datapath
-        self._qos_mgr = QosManager.get_qos_manager(datapath, self.loop, self._config)
+        self._qos_mgr.init_impl(datapath)
 
     def cleanup_on_disconnect(self, datapath):
         """

--- a/lte/gateway/python/magma/pipelined/app/gy.py
+++ b/lte/gateway/python/magma/pipelined/app/gy.py
@@ -21,7 +21,6 @@ from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.magma_match import MagmaMatch
 from magma.pipelined.openflow.messages import MessageHub
 from magma.pipelined.policy_converters import FlowMatchError
-from magma.pipelined.qos.common import QosManager
 from magma.pipelined.qos.qos_meter_impl import MeterManager
 from magma.pipelined.redirect import RedirectException, RedirectionManager
 from magma.pipelined.utils import Utils
@@ -61,7 +60,7 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
             self._service_manager.INTERNAL_MAC_IP_REWRITE_TBL_NUM
         self._bridge_ip_address = kwargs['config']['bridge_ip_address']
         self._clean_restart = kwargs['config']['clean_restart']
-        self._qos_mgr = None
+        self._qos_mgr = kwargs['qos_manager']
         self._setup_type = self._config['setup_type']
         self._redirect_manager = \
             RedirectionManager(
@@ -90,7 +89,7 @@ class GYController(PolicyMixin, RestartMixin, MagmaController):
             datapath: ryu datapath struct
         """
         self._datapath = datapath
-        self._qos_mgr = QosManager.get_qos_manager(datapath, self.loop, self._config)
+        self._qos_mgr.init_impl(datapath)
 
     def deactivate_rules(self, imsi, ip_addr, rule_ids):
         """

--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -236,6 +236,9 @@ class QosManager:
         return True
 
     def __init__(self, loop, config):
+        if 'qos' not in config.keys():
+            LOG.error("qos field not provided in config")
+            return
         self._qos_enabled = config["qos"]["enable"]
         if not self._qos_enabled:
             return

--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -169,11 +169,17 @@ class SubscriberState(object):
         return 0
 
 
-class QosManager:
+class QosManager(object):
+    """
+    Qos Manager -> add/remove subscriber qos
+    """
     # protect QoS object create and delete across all QoSManager Objects.
     lock = threading.Lock()
 
     def init_impl(self, datapath):
+        """
+        Takese in datapath, and initializes appropriate QoS manager based on config
+        """
         try:
             impl_type = QosImplType(self._config["qos"]["impl"])
 

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -80,6 +80,7 @@ from magma.pipelined.app.xwf_passthru import XWFPassthruController
 from magma.pipelined.ebpf.ebpf_manager import get_ebpf_manager
 from magma.pipelined.internal_ip_allocator import InternalIPAllocator
 from magma.pipelined.ipv6_prefix_store import InterfaceIDToPrefixMapper
+from magma.pipelined.qos.common import QosManager
 from magma.pipelined.rule_mappers import (
     RestartInfoStore,
     RuleIDToNumMapper,
@@ -632,6 +633,7 @@ class ServiceManager:
         contexts['mconfig'] = self._magma_service.mconfig
         contexts['loop'] = self._magma_service.loop
         contexts['service_manager'] = self
+        contexts['qos_manager'] = QosManager(self._magma_service.loop, self._magma_service.config)
 
         sessiond_chan = ServiceRegistry.get_rpc_channel(
             'sessiond', ServiceRegistry.LOCAL,

--- a/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
@@ -20,6 +20,7 @@ from enum import Enum
 
 from magma.pipelined.app.base import MagmaController
 from magma.pipelined.internal_ip_allocator import InternalIPAllocator
+from magma.pipelined.qos.common import QosManager
 from magma.pipelined.tests.app.exceptions import ServiceRunningError
 from ryu.base.app_manager import AppManager
 from ryu.lib import hub
@@ -219,6 +220,7 @@ class StartThread(object):
         contexts['rpc_stubs'] = self._test_setup.rpc_stubs
         contexts['service_manager'] = self._test_setup.service_manager
         contexts['ebpf_manager'] = None
+        contexts['qos_manager'] = QosManager(self._test_setup.loop, self._test_setup.config)
 
         logging.basicConfig(
             level=logging.INFO,

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -191,7 +191,8 @@ get_action_instruction",
         if self.config["qos"]["impl"] == QosImplType.LINUX_TC:
             mock_traffic_cls.read_all_classes.side_effect = lambda intf: prior_qids[intf]
 
-        qos_mgr = QosManager(MagicMock, asyncio.new_event_loop(), self.config)
+        qos_mgr = QosManager(asyncio.new_event_loop(), self.config)
+        qos_mgr.init_impl(MagicMock)
         qos_mgr._redis_store = {}
         qos_mgr._setupInternal()
         imsi, ip_addr, rule_num, qos_info = "1234", '1.1.1.1', 0, QosInfo(100000, 100000)
@@ -296,7 +297,8 @@ get_action_instruction",
             mock_traffic_cls.read_all_classes.side_effect = lambda intf: []
             mock_traffic_cls.delete_class.side_effect = lambda *args: 0
 
-        qos_mgr = QosManager(MagicMock, asyncio.new_event_loop(), self.config)
+        qos_mgr = QosManager(asyncio.new_event_loop(), self.config)
+        qos_mgr.init_impl(MagicMock)
         qos_mgr._redis_store = {}
         qos_mgr._setupInternal()
         rule_list1 = [
@@ -460,7 +462,8 @@ get_action_instruction",
         and ensure that eventually the system and qos store state remains
         consistent"""
         loop = asyncio.new_event_loop()
-        qos_mgr = QosManager(MagicMock, loop, self.config)
+        qos_mgr = QosManager(loop, self.config)
+        qos_mgr.init_impl(MagicMock)
         qos_mgr._redis_store = {}
 
         def populate_db(qid_list, rule_list):
@@ -593,7 +596,8 @@ get_action_instruction",
         AMBR configs.
         """
         loop = asyncio.new_event_loop()
-        qos_mgr = QosManager(MagicMock, loop, self.config)
+        qos_mgr = QosManager(loop, self.config)
+        qos_mgr.init_impl(MagicMock)
         qos_mgr._redis_store = {}
 
         def populate_db(qid_list, old_ambr_list, old_leaf_list, rule_list):
@@ -780,7 +784,8 @@ get_action_instruction",
         prior_qids = {self.ul_intf: [(2, 0)], self.dl_intf: [(3, 0)]}
         mock_traffic_cls.read_all_classes.side_effect = lambda intf: prior_qids[intf]
 
-        qos_mgr = QosManager(MagicMock, asyncio.new_event_loop(), self.config)
+        qos_mgr = QosManager(asyncio.new_event_loop(), self.config)
+        qos_mgr.init_impl(MagicMock)
         qos_mgr._redis_store = {}
         qos_mgr._setupInternal()
         ambr_ul, ambr_dl = 250000, 500000


### PR DESCRIPTION
## Summary

Addressing issue(https://github.com/magma/magma/issues/11242) to refactor QosManager, to create a single instance in service_manager, clean the static function and variables from the class, and pass the QosManager instance  as context to apps.

## Test Plan
ran unit test locally(make test_python)
ran make test_python_service too, but its taking longer on local machine, hoping github cli would be faster.

