### PR TITLE
fix(dp): single DB queries in RC active mode service

### DIFF
--- a/dp/cloud/python/magma/radio_controller/tests/unit/test_active_mode_controller_service.py
+++ b/dp/cloud/python/magma/radio_controller/tests/unit/test_active_mode_controller_service.py
@@ -76,10 +76,10 @@ class ActiveModeControllerTestCase(LocalDBTestCase):
             with_grant("granted_grant", Granted, 3, 0). \
             with_grant("authorized_grant", Authorized, 5, 6). \
             build()
-        expected = State(active_mode_configs=[config])
 
+        expected = State(active_mode_configs=[config])
         actual = self.amc_service.GetState(GetStateRequest(), None)
-        self.assertEqual(expected, actual)
+        self.assertEqual(actual, expected)
 
     def test_get_state_with_channels(self):
         cbsd = self._prepare_base_cbsd(). \
@@ -96,7 +96,7 @@ class ActiveModeControllerTestCase(LocalDBTestCase):
         expected = State(active_mode_configs=[config])
 
         actual = self.amc_service.GetState(GetStateRequest(), None)
-        self.assertEqual(expected, actual)
+        self.assertEqual(actual, expected)
 
     def test_get_state_with_last_seen(self):
         cbsd = self._prepare_base_cbsd().\


### PR DESCRIPTION
When building database state for Active Mode Controller,
RC active mode service should use a single select query when fetching
database data required to build the Domain Proxy state, to resolve result inconsistency when a DB commit was
issued in between the selects.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

* RC: modified DB state query as one compound select for all state-related entities