### PR TITLE
chore(monitord): monitord is bazelified

### DIFF
--- a/lte/gateway/python/magma/monitord/BUILD.bazel
+++ b/lte/gateway/python/magma/monitord/BUILD.bazel
@@ -1,0 +1,54 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+MAGMA_ROOT = "../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+py_binary(
+    name = "monitord",
+    srcs = ["main.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    # legacy_creat_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
+    legacy_create_init = False,
+    main = "main.py",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":monitord_lib",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:mobilityd_python_proto",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
+    ],
+)
+
+py_library(
+    name = "monitord_lib",
+    srcs = [
+        "cpe_monitoring.py",
+        "icmp_job.py",
+        "icmp_state.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lte/protos:mobilityd_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/magmad/check/network_check:ping",
+    ],
+)

--- a/lte/gateway/python/magma/monitord/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/monitord/tests/BUILD.bazel
@@ -1,0 +1,31 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:python_test.bzl", "pytest_test")
+
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+pytest_test(
+    name = "test_icmp_monitor",
+    srcs = ["test_icmp_monitor.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = [
+        "//lte/gateway/python/magma/monitord:monitord_lib",
+        "//lte/protos:mobilityd_python_proto",
+    ],
+)


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Module monitord is bazelified including the tests.

## Test Plan

- Run monitord:
  - `bazel run //lte/gateway/python/magma/monitord:monitord`
- Run tests:
  - `bazel test //lte/gateway/python/magma/monitord/tests:all`


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
