### PR TITLE
chore(ci): update ci clang format job to read from clang-format file

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -472,18 +472,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: DoozyX/clang-format-lint-action@v0.13
+      - name: Check clang-format for orc8r/gateway/c
+        uses: DoozyX/clang-format-lint-action@v0.13
         with:
           source: 'orc8r/gateway/c'
           extensions: 'h,hpp,c,cpp'
           clangFormatVersion: 11.1.0
-          style: '{BasedOnStyle: Google, IncludeBlocks: Preserve, SortIncludes: false}'
-      - uses: DoozyX/clang-format-lint-action@v0.13
+          # taken from .clang-format
+          style: file
+      - name: Check clang-format for lte/gateway/c
+        uses: DoozyX/clang-format-lint-action@v0.13
         with:
           source: 'lte/gateway/c'
           extensions: 'h,hpp,c,cpp'
           clangFormatVersion: 11.1.0
-          style: '{BasedOnStyle: Google, IncludeBlocks: Preserve, SortIncludes: false}'
+          # taken from .clang-format
+          style: file
 
   session_manager_test:
     needs: path_filter


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Related: https://github.com/magma/magma/pull/11750

Cleanup clang-format CI jobs to read from the .clang-format file. Now we have a single source of truth for all clang-format configs.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
