### PR TITLE
fix(pipelined): qos object creation on activate flows.

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -190,7 +190,7 @@ class QosManager(object):
             if impl_type == QosImplType.OVS_METER:
                 self.impl = MeterManager(datapath, self._loop, self._config)
             else:
-                self.impl = TCManager(datapath, self._loop, self._config)
+                self.impl = TCManager(datapath, self._config)
             self.setup()
         except ValueError:
             LOG.error("%s is not a valid qos impl type", impl_type)

--- a/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
@@ -226,11 +226,9 @@ class TCManager(object):
     def __init__(
         self,
         datapath,
-        loop,
         config,
     ) -> None:
         self._datapath = datapath
-        self._loop = loop
         self._uplink = config['nat_iface']
         self._downlink = config['enodeb_iface']
         self._max_rate = config["qos"]["max_rate"]
@@ -310,7 +308,7 @@ class TCManager(object):
             LOG.error("qos create error: qid %d err %d", qid, err_no)
             return
 
-        LOG.debug("create done: qid %d err %s", qid, err_no)
+        LOG.debug("create done: if: %s qid %d err %s", intf, qid, err_no)
 
     def add_qos(
         self, d: FlowMatch.Direction, qos_info: QosInfo,
@@ -318,8 +316,8 @@ class TCManager(object):
     ) -> int:
         LOG.debug("add QoS: %s", qos_info)
         qid = self._id_manager.allocate_idx()
-        self._loop.call_soon_threadsafe(
-            self.create_class_async, d, qos_info,
+        self.create_class_async(
+            d, qos_info,
             qid, parent, skip_filter, cleanup_rule,
         )
         LOG.debug("assigned qid: %d", qid)


### PR DESCRIPTION
create qos object synchronously to avoid race of create and
delete policy.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
ran `make test`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
