### PR TITLE
chore(ctraced): ctraced is bazelified

### DIFF
--- a/orc8r/gateway/python/magma/ctraced/BUILD.bazel
+++ b/orc8r/gateway/python/magma/ctraced/BUILD.bazel
@@ -1,0 +1,41 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+ORC8R_ROOT = "../../"
+
+py_binary(
+    name = "ctraced",
+    srcs = ["main.py"],
+    imports = [ORC8R_ROOT],
+    # legacy_creat_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
+    legacy_create_init = False,
+    main = "main.py",
+    python_version = "PY3",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
+        "//orc8r/protos:ctraced_python_grpc",
+    ],
+)
+
+py_library(
+    name = "ctraced_lib",
+    srcs = [
+        "command_builder.py",
+        "rpc_servicer.py",
+        "trace_manager.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [],
+)

--- a/orc8r/protos/BUILD.bazel
+++ b/orc8r/protos/BUILD.bazel
@@ -254,6 +254,16 @@ python_proto_library(
 )
 
 proto_library(
+    name = "ctraced_proto",
+    srcs = ["ctraced.proto"],
+)
+
+python_grpc_library(
+    name = "ctraced_python_grpc",
+    protos = [":ctraced_proto"],
+)
+
+proto_library(
     name = "bootstrapper_proto",
     srcs = ["bootstrapper.proto"],
     deps = [


### PR DESCRIPTION
ran `bazel run //orc8r/gateway/python/magma/ctraced:ctraced`

<img width="1724" alt="image" src="https://user-images.githubusercontent.com/25142344/153495232-dcbe122a-c199-4220-95a2-bbf1c1981536.png">


https://github.com/magma/magma/issues/11413