### PR TITLE
fix(dp): fix number of expected DBGrantStates in UT

### DIFF
--- a/dp/cloud/python/magma/db_service/tests/unit/test_db_initialization.py
+++ b/dp/cloud/python/magma/db_service/tests/unit/test_db_initialization.py
@@ -19,7 +19,7 @@ class DBInitializationTestCase(LocalDBTestCase):
     @parameterized.expand([
         (DBRequestType, 6),
         (DBRequestState, 2),
-        (DBGrantState, 3),
+        (DBGrantState, 4),
         (DBCbsdState, 2),
     ])
     def test_db_is_initialized_with_db_states_and_types(self, model, expected_post_init_count):


### PR DESCRIPTION
Signed-off-by: Wojciech Sadowy <wojciech.sadowy@freedomfi.com>

fix(dp): fix number of expected DBGrantStates in UT

## Summary

DBGrantState count in test_db_is_initialized_with_db_states_and_types was incorrect and not taking into consideration the new Unsync state
