### PR TITLE
chore(deps): Upgrade eventlet from v0.30.2 to v0.31.0

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -120,7 +120,7 @@ setup(
         'idna==2.8',
         'python-dateutil==2.8.1',
         'six>=1.12.0',
-        'eventlet==0.30.2',
+        'eventlet==0.31.0',
         'h2>=3.2.0',
         'hpack>=3.0',
         'freezegun>=0.3.15',


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

chore(deps): Upgrade eventlet from v0.30.2 to v0.31.0

## Summary

A websocket peer may exhaust memory on Eventlet side by sending very large websocket frames. Malicious peer may exhaust memory on Eventlet side by sending highly compressed data frame. Version 0.31.0 restricts websocket frame to reasonable limits. Eventlet package should be upgraded to v0.31.0 or later.

## Test Plan

ran magma/lte/gateway make test_python

## Additional Information

This is for dependabot alert: https://github.com/magma/magma/security/dependabot/lte/gateway/python/setup.py/eventlet/open