### PR TITLE
fix(mme): Add missing include for use of true/false

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/util/socket.c
+++ b/lte/gateway/c/core/oai/tasks/nas/util/socket.c
@@ -42,6 +42,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>  // socket, setsockopt, connect, bind, recv, send
 #include <netdb.h>       // getaddrinfo
+#include <stdbool.h>     // true, false
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/


### PR DESCRIPTION
Closes #11558.

Missing include was preventing Bazel build from compiling.

## Test plan

CI tests which include `make build_oai` and `make test_oai`.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>