### PR TITLE
feat: migrate filter list to opt-out

### DIFF
--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -139,10 +139,7 @@
         "dsn_python": "",
         "sample_rate": 1.0,
         "upload_mme_log": false,
-        "exclusion_patterns": [
-          "ConnectionError",
-          "CheckinError",
-        ]
+        "exclusion_patterns": []
       }
     },
     "state": {

--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -140,18 +140,8 @@
         "sample_rate": 1.0,
         "upload_mme_log": false,
         "exclusion_patterns": [
-          "GetServiceInfo",
-          "GetOperationalStates",
           "ConnectionError",
           "CheckinError",
-          "Checkin Error",
-          "GetChallenge error!",
-          "Connection to FluentBit",
-          "\\[SyncRPC\\]",
-          "Metrics upload error",
-          "Streaming from the cloud failed!",
-          "Fetch subscribers error!",
-          "GRPC call failed for state replication"
         ]
       }
     },

--- a/lte/gateway/python/magma/subscriberdb/client.py
+++ b/lte/gateway/python/magma/subscriberdb/client.py
@@ -235,12 +235,7 @@ class SubscriberDBCloudClient(SDWatchdogTask):
                 found_empty_token = req_page_token == ""
 
             except grpc.RpcError as err:
-                logging.error(
-                    "Fetch subscribers error! [%s] %s",
-                    err.code(),
-                    err.details(),
-                    extra=EXCLUDE_FROM_ERROR_MONITORING,
-                )
+                _log_grpc_error(err)
                 time_elapsed = datetime.datetime.now() - sync_start
                 SUBSCRIBER_SYNC_LATENCY.observe(
                     time_elapsed.total_seconds() * 1000,

--- a/lte/gateway/python/magma/subscriberdb/client.py
+++ b/lte/gateway/python/magma/subscriberdb/client.py
@@ -236,8 +236,10 @@ class SubscriberDBCloudClient(SDWatchdogTask):
 
             except grpc.RpcError as err:
                 logging.error(
-                    "Fetch subscribers error! [%s] %s", err.code(),
+                    "Fetch subscribers error! [%s] %s",
+                    err.code(),
                     err.details(),
+                    extra=EXCLUDE_FROM_ERROR_MONITORING,
                 )
                 time_elapsed = datetime.datetime.now() - sync_start
                 SUBSCRIBER_SYNC_LATENCY.observe(

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -9970,9 +9970,7 @@ definitions:
     type: object
   network_sentry_config:
     default:
-      exclusion_patterns:
-      - ConnectionError
-      - CheckinError
+      exclusion_patterns: []
       sample_rate: 1
       upload_mme_log: false
     description: Sentry.io configuration

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -9971,18 +9971,8 @@ definitions:
   network_sentry_config:
     default:
       exclusion_patterns:
-      - GetServiceInfo
-      - GetOperationalStates
       - ConnectionError
       - CheckinError
-      - Checkin Error
-      - GetChallenge error!
-      - Connection to FluentBit
-      - \[SyncRPC\]
-      - Metrics upload error
-      - Streaming from the cloud failed!
-      - Fetch subscribers error!
-      - GRPC call failed for state replication
       sample_rate: 1
       upload_mme_log: false
     description: Sentry.io configuration

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/network_sentry_config_swaggergen.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/network_sentry_config_swaggergen.go
@@ -45,7 +45,7 @@ type NetworkSentryConfig struct {
 func (m *NetworkSentryConfig) UnmarshalJSON(b []byte) error {
 	type NetworkSentryConfigAlias NetworkSentryConfig
 	var t NetworkSentryConfigAlias
-	if err := json.Unmarshal([]byte("{\"exclusion_patterns\":[\"ConnectionError\",\"CheckinError\"],\"sample_rate\":1,\"upload_mme_log\":false}"), &t); err != nil {
+	if err := json.Unmarshal([]byte("{\"exclusion_patterns\":[],\"sample_rate\":1,\"upload_mme_log\":false}"), &t); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(b, &t); err != nil {

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/network_sentry_config_swaggergen.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/network_sentry_config_swaggergen.go
@@ -45,7 +45,7 @@ type NetworkSentryConfig struct {
 func (m *NetworkSentryConfig) UnmarshalJSON(b []byte) error {
 	type NetworkSentryConfigAlias NetworkSentryConfig
 	var t NetworkSentryConfigAlias
-	if err := json.Unmarshal([]byte("{\"exclusion_patterns\":[\"GetServiceInfo\",\"GetOperationalStates\",\"ConnectionError\",\"CheckinError\",\"Checkin Error\",\"GetChallenge error!\",\"Connection to FluentBit\",\"\\\\[SyncRPC\\\\]\",\"Metrics upload error\",\"Streaming from the cloud failed!\",\"Fetch subscribers error!\",\"GRPC call failed for state replication\"],\"sample_rate\":1,\"upload_mme_log\":false}"), &t); err != nil {
+	if err := json.Unmarshal([]byte("{\"exclusion_patterns\":[\"ConnectionError\",\"CheckinError\"],\"sample_rate\":1,\"upload_mme_log\":false}"), &t); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(b, &t); err != nil {

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/swagger.v1.yml
@@ -1466,9 +1466,7 @@ definitions:
     default:
       upload_mme_log: false
       sample_rate: 1
-      exclusion_patterns:
-        - 'ConnectionError'
-        - 'CheckinError'
+      exclusion_patterns: []
 
   state_config:
     type: object

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/swagger.v1.yml
@@ -1467,18 +1467,8 @@ definitions:
       upload_mme_log: false
       sample_rate: 1
       exclusion_patterns:
-        - 'GetServiceInfo'
-        - 'GetOperationalStates'
         - 'ConnectionError'
         - 'CheckinError'
-        - 'Checkin Error'
-        - 'GetChallenge error!'
-        - 'Connection to FluentBit'
-        - '\[SyncRPC\]'
-        - 'Metrics upload error'
-        - 'Streaming from the cloud failed!'
-        - 'Fetch subscribers error!'
-        - 'GRPC call failed for state replication'
 
   state_config:
     type: object

--- a/orc8r/gateway/python/magma/common/streamer.py
+++ b/orc8r/gateway/python/magma/common/streamer.py
@@ -22,6 +22,7 @@ import snowflake
 from google.protobuf import any_pb2
 from magma.common import serialization_utils
 from magma.common.metrics import STREAMER_RESPONSES
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from magma.configuration.service_configs import get_service_config_value
 from orc8r.protos.streamer_pb2 import DataUpdate, StreamRequest
@@ -125,7 +126,9 @@ class StreamerClient(threading.Thread):
             except grpc.RpcError as err:
                 logging.error(
                     "Error! Streaming from the cloud failed! [%s] %s",
-                    err.code(), err.details(),
+                    err.code(),
+                    err.details(),
+                    extra=EXCLUDE_FROM_ERROR_MONITORING,
                 )
                 STREAMER_RESPONSES.labels(result='RpcError').inc()
             except ValueError as err:

--- a/orc8r/gateway/python/magma/common/streamer.py
+++ b/orc8r/gateway/python/magma/common/streamer.py
@@ -22,6 +22,7 @@ import snowflake
 from google.protobuf import any_pb2
 from magma.common import serialization_utils
 from magma.common.metrics import STREAMER_RESPONSES
+from magma.common.rpc_utils import indicates_connection_error
 from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from magma.configuration.service_configs import get_service_config_value
@@ -128,7 +129,7 @@ class StreamerClient(threading.Thread):
                     "Error! Streaming from the cloud failed! [%s] %s",
                     err.code(),
                     err.details(),
-                    extra=EXCLUDE_FROM_ERROR_MONITORING,
+                    extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
                 )
                 STREAMER_RESPONSES.labels(result='RpcError').inc()
             except ValueError as err:

--- a/orc8r/gateway/python/magma/eventd/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/eventd/rpc_servicer.py
@@ -20,6 +20,7 @@ from typing import Any, Dict
 import grpc
 import jsonschema
 from magma.common.rpc_utils import return_void
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.eventd.event_validator import EventValidator
 from orc8r.protos import eventd_pb2, eventd_pb2_grpc
 
@@ -77,7 +78,11 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
                 logging.debug('Sending log to FluentBit')
                 sock.sendall(json.dumps(value).encode('utf-8'))
         except socket.error as e:
-            logging.error('Connection to FluentBit failed: %s', e)
+            logging.error(
+                'Connection to FluentBit failed: %s',
+                e,
+                extra=EXCLUDE_FROM_ERROR_MONITORING,
+            )
             logging.info(
                 'FluentBit (td-agent-bit) may not be enabled '
                 'or configured correctly',

--- a/orc8r/gateway/python/magma/magmad/bootstrap_manager.py
+++ b/orc8r/gateway/python/magma/magmad/bootstrap_manager.py
@@ -26,7 +26,10 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 from google.protobuf.duration_pb2 import Duration
-from magma.common.rpc_utils import grpc_async_wrapper
+from magma.common.rpc_utils import (
+    grpc_async_wrapper,
+    indicates_connection_error,
+)
 from magma.common.sdwatchdog import SDWatchdogTask
 from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
@@ -244,7 +247,7 @@ class BootstrapManager(SDWatchdogTask):
             "GetChallenge error! [%s] %s",
             err.code(),
             err.details(),
-            extra=EXCLUDE_FROM_ERROR_MONITORING,
+            extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
         )
         BOOTSTRAP_EXCEPTION.labels(cause='GetChallengeResp').inc()
         self._schedule_next_bootstrap(hard_failure=False)

--- a/orc8r/gateway/python/magma/magmad/bootstrap_manager.py
+++ b/orc8r/gateway/python/magma/magmad/bootstrap_manager.py
@@ -28,6 +28,7 @@ from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 from google.protobuf.duration_pb2 import Duration
 from magma.common.rpc_utils import grpc_async_wrapper
 from magma.common.sdwatchdog import SDWatchdogTask
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from magma.configuration.service_configs import load_service_config
 from magma.magmad.metrics import BOOTSTRAP_EXCEPTION
@@ -239,8 +240,12 @@ class BootstrapManager(SDWatchdogTask):
         await self._request_sign(response)
 
     def _get_challenge_done_fail(self, err):
-        err = 'GetChallenge error! [%s] %s' % (err.code(), err.details())
-        logging.error(err)
+        logging.error(
+            "GetChallenge error! [%s] %s",
+            err.code(),
+            err.details(),
+            extra=EXCLUDE_FROM_ERROR_MONITORING,
+        )
         BOOTSTRAP_EXCEPTION.labels(cause='GetChallengeResp').inc()
         self._schedule_next_bootstrap(hard_failure=False)
 

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -20,6 +20,7 @@ import metrics_pb2
 import prometheus_client.core
 import requests
 import snowflake
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos import metricsd_pb2
 from orc8r.protos.common_pb2 import Void
@@ -135,9 +136,12 @@ class MetricsCollector(object):
         err = collect_future.exception()
         if err:
             logging.error(
-                "Metrics upload error for service %s (chunk %d)! "
-                "[%s] %s", service_name, chunk, err.code(),
+                "Metrics upload error for service %s (chunk %d)! [%s] %s",
+                service_name,
+                chunk,
+                err.code(),
                 err.details(),
+                extra=EXCLUDE_FROM_ERROR_MONITORING,
             )
         else:
             logging.debug(
@@ -296,7 +300,9 @@ class MetricsCollector(object):
         if err:
             logging.error(
                 "Prometheus Target Metrics upload error! [%s] %s",
-                err.code(), err.details(),
+                err.code(),
+                err.details(),
+                extra=EXCLUDE_FROM_ERROR_MONITORING,
             )
         else:
             logging.debug(

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -20,6 +20,7 @@ import metrics_pb2
 import prometheus_client.core
 import requests
 import snowflake
+from magma.common.rpc_utils import indicates_connection_error
 from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos import metricsd_pb2
@@ -141,7 +142,7 @@ class MetricsCollector(object):
                 chunk,
                 err.code(),
                 err.details(),
-                extra=EXCLUDE_FROM_ERROR_MONITORING,
+                extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
             )
         else:
             logging.debug(
@@ -302,7 +303,7 @@ class MetricsCollector(object):
                 "Prometheus Target Metrics upload error! [%s] %s",
                 err.code(),
                 err.details(),
-                extra=EXCLUDE_FROM_ERROR_MONITORING,
+                extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
             )
         else:
             logging.debug(

--- a/orc8r/gateway/python/magma/magmad/proxy_client.py
+++ b/orc8r/gateway/python/magma/magmad/proxy_client.py
@@ -15,6 +15,7 @@ import logging
 
 import aioh2
 import h2.events
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos.sync_rpc_service_pb2 import GatewayResponse, SyncRPCResponse
 
@@ -64,9 +65,9 @@ class ControlProxyHttpClient(object):
         # pylint: enable=protected-access
 
         if req_id in self._connection_table:
-            logging.error(
-                "[SyncRPC] proxy_client is already handling "
-                "request ID %s", req_id,
+            logging.warning(
+                "[SyncRPC] proxy_client is already handling request ID %s",
+                req_id,
             )
             sync_rpc_response_queue.put(
                 SyncRPCResponse(
@@ -100,12 +101,14 @@ class ControlProxyHttpClient(object):
             )
         except ConnectionAbortedError:
             logging.error(
-                "[SyncRPC] proxy_client connection "
-                "terminated by cloud",
+                "[SyncRPC] proxy_client connection terminated by cloud",
+                extra=EXCLUDE_FROM_ERROR_MONITORING,
             )
         except Exception as e:  # pylint: disable=broad-except
             logging.error(
-                "[SyncRPC] Exception in proxy_client: %s", e,
+                "[SyncRPC] Exception in proxy_client: %s",
+                e,
+                extra=EXCLUDE_FROM_ERROR_MONITORING,
             )
             sync_rpc_response_queue.put(
                 SyncRPCResponse(
@@ -121,6 +124,7 @@ class ControlProxyHttpClient(object):
                 logging.error(
                     '[SyncRPC] Error while trying to close conn: %s',
                     str(e),
+                    extra=EXCLUDE_FROM_ERROR_MONITORING,
                 )
 
     def close_all_connections(self):
@@ -132,6 +136,7 @@ class ControlProxyHttpClient(object):
                 logging.error(
                     '[SyncRPC] Error while trying to close conn: %s',
                     str(e),
+                    extra=EXCLUDE_FROM_ERROR_MONITORING,
                 )
         self._connection_table.clear()
 

--- a/orc8r/gateway/python/magma/magmad/service_poller.py
+++ b/orc8r/gateway/python/magma/magmad/service_poller.py
@@ -18,6 +18,7 @@ from typing import List
 import grpc
 from magma.common.job import Job
 from magma.common.rpc_utils import grpc_async_wrapper
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from magma.magmad.metrics import UNEXPECTED_SERVICE_RESTARTS
 from orc8r.protos.common_pb2 import Void
@@ -182,5 +183,6 @@ class ServicePoller(Job):
                     service,
                     err.code(),
                     err.details(),
+                    extra=EXCLUDE_FROM_ERROR_MONITORING,
                 )
                 self._service_info[service].continuous_timeouts += 1

--- a/orc8r/gateway/python/magma/magmad/service_poller.py
+++ b/orc8r/gateway/python/magma/magmad/service_poller.py
@@ -17,7 +17,10 @@ from typing import List
 
 import grpc
 from magma.common.job import Job
-from magma.common.rpc_utils import grpc_async_wrapper
+from magma.common.rpc_utils import (
+    grpc_async_wrapper,
+    indicates_connection_error,
+)
 from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from magma.magmad.metrics import UNEXPECTED_SERVICE_RESTARTS
@@ -183,6 +186,6 @@ class ServicePoller(Job):
                     service,
                     err.code(),
                     err.details(),
-                    extra=EXCLUDE_FROM_ERROR_MONITORING,
+                    extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
                 )
                 self._service_info[service].continuous_timeouts += 1

--- a/orc8r/gateway/python/magma/magmad/state_reporter.py
+++ b/orc8r/gateway/python/magma/magmad/state_reporter.py
@@ -78,7 +78,9 @@ class StateReporterErrorHandler:
         """
         logging.error(
             "Checkin Error! Failed to report states. [%s] %s",
-            err.code(), err.details(),
+            err.code(),
+            err.details(),
+            extra=EXCLUDE_FROM_ERROR_MONITORING,
         )
         CHECKIN_STATUS.set(0)
         self.num_failed_state_reporting += 1

--- a/orc8r/gateway/python/magma/magmad/state_reporter.py
+++ b/orc8r/gateway/python/magma/magmad/state_reporter.py
@@ -22,6 +22,7 @@ from magma.common.cert_validity import cert_is_invalid
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.rpc_utils import grpc_async_wrapper
 from magma.common.sdwatchdog import SDWatchdogTask
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service import get_service303_client
 from magma.common.service_registry import ServiceRegistry
 from magma.magmad.bootstrap_manager import BootstrapManager
@@ -236,7 +237,10 @@ class StateReporter(SDWatchdogTask):
         except Exception as err:
             logging.error(
                 "GetOperationalStates Error for %s! [%s] %s",
-                service, err.code(), err.details(),
+                service,
+                err.code(),
+                err.details(),
+                extra=EXCLUDE_FROM_ERROR_MONITORING,
             )
             return []
 

--- a/orc8r/gateway/python/magma/magmad/state_reporter.py
+++ b/orc8r/gateway/python/magma/magmad/state_reporter.py
@@ -20,7 +20,10 @@ import grpc
 import snowflake
 from magma.common.cert_validity import cert_is_invalid
 from magma.common.grpc_client_manager import GRPCClientManager
-from magma.common.rpc_utils import grpc_async_wrapper
+from magma.common.rpc_utils import (
+    grpc_async_wrapper,
+    indicates_connection_error,
+)
 from magma.common.sdwatchdog import SDWatchdogTask
 from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service import get_service303_client
@@ -80,7 +83,7 @@ class StateReporterErrorHandler:
             "Checkin Error! Failed to report states. [%s] %s",
             err.code(),
             err.details(),
-            extra=EXCLUDE_FROM_ERROR_MONITORING,
+            extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
         )
         CHECKIN_STATUS.set(0)
         self.num_failed_state_reporting += 1
@@ -242,7 +245,7 @@ class StateReporter(SDWatchdogTask):
                 service,
                 err.code(),
                 err.details(),
-                extra=EXCLUDE_FROM_ERROR_MONITORING,
+                extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
             )
             return []
 

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -268,6 +268,7 @@ class StateReplicator(SDWatchdogTask):
             logging.error(
                 "GRPC call failed for state replication: %s",
                 err,
+                extra=EXCLUDE_FROM_ERROR_MONITORING,
             )
         else:
             unreplicated_states = set()

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -268,7 +268,7 @@ class StateReplicator(SDWatchdogTask):
             logging.error(
                 "GRPC call failed for state replication: %s",
                 err,
-                extra=EXCLUDE_FROM_ERROR_MONITORING,
+                extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
             )
         else:
             unreplicated_states = set()


### PR DESCRIPTION
## Summary

Resolves https://github.com/magma/magma/issues/11211.

For the patterns configured as filters in sentry, which are persisted at [gateway.mcnofig](https://github.com/magma/magma/blob/master/lte/gateway/configs/gateway.mconfig#L142-L154) and [swagger.v1.yml](https://github.com/magma/magma/blob/master/orc8r/cloud/go/services/orchestrator/obsidian/models/swagger.v1.yml) we implemented most as opt-out.

- :heavy_check_mark: ~~The filter string `CheckinError` was not found via full text search within the repository. It might be a duplication of `Checkin Error` or come from a third party library.~~
- :heavy_check_mark: ~~The filter string `ConnectionError` was not found via full text search within the repository.~~
  - It might come from a third party library. GRPC errors need to be checked. The respective String might show up in those.
    - subscriberdb_client.py - needs to be scrutinized
  - The following files were checked, but no interesting call could be found.
    - state_recovery.py
    - service_manager.py
    - rpc_servicer.py
    - enforcment_stats.py
- Temporarily turned off server side filters for `CheckinError` and `ConnectionError` for 4h. No errors detected during that time.
:arrow_right: Assumed safe to be removed.

_Can be reviewed commit wise, if desired._

## Test Plan

- CI
  - Affected by https://github.com/magma/magma/issues/11362
- Temporarily turned off server side filters for `CheckinError` and `ConnectionError` for 4h. No errors detected during that time.

## Additional Information

- Done in pairing with @alexzurbonsen .
- Thanks to @sebathomas for input on additional improvements.
- The file to be changed manually is [swagger.v1.yml](https://github.com/magma/magma/blob/master/orc8r/cloud/go/services/orchestrator/obsidian/models/swagger.v1.yml).
The patterns can also be found in [other `swagger.yml` files](https://github.com/magma/magma/blob/master/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml#L9971) and go code. However those files are automatically created by `./build.py --generate` from the `orc8r/cloud/docker` directory.
More details are described in [first comment of #10276](https://github.com/magma/magma/pull/10276#discussion_r748615949).
  - The manually and generated changes are in two different commits in this PR to make it more clear.
- :warning: **_Server side_ filters need to stay active unchanged as long as there are instances with v1.6 out in the wild.**