### PR TITLE
chore(mme): remove folly dependencies from SpgwServiceImpl

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.cpp
@@ -14,16 +14,17 @@
  * For more information about the OpenAirInterface (OAI) Software Alliance:
  *      contact@openairinterface.org
  */
+#include "lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.h"
+
 #include <string>
+#include <arpa/inet.h>
 
 #include "lte/protos/spgw_service.pb.h"
-#include <folly/IPAddress.h>
 
 extern "C" {
 #include "lte/gateway/c/core/oai/include/spgw_service_handler.h"
 #include "lte/gateway/c/core/oai/common/log.h"
 }
-#include "lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.h"
 
 namespace grpc {
 class ServerContext;
@@ -289,35 +290,71 @@ bool SpgwServiceImpl::fillUpPacketFilterContents(
   return true;
 }
 
+// Extract and validate IP address and subnet mask
+// IPv4 network format ex.: 192.176.128.10/24
+ipv4_network_t SpgwServiceImpl::parseIpv4Network(
+    const std::string& ipv4network_str) {
+  ipv4_network_t result;
+  const int slash_pos = ipv4network_str.find("/");
+  std::string ipv4addr = (slash_pos != std::string::npos)
+                             ? ipv4network_str.substr(0, slash_pos)
+                             : ipv4network_str;
+  in_addr addr;
+  if (inet_pton(AF_INET, ipv4addr.c_str(), &addr) != 1) {
+    OAILOG_ERROR(LOG_UTIL, "Invalid address string %s \n",
+                 ipv4network_str.c_str());
+    result.success = false;
+    return result;
+  }
+  // Host Byte Order
+  result.addr_hbo = ntohl(addr.s_addr);
+  constexpr char default_mask_len_str[] = "32";
+  std::string mask_len_str = (slash_pos != std::string::npos)
+                                 ? ipv4network_str.substr(slash_pos + 1)
+                                 : default_mask_len_str;
+  int mask_len;
+  try {
+    mask_len = std::stoi(mask_len_str);
+  } catch (...) {
+    OAILOG_ERROR(LOG_UTIL, "Invalid address string %s \n",
+                 ipv4network_str.c_str());
+    result.success = false;
+    return result;
+  }
+  if (mask_len > 32 || mask_len < 0) {
+    OAILOG_ERROR(LOG_UTIL, "Invalid address string %s \n",
+                 ipv4network_str.c_str());
+    result.success = false;
+    return result;
+  }
+  result.mask_len = mask_len;
+  result.success = true;
+  return result;
+}
+
 // IPv4 address format ex.: 192.176.128.10/24
 // FEG can provide an empty string which indicates
 // ANY and it is equivalent to 0.0.0.0/0
 // But this function is called only for non-empty ipv4 string
 bool SpgwServiceImpl::fillIpv4(packet_filter_contents_t* pf_content,
-                               const std::string ipv4addr) {
-  const auto cidrNetworkExpect = folly::IPAddress::tryCreateNetwork(ipv4addr);
-  if (cidrNetworkExpect.hasError()) {
-    OAILOG_ERROR(LOG_UTIL, "Invalid address string %s \n", ipv4addr.c_str());
+                               const std::string& ipv4network_str) {
+  ipv4_network_t ipv4network = parseIpv4Network(ipv4network_str);
+  if (!ipv4network.success) {
     return false;
   }
-  // Host Byte Order
-  uint32_t ipv4addrHBO = cidrNetworkExpect.value().first.asV4().toLongHBO();
+  uint32_t ipv4addrHBO = ipv4network.addr_hbo;
   for (int i = (TRAFFIC_FLOW_TEMPLATE_IPV4_ADDR_SIZE - 1); i >= 0; --i) {
     pf_content->ipv4remoteaddr[i].addr = (unsigned char)ipv4addrHBO & 0xFF;
     ipv4addrHBO = ipv4addrHBO >> 8;
   }
-
-  // Get the mask length:
-  // folly takes care of absence of mask_len by defaulting to 32
-  // i.e., 255.255.255.255.
-  int mask_len = cidrNetworkExpect.value().second;
-  uint32_t mask = UINT32_MAX;        // all ones
-  mask = (mask << (32 - mask_len));  // first mask_len bits are 1s, rest 0s
+  uint32_t mask = UINT32_MAX;  // all ones
+  mask =
+      (mask << (32 -
+                ipv4network.mask_len));  // first mask_len bits are 1s, rest 0s
   for (int i = (TRAFFIC_FLOW_TEMPLATE_IPV4_ADDR_SIZE - 1); i >= 0; --i) {
     pf_content->ipv4remoteaddr[i].mask = (unsigned char)mask & 0xFF;
     mask = mask >> 8;
   }
-
   OAILOG_DEBUG(
       LOG_UTIL,
       "Network Address: %d.%d.%d.%d "

--- a/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.h
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.h
@@ -49,6 +49,12 @@ using magma::lte::SpgwService;
 namespace magma {
 using namespace lte;
 
+typedef struct ipv4_network {
+  uint32_t addr_hbo;
+  int mask_len;
+  bool success;
+} ipv4_network_t;
+
 class SpgwServiceImpl final : public SpgwService::Service {
  public:
   SpgwServiceImpl();
@@ -79,6 +85,8 @@ class SpgwServiceImpl final : public SpgwService::Service {
                             const DeleteBearerRequest* request,
                             DeleteBearerResult* response) override;
 
+  ipv4_network_t parseIpv4Network(const std::string& ipv4network_str);
+
  private:
   /*
    * Fill up the packet filter contents such as flags and flow tuple fields
@@ -96,7 +104,7 @@ class SpgwServiceImpl final : public SpgwService::Service {
    * @return bool: Return true if successful, false if not
    */
   bool fillIpv4(packet_filter_contents_t* pf_content,
-                const std::string ipv4addr);
+                const std::string& ipv4addr);
 
   /*
    * Fill up the ipv6 remote address field in packet filter

--- a/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(SPGW_TASK_TEST_LIB
 
 set_target_properties(SPGW_TASK_TEST_LIB PROPERTIES LINKER_LANGUAGE CXX)
 
-foreach (sgw_test spgw_state_converter spgw_procedures pgw_pco spgw_procedures_with_injected_state)
+foreach (sgw_test spgw_service_impl spgw_state_converter spgw_procedures pgw_pco spgw_procedures_with_injected_state)
   add_executable(${sgw_test}_test test_${sgw_test}.cpp)
   target_link_libraries(${sgw_test}_test SPGW_TASK_TEST_LIB TASK_GRPC_SERVICE)
   add_test(test_${sgw_test} ${sgw_test}_test)

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_service_impl.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_service_impl.cpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2022 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.h"
+
+namespace magma {
+namespace lte {
+
+class SPGWServiceImplTest : public ::testing::Test {
+  virtual void SetUp() {}
+
+  virtual void TearDown() {}
+};
+
+TEST_F(SPGWServiceImplTest, TestSpgwServiceImpl) {
+  SpgwServiceImpl test_service;
+
+  // parseIpv4Network calls with valid ip and optional valid subnet masks
+  ipv4_network_t result = test_service.parseIpv4Network("255.255.255.0/24");
+  EXPECT_EQ(result.addr_hbo, 4294967040);
+  EXPECT_EQ(result.mask_len, 24);
+  EXPECT_EQ(result.success, true);
+
+  result = test_service.parseIpv4Network("192.168.255.0");
+  EXPECT_EQ(result.addr_hbo, 3232300800);
+  EXPECT_EQ(result.mask_len, 32);
+  EXPECT_EQ(result.success, true);
+
+  result = test_service.parseIpv4Network("192.168.0.0/0");
+  EXPECT_EQ(result.addr_hbo, 3232235520);
+  EXPECT_EQ(result.mask_len, 0);
+  EXPECT_EQ(result.success, true);
+
+  result = test_service.parseIpv4Network("0.0.0.0/0");
+  EXPECT_EQ(result.addr_hbo, 0);
+  EXPECT_EQ(result.mask_len, 0);
+  EXPECT_EQ(result.success, true);
+
+  result = test_service.parseIpv4Network("192.168.0.0/32");
+  EXPECT_EQ(result.addr_hbo, 3232235520);
+  EXPECT_EQ(result.mask_len, 32);
+  EXPECT_EQ(result.success, true);
+
+  // parseIpv4Network calls with invalid combinations of ip and subnet masks
+  std::vector<std::string> false_test_ips = {"0.0.0.0//0",
+                                             "0.0.0.0\\0",
+                                             "0/0.0.0.0",
+                                             "5",
+                                             "3.5",
+                                             "abc",
+                                             "192.168.0.0/33",
+                                             "192.168.0.0/a",
+                                             "192.168.0.0/-1",
+                                             "192.468.0.0",
+                                             "192.-168.0.0",
+                                             "192.168.5"};
+
+  for (std::string false_test_ip : false_test_ips) {
+    result = test_service.parseIpv4Network(false_test_ip);
+    EXPECT_EQ(result.success, false);
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+}  // namespace lte
+}  // namespace magma


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Remove folly dependencies in MME for IP format conversion
- Replaced with standard C++ instructions
- Unit test for Ipv4 parsing is added

## Test Plan

- `make build_oai`
- `make test_oai`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
