### PR TITLE
chore(agw): opt-out connection errors from Sentry

### DIFF
--- a/lte/gateway/python/magma/pipelined/mobilityd_client.py
+++ b/lte/gateway/python/magma/pipelined/mobilityd_client.py
@@ -16,6 +16,8 @@ from typing import List
 import grpc
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
+from magma.common.rpc_utils import indicates_connection_error
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos.common_pb2 import Void
 
@@ -44,6 +46,7 @@ def get_mobilityd_gw_info() -> List[GWInfo]:
             "ListGatewayInfo error[%s] %s",
             err.code(),
             err.details(),
+            extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
         )
         return []
 

--- a/lte/gateway/python/magma/pipelined/set_interface_client.py
+++ b/lte/gateway/python/magma/pipelined/set_interface_client.py
@@ -20,6 +20,8 @@ from lte.protos.session_manager_pb2 import (
     UPFSessionConfigState,
 )
 from lte.protos.session_manager_pb2_grpc import SetInterfaceForUserPlaneStub
+from magma.common.rpc_utils import indicates_connection_error
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 
 DEFAULT_GRPC_TIMEOUT = 5
 
@@ -59,6 +61,7 @@ def send_periodic_session_update(
             "send_periodic_session_update error[%s] %s",
             err.code(),
             err.details(),
+            extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
         )
         return False
 

--- a/lte/gateway/python/magma/policydb/streamer_callback.py
+++ b/lte/gateway/python/magma/policydb/streamer_callback.py
@@ -30,6 +30,8 @@ from lte.protos.session_manager_pb2 import (
     StaticRuleInstall,
 )
 from lte.protos.session_manager_pb2_grpc import LocalSessionManagerStub
+from magma.common.rpc_utils import indicates_connection_error
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.streamer import StreamerClient
 from magma.policydb.apn_rule_map_store import ApnRuleAssignmentsDict
 from magma.policydb.basename_store import BaseNameDict
@@ -163,7 +165,11 @@ class ApnRuleMappingsStreamerCallback(StreamerClient.Callback):
         try:
             self._session_mgr_stub.SetSessionRules(update, timeout=5)
         except grpc.RpcError as e:
-            logging.error('Unable to apply apn->policy updates %s', str(e))
+            logging.error(
+                "Unable to apply apn->policy updates %s",
+                str(e),
+                extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(e) else None,
+            )
 
     def _are_sub_policies_updated(
         self,

--- a/orc8r/gateway/python/magma/common/rpc_utils.py
+++ b/orc8r/gateway/python/magma/common/rpc_utils.py
@@ -152,6 +152,19 @@ def is_grpc_error_retryable(error: grpc.RpcError) -> bool:
     return False
 
 
+def indicates_connection_error(error: grpc.RpcError) -> bool:
+    """Try to determine if an RpcError is caused by a connection error
+    to the RPC endpoint, which means that it's likely not caused by a bug in the code
+
+    Args:
+        error (grpc.RpcError): The RpcError
+
+    Returns:
+        bool: Is this a network error
+    """
+    return error.code() in {grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED}
+
+
 def print_grpc(
     message: proto_message.Message, print_grpc_payload: bool,
     message_header: str = "",

--- a/orc8r/gateway/python/magma/state/garbage_collector.py
+++ b/orc8r/gateway/python/magma/state/garbage_collector.py
@@ -15,7 +15,12 @@ import logging
 import grpc
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.redis.containers import RedisFlatDict
-from magma.common.rpc_utils import grpc_async_wrapper, print_grpc
+from magma.common.rpc_utils import (
+    grpc_async_wrapper,
+    indicates_connection_error,
+    print_grpc,
+)
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service import MagmaService
 from magma.state.keys import make_scoped_device_id
 from magma.state.redis_dicts import get_json_redis_dicts, get_proto_redis_dicts
@@ -85,6 +90,7 @@ class GarbageCollector:
             logging.error(
                 "GRPC call failed for state deletion: %s",
                 err,
+                extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
             )
         else:
             for redis_dict in self._redis_dicts:

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -19,8 +19,13 @@ import grpc
 import jsonpickle
 from google.protobuf.json_format import MessageToDict
 from magma.common.grpc_client_manager import GRPCClientManager
-from magma.common.rpc_utils import grpc_async_wrapper, print_grpc
+from magma.common.rpc_utils import (
+    grpc_async_wrapper,
+    indicates_connection_error,
+    print_grpc,
+)
 from magma.common.sdwatchdog import SDWatchdogTask
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service import MagmaService
 from magma.state.garbage_collector import GarbageCollector
 from magma.state.keys import make_mem_key, make_scoped_device_id
@@ -122,6 +127,7 @@ class StateReplicator(SDWatchdogTask):
                 logging.error(
                     "GRPC call failed for initial state re-sync: %s",
                     err,
+                    extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
                 )
                 return
         request = await self._collect_states_to_replicate()


### PR DESCRIPTION
fixes #10407
fixes #10783 
fixes #10961
fixes #10982
fixes #11298

## Summary

<!-- Enumerate changes you made and why you made them -->

Some connection errors that deserve loglevel=error, but should not appear in Sentry as they don't indicate bugs in the code are no longer sent to Sentry.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
