### PR TITLE
chore: adapt devcontainer for easier bazel migration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,6 +67,7 @@ RUN echo "Install general purpose packages" && \
         libtool \
         lld \
         make \
+        netbase \
         ninja-build \
         perl \
         pkg-config \
@@ -339,12 +340,12 @@ RUN patch -N -s -f /usr/local/lib/python3.8/dist-packages/aioeventlet.py < /tmp/
 ### install eggs (lte, orc8r)
 COPY /lte/gateway/python/ ${MAGMA_ROOT}/lte/gateway/python/
 WORKDIR ${MAGMA_ROOT}/lte/gateway/python/
-RUN pip3 install --quiet --upgrade --no-build-isolation --no-cache-dir --verbose --editable .[dev] && \
+RUN pip3 install --quiet --upgrade --no-build-isolation --no-cache-dir --verbose .[dev] && \
     rm -rf lte.egg-info
 
 COPY /orc8r/gateway/python/ ${MAGMA_ROOT}/orc8r/gateway/python/
 WORKDIR ${MAGMA_ROOT}/orc8r/gateway/python/
-RUN pip3 install --quiet --upgrade --no-build-isolation --no-cache-dir --verbose --editable .[dev] && \
+RUN pip3 install --quiet --upgrade --no-build-isolation --no-cache-dir --verbose .[dev] && \
     rm -rf orc8r.egg-info
 
 #### protos


### PR DESCRIPTION
## Summary

Apt-install the netbase package.

Temporarily pip-install lte and orc8r package/code without `--editable` flag, that is install package normally, not in development mode. The development mode creates an easy-install.pth file in `dist-packages` directory which is imported into the sys.path. This is an obstacle for current bazel python migration efforts.

## Test Plan

Built devcontainer locally.