### PR TITLE
fix(pipelined): Catch Redis ConnectionError

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -32,6 +32,7 @@ from magma.pipelined.qos.types import (
     get_subscriber_key,
 )
 from magma.pipelined.qos.utils import QosStore
+from redis import ConnectionError  # pylint: disable=redefined-builtin
 
 LOG = logging.getLogger("pipelined.qos.common")
 # LOG.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Summary

A common issue in Sentry showed an unhandled ConnectionError between pipelined and Redis. While there was already a  catch block in `is_redis_available` in pipelined, it was set up to catch the Python built-in ConnectionError, not the Redis exception of the same name.

Fixes #11476.

## Test Plan

Confirm via Sentry stack trace that the raised exception is the Redis version of ConnectionError, not the Python built-in.

## Additional Information

- [ ] This change is backwards-breaking