### PR TITLE
chore(mme): remove as_message_send from as_message.h

### DIFF
--- a/lte/gateway/c/core/oai/include/nas/as_message.h
+++ b/lte/gateway/c/core/oai/include/nas/as_message.h
@@ -592,7 +592,4 @@ typedef struct as_message_s {
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
 
-/* Implemented in the network_api.c body file */
-int as_message_send(as_message_t* as_msg);
-
 #endif /* FILE_AS_MESSAGE_H_SEEN*/

--- a/lte/gateway/c/core/oai/tasks/nas/api/network/network_api.c
+++ b/lte/gateway/c/core/oai/tasks/nas/api/network/network_api.c
@@ -411,52 +411,6 @@ status_code_e network_api_encode_data(void* data) {
   OAILOG_FUNC_RETURN(LOG_NAS, bytes);
 }
 
-/****************************************************************************
- **                                                                        **
- ** Name:  as_message_send()                                         **
- **                                                                        **
- ** Description: Service provided to the EPS Mobility Management protocol  **
- **    at the EMMAS Access Point (EMMAS-SAP) to send AS messages **
- **    to the Access Stratum sublayer.                           **
- **                                                                        **
- ** Inputs:  as_msg:  The AS message to send                     **
- **      Others:  _network_api_send_buffer, _network_api_id  **
- **                                                                        **
- ** Outputs:   Return:  The number of bytes sent when success;     **
- **       RETURNerror Otherwise                      **
- **      Others:  _network_api_send_buffer                   **
- **                                                                        **
- ***************************************************************************/
-status_code_e as_message_send(as_message_t* as_msg) {
-  int bytes;
-
-  OAILOG_FUNC_IN(LOG_NAS);
-  OAILOG_INFO(LOG_NAS,
-              "NET-API   - Send message 0x%.4x to the Access Stratum "
-              "layer",
-              as_msg->msg_id);
-  /*
-   * Encode the AS message
-   */
-  bytes = network_api_encode_data(as_msg);
-
-  if (bytes > 0) {
-    /*
-     * Get the network file descriptor
-     */
-    int fd = network_api_get_fd();
-
-    if (fd != RETURNerror) {
-      /*
-       * Send the AS message to the network
-       */
-      bytes = network_api_send_data(fd, bytes);
-    }
-  }
-
-  OAILOG_FUNC_RETURN(LOG_NAS, bytes);
-}
-
 /****************************************************************************/
 /*********************  L O C A L    F U N C T I O N S  *********************/
 /****************************************************************************/


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
`as_message_send` is not used anywhere

<img width="978" alt="Screen Shot 2022-02-14 at 10 16 52 PM" src="https://user-images.githubusercontent.com/37634144/153991726-edb81f85-fd65-4965-870e-85585a27c48a.png">

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI check for build_oai / test_oai / OAI Jenkins
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
