### PR TITLE
chore: fix directoryd unit test by pinning lupa version

### DIFF
--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -38,9 +38,9 @@ deprecated
 wrapt
 
 # unit test requirements
-fakeredis
+fakeredis==1.7.1
 #  lupa is required by fakeredis
-lupa
+lupa==1.10
 freezegun
 pytest
 pytest-cov

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -171,9 +171,9 @@ deprecated==1.2.13 \
     # via
     #   -r requirements.in
     #   redis
-fakeredis==1.7.0 \
-    --hash=sha256:6f1e04f64557ad3b6835bdc6e5a8d022cbace4bdc24a47ad58f6a72e0fbff760 \
-    --hash=sha256:c9bd12e430336cbd3e189fae0e91eb99997b93e76dbfdd6ed67fa352dc684c71
+fakeredis==1.7.1 \
+    --hash=sha256:7c2c4ba1b42e0a75337c54b777bf0671056b4569650e3ff927e4b9b385afc8ec \
+    --hash=sha256:be3668e50f6b57d5fc4abfd27f9f655bed07a2c5aecfc8b15d0aad59f997c1ba
     # via -r requirements.in
 flask==2.0.2 \
     --hash=sha256:7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2 \


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Fix failing directoryd unit test by pinning the lupa 1.10 and fakeredis 1.7.1 versions in `requirements.in`. 
- Cf. #11765.
- Note: Newer lupa 1.12 version is already released and seems to be working with bazel. Will keep the lupa 1.10 version in order to be in sync with `setup.py`.

## Test Plan

- Run orc8r/lte tests: 
  - `bazel test //orc8r/gateway/python/magma/...`
  -  `bazel test //lte/gateway/python/magma/...`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
