### PR TITLE
chore(nms): Upgrade json-server from 0.16.0 to 0.17.0

### DIFF
--- a/nms/packages/magmalte/package.json
+++ b/nms/packages/magmalte/package.json
@@ -84,7 +84,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.4.2",
     "jest-cli": "^26.4.2",
-    "json-server": "^0.16.1",
+    "json-server": "^0.17.0",
     "nodemon": "^2.0.4",
     "postcss-flexbugs-fixes": "^4.2.1",
     "postcss-loader": "^3.0.0",


### PR DESCRIPTION
Signed-off-by: Nikola Knezevic <nkcodeplus@gmail.com>
chore(nms): Upgrade json-server from 0.16.0 to 0.17.0
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Dependabot didn't succeed in automatically updating dependency for nonoid is required by  json-server": "^0.16.1" there is version 0.17.0 that depend on "nanoid": "^3.1.23"
https://github.com/ospoco/magma-issue-tracker/issues/57
solution: update json-server to 0.17.0 and test
## Test Plan
yarn run eslint
yarn run flow
yarn run test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
