### PR TITLE
chore(ci): update the Bazel build job to run for Python changes as well

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -37,9 +37,9 @@ jobs:
           filters: |
             files_changed:
               - '.github/workflows/bazel.yml'
-              - 'orc8r/gateway/c/**'
+              - 'orc8r/gateway/**'
               - 'orc8r/protos/**'
-              - 'lte/gateway/c/**'
+              - 'lte/gateway/**'
               - 'lte/protos/**'
               - 'src/go/**'
               - '**/BUILD'


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
We are starting to roll out build files for Python AGW services, trigger this non-required job for Python changes as well.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
N/A
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
