### PR TITLE
chore(mme): Provides unique function name for convert_itti_sgsap_...

### DIFF
--- a/lte/gateway/c/core/oai/lib/sms_orc8r_client/SMSOrc8rClient.cpp
+++ b/lte/gateway/c/core/oai/lib/sms_orc8r_client/SMSOrc8rClient.cpp
@@ -51,7 +51,7 @@ void SMSOrc8rClient::send_uplink_unitdata(
     std::function<void(grpc::Status, Void)> callback) {
   SMSOrc8rClient& client = get_instance();
   SMOUplinkUnitdata proto_msg =
-      convert_itti_sgsap_uplink_unitdata_to_proto_msg(msg);
+      convert_itti_sgsap_uplink_unitdata_to_smo_proto_msg(msg);
   auto local_response =
       new AsyncLocalResponse<Void>(std::move(callback), RESPONSE_TIMEOUT);
   auto response_reader = client.stub_->AsyncSMOUplink(

--- a/lte/gateway/c/core/oai/lib/sms_orc8r_client/itti_msg_to_proto_msg.cpp
+++ b/lte/gateway/c/core/oai/lib/sms_orc8r_client/itti_msg_to_proto_msg.cpp
@@ -37,7 +37,7 @@ extern "C" {
 namespace magma {
 using namespace lte;
 
-SMOUplinkUnitdata convert_itti_sgsap_uplink_unitdata_to_proto_msg(
+SMOUplinkUnitdata convert_itti_sgsap_uplink_unitdata_to_smo_proto_msg(
     const itti_sgsap_uplink_unitdata_t* msg) {
   SMOUplinkUnitdata ret;
   ret.Clear();

--- a/lte/gateway/c/core/oai/lib/sms_orc8r_client/itti_msg_to_proto_msg.h
+++ b/lte/gateway/c/core/oai/lib/sms_orc8r_client/itti_msg_to_proto_msg.h
@@ -30,7 +30,7 @@ extern "C" {
 namespace magma {
 using namespace lte;
 
-SMOUplinkUnitdata convert_itti_sgsap_uplink_unitdata_to_proto_msg(
+SMOUplinkUnitdata convert_itti_sgsap_uplink_unitdata_to_smo_proto_msg(
     const itti_sgsap_uplink_unitdata_t* msg);
 
 }  // namespace magma


### PR DESCRIPTION
Closes #11571.

Build success for this PR appears blocked on merge of #11569.

The Bazel build is linking much of the c/core code-base all at once,
which causes a symbol name collision between the two definitions of convert_itti_sgsap_uplink_unitdata_to_proto_msg. This PR renames one of the functions to indicate the differing return values.

## Test Plan

CI tests which include `make build_oai` and `make test_oai`.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>