### PR TITLE
fix(mme): Move the zmq context into truly shared file in mme_app_task

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.cpp
@@ -21,7 +21,6 @@
 #include "lte/gateway/c/core/oai/lib/s6a_proxy/proto_msg_to_itti_msg.h"
 
 extern "C" {
-#include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.003.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_36.413.h"
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
@@ -30,7 +29,7 @@ extern "C" {
 namespace magma {
 namespace lte {
 
-extern task_zmq_ctx_t task_zmq_ctx_main;
+task_zmq_ctx_t task_zmq_ctx_main;
 
 #define DEFAULT_TEID 1
 #define DEFAULT_MME_S1AP_UE_ID 1

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -15,6 +15,7 @@
 #include <gmock/gmock-matchers.h>
 
 extern "C" {
+#include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_29.274.h"
 #include "lte/gateway/c/core/oai/include/mme_config.h"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
@@ -26,6 +27,8 @@ using std::vector;
 
 namespace magma {
 namespace lte {
+
+extern task_zmq_ctx_t task_zmq_ctx_main;
 
 #define MME_APP_TIMER_TO_MSEC 10
 #define STATE_MAX_WAIT_MS 2000

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -48,8 +48,6 @@ namespace lte {
 
 ACTION_P(ReturnFromAsyncTask, cv) { cv->notify_all(); }
 
-task_zmq_ctx_t task_zmq_ctx_main;
-
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);
 


### PR DESCRIPTION
In breaking up these unit tests to run more concurrently, I had linking
errors in finding this symbol.  Turns out we have defined the symbol in
one place (test utilities header file) but actually instantitated it in
a non-shared c file (at least not part of utilities).

This PR moves the declaration to a more sensible place, the
mme_app_test_util.cpp file.

## Test Plan

Execution of CI tests including `make build_oai` and `make test_oai`.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>