### PR TITLE
chore(mme): scrub the mme feature from Makefile

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -10,7 +10,7 @@ ENABLE_ASAN ?= 0
 # interfaces.
 # AGW means Acces GateWay, is the result of the aggregation of MME, SGW and PGW.
 # First in FEATURES, select what to you want to build : mme or agw with OpenFlow
-# (OVS): FEATURE=mme or agw_of
+# (OVS): FEATURE=mme_oai or agw_of
 # Then you can have other features that can be built for mme or agw :
 # s6a with fd (freeDiameter)
 
@@ -18,9 +18,9 @@ ENABLE_ASAN ?= 0
 FEATURES ?= agw_of
 # EXCLUSIVE_FEATURE_LIST : list of primary features that cannot be requested
 # together.
-EXCLUSIVE_FEATURE_LIST = mme agw_of mme_oai
+EXCLUSIVE_FEATURE_LIST = agw_of mme_oai
 # AVAILABLE_FEATURE_LIST : every feature not in this list will trigger an error.
-AVAILABLE_FEATURE_LIST = s6a_fd mme agw_of mme_oai
+AVAILABLE_FEATURE_LIST = s6a_fd agw_of mme_oai
 REQUESTED_FEATURE_LIST = $(sort $(FEATURES))
 
 ifeq ($(BUILD_TYPE),Debug)
@@ -45,6 +45,7 @@ ifneq ($(words $(strip $(filter $(EXCLUSIVE_FEATURE_LIST),$(REQUESTED_FEATURE_LI
 endif
 
 MAIN_FEATURE = $(strip $(filter $(EXCLUSIVE_FEATURE_LIST),$(REQUESTED_FEATURE_LIST)))
+$(info MAIN_FEATURE $(MAIN_FEATURE))
 
 ifneq ($(words $(strip $(filter $(REQUESTED_FEATURE_LIST),s6a_fd))), 0)
 S6A_FLAGS = -DS6A_OVER_GRPC=False
@@ -53,19 +54,14 @@ else
 S6A_FLAGS = -DS6A_OVER_GRPC=True
 endif
 
-ifeq ($(MAIN_FEATURE),mme)
-# Here force S6A to use freeDiameter
-OAI_FLAGS = -DS6A_OVER_GRPC=True
-else ifeq ($(MAIN_FEATURE),mme_oai)
+ifeq ($(MAIN_FEATURE),mme_oai)
 # Set DS6A_OVER_GRPC=False if using OAI-HSS
 OAI_FLAGS = -DS6A_OVER_GRPC=False
 else ifeq ($(MAIN_FEATURE),agw_of)
 OAI_FLAGS = $(S6A_FLAGS) -DEMBEDDED_SGW=True
-
 else
 # default
 OAI_FLAGS = $(S6A_FLAGS) -DEMBEDDED_SGW=True
-
 endif
 
 # debian stretch build uses older cc not recognizing options needed on ubuntu focal


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Discussion: https://magmacore.slack.com/archives/C02GMJ8S8FR/p1644937945289039

The mme feature flag is no longer used. Removing it to avoid confusion.

According to Shruti:
> the gtpnl data path feature set was removed in https://github.com/magma/magma/pull/9747/files . I think the mme feature > was kept to accommodate other S6a over GRPC with non-openflow data path, but we never used that one, so it is better 
> to remove it.


In testing all build features for MME, I see that unit tests do not compile (fail to link) when compiled with the `-DS6A_OVER_GRPC=False` flag. This behavior is consistently seen on master as well, so I think this PR is not breaking any feature that is working on master. Filed a follow up task : https://github.com/magma/magma/issues/11617
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Triggered an LTE Integ Test run here: https://github.com/themarwhal/magma/actions/runs/1848608621


👇 Manual testing in GitHub codespaces 👇 
### default, nothing specified (agw_of)
✅ build
```
magma % make -C lte/gateway build_oai
make: Entering directory '/workspaces/magma/lte/gateway'
BAZEL_FLAGS --config=development
MAIN_FEATURE agw_of
OAI_FLAGS -DS6A_OVER_GRPC=True -DEMBEDDED_SGW=True
```
✅ test
```
magma % make -C lte/gateway test_oai
... Success
```

### manually specify agw_of (should be identical to the one above)
✅ build
```
magma % make FEATURES='agw_of' -C lte/gateway build_oai 
make: Entering directory '/workspaces/magma/lte/gateway'
BAZEL_FLAGS --config=development
MAIN_FEATURE agw_of
OAI_FLAGS -DS6A_OVER_GRPC=True -DEMBEDDED_SGW=True
```
✅ test
```
magma % make FEATURES='agw_of' -C lte/gateway test_oai 
... Success
```

### manually specify agw_of AND s6a_fd
✅ build
```
magma % make FEATURES='agw_of s6a_fd' -C lte/gateway build_oai 
make: Entering directory '/workspaces/magma/lte/gateway'
BAZEL_FLAGS --config=development
MAIN_FEATURE agw_of
OAI_FLAGS -DS6A_OVER_GRPC=False -DEMBEDDED_SGW=True
```
❌ test (also broken on master)
```
magma % make FEATURES='agw_of s6a_fd' -C lte/gateway test_oai 
...
/usr/bin/ld: tasks/s6a/libTASK_S6A.a(s6a_auth_info.o): in function `s6a_generate_authentication_info_req':
/workspaces/magma/lte/gateway/c/core/oai/tasks/s6a/s6a_auth_info.c:369: undefined reference to `mme_config_find_mnc_length'
/usr/bin/ld: tasks/s6a/libTASK_S6A.a(s6a_up_loc.o): in function `s6a_generate_update_location':
/workspaces/magma/lte/gateway/c/core/oai/tasks/s6a/s6a_up_loc.c:265: undefined reference to `mme_config_find_mnc_length'
collect2: error: ld returned 1 exit status
```

### manually specify mme_oai
✅ build
```
magma % make FEATURES='mme_oai' -C lte/gateway build_oai 
make: Entering directory '/workspaces/magma/lte/gateway'
BAZEL_FLAGS --config=development
MAIN_FEATURE mme_oai
OAI_FLAGS -DS6A_OVER_GRPC=False
```
❌ test (also broken on master)
```
magma % make FEATURES='mme_oai' -C lte/gateway test_oai 
...
/usr/bin/ld: tasks/s6a/libTASK_S6A.a(s6a_auth_info.o): in function `s6a_generate_authentication_info_req':
/workspaces/magma/lte/gateway/c/core/oai/tasks/s6a/s6a_auth_info.c:369: undefined reference to `mme_config_find_mnc_length'
/usr/bin/ld: tasks/s6a/libTASK_S6A.a(s6a_up_loc.o): in function `s6a_generate_update_location':
/workspaces/magma/lte/gateway/c/core/oai/tasks/s6a/s6a_up_loc.c:265: undefined reference to `mme_config_find_mnc_length'
collect2: error: ld returned 1 exit status
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->


<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
