### PR TITLE
fix: remove node ports from local deployment to fix port collisions

### DIFF
--- a/dp/tools/deployment/vendor/fake_sas.yml
+++ b/dp/tools/deployment/vendor/fake_sas.yml
@@ -54,6 +54,5 @@ spec:
     - name: https
       port: 443
       targetPort: 9000
-      nodePort: 30443
   selector:
     app: fake-sas

--- a/dp/tools/deployment/vendor/postgresql.yml
+++ b/dp/tools/deployment/vendor/postgresql.yml
@@ -125,8 +125,6 @@ spec:
     - name: db1
       port: 5432
       targetPort: 5432
-      nodePort: 30432
     - name: db2
       port: 5433
       targetPort: 5433
-      nodePort: 30433


### PR DESCRIPTION
Signed-off-by: Marcin Trojanowski <marcin.trojanowski@freedomfi.com>


## Summary

This PR removes hardcoded NodePorts in local deployment backing systems so there won't interfere in case of multiple deployments.

## Test Plan

All tests should pass

## Additional Information
