### PR TITLE
chore: remove clang-format-7 references

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,7 +48,6 @@ RUN echo "Install general purpose packages" && \
         build-essential \
         ca-certificates \
         clang-11 \
-        clang-format-7 \
         clang-format-11 \
         clang-tidy-11 \
         curl \
@@ -85,10 +84,9 @@ RUN echo "Install general purpose packages" && \
         gem install fpm && \
         update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10 && \
         update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-11/bin/clang++ 10 && \
-        update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-7/bin/clang-format 10 && \
+        update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-11/bin/clang-format 10 && \
         update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-11/bin/clang-tidy 10 && \
         update-alternatives --install /usr/bin/clang-apply-replacements clang-apply-replacements /usr/lib/llvm-11/bin/clang-apply-replacements 10
-
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y clangd-12
 

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -157,7 +157,6 @@
       - autoconf
       - build-essential
       - ccache
-      - clang-format-7
       - ninja-build
       - git
       - libtool
@@ -399,7 +398,7 @@
 
 - name: Create links for clang-format
   become: yes
-  command: "update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7 1000"
+  command: "update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 1000"
   when: preburn
 
 - file:

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -19,14 +19,14 @@ RUN [ "/bin/bash", "-c", "echo \"Install general purpose packages\" && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg wget software-properties-common autoconf automake \
     libtool curl make g++ unzip git build-essential autoconf libtool pkg-config \
     gcc-7 g++-7 apt-transport-https ca-certificates apt-utils vim redis-server tzdata \
-    libssl-dev ninja-build golang python2.7 automake perl libgmp3-dev clang-format-11 && \
+    libssl-dev ninja-build golang python2.7 automake perl libgmp3-dev clang-format-7 && \
     echo \"Configure C/C++ compiler v7.5 as primary\" && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 20 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 20 && \
     echo \"Add required package repository for CMake\" && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
-    ln -s /usr/bin/clang-format-11 /usr/bin/clang-format" ]
+    ln -s /usr/bin/clang-format-7 /usr/bin/clang-format" ]
 
 RUN echo "Install 3rd party dependencies" && \
     apt-get update && \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -19,14 +19,14 @@ RUN [ "/bin/bash", "-c", "echo \"Install general purpose packages\" && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg wget software-properties-common autoconf automake \
     libtool curl make g++ unzip git build-essential autoconf libtool pkg-config \
     gcc-7 g++-7 apt-transport-https ca-certificates apt-utils vim redis-server tzdata \
-    libssl-dev ninja-build golang python2.7 automake perl libgmp3-dev clang-format-7 && \
+    libssl-dev ninja-build golang python2.7 automake perl libgmp3-dev clang-format-11 && \
     echo \"Configure C/C++ compiler v7.5 as primary\" && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 20 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 20 && \
     echo \"Add required package repository for CMake\" && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
-    ln -s /usr/bin/clang-format-7 /usr/bin/clang-format" ]
+    ln -s /usr/bin/clang-format-11 /usr/bin/clang-format" ]
 
 RUN echo "Install 3rd party dependencies" && \
     apt-get update && \


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Remove references to clang-format-7 in dev env setup config / scripts
<!-- Enumerate changes you made and why you made them -->

## Test Plan
destroyed and provisioned all VMs
CI check to make sure devcontainer builds
Ran `magma git:(remove-clang-format-7) ✗ docker build -f lte/gateway/docker/mme/Dockerfile.ubuntu18.04 .`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
