### PR TITLE
chore: add a symlink for clangd -> clangd-12

### DIFF
--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -441,12 +441,21 @@
       - lld
 
 # TODO: preburn this
-- name: Install clang-format-11 c/c++ formatting tooling
+- name: Install requirements for VSCode <-> Bazel integration
   retries: 5
   apt:
     state: latest
     pkg:
-      - clang-format-11
+      - clangd-12
+      - lld
+
+# TODO: preburn this
+- name: Create a symlink for clangd
+  file:
+    src: '/usr/bin/clangd-12'
+    path: '/usr/bin/clangd'
+    state: link
+    force: yes
 
 # TODO: this can be removed once the role below is preburned
 - name: Remove all links for clang-format

--- a/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
+++ b/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
@@ -33,7 +33,7 @@
 		"bsv.bzl.lsp.enableCodelensRun": false,
 		"bsv.bzl.remoteCache.enabled": false,
 		"bsv.bzl.starlarkDebugger.enabled": false,
-		"clangd.path": "clangd-12",
+		"clangd.path": "/usr/bin/clangd-12",
 		"clangd.arguments": [
 			"-log=verbose",
 			"-pretty",


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
1. add a symlink so that /usr/bin/clangd points to /usr/bin/clangd-12. This is a workaround solution to make sure VSCode is able to find clangd-12 installed in the Magma VM. I'm not exactly sure why VSCode for some look for clangd and not clangd-12, but this solution will make sure clangd is found.
2. modify the VM workspace config to fully specify /usr/bin/clangd-12
<!-- Enumerate changes you made and why you made them -->

## Test Plan
destroyed and provisioned the Magma VM. made sure that /usr/bin/clangd points to /usr/bin/clangd-12

```bash
vagrant@magma-dev-focal:~$ stat /usr/bin/clangd
  File: /usr/bin/clangd -> /usr/bin/clangd-12
  Size: 18        	Blocks: 0          IO Block: 4096   symbolic link
Device: 801h/2049d	Inode: 282         Links: 1
Access: (0777/lrwxrwxrwx)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2022-02-23 18:35:08.954009321 +0000
Modify: 2022-02-23 18:34:28.246007380 +0000
Change: 2022-02-23 18:34:28.246007380 +0000
 Birth: -
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
