### PR TITLE
feat: lldb is used for C minidump debugging

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,6 +66,7 @@ RUN echo "Install general purpose packages" && \
         libssl-dev \
         libtool \
         lld \
+        lldb \
         make \
         ninja-build \
         perl \


### PR DESCRIPTION
## Summary

The lldb debugger is more convenient in comparison to gdb, and will be the new recommended way to look at mini-dump files, as provided by Sentry.

## Test Plan

- CI successfully builds docker image
