### PR TITLE
feat(agw): Enable Sentry monitoring for LiAgentD

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -245,6 +245,12 @@ jobs:
           SENTRY_ORG: lf-9c
           PATH_TO_EXEC: "./executables"
           SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
+      - uses: ./.github/workflows/composite/sentry-create-and-upload-artifacts
+        with:
+          EXECUTABLE_NAME: liagentd
+          SENTRY_ORG: lf-9c
+          PATH_TO_EXEC: "./executables"
+          SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
       - name: Create a release in Sentry.io with the commit hash
         env:
           SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -23,6 +23,7 @@ cc_binary(
         ":interface_monitor",
         "//orc8r/gateway/c/common/config:mconfig_loader",
         "//orc8r/gateway/c/common/logging",
+        "//orc8r/gateway/c/common/sentry:sentry_wrapper",
         "//orc8r/gateway/c/common/service303",
     ],
 )

--- a/lte/gateway/c/li_agent/src/CMakeLists.txt
+++ b/lte/gateway/c/li_agent/src/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(SERVICE_REGISTRY REQUIRED)
 find_package(MAGMA_CONFIG REQUIRED)
 find_package(ASYNC_GRPC REQUIRED)
 find_package(MAGMA_LOGGING REQUIRED)
+find_package(MAGMA_SENTRY REQUIRED)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 
@@ -76,7 +77,7 @@ add_library(LI_AGENT
     ${PROTO_HDRS})
 
 target_link_libraries(LI_AGENT
-    SERVICE303_LIB SERVICE_REGISTRY MAGMA_CONFIG ASYNC_GRPC MAGMA_LOGGING
+    SERVICE303_LIB SERVICE_REGISTRY MAGMA_CONFIG ASYNC_GRPC MAGMA_LOGGING MAGMA_SENTRY
     glog gflags folly pthread ${GCOV_LIB} grpc++ grpc yaml-cpp protobuf cpp_redis
     prometheus-cpp tacopie mnl tins pcap ssl crypto uuid
     )

--- a/lte/gateway/c/li_agent/src/main.cpp
+++ b/lte/gateway/c/li_agent/src/main.cpp
@@ -24,6 +24,7 @@
 #include "lte/gateway/c/li_agent/src/ProxyConnector.h"
 #include "lte/gateway/c/li_agent/src/Utilities.h"
 #include "orc8r/gateway/c/common/logging/magma_logging_init.h"
+#include "orc8r/gateway/c/common/sentry/includes/SentryWrapper.h"
 
 static uint32_t get_log_verbosity(const YAML::Node& config,
                                   magma::mconfig::LIAgentD mconfig) {
@@ -66,6 +67,9 @@ int main(void) {
     MLOG(MINFO) << "LI Agent service disabled";
     return 0;
   }
+
+  sentry_config_t sentry_config = construct_sentry_config_from_mconfig();
+  initialize_sentry(SENTRY_TAG_LI_AGENTD, &sentry_config);
 
   MLOG(MINFO) << "Starting LI Agent service " << config;
 
@@ -111,5 +115,6 @@ int main(void) {
     return -1;
   }
 
+  shutdown_sentry();
   return 0;
 }

--- a/orc8r/gateway/c/common/sentry/includes/SentryWrapper.h
+++ b/orc8r/gateway/c/common/sentry/includes/SentryWrapper.h
@@ -21,6 +21,7 @@ extern "C" {
 #define SENTRY_TAG_MME "MME"
 #define SENTRY_TAG_CONNECTIOND "ConnectionD"
 #define SENTRY_TAG_SESSIOND "SessionD"
+#define SENTRY_TAG_LI_AGENTD "LiAgentD"
 #define SENTRY_TAG_SCTPD "SctpD"
 #define SENTRY_TAG_LEN 16
 #define SENTRY_DB_PREFIX ".sentry-native-"


### PR DESCRIPTION
## Summary

Set up Sentry monitoring for liagentd.

Fixes #9511.

## Test Plan

Sent events to a Sentry test account. This didn't work in the VM without adding a wait time in the main thread, otherwise the service would shut down before being able to connect to Sentry. However, that's only a problem in the VM setup and shouldn't be an issue in production because there the service can actually run.

![liagent_sentry](https://user-images.githubusercontent.com/14236667/152982926-b7ce44a2-0467-43ea-aa8e-9569afc13c62.png)

## Additional Information

- [ ] This change is backwards-breaking
