### PR TITLE
chore: iputils-ping is added to the devcontainer (needed by python services)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -56,6 +56,8 @@ RUN echo "Install general purpose packages" && \
         g++ \
         g++-9 \
         gcc-9 \
+        # iputils-ping is a dependency of python services (e.g. magmad)
+        iputils-ping \
         lcov \
         gdb \
         git \


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

First step to add iputils-ping dependency to the devcontainer (needed for python services).

## Test Plan



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
