### PR TITLE
docs: update documentation for rootCA and SSL certs

### DIFF
--- a/docs/readmes/howtos/troubleshooting/update_certificates.md
+++ b/docs/readmes/howtos/troubleshooting/update_certificates.md
@@ -69,7 +69,7 @@ hide_title: true
 
     ```bash
     terraform taint module.orc8r-app.null_resource.orc8r_seed_secrets
-    terraform apply --target=module.orc8rapp.null_resource.orc8r_seed_secrets
+    terraform apply --target=module.orc8r-app.null_resource.orc8r_seed_secrets
     terraform apply
     ```
 


### PR DESCRIPTION
Signed-off-by: Jared Mullane <jmullane@fb.com>

## Summary

Fixed a typo in the documentation that could cause errors when updating rootCA and SSL certs.

## Test Plan

Very minor change
