### PR TITLE
fix(agw): Bump mysqlclient to 1.3.13

### DIFF
--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -16,7 +16,7 @@ $(PYTHON_BUILD)/setupinteg_env:
 	@echo "Copying s1aptester config files"
 	cp $(S1AP_TESTER_CFG)/* $(S1AP_TESTER_ROOT)
 	@echo "Install MySQL for upstreaming"
-	$(VIRT_ENV_PIP_INSTALL) mysqlclient==1.3.12
+	$(VIRT_ENV_PIP_INSTALL) mysqlclient==1.3.13
 	@echo export PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) >> $(PYTHON_BUILD)/bin/activate
 	touch $(PYTHON_BUILD)/setupinteg_env
 


### PR DESCRIPTION
Signed-off-by: Ramon Melero <ramonmelero@fb.com>


## Summary

While trying to run the make command under ubuntu 20.04, [the pip install command for mysqlclient fails](https://gist.github.com/rmeleromira/cac845c1d12a24f3c741bea38b17bdaa#compilation-error-for-mysqlclient-1312-used-here). 

[Bumping the version to 1.3.13 fixes the issue.](https://gist.github.com/rmeleromira/cac845c1d12a24f3c741bea38b17bdaa#bumping-to-1313-fixes-the-compile-errors)


## Test Plan

Compile was failing before change, and after bumping the version, compite warnings and errors go away.

## Additional Information

- [ ] This change is backwards-breaking