### PR TITLE
feat(agw) add management server and sync 1588 parameters

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -2460,6 +2460,67 @@ definitions:
           - 'NuRAN Cavium OC-LTE'
           - 'FreedomFi One'
         x-nullable: false
+      mme_pool_1:
+        type: string
+        format: ipv4
+        example: ''
+      mme_pool_2:
+        type: string
+        format: ipv4
+        example: ''
+      managementServer:
+        $ref: '#/definitions/managementServer'
+      sync_1588:
+        $ref: '#/definitions/sync_1588'
+  sync_1588:
+    description: sync_1588 Configuration for  eNodeb devices.
+    type: object
+    properties:
+      sync_1588_switch:
+        type: boolean
+        example: false
+      sync_1588_domain:
+        type: integer
+        format: int32
+        example: 0
+      sync_1588_msg_interval:
+        type: integer
+        format: int32
+        example: 60
+      sync_1588_delay_rq_msg_interval:
+        type: integer
+        format: int32
+        example: 60
+      sync_1588_holdover:
+        type: integer
+        format: uint32
+        example: 300
+      sync_1588_asymmetry:
+        type: integer
+        format: uint32
+        example: 300
+      sync_1588_unicast_enable:
+        type: boolean
+        example: true
+      sync_1588_unicast_serverIp:
+        type: string
+        format: ipv4
+        example: '0.0.0.0'
+
+  managementServer:
+    description: ManagementServer Configuration for  eNodeb devices.
+    type: object
+    properties:
+      management_server_host:
+        type: string
+        example: 'baiomc.cloudapp.net'
+      management_server_port:
+        type: integer
+        format: uint32
+        example: 48080
+      management_server_ssl_enable:
+        type: boolean
+        example: false
 
   unmanaged_enodeb_configuration:
     description: Configuration for externally managed eNodeb devices.

--- a/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
@@ -426,6 +426,11 @@ func getEnodebConfigsBySerial(nwConfig *lte_models.NetworkCellularConfigs, gwCon
 			enbMconfig.BandwidthMhz = int32(cellularEnbConfig.BandwidthMhz)
 			enbMconfig.Tac = int32(cellularEnbConfig.Tac)
 			enbMconfig.CellId = int32(swag.Uint32Value(cellularEnbConfig.CellID))
+			enbMconfig.MmeIp = gwConfig.Epc.IPV4SgwS1uAddr
+			enbMconfig.MmePool_1 = string(cellularEnbConfig.MmePool1)
+			enbMconfig.MmePool_2 = string(cellularEnbConfig.MmePool2)
+			getManagementSeverConfig(enbMconfig, cellularEnbConfig)
+			getSysc1158Config(enbMconfig, cellularEnbConfig)
 
 			// override zero values with network/gateway configs
 			if enbMconfig.Earfcndl == 0 {
@@ -700,4 +705,33 @@ func (s *builderServicer) getSyncInterval(nwEpc *lte_models.NetworkEpcConfigs, g
 func (s *builderServicer) getRandomizedSyncInterval(gwKey string, nwEpc *lte_models.NetworkEpcConfigs, gwEpc *lte_models.GatewayEpcConfigs) uint32 {
 	syncInterval := s.getSyncInterval(nwEpc, gwEpc)
 	return math.JitterUint32(syncInterval, gwKey, 0.2)
+}
+
+// Management Server
+func getManagementSeverConfig(enbMconfig *lte_mconfig.EnodebD_EnodebConfig, cellularEnbConfig *lte_models.EnodebConfiguration) {
+	cellManagementSeverConfig := cellularEnbConfig.ManagementServer
+	if cellManagementSeverConfig != nil {
+		enbManagementSeverConfig := &lte_mconfig.EnodebD_EnodebConfig_ManagementServerConfig{}
+		enbManagementSeverConfig.ManagementServerHost = cellManagementSeverConfig.ManagementServerHost
+		enbManagementSeverConfig.ManagementServerPort = cellManagementSeverConfig.ManagementServerPort
+		enbManagementSeverConfig.ManagementServerSslEnable = cellManagementSeverConfig.ManagementServerSslEnable
+		enbMconfig.ManagementServerConfig = enbManagementSeverConfig
+	}
+}
+
+// sysc 1158 config
+func getSysc1158Config(enbMconfig *lte_mconfig.EnodebD_EnodebConfig, cellularEnbConfig *lte_models.EnodebConfiguration) {
+	cellSyscConfig := cellularEnbConfig.Sync1588
+	if cellSyscConfig != nil {
+		enbSyscConfig := &lte_mconfig.EnodebD_EnodebConfig_Sync1588Config{}
+		enbSyscConfig.Sync_1588Switch = cellSyscConfig.Sync1588Switch
+		enbSyscConfig.Sync_1588Domain = cellSyscConfig.Sync1588Domain
+		enbSyscConfig.Sync_1588MsgInterval = cellSyscConfig.Sync1588MsgInterval
+		enbSyscConfig.Sync_1588DelayRqMsgInterval = cellSyscConfig.Sync1588DelayRqMsgInterval
+		enbSyscConfig.Sync_1588Holdover = cellSyscConfig.Sync1588Holdover
+		enbSyscConfig.Sync_1588Asymmetry = cellSyscConfig.Sync1588Asymmetry
+		enbSyscConfig.Sync_1588UnicastEnable = cellSyscConfig.Sync1588UnicastEnable
+		enbSyscConfig.Sync_1588UnicastServerIp = string(cellSyscConfig.Sync1588UnicastServerIP)
+		enbMconfig.Sync_1588Config = enbSyscConfig
+	}
 }

--- a/lte/gateway/python/magma/enodebd/data_models/data_model_parameters.py
+++ b/lte/gateway/python/magma/enodebd/data_models/data_model_parameters.py
@@ -45,8 +45,6 @@ class ParameterName():
     UL_BANDWIDTH = 'UL bandwidth'
     SUBFRAME_ASSIGNMENT = 'Subframe assignment'
     SPECIAL_SUBFRAME_PATTERN = 'Special subframe pattern'
-    POWER_SPECTRAL_DENSITY = 'Power Spectral Density'
-    RADIO_ENABLE = "Radio Enable"
 
     # Other LTE parameters
     ADMIN_STATE = 'Admin state'
@@ -63,6 +61,8 @@ class ParameterName():
     NUM_PLMNS = 'Num PLMNs'
     PLMN = 'PLMN'
     PLMN_LIST = 'PLMN List'
+    MME_POOL_1 = 'MME Pool 1'
+    MME_POOL_2 = 'MME Pool 2'
 
     # PLMN parameters
     PLMN_N = 'PLMN %d'
@@ -87,10 +87,20 @@ class ParameterName():
     PERF_MGMT_USER = 'Perf mgmt username'
     PERF_MGMT_PASSWORD = 'Perf mgmt password'
 
-    SAS_ENABLED = 'SAS enabled'
-    SAS_FCC_ID = 'SAS FCC ID'
-    SAS_USER_ID = 'SAS User ID'
-    SAS_RADIO_ENABLE = 'SAS Radio Enable'
+    # management server
+    MANAGEMENT_SERVER = 'Management Server'
+    MANAGEMENT_SERVER_PORT = 'Management Server Port'
+    MANAGEMENT_SERVER_SSL_ENABLE = 'Management Server SSL Enable'
+
+    # Sync
+    SYNC_1588_SWITCH = '1588 sync switch'
+    SYNC_1588_DOMAIN = '1588 domain'
+    SYNC_1588_SYNC_MSG_INTREVAL = '1588 sync message interval'
+    SYNC_1588_DELAY_REQUEST_MSG_INTERVAL = '1588 delay request msg interval'
+    SYNC_1588_HOLDOVER = '1588 holdover'
+    SYNC_1588_ASYMMETRY = '1588 asymmetry'
+    SYNC_1588_UNICAST_ENABLE = '1588 unicast enable'
+    SYNC_1588_UNICAST_SERVERIP = '1588 unicast server IP'
 
 
 class TrParameterType():

--- a/lte/gateway/python/magma/enodebd/devices/baicells_rts.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_rts.py
@@ -203,6 +203,10 @@ class BaicellsRTSTrDataModel(DataModel):
             FAPSERVICE_PATH
             + 'FAPControl.LTE.Gateway.X_BAICELLS_COM_MmePool.Enable', True, TrParameterType.BOOLEAN, False,
         ),
+        ParameterName.MME_POOL_1:
+            TrParam(FAPSERVICE_PATH + 'FAPControl.LTE.Gateway.X_BAICELLS_COM_MmePool.MmePool1List', True, TrParameterType.STRING, False),
+        ParameterName.MME_POOL_2:
+            TrParam(FAPSERVICE_PATH + 'FAPControl.LTE.Gateway.X_BAICELLS_COM_MmePool.MmePool2List', True, TrParameterType.STRING, False),
 
         # Management server parameters
         ParameterName.PERIODIC_INFORM_ENABLE:
@@ -220,6 +224,32 @@ class BaicellsRTSTrDataModel(DataModel):
         ParameterName.PERF_MGMT_UPLOAD_URL: TrParam(
             DEVICE_PATH + 'FAP.PerfMgmt.Config.1.URL', False, TrParameterType.STRING, False,
         ),
+
+        # Management server
+        ParameterName.MANAGEMENT_SERVER:
+            TrParam('Device.ManagementServer.URL', True, TrParameterType.STRING, False),
+        ParameterName.MANAGEMENT_SERVER_PORT:
+            TrParam('Device.ManagementServer.tr069_port', True, TrParameterType.INT, False),
+        ParameterName.MANAGEMENT_SERVER_SSL_ENABLE:
+            TrParam('Device.ManagementServer.ssl_enable', True, TrParameterType.BOOLEAN, False),
+
+        # SYNC
+        ParameterName.SYNC_1588_SWITCH:
+            TrParam('Device.DeviceInfo.X_BAICELLS_COM_1588SyncEnable', True, TrParameterType.BOOLEAN, False),
+        ParameterName.SYNC_1588_DOMAIN:
+            TrParam('Device.DeviceInfo.X_COM_1588Domain_Num', True, TrParameterType.INT, False),
+        ParameterName.SYNC_1588_SYNC_MSG_INTREVAL:
+            TrParam('Device.DeviceInfo.X_COM_1588Sync_Message_Interval', True, TrParameterType.INT, False),
+        ParameterName.SYNC_1588_DELAY_REQUEST_MSG_INTERVAL:
+            TrParam('Device.DeviceInfo.X_COM_1588Delay_Request_Message_Interval', True, TrParameterType.INT, False),
+        ParameterName.SYNC_1588_HOLDOVER:
+            TrParam('Device.DeviceInfo.X_COM_1588Holdover', True, TrParameterType.INT, False),
+        ParameterName.SYNC_1588_ASYMMETRY:
+            TrParam('Device.DeviceInfo.X_COM_1588Asymmetry_Value', True, TrParameterType.INT, False),
+        ParameterName.SYNC_1588_UNICAST_ENABLE:
+            TrParam('Device.DeviceInfo.X_COM_1588Unicast_Switch', True, TrParameterType.INT, False),
+        ParameterName.SYNC_1588_UNICAST_SERVERIP:
+            TrParam('Device.DeviceInfo.X_COM_1588Unicast_IpAddr', True, TrParameterType.STRING, False),
 
     }
 

--- a/lte/protos/mconfig/mconfigs.proto
+++ b/lte/protos/mconfig/mconfigs.proto
@@ -74,6 +74,29 @@ message EnodebD {
         int32 tac = 8;
         int32 cell_id = 9;
         string ip_address = 10;
+        string mme_ip = 11;
+        string mme_pool_1 = 17;
+        string mme_pool_2 = 18;
+        ManagementServerConfig management_server_config = 19;
+        Sync1588Config sync_1588_config = 20;
+
+        //management server config
+        message ManagementServerConfig {
+            string management_server_host = 1;
+            uint32 management_server_port = 2;
+            bool management_server_ssl_enable = 3;
+        }
+        //sync 1588 config
+        message Sync1588Config {
+            bool sync_1588_switch = 1;
+            int32 sync_1588_domain = 2;
+            int32 sync_1588_msg_interval = 3;
+            int32 sync_1588_delay_rq_msg_interval = 4;
+            uint32 sync_1588_holdover = 5;
+            uint32 sync_1588_asymmetry = 6;
+            bool sync_1588_unicast_enable = 7;
+            string sync_1588_unicast_serverIp = 8;
+        }
     }
 
     orc8r.LogLevel log_level = 1;

--- a/nms/packages/magmalte/app/views/equipment/EnodebDetailConfig.js
+++ b/nms/packages/magmalte/app/views/equipment/EnodebDetailConfig.js
@@ -236,6 +236,109 @@ function EnodebManagedRanConfig({
     ],
     [
       {
+        category: 'MME Pool 1',
+        value: enbInfo.enb.enodeb_config?.managed_config?.mme_pool_1 ?? '-',
+      },
+    ],
+    [
+      {
+        category: 'MME Pool 2',
+        value: enbInfo.enb.enodeb_config?.managed_config?.mme_pool_2 ?? '-',
+      },
+    ],
+    [
+      {
+        category: 'Management Server SSL Enable',
+        value: enbInfo.enb.enodeb_config?.managed_config?.managementServer
+          ?.management_server_ssl_enable
+          ? 'Enabled'
+          : 'Disabled',
+      },
+    ],
+    [
+      {
+        category: 'Management Server Host',
+        value:
+          enbInfo.enb.enodeb_config?.managed_config?.managementServer
+            ?.management_server_host ?? '-',
+      },
+    ],
+    [
+      {
+        category: 'Management Server Port',
+        value:
+          enbInfo.enb.enodeb_config?.managed_config?.managementServer
+            ?.management_server_port ?? '',
+      },
+    ],
+    [
+      {
+        category: '1588 SYNC Switch',
+        value: enbInfo.enb.enodeb_config?.managed_config?.sync_1588
+          ?.sync_1588_switch
+          ? 'Enabled'
+          : 'Disabled',
+      },
+    ],
+    [
+      {
+        category: '1588 SYNC domain num',
+        value:
+          enbInfo.enb.enodeb_config?.managed_config?.sync_1588
+            ?.sync_1588_domain ?? '',
+      },
+    ],
+    [
+      {
+        category: '1588 SYNC asymmetry',
+        value:
+          enbInfo.enb.enodeb_config?.managed_config?.sync_1588
+            ?.sync_1588_asymmetry ?? '',
+      },
+    ],
+    [
+      {
+        category: '1588 SYNC holdover',
+        value:
+          enbInfo.enb.enodeb_config?.managed_config?.sync_1588
+            ?.sync_1588_holdover ?? '',
+      },
+    ],
+    [
+      {
+        category: '1588 SYNC Message Interval',
+        value:
+          enbInfo.enb.enodeb_config?.managed_config?.sync_1588
+            ?.sync_1588_msg_interval ?? '',
+      },
+    ],
+    [
+      {
+        category: '1588 SYNC Delay request message Interval',
+        value:
+          enbInfo.enb.enodeb_config?.managed_config?.sync_1588
+            ?.sync_1588_delay_rq_msg_interval ?? '',
+      },
+    ],
+    [
+      {
+        category: '1588 unicast switch',
+        value: enbInfo.enb.enodeb_config?.managed_config?.sync_1588
+          ?.sync_1588_unicast_enable
+          ? 'Unicast'
+          : 'Multicast',
+      },
+    ],
+    [
+      {
+        category: '1588 SYNC Unicast ServerIp',
+        value:
+          enbInfo.enb.enodeb_config?.managed_config?.sync_1588
+            ?.sync_1588_unicast_serverIp ?? '',
+      },
+    ],
+    [
+      {
         category: 'Transmit',
         value: enbInfo.enb.enodeb_config?.managed_config?.transmit_enabled
           ? 'Enabled'


### PR DESCRIPTION
Signed-off-by: root <369888042@qq.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
 feat(agw): add management server and sync 1588 parameters
   

## Summary

<!-- Enumerate changes you made and why you made them  -->
add None 243  management server and sync 1588 parameters

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
1.Start the magma service
2.Configure the base station none-243 to connect to the gateway
3.Test and issue parameters through the magma swagger API(https://magma-test.localhost:9443/swagger/v1/ui/lte#/EnodeBs/get_lte__network_id__enodebs__enodeb_serial_)
![image](https://user-images.githubusercontent.com/87301024/133762970-16046f04-15ad-48e9-bfb6-ab1ae844b3e7.png)

4.View the configuration file and verify whether the parameters are distributed to the gateway
（ sudo tail -1000f /var/opt/magma/configs/gateway.mconfig ）
![image](https://user-images.githubusercontent.com/87301024/133763065-c1f5f0df-fa8b-4873-84ee-9ea4adfa0601.png)

5.Check whether the parameters are successfully distributed to the base station
sudo tail -1000f /var/log/enodebd.log
![image](https://user-images.githubusercontent.com/87301024/133763163-e5bad52b-d77b-4162-9fb0-017205f91342.png)

![image](https://user-images.githubusercontent.com/87301024/133763195-1b1110ab-0372-4c6e-ae92-0b88a920dfe8.png)




## Additional Information



<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->