### PR TITLE
fix(amf): Convert std logs to OAI Logs

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/amf_client_proto_msg_to_itti_msg.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/amf_client_proto_msg_to_itti_msg.cpp
@@ -10,6 +10,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_38.413.h"
+#include "lte/gateway/c/core/oai/common/log.h"
+#ifdef __cplusplus
+}
+#endif
 
 #include "lte/gateway/c/core/oai/lib/n11/amf_client_proto_msg_to_itti_msg.h"
 
@@ -34,8 +42,9 @@ void convert_proto_msg_to_itti_m5g_auth_info_ans(
     M5GAuthenticationInformationAnswer msg,
     itti_amf_subs_auth_info_ans_t* itti_msg) {
   if (msg.m5gauth_vectors_size() > MAX_EPS_AUTH_VECTORS) {
-    std::cout << "[ERROR] Number of m5g auth vectors received is:"
-              << msg.m5gauth_vectors_size() << std::endl;
+    OAILOG_ERROR(
+        LOG_AMF_APP, "Number of m5g auth vectors received is:%d\n",
+        msg.m5gauth_vectors_size());
     return;
   }
   itti_msg->auth_info.nb_of_vectors = msg.m5gauth_vectors_size();
@@ -58,8 +67,7 @@ void convert_proto_msg_to_itti_m5g_auth_info_ans(
           itti_m5gauth_vector->xres_star.data,
           m5gauth_vector.xres_star().c_str(), xres_star_len);
     } else {
-      std::cout << "[ERROR] Invalid xres_star length " << xres_star_len
-                << std::endl;
+      OAILOG_ERROR(LOG_AMF_APP, "Invalid xres_star length %d\n", xres_star_len);
       return;
     }
     if (m5gauth_vector.autn().length() == AUTN_LENGTH_OCTETS) {
@@ -67,8 +75,9 @@ void convert_proto_msg_to_itti_m5g_auth_info_ans(
           itti_m5gauth_vector->autn, m5gauth_vector.autn().c_str(),
           m5gauth_vector.autn().length());
     } else {
-      std::cout << "[ERROR] Invalid AUTN length "
-                << m5gauth_vector.autn().length() << std::endl;
+      OAILOG_ERROR(
+          LOG_AMF_APP, "Invalid AUTN length %lu\n",
+          m5gauth_vector.autn().length());
       return;
     }
     if (m5gauth_vector.kseaf().length() == KSEAF_LENGTH_OCTETS) {
@@ -76,8 +85,9 @@ void convert_proto_msg_to_itti_m5g_auth_info_ans(
           itti_m5gauth_vector->kseaf, m5gauth_vector.kseaf().c_str(),
           m5gauth_vector.kseaf().length());
     } else {
-      std::cout << "[ERROR] Invalid KSEAF length "
-                << m5gauth_vector.kseaf().length() << std::endl;
+      OAILOG_ERROR(
+          LOG_AMF_APP, "Invalid KSEAF length %lu\n",
+          m5gauth_vector.kseaf().length());
       return;
     }
     ++idx;
@@ -89,8 +99,9 @@ void convert_proto_msg_to_itti_amf_decrypted_imsi_info_ans(
     M5GSUCIRegistrationAnswer response,
     itti_amf_decrypted_imsi_info_ans_t* amf_app_decrypted_imsi_info_resp) {
   if (response.ue_msin_recv().length() <= 0) {
-    std::cout << "[ERROR] Decrypted IMSI response is invalid:"
-              << response.ue_msin_recv().length() << std::endl;
+    OAILOG_ERROR(
+        LOG_AMF_APP, "Decrypted IMSI response is invalid:%lu\n",
+        response.ue_msin_recv().length());
     return;
   }
   amf_app_decrypted_imsi_info_resp->imsi_length =


### PR DESCRIPTION
Signed-off-by: Akshayp77 <akshay.patidar@wavelabs.ai>



## Summary

Converting std logs to OAI Logs in amf client library.
Currently the std logs will be redirected to syslog. Where as for all mme logs should be present in mme.log

## Test Plan


## Additional Information

#11443 

