### PR TITLE
fix(agw): Replace master with main for S1apTester repo

### DIFF
--- a/lte/gateway/deploy/roles/magma_test/files/update_package.sh
+++ b/lte/gateway/deploy/roles/magma_test/files/update_package.sh
@@ -17,9 +17,9 @@ SCRIPT_DIR=$MAGMA_ROOT/lte/gateway/deploy/roles/magma_test/files
 # Clone the code
 $SCRIPT_DIR/clone_s1_tester.sh
 
-# If any pull request is provided, apply them, else use master
+# If any pull request is provided, apply them, else use main
 pushd "$S1AP_TESTER_SRC" || exit
-git checkout master
+git checkout main
 git branch | grep -v '^*' | xargs --no-run-if-empty git branch -D
 
 if [ "$#" == 1 ]; then


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The script to update S1apTester library on Magma test VM was failing since it was referring to `main` branch of [S1APTester repo](https://github.com/facebookexperimental/S1APTester) as `master`. This change fixes this terminology.

## Test Plan

On `magma_test VM`, verified that:
- `update_package.sh <pull request> ` executes without error
- a new `~/s1ap-tester/bin/libtfw.so` is generated after the above script succeeds

