### PR TITLE
fix(mme): make GCC warnings disappear

### DIFF
--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c
@@ -49,17 +49,18 @@ const struct gtp_tunnel_ops* upf_gtp_tunnel_ops_init_openflow(void) {
 }
 
 int upf_add_tunnel(struct in_addr ue, struct in6_addr* ue_ipv6, int vlan,
-                   struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
-                   Imsi_t imsi, struct ip_flow_dl* flow_dl,
-                   uint32_t flow_precedence_dl, char* apn) {
+                   struct in_addr enb, struct in6_addr* unused_in6_addr,
+                   uint32_t i_tei, uint32_t o_tei, Imsi_t imsi,
+                   struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl,
+                   char* apn) {
   return upf_classifier_add_tunnel(ue, ue_ipv6, vlan, enb, i_tei, o_tei,
                                    (const char*)imsi.digit, flow_dl,
                                    flow_precedence_dl, apn);
 }
 
-int upf_del_tunnel(struct in_addr enb, struct in_addr ue,
-                   struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
-                   struct ip_flow_dl* flow_dl) {
+int upf_del_tunnel(struct in_addr enb, struct in6_addr* unused_in6_addr,
+                   struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+                   uint32_t o_tei, struct ip_flow_dl* flow_dl) {
   return upf_classifier_del_tunnel(enb, ue, ue_ipv6, i_tei, o_tei, flow_dl);
 }
 
@@ -75,10 +76,12 @@ int upf_forward_data_on_tunnel(struct in_addr ue, struct in6_addr* ue_ipv6,
                                                flow_precedence_dl);
 }
 
-int upf_add_paging_rule(struct in_addr ue) {
+int upf_add_paging_rule(Imsi_t unused_imsi_t, struct in_addr ue,
+                        struct in6_addr* unused_in6_addr) {
   return upf_classifier_add_paging_rule(ue);
 }
 
-int upf_delete_paging_rule(struct in_addr ue) {
+int upf_delete_paging_rule(struct in_addr ue,
+                           struct in6_addr* unused_in6_addr) {
   return upf_classifier_delete_paging_rule(ue);
 }

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.h
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.h
@@ -22,13 +22,14 @@
 const struct gtp_tunnel_ops* upf_gtp_tunnel_ops_init_openflow(void);
 
 int upf_add_tunnel(struct in_addr ue, struct in6_addr* ue_ipv6, int vlan,
-                   struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
-                   Imsi_t imsi, struct ip_flow_dl* flow_dl,
-                   uint32_t flow_precedence_dl, char* apn);
+                   struct in_addr enb, struct in6_addr* unused_in6_addr,
+                   uint32_t i_tei, uint32_t o_tei, Imsi_t imsi,
+                   struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl,
+                   char* apn);
 
-int upf_del_tunnel(struct in_addr enb, struct in_addr ue,
-                   struct in6_addr* ue_ipv6, uint32_t i_tei, uint32_t o_tei,
-                   struct ip_flow_dl* flow_dl);
+int upf_del_tunnel(struct in_addr enb, struct in6_addr* unused_in6_addr,
+                   struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+                   uint32_t o_tei, struct ip_flow_dl* flow_dl);
 
 int upf_discard_data_on_tunnel(struct in_addr ue, struct in6_addr* ue_ipv6,
                                uint32_t i_tei, struct ip_flow_dl* flow_dl);
@@ -37,6 +38,7 @@ int upf_forward_data_on_tunnel(struct in_addr ue, struct in6_addr* ue_ipv6,
                                uint32_t i_tei, struct ip_flow_dl* flow_dl,
                                uint32_t flow_precedence_dl);
 
-int upf_add_paging_rule(struct in_addr ue);
+int upf_add_paging_rule(Imsi_t unused_imsi_t, struct in_addr ue,
+                        struct in6_addr* unused_in6_addr);
 
-int upf_delete_paging_rule(struct in_addr ue);
+int upf_delete_paging_rule(struct in_addr ue, struct in6_addr* unused_in6_addr);


### PR DESCRIPTION
Issue: https://github.com/magma/magma/issues/10166

## Summary

Looks like pointers of functions with different function signatures have been assigned.

```
[lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c#L36](https://github.com/magma/magma/commit/005c5f378725a43d3040b380796cd8fade8c7bad#annotation_2776830515)
initialization of 'int (*)(struct in_addr,  struct in6_addr *, int,  struct in_addr,  struct in6_addr *, uint32_t,  uint32_t,  Imsi_t,  struct ip_flow_dl *, uint32_t,  char *)' {aka 'int (*)(struct in_addr,  struct in6_addr *, int,  struct in_addr,  struct in6_addr *, unsigned int,  unsigned int,  struct <anonymous>,  struct ip_flow_dl *, unsigned int,  char *)'} from incompatible pointer type 'int (*)(struct in_addr,  struct in6_addr *, int,  struct in_addr,  uint32_t,  uint32_t,  Imsi_t,  struct ip_flow_dl *, uint32_t,  char *)' {aka 'int (*)(struct in_addr,  struct in6_addr *, int,  struct in_addr,  unsigned int,  unsigned int,  struct <anonymous>,  struct ip_flow_dl *, unsigned int,  char *)'} [-Wincompatible-pointer-types]

[lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c#L37](https://github.com/magma/magma/commit/005c5f378725a43d3040b380796cd8fade8c7bad#annotation_2776830518)
initialization of 'int (*)(struct in_addr,  struct in6_addr *, struct in_addr,  struct in6_addr *, uint32_t,  uint32_t,  struct ip_flow_dl *)' {aka 'int (*)(struct in_addr,  struct in6_addr *, struct in_addr,  struct in6_addr *, unsigned int,  unsigned int,  struct ip_flow_dl *)'} from incompatible pointer type 'int (*)(struct in_addr,  struct in_addr,  struct in6_addr *, uint32_t,  uint32_t,  struct ip_flow_dl *)' {aka 'int (*)(struct in_addr,  struct in_addr,  struct in6_addr *, unsigned int,  unsigned int,  struct ip_flow_dl *)'} [-Wincompatible-pointer-types]

[lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c#L40](https://github.com/magma/magma/commit/005c5f378725a43d3040b380796cd8fade8c7bad#annotation_2776830521)
initialization of 'int (*)(Imsi_t,  struct in_addr,  struct in6_addr *)' {aka 'int (*)(struct <anonymous>,  struct in_addr,  struct in6_addr *)'} from incompatible pointer type 'int (*)(struct in_addr)' [-Wincompatible-pointer-types]

[lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.c#L41](https://github.com/magma/magma/commit/005c5f378725a43d3040b380796cd8fade8c7bad#annotation_2776830523)
initialization of 'int (*)(struct in_addr, struct in6_addr *)' from incompatible pointer type 'int (*)(struct in_addr)' [-Wincompatible-pointer-types]
```

Added unused parameters so that signatures match.

## Test Plan

```
cd /workspaces/magma/lte/gateway
make build_oai
```
Compilation successful
