### PR TITLE
fix(ctraced): missing dependency is added

### DIFF
--- a/orc8r/gateway/python/magma/ctraced/BUILD.bazel
+++ b/orc8r/gateway/python/magma/ctraced/BUILD.bazel
@@ -23,9 +23,9 @@ py_binary(
     python_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
+        ":ctraced_lib",
         "//orc8r/gateway/python/magma/common:sentry",
         "//orc8r/gateway/python/magma/common:service",
-        "//orc8r/protos:ctraced_python_grpc",
     ],
 )
 
@@ -36,6 +36,6 @@ py_library(
         "rpc_servicer.py",
         "trace_manager.py",
     ],
-    visibility = ["//visibility:public"],
-    deps = [],
+    visibility = ["//visibility:private"],
+    deps = ["//orc8r/protos:ctraced_python_grpc"],
 )


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Missing bazel dependency is added in module ctraced.

## Test Plan

-  Run ctraced: 
   - `bazel run //orc8r/gateway/python/magma/ctraced:ctraced`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
