### PR TITLE
chore: generate Python proto files in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -347,6 +347,23 @@ WORKDIR ${MAGMA_ROOT}/orc8r/gateway/python/
 RUN pip3 install --quiet --upgrade --no-build-isolation --no-cache-dir --verbose --editable .[dev] && \
     rm -rf orc8r.egg-info
 
+#### protos
+ARG PYTHON_LIB=/usr/local/lib/python3.8
+
+COPY /protos/ ${MAGMA_ROOT}/protos/
+COPY /lte/protos/ ${MAGMA_ROOT}/lte/protos/
+COPY /orc8r/protos/ ${MAGMA_ROOT}/orc8r/protos/
+COPY /feg/protos/ ${MAGMA_ROOT}/feg/protos/
+COPY /dp/protos/ ${MAGMA_ROOT}/dp/protos/
+WORKDIR $MAGMA_ROOT
+RUN pip install mypy-protobuf && \
+    mkdir $PYTHON_LIB/gen && \
+    for PROTO_SRC in orc8r lte feg dp; \
+    do \
+    python protos/gen_protos.py ${PROTO_SRC}/protos ${MAGMA_ROOT},orc8r/protos/prometheus ${MAGMA_ROOT} $PYTHON_LIB/gen && \
+    python protos/gen_prometheus_proto.py ${MAGMA_ROOT} $PYTHON_LIB/gen; \
+    done && \
+    echo "$PYTHON_LIB/gen" > $PYTHON_LIB/dist-packages/magma_gen.pth
 
 RUN ln -s $MAGMA_ROOT/bazel/bazelrcs/devcontainer.bazelrc /etc/bazelrc
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
 		"ms-python.python",
 		"ms-python.vscode-pylance",
 		"njpwerner.autodocstring",
+		"zxh404.vscode-proto3",
 	],
 	"image": "ghcr.io/magma/magma/devcontainer:sha-206a67a",
 	"settings": {


### PR DESCRIPTION
## Summary

Generate Python proto files in DevContainer analogously to the make files (by using `gen_protos.py` and `gen_prometheus_proto.py` modules).

Add extension to VSCode:
 - [proto3 extension](https://marketplace.visualstudio.com/items?itemName=zxh404.vscode-proto3): understands proto (syntax highlighting, code completion, code formatting and more)

## Test Plan

Built DevContainer locally. Checked that proto modules can be imported.