### PR TITLE
fix(mme): Adds missing include to sgs_defs.h

### DIFF
--- a/lte/gateway/c/core/oai/tasks/sgs/sgs_defs.h
+++ b/lte/gateway/c/core/oai/tasks/sgs/sgs_defs.h
@@ -26,6 +26,7 @@
 #define FILE_SGS_SEEN
 #include <stdint.h>
 #include <netinet/in.h>
+#include "lte/gateway/c/core/oai/include/mme_config.h"
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
 #include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
 #include "lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/queue.h"


### PR DESCRIPTION
Fixes #11560. Defines from `mme_config.h` are referenced in `sgs_defs.h` but include was missing.

## Test plan

CI tests which include `make build_oai` and `make test_oai`.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>