### PR TITLE
chore: Add LLDB debugger to VM

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -184,6 +184,15 @@
       - python3-aioeventlet
   retries: 5
 
+- name: Install LLDB debugger
+  # TODO: Make this preburn
+  apt:
+    pkg: lldb
+    state: present
+    update_cache: no
+  retries: 5
+  when: full_provision
+
 # /etc/environment doesn't expand variables, so if we want to modify the path,
 # we need to do it in profile.d
 - name: Create the env script


### PR DESCRIPTION
## Summary

Add LLDB debugger to virtual machine. As described at https://github.com/magma/magma/wiki/Error-monitoring-and-triaging-workflow, this is the preferred debugger for Sentry.

## Test Plan

```
vagrant up magma --provision
vagrant ssh magma
lldb --version
```
```
lldb version 10.0.0
```

## Additional Information

- [ ] This change is backwards-breaking