### PR TITLE
chore(sessiond): remove sentry transaction tags

### DIFF
--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -73,7 +73,6 @@ LocalSessionManagerHandlerImpl::LocalSessionManagerHandlerImpl(
 void LocalSessionManagerHandlerImpl::ReportRuleStats(
     ServerContext* context, const RuleRecordTable* request,
     std::function<void(Status, Void)> response_callback) {
-  set_sentry_transaction("ReportRuleStats");
   auto& request_cpy = *request;
   if (request_cpy.records_size() > 0) {
     PrintGrpcMessage(
@@ -281,7 +280,6 @@ grpc::Status LocalSessionManagerHandlerImpl::validate_create_session_request(
 void LocalSessionManagerHandlerImpl::CreateSession(
     ServerContext* context, const LocalCreateSessionRequest* request,
     std::function<void(Status, LocalCreateSessionResponse)> response_callback) {
-  set_sentry_transaction("CreateSession");
   auto& request_cpy = *request;
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   enforcer_->get_event_base().runInEventBaseThread([this, response_callback,
@@ -553,7 +551,6 @@ void LocalSessionManagerHandlerImpl::add_session_to_directory_record(
 void LocalSessionManagerHandlerImpl::EndSession(
     ServerContext* context, const LocalEndSessionRequest* request,
     std::function<void(Status, LocalEndSessionResponse)> response_callback) {
-  set_sentry_transaction("EndSession");
   auto& request_cpy = *request;
   auto& sid = request->sid();
   auto& apn = request->apn();
@@ -597,7 +594,6 @@ void LocalSessionManagerHandlerImpl::BindPolicy2Bearer(
     ServerContext* context, const PolicyBearerBindingRequest* request,
     std::function<void(Status, PolicyBearerBindingResponse)>
         response_callback) {
-  set_sentry_transaction("BindPolicy2Bearer");
   auto& request_cpy = *request;
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   MLOG(MINFO) << "Received a BindPolicy2Bearer request for "
@@ -632,7 +628,6 @@ void LocalSessionManagerHandlerImpl::BindPolicy2Bearer(
 void LocalSessionManagerHandlerImpl::UpdateTunnelIds(
     ServerContext* context, UpdateTunnelIdsRequest* request,
     std::function<void(Status, UpdateTunnelIdsResponse)> response_callback) {
-  set_sentry_transaction("UpdateTunnelIds");
   auto& request_cpy = *request;
   auto imsi = request->sid().id();
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
@@ -667,7 +662,6 @@ void LocalSessionManagerHandlerImpl::UpdateTunnelIds(
 void LocalSessionManagerHandlerImpl::SetSessionRules(
     ServerContext* context, const SessionRules* request,
     std::function<void(Status, Void)> response_callback) {
-  set_sentry_transaction("SetSessionRules");
   auto& request_cpy = *request;
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   MLOG(MDEBUG) << "Received session <-> rule associations";

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
@@ -46,7 +46,6 @@ SessionProxyResponderHandlerImpl::SessionProxyResponderHandlerImpl(
 void SessionProxyResponderHandlerImpl::ChargingReAuth(
     ServerContext* context, const ChargingReAuthRequest* request,
     std::function<void(Status, ChargingReAuthAnswer)> response_callback) {
-  set_sentry_transaction("ChargingReAuth");
   auto& request_cpy = *request;
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   MLOG(MDEBUG) << "Received a Gy (Charging) ReAuthRequest for "
@@ -87,8 +86,6 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
 void SessionProxyResponderHandlerImpl::PolicyReAuth(
     ServerContext* context, const PolicyReAuthRequest* request,
     std::function<void(Status, PolicyReAuthAnswer)> response_callback) {
-  set_sentry_transaction("PolicyReAuth");
-
   auto& request_cpy = *request;
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   MLOG(MDEBUG) << "Received a Gx (Policy) ReAuthRequest for session_id "

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -420,7 +420,6 @@ int main(int argc, char* argv[]) {
     std::promise<magma::OpState> result;
     std::future<magma::OpState> future = result.get_future();
     evb->runInEventBaseThread([session_store, &result]() {
-      set_sentry_transaction("GetOperationalStates");
       result.set_value(magma::get_operational_states(session_store));
     });
     return future.get();


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Removing the transaction tags I added way back. I'm not entirely sure if I'm using the tag properly, and have noticed that sometimes the tag looks wrong. (It might be that I'm using it wrong). As it's not providing any useful information for now and it can be confusing, removing it until we can figure out how to put it back in. 
<img width="655" alt="Screen Shot 2022-02-18 at 10 28 59 AM" src="https://user-images.githubusercontent.com/37634144/154723091-5f2335d6-fe7d-41c4-98fb-c0b58e2e979b.png">

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
