### PR TITLE
fix(agw): Update protobuf version to 3.19.0

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -115,7 +115,7 @@ MAGMA_DEPS=(
     "lighttpd >= 1.4.45"
     "libxslt1.1"
     "nghttp2-proxy >= 1.18.1"
-    "python3-protobuf >= 3.14.0"
+    "python3-protobuf >= 3.19.0"
     "redis-server >= 3.2.0"
     "sudo"
     "dnsmasq >= 2.7"

--- a/lte/gateway/release/magma.lockfile.ubuntu
+++ b/lte/gateway/release/magma.lockfile.ubuntu
@@ -812,7 +812,7 @@
           "root": true,
           "source": "pypi",
           "sysdep": "python3-protobuf",
-          "version": "3.14.0"
+          "version": "3.19.0"
         },
         "psutil": {
           "root": true,
@@ -1096,7 +1096,7 @@
           "version": "0.3.1"
         },
         "protobuf": {
-          "version": "3.14.0"
+          "version": "3.19.0"
         },
         "psutil": {
           "version": "5.8.0"

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -70,7 +70,7 @@ setup(
         'python-redis-lock>=3.7.0',
         'aiohttp>=0.17.2',
         'grpcio>=1.16.1',
-        'protobuf>=3.14.0',
+        'protobuf==3.19.0',
         'Jinja2>=2.8',
         'netifaces>=0.10.4',
         'pylint>=1.7.1',


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Current protobuf pydep version (3.14.0) causes an issue on all python services:
```
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:   File "/usr/local/bin/service_util.py", line 20, in <module>
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:     from magma.common.health.service_state_wrapper import ServiceStateWrapper
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:   File "/usr/local/lib/python3.8/dist-packages/magma/common/health/service_state_wrapper.py", line 14, in <module>
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:     from magma.common.redis.client import get_default_client
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:   File "/usr/local/lib/python3.8/dist-packages/magma/common/redis/client.py", line 14, in <module>
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:     from magma.configuration.service_configs import get_service_config_value
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:   File "/usr/local/lib/python3.8/dist-packages/magma/configuration/__init__.py", line 12, in <module>
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:     importlib.import_module(mod)
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:   File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:     return _bootstrap._gcd_import(name[level:], package, level)
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:   File "/usr/local/lib/python3.8/dist-packages/orc8r/protos/mconfig/mconfigs_pb2.py", line 15, in <module>
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:     from orc8r.protos import common_pb2 as orc8r_dot_protos_dot_common__pb2
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:   File "/usr/local/lib/python3.8/dist-packages/orc8r/protos/common_pb2.py", line 20, in <module>
Feb 18 17:23:09 mpk-dogfooding magmad[14487]:     _LOGLEVEL = DESCRIPTOR.enum_types_by_name['LogLevel']
Feb 18 17:23:09 mpk-dogfooding magmad[14487]: AttributeError: 'NoneType' object has no attribute 'enum_types_by_name'
```
- This is likely due to a third-party pydep having a newer version of the dependency which causes this mismatch issue

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- Verified on TVM agw issue is fixed:
```
magma@tvm1-agw2:~$ sudo journalctl -fu magma@magmad
-- Logs begin at Fri 2022-02-11 21:06:00 PST. --
Feb 18 17:18:37 tvm1-agw2 magmad[140218]: INFO:root:[SyncRPC] Opening stream to cloud
Feb 18 17:18:37 tvm1-agw2 magmad[140218]: INFO:root:[SyncRPC] Waiting for requests
Feb 18 17:18:37 tvm1-agw2 magmad[140218]: ERROR:root:[SyncRPC] Failing to forward request, err: failed to connect to all addresses
Feb 18 17:18:37 tvm1-agw2 magmad[140218]: ERROR:root:[SyncRPC] gRPC error: failed to connect to all addresses, reconnecting to cloud.
Feb 18 17:18:37 tvm1-agw2 magmad[140218]: INFO:root:[SyncRPC] Opening stream to cloud
Feb 18 17:18:37 tvm1-agw2 magmad[140218]: INFO:root:[SyncRPC] Waiting for requests
Feb 18 17:18:37 tvm1-agw2 magmad[140218]: ERROR:root:[SyncRPC] Failing to forward request, err: failed to connect to all addresses
Feb 18 17:18:37 tvm1-agw2 magmad[140218]: ERROR:root:[SyncRPC] gRPC error: failed to connect to all addresses, reconnecting to cloud.
Feb 18 17:18:38 tvm1-agw2 magmad[140218]: INFO:root:[SyncRPC] Opening stream to cloud
Feb 18 17:18:38 tvm1-agw2 magmad[140218]: INFO:root:[SyncRPC] Waiting for requests
Feb 18 17:18:46 tvm1-agw2 magmad[140218]: ERROR:root:GetOperationalStates Error for pipelined! [StatusCode.UNAVAILABLE] failed to connect to all addresses
Feb 18 17:18:46 tvm1-agw2 magmad[140218]: INFO:root:Checkin Successful! Successfully sent states to the cloud!
```
- Verified local installation on magma VM and magma_test VM

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
