### PR TITLE
fix(pipelined): Fix Unit Test arg init for qos, add ebpf guards

### DIFF
--- a/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
@@ -52,6 +52,9 @@ def get_ebpf_manager(config):
     else:
         enabled = False
     gw_info = get_mobilityd_gw_info()
+    if not ('nat_iface' in config and 'enodeb_iface' in config):
+        LOG.info("eBPF manager: Missing nat_iface/ennodeb_iface")
+        return None
     for gw in gw_info:
         if gw.ip.version != IPAddress.IPV4:
             continue


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
 -  Qos init seems to fail in unit tests because in qos init we don't initiliaze all the args because of the premature return statements (introduced here https://github.com/magma/magma/pull/11287, cc @ankitbhadoria21 )
 - Also noticed some ebpf issues with nat_iface lookup in tests, added some checcks

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
