### PR TITLE
feat(agw): benchmark UE MM Context serialization

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -28,7 +28,7 @@ ifeq ($(BUILD_TYPE),Debug)
 	ifeq ($(ENABLE_ASAN),1)
 		BAZEL_FLAGS := $(BAZEL_FLAGS) --config=asan
 	endif
-else 
+else
 	## RelWithDebInfo enable LSAN and add debug information
 	BAZEL_FLAGS = --config=production
 endif
@@ -80,6 +80,8 @@ TEST_FLAG = -DBUILD_TESTS=1
 OAI_TEST_FLAGS = -DMME_UNIT_TEST=True
 OAI_NOTEST_FLAGS = -DMME_UNIT_TEST=False
 OAI_TESTS ?= ".*"
+OAI_BENCHMARK_FLAGS = -DMME_BENCHMARK=True
+OAI_NOBENCHMARK_FLAGS = -DMME_BENCHMARK=False
 
 all: build
 
@@ -159,6 +161,10 @@ mkdir -p $(C_BUILD)/$(1)
 sudo cp -f $(MAGMA_ROOT)/bazel-bin/lte/gateway/c/$(1)/$(2) $(C_BUILD)/$(1)/$(2)
 endef
 
+
+benchmark_pb: ## Benchmark ProtoBuf, same build_oai but with -DMME_BENCHMARK=True
+	$(call run_cmake, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(COMMON_FLAGS) $(OAI_NOTEST_FLAGS) $(OAI_BENCHMARK_FLAGS))
+
 build_c:  ## Build C/C++ targets with Bazel
 	bazel build $(BAZEL_FLAGS) //lte/gateway/c/session_manager:sessiond //lte/gateway/c/sctpd/src:sctpd //lte/gateway/c/connection_tracker/src:connectiond //lte/gateway/c/li_agent/src:liagentd
 	$(call copy_bazel_c_build,session_manager,sessiond)
@@ -167,7 +173,7 @@ build_c:  ## Build C/C++ targets with Bazel
 	$(call copy_bazel_c_build,li_agent/src,liagentd)
 
 build_oai: ## Build OAI
-	$(call run_cmake, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(COMMON_FLAGS) $(OAI_NOTEST_FLAGS))
+	$(call run_cmake, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(COMMON_FLAGS) $(OAI_NOTEST_FLAGS) $(OAI_NOBENCHMARK_FLAGS))
 
 format_all:
 	find $(MAGMA_ROOT)/orc8r/gateway/c/ \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) -exec \
@@ -214,7 +220,7 @@ test_c: ## Run all Bazel-ified C/C++ tests
 	bazel test $(BAZEL_FLAGS) -- //orc8r/gateway/c/...:* //lte/gateway/c/...:* -//lte/gateway/c/core/...:*
 
 test_oai: ## Run all OAI-specific tests
-	$(call run_ctest, $(C_BUILD)/core, $(C_BUILD)/core/oai, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(OAI_TEST_FLAGS), $(OAI_TESTS))
+	$(call run_ctest, $(C_BUILD)/core, $(C_BUILD)/core/oai, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(OAI_TEST_FLAGS) $(OAI_NOBENCHMARK_FLAGS), $(OAI_TESTS))
 
 test_sctpd: ## Run all tests for sctpd
 	$(call run_ctest, $(C_BUILD)/sctp, $(C_BUILD)/sctp/src, $(GATEWAY_C_DIR)/sctpd, )
@@ -247,7 +253,7 @@ precommit_sm: format_all test_session_manager
 precommit_oai: format_all test_oai
 
 build_oai_clang: ## Build OAI with Clang, store compiler outputs to log
-	$(call run_cmake, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(COMMON_FLAGS) $(OAI_NOTEST_FLAGS), CC="clang" CXX="clang++") 2>&1 | tee /tmp/clang-build.oai.log
+	$(call run_cmake, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(COMMON_FLAGS) $(OAI_NOTEST_FLAGS) $(OAI_NOBENCHMARK_FLAGS), CC="clang" CXX="clang++") 2>&1 | tee /tmp/clang-build.oai.log
 
 # Upload Clang-Warning counts by type to Google Sheet via Google Survey
 #  Graph available at https://docs.google.com/spreadsheets/d/1ndiIKJNI2IJZBwavnu1x_KwwvlQppnoYEOtYdihqiIQ/edit#gid=734064581

--- a/lte/gateway/c/core/oai/CMakeAgwOptions.txt
+++ b/lte/gateway/c/core/oai/CMakeAgwOptions.txt
@@ -4,3 +4,4 @@
 add_boolean_option(S6A_OVER_GRPC      True  "S6a messages sent over gRPC")
 add_boolean_option(EMBEDDED_SGW       True  "S11/GTPV2-C interface not present")
 add_boolean_option(MME_UNIT_TEST    False  "MME unit testing is enabled")
+add_boolean_option(MME_BENCHMARK    False  "Benchmarking Protobuf is enabled")

--- a/lte/gateway/c/core/oai/CMakeMmeOptions.txt
+++ b/lte/gateway/c/core/oai/CMakeMmeOptions.txt
@@ -4,3 +4,4 @@
 add_boolean_option(S6A_OVER_GRPC       False    "S6a messages sent over gRPC")
 add_boolean_option(EMBEDDED_SGW        False    "S11/GTPV2-C interface present")
 add_boolean_option(MME_UNIT_TEST    False  "MME unit testing is enabled")
+add_boolean_option(MME_BENCHMARK    False  "Benchmarking Protobuf is enabled")

--- a/lte/gateway/c/core/oai/include/mme_app_messages_def.h
+++ b/lte/gateway/c/core/oai/include/mme_app_messages_def.h
@@ -60,3 +60,8 @@ MESSAGE_DEF(MME_APP_HANDOVER_REQUEST, itti_mme_app_handover_request_t,
             mme_app_handover_request)
 MESSAGE_DEF(MME_APP_HANDOVER_COMMAND, itti_mme_app_handover_command_t,
             mme_app_handover_command)
+#if MME_BENCHMARK
+MESSAGE_DEF(MME_APP_TEST_PROTOBUF_SERIALIZATION,
+            itti_mme_app_test_protobuf_serialization_t,
+            mme_app_test_protobuf_serialization)
+#endif

--- a/lte/gateway/c/core/oai/include/mme_app_messages_types.h
+++ b/lte/gateway/c/core/oai/include/mme_app_messages_types.h
@@ -65,6 +65,10 @@
   (mSGpTR)->ittiMsg.mme_app_handover_request
 #define MME_APP_HANDOVER_COMMAND(mSGpTR) \
   (mSGpTR)->ittiMsg.mme_app_handover_command
+#if MME_BENCHMARK
+#define MME_APP_TEST_PROTOBUF_SERIALIZATION(mSGpTR) \
+  (mSGpTR)->ittiMsg.mme_app_test_protobuf_serialization
+#endif
 
 typedef struct itti_mme_app_connection_establishment_cnf_s {
   mme_ue_s1ap_id_t ue_id;
@@ -191,4 +195,9 @@ typedef struct itti_mme_app_handover_command_s {
   uint32_t target_enb_id;
 } itti_mme_app_handover_command_t;
 
+#if MME_BENCHMARK
+typedef struct itti_mme_app_test_protobuf_serialization_s {
+  uint num_ues;
+} itti_mme_app_test_protobuf_serialization_t;
+#endif
 #endif /* FILE_MME_APP_MESSAGES_TYPES_SEEN */

--- a/lte/gateway/c/core/oai/include/mme_config.h
+++ b/lte/gateway/c/core/oai/include/mme_config.h
@@ -245,6 +245,9 @@
 #define MME_CONFIG_STRING_URL_NATIVE "URL_NATIVE"
 
 typedef enum { RUN_MODE_TEST = 0, RUN_MODE_OTHER } run_mode_t;
+#if MME_BENCHMARK
+typedef enum { TEST_SERIALIZATION_PROTOBUF = 0 } test_type_t;
+#endif
 
 typedef struct eps_network_feature_config_s {
   uint8_t ims_voice_over_ps_session_in_s1;
@@ -391,6 +394,11 @@ typedef struct mme_config_s {
   uint8_t daylight_saving_time;
 
   run_mode_t run_mode;
+#if MME_BENCHMARK
+  // Integer value for testing serialization
+  test_type_t test_type;
+  uint32_t test_param;
+#endif
 
   uint32_t max_enbs;
   uint32_t max_ues;

--- a/lte/gateway/c/core/oai/include/state_manager.h
+++ b/lte/gateway/c/core/oai/include/state_manager.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#if MME_BENCHMARK
+#include <chrono>
+#endif
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -164,21 +167,42 @@ class StateManager {
         is_initialized,
         "StateManager init() function should be called to initialize state");
 
+#if MME_BENCHMARK
+    auto start = std::chrono::high_resolution_clock::now();
+#endif
     std::string proto_str;
     ProtoUe ue_proto = ProtoUe();
     StateConverter::ue_to_proto(ue_context, &ue_proto);
     redis_client->serialize(ue_proto, proto_str);
     std::size_t new_hash = std::hash<std::string>{}(proto_str);
-
+#if MME_BENCHMARK
+    auto stop = std::chrono::high_resolution_clock::now();
+    std::cout << "TIME PROTOBUF CONVERSION : "
+              << (std::chrono::duration_cast<std::chrono::nanoseconds>(stop -
+                                                                       start))
+                     .count()
+              << std::endl;
+#endif
     if (new_hash != this->ue_state_hash[imsi_str]) {
       std::string key = IMSI_PREFIX + imsi_str + ":" + task_name;
+
+#if MME_BENCHMARK
+      start = std::chrono::high_resolution_clock::now();
+#endif
       if (redis_client->write_proto_str(
               key, proto_str, ue_state_version[imsi_str]) != RETURNok) {
         OAILOG_ERROR(log_task, "Failed to write UE state to db for IMSI %s",
                      imsi_str.c_str());
         return;
       }
-
+#if MME_BENCHMARK
+      stop = std::chrono::high_resolution_clock::now();
+      std::cout << "TIME PROTOBUF REDIS SERIALIZATION : "
+                << std::chrono::duration_cast<std::chrono::nanoseconds>(stop -
+                                                                        start)
+                       .count()
+                << std::endl;
+#endif
       this->ue_state_version[imsi_str]++;
       this->ue_state_hash[imsi_str] = new_hash;
       OAILOG_DEBUG(log_task, "Finished writing UE state for IMSI %s",

--- a/lte/gateway/c/core/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/core/oai/oai_mme/oai_mme.c
@@ -63,6 +63,9 @@
 #include "lte/gateway/c/core/oai/include/service303.h"
 #include "lte/gateway/c/core/oai/common/shared_ts_log.h"
 #include "lte/gateway/c/core/oai/include/grpc_service.h"
+#if MME_BENCHMARK
+#include "lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.h"
+#endif
 
 static void send_timer_recovery_message(void);
 
@@ -179,6 +182,15 @@ int main(int argc, char* argv[]) {
   if (mme_config.use_stateless) {
     send_timer_recovery_message();
   }
+
+#if MME_BENCHMARK
+  if (mme_config.run_mode == RUN_MODE_TEST) {
+    if (mme_config.test_type == TEST_SERIALIZATION_PROTOBUF) {
+      mme_app_schedule_test_protobuf_serialization(mme_config.test_param);
+    }
+  }
+#endif
+
   /*
    * Handle signals here
    */

--- a/lte/gateway/c/core/oai/tasks/mme_app/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/mme_app/CMakeLists.txt
@@ -14,6 +14,14 @@ if (EMBEDDED_SGW)
   set(S11_RELATED_SRCS mme_app_embedded_spgw.c)
 endif (EMBEDDED_SGW)
 
+list(APPEND MME_BENCHMARK_SRCS "")
+if (MME_BENCHMARK)
+  list(APPEND MME_BENCHMARK_SRCS
+        "experimental/mme_app_serialization.cpp"
+        "experimental/mme_app_serialization.h"
+      )
+endif (MME_BENCHMARK)
+
 add_library(TASK_MME_APP
     mme_app_capabilities.c
     mme_app_context.c
@@ -58,6 +66,7 @@ add_library(TASK_MME_APP
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     ${S11_RELATED_SRCS}
+    ${MME_BENCHMARK_SRCS}
     )
 
 target_compile_definitions(TASK_MME_APP PRIVATE

--- a/lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.cpp
@@ -1,0 +1,285 @@
+/**
+ * Copyright 2021 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// --C includes ---------------------------------------------------------------
+#include "lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.h"
+#include <mcheck.h>
+#include <sys/time.h>      // rusage()
+#include <sys/resource.h>  // rusage()
+// --C++ includes -------------------------------------------------------------
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <vector>
+// --Other includes -----------------------------------------------------------
+extern "C" {
+#include "lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h"
+#include "lte/gateway/c/core/oai/tasks/nas/emm/emm_proc.h"
+#include "lte/gateway/c/core/oai/tasks/nas/esm/esm_proc.h"
+#include "lte/gateway/c/core/oai/tasks/nas/nas_procedures.h"
+#include "lte/gateway/c/core/oai/common/log.h"
+#include "lte/gateway/c/core/oai/common/dynamic_memory_check.h"
+#include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
+#include "lte/gateway/c/core/oai/common/common_types.h"
+#include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
+#include "lte/gateway/c/core/oai/lib/itti/itti_types.h"
+#include "lte/gateway/c/core/oai/include/mme_app_state.h"
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.003.h"
+}
+
+#include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.h"
+extern task_zmq_ctx_t main_zmq_ctx;
+
+using magma::lte::MmeNasStateManager;
+
+uint64_t kFirstImsi = 1010000000000;
+
+std::vector<ue_mm_context_t*> mme_app_allocate_ues(uint num_ues);
+void mme_app_deallocate_ues(mme_app_desc_t* mme_app_desc,
+                            std::vector<ue_mm_context_t*>* contexts);
+void mme_app_insert_ues(mme_app_desc_t* mme_app_desc,
+                        const std::vector<ue_mm_context_t*>& contexts);
+void mme_app_serialize_ues(const std::vector<ue_mm_context_t*>& contexts);
+void mme_app_deserialize_ues(void);
+
+void mme_app_schedule_test_protobuf_serialization(uint num_ues) {
+  MessageDef* message_p =
+      itti_alloc_new_message(TASK_UNKNOWN, MME_APP_TEST_PROTOBUF_SERIALIZATION);
+  MME_APP_TEST_PROTOBUF_SERIALIZATION(message_p).num_ues = num_ues;
+  send_msg_to_task(&main_zmq_ctx, TASK_MME_APP, message_p);
+  return;
+}
+
+std::vector<ue_mm_context_t*> mme_app_allocate_ues(uint num_ues) {
+  enb_s1ap_id_key_t enb_s1ap_id_key = INVALID_ENB_UE_S1AP_ID_KEY;
+  unsigned int seed = 0;
+  enb_ue_s1ap_id_t enb_ue_s1ap_id = rand_r(&seed) & 0X00FFFFFF;
+  mme_ue_s1ap_id_t mme_ue_s1ap_id = rand_r(&seed);
+  std::vector<ue_mm_context_t*> contexts;
+
+  contexts.reserve(num_ues);
+
+  for (int i = 0; i < num_ues; i++) {
+    ue_mm_context_t* ue_mm_context = mme_create_new_ue_context();
+    emm_context_t* emm_ctx = &ue_mm_context->emm_context;
+    esm_context_t* esm_ctx = &emm_ctx->esm_ctx;
+
+    enb_ue_s1ap_id++;
+    mme_ue_s1ap_id++;
+
+    imsi64_t imsi64 = kFirstImsi + i;
+    imsi_t imsi = {};
+    imsi.u.num.digit1 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 14)) % 10);
+    imsi.u.num.digit2 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 13)) % 10);
+    imsi.u.num.digit3 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 12)) % 10);
+    imsi.u.num.digit4 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 11)) % 10);
+    imsi.u.num.digit5 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 10)) % 10);
+    imsi.u.num.digit6 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 9)) % 10);
+    imsi.u.num.digit7 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 8)) % 10);
+    imsi.u.num.digit8 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 7)) % 10);
+    imsi.u.num.digit9 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 6)) % 10);
+    imsi.u.num.digit10 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 5)) % 10);
+    imsi.u.num.digit11 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 4)) % 10);
+    imsi.u.num.digit12 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 3)) % 10);
+    imsi.u.num.digit13 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 2)) % 10);
+    imsi.u.num.digit14 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 1)) % 10);
+    imsi.u.num.digit15 = (uint8_t)((imsi64_t)(imsi64 / std::pow(10, 0)) % 10);
+    imsi.u.num.parity = 0xF;
+    emm_ctx->saved_imsi64 = imsi64;
+
+    guti_t guti = {};
+    guti.gummei.plmn.mcc_digit2 = 0;
+    guti.gummei.plmn.mcc_digit1 = 0;
+    guti.gummei.plmn.mnc_digit3 = 1;
+    guti.gummei.plmn.mcc_digit3 = 0xF;
+    guti.gummei.plmn.mnc_digit2 = 1;
+    guti.gummei.plmn.mnc_digit1 = 0;
+    guti.gummei.mme_gid = 1;
+    guti.gummei.mme_code = 1;
+    guti.m_tmsi = 2106150532 + i;
+    guti_t old_guti = {};
+    old_guti.gummei.plmn.mcc_digit2 = 0;
+    old_guti.gummei.plmn.mcc_digit1 = 0;
+    old_guti.gummei.plmn.mnc_digit3 = 0;
+    old_guti.gummei.plmn.mcc_digit3 = 0;
+    old_guti.gummei.plmn.mnc_digit2 = 0;
+    old_guti.gummei.plmn.mnc_digit1 = 0;
+    old_guti.gummei.mme_gid = 0;
+    old_guti.gummei.mme_code = 0;
+    old_guti.m_tmsi = 429496729 + i;
+
+    emm_ctx_set_valid_imsi(emm_ctx, &imsi, imsi64);
+    emm_ctx_set_valid_guti(emm_ctx, &guti);
+    emm_ctx_set_valid_old_guti(emm_ctx, &old_guti);
+
+    emm_ctx->emm_cause = -1;
+    emm_ctx->_emm_fsm_state = EMM_REGISTERED;
+
+    esm_ctx->n_active_ebrs = 2;
+    esm_ctx->esm_proc_data =
+        (struct esm_proc_data_s*)calloc(1, sizeof(struct esm_proc_data_s));
+    struct esm_proc_data_s* esm_proc_data = esm_ctx->esm_proc_data;
+    esm_proc_data->pti = 1;
+    esm_proc_data->request_type = 1;
+    esm_proc_data->apn = bfromcstr("ims");
+    esm_proc_data->pdn_cid = 1;
+    esm_proc_data->pdn_type = ESM_PDN_TYPE_IPV4;
+    esm_proc_data->bearer_qos.pci = 1;
+    esm_proc_data->bearer_qos.pl = 15;
+    esm_proc_data->bearer_qos.qci = 5;
+    // no bearer_qos.gbr, bearer_qos.mbr
+    // no pco
+
+    MME_APP_ENB_S1AP_ID_KEY(ue_mm_context->enb_s1ap_id_key, rand() & 0X0000FFFF,
+                            enb_ue_s1ap_id);
+    ue_mm_context->enb_ue_s1ap_id = enb_ue_s1ap_id;
+    ue_mm_context->mme_ue_s1ap_id = mme_ue_s1ap_id;
+
+    contexts.push_back(ue_mm_context);
+  }
+  return contexts;
+}
+
+void mme_app_deallocate_ues(mme_app_desc_t* mme_app_desc,
+                            std::vector<ue_mm_context_t*>* contexts) {
+  while (!contexts.empty()) {
+    mme_remove_ue_context(&mme_app_desc->mme_ue_contexts, contexts.back());
+    contexts.pop_back();
+  }
+}
+
+void mme_app_serialize_ues(mme_app_desc_t* mme_app_desc,
+                           const std::vector<ue_mm_context_t*>& contexts) {
+  for (auto it = contexts.begin(); it != contexts.end(); ++it) {
+    put_mme_ue_state(mme_app_desc, (*it)->emm_context.saved_imsi64, true);
+  }
+}
+
+void mme_app_insert_ues(mme_app_desc_t* mme_app_desc,
+                        const std::vector<ue_mm_context_t*>& contexts) {
+  for (auto it = contexts.begin(); it != contexts.end(); ++it) {
+    if (mme_insert_ue_context(&mme_app_desc->mme_ue_contexts, *it) !=
+        RETURNok) {
+      OAILOG_ERROR_UE(
+          LOG_MME_APP, (*it)->emm_context.saved_imsi64,
+          "Failed to insert UE contxt, MME UE S1AP Id: " MME_UE_S1AP_ID_FMT
+          "\n",
+          (*it)->mme_ue_s1ap_id);
+      return;
+    }
+  }
+}
+
+void mme_app_deserialize_ues(void) {
+  mme_app_desc_t* mme_app_desc2 = get_mme_nas_state(true);
+  MmeNasStateManager::getInstance().read_ue_state_from_db();
+}
+
+void log_rusage(const struct rusage& ru, const char* context) {
+  std::cout << context
+            << "\tCpu user/system: " << static_cast<int>(ru.ru_utime.tv_sec)
+            << "." << static_cast<int>(ru.ru_utime.tv_usec) << " / "
+            << static_cast<int>(ru.ru_stime.tv_sec) << "."
+            << static_cast<int>(ru.ru_stime.tv_usec) << std::endl;
+  std::cout << context << "\tMaximum resident set size: " << ru.ru_maxrss
+            << std::endl;
+  std::cout << context
+            << "\tPage reclaims (soft/hard page faults): " << ru.ru_minflt
+            << " / " << ru.ru_majflt << std::endl;
+  std::cout << context << "\tBlock operations (input/output): " << ru.ru_inblock
+            << " / " << ru.ru_oublock << std::endl;
+  std::cout << context
+            << "\tContext switches (voluntary/involuntary): " << ru.ru_nvcsw
+            << " / " << ru.ru_nivcsw << std::endl;
+}
+
+void log_rusage_diff(const struct rusage& ru_first,
+                     const struct rusage& ru_last, const char* context) {
+  struct rusage ru_diff = {0};
+  ru_diff.ru_utime.tv_sec = ru_last.ru_utime.tv_sec - ru_first.ru_utime.tv_sec;
+  ru_diff.ru_utime.tv_usec =
+      ru_last.ru_utime.tv_usec - ru_first.ru_utime.tv_usec;
+  ru_diff.ru_stime.tv_sec = ru_last.ru_stime.tv_sec - ru_first.ru_stime.tv_sec;
+  ru_diff.ru_stime.tv_usec =
+      ru_last.ru_stime.tv_usec - ru_first.ru_stime.tv_usec;
+
+  ru_diff.ru_maxrss = ru_last.ru_maxrss - ru_first.ru_maxrss;
+  ru_diff.ru_minflt = ru_last.ru_minflt - ru_first.ru_minflt;
+  ru_diff.ru_majflt = ru_last.ru_majflt - ru_first.ru_majflt;
+  ru_diff.ru_inblock = ru_last.ru_inblock - ru_first.ru_inblock;
+  ru_diff.ru_oublock = ru_last.ru_oublock - ru_first.ru_oublock;
+  ru_diff.ru_nvcsw = ru_last.ru_nvcsw - ru_first.ru_nvcsw;
+  ru_diff.ru_nivcsw = ru_last.ru_nivcsw - ru_first.ru_nivcsw;
+  std::string str3(context);
+  log_rusage(ru_diff, str3.c_str());
+}
+
+void mme_app_test_protobuf_serialization(mme_app_desc_t* mme_app_desc,
+                                         uint num_ues) {
+  srand(time(NULL));
+  ue_mm_context_t* ue_mm_contexts[num_ues][2] = {};
+
+  std::vector<ue_mm_context_t*> contexts = mme_app_allocate_ues(num_ues);
+
+  mme_app_insert_ues(mme_app_desc, contexts);
+
+  struct rusage ru_start_ctxt_to_proto, ru_end_ctxt_to_proto;
+
+  getrusage(RUSAGE_SELF, &ru_start_ctxt_to_proto);
+  auto start_ctxt_to_proto = std::chrono::high_resolution_clock::now();
+  mme_app_serialize_ues(mme_app_desc, contexts);
+  auto end_ctxt_to_proto = std::chrono::high_resolution_clock::now();
+  getrusage(RUSAGE_SELF, &ru_end_ctxt_to_proto);
+  log_rusage_diff(ru_start_ctxt_to_proto, ru_end_ctxt_to_proto,
+                  "RUSAGE Contexts serialization");
+  auto duration_ctxt_to_proto =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end_ctxt_to_proto -
+                                                           start_ctxt_to_proto);
+  std::cout << "Time taken to serialize contexts " << num_ues
+            << " UEs : " << duration_ctxt_to_proto.count() << " nanoseconds"
+            << std::endl;
+  OAILOG_INFO(LOG_MME_APP, "Time taken to serialize contexts %d UEs: %ld µs\n",
+              num_ues, duration_ctxt_to_proto.count());
+
+  struct rusage ru_start_proto_to_ctxt, ru_end_proto_to_ctxt;
+  getrusage(RUSAGE_SELF, &ru_start_proto_to_ctxt);
+  auto start_proto_to_ctxt = std::chrono::high_resolution_clock::now();
+  mme_app_deserialize_ues();
+  auto end_proto_to_ctxt = std::chrono::high_resolution_clock::now();
+  getrusage(RUSAGE_SELF, &ru_end_proto_to_ctxt);
+  log_rusage_diff(ru_start_proto_to_ctxt, ru_end_proto_to_ctxt,
+                  "RUSAGE Contexts deserialization");
+  auto duration_proto_to_ctxt =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end_proto_to_ctxt -
+                                                           start_proto_to_ctxt);
+  std::cout << "Time taken to deserialize contexts " << num_ues
+            << " UEs : " << duration_proto_to_ctxt.count() << " nanoseconds"
+            << std::endl;
+  OAILOG_INFO(LOG_MME_APP, "Time taken to serialize contexts %d UEs : %ld ns\n",
+              num_ues, duration_proto_to_ctxt.count());
+  /*auto imsi_str = MmeNasStateManager::getInstance().get_imsi_str(imsi64);
+  MmeNasStateManager::getInstance().write_ue_state_to_db(
+      ue_context, imsi_str);
+  put_mme_ue_state(mme_app_desc_p, imsi64, force_ue_write);
+  put_mme_nas_state(); */
+  mme_app_desc_t* mme_app_desc_p = get_mme_nas_state(false);
+  if (!mme_app_desc_p) {
+    OAILOG_ERROR(LOG_MME_APP, "Failed to fetch mme_app_desc_p \n");
+    return;
+  }
+  mme_app_deallocate_ues(mme_app_desc_p, &contexts);
+
+  send_terminate_message_fatal(&main_zmq_ctx);
+  sleep(1);
+  exit(0);
+  return;
+}

--- a/lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.h
+++ b/lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.h
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// C includes --------------------------------------------------------------
+#include "lte/gateway/c/core/oai/include/mme_app_desc.h"
+
+void mme_app_schedule_test_protobuf_serialization(uint num_ues);
+void mme_app_test_protobuf_serialization(mme_app_desc_t* mme_app_desc,
+                                         uint num_ues);
+#ifdef __cplusplus
+}
+#endif

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_embedded_spgw.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_embedded_spgw.c
@@ -57,15 +57,23 @@ status_code_e mme_config_embedded_spgw_parse_opt_line(
   spgw_config_init(spgw_config_p);
   amf_config_init(amf_config_p);
 
-  while ((c = getopt(argc, argv, "c:hi:Ks:v:V")) != -1) {
+  while ((c = getopt(argc, argv, "c:hi:Ks:v:V:p:")) != -1) {
     switch (c) {
       case 'c':
         mme_config_p->config_file = bfromcstr(optarg);
-
         OAILOG_DEBUG(LOG_CONFIG, "mme_config.config_file %s",
                      bdata(mme_config_p->config_file));
-
         break;
+
+#if MME_BENCHMARK
+      case 'p': {
+        mme_config_p->test_param = atoi(optarg);
+        mme_config_p->test_type = TEST_SERIALIZATION_PROTOBUF;
+        mme_config_p->run_mode = RUN_MODE_TEST;
+        OAI_FPRINTF_INFO("Test serialization protobuf, parameter %u\n",
+                         mme_config_p->test_param);
+      } break;
+#endif
 
       case 'v':
         mme_config_p->log_config.asn1_verbosity_level = atoi(optarg);
@@ -102,6 +110,9 @@ status_code_e mme_config_embedded_spgw_parse_opt_line(
         break;
 
       case 'h':
+#if !MME_BENCHMARK
+      case 'p':
+#endif
       default:
         usage(argv[0]);
         exit(0);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -50,6 +50,9 @@
 #include "lte/gateway/c/core/oai/include/mme_app_state.h"
 #include "lte/gateway/c/core/oai/include/s11_messages_types.h"
 #include "lte/gateway/c/core/oai/include/s1ap_messages_types.h"
+#if MME_BENCHMARK
+#include "lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.h"
+#endif
 
 static void check_mme_healthy_and_notify_service(void);
 static bool is_mme_app_healthy(void);
@@ -459,6 +462,15 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           mme_app_desc_p, &S1AP_REMOVE_STALE_UE_CONTEXT(received_message_p));
     } break;
 
+#if MME_BENCHMARK
+    case MME_APP_TEST_PROTOBUF_SERIALIZATION: {
+      mme_app_test_protobuf_serialization(
+          mme_app_desc_p,
+          MME_APP_TEST_PROTOBUF_SERIALIZATION(received_message_p).num_ues);
+      force_ue_write = false;
+      is_task_state_same = true;
+    } break;
+#endif
     case TERMINATE_MESSAGE: {
       itti_free_msg_content(received_message_p);
       free(received_message_p);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_state_manager.cpp
@@ -219,10 +219,11 @@ status_code_e MmeNasStateManager::read_ue_state_from_db() {
     for (const auto& key : keys) {
       OAILOG_DEBUG(log_task, "Reading UE state from db for %s", key.c_str());
       oai::UeContext ue_proto = oai::UeContext();
-      auto* ue_context = (ue_mm_context_t*)(calloc(1, sizeof(ue_mm_context_t)));
       if (redis_client->read_proto(key, ue_proto) != RETURNok) {
         return RETURNerror;
       }
+      auto* ue_context = reinterpret_cast<ue_mm_context_t*>(
+          calloc(1, sizeof(ue_mm_context_t)));
       MmeNasStateConverter::proto_to_ue(ue_proto, ue_context);
 
       hashtable_rc_t h_rc = hashtable_ts_insert(

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.c
@@ -1843,6 +1843,13 @@ void mme_config_display(mme_config_t* config_pP) {
               config_pP->daylight_saving_time);
   OAILOG_INFO(LOG_CONFIG, "- Run mode .............................: %s\n",
               (RUN_MODE_TEST == config_pP->run_mode) ? "TEST" : "NORMAL");
+#if MME_BENCHMARK
+  if (RUN_MODE_TEST == config_pP->run_mode) {
+    OAILOG_INFO(LOG_CONFIG,
+                "- Benchmark Test param ...........................: %u\n",
+                config_pP->test_param);
+  }
+#endif
   OAILOG_INFO(LOG_CONFIG, "- Max eNBs .............................: %u\n",
               config_pP->max_enbs);
   OAILOG_INFO(LOG_CONFIG, "- Max UEs ..............................: %u\n",
@@ -2173,7 +2180,7 @@ int mme_config_parse_opt_line(int argc, char* argv[], mme_config_t* config_pP) {
   /*
    * Parsing command line
    */
-  while ((c = getopt(argc, argv, "c:s:h:v:V")) != -1) {
+  while ((c = getopt(argc, argv, "c:s:p:h:v:V")) != -1) {
     switch (c) {
       case 'c': {
         /*
@@ -2196,6 +2203,15 @@ int mme_config_parse_opt_line(int argc, char* argv[], mme_config_t* config_pP) {
             PACKAGE_NAME, PACKAGE_VERSION, PACKAGE_BUGREPORT);
       } break;
 
+#if MME_BENCHMARK
+      case 'p': {
+        config_pP->test_param = atoi(optarg);
+        config_pP->test_type = TEST_SERIALIZATION_PROTOBUF;
+        config_pP->run_mode = RUN_MODE_TEST;
+        OAI_FPRINTF_INFO("Test serialization protobuf, parameter %u\n",
+                         config_pP->test_param);
+      } break;
+#endif
       case 's': {
         OAI_FPRINTF_INFO(
             "Ignoring command line option s as there is no embedded sgw \n");
@@ -2203,6 +2219,9 @@ int mme_config_parse_opt_line(int argc, char* argv[], mme_config_t* config_pP) {
 
       case 'h': /* Fall through */
 
+#if !MME_BENCHMARK
+      case 'p': /* Fall through */
+#endif
       default:
         OAI_FPRINTF_ERR("Unknown command line option %c\n", c);
         usage(argv[0]);


### PR DESCRIPTION
## Summary

Quantify and obtain measurements of the memory and time spent on serialization of UE MM context using protobuf library, using a minimal test object

Benchmark performance data such as memory, CPU spent, time during serialization and deserialization.
 
For time benchmarking, std::chrono is used and measurements are flushed to stdout.

For memory benchmarking, [rusage](https://linux.die.net/man/2/getrusage) is used.


## Test Plan

  Benchmarking for AGW is done on the magma dev VM. You just need to bring only this VM up.

Inside magma VM, build mme:

```bash
[VM] cd $MAGMA_ROOT/lte/gateway
[VM] make benchmark_pb
```

  in magma VM
  ```bash
  # N = number of UEs connected
  N=50
  # Measurements are collected from stdout
  sudo service magma@magmad stop
  sudo rm -f /var/lib/redis/dump.rdb /var/opt/magma/redis_dump.rdb stdout.all.txt
  sudo service magma@magmad start
  sudo service magma@mme stop
  sudo service sctpd start
  sudo service magma@mobilityd start
  sudo service magma@pipelined start
  sudo service magma@sessiond start
  sudo rm -f /var/lib/redis/dump.rdb /var/opt/magma/redis_dump.rdb
  sudo cp /var/opt/magma/tmp/mme.conf /usr/local/etc/oai
  sudo cp /var/opt/magma/tmp/spgw.conf /usr/local/etc/oai
  sudo /home/vagrant/build/c/core/oai/oai_mme/mme -p$N | tee stdout.all.txt
```
Here is a script example for extracting values from run (still in magma dev VM):

  ```bash
  cat stdout.all.txt | grep 'TIME PROTOBUF CONVERSION' | cut -d ':' -f2 >> protobuf_conv$N.txt
  cat stdout.all.txt | grep 'TIME PROTOBUF REDIS SERIALIZATION' | cut -d ':' -f2 >> protobuf_redis$N.txt
  cat stdout.all.txt | grep 'Time taken to deserialize contexts' | cut -d ':' -f2 >> protobuf_deserialize_contexts$N.txt
  cat stdout.all.txt | grep 'Time taken to serialize contexts' | cut -d ':' -f2 >> protobuf_serialize_contexts$N.txt
  cat stdout.all.txt | grep 'RUSAGE Contexts serialization'  | grep 'Cpu' | cut -d ':' -f2 >> protobuf_rusage_cpu$N.txt
  cat stdout.all.txt | grep 'RUSAGE Contexts serialization'  | grep 'Maximum resident' | cut -d ':' -f2 >> protobuf_rusage_mrss$N.txt
  cat stdout.all.txt | grep 'RUSAGE Contexts serialization'  | grep 'Page reclaims' | cut -d ':' -f2 >> protobuf_rusage_reclaims$N.txt
  cat stdout.all.txt | grep 'RUSAGE Contexts serialization'  | grep 'Block operations' | cut -d ':' -f2 >> protobuf_rusage_block$N.txt
  cat stdout.all.txt | grep 'RUSAGE Contexts serialization'  | grep 'Context switches ' | cut -d ':' -f2 >> protobuf_rusage_switches$N.txt
```
