### PR TITLE
chore(mme): Fix up newly-added non-full-path include statements

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.h
@@ -17,16 +17,16 @@
 extern "C" {
 #endif
 #include "lte/gateway/c/core/oai/common/assertions.h"
-#include "hashtable.h"
-#include "obj_hashtable.h"
+#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
+#include "lte/gateway/c/core/oai/lib/hashtable/obj_hashtable.h"
 #ifdef __cplusplus
 }
 #endif
 
-#include "amf_smfDefs.h"
-#include "amf_app_defs.h"
+#include "lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.h"
+#include "lte/gateway/c/core/oai/tasks/amf/amf_app_defs.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.h"
-#include <lte/gateway/c/core/oai/include/state_manager.h>
+#include "lte/gateway/c/core/oai/include/state_manager.h"
 
 using magma::lte::oai::MmeNasState;
 namespace magma5g {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -11,13 +11,13 @@
  * limitations under the License.
  */
 
-#include "include/amf_client_servicer.h"
-#include "M5GAuthenticationServiceClient.h"
-#include "M5GSUCIRegistrationServiceClient.h"
-#include "amf_common.h"
 #include <memory>
+#include "lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h"
+#include "lte/gateway/c/core/oai/lib/n11/M5GAuthenticationServiceClient.h"
 #include "lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.h"
+#include "lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.h"
 #include "lte/gateway/c/core/oai/lib/n11/SmfServiceClient.h"
+#include "lte/gateway/c/core/oai/tasks/amf/amf_common.h"
 
 using magma5g::AsyncM5GAuthenticationServiceClient;
 using magma5g::AsyncM5GSUCIRegistrationServiceClient;

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -16,11 +16,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "log.h"
-#include "dynamic_memory_check.h"
-#include "intertask_interface_types.h"
-#include "intertask_interface.h"
-#include "itti_free_defined_msg.h"
+#include "lte/gateway/c/core/oai/common/log.h"
+#include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
+#include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
+#include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
+#include "lte/gateway/c/core/oai/common/itti_free_defined_msg.h"
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.c
@@ -20,13 +20,13 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "AttachRequest.h"
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h"
 #include "lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.h"
 #include "lte/gateway/c/core/oai/common/common_defs.h"
 #include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/common/log.h"
+#include "lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.h"
 #include "lte/gateway/c/core/oai/tasks/nas/emm/msg/emm_cause.h"
 #include "lte/gateway/c/core/oai/tasks/nas/emm/emm_proc.h"
 #include "lte/gateway/c/core/oai/include/3gpp_requirements_24.301.h"

--- a/lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.c
@@ -49,7 +49,7 @@
 #include "lte/gateway/c/core/oai/tasks/s11/s11_common.h"
 #include "lte/gateway/c/core/oai/tasks/s11/s11_mme_session_manager.h"
 
-#include "../gtpv2-c/gtpv2c_ie_formatter/shared/gtpv2c_ie_formatter.h"
+#include "lte/gateway/c/core/oai/lib/gtpv2-c/gtpv2c_ie_formatter/shared/gtpv2c_ie_formatter.h"
 #include "lte/gateway/c/core/oai/tasks/s11/s11_ie_formatter.h"
 #include "lte/gateway/c/core/oai/include/s11_messages_types.h"
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -15,9 +15,9 @@
  *      contact@openairinterface.org
  */
 
-#include "lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.h"
-#include "3gpp_36.413.h"
 #include "lte/gateway/c/core/oai/common/common_defs.h"
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_36.413.h"
+#include "lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.h"
 
 namespace {
 constexpr char S1AP_ENB_COLL[] = "s1ap_eNB_coll";

--- a/lte/gateway/c/core/oai/test/amf/test_amf_algorithm_selection.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_algorithm_selection.cpp
@@ -12,11 +12,11 @@
  */
 
 #include <gtest/gtest.h>
-#include "../../tasks/amf/amf_app_ue_context_and_proc.h"
+#include "lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h"
 
 extern "C" {
-#include "log.h"
-#include "include/amf_config.h"
+#include "lte/gateway/c/core/oai/common/log.h"
+#include "lte/gateway/c/core/oai/include/amf_config.h"
 }
 
 using ::testing::Test;

--- a/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.cpp
+++ b/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.cpp
@@ -12,9 +12,9 @@
  */
 
 #include <iostream>
-#include "util_nas5g_pkt.h"
-#include "include/s6a_messages_types.h"
-#include "util_s6a_update_location.h"
+#include "lte/gateway/c/core/oai/test/amf/util_nas5g_pkt.h"
+#include "lte/gateway/c/core/oai/include/s6a_messages_types.h"
+#include "lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h"
 
 namespace magma5g {
 // api to mock handling of s6a_update_location_ans

--- a/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h
+++ b/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h
@@ -12,8 +12,8 @@
  */
 
 #include <iostream>
-#include "util_nas5g_pkt.h"
-#include "include/s6a_messages_types.h"
+#include "lte/gateway/c/core/oai/test/amf/util_nas5g_pkt.h"
+#include "lte/gateway/c/core/oai/include/s6a_messages_types.h"
 
 namespace magma5g {
 // api to mock handling s6a_update_location_ans

--- a/lte/gateway/c/core/oai/test/mock_tasks/grpc_mock.cpp
+++ b/lte/gateway/c/core/oai/test/mock_tasks/grpc_mock.cpp
@@ -13,9 +13,9 @@
 
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/security/server_credentials.h>
-#include "mock_tasks.h"
-#include "grpc_service.h"
+#include "lte/gateway/c/core/oai/include/grpc_service.h"
 #include "lte/gateway/c/core/oai/tasks/grpc_service/S8ServiceImpl.h"
+#include "lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h"
 
 task_zmq_ctx_t task_zmq_ctx_grpc;
 grpc_service_data_t grpc_service_config = {0};

--- a/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.h
+++ b/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.h
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "common_types.h"
+#include "lte/gateway/c/core/oai/common/common_types.h"
 extern "C" {
 #include "lte/gateway/c/core/oai/include/s1ap_types.h"
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"

--- a/lte/gateway/c/core/oai/test/sgw_s8_task/sgw_s8_recv_grpc_messages.cpp
+++ b/lte/gateway/c/core/oai/test/sgw_s8_task/sgw_s8_recv_grpc_messages.cpp
@@ -13,11 +13,11 @@
 
 #include <gtest/gtest.h>
 #include <thread>
-#include "../mock_tasks/mock_tasks.h"
-#include "S8ServiceImpl.h"
 #include "feg/protos/s8_proxy.grpc.pb.h"
+#include "lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h"
+#include "lte/gateway/c/core/oai/tasks/grpc_service/S8ServiceImpl.h"
 extern "C" {
-#include "grpc_service.h"
+#include "lte/gateway/c/core/oai/include/grpc_service.h"
 }
 
 using grpc::ServerContext;

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test.cpp
@@ -14,7 +14,7 @@
 #include <gtest/gtest.h>
 
 extern "C" {
-#include "log.h"
+#include "lte/gateway/c/core/oai/common/log.h"
 }
 
 int main(int argc, char** argv) {

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_state_converter.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_state_converter.cpp
@@ -10,20 +10,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.h>
 #include <string.h>
 #include <gtest/gtest.h>
 #include <cstdio>
 #include <cstdlib>
 
 #include "lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.h"
+#include "lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.h"
 #include "lte/gateway/c/core/oai/test/spgw_task/state_creators.h"
 #include "lte/protos/oai/mme_nas_state.pb.h"
 
 extern "C" {
-#include "ie_to_bytes.h"
+#include "lte/gateway/c/core/oai/include/spgw_state.h"
+#include "lte/gateway/c/core/oai/lib/message_utils/ie_to_bytes.h"
 #include "lte/gateway/c/core/oai/tasks/sgw/sgw_defs.h"
-#include "spgw_state.h"
 }
 
 namespace magma {


### PR DESCRIPTION
The Bazel build migration wants all include paths to be fully specified
and relative to repo root. This was accomplished in #9861 but has
regressed as no CI job enforces this property.  This will change once
Bazel build of MME is committed to the repo (fully paths will be
enforced by CI).

This PR works towards #11578 for the regression.

This PR does re-order some of the includes (alphabetic / Google style) and that poses some risk in Magma code base (it should not... but does) - but builds seem to be OKing the change.

## Test Plan

CI tests which include `make build_oai` and `make test_oai`.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>