### PR TITLE
chore(orc8r): Removed thanos acl variable from terraform

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/thanos.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/thanos.tf
@@ -15,7 +15,6 @@ resource "aws_s3_bucket" "thanos_object_store_bucket" {
   count = var.thanos_enabled ? 1 : 0
 
   bucket = var.thanos_object_store_bucket_name
-  acl = "private"
   tags = {
     Name = "Thanos Object Store"
   }


### PR DESCRIPTION
Removed the thanos variable bc it was causing an issue when deploying to dev and thanos itself is turned off 

![image](https://user-images.githubusercontent.com/25142344/153640012-ac02d167-3b78-4d74-8d7c-f10100704d3f.png)
