### PR TITLE
fix(orc8r): fix orc8r docker build on M1 Macs

### DIFF
--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -1,7 +1,9 @@
 # ------------------------------------------------------------------------------
 # Base: for tests, precommit, codegen, etc.
 # ------------------------------------------------------------------------------
-FROM ubuntu:xenial as base
+ARG PLATFORM=linux/amd64
+
+FROM --platform=$PLATFORM ubuntu:xenial as base
 
 ENV GO111MODULE on
 ENV GOPATH ${USER}/go


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>


## Summary

The change fixes orc8r build on Mac M1 (issue #10297)

## Test Plan

build.py -g; build.py -a ...

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
