### PR TITLE
fix(orc8r): Try fix Helm deploy bug with numeric version

### DIFF
--- a/orc8r/cloud/helm/orc8rlib/templates/_container.yaml
+++ b/orc8r/cloud/helm/orc8rlib/templates/_container.yaml
@@ -65,9 +65,9 @@ env:
   - name: SERVICE_REGISTRY_NAMESPACE
     value: {{ .Release.Namespace }}
   - name: HELM_VERSION_TAG
-    value: {{ .Chart.Version }}
+    value: {{ .Chart.Version | quote }}
   - name: VERSION_TAG
-    value: {{ .Values.controller.image.tag }}
+    value: {{ .Values.controller.image.tag | quote }}
 livenessProbe:
   tcpSocket:
     port: 9180


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Env var was unquoted, which normally is fine, but when we tried to deploy an all-numeric hash, threw a type err. To fix, we'll quote the value to ensure it's always interpreted as a string

## Test Plan

do_it_live.jpg

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->