### PR TITLE
chore: change devcontainer image sha to master

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 		"njpwerner.autodocstring",
 		"zxh404.vscode-proto3",
 	],
-	"image": "ghcr.io/magma/magma/devcontainer:sha-e05d447",
+	"image": "ghcr.io/magma/magma/devcontainer:master",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"files.watcherExclude": {

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
     # Run four times a day to build bazel cache
     - cron: '0 0,6,12,18 * * *'
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:sha-206a67a"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:master"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 


### PR DESCRIPTION
## Summary

Update DevContainer image sha to `master` (the latest image does not come with a sha, thus switch to `master`).

The change in docker image tagging was activated with https://github.com/magma/magma/pull/11508.