### PR TITLE
chore(state): state service is bazelified

### DIFF
--- a/lte/protos/BUILD.bazel
+++ b/lte/protos/BUILD.bazel
@@ -454,3 +454,32 @@ python_grpc_library(
     name = "subscriberauth_python_grpc",
     protos = [":subscriberauth_proto"],
 )
+
+# This proto library is exclusively meant for the state service.
+# Users can manually add proto libraries to state.yml.
+# This means that all proto libraries need to be available
+# in builds of the state service.
+proto_library(
+    name = "all_proto",
+    srcs = glob(["*.proto"]),
+    visibility = ["//visibility:private"],
+    deps = [
+        "//orc8r/protos:common_proto",
+        "//orc8r/protos:digest_proto",
+        "//orc8r/protos:service303_proto",
+        "@protobuf//:field_mask_proto",
+        "@protobuf//:timestamp_proto",
+    ],
+)
+
+# See comment at :all_proto
+python_proto_library(
+    name = "all_python_proto",
+    protos = [":all_proto"],
+    visibility = ["//orc8r/gateway/python/magma/state:__pkg__"],
+    deps = [
+        "//orc8r/protos:common_python_proto",
+        "//orc8r/protos:digest_python_proto",
+        "//orc8r/protos:service303_python_proto",
+    ],
+)

--- a/lte/protos/oai/BUILD.bazel
+++ b/lte/protos/oai/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_proto_grpc//cpp:defs.bzl", "cpp_proto_library")
+load("@rules_proto_grpc//python:defs.bzl", "python_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -131,4 +132,22 @@ proto_library(
 cpp_proto_library(
     name = "ngap_state_cpp_proto",
     protos = [":ngap_state_proto"],
+)
+
+# This proto library is exclusively meant for the state service.
+# Users can manually add proto libraries to state.yml.
+# This means that all proto libraries need to be available
+# in builds of the state service.
+proto_library(
+    name = "all_proto",
+    srcs = glob(["*.proto"]),
+    visibility = ["//visibility:private"],
+    deps = ["@protobuf//:timestamp_proto"],
+)
+
+# See comment at :all_proto
+python_proto_library(
+    name = "all_python_proto",
+    protos = [":all_proto"],
+    visibility = ["//orc8r/gateway/python/magma/state:__pkg__"],
 )

--- a/orc8r/gateway/python/magma/state/BUILD.bazel
+++ b/orc8r/gateway/python/magma/state/BUILD.bazel
@@ -19,7 +19,7 @@ py_binary(
     name = "state",
     srcs = ["main.py"],
     imports = [ORC8R_ROOT],
-    # legacy_creat_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
+    # legacy_create_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
@@ -27,6 +27,8 @@ py_binary(
     deps = [
         ":garbage_collector",
         ":state_replicator",
+        "//lte/protos:all_python_proto",  # Dependency loaded via state.yml
+        "//lte/protos/oai:all_python_proto",  # Dependency loaded via state.yml
         "//orc8r/gateway/python/magma/common:grpc_client_manager",
         "//orc8r/gateway/python/magma/common:sentry",
     ],

--- a/orc8r/gateway/python/magma/state/BUILD.bazel
+++ b/orc8r/gateway/python/magma/state/BUILD.bazel
@@ -1,0 +1,67 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+MAGMA_ROOT = "../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+py_binary(
+    name = "state",
+    srcs = ["main.py"],
+    imports = [ORC8R_ROOT],
+    # legacy_creat_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
+    legacy_create_init = False,
+    main = "main.py",
+    python_version = "PY3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":garbage_collector",
+        ":state_replicator",
+        "//orc8r/gateway/python/magma/common:grpc_client_manager",
+        "//orc8r/gateway/python/magma/common:sentry",
+    ],
+)
+
+py_library(
+    name = "garbage_collector",
+    srcs = ["garbage_collector.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":keys",
+        ":redis_dicts",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common/redis:client",
+        "//orc8r/protos:state_python_grpc",
+    ],
+)
+
+py_library(
+    name = "keys",
+    srcs = ["keys.py"],
+    visibility = ["//visibility:private"],
+    deps = ["//orc8r/gateway/python/magma/common:misc_utils"],
+)
+
+py_library(
+    name = "redis_dicts",
+    srcs = ["redis_dicts.py"],
+    visibility = ["//visibility:private"],
+)
+
+py_library(
+    name = "state_replicator",
+    srcs = ["state_replicator.py"],
+    visibility = ["//visibility:public"],
+    deps = ["//orc8r/gateway/python/magma/common:sdwatchdog"],
+)

--- a/orc8r/gateway/python/magma/state/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/state/tests/BUILD.bazel
@@ -1,0 +1,45 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("//bazel:python_test.bzl", "pytest_test")
+
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+pytest_test(
+    name = "garbage_collector_test",
+    srcs = ["garbage_collector_test.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/common:grpc_client_manager",
+        "//orc8r/gateway/python/magma/common/redis:client",
+        "//orc8r/gateway/python/magma/magmad:magmad_lib",  # Needed for mocking
+        "//orc8r/gateway/python/magma/state:garbage_collector",
+        requirement("fakeredis"),
+        requirement("lupa"),
+    ],
+)
+
+pytest_test(
+    name = "state_replicator_test",
+    srcs = ["state_replicator_test.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/common:grpc_client_manager",
+        "//orc8r/gateway/python/magma/common/redis:client",
+        "//orc8r/gateway/python/magma/magmad:magmad_lib",  # Needed for mocking
+        "//orc8r/gateway/python/magma/state:garbage_collector",
+        "//orc8r/gateway/python/magma/state:state_replicator",
+        requirement("fakeredis"),
+    ],
+)


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Module state is bazelified including the tests.
- The state service has a unique feature: additional proto libraries can be loaded by adding them to `state.yml`. This means we need to depend on all proto libraries in `lte/protos` and `lte/protos/oai`. Other proto libraries should not be needed (discussed with @ardzoht).
 - This is solved by providing targets that provide all proto files from these folders. We know this is sort of an anti-pattern, but seems to be the solution that involves the least effort on the developer side for future changes. 

## Test Plan
In dev-container, magma-vm and bazel-base:

-  Run state: 
   - `bazel run //orc8r/gateway/python/magma/state:state`
- Run tests: 
  - `bazel test //orc8r/gateway/python/magma/state/tests:all`
- Adding  `state.yml` dependency
  - Add the following code: 
   ```
   - proto_file: "lte.protos.sctpd_pb2"
     proto_msg: "InitReq"
     redis_key: "mobilityd_ipdesc_record"
     state_scope: "network"
   ```
  - the following logging should not occur with a `bazel run` on state
    `ERROR:root:No module named 'lte.protos.sctpd_pb2'` 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
