### PR TITLE
feat(ci): Set token permissions to read only

### DIFF
--- a/.github/workflows/agw-docker-load-test.yaml
+++ b/.github/workflows/agw-docker-load-test.yaml
@@ -13,6 +13,8 @@ on:  # yamllint disable-line rule:truthy
 
 concurrency: ${{ github.workflow }}
 
+permissions: read-all
+
 jobs:
   docker-load-test:
     name: agw docker load tests

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -21,6 +21,8 @@ env:
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 
+permissions: read-all
+
 jobs:
   path_filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/amis-workflow.yml
+++ b/.github/workflows/amis-workflow.yml
@@ -9,6 +9,8 @@ on:  # yamllint disable-line rule:truthy
 env:
   MAGMA_VERSION: "1.7.0"
 
+permissions: read-all
+
 jobs:
   publish-amis-to-marketplace:
     name: publish-amis-to-marketplace job

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -29,6 +29,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   AutoLabelPR:
     runs-on: ubuntu-latest

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,6 +6,8 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
 
+permissions: read-all
+
 jobs:
   backport:
     name: backport

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -23,6 +23,9 @@ env:
 
   DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
 
+permissions:
+  contents: read
+
 jobs:
   bazel-build-magma-vm-and-push-cache:
     runs-on: macos-10.15

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -25,6 +25,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   path_filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -12,6 +12,8 @@ on:  # yamllint disable-line rule:truthy
       - 'v1.*'
     types: [opened, reopened, synchronize]
 
+permissions: read-all
+
 jobs:
   build_publish_helm_charts:
     if: github.repository_owner == 'magma'

--- a/.github/workflows/check-rebase.yml
+++ b/.github/workflows/check-rebase.yml
@@ -7,6 +7,9 @@ on:  # yamllint disable-line rule:truthy
       - master
       - 'v1.*'
 
+permissions:
+  contents: read
+
 jobs:
   checkRebase:
     runs-on: ubuntu-latest

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -16,6 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   path_filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeowners-syntax.yml
+++ b/.github/workflows/codeowners-syntax.yml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   sanity:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event.workflow.name }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   skip_check:
     name: Job to check if the workflow ${{ github.event.workflow.name }} can be skipped

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -16,6 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   path_filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -15,6 +15,8 @@ on:  # yamllint disable-line rule:truthy
 env:
   SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
 
+permissions: read-all
+
 jobs:
   docker-build:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -15,6 +15,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   path_filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -8,6 +8,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   reverted-pr-check:
     name: Reverted PR Check Job

--- a/.github/workflows/deploy-build-from-pr.yml
+++ b/.github/workflows/deploy-build-from-pr.yml
@@ -7,6 +7,9 @@ on:  # yamllint disable-line rule:truthy
       - build-all
     types:
       - completed
+
+permissions: read-all
+
 # Replace registries with new test registries reserved for PR builds
 jobs:
   deploy:

--- a/.github/workflows/docker-builder-bazel-base.yml
+++ b/.github/workflows/docker-builder-bazel-base.yml
@@ -26,6 +26,8 @@ env:
   IMAGE_TAGS: type=sha
   DOCKERFILE: experimental/bazel-base/Dockerfile
 
+permissions: read-all
+
 jobs:
   build_dockerfile:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -26,6 +26,8 @@ env:
   IMAGE_TAGS: type=sha
   DOCKERFILE: .devcontainer/Dockerfile
 
+permissions: read-all
+
 jobs:
   build_dockerfile:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -26,6 +26,8 @@ env:
   IMAGE_TAGS: type=sha
   DOCKERFILE: lte/gateway/docker/python-precommit/Dockerfile
 
+permissions: read-all
+
 jobs:
   build_dockerfile:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   path_filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/docusaurus-workflow.yml
+++ b/.github/workflows/docusaurus-workflow.yml
@@ -5,6 +5,9 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - master
+
+permissions: read-all
+
 jobs:
   docusaurus-build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -11,6 +11,8 @@ on:  # yamllint disable-line rule:truthy
       - 'v1.*'
     types: [opened, reopened, synchronize]
 
+permissions: read-all
+
 jobs:
   path_filter:
     runs-on: ubuntu-latest
@@ -127,6 +129,9 @@ jobs:
           verbose: true
 
   active_mode_controller_unit_tests:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     needs: path_filter
     if: ${{ needs.path_filter.outputs.am == 'true' }}
     name: "Active mode controller unit tests"

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -17,6 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   path_filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/fossa-workflow.yml
+++ b/.github/workflows/fossa-workflow.yml
@@ -15,6 +15,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   fossa-analyze:
     env:

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -31,6 +31,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 # See [Example Sharing Container Between Jobs](https://github.com/docker/build-push-action/issues/225)
 jobs:
   path_filter:

--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -18,6 +18,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   pre_job_src_go_determinator:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -20,6 +20,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   check_helm_chart_dependencies:
     env:

--- a/.github/workflows/helm-deploy-on-demand.yml
+++ b/.github/workflows/helm-deploy-on-demand.yml
@@ -4,6 +4,9 @@ name: helm-build-on-demand
 # Temporary on demand Job until we refactor helm build job in build-all
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   build_publish_helm_charts_on_demand:
     env:

--- a/.github/workflows/insync-checkin.yml
+++ b/.github/workflows/insync-checkin.yml
@@ -16,6 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   insync-checkin:
     name: insync checkin job

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -13,6 +13,8 @@ on:  # yamllint disable-line rule:truthy
     types:
       - completed
 
+permissions: read-all
+
 jobs:
   lte-integ-test:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/nms-workflow.yml
+++ b/.github/workflows/nms-workflow.yml
@@ -19,6 +19,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   path_filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -6,6 +6,8 @@ on:  # yamllint disable-line rule:truthy
   pull_request_target:
     types: [opened]
 
+permissions: read-all
+
 jobs:
   # This job is a manual approximation of https://github.com/peter-evans/create-or-update-comment
   comment:

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -18,6 +18,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   pre_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -3,9 +3,14 @@ name: Automatic Rebase
 on:  # yamllint disable-line rule:truthy
   issue_comment:
     types: [created]
+permissions:
+  contents: read
+
 jobs:
   # This job is based on https://github.com/marketplace/actions/automatic-rebase
   rebase:
+    permissions:
+      contents: none
     name: Rebase
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest

--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -15,6 +15,8 @@ concurrency:
 # github-pr-check: Adds lint as annotations in the PR that can be toggled by pressing 'a'
 # github-pr-review: Adds lint as GitHub comments
 
+permissions: read-all
+
 jobs:
   pre_job_go_determinator:
     runs-on: ubuntu-latest
@@ -47,6 +49,10 @@ jobs:
               - [".github/workflows/reviewdog-workflow.yml", "lte/gateway/c/**", "orc8r/gateway/c/**"]
 
   cpplint:
+    permissions:
+      checks: write  # for reviewdog
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: write  # for reviewdog
     needs: pre_job_c_cpp_determinator
     if: ${{ needs.pre_job_c_cpp_determinator.outputs.should_not_skip == 'true' }}
     ##
@@ -83,6 +89,9 @@ jobs:
             | ./reviewdog -efm="%f:%l: %m" -name="cpplint" -reporter="github-pr-check" -level="warning"
 
   golangci-lint:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: write  # for reviewdog/action-golangci-lint to report issues using PR comments
     needs: pre_job_go_determinator
     if: ${{ needs.pre_job_go_determinator.outputs.should_not_skip == 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -13,6 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   reverted-pr-check:
     name: Reverted PR Check Job

--- a/.github/workflows/testim-workflow.yml
+++ b/.github/workflows/testim-workflow.yml
@@ -6,6 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   testim_check_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -11,6 +11,8 @@ on:  # yamllint disable-line rule:truthy
     types:
       - completed
 
+permissions: read-all
+
 jobs:
   skip_check:
     name: Job to retrieve the value in pr/skipped file

--- a/src/go/capture/gen/main.go
+++ b/src/go/capture/gen/main.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -97,7 +98,7 @@ func parsePrecommitTestsFromMakefile(path string) []string {
 	prefix := "s1aptests/test_"
 	suffix := " \\"
 
-	fileb, err := os.ReadFile(path)
+	fileb, err := ioutil.ReadFile(path)
 	if err != nil {
 		println("failed to read in makefile")
 		panic(err)
@@ -151,7 +152,7 @@ func runAndCaptureTests(ctx context.Context, dir, outputPathFmt string, captureC
 		// Write out golden file.
 		goldenfilename := fmt.Sprintf(outputPathFmt, test)
 		println(goldenfilename)
-		err = os.WriteFile(goldenfilename, []byte(resp.Recording.String()), 0666)
+		err = ioutil.WriteFile(goldenfilename, []byte(resp.Recording.String()), 0666)
 		if err != nil {
 			println("failed to write golden")
 			panic(err)


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

feat(ci): Set token permissions to read only

## Summary

The OpenSSF Scorecard flagged a number of Dangerous-Workflow items. This check "Determines if the project's GitHub Action workflows avoid dangerous patterns." For detailed background see https://github.com/ossf/scorecard/blob/5d3f19838078ad86630f1f80c5ad051249594a1a/docs/checks.md#token-permissions
There were 42 instances of non read-only tokens detected in GitHub workflows. [See token-permissions.txt](https://github.com/ospoco/magma-issue-tracker/files/7946382/token-permissions.txt)

In all files I added top level permissions set to read-all. I also used online tool https://app.stepsecurity.io/


## Additional Information
This is for issue: https://github.com/ospoco/magma-issue-tracker/issues/54

