### PR TITLE
chore(subscriberdb): Handle unknown ID in request gracefully

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/protocols/m5g_auth_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/m5g_auth_servicer.py
@@ -13,13 +13,14 @@ limitations under the License.
 
 import logging
 
+from grpc import StatusCode
 from lte.protos import (
     subscriberauth_pb2,
     subscriberauth_pb2_grpc,
     subscriberdb_pb2,
     subscriberdb_pb2_grpc,
 )
-from magma.common.rpc_utils import print_grpc
+from magma.common.rpc_utils import print_grpc, set_grpc_err
 from magma.subscriberdb import metrics
 from magma.subscriberdb.crypto.ECIES import ECIES_HN
 from magma.subscriberdb.crypto.utils import CryptoError
@@ -147,7 +148,14 @@ class M5GSUCIRegRpcServicer(subscriberdb_pb2_grpc.M5GSUCIRegistrationServicer):
         aia = subscriberdb_pb2.M5GSUCIRegistrationAnswer()
 
         try:
-            suciprofile = self.suciprofile_db[request.ue_pubkey_identifier]
+            suciprofile = self.suciprofile_db.get(request.ue_pubkey_identifier)
+            if suciprofile is None:
+                set_grpc_err(
+                    context,
+                    StatusCode.NOT_FOUND,
+                    f"identifier {request.ue_pubkey_identifier} not found",
+                )
+                return aia
 
             if suciprofile.protection_scheme == 0:
                 profile = 'A'


### PR DESCRIPTION
## Summary

Return a NOT_FOUND for an M5GDecryptImsiSUCIRegistration request where the public key identifier could not be found instead of failing with a KeyError.

Fixes #11407.

## Additional Information

- [ ] This change is backwards-breaking