### PR TITLE
fix(nms): Fix 11492, gateway page was crashing

### DIFF
--- a/nms/packages/magmalte/app/views/equipment/EquipmentGateway.js
+++ b/nms/packages/magmalte/app/views/equipment/EquipmentGateway.js
@@ -342,9 +342,9 @@ function GatewayStatusTable(props: WithAlert & {refresh: boolean}) {
         name: gateway.name,
         id: gateway.id,
         num_enodeb: numEnodeBs,
-        num_subscribers: gateway.device
-          ? gwSubscriberMap?.[gateway.device?.hardware_id].length
-          : 0,
+        num_subscribers:
+          // $FlowIgnore: gateway.device should be present
+          gwSubscriberMap?.[gateway.device.hardware_id]?.length ?? 0,
         health: isGatewayHealthy(gateway) ? 'Good' : 'Bad',
         checkInTime: checkInTime,
       });


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

#11492 

Gateway page was crashing due to the offending [line](https://github.com/magma/magma/blob/master/nms/packages/magmalte/app/views/equipment/EquipmentGateway.js#L346)

`gwSubscriberMap` may not have contained the key

This change has been reverted.

## Test Plan

Tested gateway tab in NMS before and after to verify that the gateway page was no longer crashing

## Additional Information

- [ ] This change is backwards-breaking
