### PR TITLE
chore(agw): Include LiAgentD in release

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -551,6 +551,7 @@ def _copy_out_c_execs_in_magma_vm():
         exec_paths = [
             '/usr/local/bin/sessiond', '/usr/local/bin/mme',
             '/usr/local/sbin/sctpd', '/usr/local/bin/connectiond',
+            '/usr/local/bin/liagentd',
         ]
         dest_path = '~/magma-packages/executables'
         run('mkdir -p ' + dest_path)

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -244,12 +244,14 @@ cd "${MAGMA_ROOT}/lte/gateway"
 OAI_BUILD="${C_BUILD}/core/oai"
 SESSIOND_BUILD="${C_BUILD}/session_manager"
 CONNECTIOND_BUILD="${C_BUILD}/connection_tracker"
+LI_AGENT_BUILD="${C_BUILD}/li_agent"
 SCTPD_BUILD="${C_BUILD}/sctpd/src"
 
 make build_oai BUILD_TYPE="${BUILD_TYPE}"
 make build_session_manager BUILD_TYPE="${BUILD_TYPE}"
 make build_sctpd BUILD_TYPE="${BUILD_TYPE}"
 make build_connection_tracker BUILD_TYPE="${BUILD_TYPE}"
+make build_li_agent BUILD_TYPE="${BUILD_TYPE}"
 
 # Build Magma Envoy Controller service
 cd "${MAGMA_ROOT}/feg/gateway"
@@ -358,6 +360,7 @@ ${SYSTEM_DEPS} \
 ${OAI_BUILD}/oai_mme/mme=/usr/local/bin/ \
 ${SESSIOND_BUILD}/sessiond=/usr/local/bin/ \
 ${CONNECTIOND_BUILD}/src/connectiond=/usr/local/bin/ \
+${LI_AGENT_BUILD}/src/liagentd=/usr/local/bin/ \
 ${GO_BUILD}/envoy_controller=/usr/local/bin/ \
 ${SCTPD_MIN_VERSION_FILE}=/usr/local/share/magma/sctpd_min_version \
 ${COMMIT_HASH_FILE}=/usr/local/share/magma/commit_hash \


### PR DESCRIPTION
## Summary

The LiAgentD artifact is required to enable Sentry monitoring for the agent but it was not bundled in the release before.

## Test Plan

Create a release via `fab release package` and confirm that the `liagentd` executable is included.

## Additional Information

- [ ] This change is backwards-breaking