### PR TITLE
chore: bazel codeowners/approvers are configured

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -61,6 +61,18 @@
 /docs/ @magma/approvers-docs
 /docs/readmes/proposals @electronjoe
 
+# approvers-bazel
+/.bazel-cache/ @magma/approvers-bazel
+/.bazel-cache-repo/ @magma/approvers-bazel
+/.github/workflows/bazel-cache-push.yml @magma/approvers-bazel
+/.github/workflows/bazel.yml @magma/approvers-bazel
+/.github/workflows/docker-builder-bazel-base.yml @magma/approvers-bazel
+/bazel/ @magma/approvers-bazel
+/experimental/bazel-base/ @magma/approvers-bazel
+/.bazelignore @magma/approvers-bazel
+/.bazelrc @magma/approvers-bazel
+*.bazel @magma/approvers-bazel
+
 /CODEOWNERS @amarpad @electronjoe @hcgatewood
 
 # Generated code excluded from code ownership


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

chore: bazel codeowners/approvers are configured

## Summary

Proposal for CODEOWNER configuration for (temporary) bazel codeowners/approvers.

Precondition is that the group @magma/approvers-bazel exists.

The single lines are explained as follows:

**Essential**
* `/bazel/ @magma/approvers-bazel`
  * All custom bazel functionality
* `/.bazelrc @magma/approvers-bazel`
  * Bazel configuration
* `*.bazel @magma/approvers-bazel`
  * All BUILD.bazel files and WORKSPACE.bazel

**Semi-essential**
* `/.github/workflows/bazel-cache-push.yml @magma/approvers-bazel`
  * Bazel build and publish caches
* `/.github/workflows/bazel.yml @magma/approvers-bazel`
  * Base bazel build and test workflow
* `/.github/workflows/docker-builder-bazel-base.yml @magma/approvers-bazel`
  * Bazel base build workflow
* `/experimental/bazel-base/ @magma/approvers-bazel`
  * Bazel minimal external dependency environment
* `/.bazelignore @magma/approvers-bazel`
  * Bazel configuration

**Non-essential**
* `/.bazel-cache/ @magma/approvers-bazel`
  * basically only the .gitignore file in an empty folder - not essential (i.e. line can be removed if requested)
* `/.bazel-cache-repo/ @magma/approvers-bazel`
  * basically only the .gitignore file in an empty folder - not essential (i.e. line can be removed if requested)

**Notes**:
* All our `.bzl` files are in `/bazel`. This should be a design pattern, i.e. we do not need a general `*.bzl` entry.
* `agw-workflow.yml` contains some Bazel build steps, but is too much agw related.

## Test Plan

* Tests make sense after the group @magma/approvers-bazel is created.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
