### PR TITLE
chore: update devcontainer image to latest sha

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 		"njpwerner.autodocstring",
 		"zxh404.vscode-proto3",
 	],
-	"image": "ghcr.io/magma/magma/devcontainer:sha-ad15c84",
+	"image": "ghcr.io/magma/magma/devcontainer:sha-e05d447",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"files.watcherExclude": {


### PR DESCRIPTION
## Summary

Update DevContainer image sha to latest available version, which includes changes from #11406 and #11410.
