### PR TITLE
chore: pin Bazel build tools version to 5.0.1

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -61,8 +61,9 @@ gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    strip_prefix = "buildtools-master",
-    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
+    sha256 = "7f43df3cca7bb4ea443b4159edd7a204c8d771890a69a50a190dc9543760ca21",
+    strip_prefix = "buildtools-5.0.1",
+    url = "https://github.com/bazelbuild/buildtools/archive/refs/tags/5.0.1.tar.gz",
 )
 ### BUILDIFIER DEPENDENCIES
 


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Pinning it to a specific version so that the sha256 value does not change. Having a fixed version / sha256 will reduce the need for Bazel to fetch the repository often. (I think it might be everytime the Bazel server restarts? I am actually not sure). 

Now that GitHub Codespaces pulls in build cache on container start (https://github.com/magma/magma/pull/11747), this should mean that buildifier is never built from scratch unless the version is updated. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
