### PR TITLE
fix: Set feg-precommit label on github action

### DIFF
--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -43,7 +43,7 @@ jobs:
           name: pr
           path: pr/
 
-  feg-lint-precommit:
+  feg-precommit:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: feg lint and precommit
@@ -60,31 +60,6 @@ jobs:
       - name: Run golang_before_install.sh script
         run: |
               ./circleci/golang_before_install.sh
-      - name: Run go mod download with retry
-        uses: nick-invision/retry@v2
-        if: always()
-        id: feg-lint-init
-        with:
-          command: cd ${MAGMA_ROOT}/cwf/gateway && go mod download
-          timeout_minutes: 10
-      - name: Go lint code
-        if: always() && steps.feg-lint-init.outcome=='success'
-        id: feg-lint
-        run: |
-              cd ${MAGMA_ROOT}/feg/gateway
-              make -C ${MAGMA_ROOT}/feg/gateway lint
-      - name: Generate test coverage
-        if: always() && steps.feg-lint.outcome=='success'
-        id: feg-lint-cov
-        run: |
-              cd ${MAGMA_ROOT}/feg/gateway
-              make -C ${MAGMA_ROOT}/feg/gateway cover
-      - uses: codecov/codecov-action@v1
-        if: always()
-        id: feg-lint-codecov
-        with:
-          files: '${{ env.MAGMA_ROOT}}/feg/gateway/coverage/feg.gocov'
-          flags: feg-lint
       - name: make feg precommit
         if: always()
         id: feg-precommit
@@ -92,6 +67,18 @@ jobs:
           go get gotest.tools/gotestsum
           cd ${MAGMA_ROOT}/feg/gateway
           make -C ${MAGMA_ROOT}/feg/gateway precommit
+      - name: Generate test coverage
+        if: always()
+        id: feg-gen-cov
+        run: |
+          cd ${MAGMA_ROOT}/feg/gateway
+          make -C ${MAGMA_ROOT}/feg/gateway cover
+      - uses: codecov/codecov-action@v1
+        if: always()
+        id: feg-upload-codecov
+        with:
+          files: '${{ env.MAGMA_ROOT}}/feg/gateway/coverage/feg.gocov'
+          flags: feg-lint
       - name: Upload Test Results
         id: feg-precommit-upload
         if: always()
@@ -108,12 +95,12 @@ jobs:
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
-        if: ( steps.feg-lint-init.outcome=='failure' || steps.feg-lint.outcome=='failure' || steps.feg-lint-cov.outcome=='failure' || steps.feg-lint-codecov.outcome=='failure'  ) && github.event_name == 'push'
+        if: ( steps.feg-gen-cov.outcome=='failure' || steps.feg-upload-codecov.outcome=='failure'  ) && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_TITLE: "FeG-lint tests failed"
+          SLACK_TITLE: "FeG CodeCov tests failed"
           SLACK_USERNAME: "FeG workflow"
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

FEG precommit includes lint, so we don't need to run it separately
```
from feg Makefile

precommit: tools fmt lint test vet
```

Also FEG shouldn't be running code at cwf

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

Linter executed here 

![image](https://user-images.githubusercontent.com/16157139/151490940-f51727a8-c856-4601-8adc-8dccdf898085.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
