### PR TITLE
fix(subscriberdb): Remove extra zeros to set defaults to 1 and 2 gbps

### DIFF
--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -39,8 +39,8 @@ mme_host_address: 127.0.0.1
 mme_port: 3868
 
 # Default Subscription Profile
-default_max_ul_bit_rate: 200000000000  # 2 Gbps
-default_max_dl_bit_rate: 400000000000  # 4 Gbps
+default_max_ul_bit_rate: 2000000000  # 2 Gbps
+default_max_dl_bit_rate: 4000000000  # 4 Gbps
 
 # Relay S6A via gRPC
 relay_mode: False


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
The defaults were set as 200/100Gbps rather than the intended 2/1 Gbps.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
s1ap integ tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
