### PR TITLE
feat(ci): activate more diverse docker image tagging

### DIFF
--- a/.github/workflows/docker-builder-bazel-base.yml
+++ b/.github/workflows/docker-builder-bazel-base.yml
@@ -23,7 +23,6 @@ on:  # yamllint disable-line rule:truthy
 env:
   REGISTRY: ghcr.io
   IMAGE_STREAM: ${{ github.repository }}/bazel-base
-  IMAGE_TAGS: type=sha
   DOCKERFILE: experimental/bazel-base/Dockerfile
 
 jobs:

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -23,7 +23,6 @@ on:  # yamllint disable-line rule:truthy
 env:
   REGISTRY: ghcr.io
   IMAGE_STREAM: ${{ github.repository }}/devcontainer
-  IMAGE_TAGS: type=sha
   DOCKERFILE: .devcontainer/Dockerfile
 
 jobs:

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -23,7 +23,6 @@ on:  # yamllint disable-line rule:truthy
 env:
   REGISTRY: ghcr.io
   IMAGE_STREAM: ${{ github.repository }}/python-precommit
-  IMAGE_TAGS: type=sha
   DOCKERFILE: lte/gateway/docker/python-precommit/Dockerfile
 
 jobs:


### PR DESCRIPTION
## Summary

Within #10711 the foundation was laid and an argument was made for a more diverse docker image tagging. However, it turns out that only the `latest` tag was indeed introduced.
The default values implemented in #10711 are currently overwritten by workflow specific ones. Those workflow specific overwrites are deleted in this PR to fully activate the more diverse image tagging.

Merging the PR changes the image tagging as shown in [this diff](https://github.com/magma/magma/pull/10711/files#diff-61dc0f25a71b867e2e96ea0229335e066501eadf8f276ff55b81d4cfe9bf40c5R13-R18).

## Test Plan

- CI
