### PR TITLE
chore(mobilityd): Exclude invalid IP block error from monitoring

### DIFF
--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -17,7 +17,7 @@ from typing import Any, Optional
 from lte.protos.mconfig import mconfigs_pb2
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
 from magma.common.redis.client import get_default_client
-from magma.common.sentry import sentry_init
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING, sentry_init
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
 from magma.mobilityd.ip_address_man import IPAddressManager
@@ -132,7 +132,11 @@ def _get_ip_block(
     try:
         ip_block = ipaddress.ip_network(ip_block_str)
     except ValueError:
-        logging.error("Invalid IP block format: %s", ip_block_str)
+        logging.error(
+            "Invalid IP block format: %s",
+            ip_block_str,
+            extra=EXCLUDE_FROM_ERROR_MONITORING,
+        )
         return None
     return ip_block
 


### PR DESCRIPTION
## Summary

User configuration errors don't need to be tracked in error monitoring.

In principle it would also be possible to set `strict=False` in the IP address conversion. However, it is probably better to be strict here instead of trying to interpret ambiguous IP ranges given by the user.

Fixes #10846.

## Additional Information

- [ ] This change is backwards-breaking