### PR TITLE
fix(mme): Update GetENBState to remove S1AP state mgr dependency

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/CMakeLists.txt
@@ -60,6 +60,11 @@ generate_cpp_protos("${S1APSRV_LTE_CPP_PROTOS}" "${PROTO_SRCS}"
 generate_grpc_protos("${S1APSRV_LTE_GRPC_PROTOS}" "${PROTO_SRCS}"
     "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_OUT_DIR})
 
+set(S1AP_STATE_CPP_PROTOS s1ap_state)
+set(STATE_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/lte/protos/oai")
+generate_cpp_protos("${S1AP_STATE_CPP_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}"
+    "${STATE_PROTO_DIR}" "${STATE_OUT_DIR}")
+
 # HA Service
 set(HASRV_LTE_CPP_PROTOS ha_service)
 set(HASRV_LTE_GRPC_PROTOS ha_service)

--- a/lte/gateway/c/core/oai/tasks/grpc_service/S1apServiceImpl.h
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/S1apServiceImpl.h
@@ -19,8 +19,9 @@
 #include <grpc++/grpc++.h>
 #include <grpcpp/impl/codegen/status.h>
 
-#include "orc8r/protos/common.pb.h"
+#include "lte/gateway/c/core/oai/common/redis_utils/redis_client.h"
 
+#include "orc8r/protos/common.pb.h"
 #include "lte/protos/s1ap_service.grpc.pb.h"
 
 extern "C" {
@@ -28,11 +29,18 @@ extern "C" {
 }
 
 namespace magma {
-using namespace lte;
+namespace lte {
 
-class S1apServiceImpl final : public magma::S1apService::Service {
+class S1apServiceImpl final : public S1apService::Service {
  public:
   S1apServiceImpl();
+
+  /**
+   * Helper to initialize redis client connection as grpc::Service constructor
+   * does not allow init parameters
+   * @param client RedisClient ptr
+   */
+  void init(std::shared_ptr<RedisClient> client);
 
   /**
    * Returns map of S1 connected eNB id as key, with num of UEs connected
@@ -45,6 +53,10 @@ class S1apServiceImpl final : public magma::S1apService::Service {
   grpc::Status GetENBState(
       grpc::ServerContext* context, const magma::orc8r::Void* request,
       magma::lte::EnbStateResult* response) override;
+
+ private:
+  std::shared_ptr<RedisClient> client_;
 };
 
+}  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/core/oai/tasks/grpc_service/grpc_service.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/grpc_service.cpp
@@ -94,6 +94,10 @@ void start_grpc_service(bstring server_address) {
   builder.RegisterService(&s8_service);
 #endif
   server = builder.BuildAndStart();
+
+  std::shared_ptr<magma::RedisClient> client =
+      std::make_shared<magma::RedisClient>(true);
+  s1ap_service.init(client);
 }
 
 void stop_grpc_service(void) {


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Removes `get_s1ap_state` usage from S1AP GRPC service which was causing segfault due to `s1ap_state` nullptr, closes #8450 
- Refactors `S1apServiceImpl::GetENBState` for using direct access to redis to construct GRPC response 
- Formatting changes

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Testing on local environment to ensure eNB state is retrieved by `enodebd` service
- Pending: Add unit test / integ test for `GetENBState` endpoint

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
