### PR TITLE
fix(nms): Fix 11172 with allow register eNB to multiple AGW

### DIFF
--- a/nms/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -16,7 +16,6 @@
 import type {
   apn_resources,
   challenge_key,
-  enodeb,
   enodeb_serials,
   gateway_device,
   gateway_dns_configs,
@@ -387,8 +386,9 @@ export function ConfigEdit(props: Props) {
         device: {...gatewayDevice, key: challengeKey},
       };
       if (props.isAdd) {
-        // check if it is not a modify during add i.e we aren't switching tabs back
-        // during add and modifying the information other than the serial number
+        // check if it is not a modify during add i.e we aren't switching tabs
+        // back during add and modifying the information other than the serial
+        // number
         if (gateway.id in ctx.state && gateway.id !== props.gateway?.id) {
           setError(`Gateway ${gateway.id} already exists`);
           return;
@@ -775,43 +775,12 @@ export function RanEdit(props: Props) {
   const [connectedEnodebs, setConnectedEnodebs] = useState<enodeb_serials>(
     props.gateway.connected_enodeb_serials,
   );
-  const [unregisteredEnbsInfo, setUnregisteredEnbsInfo] = useState([]);
   const handleRanChange = (key: string, val) => {
     setRanConfig({...ranConfig, [key]: val});
   };
   const handleDnsChange = (key: string, val) => {
     setDnsConfig({...dnsConfig, [key]: val});
   };
-  useEffect(() => {
-    const isEnodebUnregistered = (enb: enodeb, currentGateway: lte_gateway) => {
-      const gatewaysList = Object.keys(ctx.state);
-      for (const gatewayId of gatewaysList) {
-        if (
-          ctx.state[gatewayId].connected_enodeb_serials?.includes(enb.serial) &&
-          ctx.state[gatewayId].id != currentGateway.id
-        ) {
-          return false;
-        }
-      }
-      return true;
-    };
-    const newUnregisteredEnbsInfo = [];
-    if (enbsCtx?.state?.enbInfo) {
-      Object.keys(enbsCtx.state.enbInfo).map(enbSerial => {
-        if (
-          isEnodebUnregistered(
-            enbsCtx.state.enbInfo[enbSerial].enb,
-            props.gateway,
-          )
-        ) {
-          newUnregisteredEnbsInfo.push({
-            [enbSerial]: enbsCtx.state.enbInfo[enbSerial],
-          });
-        }
-      });
-    }
-    setUnregisteredEnbsInfo(newUnregisteredEnbsInfo);
-  }, [ctx?.state, enbsCtx?.state?.enbInfo, props?.gateway]);
   const onSave = async () => {
     try {
       const gateway = {
@@ -884,18 +853,16 @@ export function RanEdit(props: Props) {
                   className={connectedEnodebs.length ? '' : classes.placeholder}
                 />
               }>
-              {unregisteredEnbsInfo.map(unregisteredEnbInfo => {
-                const enbSerial = Object.keys(unregisteredEnbInfo)[0];
-                return (
+              {enbsCtx?.state &&
+                Object.keys(enbsCtx.state.enbInfo).map(enbSerial => (
                   <MenuItem key={enbSerial} value={enbSerial}>
                     <Checkbox checked={connectedEnodebs.includes(enbSerial)} />
                     <ListItemText
-                      primary={unregisteredEnbInfo[enbSerial].enb.name}
+                      primary={enbsCtx.state.enbInfo[enbSerial].enb.name}
                       secondary={enbSerial}
                     />
                   </MenuItem>
-                );
-              })}
+                ))}
             </Select>
           </AltFormField>
           <AltFormField label={'Transmit Enabled'}>

--- a/nms/packages/magmalte/app/views/equipment/GatewayDetailSubscribers.js
+++ b/nms/packages/magmalte/app/views/equipment/GatewayDetailSubscribers.js
@@ -45,10 +45,11 @@ export default function GatewayDetailSubscribers(props: GatewayDetailType) {
     refresh: props.refresh,
   });
   const subscriberCtx = useContext(SubscriberContext);
-  const gwSubscriberMap = props.gwInfo?.device
-    ? subscriberCtx.gwSubscriberMap[props.gwInfo?.device?.hardware_id]
-    : [];
+  const gwSubscriberMap =
+    // $FlowIgnore
+    subscriberCtx.gwSubscriberMap[props.gwInfo?.device?.hardware_id] || [];
 
+  console.log('gwSubscriberMap: ', gwSubscriberMap);
   const subscriberRows: Array<SubscriberRowType> = gwSubscriberMap.map(
     (serialNum: string) => {
       // $FlowIgnore


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Fixes #11172 

A change in PR [7314](https://github.com/magma/magma/pull/7314) limited eNBs to only be able to registered to a single AGW through the NMS. This has been undone, as this interfered with AGW HA configuration.

## Test Plan

Tested that configuration with multiple AGWs having the same eNB was possible now.

<img width="1215" alt="Screen Shot 2022-02-10 at 11 05 12 PM" src="https://user-images.githubusercontent.com/804385/153550127-9efaada5-d4fd-4568-bb24-42602290d976.png">
<img width="1214" alt="Screen Shot 2022-02-10 at 11 05 07 PM" src="https://user-images.githubusercontent.com/804385/153550130-e0000a4c-89af-4566-8ea1-0804ca3a9afe.png">

## Additional Information

- [ ] This change is backwards-breaking
