### PR TITLE
fix(amf): Fixes for pco and mobile updating

### DIFF
--- a/lte/gateway/c/core/oai/include/n11_messages_types.h
+++ b/lte/gateway/c/core/oai/include/n11_messages_types.h
@@ -19,11 +19,6 @@
  *  @brief Create PDU Session Response */
 
 /***********************pdu_res_set_change starts*************************/
-typedef enum {
-  SHALL_NOT_TRIGGER_PRE_EMPTION,
-  MAY_TRIGGER_PRE_EMPTION,
-} pre_emption_capability;
-
 typedef enum sm_session_fsm_state_e {
   CREATING,
   CREATE,
@@ -32,15 +27,10 @@ typedef enum sm_session_fsm_state_e {
   RELEASED
 } sm_session_fsm_state_t;
 
-typedef enum {
-  NOT_PREEMPTABLE,
-  PRE_EMPTABLE,
-} pre_emption_vulnerability;
-
 typedef struct m5g_allocation_and_retention_priority_s {
   int priority_level;
-  pre_emption_capability pre_emption_cap;
-  pre_emption_vulnerability pre_emption_vul;
+  pre_emption_capability_t pre_emption_cap;
+  pre_emption_vulnerability_t pre_emption_vul;
 } m5g_allocation_and_retention_priority;
 
 typedef struct non_dynamic_5QI_descriptor_s {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.cpp
@@ -655,10 +655,10 @@ void AmfNasStateConverter::proto_to_qos_flow_level_parameters(
   state_qos_flow_parameters->alloc_reten_priority.priority_level =
       qos_flow_parameters_proto.priority_level();
   state_qos_flow_parameters->alloc_reten_priority.pre_emption_vul =
-      static_cast<pre_emption_vulnerability>(
+      static_cast<pre_emption_vulnerability_t>(
           qos_flow_parameters_proto.preemption_vulnerability());
   state_qos_flow_parameters->alloc_reten_priority.pre_emption_cap =
-      static_cast<pre_emption_capability>(
+      static_cast<pre_emption_capability_t>(
           qos_flow_parameters_proto.preemption_capability());
 }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -1379,18 +1379,20 @@ uint16_t amf_as_establish_cnf(const amf_as_establish_t* msg,
 
     if (registration_proc && !(registration_proc->registration_accept_sent) &&
         (state != REGISTERED_CONNECTED)) {
-      /*GNB key, generated in AMF from KAMF and shared with gNB as part of
-       * InitialContextSetupRequest*/
-      derive_5gkey_gnb(amf_security_context->kamf, as_msg->nas_ul_count,
-                       amf_security_context->kgnb);
       registration_proc->registration_accept_sent++;
     }
 
-    if ((ue_mm_context->ue_context_request &&
-         (msg->nas_info == AMF_AS_NAS_INFO_REGISTERED)) ||
-        ((msg->nas_info == AMF_AS_NAS_INFO_SR) &&
-         (msg->pdu_session_status_ie &
-          AMF_AS_PDU_SESSION_REACTIVATION_STATUS))) {
+    // Condition for sending ICS :
+    //  1. Context is request and message is registration
+    //  2. Service Request message (data or signalling)
+    if (ue_mm_context->ue_context_request &&
+        (ue_mm_context->mm_state != REGISTERED_CONNECTED)) {
+      // Every time ICS is sent this kgnb needs to be re-calculated
+      OAILOG_INFO(LOG_AMF_APP, "kgnb nas ul count=%u\n", as_msg->nas_ul_count);
+
+      derive_5gkey_gnb(amf_security_context->kamf, as_msg->nas_ul_count,
+                       amf_security_context->kgnb);
+
       initial_context_setup_request(as_msg->ue_id, amf_ctx, as_msg->nas_msg);
     } else {
       amf_app_handle_nas_dl_req(as_msg->ue_id, as_msg->nas_msg, M5G_AS_SUCCESS);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_identity.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_identity.cpp
@@ -119,7 +119,7 @@ int amf_proc_identification_complete(const amf_ue_ngap_id_t ue_id,
                                      uint32_t* const tmsi,
                                      guti_m5_t* amf_ctx_guti) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  int rc = RETURNok;
   amf_sap_t amf_sap = {};
   amf_context_t* amf_ctx = NULL;
 
@@ -136,10 +136,13 @@ int amf_proc_identification_complete(const amf_ue_ngap_id_t ue_id,
     nas_amf_ident_proc_t* ident_proc =
         get_5g_nas_common_procedure_identification(amf_ctx);
 
-    // if (ident_proc) {
-    /*
-     * Stop timer T3570
-     */
+    if (ident_proc == NULL) {
+      OAILOG_ERROR(LOG_AMF_APP,
+                   "Failed to start identity procedure for "
+                   "ue_id " AMF_UE_NGAP_ID_FMT "\n",
+                   ue_id);
+      OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+    }
 
     OAILOG_DEBUG(LOG_AMF_APP, "Timer: Stopping Identity timer with ID %lu\n",
                  ident_proc->T3570.id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -252,6 +252,30 @@ int amf_copy_plmn_to_context(const ImsiM5GSMobileIdentity& imsi,
   return RETURNok;
 }
 
+void amf_get_registration_type_request(
+    uint8_t received_reg_type, amf_proc_registration_type_t* params_reg_type) {
+  std::string reg_type;
+
+  if (received_reg_type == AMF_REGISTRATION_TYPE_INITIAL) {
+    reg_type = "INITIAL REGISTRATION TYPE";
+  } else if (received_reg_type == AMF_REGISTRATION_TYPE_MOBILITY_UPDATING) {
+    reg_type = "MOBILITY UPDATING REGISTRATION TYPE";
+  } else if (received_reg_type == AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
+    reg_type = "PERIODIC UPDATING REGISTRATION TYPE";
+  } else if (received_reg_type == AMF_REGISTRATION_TYPE_EMERGENCY) {
+    reg_type = "EMERGENCY TYPE REGISTRATION";
+  } else if (received_reg_type == AMF_REGISTRATION_TYPE_RESERVED) {
+    reg_type = "RESERVED REGISTRATION TYPE";
+  } else {
+    reg_type = "UNKOWN REGISTRATION TYPE";
+  }
+
+  *params_reg_type =
+      static_cast<amf_proc_registration_type_t>(received_reg_type);
+
+  OAILOG_INFO(LOG_AMF_APP, "Received registration type %s", reg_type.c_str());
+}
+
 /* Identifies 5GS Registration type and processes the Message accordingly */
 int amf_handle_registration_request(
     amf_ue_ngap_id_t ue_id, tai_t* originating_tai, ecgi_t* originating_ecgi,
@@ -271,37 +295,32 @@ int amf_handle_registration_request(
     rc = amf_proc_registration_reject(ue_id, amf_cause);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
-  amf_registration_request_ies_t* params =
-      new (amf_registration_request_ies_t)();
-  /*
-   * Message processing
-   */
-  /*
-   * Get the 5GS Registration type
-   */
-  params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_RESERVED;
-  if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_INITIAL) {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_INITIAL;
-  } else if (msg->m5gs_reg_type.type_val ==
-             AMF_REGISTRATION_TYPE_MOBILITY_UPDATING) {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_MOBILITY_UPDATING;
-  } else if (msg->m5gs_reg_type.type_val ==
-             AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_PERIODIC_UPDATING;
-  } else if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_EMERGENCY) {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_EMERGENCY;
-  } else if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_RESERVED) {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_RESERVED;
-  } else {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_INITIAL;
+
+  // Get the 5GS Registration type
+  amf_proc_registration_type_t m5gsregistrationtype =
+      AMF_REGISTRATION_TYPE_RESERVED;
+
+  amf_get_registration_type_request(msg->m5gs_reg_type.type_val,
+                                    &m5gsregistrationtype);
+
+  if (m5gsregistrationtype > AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
+    OAILOG_ERROR(LOG_AMF_APP, "Registration type not supported \n");
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
 
   ue_m5gmm_context_s* ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   if (ue_context == NULL) {
     OAILOG_ERROR(LOG_AMF_APP,
                  "UE context is null for UE ID: " AMF_UE_NGAP_ID_FMT, ue_id);
-    return RETURNerror;
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
+
+  amf_registration_request_ies_t* params =
+      new (amf_registration_request_ies_t)();
+
+  // Store the registration type in params
+  params->m5gsregistrationtype = m5gsregistrationtype;
+
   // Save the UE Security Capability into AMF's UE Context
   memcpy(&(ue_context->amf_context.ue_sec_capability),
          &(msg->ue_sec_capability), sizeof(UESecurityCapabilityMsg));
@@ -310,7 +329,11 @@ int amf_handle_registration_request(
 
   ue_context->amf_context.decode_status = decode_status;
 
-  if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_INITIAL) {
+  // If registration type is intial registration or
+  // Context is new and registration type is mobile updating start registration
+  if ((params->m5gsregistrationtype == AMF_REGISTRATION_TYPE_INITIAL) ||
+      ((is_amf_ctx_new == true) && (params->m5gsregistrationtype ==
+                                    AMF_REGISTRATION_TYPE_MOBILITY_UPDATING))) {
     OAILOG_DEBUG(LOG_NAS_AMF, "New REGISTRATION_REQUEST processing\n");
     // Check integrity and ciphering algorithm bits
     // If all bits are zero it means integrity and ciphering algorithms are not
@@ -453,9 +476,8 @@ int amf_handle_registration_request(
       params->guti = new (guti_m5_t)();
       ue_context->amf_context.reg_id_type = M5GSMobileIdentityMsg_GUTI;
     }
-  }  // end of AMF_REGISTRATION_TYPE_INITIAL
-
-  if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
+  } else if (params->m5gsregistrationtype ==
+             AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
     /*
      * This request for periodic registration update
      * For registered UE, is_amf_ctx_new = False
@@ -522,10 +544,11 @@ int amf_handle_registration_request(
           LOG_AMF_APP,
           "UE context was not existing or UE identity type is not GUTI "
           "Periodic Registration Update failed and sending reject message\n");
-      // TODO Implement Reject message
-      return RETURNerror;
+      OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
     }
-  }  // end of AMF_REGISTRATION_TYPE_PERIODIC_UPDATING
+  } else {
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+  }
 
   params->decode_status = decode_status;
   /*

--- a/lte/gateway/c/core/oai/tasks/amf/amf_session_manager_pco.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_session_manager_pco.cpp
@@ -37,7 +37,7 @@ void sm_free_protocol_configuration_options(
     protocol_configuration_options_t** const protocol_configuration_options) {
   protocol_configuration_options_t* pco = *protocol_configuration_options;
   if (pco) {
-    for (int i = 0; i < PCO_UNSPEC_MAXIMUM_PROTOCOL_ID_OR_CONTAINER_ID; i++) {
+    for (int i = 0; i < pco->num_protocol_or_container_id; i++) {
       if (pco->protocol_or_container_ids[i].contents) {
         bdestroy_wrapper(&pco->protocol_or_container_ids[i].contents);
       }
@@ -49,6 +49,8 @@ void sm_copy_protocol_configuration_options(
     protocol_configuration_options_t* const pco_dst,
     const protocol_configuration_options_t* const pco_src) {
   if ((pco_dst) && (pco_src)) {
+    memset(pco_dst, 0, sizeof(protocol_configuration_options_t));
+
     pco_dst->ext = pco_src->ext;
     pco_dst->spare = pco_src->spare;
     pco_dst->configuration_protocol = pco_src->configuration_protocol;
@@ -191,17 +193,17 @@ uint16_t sm_process_pco_request_ipcp(
 
 uint16_t sm_process_pco_request(protocol_configuration_options_t* pco_req,
                                 protocol_configuration_options_t* pco_resp) {
-  auto rc = 0;
+  auto length = 0;
 
   for (auto id = 0; id < pco_req->num_protocol_or_container_id; id++) {
     switch (pco_req->protocol_or_container_ids[id].id) {
       case PCO_PI_IPCP:
-        rc = sm_process_pco_request_ipcp(
+        length += sm_process_pco_request_ipcp(
             pco_resp, &pco_req->protocol_or_container_ids[id]);
         break;
 
       case PCO_CI_DNS_SERVER_IPV4_ADDRESS_REQUEST:
-        rc = sm_process_pco_dns_server_request(pco_resp);
+        length += sm_process_pco_dns_server_request(pco_resp);
         break;
 
       default:
@@ -209,7 +211,7 @@ uint16_t sm_process_pco_request(protocol_configuration_options_t* pco_req,
     }
   }
 
-  return (rc);
+  return (length);
 }
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -487,16 +487,13 @@ int amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ue_id,
       amf_smf_msg.u.establish.gnb_gtp_teid =
           smf_ctx->gtp_tunnel_id.gnb_gtp_teid;
 
-      // Initialize DNN
-      char* default_dnn = bstr2cstr(amf_config.default_dnn, '?');
-
       int index_dnn = 0;
       bool ue_sent_dnn = true;
       std::string dnn_string;
 
       if (msg->dnn.len <= 1) {
         ue_sent_dnn = false;
-        dnn_string = default_dnn;
+        dnn_string.assign(bdata(amf_config.default_dnn));
       } else {
         dnn_string.assign(reinterpret_cast<char*>(msg->dnn.dnn),
                           msg->dnn.len - 1);
@@ -504,7 +501,6 @@ int amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ue_id,
 
       int validate = amf_validate_dnn(&ue_context->amf_context, dnn_string,
                                       &index_dnn, ue_sent_dnn);
-      free(default_dnn);
 
       if (validate == RETURNok) {
         smf_dnn_ambr_select(smf_ctx, ue_context, index_dnn);
@@ -591,6 +587,34 @@ void smf_dnn_ambr_select(const std::shared_ptr<smf_context_t>& smf_ctx,
       &ue_context->amf_context.apn_config_profile.apn_configuration[index_dnn]
            .ambr,
       sizeof(ambr_t));
+
+  // Good idea to store the QCI and other values as well
+  eps_subscribed_qos_profile_t* subscribed_qos =
+      &(ue_context->amf_context.apn_config_profile.apn_configuration[index_dnn]
+            .subscribed_qos);
+
+  qos_flow_setup_request_item* ctxt_qos_flow_req_item =
+      &(smf_ctx->subscribed_qos_profile.qos_flow_req_item);
+
+  // Update the qfi and fiveqi
+  ctxt_qos_flow_req_item->qos_flow_identifier = subscribed_qos->qci;
+  ctxt_qos_flow_req_item->qos_flow_level_qos_param.qos_characteristic
+      .non_dynamic_5QI_desc.fiveQI = subscribed_qos->qci;
+
+  // Update the retention priority
+  ctxt_qos_flow_req_item->qos_flow_level_qos_param.alloc_reten_priority
+      .priority_level =
+      subscribed_qos->allocation_retention_priority.priority_level;
+
+  // Update the pre-emption capability
+  ctxt_qos_flow_req_item->qos_flow_level_qos_param.alloc_reten_priority
+      .pre_emption_cap =
+      subscribed_qos->allocation_retention_priority.pre_emp_capability;
+
+  // Update the pre-emption vulnerability
+  ctxt_qos_flow_req_item->qos_flow_level_qos_param.alloc_reten_priority
+      .pre_emption_vul =
+      subscribed_qos->allocation_retention_priority.pre_emp_vulnerability;
 }
 /***************************************************************************
 **                                                                        **
@@ -828,8 +852,8 @@ int amf_smf_handle_ip_address_response(
                                                   response_p->pdu_session_id);
   if (NULL == smf_ctx) {
     OAILOG_ERROR(LOG_AMF_APP,
-                 "Smf Context not found for pdu session id: [%s] \n",
-                 reinterpret_cast<char*>(response_p->pdu_session_id));
+                 "Smf Context not found for pdu session id: [%u] \n",
+                 response_p->pdu_session_id);
     return rc;
   }
 

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_smf_session_context.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_smf_session_context.h
@@ -27,4 +27,7 @@ status_code_e amf_smf_context_ue_aggregate_max_bit_rate_set(
 status_code_e amf_smf_context_ue_aggregate_max_bit_rate_get(
     const amf_context_s* amf_ctxt_p, bit_rate_t* subscriber_ambr_dl,
     bit_rate_t* subscriber_ambr_ul);
+
+void amf_smf_get_slice_configuration(std::shared_ptr<smf_context_t> smf_ctx,
+                                     s_nssai_t* slice_config);
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -369,6 +369,8 @@ int amf_proc_identification(amf_context_t* const amf_context,
       ident_proc->identity_type = type;
       ident_proc->retransmission_count = 0;
       ident_proc->ue_id = ue_id;
+      (reinterpret_cast<nas5g_base_proc_t*>(ident_proc))->parent =
+          reinterpret_cast<nas5g_base_proc_t*>(amf_proc);
       ident_proc->amf_com_proc.amf_proc.delivered = NULL;
       ident_proc->amf_com_proc.amf_proc.base_proc.success_notif = success;
       ident_proc->amf_com_proc.amf_proc.base_proc.failure_notif = failure;

--- a/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -140,10 +140,10 @@ Status AmfServiceImpl::SetSmfSessionContext(
       req_m5g.qos().arp().priority_level();  // uint32
   itti_msg.qos_list.qos_flow_req_item.qos_flow_level_qos_param
       .alloc_reten_priority.pre_emption_cap =
-      (pre_emption_capability)req_m5g.qos().arp().pre_capability();  // enum
+      (pre_emption_capability_t)req_m5g.qos().arp().pre_capability();  // enum
   itti_msg.qos_list.qos_flow_req_item.qos_flow_level_qos_param
       .alloc_reten_priority.pre_emption_vul =
-      (pre_emption_vulnerability)req_m5g.qos()
+      (pre_emption_vulnerability_t)req_m5g.qos()
           .arp()
           .pre_vulnerability();  // enum
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQOSRules.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQOSRules.h
@@ -22,8 +22,7 @@ class NewQOSRulePktFilter {
   uint8_t pkt_filter_dir : 2;
   uint8_t pkt_filter_id : 4;
   uint8_t len;
-  uint8_t contents[1 * ONE_K];  // need to revisit if the QOS rules occupy more
-                                // space than 4k.
+  uint8_t contents;
   NewQOSRulePktFilter();
   ~NewQOSRulePktFilter();
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQOSRules.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQOSRules.cpp
@@ -70,7 +70,7 @@ int QOSRulesMsg::DecodeQOSRulesMsg(QOSRulesMsg* qos_rules, uint8_t iei,
 
       IES_DECODE_U8(buffer, decoded,
                     qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len);
-      memcpy(qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].contents,
+      memcpy(&(qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].contents),
              buffer + decoded,
              qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len);
       decoded += qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len;
@@ -127,7 +127,7 @@ int QOSRulesMsg::EncodeQOSRulesMsg(QOSRulesMsg* qos_rules, uint8_t iei,
           qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len;
       encoded++;
       memcpy(buffer + encoded,
-             qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].contents,
+             &(qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].contents),
              qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len);
       encoded = encoded + qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len;
     }

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -47,6 +47,75 @@ imsi64_t send_initial_ue_message_no_tmsi(
   return imsi64;
 }
 
+/* For guti based registration */
+uint64_t send_initial_ue_message_with_tmsi(
+    amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,
+    uint32_t gnb_id, gnb_ue_ngap_id_t gnb_ue_ngap_id,
+    amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, uint32_t m_tmsi,
+    const uint8_t* nas_msg, uint8_t nas_msg_length) {
+  tai_t originating_tai = {};
+  int rc = RETURNerror;
+  tai_t tai = {.plmn = plmn, .tac = 1};
+
+  itti_ngap_initial_ue_message_t initial_ue_message = {};
+
+  initial_ue_message.nas = blk2bstr(nas_msg, nas_msg_length);
+
+  initial_ue_message.sctp_assoc_id = sctp_assoc_id;
+  initial_ue_message.gnb_ue_ngap_id = gnb_ue_ngap_id;
+  initial_ue_message.gnb_id = gnb_id;
+  initial_ue_message.m5g_rrc_establishment_cause = M5G_MO_SIGNALING;
+  initial_ue_message.is_s_tmsi_valid = true;
+  initial_ue_message.opt_s_tmsi.amf_set_id = 1;
+  initial_ue_message.opt_s_tmsi.amf_pointer = 0;
+  initial_ue_message.opt_s_tmsi.m_tmsi = m_tmsi;
+  initial_ue_message.tai = tai;
+  initial_ue_message.ue_context_request = M5G_UEContextRequest_requested;
+
+  amf_app_handle_initial_ue_message(amf_app_desc_p, &initial_ue_message);
+
+  guti_m5_t guti_search;
+  memset(&guti_search, 0, sizeof(guti_m5_t));
+
+  guti_search.guamfi.amf_regionid = 1;
+  guti_search.guamfi.amf_set_id = 1;
+  guti_search.guamfi.amf_pointer = 0;
+  guti_search.guamfi.plmn = plmn;
+  guti_search.m_tmsi = m_tmsi;
+
+  uint64_t amf_ue_ngap_id64 = 0;
+  magma::map_rc_t m_rc = magma::MAP_KEY_NOT_EXISTS;
+  rc = amf_app_desc_p->amf_ue_contexts.guti_ue_context_htbl.get(
+      guti_search, &amf_ue_ngap_id64);
+
+  return amf_ue_ngap_id64;
+}
+
+/* Create the identiy response message */
+int send_uplink_nas_identity_response_message(amf_app_desc_t* amf_app_desc_p,
+                                              amf_ue_ngap_id_t ue_id,
+                                              const plmn_t& plmn,
+                                              const uint8_t* nas_msg,
+                                              uint8_t nas_msg_length) {
+  bstring pdu_session_req;
+  tai_t originating_tai = {};
+
+  if ((!amf_app_desc_p) || (!nas_msg) || (nas_msg_length == 0)) {
+    return RETURNerror;
+  }
+
+  pdu_session_req = blk2bstr(nas_msg, nas_msg_length);
+
+  originating_tai.plmn = plmn;
+  originating_tai.tac = 1;
+
+  int rc = RETURNerror;
+  rc = amf_app_handle_uplink_nas_message(amf_app_desc_p, pdu_session_req, ue_id,
+                                         originating_tai);
+
+  return (rc);
+}
+
 /* Create authentication answer from subscriberdb */
 int send_proc_authentication_info_answer(const std::string& imsi,
                                          amf_ue_ngap_id_t ue_id, bool success) {
@@ -275,9 +344,12 @@ void create_pdu_session_response_itti(
   response->qos_list.qos_flow_req_item.qos_flow_level_qos_param
       .alloc_reten_priority.priority_level = 1;
   response->qos_list.qos_flow_req_item.qos_flow_level_qos_param
-      .alloc_reten_priority.pre_emption_cap = SHALL_NOT_TRIGGER_PRE_EMPTION;
+      .alloc_reten_priority.pre_emption_cap =
+      static_cast<pre_emption_capability_t>(PRE_EMPTION_CAPABILITY_DISABLED);
   response->qos_list.qos_flow_req_item.qos_flow_level_qos_param
-      .alloc_reten_priority.pre_emption_vul = NOT_PREEMPTABLE;
+      .alloc_reten_priority.pre_emption_vul =
+      static_cast<pre_emption_vulnerability_t>(
+          PRE_EMPTION_VULNERABILITY_DISABLED);
   response->upf_endpoint.teid[0] = 0x7f;
   response->upf_endpoint.teid[1] = 0xff;
   response->upf_endpoint.teid[2] = 0xff;
@@ -312,6 +384,22 @@ int send_pdu_session_response_itti(pdn_type_value_t type) {
   return rc;
 }
 
+int send_pdu_session_response_missing_qfi_itti(pdn_type_value_t type) {
+  int rc = RETURNerror;
+  itti_n11_create_pdu_session_response_t response = {};
+  create_pdu_session_response_itti(type, &response);
+
+  response.qos_list.qos_flow_req_item.qos_flow_identifier = 0;
+  response.qos_list.qos_flow_req_item.qos_flow_level_qos_param
+      .qos_characteristic.non_dynamic_5QI_desc.fiveQI = 0;
+  response.qos_list.qos_flow_req_item.qos_flow_level_qos_param
+      .alloc_reten_priority.priority_level = 0;
+
+  rc = amf_app_handle_pdu_session_response(&response);
+
+  return rc;
+}
+
 void create_pdu_resource_setup_response_itti(
     itti_ngap_pdusessionresource_setup_rsp_t* response,
     amf_ue_ngap_id_t ue_id) {
@@ -339,6 +427,7 @@ void create_pdu_resource_setup_response_itti(
   qosFlow->items = 1;
   qosFlow->QosFlowIdentifier[0] = 9;
 }
+
 int send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id) {
   int rc = RETURNok;
   itti_ngap_pdusessionresource_setup_rsp_t response = {};
@@ -457,11 +546,11 @@ void send_ue_context_release_request_message(amf_app_desc_t* amf_app_desc_p,
   amf_app_handle_cm_idle_on_ue_context_release(ue_context_release_request);
 }
 
-imsi64_t send_initial_ue_message_service_request_with_pdu(
+imsi64_t send_initial_ue_message_service_request(
     amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,
     uint32_t gnb_id, gnb_ue_ngap_id_t gnb_ue_ngap_id,
     amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, const uint8_t* nas_msg,
-    uint8_t nas_msg_length) {
+    uint8_t nas_msg_length, uint8_t tmsi_offset) {
   tai_t originating_tai = {};
   int rc = RETURNerror;
   imsi64_t imsi64 = 0;
@@ -480,7 +569,8 @@ imsi64_t send_initial_ue_message_service_request_with_pdu(
    * message has uplink data status(4 bytess)
    * and PDU session status(4 bytes) after TMSI*/
   ue_tmsi = htonl(ue_tmsi);
-  memcpy(&(initial_ue_message.nas->data[nas_msg_length - sizeof(tmsi_t) - 8]),
+  memcpy(&(initial_ue_message.nas
+               ->data[nas_msg_length - sizeof(tmsi_t) - tmsi_offset]),
          &(ue_tmsi), sizeof(tmsi_t));
   initial_ue_message.sctp_assoc_id = sctp_assoc_id;
   initial_ue_message.gnb_ue_ngap_id = gnb_ue_ngap_id;

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -38,11 +38,25 @@ imsi64_t send_initial_ue_message_no_tmsi(
     amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, const uint8_t* nas_msg,
     uint8_t nas_msg_length);
 
-imsi64_t send_initial_ue_message_service_request_with_pdu(
+/* For guti based registration */
+uint64_t send_initial_ue_message_with_tmsi(
+    amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,
+    uint32_t gnb_id, gnb_ue_ngap_id_t gnb_ue_ngap_id,
+    amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, uint32_t m_tmsi,
+    const uint8_t* nas_msg, uint8_t nas_msg_length);
+
+/* For generating the identity response message */
+int send_uplink_nas_identity_response_message(amf_app_desc_t* amf_app_desc_p,
+                                              amf_ue_ngap_id_t ue_id,
+                                              const plmn_t& plmn,
+                                              const uint8_t* nas_msg,
+                                              uint8_t nas_msg_length);
+
+imsi64_t send_initial_ue_message_service_request(
     amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,
     uint32_t gnb_id, gnb_ue_ngap_id_t gnb_ue_ngap_id,
     amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, const uint8_t* nas_msg,
-    uint8_t nas_msg_length);
+    uint8_t nas_msg_length, uint8_t tmsi_offset);
 
 int send_uplink_nas_message_service_request_with_pdu(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t amf_ue_ngap_id,
@@ -91,6 +105,8 @@ void create_pdu_session_response_ipv4_itti(
     itti_n11_create_pdu_session_response_t* response);
 
 int send_pdu_session_response_itti(pdn_type_value_t type);
+
+int send_pdu_session_response_missing_qfi_itti(pdn_type_value_t type);
 
 void create_pdu_resource_setup_response_itti(
     itti_ngap_pdusessionresource_setup_rsp_t* response, amf_ue_ngap_id_t ue_id);

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -967,7 +967,7 @@ TEST(test_dnn, test_amf_handle_s6a_update_location_ans) {
   // Building s6a_update_location_ans_t
   std::string imsi = "901700000000001";
   s6a_update_location_ans_t ula_ans;
-  ula_ans = amf_send_s6a_ula(imsi);
+  ula_ans = util_amf_send_s6a_ula(imsi);
 
   // Building key value pair for amf_supi_guti_map and ue_context_map
   uint64_t imsi_64 = 901700000000001;
@@ -1014,7 +1014,7 @@ TEST(test_dnn, test_amf_validate_dnn) {
   s6a_update_location_ans_t ula_ans;
 
   // mock handling ans received from s6a_update_location_request
-  ula_ans = amf_send_s6a_ula(imsi);
+  ula_ans = util_amf_send_s6a_ula(imsi);
   memcpy(&amf_ctx.apn_config_profile,
          &ula_ans.subscription_data.apn_config_profile,
          sizeof(apn_config_profile_t));

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.h"
 #include "lte/gateway/c/core/oai/test/amf/amf_app_test_util.h"
+#include "lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h"
 
 using ::testing::Test;
 
@@ -45,6 +46,20 @@ class AMFAppProcedureTest : public ::testing::Test {
 
     init_task_context(TASK_MAIN, nullptr, 0, NULL, &amf_app_task_zmq_ctx);
 
+    char dnn[] = "internet";
+    amf_config.default_dnn = bfromcstr(dnn);
+    inet_aton("8.8.8.8", &(amf_config.ipv4.default_dns));
+    inet_aton("8.8.10.10", &(amf_config.ipv4.default_dns_sec));
+
+    /* Initialize the plmn */
+    amf_config.guamfi.nb = 1;
+    amf_config.guamfi.guamfi[0].plmn = {.mcc_digit2 = 2,
+                                        .mcc_digit1 = 2,
+                                        .mnc_digit3 = 6,
+                                        .mcc_digit3 = 2,
+                                        .mnc_digit2 = 5,
+                                        .mnc_digit1 = 4};
+
     amf_app_desc_p = get_amf_nas_state(false);
     AMFClientServicer::getInstance().msgtype_stack.clear();
   }
@@ -60,12 +75,12 @@ class AMFAppProcedureTest : public ::testing::Test {
  protected:
   amf_app_desc_t* amf_app_desc_p;
   std::string imsi = "222456000000001";
-  plmn_t plmn = {.mcc_digit2 = 0,
-                 .mcc_digit1 = 0,
-                 .mnc_digit3 = 0x0f,
-                 .mcc_digit3 = 1,
-                 .mnc_digit2 = 1,
-                 .mnc_digit1 = 0};
+  plmn_t plmn = {.mcc_digit2 = 2,
+                 .mcc_digit1 = 2,
+                 .mnc_digit3 = 6,
+                 .mcc_digit3 = 2,
+                 .mnc_digit2 = 5,
+                 .mnc_digit1 = 4};
 
   itti_amf_decrypted_imsi_info_ans_t decrypted_imsi = {
       .imsi = "222456000000001", .imsi_length = 15, .result = 1, .ue_id = 1};
@@ -82,6 +97,34 @@ class AMFAppProcedureTest : public ::testing::Test {
       0x7e, 0x00, 0x41, 0x79, 0x00, 0x0d, 0x01, 0x22, 0x62,
       0x54, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
       0x01, 0x2e, 0x04, 0xf0, 0xf0, 0xf0, 0xf0};
+
+  /* Guti based initial registration message */
+  const uint8_t guti_initial_ue_message_hexbuf[98] = {
+      0x7e, 0x01, 0x67, 0xb7, 0x6f, 0xc6, 0x03, 0x7e, 0x00, 0x41, 0x09,
+      0x00, 0x0b, 0xf2, 0x22, 0x62, 0x54, 0x01, 0x00, 0x40, 0x12, 0x70,
+      0x41, 0x77, 0x2e, 0x04, 0x80, 0xe0, 0x80, 0xe0, 0x71, 0x00, 0x41,
+      0x7e, 0x00, 0x41, 0x09, 0x00, 0x0b, 0xf2, 0x22, 0x62, 0x54, 0x01,
+      0x00, 0x40, 0x12, 0x70, 0x41, 0x77, 0x10, 0x01, 0x03, 0x2e, 0x04,
+      0x80, 0xe0, 0x80, 0xe0, 0x2f, 0x02, 0x01, 0x01, 0x52, 0x22, 0x62,
+      0x54, 0x00, 0x00, 0x01, 0x17, 0x07, 0x80, 0xe0, 0xe0, 0x60, 0x00,
+      0x1c, 0x30, 0x18, 0x01, 0x00, 0x74, 0x00, 0x0a, 0x09, 0x08, 0x69,
+      0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74, 0x53, 0x01, 0x01};
+
+  /* Mobile Termination as the initial ue message */
+  const uint8_t mu_initial_ue_message_hexbuf[93] = {
+      0x7e, 0x01, 0xa3, 0xcf, 0x4c, 0x7e, 0xd1, 0x7e, 0x00, 0x41, 0x02, 0x00,
+      0x0b, 0xf2, 0x22, 0x62, 0x54, 0x01, 0x00, 0x40, 0x8f, 0x71, 0x9f, 0x0e,
+      0x2e, 0x04, 0xf0, 0x70, 0xf0, 0x70, 0x71, 0x00, 0x3c, 0x7e, 0x00, 0x41,
+      0x02, 0x00, 0x0b, 0xf2, 0x22, 0x62, 0x54, 0x01, 0x00, 0x40, 0x8f, 0x71,
+      0x9f, 0x0e, 0x10, 0x01, 0x03, 0x2e, 0x04, 0xf0, 0x70, 0xf0, 0x70, 0x2f,
+      0x02, 0x01, 0x01, 0x52, 0x22, 0x62, 0x54, 0x00, 0x00, 0x01, 0x17, 0x07,
+      0xf0, 0x70, 0x00, 0x00, 0x18, 0x80, 0xb0, 0x50, 0x02, 0x00, 0x00, 0x18,
+      0x01, 0x01, 0x74, 0x00, 0x00, 0x90, 0x53, 0x01, 0x01};
+
+  const uint8_t identity_response[25] = {
+      0x7e, 0x01, 0xe2, 0x1d, 0xd9, 0xe5, 0x04, 0x7e, 0x00,
+      0x5c, 0x00, 0x0d, 0x01, 0x22, 0x62, 0x54, 0xf0, 0xff,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
 
   const uint8_t ue_auth_response_hexbuf[21] = {
       0x7e, 0x0,  0x57, 0x2d, 0x10, 0x25, 0x70, 0x6f, 0x9a, 0x5b, 0x90,
@@ -108,6 +151,14 @@ class AMFAppProcedureTest : public ::testing::Test {
       0xff, 0x91, 0xa1, 0x28, 0x01, 0x00, 0x7b, 0x00, 0x07, 0x80, 0x00,
       0x0a, 0x00, 0x00, 0x0d, 0x00, 0x12, 0x01, 0x81, 0x22, 0x01, 0x01,
       0x25, 0x09, 0x08, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74};
+
+  const uint8_t ue_pdu_session_est_req_no_dnn_no_slice_hexbuf[67] = {
+      0x7e, 0x00, 0x67, 0x01, 0x00, 0x3a, 0x2e, 0x01, 0x01, 0xc1, 0x00, 0x00,
+      0x91, 0x28, 0x01, 0x00, 0x7b, 0x00, 0x2d, 0x80, 0x80, 0x21, 0x10, 0x01,
+      0x00, 0x00, 0x10, 0x81, 0x06, 0x00, 0x00, 0x00, 0x00, 0x83, 0x06, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x05, 0x00,
+      0x00, 0x10, 0x00, 0x00, 0x11, 0x00, 0x00, 0x17, 0x01, 0x01, 0x00, 0x23,
+      0x00, 0x00, 0x24, 0x00, 0x12, 0x01, 0x81};
 
   const uint8_t ue_pdu_session_v6_est_req_hexbuf[44] = {
       0x7e, 0x00, 0x67, 0x01, 0x00, 0x15, 0x2e, 0x01, 0x01, 0xc1, 0xff,
@@ -168,6 +219,12 @@ class AMFAppProcedureTest : public ::testing::Test {
       0xff, 0xff, 0xff, 0xff,
       // Uplink data status and pdu session status
       0x40, 0x02, 0x20, 0x00, 0x50, 0x02, 0x20, 0x00};
+
+  const uint8_t initial_ue_msg_service_request_signalling[40] = {
+      0x7e, 0x01, 0x30, 0x6f, 0xf2, 0xae, 0x03, 0x7e, 0x00, 0x4c,
+      0x00, 0x00, 0x07, 0xf4, 0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b,
+      0x71, 0x00, 0x11, 0x7e, 0x00, 0x4c, 0x00, 0x00, 0x07, 0xf4,
+      0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b, 0x50, 0x02, 0x20, 0x00};
 };
 
 amf_context_t* get_amf_context_by_ueid(amf_ue_ngap_id_t ue_id) {
@@ -182,6 +239,31 @@ amf_context_t* get_amf_context_by_ueid(amf_ue_ngap_id_t ue_id) {
   amf_context_t* amf_ctx = &ue_m5gmm_context->amf_context;
 
   return amf_ctx;
+}
+
+bool validate_identification_procedure(amf_ue_ngap_id_t ue_id,
+                                       uint32_t expected_retransmission_count) {
+  amf_context_t* amf_ctx = get_amf_context_by_ueid(ue_id);
+  if (amf_ctx == NULL) {
+    return false;
+  }
+
+  /* Fetch security mode control procedure */
+  nas_amf_ident_proc_t* ident_proc =
+      get_5g_nas_common_procedure_identification(amf_ctx);
+  if (ident_proc == NULL) {
+    return false;
+  }
+
+  if (ident_proc->retransmission_count != expected_retransmission_count) {
+    return false;
+  }
+
+  if (ident_proc->ue_id != ue_id) {
+    return false;
+  }
+
+  return true;
 }
 
 bool validate_auth_procedure(amf_ue_ngap_id_t ue_id,
@@ -400,7 +482,254 @@ TEST_F(AMFAppProcedureTest, TestDeRegistration) {
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
 }
 
+TEST_F(AMFAppProcedureTest, TestRegistrationProcGutiBased) {
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
+      NGAP_NAS_DL_DATA_REQ,  // Security Command Mode Request to UE
+      NGAP_NAS_DL_DATA_REQ,
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
+      NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
+  };
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  uint32_t m_tmsi = 0x12704177;
+  ue_id = send_initial_ue_message_with_tmsi(
+      amf_app_desc_p, 36, 1, 1, 0, plmn, m_tmsi, guti_initial_ue_message_hexbuf,
+      sizeof(guti_initial_ue_message_hexbuf));
+
+  EXPECT_TRUE(validate_identification_procedure(ue_id, 0));
+
+  int rc = RETURNok;
+  rc = send_uplink_nas_identity_response_message(amf_app_desc_p, ue_id, plmn,
+                                                 identity_response,
+                                                 sizeof(identity_response));
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  ASSERT_NE(ue_context_p, nullptr);
+  EXPECT_TRUE(ue_context_p->amf_context.imsi64 == stoul(imsi));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Validate if authentication procedure is initialized as expected */
+  EXPECT_TRUE(validate_auth_procedure(ue_id, 0));
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Check whether security mode procedure is initiated */
+  EXPECT_TRUE(validate_smc_procedure(ue_id, 0));
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  amf_app_handle_deregistration_req(ue_id);
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
+TEST_F(AMFAppProcedureTest, TestMobileUpdatingRegistrationProcGutiBased) {
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
+      NGAP_NAS_DL_DATA_REQ,  // Security Command Mode Request to UE
+      NGAP_NAS_DL_DATA_REQ,
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
+      NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
+  };
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  uint32_t m_tmsi = 0x8f719f0e;
+  ue_id = send_initial_ue_message_with_tmsi(
+      amf_app_desc_p, 36, 1, 1, 0, plmn, m_tmsi, mu_initial_ue_message_hexbuf,
+      sizeof(mu_initial_ue_message_hexbuf));
+
+  EXPECT_TRUE(validate_identification_procedure(ue_id, 0));
+
+  int rc = RETURNok;
+  rc = send_uplink_nas_identity_response_message(amf_app_desc_p, ue_id, plmn,
+                                                 identity_response,
+                                                 sizeof(identity_response));
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  ASSERT_NE(ue_context_p, nullptr);
+  EXPECT_TRUE(ue_context_p->amf_context.imsi64 == stoul(imsi));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Validate if authentication procedure is initialized as expected */
+  EXPECT_TRUE(validate_auth_procedure(ue_id, 0));
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Check whether security mode procedure is initiated */
+  EXPECT_TRUE(validate_smc_procedure(ue_id, 0));
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  amf_app_handle_deregistration_req(ue_id);
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
 TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
+      NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
+      NGAP_PDUSESSION_RESOURCE_SETUP_REQ,  // PDU Resource Setup Request to GNB
+                                           // & PDU Session Establishment Accept
+      NGAP_PDUSESSIONRESOURCE_REL_REQ,  // PDU Session Resource Release Command
+      NGAP_NAS_DL_DATA_REQ,             // Deregistaration Accept
+      NGAP_UE_CONTEXT_RELEASE_COMMAND   // UEContextReleaseCommand
+  };
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn,
+                                           initial_ue_message_hexbuf,
+                                           sizeof(initial_ue_message_hexbuf));
+
+  /* Check if UE Context is created with correct imsi */
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for pdu session establishment request from UE */
+  rc = send_uplink_nas_pdu_session_establishment_request(
+      amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
+      sizeof(ue_pdu_session_est_req_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send ip address response  from pipelined */
+  rc = send_ip_address_response_itti(IPv4);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send pdu session setup response  from smf */
+  rc = send_pdu_session_response_itti(IPv4);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send pdu resource setup response  from UE */
+  rc = send_pdu_resource_setup_response(ue_id);
+  EXPECT_TRUE(rc == RETURNok);
+
+  rc = send_pdu_notification_response();
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  ASSERT_NE(ue_context_p, nullptr);
+
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 1);
+  std::shared_ptr<smf_context_t> smf_ctxt =
+      ue_context_p->amf_context.smf_ctxt_map.begin()->second;
+
+  EXPECT_EQ(
+      smf_ctxt->subscribed_qos_profile.qos_flow_req_item.qos_flow_identifier,
+      9);
+  EXPECT_EQ(smf_ctxt->subscribed_qos_profile.qos_flow_req_item
+                .qos_flow_level_qos_param.qos_characteristic
+                .non_dynamic_5QI_desc.fiveQI,
+            9);
+
+  /* Send uplink nas message for pdu session release request from UE */
+  rc = send_uplink_nas_pdu_session_release_message(
+      amf_app_desc_p, ue_id, plmn, pdu_sess_release_hexbuf,
+      sizeof(pdu_sess_release_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for pdu session release complete from UE */
+  rc = send_uplink_nas_pdu_session_release_message(
+      amf_app_desc_p, ue_id, plmn, pdu_sess_release_complete_hexbuf,
+      sizeof(pdu_sess_release_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 0);
+
+  rc = send_pdu_notification_response();
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for deregistration complete response from UE */
+  rc = send_uplink_nas_ue_deregistration_request(
+      amf_app_desc_p, ue_id, plmn, ue_initiated_dereg_hexbuf,
+      sizeof(ue_initiated_dereg_hexbuf));
+
+  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
+TEST_F(AMFAppProcedureTest, TestPDUSessionSetupNoDnnNoSlice) {
   int rc = RETURNerror;
   amf_ue_ngap_id_t ue_id = 0;
   std::vector<MessagesIds> expected_Ids{
@@ -452,8 +781,9 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
 
   /* Send uplink nas message for pdu session establishment request from UE */
   rc = send_uplink_nas_pdu_session_establishment_request(
-      amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
-      sizeof(ue_pdu_session_est_req_hexbuf));
+      amf_app_desc_p, ue_id, plmn,
+      ue_pdu_session_est_req_no_dnn_no_slice_hexbuf,
+      sizeof(ue_pdu_session_est_req_no_dnn_no_slice_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
   /* Send ip address response  from pipelined */
@@ -1178,7 +1508,6 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
                                         AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
                                         AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
                                         NGAP_INITIAL_CONTEXT_SETUP_REQ,
-                                        NGAP_NAS_DL_DATA_REQ,
                                         NGAP_PDUSESSIONRESOURCE_REL_REQ,
                                         NGAP_NAS_DL_DATA_REQ,
                                         NGAP_UE_CONTEXT_RELEASE_COMMAND};
@@ -1245,13 +1574,19 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
 
   /*Send initial UE message Service Request with PDU*/
   imsi64 = 0;
-  imsi64 = send_initial_ue_message_service_request_with_pdu(
-      amf_app_desc_p, 36, 1, 1, ue_id, plmn,
+  imsi64 = send_initial_ue_message_service_request(
+      amf_app_desc_p, 36, 1, 2, ue_id, plmn,
       initial_ue_msg_service_request_with_pdu,
-      sizeof(initial_ue_msg_service_request_with_pdu));
+      sizeof(initial_ue_msg_service_request_with_pdu), 8);
 
   EXPECT_EQ(REGISTERED_IDLE, ue_context->mm_state);
   EXPECT_EQ(true, ue_context->pending_service_response);
+
+  // Ue id will be freshly generated
+  EXPECT_NE(ue_context->amf_ue_ngap_id, ue_id);
+
+  // Update the ue_id
+  ue_id = ue_context->amf_ue_ngap_id;
 
   /* Send pdu session setup response  from smf */
   rc = send_pdu_session_response_itti(IPv4);
@@ -1260,13 +1595,6 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
   EXPECT_EQ(false, ue_context->pending_service_response);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
-
-  /*Send Uplink NAS transport Service request with PDU*/
-  rc = send_uplink_nas_message_service_request_with_pdu(
-      amf_app_desc_p, ue_id, plmn, initial_ue_msg_service_request_with_pdu,
-      sizeof(initial_ue_msg_service_request_with_pdu));
-  EXPECT_TRUE(rc == RETURNok);
-  EXPECT_EQ(false, ue_context->pending_service_response);
 
   /* Send uplink nas message for pdu session release request from UE */
   rc = send_uplink_nas_pdu_session_release_message(
@@ -1292,4 +1620,198 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
 
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
 }
+
+TEST_F(AMFAppProcedureTest, TestPDUSessionSetupWithMissingQFI) {
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
+      NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
+      NGAP_PDUSESSION_RESOURCE_SETUP_REQ,  // PDU Resource Setup Request to GNB
+                                           // & PDU Session Establishment Accept
+      NGAP_PDUSESSIONRESOURCE_REL_REQ,  // PDU Session Resource Release Command
+      NGAP_NAS_DL_DATA_REQ,             // Deregistaration Accept
+      NGAP_UE_CONTEXT_RELEASE_COMMAND   // UEContextReleaseCommand
+  };
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn,
+                                           initial_ue_message_hexbuf,
+                                           sizeof(initial_ue_message_hexbuf));
+
+  /* Check if UE Context is created with correct imsi */
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for pdu session establishment request from UE */
+  rc = send_uplink_nas_pdu_session_establishment_request(
+      amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
+      sizeof(ue_pdu_session_est_req_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send ip address response  from pipelined */
+  rc = send_ip_address_response_itti(IPv4);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send pdu resource setup response  from UE */
+  rc = send_pdu_session_response_missing_qfi_itti(IPv4);
+  EXPECT_TRUE(rc == RETURNok);
+
+  rc = send_pdu_notification_response();
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  ASSERT_NE(ue_context_p, nullptr);
+
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 1);
+  std::shared_ptr<smf_context_t> smf_ctxt =
+      ue_context_p->amf_context.smf_ctxt_map.begin()->second;
+
+  EXPECT_EQ(
+      smf_ctxt->subscribed_qos_profile.qos_flow_req_item.qos_flow_identifier,
+      8);
+  EXPECT_EQ(smf_ctxt->subscribed_qos_profile.qos_flow_req_item
+                .qos_flow_level_qos_param.qos_characteristic
+                .non_dynamic_5QI_desc.fiveQI,
+            8);
+
+  /* Send uplink nas message for pdu session release request from UE */
+  rc = send_uplink_nas_pdu_session_release_message(
+      amf_app_desc_p, ue_id, plmn, pdu_sess_release_hexbuf,
+      sizeof(pdu_sess_release_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for pdu session release complete from UE */
+  rc = send_uplink_nas_pdu_session_release_message(
+      amf_app_desc_p, ue_id, plmn, pdu_sess_release_complete_hexbuf,
+      sizeof(pdu_sess_release_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 0);
+
+  rc = send_pdu_notification_response();
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for deregistration complete response from UE */
+  rc = send_uplink_nas_ue_deregistration_request(
+      amf_app_desc_p, ue_id, plmn, ue_initiated_dereg_hexbuf,
+      sizeof(ue_initiated_dereg_hexbuf));
+
+  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
+TEST_F(AMFAppProcedureTest, ServiceRequestSignalling) {
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND,
+                                        AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND};
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn,
+                                           initial_ue_message_hexbuf,
+                                           sizeof(initial_ue_message_hexbuf));
+
+  /* Check if UE Context is created with correct imsi */
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /*Send UE context release request to move to idle mode*/
+  send_ue_context_release_request_message(amf_app_desc_p, 1, 1, ue_id);
+  ue_m5gmm_context_s* ue_context = nullptr;
+  ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  EXPECT_EQ(REGISTERED_IDLE, ue_context->mm_state);
+
+  /*Send initial UE message Service Request with PDU*/
+  imsi64 = 0;
+  imsi64 = send_initial_ue_message_service_request(
+      amf_app_desc_p, 36, 1, 2, ue_id, plmn,
+      initial_ue_msg_service_request_signalling,
+      sizeof(initial_ue_msg_service_request_signalling), 4);
+
+  EXPECT_EQ(REGISTERED_CONNECTED, ue_context->mm_state);
+
+  // Ue id will be freshly generated
+  EXPECT_NE(ue_context->amf_ue_ngap_id, ue_id);
+
+  // Update the ue_id
+  ue_id = ue_context->amf_ue_ngap_id;
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for deregistration complete response from UE */
+  rc = send_uplink_nas_ue_deregistration_request(
+      amf_app_desc_p, ue_id, plmn, ue_initiated_dereg_hexbuf,
+      sizeof(ue_initiated_dereg_hexbuf));
+
+  EXPECT_TRUE(rc == RETURNok);
+
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -447,9 +447,12 @@ TEST(TestAMFStateConverter, TestSMFContextToProto) {
   smf_context1.subscribed_qos_profile.qos_flow_req_item.qos_flow_level_qos_param
       .alloc_reten_priority.priority_level = 1;
   smf_context1.subscribed_qos_profile.qos_flow_req_item.qos_flow_level_qos_param
-      .alloc_reten_priority.pre_emption_cap = SHALL_NOT_TRIGGER_PRE_EMPTION;
+      .alloc_reten_priority.pre_emption_cap =
+      static_cast<pre_emption_capability_t>(PRE_EMPTION_CAPABILITY_DISABLED);
   smf_context1.subscribed_qos_profile.qos_flow_req_item.qos_flow_level_qos_param
-      .alloc_reten_priority.pre_emption_vul = NOT_PREEMPTABLE;
+      .alloc_reten_priority.pre_emption_vul =
+      static_cast<pre_emption_vulnerability_t>(
+          PRE_EMPTION_VULNERABILITY_DISABLED);
 
   AmfNasStateConverter::smf_context_to_proto(&smf_context1, &state_smf_proto);
   AmfNasStateConverter::proto_to_smf_context(state_smf_proto, &smf_context2);

--- a/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.cpp
+++ b/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.cpp
@@ -19,7 +19,7 @@
 namespace magma5g {
 // api to mock handling of s6a_update_location_ans
 
-s6a_update_location_ans_t amf_send_s6a_ula(const std::string& imsi) {
+s6a_update_location_ans_t util_amf_send_s6a_ula(const std::string& imsi) {
   s6a_update_location_ans_t itti_msg = {};
 
   // building s6a_update_location_ans_t
@@ -41,6 +41,8 @@ s6a_update_location_ans_t amf_send_s6a_ula(const std::string& imsi) {
   itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
       .context_identifier = 0;
 
+  itti_msg.subscription_data.apn_config_profile.nb_apns = 1;
+
   memset(&itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
               .ambr.br_unit,
          0, sizeof(apn_ambr_bitrate_unit_t));
@@ -60,6 +62,18 @@ s6a_update_location_ans_t amf_send_s6a_ula(const std::string& imsi) {
       strlen("internet") + 1,
       sizeof(itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
                  .service_selection_length));
+
+  itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+      .subscribed_qos.qci = 8;
+  itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+      .subscribed_qos.allocation_retention_priority.priority_level = 8;
+  itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+      .subscribed_qos.allocation_retention_priority.pre_emp_vulnerability =
+      static_cast<pre_emption_vulnerability_t>(
+          PRE_EMPTION_VULNERABILITY_ENABLED);
+  itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+      .subscribed_qos.allocation_retention_priority.pre_emp_capability =
+      static_cast<pre_emption_capability_t>(PRE_EMPTION_CAPABILITY_ENABLED);
 
   return itti_msg;
 }

--- a/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h
+++ b/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h
@@ -18,6 +18,6 @@
 namespace magma5g {
 // api to mock handling s6a_update_location_ans
 
-s6a_update_location_ans_t amf_send_s6a_ula(const std::string& imsi);
+s6a_update_location_ans_t util_amf_send_s6a_ula(const std::string& imsi);
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
@@ -17,6 +17,7 @@
 
 extern "C" {
 #include "lte/gateway/c/core/oai/common/log.h"
+#include "lte/gateway/c/core/oai/common/common_types.h"
 #include "lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.h"
 #include "lte/gateway/c/core/oai/include/amf_config.h"
 }
@@ -683,10 +684,11 @@ TEST_F(NgapFlowTest, pdu_sess_resource_setup_req_sunny_day) {
       .qos_flow_level_qos_param.alloc_reten_priority.priority_level = 1;
   amf_pdu_ses_setup_transfer_req.qos_flow_setup_request_list.qos_flow_req_item
       .qos_flow_level_qos_param.alloc_reten_priority.pre_emption_cap =
-      SHALL_NOT_TRIGGER_PRE_EMPTION;
+      static_cast<pre_emption_capability_t>(PRE_EMPTION_CAPABILITY_DISABLED);
   amf_pdu_ses_setup_transfer_req.qos_flow_setup_request_list.qos_flow_req_item
       .qos_flow_level_qos_param.alloc_reten_priority.pre_emption_vul =
-      NOT_PREEMPTABLE;
+      static_cast<pre_emption_vulnerability_t>(
+          PRE_EMPTION_VULNERABILITY_DISABLED);
   ngap_pdu_ses_setup_req->pduSessionResource_setup_list.item[0]
       .PDU_Session_Resource_Setup_Request_Transfer =
       amf_pdu_ses_setup_transfer_req;

--- a/lte/gateway/c/core/oai/test/ngap/util_ngap_amf_nas_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/util_ngap_amf_nas_procedures.cpp
@@ -511,9 +511,10 @@ bool generator_itti_ngap_pdusession_resource_setup_req(bstring& stream) {
       .fiveQI = 9;
   qos_flow->qos_flow_level_qos_param.alloc_reten_priority.priority_level = 8;
   qos_flow->qos_flow_level_qos_param.alloc_reten_priority.pre_emption_cap =
-      SHALL_NOT_TRIGGER_PRE_EMPTION;
+      static_cast<pre_emption_capability_t>(PRE_EMPTION_CAPABILITY_DISABLED);
   qos_flow->qos_flow_level_qos_param.alloc_reten_priority.pre_emption_vul =
-      PRE_EMPTABLE;
+      static_cast<pre_emption_vulnerability_t>(
+          PRE_EMPTION_VULNERABILITY_DISABLED);
 
   ue_ref.gnb_ue_ngap_id = 1001;
   ue_ref.amf_ue_ngap_id = 2001;


### PR DESCRIPTION
Fix:
   1. Fix for handling the PCO options when both IPCP and
      DNS request is coming.
   2. Added the code for handling the mobile updating scenario
      for initial registration.
   3. Selecting default slice information update in PDU Session Establishment
      request if not received in PDU Session Establishment accept.
   4. Added the unit testcases for Guti registration and mobile
      updating based registration.

Test:
   Executed all the Unit testing
   1. For fixes 1 & 3 : TestPDUSessionSetupNoDnnNoSlice
   2. For fix 2 : TestRegistrationProcGutiBased &
                  TestMobileUpdatingRegistrationProcGutiBased

Signed-off-by: Yogesh Pandey <yogesh@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
