### PR TITLE
[WIP] Add agw IPv6 config

### DIFF
--- a/nms/packages/magmalte/app/views/equipment/GatewayDetailConfig.js
+++ b/nms/packages/magmalte/app/views/equipment/GatewayDetailConfig.js
@@ -227,7 +227,12 @@ function GatewayEPC({gwInfo}: {gwInfo: lte_gateway}) {
   const collapse: DataRows[] = [
     [
       {
+        category: 'IP Block',
         value: gwInfo.cellular.epc.ip_block ?? '-',
+      },
+      {
+        category: 'IPv6 Block',
+        value: gwInfo.cellular.epc.ipv6_block ?? '-',
       },
     ],
   ];

--- a/nms/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -681,6 +681,18 @@ export function EPCEdit(props: Props) {
               onChange={({target}) => handleEPCChange('ip_block', target.value)}
             />
           </AltFormField>
+          <AltFormField label={'IPv6 Block'}>
+            <OutlinedInput
+              data-testid="ipv6Block"
+              placeholder="fdee:5:6c::/48"
+              type="string"
+              fullWidth={true}
+              value={EPCConfig.ipv6_block}
+              onChange={({target}) =>
+                handleEPCChange('ipv6_block', target.value)
+              }
+            />
+          </AltFormField>
           <AltFormField label={'DNS Primary'}>
             <OutlinedInput
               data-testid="dnsPrimary"

--- a/nms/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -452,11 +452,13 @@ describe('<AddEditGatewayButton />', () => {
     const natEnabled = getByTestId('natEnabled').firstChild;
     const gwSgiIpv6 = getByTestId('gwSgiIpv6').firstChild;
     const sgiStaticIpv6 = getByTestId('sgiStaticIpv6').firstChild;
+    const ipv6Block = getByTestId('ipv6Block').firstChild;
     if (
       natEnabled instanceof HTMLElement &&
       natEnabled.firstChild instanceof HTMLElement &&
       gwSgiIpv6 instanceof HTMLInputElement &&
-      sgiStaticIpv6 instanceof HTMLInputElement
+      sgiStaticIpv6 instanceof HTMLInputElement &&
+      ipv6Block instanceof HTMLInputElement
     ) {
       fireEvent.click(natEnabled.firstChild);
       fireEvent.change(gwSgiIpv6, {
@@ -464,6 +466,9 @@ describe('<AddEditGatewayButton />', () => {
       });
       fireEvent.change(sgiStaticIpv6, {
         target: {value: '2001:4860:4860:0:0:0:0:8888'},
+      });
+      fireEvent.change(ipv6Block, {
+        target: {value: 'fdee:5:6c::/48'},
       });
     } else {
       throw 'invalid type';
@@ -478,6 +483,7 @@ describe('<AddEditGatewayButton />', () => {
       networkId: 'test',
       config: {
         ip_block: '192.168.128.0/24',
+        ipv6_block: 'fdee:5:6c::/48',
         nat_enabled: false,
         dns_primary: '',
         dns_secondary: '',
@@ -590,6 +596,7 @@ describe('<AddEditGatewayButton />', () => {
           },
           epc: {
             ip_block: '192.168.128.0/24',
+            ipv6_block: 'fdee:5:6c::/48',
             nat_enabled: false,
             dns_primary: '',
             dns_secondary: '',
@@ -688,6 +695,7 @@ describe('<AddEditGatewayButton />', () => {
         },
         epc: {
           ip_block: '192.168.128.0/24',
+          ipv6_block: 'fdee:5:6c::/48',
           nat_enabled: false,
           dns_primary: '',
           dns_secondary: '',


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add gateway ipv6_block in EPC Config (closes #3389)

<img width="1792" alt="Capture d’écran 2022-02-28 à 16 28 59" src="https://user-images.githubusercontent.com/26038920/156010603-8f571e3b-d739-480f-84ad-5db0399a3007.png">

<img width="1791" alt="Capture d’écran 2022-02-28 à 16 29 13" src="https://user-images.githubusercontent.com/26038920/156010576-20bebbc4-0bc3-4a71-a1f4-25f3a0df8dfe.png">



## Test Plan

Modified GatewayConfigTest

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
