### PR TITLE
fix(magmad): sentry bazel dependency is added to magmad

### DIFF
--- a/orc8r/gateway/python/magma/magmad/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/BUILD.bazel
@@ -57,6 +57,7 @@ py_library(
         "//orc8r/gateway/python/magma/common:misc_utils",
         "//orc8r/gateway/python/magma/common:rpc_utils",
         "//orc8r/gateway/python/magma/common:sdwatchdog",
+        "//orc8r/gateway/python/magma/common:sentry",
         "//orc8r/gateway/python/magma/common:stateless_agw",
         "//orc8r/gateway/python/magma/common:streamer",
         "//orc8r/gateway/python/magma/common/health:service_state_wrapper",


### PR DESCRIPTION
fix(magmad): sentry bazel dependency is added to magmad in order to fulfill new python dependency

Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In https://github.com/magma/magma/pull/11446 a sentry dependency was added to `sync_rpc_client.py` in `magmad`. On the other hand https://github.com/magma/magma/pull/11445 introduced bazel support for `magmad`. Shortly after 11445 was merged to master, 11446 was merged as well, i.e., both changes were combined first time on master. This is, the sentry dependency in `magmad` is not modeled by the bazel `magmad` build file.

As the bazel effort is a cross-cutting topic, I expect this to happen more often during the migration. Ideas to mitigate:
* Rebase PRs on master after other PRs are merged - this of course adds overhead to the PR process. The overhead can be mitigated by only doing this if bazel changes are involved.
* Create more awareness for the bazel effort and current migration areas so that  PR owners have in mind that they should rebase before a merge.

## Test Plan

execute `bazel test lte/gateway/python/... orc8r/gateway/python/...`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
