### PR TITLE
chore(mme): move the if guard for s6a_fd_new_peer definition inside

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_peer.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_peer.c
@@ -40,7 +40,6 @@
 #include "lte/gateway/c/core/oai/lib/itti/itti_types.h"
 
 #if !S6A_OVER_GRPC
-
 #define NB_MAX_TRIES (8)
 
 extern __pid_t g_pid;
@@ -55,8 +54,12 @@ void s6a_peer_connected_cb(struct peer_info* info, void* arg) {
     send_activate_messages();
   }
 }
+#endif
 
 status_code_e s6a_fd_new_peer(void) {
+// We need to expose the function definition here because the declaration is
+// outside of the guard (GH11646)
+#if !S6A_OVER_GRPC
   int ret = 0;
 
   if (mme_config_read_lock(&mme_config)) {
@@ -115,10 +118,10 @@ status_code_e s6a_fd_new_peer(void) {
   bdestroy(hss_name);
   free_wrapper((void**)&fd_g_config->cnf_diamid);
   fd_g_config->cnf_diamid_len = 0;
+#endif
   return RETURNerror;
 }
 
-#endif
 /*
  * Inform S1AP and MME that connection to HSS is established
  */


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Corresponding GH issue: https://github.com/magma/magma/issues/11646

This is a workaround solution to get around the immediate issue. (Once we have some non-broken Bazel build files landed on master it will be much easier to iterate on it)

In short, the declaration of `s6a_fd_new_peer` is not guarded by any compilation flag, but the function definition is. (by ! S6A_OVER_GRPC). This leads to a linking error when building with Bazel as the definition of the function cannot be found. 

This change will not break anything, but I would prefer to have a solution where we do not rely on S6A_OVER_GRPC to decide which files to compile. I've started a discussion on this here: https://magmacore.slack.com/archives/C02GMJ8S8FR/p1645218963366419
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make test_oai and build_oai (I tested build_oai for both `mme_oai` and `agw_of`

CI (including OAI Jenkins job)
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
