### PR TITLE
fix(mme): Corrects test_mme_procedures.cpp include of bstrlib.c

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -26,7 +26,7 @@
 #include "lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h"
 
 extern "C" {
-#include "lte/gateway/c/core/oai/lib/bstr/bstrlib.c"
+#include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/common/common_types.h"
 #include "lte/gateway/c/core/oai/include/mme_config.h"


### PR DESCRIPTION
Addresses #11550

## Test plan

CI tests which include `make build_oai` and `make test_oai`.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>