### PR TITLE
chore: add a role to symlink clang-format-11 in Magma VM

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -396,11 +396,6 @@
     grub-mkconfig -o /boot/grub/grub.cfg
   when: preburn
 
-- name: Create links for clang-format
-  become: yes
-  command: "update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 1000"
-  when: preburn
-
 - file:
     path: /var/tmp/test_results
     state: directory

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -448,6 +448,16 @@
     pkg:
       - clang-format-11
 
+# TODO: this can be removed once the role below is preburned
+- name: Remove all links for clang-format
+  become: yes
+  command: 'update-alternatives --remove-all clang-format'
+
+# TODO: preburn this
+- name: Create links for clang-format
+  become: yes
+  command: 'update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 1000'
+
 - name: Symlink system wide bazelrc into the VM
   file:
     src: '/home/vagrant/magma/bazel/bazelrcs/vm.bazelrc'


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
We recently updated our default clang-format from version 7 to 11. However, we missed that the role to symlink `/usr/bin/clang-format` to `clang-format-11` is run only for preburn. @tmdzk has offered to upgrade the base image soon, but in the meantime I will move it to a provision step.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
provisioned both magma and magma_test

After provisioning, ran `/usr/bin/clang-format --version` to make sure it points to clang-format-11, not clang-format-7

```bash
vagrant@magma-dev-focal:~/magma$ /usr/bin/clang-format --version
Ubuntu clang-format version 11.0.0-2~ubuntu20.04.1
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
