### PR TITLE
fix(mme): Remove incorrect free and add ITTI initialization in unit test

### DIFF
--- a/lte/gateway/c/core/oai/test/itti/test_itti.cpp
+++ b/lte/gateway/c/core/oai/test/itti/test_itti.cpp
@@ -90,16 +90,16 @@ class ITTIMessagePassingTest : public ::testing::Test {
     init_task_context(TASK_MAIN, task_id_list, 1, NULL, &task_zmq_ctx_main);
 
     task_thread_args_t task1_thread_args = {};
-    task1_thread_args.this_task       = TASK_TEST_1;
-    task1_thread_args.task_id_list[0] = TASK_TEST_2;
-    task1_thread_args.list_size       = 1;
-    task1_thread_args.task_zmq_ctx    = &task_zmq_ctx_test1;
+    task1_thread_args.this_task          = TASK_TEST_1;
+    task1_thread_args.task_id_list[0]    = TASK_TEST_2;
+    task1_thread_args.list_size          = 1;
+    task1_thread_args.task_zmq_ctx       = &task_zmq_ctx_test1;
 
     task_thread_args_t task2_thread_args = {};
-    task2_thread_args.this_task       = TASK_TEST_2;
-    task2_thread_args.task_id_list[0] = TASK_TEST_1;
-    task2_thread_args.list_size       = 1;
-    task2_thread_args.task_zmq_ctx    = &task_zmq_ctx_test2;
+    task2_thread_args.this_task          = TASK_TEST_2;
+    task2_thread_args.task_id_list[0]    = TASK_TEST_1;
+    task2_thread_args.list_size          = 1;
+    task2_thread_args.task_zmq_ctx       = &task_zmq_ctx_test2;
 
     std::thread task1(task_thread, &task1_thread_args);
     std::thread task2(task_thread, &task2_thread_args);
@@ -146,9 +146,7 @@ class ITTIApiTest : public ::testing::Test {
         NULL);
   }
 
-  virtual void TearDown() {
-     itti_free_desc_threads();
-  }
+  virtual void TearDown() { itti_free_desc_threads(); }
 };
 
 TEST_F(ITTIApiTest, TestInitialContextSetupRsp) {

--- a/lte/gateway/c/core/oai/test/itti/test_itti.cpp
+++ b/lte/gateway/c/core/oai/test/itti/test_itti.cpp
@@ -75,8 +75,6 @@ void* task_thread(task_thread_args_t* args) {
       args->this_task, args->task_id_list, args->list_size, handle_message,
       args->task_zmq_ctx);
 
-  free(args);
-
   zloop_start(args->task_zmq_ctx->event_loop);
 
   return NULL;
@@ -91,22 +89,20 @@ class ITTIMessagePassingTest : public ::testing::Test {
     task_id_t task_id_list[4] = {TASK_TEST_1, TASK_TEST_2};
     init_task_context(TASK_MAIN, task_id_list, 1, NULL, &task_zmq_ctx_main);
 
-    task_thread_args_t* task1_thread_args =
-        (task_thread_args_t*) calloc(1, sizeof(task_thread_args_t));
-    task1_thread_args->this_task       = TASK_TEST_1;
-    task1_thread_args->task_id_list[0] = TASK_TEST_2;
-    task1_thread_args->list_size       = 1;
-    task1_thread_args->task_zmq_ctx    = &task_zmq_ctx_test1;
+    task_thread_args_t task1_thread_args = {};
+    task1_thread_args.this_task       = TASK_TEST_1;
+    task1_thread_args.task_id_list[0] = TASK_TEST_2;
+    task1_thread_args.list_size       = 1;
+    task1_thread_args.task_zmq_ctx    = &task_zmq_ctx_test1;
 
-    task_thread_args_t* task2_thread_args =
-        (task_thread_args_t*) calloc(1, sizeof(task_thread_args_t));
-    task2_thread_args->this_task       = TASK_TEST_2;
-    task2_thread_args->task_id_list[0] = TASK_TEST_1;
-    task2_thread_args->list_size       = 1;
-    task2_thread_args->task_zmq_ctx    = &task_zmq_ctx_test2;
+    task_thread_args_t task2_thread_args = {};
+    task2_thread_args.this_task       = TASK_TEST_2;
+    task2_thread_args.task_id_list[0] = TASK_TEST_1;
+    task2_thread_args.list_size       = 1;
+    task2_thread_args.task_zmq_ctx    = &task_zmq_ctx_test2;
 
-    std::thread task1(task_thread, task1_thread_args);
-    std::thread task2(task_thread, task2_thread_args);
+    std::thread task1(task_thread, &task1_thread_args);
+    std::thread task2(task_thread, &task2_thread_args);
     task1.detach();
     task2.detach();
     std::this_thread::sleep_for(std::chrono::seconds(2));
@@ -122,6 +118,7 @@ class ITTIMessagePassingTest : public ::testing::Test {
     destroy_task_context(&task_zmq_ctx_test1);
     destroy_task_context(&task_zmq_ctx_test2);
     destroy_task_context(&task_zmq_ctx_main);
+    itti_free_desc_threads();
   }
 };
 
@@ -143,9 +140,15 @@ TEST_F(ITTIMessagePassingTest, TestMessageLatency) {
 }
 
 class ITTIApiTest : public ::testing::Test {
-  virtual void SetUp() {}
+  virtual void SetUp() {
+    itti_init(
+        TASK_MAX, THREAD_MAX, MESSAGES_ID_MAX, tasks_info, messages_info, NULL,
+        NULL);
+  }
 
-  virtual void TearDown() {}
+  virtual void TearDown() {
+     itti_free_desc_threads();
+  }
 };
 
 TEST_F(ITTIApiTest, TestInitialContextSetupRsp) {


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

This change fixes two issues in ITTI unit test:
1. Argument is getting used after free in `task_thread`: Changing it to local scope for better memory management
2. Running `ITTIApiTest` individually was failing as ITTI descriptor is not initialized
```
vagrant@magma-dev-focal:~/build/c/core/oai/test/itti$ sudo ./itti_test --gtest_filter=ITTIApiTest.*
Note: Google Test filter = ITTIApiTest.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from ITTIApiTest
[ RUN      ] ITTIApiTest.TestInitialContextSetupRsp
AddressSanitizer:DEADLYSIGNAL
=================================================================
==360950==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000784 (pc 0x5640d220a21a bp 0x7ffe8ff52f70 sp 0x7ffe8ff52f40 T0)
==360950==The signal is caused by a READ memory access.
==360950==Hint: address points to the zero page.
    #0 0x5640d220a219 in DEPRECATEDitti_alloc_new_message_fatal /home/vagrant/magma/lte/gateway/c/core/oai/lib/itti/intertask_interface.c:318
    #1 0x5640d21fd929 in ITTIApiTest_TestInitialContextSetupRsp_Test::TestBody() /home/vagrant/magma/lte/gateway/c/core/oai/test/itti/test_itti.cpp:162
```

## Test Plan

`make test_oai`

Running `ITTIApiTest` individually with success
```
vagrant@magma-dev-focal:~/build/c/core/oai/test/itti$ sudo ./itti_test --gtest_filter=ITTIApiTest.*
Note: Google Test filter = ITTIApiTest.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from ITTIApiTest
[ RUN      ] ITTIApiTest.TestInitialContextSetupRsp
[       OK ] ITTIApiTest.TestInitialContextSetupRsp (0 ms)
[ RUN      ] ITTIApiTest.TestHandoverRequest
[       OK ] ITTIApiTest.TestHandoverRequest (0 ms)
[----------] 2 tests from ITTIApiTest (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 2 tests.
```
