### PR TITLE
fix(mme): Provide cpp compatible variant of PARENT_STRUCT

### DIFF
--- a/lte/gateway/c/core/oai/common/common_defs.h
+++ b/lte/gateway/c/core/oai/common/common_defs.h
@@ -51,11 +51,21 @@
 #define COUNT_OF(x) \
   ((sizeof(x) / sizeof(0 [x])) / ((size_t)(!(sizeof(x) % sizeof(0 [x])))))
 
+#ifndef __cplusplus
 #define PARENT_STRUCT(cOnTaiNeD, TyPe, MeMBeR)                    \
   ({                                                              \
     const typeof(((TyPe*)0)->MeMBeR)* __MemBeR_ptr = (cOnTaiNeD); \
     (TyPe*)((char*)__MemBeR_ptr - OFFSET_OF(TyPe, MeMBeR));       \
   })
+#endif
+
+#ifdef __cplusplus
+#define PARENT_STRUCT(cOnTaiNeD, TyPe, MeMBeR)                      \
+  ({                                                                \
+    const decltype(((TyPe*)0)->MeMBeR)* __MemBeR_ptr = (cOnTaiNeD); \
+    (TyPe*)((char*)__MemBeR_ptr - OFFSET_OF(TyPe, MeMBeR));         \
+  })
+#endif
 
 #define OAI_MAX(a, b)       \
   ({                        \


### PR DESCRIPTION
Closes #11585.

The existing macro fails to compile In Bazel build effort because some paths to the containing header are not guarded by `extern "C"`. In C++, this macro's `typeof` use must instead be `decltype`.  Missing `extern "C"` linkage is a common issue with the Magma code-base and quite challenging to fixup. It will be aided by rename of CPP headers to .hpp (see GH issue associated with that effort).

I did attempt to fixup all the missing `extern "C"` calls, but then ran into new errors on the macro compilation that appeared again related to extern "C" use.

## Test Plan

Bazel build success on prototype branch.

CI tests include `make test_oai` and `make build_oai`.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>