### PR TITLE
chore: shared mconfig refactoring for sessiond and sctpd

### DIFF
--- a/lte/gateway/c/sctpd/src/sctpd.cpp
+++ b/lte/gateway/c/sctpd/src/sctpd.cpp
@@ -85,12 +85,6 @@ static magma::mconfig::SctpD load_sctpd_mconfig() {
   return mconfig;
 }
 
-static magma::mconfig::SharedMconfig load_shared_mconfig() {
-  magma::mconfig::SharedMconfig mconfig;
-  magma::load_service_mconfig_from_file(SHARED_MCONFIG, &mconfig);
-  return mconfig;
-}
-
 static uint32_t get_log_verbosity(const YAML::Node& config,
                                   magma::mconfig::SctpD mconfig) {
   if (!config["log_level"].IsDefined()) {
@@ -122,13 +116,8 @@ int main() {
   magma::init_logging(SCTPD_SERVICE);
   magma::set_verbosity(get_log_verbosity(config, sctpd_mconfig));
 
-  auto sentry_mconfig = load_shared_mconfig().sentry_config();
-  sentry_config_t sentry_config;
-  sentry_config.sample_rate = sentry_mconfig.sample_rate();
-  strncpy(sentry_config.url_native, sentry_mconfig.dsn_native().c_str(),
-          MAX_URL_LENGTH - 1);
-  sentry_config.url_native[MAX_URL_LENGTH - 1] = '\0';
-  initialize_sentry(SENTRY_TAG_SCTPD, &sentry_config);
+  sentry_config_t sentry_config = construct_sentry_config_from_mconfig();
+  initialize_sentry(SENTRY_TAG_SESSIOND, &sentry_config);
 
   auto channel =
       grpc::CreateChannel(UPSTREAM_SOCK, grpc::InsecureChannelCredentials());

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -61,20 +61,18 @@
 #include "includes/EventdClient.h"
 #include "includes/MConfigLoader.h"
 #include "includes/MagmaService.h"
-#include "includes/SentryWrapper.h"
 #include "includes/ServiceRegistrySingleton.h"
 #include "lte/protos/mconfig/mconfigs.pb.h"
 #include "lte/protos/policydb.pb.h"
 #include "magma_logging.h"
 #include "magma_logging_init.h"
+#include "orc8r/gateway/c/common/sentry/includes/SentryWrapper.h"
 #include "orc8r/protos/common.pb.h"
-#include "orc8r/protos/mconfig/mconfigs.pb.h"
 
 namespace grpc {
 class Channel;
 }  // namespace grpc
 
-#define SHARED_MCONFIG "shared_mconfig"
 #define SESSIOND_SERVICE "sessiond"
 #define SESSION_PROXY_SERVICE "session_proxy"
 #define POLICYDB_SERVICE "policydb"
@@ -105,12 +103,6 @@ static magma::mconfig::SessionD load_mconfig() {
     MLOG(MERROR) << "Unable to load mconfig for SessionD, using default";
     return get_default_mconfig();
   }
-  return mconfig;
-}
-
-static magma::mconfig::SharedMconfig load_shared_mconfig() {
-  magma::mconfig::SharedMconfig mconfig;
-  magma::load_service_mconfig_from_file(SHARED_MCONFIG, &mconfig);
   return mconfig;
 }
 
@@ -235,16 +227,6 @@ long get_quota_exhaust_termination_time(const YAML::Node& config) {
   return quota_exhaust_termination_on_init_ms;
 }
 
-sentry_config_t get_sentry_configuration(
-    magma::mconfig::SharedMconfig mconfig) {
-  sentry_config_t configuration;
-  configuration.sample_rate = mconfig.sentry_config().sample_rate();
-  strncpy(configuration.url_native,
-          mconfig.sentry_config().dsn_native().c_str(), MAX_URL_LENGTH - 1);
-  configuration.url_native[MAX_URL_LENGTH - 1] = '\0';
-  return configuration;
-}
-
 int main(int argc, char* argv[]) {
 #ifdef DEBUG
   __gcov_flush();
@@ -253,7 +235,6 @@ int main(int argc, char* argv[]) {
   magma::init_logging(argv[0]);
 
   auto mconfig = load_mconfig();
-  auto shared_mconfig = load_shared_mconfig();
   auto config =
       magma::ServiceConfigLoader{}.load_service_config(SESSIOND_SERVICE);
   magma::set_verbosity(get_log_verbosity(config, mconfig));
@@ -262,7 +243,7 @@ int main(int argc, char* argv[]) {
     set_grpc_logging_level(config["print_grpc_payload"].as<bool>());
   }
 
-  sentry_config_t sentry_config = get_sentry_configuration(shared_mconfig);
+  sentry_config_t sentry_config = construct_sentry_config_from_mconfig();
   initialize_sentry(SENTRY_TAG_SESSIOND, &sentry_config);
 
   bool enable_5g_features = false;


### PR DESCRIPTION
## Summary

Closes #11092 .

Cleanup refactoring for the changes suggested in https://github.com/magma/magma/issues/11092. Related to https://github.com/magma/magma/pull/11257#discussion_r791063361.
With the refactoring here, sctpd and sessiond use the more general implementation of mme as well (#11257).

Depends on 
- https://github.com/magma/magma/pull/10904
- https://github.com/magma/magma/pull/11212
- https://github.com/magma/magma/pull/11257

## Test Plan

- CI
