### PR TITLE
fix: Add missing cyrpto dependency to libfluid_base build file

### DIFF
--- a/bazel/external/libfluid_base.BUILD
+++ b/bazel/external/libfluid_base.BUILD
@@ -45,6 +45,7 @@ cc_library(
     includes = [""],
     linkopts = [
         "-lssl",
+        "-lcrypto",
         "-levent",
         "-levent_pthreads",
         "-levent_openssl",


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
libfluid_base also depends on -lcrypto
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested by patching the changes to @electronjoe's MME branch
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
