### PR TITLE
fix(sessiond):  sessiond searches session based on IPv4 and IPv6

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -399,16 +399,17 @@ void LocalEnforcer::aggregate_records(SessionMap& session_map,
   RuleRecordSet dead_sessions_to_cleanup;
 
   for (const RuleRecord& record : records.records()) {
-    const std::string &imsi = record.sid(), &ip = record.ue_ipv4();
+    const std::string& imsi = record.sid();
+    const std::string& ip_v4 = record.ue_ipv4();
+    const std::string& ip_v6 = record.ue_ipv6();
     const uint32_t teid = record.teid();
-    // TODO IPv6 add ipv6 to search criteria
     SessionSearchCriteria criteria(imsi, IMSI_AND_UE_IPV4_OR_IPV6_OR_UPF_TEID,
-                                   ip, teid);
+                                   ip_v4, ip_v6, teid);
     auto session_it = session_store_.find_session(session_map, criteria);
     if (!session_it) {
-      MLOG(MERROR) << "Could not find an 4G and 5G active session for " << imsi
-                   << " and " << ip << " or " << teid
-                   << " during record aggregation";
+      MLOG(MERROR) << "Could not find a 4G and 5G active session for " << imsi
+                   << " and ip" << ip_v4 << "or ipv6" << ip_v6 << " or teid "
+                   << teid << " during record aggregation";
       dead_sessions_to_cleanup.insert(record);
       continue;
     }

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -329,12 +329,12 @@ optional<SessionVector::iterator> SessionStore::find_session(
             break;
           case RATType::TGPP_LTE:
             if (context.ue_ipv4() == criteria.secondary_key ||
-                context.ue_ipv6() == criteria.secondary_key) {
+                context.ue_ipv6() == criteria.tertiary_key) {
               return it;
             }
             break;
           case RATType::TGPP_NR:
-            if ((*it)->get_upf_local_teid() == criteria.tertiary_key_unit32) {
+            if ((*it)->get_upf_local_teid() == criteria.quaternary_key_unit32) {
               return it;
             }
             break;

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -59,8 +59,9 @@ struct SessionSearchCriteria {
   std::string imsi;
   SessionSearchCriteriaType search_type;
   std::string secondary_key;
+  std::string tertiary_key;
   uint32_t secondary_key_unit32;
-  uint32_t tertiary_key_unit32;
+  uint32_t quaternary_key_unit32;
 
   SessionSearchCriteria(const std::string p_imsi,
                         SessionSearchCriteriaType p_type,
@@ -69,19 +70,21 @@ struct SessionSearchCriteria {
 
   SessionSearchCriteria(const std::string p_imsi,
                         SessionSearchCriteriaType p_type,
-                        const uint32_t secondary_key_unit32)
+                        const uint32_t p_secondary_key_unit32)
       : imsi(p_imsi),
         search_type(p_type),
-        secondary_key_unit32(secondary_key_unit32) {}
+        secondary_key_unit32(p_secondary_key_unit32) {}
 
   SessionSearchCriteria(const std::string p_imsi,
                         SessionSearchCriteriaType p_type,
                         const std::string p_secondary_key,
-                        const uint32_t tertiary_key_unit32)
+                        const std::string p_tertiary_key,
+                        const uint32_t p_quaternary_key_unit32)
       : imsi(p_imsi),
         search_type(p_type),
         secondary_key(p_secondary_key),
-        tertiary_key_unit32(tertiary_key_unit32) {}
+        tertiary_key(p_tertiary_key),
+        quaternary_key_unit32(p_quaternary_key_unit32) {}
 };
 
 /**

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -79,6 +79,29 @@ RuleSet create_rule_set(const bool apply_subscriber_wide,
   return rule_set;
 }
 
+void create_rule_record_ipv6(const std::string& imsi, const std::string& ip,
+                             const std::string& rule_id, uint64_t bytes_rx,
+                             uint64_t bytes_tx, RuleRecord* rule_record) {
+  create_rule_record(imsi, rule_id, bytes_rx, bytes_tx, rule_record);
+  rule_record->set_dropped_rx(0);
+  rule_record->set_dropped_tx(0);
+  rule_record->set_ue_ipv6(ip);
+}
+void create_rule_record_ipv6(const std::string& imsi, const std::string& ip,
+                             const std::string& rule_id, uint64_t rule_version,
+                             uint64_t bytes_rx, uint64_t bytes_tx,
+                             uint64_t dropped_rx, uint64_t dropped_tx,
+                             RuleRecord* rule_record) {
+  rule_record->set_sid(imsi);
+  rule_record->set_rule_id(rule_id);
+  rule_record->set_bytes_rx(bytes_rx);
+  rule_record->set_bytes_tx(bytes_tx);
+  rule_record->set_dropped_rx(dropped_rx);
+  rule_record->set_dropped_tx(dropped_tx);
+  rule_record->set_ue_ipv6(ip);
+  rule_record->set_rule_version(rule_version);
+}
+
 void create_rule_record(const std::string& imsi, const std::string& rule_id,
                         uint64_t bytes_rx, uint64_t bytes_tx,
                         RuleRecord* rule_record) {

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -47,6 +47,16 @@ RuleSet create_rule_set(const bool apply_subscriber_wide,
                         std::vector<std::string> static_rules,
                         std::vector<PolicyRule> dynamic_rules);
 
+void create_rule_record_ipv6(const std::string& imsi, const std::string& ip,
+                             const std::string& rule_id, uint64_t bytes_rx,
+                             uint64_t bytes_tx, RuleRecord* rule_record);
+
+void create_rule_record_ipv6(const std::string& imsi, const std::string& ip,
+                             const std::string& rule_id, uint64_t rule_version,
+                             uint64_t bytes_rx, uint64_t bytes_tx,
+                             uint64_t dropped_rx, uint64_t dropped_tx,
+                             RuleRecord* rule_record);
+
 void create_rule_record(const std::string& imsi, const std::string& rule_id,
                         uint64_t bytes_rx, uint64_t bytes_tx,
                         RuleRecord* rule_record);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -341,8 +341,8 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_mixed_ips) {
   create_rule_record(IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule1", 10,
                      20, record_list->Add());
   // ipv6 usage for the same charging key and subscriber
-  create_rule_record(IMSI1, default_cfg_1.common_context.ue_ipv6(), "rule2", 5,
-                     15, record_list->Add());
+  create_rule_record_ipv6(IMSI1, default_cfg_1.common_context.ue_ipv6(),
+                          "rule2", 5, 15, record_list->Add());
   create_rule_record(IMSI1, default_cfg_1.common_context.ue_ipv4(), "rule3",
                      100, 150, record_list->Add());
 
@@ -547,12 +547,16 @@ TEST_F(LocalEnforcerTest, test_erroneous_data) {
   auto ipv4 = default_cfg_1.common_context.ue_ipv4();
   auto ipv6 = default_cfg_1.common_context.ue_ipv6();
   create_rule_record(IMSI1, ipv4, "rule1", 1, 15, 30, 0, 0, record_list->Add());
-  create_rule_record(IMSI1, ipv6, "rule1", 1, 10, 20, 0, 0, record_list->Add());
-  create_rule_record(IMSI1, ipv6, "rule1", 2, 40, 90, 0, 0, record_list->Add());
-  create_rule_record(IMSI1, ipv6, "rule1", 2, 16, 24, 0, 0, record_list->Add());
-  create_rule_record(IMSI1, ipv6, "rule1", 3, 50, 100, 0, 0,
-                     record_list->Add());
-  create_rule_record(IMSI1, ipv6, "rule1", 3, 25, 60, 0, 0, record_list->Add());
+  create_rule_record_ipv6(IMSI1, ipv6, "rule1", 1, 10, 20, 0, 0,
+                          record_list->Add());
+  create_rule_record_ipv6(IMSI1, ipv6, "rule1", 2, 40, 90, 0, 0,
+                          record_list->Add());
+  create_rule_record_ipv6(IMSI1, ipv6, "rule1", 2, 16, 24, 0, 0,
+                          record_list->Add());
+  create_rule_record_ipv6(IMSI1, ipv6, "rule1", 3, 50, 100, 0, 0,
+                          record_list->Add());
+  create_rule_record_ipv6(IMSI1, ipv6, "rule1", 3, 25, 60, 0, 0,
+                          record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   auto uc = get_default_update_criteria();

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -424,7 +424,8 @@ TEST_F(SessiondTest, end_to_end_success) {
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(IMSI1, ipv4_addrs, "rule1", 512, 512, record_list->Add());
-  create_rule_record(IMSI1, ipv6_addrs, "rule2", 512, 0, record_list->Add());
+  create_rule_record_ipv6(IMSI1, ipv6_addrs, "rule2", 512, 0,
+                          record_list->Add());
   create_rule_record(IMSI1, ipv4_addrs, "rule3", 32, 32, record_list->Add());
   send_update_pipelined_table(stub, table);
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

`aggregate_records` on sessions was looking for sessions with IPv4. This caused IPv6 sessions not to be found

This pr modifies how `find_session` searches when `IMSI_AND_UE_IPV4_OR_IPV6_OR_UPF_TEID` option is selected.

Note that now `SessionSearchCriteria` object has four different keys: IMSI, IPv4, IPv6, TEID. So the session will be found if any of those combinations matches
```
IMSI + IPv4
IMSI + IPv6
IMSI + TEID (for 5G)
```

## Test Plan
```
make sm_precommit
```

Tested in Spirent (phy_06)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
