### PR TITLE
test(agw): Use magma-test VM for running trf server

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -120,6 +120,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # UE trfgen network
     magma_test.vm.network "private_network", ip: "192.168.128.11", nic_type: "82540EM"
     #config.ssh.private_key_path = "~/.ssh/vagrant.key"
+    magma_test.vm.network "private_network", ip: "192.168.129.43", nic_type: "82540EM"
     config.ssh.forward_agent = true
 
     magma_test.vm.provider "virtualbox" do |vb|

--- a/lte/gateway/deploy/roles/trfserver/files/traffic_server.py
+++ b/lte/gateway/deploy/roles/trfserver/files/traffic_server.py
@@ -522,8 +522,15 @@ class TrafficTestDriver(object):
     def _get_macs(self):
         ''' Retrieves the MAC addresses of the associated test servers, based
         on the information of the instances '''
+        dev = 'eth2'
         ip = pyroute2.IPRoute()
-        mac = ip.link('get', index=ip.link_lookup(ifname='eth2')[0])[0] \
+        # In case of trf-server in namespace, the namespace only has eth3
+        # Therefore if eth2 is missing,  use eth3.
+        # This check is done for compatibility for namespace based trf-serve
+        res = ip.link_lookup(ifname=dev)
+        if len(res) == 0:
+            dev = 'eth3'
+        mac = ip.link('get', index=ip.link_lookup(ifname=dev)[0])[0] \
             .get_attr('IFLA_ADDRESS')
 
         return (mac,) * len(self._instances)

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -125,9 +125,13 @@ class TrafficUtil(object):
 
     def update_dl_route(self, ue_ip_block):
         """ Update downlink route in TRF server """
+        dev = "eth2"
+        ip = pyroute2.IPRoute()
+        if ip.link_lookup(ifname='trf1'):
+            dev = "eth3"
         ret_code = self.exec_command(
             "sudo ip route flush via 192.168.129.1 && sudo ip route "
-            "replace " + ue_ip_block + " via 192.168.129.1 dev eth2",
+            "replace " + ue_ip_block + " via 192.168.129.1 dev " + dev,
         )
         if ret_code != 0:
             return False

--- a/lte/gateway/python/integ_tests/script/setup-trf-ns.sh
+++ b/lte/gateway/python/integ_tests/script/setup-trf-ns.sh
@@ -1,0 +1,60 @@
+
+DEV="eth3"
+NS_NAME="trf_ns"
+LINK_NAME="trf"
+MAGMA_DEV=192.168.60.142
+
+function setup()
+{
+  sshpass -p vagrant ssh vagrant@$MAGMA_DEV -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no sudo ip r r 192.168.60.144 via 192.168.129.42 dev eth2
+
+  ethtool --offload eth1 rx off tx off
+  ethtool --offload eth2 rx off tx off
+  ethtool --offload eth3 rx off tx off
+
+  echo "1" > /proc/sys/net/ipv4/ip_forward
+  ip netns add $NS_NAME
+
+  ip link add "$LINK_NAME"1  type veth peer name  "$LINK_NAME"2
+
+  ip link set dev  $DEV  netns $NS_NAME
+  ip link set dev  "$LINK_NAME"2  netns $NS_NAME
+  ifconfig "$LINK_NAME"1 up
+
+  ip link set dev  "$LINK_NAME"1 address "08:00:27:62:75:8b"
+  ip r r 192.168.60.144 dev "$LINK_NAME"1
+
+  ip netns exec $NS_NAME ifconfig lo up
+  ip netns exec $NS_NAME ifconfig "$LINK_NAME"2 0.0.0.0 up
+  ip netns exec $NS_NAME ip link set dev "$LINK_NAME"2 address "08:00:27:62:75:8b"
+  ip netns exec $NS_NAME ifconfig  $DEV up
+  ip netns exec $NS_NAME ip a add 192.168.60.144/24 dev $DEV
+  ip netns exec $NS_NAME ip a add 192.168.129.42/24 dev $DEV
+  ip netns exec $NS_NAME ip r add 10.0.2.15       dev  "$LINK_NAME"2
+  ip netns exec $NS_NAME ip r add 192.168.60.141  dev  "$LINK_NAME"2
+  ip netns exec $NS_NAME ip r add 192.168.128.11  dev  "$LINK_NAME"2
+  ip netns exec $NS_NAME ip r add default  via 192.168.129.1 dev $DEV
+
+  sleep 2
+  ip netns exec $NS_NAME /usr/sbin/sshd
+  sleep 1
+  nohup ip netns exec $NS_NAME /home/vagrant/magma/lte/gateway/deploy/roles/trfserver/files/traffic_server.py 192.168.60.144 62462 &
+}
+
+function destroy()
+{
+  ip netns exec $NS_NAME ip link set $DEV  netns 1
+  sleep 1
+  ip netns del $NS_NAME
+  ip link  del "$LINK_NAME"1
+
+  ifconfig  $DEV up
+}
+
+function reset()
+{
+  destroy
+  setup
+}
+
+$1


### PR DESCRIPTION
This creates separate namespace to run trf-server on magma-test
VM thus eliminating need of running magma-trfserver in
separate VM.
This would further reduce requirement of running magma integ-tests.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
