### PR TITLE
fix(amf): Unit test case fix of stateless amf

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -953,11 +953,11 @@ TEST_F(AMFAppStatelessTest, TestAfterPDUSessionEstReq) {
   EXPECT_EQ(amf_supi_guti_map.size(), 1);
 
   /* Send ip address response  from pipelined */
-  rc = send_ip_address_response_itti();
+  rc = send_ip_address_response_itti(IPv4);
   EXPECT_EQ(rc, RETURNok);
 
   /* Send pdu session setup response  from smf */
-  rc = send_pdu_session_response_itti();
+  rc = send_pdu_session_response_itti(IPv4);
   EXPECT_EQ(rc, RETURNok);
 
   /* Send pdu resource setup response  from UE */
@@ -1044,11 +1044,11 @@ TEST_F(AMFAppStatelessTest, TestAfterPDUSessionReleaseComplete) {
   EXPECT_EQ(rc, RETURNok);
 
   /* Send ip address response  from pipelined */
-  rc = send_ip_address_response_itti();
+  rc = send_ip_address_response_itti(IPv4);
   EXPECT_EQ(rc, RETURNok);
 
   /* Send pdu session setup response  from smf */
-  rc = send_pdu_session_response_itti();
+  rc = send_pdu_session_response_itti(IPv4);
   EXPECT_EQ(rc, RETURNok);
 
   /* Send pdu resource setup response  from UE */


### PR DESCRIPTION
Signed-off-by: Rajeshs23 <rajesh.sure@wavelabs.ai>

    fix(amf): Unit test case fix of stateless amf
## Summary
Since Stateless feature PR and IPV6 PR are merged parallel there is test case error in stateless test case where we need to specify the pdu type which previously not needed. So this lead to the error. It is modified and given specific type. Now this is resolved and test cases are passing.

## Test Plan

- Verified UT cases

## Additional Information
Error occurred:
![testcasesfail](https://user-images.githubusercontent.com/91061578/152760052-f596e922-01ab-4346-8aa2-a08e1f107b38.PNG)
Unit Test cases passing after resolving:
![testcasepass](https://user-images.githubusercontent.com/91061578/152760141-6987b27b-3209-407b-9011-fc9148fc4af9.PNG)
