### PR TITLE
chore(nms): Upgrade @fbcnms/platform-server from 0.2.0 to 0.3.0

### DIFF
--- a/nms/packages/magmalte/package.json
+++ b/nms/packages/magmalte/package.json
@@ -30,7 +30,7 @@
     "@fbcnms/auth": "^0.1.0",
     "@fbcnms/babel-register": "^0.1.2",
     "@fbcnms/express-middleware": "^0.1.5",
-    "@fbcnms/platform-server": "^0.2.3",
+    "@fbcnms/platform-server": "^0.3.0",
     "@fbcnms/projects": "^0.1.0",
     "@fbcnms/sequelize-models": "^0.1.12",
     "@fbcnms/strings": "^0.1.0",

--- a/nms/yarn.lock
+++ b/nms/yarn.lock
@@ -1614,9 +1614,9 @@
     passport-saml "^1.0.0"
 
 "@fbcnms/auth@^0.1.3":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@fbcnms/auth/-/auth-0.1.4.tgz#21d50e058bdf4a1af0d46a2398139478292b837f"
-  integrity sha512-zyNAwWzM+PWtzDgMaT4k6CI9NdhMs1Y8ouyrSB2XLj7q4huYuWhLrYFjdIrTxk7p2XxCXCpxGXuFexr3zebE5w==
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@fbcnms/auth/-/auth-0.1.5.tgz#6ecb64d60224d7e5d19e273e9cc7dc6101901618"
+  integrity sha512-c9v8cLUa/bPMbY3ObEIKoGnqqS55vUckH9EpZRV40HdF4MCUh9dNt+W56kjOS8iYxi07Lb4UeVmbs6RGabk3Lw==
   dependencies:
     "@fbcnms/sequelize-models" "^0.1.11"
     "@fbcnms/webpack-config" "^0.1.0"
@@ -1626,7 +1626,7 @@
     passport-http "^0.3.0"
     passport-http-bearer "^1.0.1"
     passport-local "^1.0.0"
-    passport-saml "^1.0.0"
+    passport-saml "^3.1.0"
 
 "@fbcnms/babel-register@^0.1.0", "@fbcnms/babel-register@^0.1.2":
   version "0.1.2"
@@ -1658,10 +1658,10 @@
     morgan "^1.9.1"
     winston "^3.0.0"
 
-"@fbcnms/platform-server@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@fbcnms/platform-server/-/platform-server-0.2.3.tgz#beac29c761e1fbbd74801031cf1c78a41fc2650b"
-  integrity sha512-i9qJClQO3sb9k2o9vwdFGYwORpVK1LEtKg0RUUWUoCyXo2OqiobHC9pI3tki+iiGtG+Gtk8eD8CoblfuvYO8vg==
+"@fbcnms/platform-server@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@fbcnms/platform-server/-/platform-server-0.3.0.tgz#e24f86f44ee9fedff5225d9f941ea4f887e6b996"
+  integrity sha512-Asft/TuONJDOJ2PnFxYp2UOBbtWMaCOK9DamOB1+ffoc9Pimyq/IHeRl5Ap0lX8vDMeznJOKmFXCLsIozAEkvg==
   dependencies:
     "@fbcnms/auth" "^0.1.3"
     "@fbcnms/babel-register" "^0.1.0"
@@ -1697,19 +1697,7 @@
   resolved "https://registry.yarnpkg.com/@fbcnms/projects/-/projects-0.1.0.tgz#7e1d6641e6dbe0f8137560f25c6d89b1d5cd9354"
   integrity sha512-vdP5+Y4XWkdVR3H97NCbZiuMpi2xSelyUFg5AR7vZXWzXLFKVziSQEvvqG442U3PQbuLV15LShfYJhEHDc13fA==
 
-"@fbcnms/sequelize-models@^0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@fbcnms/sequelize-models/-/sequelize-models-0.1.11.tgz#cdaff770ae08075593d269d5e215c304a88d20e7"
-  integrity sha512-Hipcb1DhO+pIWMrfZwxpPHOlWRkfGpABKOINhnKbyAOzXMkfmSOm4iSD52GN+mKtqzFEhzUNoHdAyyrP/bBlIw==
-  dependencies:
-    "@fbcnms/babel-register" "^0.1.0"
-    inquirer "^8.0.0"
-    mariadb "^2.4.2"
-    minimist "^1.2.5"
-    pg "^8.6.0"
-    sequelize "^5.8.5"
-
-"@fbcnms/sequelize-models@^0.1.12":
+"@fbcnms/sequelize-models@^0.1.11", "@fbcnms/sequelize-models@^0.1.12":
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/@fbcnms/sequelize-models/-/sequelize-models-0.1.12.tgz#55f8a9f0a801a3b3271c43de58664ddd903ba1b4"
   integrity sha512-5KhwvwTKYuG8Jemg3OMXS+WmSd6TTJfXtdSECKRmKUsHwOtHtMcp6uyeXpaxLeAZ/dxLf0U07Z5TMgHBAGuh5g==
@@ -2933,6 +2921,11 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@xmldom/xmldom@^0.7.0", "@xmldom/xmldom@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.5.tgz#09fa51e356d07d0be200642b0e4f91d8e6dd408d"
+  integrity sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -5215,7 +5208,7 @@ debug@^3.0.1, debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.3.3:
+debug@^4.1.0, debug@^4.3.2, debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -7869,9 +7862,9 @@ inflection@1.12.0:
   integrity sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=
 
 inflection@^1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.13.1.tgz#c5cadd80888a90cf84c2e96e340d7edc85d5f0cb"
-  integrity sha512-dldYtl2WlN0QDkIDtg8+xFwOS2Tbmp12t1cHa5/YClU6ZQjTFm7B66UcVbh9NQB+HvT5BAd2t5+yKsBkw5pcqA==
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.13.2.tgz#15e8c797c6c3dadf31aa658f8df8a4ea024798b0"
+  integrity sha512-cmZlljCRTBFouT8UzMzrGcVEvkv6D/wBdcdKG7J1QH5cXjtU75Dm+P27v9EKu/Y43UYyCJd1WC4zLebRrC8NBw==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -10949,7 +10942,20 @@ passport-saml@^1.0.0:
     xmlbuilder "^11.0.0"
     xmldom "0.1.x"
 
-passport-strategy@*, passport-strategy@1.x.x:
+passport-saml@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/passport-saml/-/passport-saml-3.2.1.tgz#c489a61a4c2dd93ddec1d53952a595b9f33e15e8"
+  integrity sha512-Y8aD94B6MTLht57BlBrDauEgvtWjuSeINKk7NadXlpT/OBmsoGGYPpb0FJeBtdyGX4GEbZARAkxvBEqsL8E7XQ==
+  dependencies:
+    "@xmldom/xmldom" "^0.7.5"
+    debug "^4.3.2"
+    passport-strategy "^1.0.0"
+    xml-crypto "^2.1.3"
+    xml-encryption "^2.0.0"
+    xml2js "^0.4.23"
+    xmlbuilder "^15.1.1"
+
+passport-strategy@*, passport-strategy@1.x.x, passport-strategy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
   integrity sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ=
@@ -12993,9 +12999,9 @@ sequelize@^5.8.5:
     wkx "^0.4.8"
 
 sequelize@^6.12.2:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-6.13.0.tgz#ce042fc511313094c1e4ca2b2ee13a563359e7b6"
-  integrity sha512-p0dXXGZSc0Ng7CdGwlKN4P6DTRD/w9Ar2CnmHamNVDnqEWh6pMVOp3xrlG5+IWhbwrqL3SjIYEYt3Xog1vXRDw==
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-6.15.0.tgz#536874e327ab412ff4688bce7c45eabecc151df6"
+  integrity sha512-Ks2jSaKMfICZ8jMlhH401fLw5ikE8Vqt6slcR2peKOn4lA3H+LRfXdlnAl/CUDO1MflFl7PhifnzPxwhamciGQ==
   dependencies:
     "@types/debug" "^4.1.7"
     debug "^4.3.3"
@@ -15100,6 +15106,14 @@ xml-crypto@^2.0.0:
     xmldom "0.1.27"
     xpath "0.0.27"
 
+xml-crypto@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/xml-crypto/-/xml-crypto-2.1.3.tgz#6a7272b610ea3e4ea7f13e9e4876f1b20cbc32c8"
+  integrity sha512-MpXZwnn9JK0mNPZ5mnFIbNnQa+8lMGK4NtnX2FlJMfMWR60sJdFO9X72yO6ji068pxixzk53O7x0/iSKh6IhyQ==
+  dependencies:
+    "@xmldom/xmldom" "^0.7.0"
+    xpath "0.0.32"
+
 xml-encryption@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/xml-encryption/-/xml-encryption-1.2.1.tgz#e6d18817c4309fd07ca7793cca93c3fd06745baa"
@@ -15110,12 +15124,21 @@ xml-encryption@1.2.1:
     xmldom "~0.1.15"
     xpath "0.0.27"
 
+xml-encryption@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xml-encryption/-/xml-encryption-2.0.0.tgz#d4e1eb3ec1f2c5d2a2a0a6e23d199237e8b4bf83"
+  integrity sha512-4Av83DdvAgUQQMfi/w8G01aJshbEZP9ewjmZMpS9t3H+OCZBDvyK4GJPnHGfWiXlArnPbYvR58JB9qF2x9Ds+Q==
+  dependencies:
+    "@xmldom/xmldom" "^0.7.0"
+    escape-html "^1.0.3"
+    xpath "0.0.32"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@0.4.x:
+xml2js@0.4.x, xml2js@^0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
@@ -15127,6 +15150,11 @@ xmlbuilder@^11.0.0, xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmlbuilder@^15.1.1:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
+  integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
 
 xmlchars@^2.2.0:
   version "2.2.0"
@@ -15147,6 +15175,11 @@ xpath@0.0.27:
   version "0.0.27"
   resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.27.tgz#dd3421fbdcc5646ac32c48531b4d7e9d0c2cfa92"
   integrity sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==
+
+xpath@0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.32.tgz#1b73d3351af736e17ec078d6da4b8175405c48af"
+  integrity sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

chore(nms): Upgrade @fbcnms/platform-server from 0.2.0 to 0.3.0

## Summary

   If a remote attacker was able to control the pretty option of the pug compiler, e.g. if you spread a user provided object such as the query parameters of a request into the pug template inputs, it was possible for them to achieve remote code execution on the node.js backend.
   pug_code_gen package is indirectly used in package pug v2.0.3. which is used in  @fbcnms/platform-server v0.2.0.  @fbcnms/platform-server needs to be upgraded to version 0.3.0 so pug_code_gen v2.0.2 is no longer needed. 


## Test Plan
ran in /magma/nms folder:
yarn run eslint
yarn run flow
yarn run test

## Additional Information

PR is fix for dependabot alert: https://github.com/magma/magma/security/dependabot/nms/yarn.lock/pug-code-gen/open
