### PR TITLE
chore: add python formatter and accompanying vscode settings to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -347,6 +347,9 @@ WORKDIR ${MAGMA_ROOT}/orc8r/gateway/python/
 RUN pip3 install --quiet --upgrade --no-build-isolation --no-cache-dir --verbose --editable .[dev] && \
     rm -rf orc8r.egg-info
 
+# install formatter autopep8
+RUN pip install --no-cache-dir autopep8
+
 #### protos
 ARG PYTHON_LIB=/usr/local/lib/python3.8
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -69,7 +69,18 @@
 			"/workspaces/magma/lte/gateway/python/",
 		],
 		"python.defaultInterpreterPath": "/usr/bin/python",
-	},
+		"python.formatting.provider": "autopep8",
+		"python.formatting.autopep8Args": [
+			// This should be the same set of flags as ones specified in `lte/gateway/precommit.py`
+			"--select=W191,W291,W292,W293,W391,E131,E2,E3"
+		],
+		"[python]": {
+			"editor.formatOnSave": true,
+			"editor.codeActionsOnSave": {
+				"source.organizeImports": true
+			}
+		}
+    },
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
 	],


### PR DESCRIPTION
## Summary

Install formatter (autopep8) and add respective VSCode settings (in python code: format on save, sort imports on save, use same options as in precommit.py script for autopep8).

## Test Plan

Tested locally.