### PR TITLE
chore(pipelined): Change loglevel for request validation errors

### DIFF
--- a/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager.py
+++ b/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager.py
@@ -111,8 +111,8 @@ class SessionStateManager:
 
     def process_session_message(self, new_session, process_pdr_rules):
         """
-        Process the messages recevied from session. Return True
-        if parsing is successfull.
+        Process the messages received from session. Return True
+        if parsing is successful.
         """
 
         # Assume things are green
@@ -129,7 +129,7 @@ class SessionStateManager:
         context_response.cause_info.cause_ie = \
                   SessionStateManager.validate_session_msg(new_session)
         if context_response.cause_info.cause_ie != CauseIE.REQUEST_ACCEPTED:
-            self.logger.error(
+            self.logger.warning(
                 "Error : Parsing Error in SetInterface Message %d",
                 context_response.cause_info.cause_ie,
             )


### PR DESCRIPTION
## Summary

If a gRPC request is invalid, this is not an error inside pipelined and should not be logged on level error.

See #11402 for the context of this error.

## Additional Information

- [ ] This change is backwards-breaking