### PR TITLE
chore(pipelined): Exclude disconnection errors from monitoring

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement.py
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from lte.protos.pipelined_pb2 import RuleModResult
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.pipelined.app.base import ControllerType, MagmaController
 from magma.pipelined.app.enforcement_stats import EnforcementStatsController
 from magma.pipelined.app.policy_mixin import PolicyMixin
@@ -231,7 +232,7 @@ class EnforcementController(PolicyMixin, RestartMixin, MagmaController):
         except MagmaDPDisconnectedError:
             self.logger.error(
                 "Datapath disconnected, failed to install rule %s"
-                "for imsi %s", rule, imsi,
+                "for imsi %s", rule, imsi, extra=EXCLUDE_FROM_ERROR_MONITORING,
             )
             return RuleModResult.FAILURE
         return self._wait_for_rule_responses(imsi, ip_addr, rule, chan)

--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -23,6 +23,7 @@ from lte.protos.session_manager_pb2 import (
     RuleRecordTable,
     UPFSessionState,
 )
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.pipelined.app.base import (
     ControllerType,
     MagmaController,
@@ -221,7 +222,7 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
         except MagmaDPDisconnectedError:
             self.logger.error(
                 "Datapath disconnected, failed to install rule %s"
-                "for imsi %s", rule, imsi,
+                "for imsi %s", rule, imsi, extra=EXCLUDE_FROM_ERROR_MONITORING,
             )
             return RuleModResult.FAILURE
         for _ in range(len(msgs)):

--- a/lte/gateway/python/magma/pipelined/openflow/messages.py
+++ b/lte/gateway/python/magma/pipelined/openflow/messages.py
@@ -15,6 +15,7 @@ from typing import Any, List, Optional
 
 # there's a cyclic dependency in ryu
 import ryu.base.app_manager  # pylint: disable=unused-import
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.pipelined.metrics import DP_SEND_MSG_ERROR
 from magma.pipelined.openflow.exceptions import (
     MagmaDPDisconnectedError,
@@ -60,7 +61,7 @@ def send_msg(datapath, msg, retries=3):
             if i == retries - 1:    # Only propagate if all retries are up
                 logging.error(
                     'Send msg error! Type: %s, Reason: %s',
-                    type(e).__name__, e,
+                    type(e).__name__, e, extra=EXCLUDE_FROM_ERROR_MONITORING,
                 )
                 DP_SEND_MSG_ERROR.labels(cause=type(e).__name__).inc()
                 raise MagmaOFError(e)


### PR DESCRIPTION
## Summary

Datapath disconnection errors are application errors that don't need to be tracked in Sentry.

Fixes #10785.

## Additional Information

- [ ] This change is backwards-breaking