### PR TITLE
feat(nms): Restore data plan editing

### DIFF
--- a/nms/packages/magmalte/app/components/context/LteNetworkContext.js
+++ b/nms/packages/magmalte/app/components/context/LteNetworkContext.js
@@ -23,11 +23,13 @@ import type {
 
 import React from 'react';
 
+export type UpdateNetworkContextProps = $Shape<
+  LteUpdateNetworkProps & FegLteUpdateNetworkProps,
+>;
+
 export type LteNetworkContextType = {
   state: $Shape<lte_network & feg_lte_network>,
-  updateNetworks: (
-    props: $Shape<LteUpdateNetworkProps & FegLteUpdateNetworkProps>,
-  ) => Promise<void>,
+  updateNetworks: (props: UpdateNetworkContextProps) => Promise<void>,
 };
 
 export default React.createContext<LteNetworkContextType>({});

--- a/nms/packages/magmalte/app/state/lte/NetworkState.js
+++ b/nms/packages/magmalte/app/state/lte/NetworkState.js
@@ -41,7 +41,7 @@ export async function UpdateNetworkState(props: UpdateNetworkProps) {
   const requests = [];
   if (props.lteNetwork) {
     requests.push(
-      await MagmaV1API.putLteByNetworkId({
+      MagmaV1API.putLteByNetworkId({
         networkId: networkId,
         lteNetwork: {
           ...props.lteNetwork,
@@ -52,15 +52,15 @@ export async function UpdateNetworkState(props: UpdateNetworkProps) {
 
   if (props.epcConfigs) {
     requests.push(
-      await MagmaV1API.putLteByNetworkIdCellularEpc({
+      MagmaV1API.putLteByNetworkIdCellularEpc({
         networkId: props.networkId,
-        config: props.epcConfigs,
+        config: props.epcConfigs, // $FlowIgnore
       }),
     );
   }
   if (props.lteRanConfigs) {
     requests.push(
-      await MagmaV1API.putLteByNetworkIdCellularRan({
+      MagmaV1API.putLteByNetworkIdCellularRan({
         networkId: props.networkId,
         config: props.lteRanConfigs,
       }),
@@ -68,7 +68,7 @@ export async function UpdateNetworkState(props: UpdateNetworkProps) {
   }
   if (props.lteDnsConfig) {
     requests.push(
-      await MagmaV1API.putLteByNetworkIdDns({
+      MagmaV1API.putLteByNetworkIdDns({
         networkId: props.networkId,
         config: props.lteDnsConfig,
       }),
@@ -76,12 +76,13 @@ export async function UpdateNetworkState(props: UpdateNetworkProps) {
   }
   if (props.subscriberConfig) {
     requests.push(
-      await MagmaV1API.putLteByNetworkIdSubscriberConfig({
+      MagmaV1API.putLteByNetworkIdSubscriberConfig({
         networkId: props.networkId,
         record: props.subscriberConfig,
       }),
     );
   }
+  // TODO(andreilee): Provide a way to handle errors here
   await Promise.all(requests);
   if (props.refreshState) {
     setLteNetwork(await MagmaV1API.getLteByNetworkId({networkId}));

--- a/nms/packages/magmalte/app/views/traffic/DataPlanEdit.js
+++ b/nms/packages/magmalte/app/views/traffic/DataPlanEdit.js
@@ -1,0 +1,273 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import type {network_epc_configs} from '../../../generated/MagmaAPIBindings';
+
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '../../theme/design-system/DialogTitle';
+import FormLabel from '@material-ui/core/FormLabel';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import LteNetworkContext from '../../components/context/LteNetworkContext';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
+import React from 'react';
+import Text from '../../theme/design-system/Text';
+import nullthrows from '@fbcnms/util/nullthrows';
+import {AltFormField, AltFormFieldSubheading} from '../../components/FormField';
+import {useContext, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import {useRouter} from '@fbcnms/ui/hooks';
+import type {UpdateNetworkContextProps} from '../../components/context/LteNetworkContext';
+
+import {
+  BITRATE_MULTIPLIER,
+  DATA_PLAN_UNLIMITED_RATES,
+} from '../../components/network/DataPlanConst';
+
+type CellularNetworkProfile = $Values<
+  $NonMaybeType<$PropertyType<network_epc_configs, 'sub_profiles'>>,
+>;
+
+/**
+ * Calculates the bitrate value in bps based on the default
+ * value input in the form, and the previous (default) bitrate.
+ *
+ * @param {?CellularNetworkProfile} dataPlan
+ *    - network epc configs including dataplans
+ * @param {?editedValue} editedValue
+ *    - the new specified bit rate in Mbps
+ * @param {'max_ul_bit_rate' | 'max_dl_bit_rate'}
+ *    - specifies whether we are editing upload of download bitrate
+ */
+function _getBitRateValue(props: {
+  dataPlan: ?CellularNetworkProfile,
+  editedValue: ?string,
+  field: 'max_ul_bit_rate' | 'max_dl_bit_rate',
+}): number {
+  const {dataPlan, editedValue, field} = props;
+  if (editedValue !== null && editedValue === '') {
+    return DATA_PLAN_UNLIMITED_RATES[field];
+  } else if (editedValue !== null) {
+    return Math.max(
+      parseFloat(0),
+      parseFloat(editedValue) * BITRATE_MULTIPLIER,
+    );
+  }
+  return dataPlan ? dataPlan[field] : DATA_PLAN_UNLIMITED_RATES[field];
+}
+
+/**
+ * A prop passed to DataPlanEditDialog
+ *
+ * @property {boolean} open - Whether the dialog is visible
+ * @property {() => void} onClose - Callback after closing dialog
+ * @property {?string} dataPlanId
+ *    - Supplied if editing a data plan.
+ *      Not supplied if creating a new data plan.
+ */
+type DialogProps = {
+  open: boolean,
+  onClose: () => void,
+  dataPlanId: ?string,
+};
+
+/**
+ * Modal dialog for adding/editing a single data plan.
+ * Displays conditionally depending on props.
+ *
+ * @param {DialogProps} props
+ */
+export default function DataPlanEditDialog(props: DialogProps) {
+  const isAdd = props.dataPlanId ? false : true;
+  const onClose = () => {
+    props.onClose();
+  };
+
+  return (
+    <Dialog
+      data-testid="editDialog"
+      open={props.open}
+      fullWidth={true}
+      maxWidth="sm">
+      <DialogTitle
+        label={isAdd ? 'Add New Data Plan' : 'Edit Data Plan'}
+        onClose={onClose}
+      />
+      <DataPlanEdit
+        onSave={() => {
+          onClose();
+        }}
+        onClose={onClose}
+        dataPlanId={props.dataPlanId || ''}
+      />
+    </Dialog>
+  );
+}
+
+/**
+ * A prop passed to DataPlanEdit
+ *
+ * @property {() => void} onSave
+ *    - Callback after data plan has been saved
+ * @property {() => onClose} onClose
+ *    - Callback after dialog has been closed
+ * @property {string} dataPlanId
+ */
+type Props = {
+  onSave: () => void,
+  onClose: () => void,
+  dataPlanId: string,
+};
+
+/**
+ * Modal dialog for adding/editing a single data plan.
+ * Always displays.
+ *
+ * @param {DialogProps} props
+ */
+export function DataPlanEdit(props: Props) {
+  const {match} = useRouter();
+  const networkID = nullthrows(match.params.networkId);
+  const [error, setError] = useState('');
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const ctx = useContext(LteNetworkContext);
+  const epcConfig = ctx.state.cellular.epc;
+  const [editedName, setEditedName] = useState(props.dataPlanId || '');
+  const dataPlan =
+    (props.dataPlanId && epcConfig.sub_profiles?.[props.dataPlanId]) || null;
+
+  // These bit rates are in Mbps
+  const [editedMaxDlBitRate, setEditedMaxDlBitRate] = useState(
+    dataPlan ? dataPlan.max_dl_bit_rate / BITRATE_MULTIPLIER : '',
+  );
+  const [editedMaxUlBitRate, setEditedMaxUlBitRate] = useState(
+    dataPlan ? dataPlan.max_ul_bit_rate / BITRATE_MULTIPLIER : '',
+  );
+
+  const onSave = async () => {
+    if (!props.dataPlanId && (epcConfig.sub_profiles || {})[editedName]) {
+      setError('Data plan name is already used. Please use a different name');
+      return;
+    }
+
+    const subProfiles = epcConfig.sub_profiles
+      ? {...epcConfig.sub_profiles}
+      : {};
+
+    subProfiles[editedName] = {
+      max_dl_bit_rate: _getBitRateValue({
+        dataPlan,
+        field: 'max_dl_bit_rate',
+        editedValue: editedMaxDlBitRate.toString(),
+      }),
+      max_ul_bit_rate: _getBitRateValue({
+        dataPlan,
+        field: 'max_ul_bit_rate',
+        editedValue: editedMaxUlBitRate.toString(),
+      }),
+    };
+
+    const newConfig = {
+      ...epcConfig,
+      sub_profiles: subProfiles,
+    };
+
+    try {
+      const updateNetworkProps: UpdateNetworkContextProps = {
+        networkId: networkID,
+        epcConfigs: newConfig,
+      };
+      await ctx.updateNetworks(updateNetworkProps);
+      props.onSave();
+      enqueueSnackbar('Data plan saved successfully', {
+        variant: 'success',
+      });
+    } catch (error) {
+      setError(error.response?.data?.message || error);
+    }
+  };
+  return (
+    <>
+      <DialogContent data-testid="dataPlanEditDialog">
+        <List>
+          {error !== '' && (
+            <AltFormField label={''}>
+              <FormLabel data-testid="configEditError" error>
+                {error}
+              </FormLabel>
+            </AltFormField>
+          )}
+          <div>
+            <ListItem dense disableGutters />
+            <AltFormField label={'Data Plan ID'}>
+              <OutlinedInput
+                data-testid="dataPlanID"
+                placeholder="Plan 1"
+                fullWidth={true}
+                value={editedName}
+                onChange={({target}) => setEditedName(target.value)}
+              />
+            </AltFormField>
+            <AltFormField label={'Max Bit Rate'}>
+              <AltFormFieldSubheading label={'Download'}>
+                <OutlinedInput
+                  data-testid="dataPlanMaxDlBitRate"
+                  placeholder="Unlimited"
+                  type="number"
+                  min={0}
+                  value={editedMaxDlBitRate}
+                  onChange={({target}) => setEditedMaxDlBitRate(target.value)}
+                  endAdornment={
+                    <InputAdornment position="end">
+                      <Text variant="subtitle3">Mbps</Text>
+                    </InputAdornment>
+                  }
+                />
+              </AltFormFieldSubheading>
+              <AltFormFieldSubheading label={'Upload'}>
+                <OutlinedInput
+                  data-testid="dataPlanMaxUlBitRate"
+                  placeholder="Unlimited"
+                  type="number"
+                  min={0}
+                  value={editedMaxUlBitRate}
+                  onChange={({target}) => setEditedMaxUlBitRate(target.value)}
+                  endAdornment={
+                    <InputAdornment position="end">
+                      <Text variant="subtitle3">Mbps</Text>
+                    </InputAdornment>
+                  }
+                />
+              </AltFormFieldSubheading>
+            </AltFormField>
+          </div>
+        </List>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onClose} skin="regular">
+          Cancel
+        </Button>
+        <Button onClick={onSave} variant="contained" color="primary">
+          {'Save'}
+        </Button>
+      </DialogActions>
+    </>
+  );
+}

--- a/nms/packages/magmalte/app/views/traffic/DataPlanOverview.js
+++ b/nms/packages/magmalte/app/views/traffic/DataPlanOverview.js
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
+
+import ActionTable from '../../components/ActionTable';
+import CardTitleRow from '../../components/layout/CardTitleRow';
+import CellWifiIcon from '@material-ui/icons/CellWifi';
+import DataPlanEditDialog from './DataPlanEdit';
+import Link from '@material-ui/core/Link';
+import LteNetworkContext from '../../components/context/LteNetworkContext';
+import React from 'react';
+import withAlert from '@fbcnms/ui/components/Alert/withAlert';
+
+import nullthrows from '@fbcnms/util/nullthrows';
+import {makeStyles} from '@material-ui/styles';
+import {useContext, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import {useRouter} from '@fbcnms/ui/hooks';
+import type {UpdateNetworkContextProps} from '../../components/context/LteNetworkContext';
+
+import {
+  BITRATE_MULTIPLIER,
+  DATA_PLAN_UNLIMITED_RATES,
+} from '../../components/network/DataPlanConst';
+
+const useStyles = makeStyles(theme => ({
+  dashboardRoot: {
+    margin: theme.spacing(3),
+    flexGrow: 1,
+  },
+}));
+
+/**
+ * Stores info for a single row of the data plan table.
+ *
+ * @property {string} dataPlanID
+ * @property {string} maxUploadBitRate
+ *    - bit rate specified in Mbps
+ * @property {string} maxDownloadBitRate
+ *    - bit rate specified in Mbps
+ */
+type DataPlanRowType = {
+  dataPlanID: string,
+  maxUploadBitRate: string,
+  maxDownloadBitRate: string,
+};
+
+/**
+ * Table displaying all data plans for the current network.
+ *
+ * Functionality provided also for editing/deleting data plans.
+ * Functionality not provided in this table for adding data plans.
+ *
+ * @param {WithAlert} props
+ */
+function DataPlanOverview(props: WithAlert) {
+  const {match} = useRouter();
+  const networkID = nullthrows(match.params.networkId);
+  const classes = useStyles();
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const [currRow, setCurrRow] = useState<DataPlanRowType>({});
+  const [open, setOpen] = React.useState(false);
+  const ctx = useContext(LteNetworkContext);
+  const epcConfig = ctx.state.cellular.epc;
+
+  const dataPlans = ctx.state.cellular.epc.sub_profiles;
+  const dataPlanRows: Array<DataPlanRowType> = dataPlans
+    ? Object.keys(dataPlans || {}).map((id: string) => {
+        const profile = nullthrows(dataPlans)[id];
+        return {
+          dataPlanID: id,
+          maxUploadBitRate:
+            profile.max_dl_bit_rate ===
+            DATA_PLAN_UNLIMITED_RATES.max_dl_bit_rate
+              ? 'Unlimited'
+              : profile.max_dl_bit_rate / BITRATE_MULTIPLIER + ' Mbps',
+          maxDownloadBitRate:
+            profile.max_ul_bit_rate ===
+            DATA_PLAN_UNLIMITED_RATES.max_ul_bit_rate
+              ? 'Unlimited'
+              : profile.max_ul_bit_rate / BITRATE_MULTIPLIER + ' Mbps',
+        };
+      })
+    : [];
+
+  const onDelete = async (dataPlanId: string) => {
+    const subProfiles = epcConfig.sub_profiles || {};
+    delete subProfiles[dataPlanId];
+
+    const newConfig = {
+      ...epcConfig,
+      sub_profiles: subProfiles,
+    };
+    const updateNetworkProps: UpdateNetworkContextProps = {
+      networkId: networkID,
+      epcConfigs: newConfig,
+    };
+
+    try {
+      await ctx.updateNetworks(updateNetworkProps);
+      enqueueSnackbar('Data plan deleted successfully', {
+        variant: 'success',
+      });
+    } catch (error) {
+      enqueueSnackbar('error.response?.data?.message || error', {
+        variant: 'error',
+      });
+    }
+  };
+
+  return (
+    <div className={classes.dashboardRoot}>
+      <>
+        <CardTitleRow key="title" icon={CellWifiIcon} label={'Data Plans'} />
+        <DataPlanEditDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          dataPlanId={currRow.dataPlanID}
+        />
+        <ActionTable
+          data={dataPlanRows}
+          columns={[
+            {
+              title: 'Data Plan ID',
+              field: 'dataPlanID',
+              render: currRow => (
+                <Link
+                  variant="body2"
+                  component="button"
+                  onClick={() => {
+                    setCurrRow(currRow);
+                    setOpen(true);
+                  }}>
+                  {currRow.dataPlanID}
+                </Link>
+              ),
+            },
+            {
+              title: 'Max Upload Bit Rate',
+              field: 'maxUploadBitRate',
+              type: 'numeric',
+            },
+            {
+              title: 'Max Download Bit Rate',
+              field: 'maxDownloadBitRate',
+              type: 'numeric',
+            },
+          ]}
+          handleCurrRow={(row: DataPlanRowType) => setCurrRow(row)}
+          menuItems={[
+            {
+              name: 'Edit',
+              handleFunc: () => {
+                setOpen(true);
+              },
+            },
+            {
+              name: 'Remove',
+              handleFunc: () => {
+                props
+                  .confirm(
+                    `Are you sure you want to delete data plan ${currRow.dataPlanID}?`,
+                  )
+                  .then(async confirmed => {
+                    if (!confirmed) {
+                      return;
+                    }
+
+                    try {
+                      await onDelete(currRow.dataPlanID);
+                    } catch (e) {
+                      enqueueSnackbar(
+                        'failed deleting data plan ' + currRow.dataPlanID,
+                        {
+                          variant: 'error',
+                        },
+                      );
+                    }
+                  });
+              },
+            },
+          ]}
+          options={{
+            actionsColumnIndex: -1,
+            pageSizeOptions: [5, 10],
+          }}
+        />
+      </>
+    </div>
+  );
+}
+
+export default withAlert(DataPlanOverview);

--- a/nms/packages/magmalte/app/views/traffic/TrafficOverview.js
+++ b/nms/packages/magmalte/app/views/traffic/TrafficOverview.js
@@ -17,6 +17,9 @@ import ApnEditDialog from './ApnEdit';
 import ApnOverview from './ApnOverview';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import Button from '@material-ui/core/Button';
+import CellWifiIcon from '@material-ui/icons/CellWifi';
+import DataPlanEditDialog from './DataPlanEdit';
+import DataPlanOverview from './DataPlanOverview';
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -74,6 +77,9 @@ const StyledMenu = withStyles({
   />
 ));
 
+/**
+ * Button for creation of policies, rating groups, and profiles
+ */
 function PolicyMenu() {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -127,6 +133,9 @@ function PolicyMenu() {
   );
 }
 
+/**
+ * Wrapper for "Create APN" button
+ */
 function ApnMenu() {
   const classes = useStyles();
   const [open, setOpen] = React.useState(false);
@@ -144,6 +153,44 @@ function ApnMenu() {
   );
 }
 
+/**
+ * Wrapper for "Create Data Plan" button
+ */
+function DataPlanMenu() {
+  const classes = useStyles();
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div>
+      <DataPlanEditDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        dataPlanId={''}
+      />
+      <Button
+        data-testid="newDataPlanButton"
+        onClick={() => setOpen(true)}
+        className={classes.appBarBtn}>
+        Create New Data Plan
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Dashboard for "Traffic" related features.
+ *
+ * Provides a management interface for:
+ *  - policies
+ *  - rating groups
+ *  - profiles
+ *  - APNs
+ *  - data plans
+ *
+ * "Read" and "Edit" functionality provided through tables
+ * "Create" functiona provided through a header with "Create New"
+ * button.
+ */
 export default function TrafficDashboard() {
   const {relativePath, relativeUrl} = useRouter();
 
@@ -164,6 +211,12 @@ export default function TrafficDashboard() {
             icon: RssFeedIcon,
             filters: <ApnMenu />,
           },
+          {
+            label: 'Data Plans',
+            to: '/data_plan',
+            icon: CellWifiIcon,
+            filters: <DataPlanMenu />,
+          },
         ]}
       />
 
@@ -179,6 +232,7 @@ export default function TrafficDashboard() {
         <Route path={relativePath('/apn/json')} component={ApnJsonConfig} />
         <Route path={relativePath('/policy')} component={PolicyOverview} />
         <Route path={relativePath('/apn')} component={ApnOverview} />
+        <Route path={relativePath('/data_plan')} component={DataPlanOverview} />
         <Redirect to={relativeUrl('/policy')} />
       </Switch>
     </>


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Previously existing data plan editing functionality was removed during the transition from NMS V1 to NMS V2. This functionality is being added back with this pull request.

**Before adding back data plan editing**
![Screen Shot 2022-01-26 at 3 40 56 PM](https://user-images.githubusercontent.com/804385/151265323-ed89f53f-2be9-4d40-a85c-368820c26fa3.png)

**After adding back data plan editing**
![Screen Shot 2022-01-26 at 3 17 26 PM](https://user-images.githubusercontent.com/804385/151263747-fdad7b80-0fa3-48bf-8907-a30d8517e4ad.png)


## Test Plan

Tested adding, editing, and deleting data plans.

## Additional Information

- [ ] This change is backwards-breaking
