### PR TITLE
chore: fix agw python unit tests by pinning lupa version

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -110,7 +110,8 @@ setup(
     ],
     extras_require={
         'dev': [
-            "fakeredis[lua]",
+            "lupa==1.10",
+            "fakeredis[lua]==1.7.1",
         ],
     },
 )


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
The AGW python unit tests that rely on fakeredis (which relies on lupa) are broken on master. (Seen on both CI and locally with Magma VM) 

Lupa released a new version (1.11) this morning, and I am wondering if the new version is causing the issue. Pinning its version to 1.10 seems to fix the issue for now.

Pinning fakeredis to 7.1.1 (latest as of today): https://github.com/jamesls/fakeredis
Pinning lupa to 1.10 (second to latest as of today): https://github.com/scoder/lupa
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI

`make test_python_service MAGMA_SERVICE=directoryd` and `make test_python` fails on master but does not fail with this change
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
