### PR TITLE
Revert "chore(agw): Update metrics naming on exporting (#11474)"

### DIFF
--- a/orc8r/gateway/python/magma/common/metrics_export.py
+++ b/orc8r/gateway/python/magma/common/metrics_export.py
@@ -11,20 +11,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import logging
 import time
-from typing import List
 
 import metrics_pb2
-from prometheus_client import REGISTRY, CollectorRegistry
+from orc8r.protos import metricsd_pb2
+from prometheus_client import REGISTRY
 
 
-def get_metrics(registry: CollectorRegistry = REGISTRY, verbose: bool = False):
+def get_metrics(registry=REGISTRY, verbose=False):
     """
     Collects timeseries samples from prometheus metric collector registry
     adds a common timestamp, and encodes them to protobuf
 
     Arguments:
-        registry: a prometheus CollectorRegistry instance
+        regsitry: a prometheus CollectorRegistry instance
         verbose: whether to optimize for bandwidth and ignore metric name/help
 
     Returns:
@@ -39,10 +40,16 @@ def get_metrics(registry: CollectorRegistry = REGISTRY, verbose: bool = False):
         elif metric_family.type == 'histogram':
             family_proto = encode_histogram(metric_family, timestamp_ms)
 
-        family_proto.name = metric_family.name
         if verbose:
             family_proto.help = metric_family.documentation
-
+            family_proto.name = metric_family.name
+        else:
+            try:
+                family_proto.name = \
+                    str(metricsd_pb2.MetricName.Value(metric_family.name))
+            except ValueError as e:
+                logging.debug(e)  # If enum is not defined
+                family_proto.name = metric_family.name
         yield family_proto
 
 
@@ -58,6 +65,8 @@ def encode_counter_gauge(family, timestamp_ms):
     Arguments:
         family: a prometheus gauge metric family
         timestamp_ms: the timestamp to attach to the samples
+    Raises:
+        ValueError if metric name is not defined in MetricNames protobuf
     Returns:
         A Counter or Gauge prometheus MetricFamily protobuf
     """
@@ -72,7 +81,7 @@ def encode_counter_gauge(family, timestamp_ms):
             metric_proto.gauge.value = sample[2]
         # Add meta-data to the timeseries
         metric_proto.timestamp_ms = timestamp_ms
-        metric_proto.label.extend(_convert_labels_to_pb_pairs(sample[1].items()))
+        metric_proto.label.extend(_convert_labels_to_enums(sample[1].items()))
         # Append metric sample to family
         family_proto.metric.extend([metric_proto])
     return family_proto
@@ -92,6 +101,8 @@ def encode_summary(family, timestamp_ms):
     Arguments:
         family: a prometheus summary metric family
         timestamp_ms: the timestamp to attach to the samples
+    Raises:
+        ValueError if metric name is not defined in MetricNames protobuf
     Returns:
         a Summary prometheus MetricFamily protobuf
     """
@@ -118,7 +129,7 @@ def encode_summary(family, timestamp_ms):
     # Go back and add meta-data to the timeseries
     for labels, metric_proto in metric_protos.items():
         metric_proto.timestamp_ms = timestamp_ms
-        metric_proto.label.extend(_convert_labels_to_pb_pairs(labels))
+        metric_proto.label.extend(_convert_labels_to_enums(labels))
         # Add it to the family
         family_proto.metric.extend([metric_proto])
     return family_proto
@@ -139,6 +150,8 @@ def encode_histogram(family, timestamp_ms):
     Arguments:
         family: a prometheus histogram metric family
         timestamp_ms: the timestamp to attach to the samples
+    Raises:
+        ValueError if metric name is not defined in MetricNames protobuf
     Returns:
         a Histogram prometheus MetricFamily protobuf
     """
@@ -163,7 +176,7 @@ def encode_histogram(family, timestamp_ms):
     # Go back and add meta-data to the timeseries
     for labels, metric_proto in metric_protos.items():
         metric_proto.timestamp_ms = timestamp_ms
-        metric_proto.label.extend(_convert_labels_to_pb_pairs(labels))
+        metric_proto.label.extend(_convert_labels_to_enums(labels))
         # Add it to the family
         family_proto.metric.extend([metric_proto])
     return family_proto
@@ -180,13 +193,20 @@ def _goStringToFloat(s):
         return float(s)
 
 
-def _convert_labels_to_pb_pairs(labels: List) -> List[metrics_pb2.LabelPair]:
+def _convert_labels_to_enums(labels):
     """
-    Try to convert both the label names and label values to LabelPair protobuf objects.
+    Try to convert both the label names and label values to enum values.
     Defaults to the given name and value if it fails to convert.
     Arguments:
-        labels: an array of label pairs with name and value properties
+        labels: an array of label pairs that may contain enum names
     Returns:
-        an array of protobuf LabelPair objects with name and value properties 
+        an array of label pairs with enum names converted to enum values
     """
-    return [metrics_pb2.LabelPair(name=name, value=value) for name, value in labels]
+    new_labels = []
+    for name, value in labels:
+        try:
+            name = str(metricsd_pb2.MetricLabelName.Value(name))
+        except ValueError as e:
+            logging.debug(e)
+        new_labels.append(metrics_pb2.LabelPair(name=name, value=value))
+    return new_labels

--- a/orc8r/gateway/python/magma/common/tests/metrics_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/metrics_tests.py
@@ -16,6 +16,7 @@ import unittest.mock
 
 import metrics_pb2
 from magma.common import metrics_export
+from orc8r.protos import metricsd_pb2
 from prometheus_client import (
     CollectorRegistry,
     Counter,
@@ -37,9 +38,8 @@ class Service303MetricTests(unittest.TestCase):
     def test_counter(self):
         """Test that we can track counters in Service303"""
         # Add a counter with a label to the regisry
-        process_max_metric_name = 'process_max_fds'
         c = Counter(
-            process_max_metric_name, 'A counter', ['result'],
+            'process_max_fds', 'A counter', ['result'],
             registry=self.registry,
         )
 
@@ -59,15 +59,15 @@ class Service303MetricTests(unittest.TestCase):
             timestamp_ms=1234000,
         )
         family = metrics_pb2.MetricFamily(
-            name=process_max_metric_name,
+            name=str(metricsd_pb2.process_max_fds),
             type=metrics_pb2.COUNTER,
         )
         metric1.label.add(
-            name='result',
+            name=str(metricsd_pb2.result),
             value='success',
         )
         metric2.label.add(
-            name='result',
+            name=str(metricsd_pb2.result),
             value='failure',
         )
         family.metric.extend([metric1, metric2])
@@ -82,9 +82,8 @@ class Service303MetricTests(unittest.TestCase):
     def test_gauge(self):
         """Test that we can track gauges in Service303"""
         # Add a gauge with a label to the regisry
-        process_max_metric_name = 'process_max_fds'
         c = Gauge(
-            process_max_metric_name, 'A gauge', ['result'],
+            'process_max_fds', 'A gauge', ['result'],
             registry=self.registry,
         )
 
@@ -104,15 +103,15 @@ class Service303MetricTests(unittest.TestCase):
             timestamp_ms=1234000,
         )
         family = metrics_pb2.MetricFamily(
-            name=process_max_metric_name,
+            name=str(metricsd_pb2.process_max_fds),
             type=metrics_pb2.GAUGE,
         )
         metric1.label.add(
-            name='result',
+            name=str(metricsd_pb2.result),
             value='success',
         )
         metric2.label.add(
-            name='result',
+            name=str(metricsd_pb2.result),
             value='failure',
         )
         family.metric.extend([metric1, metric2])
@@ -127,9 +126,8 @@ class Service303MetricTests(unittest.TestCase):
     def test_summary(self):
         """Test that we can track summaries in Service303"""
         # Add a summary with a label to the regisry
-        process_max_metric_name = 'process_max_fds'
         c = Summary(
-            process_max_metric_name, 'A summary', [
+            'process_max_fds', 'A summary', [
             'result',
             ], registry=self.registry,
         )
@@ -148,15 +146,15 @@ class Service303MetricTests(unittest.TestCase):
             timestamp_ms=1234000,
         )
         family = metrics_pb2.MetricFamily(
-            name=process_max_metric_name,
+            name=str(metricsd_pb2.process_max_fds),
             type=metrics_pb2.SUMMARY,
         )
         metric1.label.add(
-            name='result',
+            name=str(metricsd_pb2.result),
             value='success',
         )
         metric2.label.add(
-            name='result',
+            name=str(metricsd_pb2.result),
             value='failure',
         )
         family.metric.extend([metric1, metric2])
@@ -171,9 +169,8 @@ class Service303MetricTests(unittest.TestCase):
     def test_histogram(self):
         """Test that we can track histogram in Service303"""
         # Add a histogram with a label to the regisry
-        process_max_metric_name = 'process_max_fds'
         c = Histogram(
-            process_max_metric_name, 'A summary', ['result'],
+            'process_max_fds', 'A summary', ['result'],
             registry=self.registry, buckets=[0, 2, float('inf')],
         )
         c.labels('success').observe(1.23)
@@ -197,15 +194,15 @@ class Service303MetricTests(unittest.TestCase):
             timestamp_ms=1234000,
         )
         family = metrics_pb2.MetricFamily(
-            name=process_max_metric_name,
+            name=str(metricsd_pb2.process_max_fds),
             type=metrics_pb2.HISTOGRAM,
         )
         metric1.label.add(
-            name='result',
+            name=str(metricsd_pb2.result),
             value='success',
         )
         metric2.label.add(
-            name='result',
+            name=str(metricsd_pb2.result),
             value='failure',
         )
         family.metric.extend([metric1, metric2])
@@ -219,9 +216,10 @@ class Service303MetricTests(unittest.TestCase):
 
     def test_converted_enums(self):
         """ Test that metric names and labels are auto converted """
-        mme_metric_name = 'mme_new_association'
+        # enum values (from metricsd.proto):
+        # mme_new_association => 500, result => 0
         c = Counter(
-            mme_metric_name, 'A counter', ['result'],
+            'mme_new_association', 'A counter', ['result'],
             registry=self.registry,
         )
 
@@ -231,11 +229,11 @@ class Service303MetricTests(unittest.TestCase):
 
         self.assertEqual(
             metric_family.name,
-            mme_metric_name,
+            str(metricsd_pb2.mme_new_association),
         )
         metric_labels = metric_family.metric[0].label
         # Order not guaranteed=
-        self.assertEqual(metric_labels[0].name, 'result')
+        self.assertEqual(metric_labels[0].name, str(metricsd_pb2.result))
         self.assertEqual(metric_labels[0].value, 'success')
 
 

--- a/orc8r/gateway/python/magma/magmad/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/tests/BUILD.bazel
@@ -30,6 +30,12 @@ pytest_test(
 )
 
 pytest_test(
+    name = "metrics_tests",
+    srcs = ["metrics_tests.py"],
+    deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
+)
+
+pytest_test(
     name = "proxy_client_tests",
     srcs = ["proxy_client_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],

--- a/orc8r/gateway/python/magma/magmad/tests/metrics_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/metrics_tests.py
@@ -1,0 +1,35 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+
+from magma.common import metrics_export
+
+
+class MetricTests(unittest.TestCase):
+    """
+    Tests for the Service303 metrics interface
+    """
+
+    def test_metrics_defined(self):
+        """ Test that all metrics are defined in proto enum """
+        import magma.magmad.metrics
+
+        # Avoid lint error about unused imports
+        magma.magmad.metrics.CPU_PERCENT.set(1)
+
+        metrics_protos = metrics_export.get_metrics()
+        for metrics_proto in metrics_protos:
+            # Check that all proto names have been mapped to numbers. Will
+            # raise ValueError if not
+            int(metrics_proto.name)


### PR DESCRIPTION
This reverts commit 22a35faacd818ffffbcb7d5c63dc050e0f832f61.

Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Reverts #11474 
- Original commit failing on metrics validation done on S1AP tester, further changes required, reverting for now to unblock master 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Ran `make integ_test` locally to ensure metrics validation is successful

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
