### PR TITLE
chore(policydb): policydb is bazelified

### DIFF
--- a/lte/gateway/python/magma/policydb/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/BUILD.bazel
@@ -1,0 +1,61 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+LTE_ROOT = "../../"
+
+ORC8R_ROOT = LTE_ROOT + "../../../orc8r/gateway/python"
+
+DEPS = [
+    "//lte/protos:mconfigs_python_proto",
+    "//lte/protos:policydb_python_grpc",
+    "//lte/protos:session_manager_python_grpc",
+    "//lte/gateway/python/magma/policydb/servicers:policy_servicer",
+    "//lte/gateway/python/magma/policydb/servicers:session_servicer",
+    "//orc8r/gateway/python/magma/common:sentry",
+    "//orc8r/gateway/python/magma/common:service",
+    "//orc8r/gateway/python/magma/common:streamer",
+    "//orc8r/gateway/python/magma/common:rpc_utils",
+    "//orc8r/gateway/python/magma/common/redis:client",
+]
+
+SRCS = [
+    "main.py",
+    "apn_rule_map_store.py",
+    "basename_store.py",
+    "rating_group_store.py",
+    "reauth_handler.py",
+    "rule_map_store.py",
+    "streamer_callback.py",
+    "rule_store.py",
+]
+
+py_binary(
+    name = "policydb",
+    srcs = SRCS,
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    # legacy_creat_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
+    legacy_create_init = False,
+    main = "main.py",
+    python_version = "PY3",
+    visibility = ["//visibility:public"],
+    deps = DEPS,
+)
+
+py_library(
+    name = "default_rules",
+    srcs = ["default_rules.py"],
+    visibility = ["//visibility:public"],
+)

--- a/lte/gateway/python/magma/policydb/main.py
+++ b/lte/gateway/python/magma/policydb/main.py
@@ -30,8 +30,7 @@ from magma.policydb.reauth_handler import ReAuthHandler
 from magma.policydb.rule_map_store import RuleAssignmentsDict
 from magma.policydb.servicers.policy_servicer import PolicyRpcServicer
 from magma.policydb.servicers.session_servicer import SessionRpcServicer
-
-from .streamer_callback import (
+from magma.policydb.streamer_callback import (
     ApnRuleMappingsStreamerCallback,
     PolicyDBStreamerCallback,
     RatingGroupsStreamerCallback,
@@ -89,7 +88,6 @@ def main():
                 'rating_groups': RatingGroupsStreamerCallback(
                     rating_groups_dict,
                 ),
-
             },
             service.loop,
         )

--- a/lte/gateway/python/magma/policydb/servicers/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/servicers/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "policy_servicer",
+    srcs = ["policy_servicer.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "session_servicer",
+    srcs = ["session_servicer.py"],
+    visibility = ["//visibility:public"],
+    deps = ["//lte/gateway/python/magma/policydb:default_rules"],
+)

--- a/lte/gateway/python/magma/policydb/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/tests/BUILD.bazel
@@ -1,0 +1,45 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
+load("//bazel:python_test.bzl", "pytest_test")
+
+COMMON_TEST_DEPS = ["//lte/gateway/python/magma/policydb:policydb"]
+
+pytest_test(
+    name = "test_policy_servicer",
+    srcs = ["test_policy_servicer.py"],
+    deps = COMMON_TEST_DEPS + [requirement("grpcio")],
+)
+
+pytest_test(
+    name = "test_reauth_handler",
+    srcs = ["test_reauth_handler.py"],
+    deps = COMMON_TEST_DEPS,
+)
+
+pytest_test(
+    name = "test_session_servicer",
+    srcs = ["test_session_servicer.py"],
+    deps = COMMON_TEST_DEPS,
+)
+
+pytest_test(
+    name = "test_streamer_callback",
+    srcs = ["test_streamer_callback.py"],
+    deps = COMMON_TEST_DEPS + [":mock_stubs"],
+)
+
+py_library(
+    name = "mock_stubs",
+    srcs = ["mock_stubs.py"],
+)

--- a/lte/protos/BUILD.bazel
+++ b/lte/protos/BUILD.bazel
@@ -188,6 +188,12 @@ python_proto_library(
     ],
 )
 
+python_grpc_library(
+    name = "policydb_python_grpc",
+    protos = [":policydb_proto"],
+    deps = [":mobilityd_python_proto"],
+)
+
 proto_library(
     name = "sctpd_proto",
     srcs = ["sctpd.proto"],
@@ -243,6 +249,11 @@ proto_library(
         "//orc8r/protos:common_proto",
         "@protobuf//:timestamp_proto",
     ],
+)
+
+python_grpc_library(
+    name = "session_manager_python_grpc",
+    protos = [":session_manager_proto"],
 )
 
 cpp_proto_library(

--- a/orc8r/gateway/python/magma/common/BUILD.bazel
+++ b/orc8r/gateway/python/magma/common/BUILD.bazel
@@ -49,3 +49,9 @@ py_library(
         requirement("prometheus_client"),
     ],
 )
+
+py_library(
+    name = "streamer",
+    srcs = ["streamer.py"],
+    deps = ["//orc8r/protos:streamer_python_grpc"],
+)

--- a/orc8r/protos/BUILD.bazel
+++ b/orc8r/protos/BUILD.bazel
@@ -209,3 +209,14 @@ proto_library(
         "@protobuf//:wrappers_proto",
     ],
 )
+
+proto_library(
+    name = "streamer_proto",
+    srcs = ["streamer.proto"],
+    deps = ["@protobuf//:any_proto"],
+)
+
+python_grpc_library(
+    name = "streamer_python_grpc",
+    protos = [":streamer_proto"],
+)


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Module policydb is bazelified including the test.
- Please note: 
  - policydb source depends on policydb/servicers/session_servicer.py, which in turn depends on policydb/default_rules.py
  - At first glance this looks circular
  - Solution: default_rules.py is modeled as an independent library (there are no direct relations to the rest of the policydb source).
-  #11357 is applied here

## Test Plan

-  Run policydb: 
   - `bazel run //lte/gateway/python/magma/policydb:policydb`
   - Note: orc8r connection is needed in order to run this service in magma-vm.
- Run test: 
  - `bazel test //lte/gateway/python/magma/policydb/tests:all`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
