### PR TITLE
chore(nms): Log the actual error in case the DB migrations fail

### DIFF
--- a/nms/packages/magmalte/scripts/migrate.js
+++ b/nms/packages/magmalte/scripts/migrate.js
@@ -28,4 +28,4 @@ const {runMigrations} = require('./runMigrations');
 
 runMigrations()
   .then(_ => console.log('Ran migrations successfully'))
-  .catch(_ => console.error('Failed to run migrations'));
+  .catch(err => console.error('Failed to run migrations', err));


### PR DESCRIPTION
## Summary

It's hard to debug if something goes wrong in these migrations, see discussion at #11325.

## Test Plan

I provoked an error locally and got the following output:
```
Failed to run migrations { SequelizeDatabaseError: column "networkIDs" of relation "Users" already exists
    at Query.formatError (/usr/src/node_modules/sequelize/lib/dialects/postgres/query.js:366:16)
    at query.catch.err (/usr/src/node_modules/sequelize/lib/dialects/postgres/query.js:72:18)
    at tryCatcher (/usr/src/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/usr/src/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/usr/src/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/usr/src/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/usr/src/node_modules/bluebird/js/release/promise.js:725:18)
    at _drainQueueStep (/usr/src/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/usr/src/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/usr/src/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/usr/src/node_modules/bluebird/js/release/async.js:15:14)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
  name: 'SequelizeDatabaseError',
  parent:
   { error: column "networkIDs" of relation "Users" already exists
       at Parser.parseErrorMessage (/usr/src/node_modules/pg-protocol/src/parser.ts:369:69)
       at Parser.handlePacket (/usr/src/node_modules/pg-protocol/src/parser.ts:188:21)
       at Parser.parse (/usr/src/node_modules/pg-protocol/src/parser.ts:103:30)
       at Socket.stream.on (/usr/src/node_modules/pg-protocol/src/index.ts:7:48)
       at Socket.emit (events.js:198:13)
       at addChunk (_stream_readable.js:288:12)
       at readableAddChunk (_stream_readable.js:269:11)
       at Socket.Readable.push (_stream_readable.js:224:10)
       at TCP.onStreamRead [as onread] (internal/stream_base_commons.js:94:17)
     length: 127,
     name: 'error',
     severity: 'ERROR',
     code: '42701',
     detail: undefined,
     hint: undefined,
     position: undefined,
     internalPosition: undefined,
     internalQuery: undefined,
     where: undefined,
     schema: undefined,
     table: undefined,
     column: undefined,
     dataType: undefined,
     constraint: undefined,
     file: 'tablecmds.c',
     line: '5131',
     routine: 'check_for_column_name_collision',
     sql:
      'ALTER TABLE "public"."Users" ADD COLUMN "networkIDs" JSON NOT NULL DEFAULT \'"[]"\';',
     parameters: undefined },
  original:
   { error: column "networkIDs" of relation "Users" already exists
       at Parser.parseErrorMessage (/usr/src/node_modules/pg-protocol/src/parser.ts:369:69)
       at Parser.handlePacket (/usr/src/node_modules/pg-protocol/src/parser.ts:188:21)
       at Parser.parse (/usr/src/node_modules/pg-protocol/src/parser.ts:103:30)
       at Socket.stream.on (/usr/src/node_modules/pg-protocol/src/index.ts:7:48)
       at Socket.emit (events.js:198:13)
       at addChunk (_stream_readable.js:288:12)
       at readableAddChunk (_stream_readable.js:269:11)
       at Socket.Readable.push (_stream_readable.js:224:10)
       at TCP.onStreamRead [as onread] (internal/stream_base_commons.js:94:17)
     length: 127,
     name: 'error',
     severity: 'ERROR',
     code: '42701',
     detail: undefined,
     hint: undefined,
     position: undefined,
     internalPosition: undefined,
     internalQuery: undefined,
     where: undefined,
     schema: undefined,
     table: undefined,
     column: undefined,
     dataType: undefined,
     constraint: undefined,
     file: 'tablecmds.c',
     line: '5131',
     routine: 'check_for_column_name_collision',
     sql:
      'ALTER TABLE "public"."Users" ADD COLUMN "networkIDs" JSON NOT NULL DEFAULT \'"[]"\';',
     parameters: undefined },
  sql:
   'ALTER TABLE "public"."Users" ADD COLUMN "networkIDs" JSON NOT NULL DEFAULT \'"[]"\';',
  parameters: undefined }
```

## Additional Information

- [ ] This change is backwards-breaking