### PR TITLE
chore(agw): Update installed Magma version from 1.6.0 to 1.6.1

### DIFF
--- a/lte/gateway/deploy/roles/magma_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/magma_deploy/vars/all.yaml
@@ -14,7 +14,7 @@
 magma_pkgrepo_proto: https
 magma_pkgrepo_host: artifactory.magmacore.org/artifactory/debian
 magma_pkgrepo_path: ""
-magma_pkgrepo_dist: focal-1.6.0
+magma_pkgrepo_dist: focal-1.6.1
 magma_pkgrepo_component: main
 magma_pkgrepo_name: "magma"
 


### PR DESCRIPTION
## Summary

This updates the magma version that gets installed when following
https://docs.magmacore.org/docs/lte/deploy_install from v1.6.0 to v1.6.1

This was done on the master branch in #10956 
When following the installation guide in the above link, code from the v1.6 branch gets used, so I duplicated this change here.

## Test Plan

Not tested. I verified that `export MAGMA_VERSION=master` before `bash agw_install_ubuntu.sh` installs version 1.6.1 as expected.
