### PR TITLE
fix(pipelined): Fixes qos unit test

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -18,6 +18,7 @@ from enum import Enum
 from typing import Dict, List  # noqa
 
 from lte.protos.policydb_pb2 import FlowMatch
+from magma.common.redis.client import get_default_client
 from magma.configuration.service_configs import load_service_config
 from magma.pipelined.qos.qos_meter_impl import MeterManager
 from magma.pipelined.qos.qos_tc_impl import TCManager, TrafficClass
@@ -238,7 +239,7 @@ class QosManager(object):
             return False
         return True
 
-    def __init__(self, loop, config):
+    def __init__(self, loop, config, client=get_default_client()):
         self._initialized = False
         self._clean_restart = config["clean_restart"]
         self._subscriber_state = {}
@@ -255,7 +256,7 @@ class QosManager(object):
             return
         self._apn_ambr_enabled = config["qos"].get("apn_ambr_enabled", True)
         LOG.info("QoS: apn_ambr_enabled: %s", self._apn_ambr_enabled)
-        self._redis_store = QosStore(self.__class__.__name__)
+        self._redis_store = QosStore(self.__class__.__name__, client)
         self.impl = None
 
     def setup(self):

--- a/lte/gateway/python/magma/pipelined/qos/utils.py
+++ b/lte/gateway/python/magma/pipelined/qos/utils.py
@@ -14,7 +14,6 @@ limitations under the License.
 import logging
 from collections import deque
 
-from magma.common.redis.client import get_default_client
 from magma.common.redis.containers import RedisHashDict
 from magma.common.redis.serializers import (
     get_json_deserializer,
@@ -73,8 +72,8 @@ class IdManager(object):
 
 
 class QosStore(RedisHashDict):
-    def __init__(self, redis_type):
-        self.client = get_default_client()
+    def __init__(self, redis_type, client):
+        self.client = client
         super().__init__(
             self.client, redis_type,
             get_json_serializer(), get_json_deserializer(),

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -17,6 +17,7 @@ import unittest
 from collections import namedtuple
 from unittest.mock import MagicMock, call, patch
 
+import fakeredis
 from lte.protos.policydb_pb2 import FlowMatch
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.qos.common import QosImplType, QosManager, SubscriberState
@@ -191,7 +192,7 @@ get_action_instruction",
         if self.config["qos"]["impl"] == QosImplType.LINUX_TC:
             mock_traffic_cls.read_all_classes.side_effect = lambda intf: prior_qids[intf]
 
-        qos_mgr = QosManager(asyncio.new_event_loop(), self.config)
+        qos_mgr = QosManager(asyncio.new_event_loop(), self.config, fakeredis.FakeStrictRedis())
         qos_mgr.init_impl(MagicMock)
         qos_mgr._redis_store = {}
         qos_mgr._setupInternal()
@@ -297,7 +298,7 @@ get_action_instruction",
             mock_traffic_cls.read_all_classes.side_effect = lambda intf: []
             mock_traffic_cls.delete_class.side_effect = lambda *args: 0
 
-        qos_mgr = QosManager(asyncio.new_event_loop(), self.config)
+        qos_mgr = QosManager(asyncio.new_event_loop(), self.config, fakeredis.FakeStrictRedis())
         qos_mgr.init_impl(MagicMock)
         qos_mgr._redis_store = {}
         qos_mgr._setupInternal()
@@ -462,7 +463,7 @@ get_action_instruction",
         and ensure that eventually the system and qos store state remains
         consistent"""
         loop = asyncio.new_event_loop()
-        qos_mgr = QosManager(loop, self.config)
+        qos_mgr = QosManager(loop, self.config, fakeredis.FakeStrictRedis())
         qos_mgr.init_impl(MagicMock)
         qos_mgr._redis_store = {}
 
@@ -596,7 +597,7 @@ get_action_instruction",
         AMBR configs.
         """
         loop = asyncio.new_event_loop()
-        qos_mgr = QosManager(loop, self.config)
+        qos_mgr = QosManager(loop, self.config, fakeredis.FakeStrictRedis())
         qos_mgr.init_impl(MagicMock)
         qos_mgr._redis_store = {}
 
@@ -784,7 +785,7 @@ get_action_instruction",
         prior_qids = {self.ul_intf: [(2, 0)], self.dl_intf: [(3, 0)]}
         mock_traffic_cls.read_all_classes.side_effect = lambda intf: prior_qids[intf]
 
-        qos_mgr = QosManager(asyncio.new_event_loop(), self.config)
+        qos_mgr = QosManager(asyncio.new_event_loop(), self.config, fakeredis.FakeStrictRedis())
         qos_mgr.init_impl(MagicMock)
         qos_mgr._redis_store = {}
         qos_mgr._setupInternal()


### PR DESCRIPTION
QoS manager restructuring needs fake redis client.
Following PR uses fake client for QoS manager redis map.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
