### PR TITLE
chore(mme): add missing include for assertions.h

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/ies/MobileStationClassmark3.c
+++ b/lte/gateway/c/core/oai/tasks/nas/ies/MobileStationClassmark3.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#include "lte/gateway/c/core/oai/common/assertions.h"
 #include "lte/gateway/c/core/oai/common/TLVEncoder.h"
 #include "lte/gateway/c/core/oai/common/TLVDecoder.h"
 #include "lte/gateway/c/core/oai/tasks/nas/ies/MobileStationClassmark3.h"

--- a/lte/gateway/c/core/oai/tasks/nas/ies/ProcedureTransactionIdentity.c
+++ b/lte/gateway/c/core/oai/tasks/nas/ies/ProcedureTransactionIdentity.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#include "lte/gateway/c/core/oai/common/assertions.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.007.h"
 #include "lte/gateway/c/core/oai/common/TLVEncoder.h"
 #include "lte/gateway/c/core/oai/common/TLVDecoder.h"

--- a/lte/gateway/c/core/oai/tasks/nas/ies/ProtocolDiscriminator.c
+++ b/lte/gateway/c/core/oai/tasks/nas/ies/ProtocolDiscriminator.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#include "lte/gateway/c/core/oai/common/assertions.h"
 #include "lte/gateway/c/core/oai/common/TLVEncoder.h"
 #include "lte/gateway/c/core/oai/common/TLVDecoder.h"
 #include "lte/gateway/c/core/oai/tasks/nas/ies/ProtocolDiscriminator.h"

--- a/lte/gateway/c/core/oai/tasks/nas/ies/TrafficFlowAggregateDescription.c
+++ b/lte/gateway/c/core/oai/tasks/nas/ies/TrafficFlowAggregateDescription.c
@@ -19,8 +19,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "lte/gateway/c/core/oai/common/assertions.h"
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
-
 #include "lte/gateway/c/core/oai/common/log.h"
 #include "lte/gateway/c/core/oai/common/TLVEncoder.h"
 #include "lte/gateway/c/core/oai/common/TLVDecoder.h"


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
All of the modified files in this file have a dependency on the assertions file, but they are missing the include statement. Without this change, the tests are not able to link dynamically.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI (ran test_oai manually)
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
