### PR TITLE
fix(amf): Send ICS+SRVC Accept for service type signaling

### DIFF
--- a/lte/gateway/c/core/oai/common/common_types.h
+++ b/lte/gateway/c/core/oai/common/common_types.h
@@ -82,7 +82,6 @@ typedef uint64_t enb_s1ap_id_key_t;
 // UE NGAP IDs
 #define INVALID_AMF_UE_NGAP_ID 0x0
 #define INVALID_GNB_UE_NGAP_ID_KEY 0xFFFFFFFFFFFFFFFF
-#define GNB_UE_NGAP_ID_MASK 0x00FFFFFF
 #define GNB_UE_NGAP_ID_FMT "%u"
 #define AMF_UE_NGAP_ID_FMT "%lu"
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -355,6 +355,7 @@ imsi64_t amf_app_handle_initial_ue_message(
           amf_app_desc_p->amf_ue_contexts.gnb_ue_ngap_id_ue_context_htbl.remove(
               ue_context_p->gnb_ngap_id_key);
           ue_context_p->gnb_ngap_id_key = INVALID_GNB_UE_NGAP_ID_KEY;
+          ue_context_p->mm_state = DEREGISTERED;
         }
 
         /* remove amf_ngap_ud_id entry from ue context */

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -117,7 +117,11 @@ int amf_handle_service_request(
 
     if (msg->service_type.service_type_value == SERVICE_TYPE_SIGNALING) {
       OAILOG_DEBUG(LOG_NAS_AMF, "Service request type is signalling \n");
-      amf_sap.primitive = AMFAS_ESTABLISH_CNF;
+      if (ue_context->amf_context._security.eksi != KSI_NO_KEY_AVAILABLE) {
+        amf_sap.primitive = AMFAS_ESTABLISH_CNF;
+      } else {
+        amf_sap.primitive = AMFAS_ESTABLISH_REJ;
+      }
 
       amf_sap.u.amf_as.u.establish.ue_id = ue_id;
       amf_sap.u.amf_as.u.establish.nas_info = AMF_AS_NAS_INFO_SR;

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -932,8 +932,7 @@ int ngap_amf_handle_ue_context_release_request(ngap_state_t* state,
   NGAP_FIND_PROTOCOLIE_BY_ID(Ngap_UEContextReleaseRequest_IEs_t, ie, container,
                              Ngap_ProtocolIE_ID_id_RAN_UE_NGAP_ID, true);
   if (ie) {
-    gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID &
-                                        GNB_UE_NGAP_ID_MASK);
+    gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID);
   } else {
     OAILOG_FUNC_RETURN(LOG_NGAP, RETURNerror);
   }


### PR DESCRIPTION
fix(amf): Send ICS+SRVC Accept for service type signaling

Signed-off-by: Moinuddin Khan <moinuddin.khan@wavelabs.ai>

## Summary
Following fixes are included:
- Upon receiving service request with service type as signaling, send service accept along with initial context setup request towards gNB and UE.
- UE did not respond with Registration Complete, hence after max retries of Registration Accept, UE context is released in AMF.
  Hence, in this condition upon receiving Initial UE message Service Request, the AMF will reject it as the security context is not established yet.
 
## Test Plan

Tested the following TCs in TVM setup successfully.
TC7, TC7a, TC7b, 7c2, 7c, 7e, 7f, TC2c, TC2d, TC2e, TC8, TC8b, TC9 TC9a, TC9b, TC59, TC60
[SA_TC2c_Verify_Idle_and_Active_Mode_transition_with_Multi_PDU_session_220217_032911-1.zip](https://github.com/magma/magma/files/8089933/SA_TC2c_Verify_Idle_and_Active_Mode_transition_with_Multi_PDU_session_220217_032911-1.zip)
[SA_TC7c_Verify_Service_Reject_for_SReq_MO_Signaling_220225_021258-1.zip](https://github.com/magma/magma/files/8140823/SA_TC7c_Verify_Service_Reject_for_SReq_MO_Signaling_220225_021258-1.zip)
[SA_TC60_SCTP_Connection_Abort_Verify_N2_N1_State_in_AGW_220225_035748-1.zip](https://github.com/magma/magma/files/8140944/SA_TC60_SCTP_Connection_Abort_Verify_N2_N1_State_in_AGW_220225_035748-1.zip)


 
## Additional Information
Addresses the following tickets
#11609 #11473 
- [ ] This change is backwards-breaking