### PR TITLE
fix(orc8r): Log entries created from user input

### DIFF
--- a/fbinternal/cloud/go/services/download/servicers/server_lib.go
+++ b/fbinternal/cloud/go/services/download/servicers/server_lib.go
@@ -16,6 +16,7 @@ import (
 
 	"magma/fbinternal/cloud/go/services/download"
 	"magma/orc8r/lib/go/registry"
+	"magma/orc8r/lib/go/util"
 )
 
 const (
@@ -25,7 +26,7 @@ const (
 
 func RootHandler(config DownloadServiceConfig) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		glog.V(2).Infof("Download svc called with '%s'", r.URL.Path)
+		util.SafeLog("Download svc called with '%s'", r.URL.Path)
 
 		if !(strings.HasPrefix(r.URL.Path, s3Prefix)) {
 			// Return 400 since the download path is unknown
@@ -74,7 +75,7 @@ func s3Handler(
 	if reqRange != "" {
 		s3Req.SetRange(reqRange)
 	}
-	glog.V(2).Infof("Fetching s3 object %s from bucket %s", key, bucket)
+	util.SafeLog("Fetching s3 object %s from bucket %s", key, bucket)
 	result, err := s3svc.GetObject(&s3Req)
 	if err != nil {
 		glog.Errorf("Error with s3 GetObj: %s", err.Error())

--- a/feg/gateway/sbi/sbi_logger.go
+++ b/feg/gateway/sbi/sbi_logger.go
@@ -19,7 +19,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/golang/glog"
+	"magma/orc8r/lib/go/util"
 )
 
 // SbiLogger logs to glog when verbose level is set to 2
@@ -31,7 +31,7 @@ func (logger *SbiLogger) LogRequest(method string, url *url.URL, reqBody []byte,
 	if len(reqBody) != 0 {
 		extraReqInfo = fmt.Sprintf("\nBody = %s", string(reqBody))
 	}
-	glog.V(2).Infof("Request %s %v %s\n", method, url.Path, extraReqInfo)
+	util.SafeLog("Request %s %v %s\n", method, url.Path, extraReqInfo)
 }
 
 // LogResponse logs http response related info after receiving the response from the server
@@ -44,5 +44,5 @@ func (logger *SbiLogger) LogResponse(url *url.URL, status string, resBody []byte
 	if len(resBody) != 0 {
 		extraResInfo = fmt.Sprintf("%s\nBody = %s", extraResInfo, string(resBody))
 	}
-	glog.V(2).Infof("Response %v for %v took %dms %s\n", status, url.Path, latency.Milliseconds(), extraResInfo)
+	util.SafeLog("Response %v for %v took %dms %s\n", status, url.Path, latency.Milliseconds(), extraResInfo)
 }

--- a/orc8r/cloud/go/http2/http2_log.go
+++ b/orc8r/cloud/go/http2/http2_log.go
@@ -17,12 +17,14 @@ import (
 	"net/http"
 
 	"github.com/golang/glog"
+
+	"magma/orc8r/lib/go/util"
 )
 
 //LogRequestWithVerbosity prints out request when the service binary is run
 // with log_verbosity verbosity
 func LogRequestWithVerbosity(req *http.Request, verbosity glog.Level) {
-	glog.V(verbosity).Infof("Printing request metadata: \nHost: %v\n"+
+	util.SafeLog("Printing request metadata: \nHost: %v\n"+
 		"URL: %v\nTrailer: %v\nProto: %v\nRequestURI: %v\n"+
 		"RemoteAddr: %v\nMethod: %v\n", req.Host, req.URL,
 		req.Trailer, req.Proto, req.RequestURI, req.RemoteAddr, req.Method)

--- a/orc8r/cloud/go/obsidian/handler.go
+++ b/orc8r/cloud/go/obsidian/handler.go
@@ -218,7 +218,7 @@ func CheckNetworkAccess(c echo.Context, networkId string) *echo.HTTPError {
 			return nil
 		}
 	}
-	glog.Infof("Client cert %s is not authorized for network: %+v", util.FormatPkixSubject(&cert.Subject), networkId)
+	util.SafeLog("Client cert %s is not authorized for network: %+v", util.FormatPkixSubject(&cert.Subject), networkId)
 	return echo.NewHTTPError(http.StatusForbidden, "Client certificate is not authorized")
 }
 

--- a/orc8r/cloud/go/obsidian/server/metrics.go
+++ b/orc8r/cloud/go/obsidian/server/metrics.go
@@ -16,9 +16,10 @@ package server
 import (
 	"strconv"
 
-	"github.com/golang/glog"
 	"github.com/labstack/echo"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"magma/orc8r/lib/go/util"
 )
 
 var (
@@ -50,7 +51,7 @@ func CollectStats(next echo.HandlerFunc) echo.HandlerFunc {
 		requestCount.Inc()
 		status := strconv.Itoa(c.Response().Status)
 		respStatuses.WithLabelValues(status, c.Request().Method).Inc()
-		glog.V(2).Infof(
+		util.SafeLog(
 			"REST API code: %v, method: %v, url: %v\n",
 			status,
 			c.Request().Method,

--- a/orc8r/lib/go/util/util.go
+++ b/orc8r/lib/go/util/util.go
@@ -17,6 +17,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"io/ioutil"
 	"net"
@@ -25,6 +26,9 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unicode"
+
+	"github.com/golang/glog"
 )
 
 func GetFreeTcpPort(preferredPort int) int {
@@ -160,4 +164,27 @@ func GetEnvBool(envVariable string, defaultValue ...bool) bool {
 		return defaultValue[0]
 	}
 	return false
+}
+
+func SafeLog(strInput string, args ...interface{}) {
+	//format string
+	strInput = fmt.Sprintf(strInput, args...)
+	//remove non UTF-8 chars
+	strInput = strings.ToValidUTF8(strInput, "")
+	//remove non unicode characters
+	tmpSanitized := ""
+	for _, item := range strInput {
+		if unicode.IsPrint(item) {
+			tmpSanitized += string(item)
+		} else {
+			tmpSanitized += " "
+		}
+	}
+	//escape special characters in HTML text
+	tmpSanitized = html.EscapeString(tmpSanitized)
+	//limit output to 1024 chars
+	if len(tmpSanitized) > 1024 {
+		tmpSanitized = tmpSanitized[:1024]
+	}
+	glog.V(2).Infof(tmpSanitized)
 }


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

fix(orc8r): Log entries created from user input

## Summary

If unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries. 
In orc8r/lib/go/util/util.go an **SafeLog()** function is added that:
- can accept a string with arguments, just like the Sprintf command 
- checks for unicode characters
- checks for non UTF-8 chars
- checks for values longer than 1024 characters
- escapes special characters in HTML text


## Test Plan

ran:
magma/feg/gateway/docker/ ./build.py -c
magma/orc8r/cloud/docker/  ./build.py -c
orc8r/lib/go/util/util_test.go


## Additional Information
This is for code scannign alerts:
https://github.com/magma/magma/security/code-scanning/59
https://github.com/magma/magma/security/code-scanning/58
https://github.com/magma/magma/security/code-scanning/57
https://github.com/magma/magma/security/code-scanning/40
https://github.com/magma/magma/security/code-scanning/39
https://github.com/magma/magma/security/code-scanning/38
https://github.com/magma/magma/security/code-scanning/37
https://github.com/magma/magma/security/code-scanning/36
https://github.com/magma/magma/security/code-scanning/35
