### PR TITLE
chore(monitord): Exclude frequent error from Sentry

### DIFF
--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -19,7 +19,11 @@ from typing import Dict, List, NamedTuple, Optional
 import grpc
 from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
-from magma.common.rpc_utils import grpc_async_wrapper
+from magma.common.rpc_utils import (
+    grpc_async_wrapper,
+    indicates_connection_error,
+)
+from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from magma.magmad.check.network_check.ping import PingCommandResult
 from magma.monitord.icmp_state import ICMPMonitoringResponse
@@ -95,6 +99,11 @@ class CpeMonitoringModule:
                 "GetSubscribers Error for %s! %s",
                 err.code(),
                 err.details(),
+                extra=(
+                    EXCLUDE_FROM_ERROR_MONITORING
+                    if indicates_connection_error(err)
+                    else None
+                ),
             )
         return PingedTargets(ping_targets, ping_addresses)
 


### PR DESCRIPTION
## Summary

GRPC errors don't need to be sent to error monitoring if they're just due to services being down.
Fixes #11705.

## Additional Information

- [ ] This change is backwards-breaking