### PR TITLE
chore: pull build cache on codespace start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -86,7 +86,7 @@
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
 	],
-	"postCreateCommand": "sudo ln -s ${containerWorkspaceFolder}/lte/gateway/configs /etc/magma; echo \"\nalias magtivate='source /home/vscode/build/python/bin/activate'\" >> ~/.bashrc",
+	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/post-create-commands.sh ${containerWorkspaceFolder}",
 	// multiple postCreateCommands: currently only possible with '&&'/';' or shell script (https://github.com/microsoft/vscode-remote-release/issues/3527)
 	"runArgs": [
 		"--init"

--- a/.devcontainer/post-create-commands.sh
+++ b/.devcontainer/post-create-commands.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# $1: should be containerWorkspaceFolder from https://code.visualstudio.com/docs/remote/devcontainerjson-reference
+
+sudo ln -s "$1"/lte/gateway/configs /etc/magma
+echo "alias magtivate='source /home/vscode/build/python/bin/activate'" >> ~/.bashrc
+
+# Pull in cache to speed up Bazel build. The cache is populated by a GitHub Action job periodically (.github/workflows/bazel-cache-push.yml)
+# Fetch repository cache
+wget -qO- https://magma-cache.s3.amazonaws.com/bazel-cache-repo-devcontainer.tar.gz | tar xvfz - 
+# Fetch build cache
+wget -qO- https://magma-cache.s3.amazonaws.com/bazel-cache-devcontainer.tar.gz | tar xvfz - 


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Add two extra commands that get executed on Codespace creation to pull in cache for Bazel build. The cache is pulled from S3 which is populated by a daily GitHub Action job. (See https://github.com/magma/magma/actions/workflows/bazel-cache-push.yml)

While we save ~3 minutes on `bazel build //...`, we will spend about 5-10 seconds more pulling in the cache on Codespace startup. I believe this will not affect restarting a codespace that has already been created. 

## Numbers
Running `bazel build //...` on a new Codespace (16 cores) on master takes 4m 42s
<img width="467" alt="Screen Shot 2022-02-22 at 3 44 32 PM" src="https://user-images.githubusercontent.com/37634144/155216153-11af896a-e61c-4253-9323-02bc488823e6.png">

Running `bazel build //...` on a new Codespace (16 cores) off of this PR takes 1m 23s
<img width="608" alt="Screen Shot 2022-02-22 at 3 50 27 PM" src="https://user-images.githubusercontent.com/37634144/155217018-abfbcc5e-c0fa-43bb-a41f-1e009430b3b7.png">

A Codespace can be spun up by clicking on the Code button like this
<img width="420" alt="Screen Shot 2022-02-22 at 3 47 12 PM" src="https://user-images.githubusercontent.com/37634144/155216579-0880f268-c235-4c8b-a390-e79e49625fed.png">


<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested by spinning up a Codespace from this PR.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
