### PR TITLE
fix(agw): Updating priority of default rule in AGW

### DIFF
--- a/lte/gateway/python/magma/policydb/default_rules.py
+++ b/lte/gateway/python/magma/policydb/default_rules.py
@@ -29,8 +29,9 @@ def get_allow_all_policy_rule(
         # Don't set the rating group
         # Don't set the monitoring key
         # Don't set the hard timeout
+        # Setting priority to a low value
         id=policy_id,
-        priority=2,
+        priority=65530,
         flow_list=_get_allow_all_flows(),
         tracking_type=PolicyRule.TrackingType.Value("NO_TRACKING"),
     )


### PR DESCRIPTION
## Summary

Default rule was previously installed with priority 2. 
This is inverted before flows are pushed to OVS - Which resulted in very high priority for "this" rule.
This caused side effects when multiple policies are tested with differing priorities. 
Fix involves changing priority to a very high value (Lowering priority). 


## Test Plan

Bring up end to end setup. Attach UE with atleast two policies. Dump flows in OVS and inspect.

pipelined_cli.py debug display_flows | grep "table=enforcement(main_table)" 

![image](https://user-images.githubusercontent.com/97009526/152102412-1a76f0f6-4928-4fa1-9d0c-9196a731e8bb.png)

Check if the default rules are installed with low priority in OVS
(See screenshot above): Default rules are installed with PRIORITY=5 (very low)
The other rules (defaultBearerPolicy, dedicatedBearerTCP) are installed with higher priorities


## Additional Information


