### PR TITLE
fix: modify poll interval to check for new version in magmad

### DIFF
--- a/orc8r/gateway/python/magma/magmad/metrics.py
+++ b/orc8r/gateway/python/magma/magmad/metrics.py
@@ -24,7 +24,7 @@ from magma.magmad.check.network_check import ping
 from orc8r.protos.mconfig import mconfigs_pb2
 from prometheus_client import Counter, Gauge
 
-POLL_INTERVAL_SECONDS = 10
+POLL_INTERVAL_SECONDS = 100
 
 MAGMAD_PING_STATS = Gauge(
     'magmad_ping_rtt_ms',


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Magmad is getting clogged with lots of tasks to be run with asycio. That causes high latencies that are jeopardizing other tasks: for example syn_grpc sometimes takes 10s to resopnd back a messge

This change aims to  increases the poll time to check if version of AGW should be updated. That will leave more cycles on magmad for other tasks


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
