### PR TITLE
fix(nms): Backport update @fbcnms/sequelize-models to ^0.1.10

### DIFF
--- a/nms/app/packages/magmalte/package.json
+++ b/nms/app/packages/magmalte/package.json
@@ -33,7 +33,7 @@
     "@fbcnms/magma-api": "^0.1.0",
     "@fbcnms/platform-server": "^0.1.29",
     "@fbcnms/projects": "^0.1.0",
-    "@fbcnms/sequelize-models": "^0.1.9",
+    "@fbcnms/sequelize-models": "^0.1.10",
     "@fbcnms/strings": "^0.1.0",
     "@fbcnms/types": "^0.1.11",
     "@fbcnms/ui": "^0.1.11",

--- a/nms/app/yarn.lock
+++ b/nms/app/yarn.lock
@@ -1571,6 +1571,18 @@
     pg "^8.6.0"
     sequelize "^5.8.5"
 
+"@fbcnms/sequelize-models@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@fbcnms/sequelize-models/-/sequelize-models-0.1.10.tgz#f2207602361aeb0edd1e61872a116d1e82e0fcc4"
+  integrity sha512-msnqzWmcZ0FzmcxX+6MQiaO0XIMMHTRWZEJLHqPeT/A9LThrx3y4IcZSGfL+7Io250lfY/m00rmN/AaSAP6X6A==
+  dependencies:
+    "@fbcnms/babel-register" "^0.1.0"
+    inquirer "^8.0.0"
+    mariadb "^2.4.2"
+    minimist "^1.2.5"
+    pg "^8.6.0"
+    sequelize "^5.8.5"
+
 "@fbcnms/strings@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@fbcnms/strings/-/strings-0.1.0.tgz#50dae22b4cb7cb7d1a30c013d0b40c96b741a1f1"


### PR DESCRIPTION
Cherry-pick b636384192abce5642288dfe525dc9e359f67a79 ([nms] Upgrade
@fbcnms/sequelize-models to ^0.1.10 (#7690)) sent by Andrei Lee.

Fixes #11291.

Tested on top of releases v1.6.0 and v1.6.1, and current v1.6 branch. In all three cases, after applying the patch and rebuilding the containers, the magmalte_magmalte_1 container appears in "healthy" condition, and running `scripts/dev_setup.sh` succeeds in migrating and creating the admin@magma.test user.