### PR TITLE
chore(mme): use a simplified PARENT_STRUCT macro definition to appeas…

### DIFF
--- a/lte/gateway/c/core/oai/common/common_defs.h
+++ b/lte/gateway/c/core/oai/common/common_defs.h
@@ -51,11 +51,43 @@
 #define COUNT_OF(x) \
   ((sizeof(x) / sizeof(0 [x])) / ((size_t)(!(sizeof(x) % sizeof(0 [x])))))
 
-#define PARENT_STRUCT(cOnTaiNeD, TyPe, MeMBeR)                    \
-  ({                                                              \
-    const typeof(((TyPe*)0)->MeMBeR)* __MemBeR_ptr = (cOnTaiNeD); \
-    (TyPe*)((char*)__MemBeR_ptr - OFFSET_OF(TyPe, MeMBeR));       \
-  })
+// Taken from FreeBSD contrib/ofed/opensm/include/complib/cl_types.h
+/****d* Component Library: Pointer Manipulation/PARENT_STRUCT
+ * NAME
+ *	PARENT_STRUCT
+ *
+ * DESCRIPTION
+ *	The PARENT_STRUCT macro returns a pointer to a structure
+ *	given a name and pointer to one of its members.
+ *
+ * SYNOPSIS
+ *	PARENT_TYPE*
+ *	PARENT_STRUCT(
+ *		IN void* const p_member,
+ *		IN PARENT_TYPE,
+ *		IN MEMBER_NAME );
+ *
+ * PARAMETERS
+ *	p_member
+ *		[in] Pointer to the MEMBER_NAME member of a PARENT_TYPE
+ *structure.
+ *
+ *	PARENT_TYPE
+ *		[in] Name of the structure containing the specified member.
+ *
+ *	MEMBER_NAME
+ *		[in] Name of the member whose address is passed in the p_member
+ *		parameter.
+ *
+ * RETURN VALUE
+ *	Pointer to a structure of type PARENT_TYPE whose MEMBER_NAME member is
+ *	located at p_member.
+ *
+ * SEE ALSO
+ *	offsetof
+ *********/
+#define PARENT_STRUCT(p_member, PARENT_TYPE, MEMBER_NAME) \
+  ((PARENT_TYPE*)((uint8_t*)(p_member)-offsetof(PARENT_TYPE, MEMBER_NAME)))
 
 #define OAI_MAX(a, b)       \
   ({                        \


### PR DESCRIPTION
…e the compiler

Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
With the current macro definition of PARENT_STRUCT, the bazel compilation is very unhappy.
```bash
lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp:325:50: error: cannot convert 'magma5g::amf_context_t' {aka 'magma5g::amf_context_s'} to 'const int' in initialization
  325 |       PARENT_STRUCT(amf_ctx, ue_m5gmm_context_s, amf_context)->amf_ue_ngap_id;
./lte/gateway/c/core/oai/common/common_defs.h:89:31: note: in definition of macro 'PARENT_STRUCT'
   89 |      const typeof(((TyPe*)0)->MeMBeR)* __MemBeR_ptr = (cOnTaiNeD); \
      |                               ^~~~~~
./lte/gateway/c/core/oai/common/common_defs.h:90:21: error: '__MemBeR_ptr' was not declared in this scope
   90 |      (TyPe*)((char*)__MemBeR_ptr - OFFSET_OF(TyPe, MeMBeR));       \
      |                     ^~~~~~~~~~~~
lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp:325:7: note: in expansion of macro 'PARENT_STRUCT'
  325 |       PARENT_STRUCT(amf_ctx, ue_m5gmm_context_s, amf_context)->amf_ue_ngap_id;
      |       ^~~~~~~~~~~~~
./lte/gateway/c/core/oai/common/common_defs.h:89:12: warning: unused variable 'typeof' [-Wunused-variable]
   89 |      const typeof(((TyPe*)0)->MeMBeR)* __MemBeR_ptr = (cOnTaiNeD); \
      |            ^~~~~~
lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp:325:7: note: in expansion of macro 'PARENT_STRUCT'
  325 |       PARENT_STRUCT(amf_ctx, ue_m5gmm_context_s, amf_context)->amf_ue_ngap_id;
      |       ^~~~~~~~~~~~~
./lte/gateway/c/core/oai/common/common_defs.h:90:60: error: void value not ignored as it ought to be
   90 |      (TyPe*)((char*)__MemBeR_ptr - OFFSET_OF(TyPe, MeMBeR));       \
      |                                                            ^
lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp:325:7: note: in expansion of macro 'PARENT_STRUCT'
  325 |       PARENT_STRUCT(amf_ctx, ue_m5gmm_context_s, amf_context)->amf_ue_ngap_id;
      |       ^~~~~~~~~~~~~
lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp:325:62: error: base operand of '->' is not a pointer
  325 |       PARENT_STRUCT(amf_ctx, ue_m5gmm_context_s, amf_context)->amf_ue_ngap_id;
      |                                                              ^~
In file included from ./lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h:46,
                 from ./lte/gateway/c/core/oai/tasks/amf/amf_asDefs.h:27,
                 from lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp:27:
```

From a quick search on source graph, it looks like we inherited this defintion from OAI. 
<img width="753" alt="Screen Shot 2022-02-18 at 5 11 22 PM" src="https://user-images.githubusercontent.com/37634144/154773146-dfa7706c-3b94-48d3-8a70-6c17bfa7ca22.png">

The vast majority of the projects seem to use this particular definition used by FreeBSD.
<img width="917" alt="Screen Shot 2022-02-18 at 5 12 33 PM" src="https://user-images.githubusercontent.com/37634144/154773263-aac9a904-6e56-4f28-8a55-abecdc4d016c.png">

To my eyes, they seem to be identical. But the compiler seems to disagree. I've ran the unit tests and will let CI do its job over the weekend.


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
