### PR TITLE
feat(nms): Enable S8 configuration on federation gateways

### DIFF
--- a/nms/app/components/feg/FEGGatewayDialog.js
+++ b/nms/app/components/feg/FEGGatewayDialog.js
@@ -20,6 +20,7 @@ import type {
   federation_gateway,
   gateway_federation_configs,
   gx,
+  s8,
   virtual_apn_rule,
 } from '../../../generated/MagmaAPIBindings';
 
@@ -91,6 +92,24 @@ function getInitialSCTPConfigs(cfg: ?csfb): SCTPValues {
   };
 }
 
+type S8Values = {
+  local_address: string,
+  pgw_address: string,
+  apn_operator_suffix: string,
+};
+
+function getS8Configs(cfg: S8Values): s8 {
+  return {...cfg};
+}
+
+function getInitialS8Configs(cfg: ?s8): S8Values {
+  return {
+    local_address: cfg?.local_address || '',
+    pgw_address: cfg?.pgw_address || '',
+    apn_operator_suffix: cfg?.apn_operator_suffix || '',
+  };
+}
+
 type DiameterValues = {
   address: string,
   dest_host: string,
@@ -109,6 +128,7 @@ export const TAB_OPTIONS = Object.freeze({
   GY: 'gy',
   SWX: 'swx',
   S6A: 's6a',
+  S8: 's8',
   CSFB: 'csfb',
 });
 
@@ -177,6 +197,9 @@ export default function FEGGatewayDialog(props: Props) {
   const [s6a, setS6A] = useState<DiameterValues>(
     getDiameterServerConfig(editingGateway?.federation?.s6a?.server),
   );
+  const [s8, setS8] = useState<S8Values>(
+    getInitialS8Configs(editingGateway?.federation?.s8),
+  );
 
   const [csfb, setCSFB] = useState<SCTPValues>(
     getInitialSCTPConfigs(editingGateway?.federation?.csfb),
@@ -217,6 +240,7 @@ export default function FEGGatewayDialog(props: Props) {
     health: {},
     hss: {},
     s6a: {...getDiameterConfigs(s6a), plmn_ids: []},
+    s8: {...getS8Configs(s8)},
     served_network_ids: [],
     swx: {...getDiameterConfigs(swx)},
     csfb: {...getSCTPConfigs(csfb)},
@@ -333,6 +357,9 @@ export default function FEGGatewayDialog(props: Props) {
         />
       );
       break;
+    case TAB_OPTIONS.S8:
+      content = <S8Fields onChange={setS8} values={s8} />;
+      break;
     case TAB_OPTIONS.CSFB:
       content = <SCTPFields onChange={setCSFB} values={csfb} />;
       break;
@@ -351,6 +378,7 @@ export default function FEGGatewayDialog(props: Props) {
           <Tab label="Gy" value="gy" />
           <Tab label="SWx" value="swx" />
           <Tab label="S6A" value="s6a" />
+          <Tab label="S8" value="s8" />
           <Tab label="CSFB" value="csfb" />
         </Tabs>
       </AppBar>
@@ -367,6 +395,43 @@ export default function FEGGatewayDialog(props: Props) {
         </Button>
       </DialogActions>
     </Dialog>
+  );
+}
+
+function S8Fields(props: {values: S8Values, onChange: S8Values => void}) {
+  const classes = useStyles();
+  const {values} = props;
+  const onChange = field => event =>
+    // $FlowFixMe Set state for each field
+    props.onChange({...values, [field]: event.target.value});
+
+  return (
+    <>
+      <TextField
+        label="Local Address"
+        className={classes.input}
+        value={values.local_address}
+        onChange={onChange('local_address')}
+        placeholder="example.magma.com:5555"
+        inputProps={{'data-testid': 'localAddress'}}
+      />
+      <TextField
+        label="PGW Address"
+        className={classes.input}
+        value={values.pgw_address}
+        onChange={onChange('pgw_address')}
+        placeholder="pgw.magma.com:5555"
+        inputProps={{'data-testid': 'pgwAddress'}}
+      />
+      <TextField
+        label="APN Operator Suffix"
+        className={classes.input}
+        value={values.apn_operator_suffix}
+        onChange={onChange('apn_operator_suffix')}
+        placeholder=".operator.com"
+        inputProps={{'data-testid': 'apnOperatorSuffix'}}
+      />
+    </>
   );
 }
 

--- a/nms/app/state/feg_lte/NetworkState.js
+++ b/nms/app/state/feg_lte/NetworkState.js
@@ -23,7 +23,7 @@ import type {
   network_subscriber_config,
 } from '../../../generated/MagmaAPIBindings';
 
-import MagmaV1API from '../../../generated/MagmaAPIBindings';
+import MagmaV1API from '../../../generated/WebClient';
 
 import {UpdateNetworkState as UpdateLteNetworkState} from '../lte/NetworkState';
 export type UpdateNetworkProps = {

--- a/nms/app/views/equipment/FEGGatewayDetailConfig.js
+++ b/nms/app/views/equipment/FEGGatewayDetailConfig.js
@@ -19,6 +19,7 @@ import type {TabOption} from '../../components/feg/FEGGatewayDialog';
 import type {
   diameter_client_configs,
   federation_gateway,
+  s8,
   sctp_client_configs,
 } from '../../../generated/MagmaAPIBindings';
 
@@ -53,6 +54,8 @@ export default function FEGGatewayConfig() {
   const gatewayId: string = nullthrows(params.gatewayId);
   const ctx = useContext(FEGGatewayContext);
   const gwInfo: federation_gateway = ctx.state[gatewayId];
+
+  console.log('gwInfo:', gwInfo);
 
   function editFilter(tabOption: TabOption) {
     return (
@@ -93,6 +96,16 @@ export default function FEGGatewayConfig() {
                   <GatewaySctpServerConfig
                     serverConfig={gwInfo?.federation?.csfb?.client || {}}
                     testID={'CSFB'}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <CardTitleRow
+                    label="S8"
+                    filter={() => editFilter(TAB_OPTIONS.S8)}
+                  />
+                  <GatewayS8Config
+                    s8Config={gwInfo?.federation?.s8 || {}}
+                    testID={'S8'}
                   />
                 </Grid>
               </Grid>
@@ -240,6 +253,37 @@ function GatewayDiameterServerConfig({
       {
         category: 'Protocol',
         value: serverConfig?.protocol || '-',
+      },
+    ],
+  ];
+
+  return <DataGrid data={data} testID={testID} />;
+}
+
+/**
+ * Returns useful information about the federation gateway's diameter based
+ * server.
+ * @param {s8} s8Config Configuration object of the diameter based server.
+ * @param {string} testId
+ */
+function GatewayS8Config({s8Config, testID}: {s8Config: s8, testID: string}) {
+  const data: DataRows[] = [
+    [
+      {
+        category: 'Local Address',
+        value: s8Config?.local_address || '-',
+      },
+    ],
+    [
+      {
+        category: 'PGW Address',
+        value: s8Config?.pgw_address || '-',
+      },
+    ],
+    [
+      {
+        category: 'APN Operator Suffix',
+        value: s8Config?.apn_operator_suffix || '-',
       },
     ],
   ];

--- a/nms/app/views/equipment/FEGGatewayDetailConfig.js
+++ b/nms/app/views/equipment/FEGGatewayDetailConfig.js
@@ -55,8 +55,6 @@ export default function FEGGatewayConfig() {
   const ctx = useContext(FEGGatewayContext);
   const gwInfo: federation_gateway = ctx.state[gatewayId];
 
-  console.log('gwInfo:', gwInfo);
-
   function editFilter(tabOption: TabOption) {
     return (
       <EditGatewayButton

--- a/nms/app/views/equipment/FEGGatewayTable.js
+++ b/nms/app/views/equipment/FEGGatewayTable.js
@@ -139,6 +139,7 @@ function GatewayStatusTable(props: WithAlert & {refresh: boolean}) {
         gy: gateway.federation?.gy?.server?.address || '-',
         swx: gateway.federation?.swx?.server?.address || '-',
         s6a: gateway.federation?.s6a?.server?.address || '-',
+        s8: gateway.federation?.s8?.local_address || '-',
         csfb: gateway.federation?.csfb?.client?.server_address || '-',
       });
     });
@@ -187,6 +188,7 @@ function GatewayStatusTable(props: WithAlert & {refresh: boolean}) {
           {title: 'Gy', field: 'gy'},
           {title: 'SWx', field: 'swx'},
           {title: 'S6a', field: 's6a'},
+          {title: 'S8', field: 's8'},
           {title: 'CSFB', field: 'csfb'},
         ]}
         handleCurrRow={(row: EquipmentFegGatewayRowType) => setCurrRow(row)}

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
@@ -129,6 +129,11 @@ const mockGw0: federation_gateway = {
     health: {},
     hss: {},
     s6a: mockS6a,
+    s8: {
+      apn_operator_suffix: '',
+      local_address: '',
+      pgw_address: '',
+    },
     served_network_ids: [],
     swx: mockSwx,
     csfb: mockCsfb,


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Enables S8 configuration for federation gateways.

This is a step towards enabling Inbound Roaming configuration on the NMS without direct API access. See [here](https://docs.magmacore.org/docs/next/howtos/inbound_roaming#configuration-example).

Some examples of additions to the UI for S8 configuration editing:
![Screen Shot 2022-02-15 at 2 54 26 PM](https://user-images.githubusercontent.com/804385/154163595-d9951d69-d8a9-4ed6-8e69-c7c93a9a30d1.png)
![Screen Shot 2022-02-15 at 2 54 22 PM](https://user-images.githubusercontent.com/804385/154163599-0689acca-0d6c-4c4b-b28f-9d4c9b2ffa88.png)
![Screen Shot 2022-02-15 at 2 54 13 PM](https://user-images.githubusercontent.com/804385/154163601-1326b4a4-df94-45cc-9a83-9b62d4787023.png)



## Test Plan

(See screenshots in the summary for examples)

- Checked adding and editing S8 configuration on a federation gateway in a test Docker setup
- Reloaded page to see that S8 configuration persisted, and checked through API calls

## Additional Information

- [ ] This change is backwards-breaking
