### PR TITLE
fix(agw): Don't exclude everything from Sentry in edge case

### DIFF
--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -119,17 +119,24 @@ def _filter_excluded_messages(event: Event, hint: Hint, patterns_to_exclude: Lis
     return event
 
 
-def _get_before_send_hook(patterns_to_exclude: List[str]) -> Optional[SentryHook]:
+def _get_before_send_hook(patterns_to_exclude: List[str]) -> SentryHook:
 
     def filter_excluded_and_marked_messages(
             event: Event, hint: Hint,
     ) -> Optional[Event]:
         event = _ignore_if_marked(event)
-        if event and patterns_to_exclude:
+        if event:
             return _filter_excluded_messages(event, hint, patterns_to_exclude)
         return None
 
-    return filter_excluded_and_marked_messages
+    def filter_marked_messages(
+            event: Event, _: Hint,
+    ) -> Optional[Event]:
+        return _ignore_if_marked(event)
+
+    if patterns_to_exclude:
+        return filter_excluded_and_marked_messages
+    return filter_marked_messages
 
 
 def sentry_init(service_name: str, sentry_mconfig: mconfigs_pb2.SharedSentryConfig) -> None:

--- a/orc8r/gateway/python/magma/common/tests/sentry_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/sentry_tests.py
@@ -99,12 +99,24 @@ class SentryTests(unittest.TestCase):
     def test_get_before_send_hook_returns_exclusion_and_filter_hook(self):
         """Test that the returned hook excludes marked events and applies the filter"""
         hook = _get_before_send_hook(["message to exclude"])
+        self.assertEqual(hook.__name__, 'filter_excluded_and_marked_messages')
 
         excluded_event = {"key": "value", "extra": {"exclude_from_error_monitoring": True}}
         self.assertIsNone(hook(excluded_event, {}))
 
         filtered_event = _event_with_log_message("some message to exclude")
         self.assertIsNone(hook(filtered_event, {}))
+
+        unfiltered_event = _event_with_log_message("another message")
+        self.assertEqual(unfiltered_event, hook(unfiltered_event, {}))
+
+    def test_get_before_send_hook_handles_missing_filters_correctly(self):
+        """Test that the returned hook excludes only marked events if there's no filter"""
+        hook = _get_before_send_hook([])
+        self.assertEqual(hook.__name__, 'filter_marked_messages')
+
+        excluded_event = {"key": "value", "extra": {"exclude_from_error_monitoring": True}}
+        self.assertIsNone(hook(excluded_event, {}))
 
         unfiltered_event = _event_with_log_message("another message")
         self.assertEqual(unfiltered_event, hook(unfiltered_event, {}))


### PR DESCRIPTION
## Summary

Fixes a bug in the Sentry Python code where, if the list of client filters was empty, we excluded all events from Sentry.

## Test Plan

Added a unit test for the edge case.

## Additional Information

- [ ] This change is backwards-breaking