### PR TITLE
docs(agw): add CUPS to AGW deploy config

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.6.X/lte/deploy_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/lte/deploy_install.md
@@ -11,16 +11,26 @@ original_id: deploy_install
 
 ## Prerequisites
 
-To setup a Magma Access Gateway, you will need a machine that
+To set up a Magma Access Gateway, you will need a machine that
 satisfies the following requirements:
 
-- AGW_HOST: 64bit-X86 machine, baremetal strongly recommended (not virtualized).
-  You will need two ethernet ports. We use enp1s0 and enp2s0 in this guide.
-  They might have different names on your hardware so just replace enp1s0 and
-  enp2s0 with your current interfaces name in this guideline.
-  One port is for the SGi interface (default: enp1s0) and one for the S1
-  interface (default: enp2s0). Note that the `agw_install_ubuntu.sh` script will
-  rename the `enp1s0` interface to `eth0`.
+- AGW_HOST: 64bit-X86 machine, baremetal strongly recommended
+  (not virtualized). You will need two ethernet ports. We use
+  `enp1s0` and `enp2s0` in this guide.
+  - `enp1s0`: Will carry any traffic that is not S1. So data plane traffic (SGi)
+    control plane traffic (Orc8r HTTP2), management (ssh)
+  - `enp2s0`: S1 interface.
+
+  *Note interface names might have different names on your hardware so just
+  replace `enp1s0` and `enp2s0` with your current interfaces name
+  in this guideline.
+
+  *Note that the `agw_install_ubuntu.sh` script will rename the `enp1s0`
+   interface to `eth0`.
+
+  *Note if you don't want all internet traffic to go through `enp1s0`
+  to separate control plane (Orc8r Http2 traffic) from user plane, you
+  may want to add another interface and configure proper routing.
 
 ## Deployment
 

--- a/docs/readmes/howtos/package.md
+++ b/docs/readmes/howtos/package.md
@@ -37,7 +37,7 @@ You should always do this. In general, try your best not to release broken packa
 1. Build the release like you normally would.
 2. Spin up a fresh prod VM or gateway machine and copy the `magma_<version>.deb`
 generated above.
-3. Run `sudo apt-get install gdebi; sudo gdebi magma_<version>.deb'
+3. Run `sudo apt-get install gdebi; sudo gdebi magma_<version>.deb`
 4. A VM reload or gateway reboot will likely be required due to kernel upgrade.
 
 This will simulate the exact steps that apt-get performs in production.

--- a/docs/readmes/lte/deploy_install.md
+++ b/docs/readmes/lte/deploy_install.md
@@ -10,16 +10,26 @@ hide_title: true
 
 ## Prerequisites
 
-To setup a Magma Access Gateway, you will need a machine that
+To set up a Magma Access Gateway, you will need a machine that
 satisfies the following requirements:
 
-- AGW_HOST: 64bit-X86 machine, baremetal strongly recommended (not virtualized).
-  You will need two ethernet ports. We use enp1s0 and enp2s0 in this guide.
-  They might have different names on your hardware so just replace enp1s0 and
-  enp2s0 with your current interfaces name in this guideline.
-  One port is for the SGi interface (default: enp1s0) and one for the S1
-  interface (default: enp2s0). Note that the `agw_install_ubuntu.sh` script will
-  rename the `enp1s0` interface to `eth0`.
+- AGW_HOST: 64bit-X86 machine, baremetal strongly recommended
+  (not virtualized). You will need two ethernet ports. We use
+  `enp1s0` and `enp2s0` in this guide.
+    - `enp1s0`: Will carry any traffic that is not S1. So data plane traffic (SGi)
+    control plane traffic (Orc8r HTTP2), management (ssh)
+    - `enp2s0`: S1 interface.
+
+  *Note interface names might have different names on your hardware so just
+  replace `enp1s0` and `enp2s0` with your current interfaces name
+  in this guideline.
+
+  *Note that the `agw_install_ubuntu.sh` script will rename the `enp1s0`
+   interface to `eth0`.
+
+  *Note if you don't want all internet traffic to go through `enp1s0`
+  to separate control plane (Orc8r Http2 traffic) from user plane, you
+  may want to add another interface and configure proper routing.
 
 ## Deployment
 

--- a/docs/readmes/orc8r/upgrade_1_5.md
+++ b/docs/readmes/orc8r/upgrade_1_5.md
@@ -141,7 +141,7 @@ successfully upgraded.
 A new `Duplicate Request Alert` has been added, which triggers when more than
 100 alerts within the last 5 minutes have been raised.
 
-To enable this alert, you must "Sync Pre-Defined Alerts" for _*every*_ network
+To enable this alert, you must "Sync Pre-Defined Alerts" for **every** network
 defined in the Orc8r.
 See the [NMS Alerts Guide](../nms/alerts#predefined-alerts) for guidance
 on this process.
@@ -178,7 +178,7 @@ If you would like to customize this alert, refer to
 [NMS alerts guide - custom alert rules](../nms/alerts#custom-alert-rules).
 
 In order to start receiving these alarms, it is necessary to click on the
-“Sync Pre-Defined alerts” in the NMS window for _*every*_ network defined in
+“Sync Pre-Defined alerts” in the NMS window for **every** network defined in
 the Orc8r. For more details on this process, see the [NMS alerts guide](../nms/alerts#predefined-alerts)
 Syncing the alerts once on the NMS does not replicate the behavior to other
 networks managed by the same NMS.


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add documentation to note AGW do not separate or8cr traffic from SGI traffic. Any separation must be done by configuring the routing on the gateway separately. 

Suggested in here [here](https://magmacore.slack.com/archives/C01MDUQDFC3/p1643306253054200?thread_ts=1643229981.042900&cid=C01MDUQDFC3)

## Test Plan
![image](https://user-images.githubusercontent.com/16157139/151436005-5306c2ff-9037-4b1a-857a-868e15075dff.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
