### PR TITLE
chore(enodebd): unused code is removed (remove unittest.mock from production code)

### DIFF
--- a/lte/gateway/python/magma/enodebd/main.py
+++ b/lte/gateway/python/magma/enodebd/main.py
@@ -13,7 +13,6 @@ limitations under the License.
 
 from threading import Thread
 from typing import List
-from unittest import mock
 
 from lte.protos.mconfig import mconfigs_pb2
 from magma.common.sentry import sentry_init
@@ -22,22 +21,13 @@ from magma.enodebd.enodeb_status import (
     get_operational_states,
     get_service_status_old,
 )
+from magma.enodebd.enodebd_iptables_rules import set_enodebd_iptables_rule
 from magma.enodebd.logger import EnodebdLogger as logger
+from magma.enodebd.rpc_servicer import EnodebdRpcServicer
 from magma.enodebd.state_machines.enb_acs_manager import StateMachineManager
+from magma.enodebd.stats_manager import StatsManager
+from magma.enodebd.tr069.server import tr069_server
 from orc8r.protos.service303_pb2 import State
-
-from .enodebd_iptables_rules import set_enodebd_iptables_rule
-from .rpc_servicer import EnodebdRpcServicer
-from .stats_manager import StatsManager
-from .tr069.server import tr069_server
-
-
-def get_context(ip: str):
-    with mock.patch('spyne.server.wsgi.WsgiApplication') as MockTransport:
-        MockTransport.req_env = {"REMOTE_ADDR": ip}
-        with mock.patch('spyne.server.wsgi.WsgiMethodContext') as MockContext:
-            MockContext.transport = MockTransport
-            return MockContext
 
 
 def main():


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Cleanup issue from https://github.com/magma/magma/issues/11730.
> lte/gateway/python/magma/enodebd/main.py uses unittest.mock - using mock in production code seems wrong

* code was introduced in https://github.com/magma/magma/pull/225, but it looks like it was not used (artifact?)
* later `lte/gateway/python/magma/enodebd/tests/test_utils/spyne_builder.py` was introducced and seems to provide the same functionality

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
