### PR TITLE
fix(mme): Removes duplicate macro implementations

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.h
@@ -19,16 +19,11 @@
 #include "lte/gateway/c/core/oai/include/TrackingAreaIdentity.h"
 #include "lte/gateway/c/core/oai/include/amf_config.h"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/SmfMessage.h"
+#include "lte/gateway/c/core/oai/common/common_defs.h"
 
 #define NAS_MESSAGE_SECURITY_HEADER_SIZE 7
 typedef uint8_t amf_cause_t;
 namespace magma5g {
-#define OFFSET_OF(TyPe, MeMBeR) ((size_t) & ((TyPe*)0)->MeMBeR)
-#define PARENT_STRUCT(cOnTaiNeD, TyPe, MeMBeR)                    \
-  ({                                                              \
-    const typeof(((TyPe*)0)->MeMBeR)* __MemBeR_ptr = (cOnTaiNeD); \
-    (TyPe*)((char*)__MemBeR_ptr - OFFSET_OF(TyPe, MeMBeR));       \
-  })
 //------------------------------------------------------------------------------
 // Causes related to invalid messages
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #11556.

This macro was copy-pasted from elsewhere and causes linking failures in
the Bazel effort, further it's purely duplicated code for no reason.
This PR removes the duplicates and includes the origin.

## Test plan

CI tests which include `make build_oai` and `make test_oai`.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>