### PR TITLE
chore(pipelined): Exclude config errors from Sentry

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/ipfix.py
+++ b/lte/gateway/python/magma/pipelined/app/ipfix.py
@@ -13,6 +13,7 @@ limitations under the License.
 import subprocess
 from typing import Dict, NamedTuple
 
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.pipelined.app.base import ControllerType, MagmaController
 from magma.pipelined.app.dpi import DPIController
 from magma.pipelined.imsi import encode_imsi
@@ -83,11 +84,11 @@ class IPFIXController(MagmaController):
         collector_port = mconfig.ipdr_export_dst.port
         if not mconfig.ipdr_export_dst.ip:
             if 'collector_ip' in config_dict['ipfix']:
-                self.logger.error("Missing IPDR dest IP, using val from .yml")
+                self.logger.error("Missing IPDR dest IP, using val from .yml", extra=EXCLUDE_FROM_ERROR_MONITORING)
                 collector_ip = config_dict['ipfix']['collector_ip']
                 collector_port = config_dict['ipfix']['collector_port']
             else:
-                self.logger.error("Missing mconfig IPDR dest IP")
+                self.logger.error("Missing mconfig IPDR dest IP", extra=EXCLUDE_FROM_ERROR_MONITORING)
                 return self.IPFIXConfig(
                     enabled=False, probability=0,
                     collector_ip='', collector_port=0, collector_set_id=0,
@@ -96,7 +97,7 @@ class IPFIXController(MagmaController):
                 )
 
         if collector_port == 0:
-            self.logger.error("Missing mconfig IPDR dest port")
+            self.logger.error("Missing mconfig IPDR dest port", extra=EXCLUDE_FROM_ERROR_MONITORING)
             return self.IPFIXConfig(
                 enabled=False, probability=0,
                 collector_ip='', collector_port=0, collector_set_id=0,


### PR DESCRIPTION
## Summary

User configuration errors don't need to be tracked in error monitoring.

Fixes #10983.

## Additional Information

- [ ] This change is backwards-breaking