### PR TITLE
fix(pipelined): Only destroy qos classes after initialization

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
@@ -249,6 +249,10 @@ class TCManager(object):
         )
 
     def destroy(self):
+        if not TrafficClass.tc_ops:
+            LOG.info("TC not initialized, skip destroying existing qos classes")
+            return
+
         LOG.info("destroying existing qos classes")
         # ensure ordering during deletion of classes, children should be deleted
         # prior to the parent class ids


### PR DESCRIPTION
## Summary

If `clean_restart` is enabled in the pipelined config, the QoS setup will fail because classes are destroyed before the necessary infrastructure is initialized. This fix avoids the error via a null check.

The problem seems to be that the first run of `QosManager._setup_internal` goes into the "clean restart" block instead of the "else" block. I am not sure if this fix is enough by avoiding the error or if it would be necessary to make it go into the "else" block.

Fixes #11384.

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking