### PR TITLE
refactor: bazel root definitions are refactored

### DIFF
--- a/lte/gateway/python/magma/mobilityd/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/BUILD.bazel
@@ -12,9 +12,11 @@
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
 
-LTE_ROOT = "../../"
+MAGMA_ROOT = "../../../../../"
 
-ORC8R_ROOT = LTE_ROOT + "../../../orc8r/gateway/python"
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 DEPS = [
     "//lte/protos:keyval_python_proto",

--- a/lte/gateway/python/magma/policydb/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/BUILD.bazel
@@ -11,9 +11,11 @@
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
-LTE_ROOT = "../../"
+MAGMA_ROOT = "../../../../../"
 
-ORC8R_ROOT = LTE_ROOT + "../../../orc8r/gateway/python"
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 DEPS = [
     "//lte/protos:mconfigs_python_proto",

--- a/lte/gateway/python/magma/redirectd/BUILD.bazel
+++ b/lte/gateway/python/magma/redirectd/BUILD.bazel
@@ -12,9 +12,11 @@
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
 
-LTE_ROOT = "../../"
+MAGMA_ROOT = "../../../../../"
 
-ORC8R_ROOT = LTE_ROOT + "../../../orc8r/gateway/python"
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 DEPS = [
     "//lte/protos:mconfigs_python_proto",

--- a/lte/gateway/python/magma/subscriberdb/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/BUILD.bazel
@@ -12,9 +12,11 @@
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
-LTE_ROOT = "../../"
+MAGMA_ROOT = "../../../../../"
 
-ORC8R_ROOT = LTE_ROOT + "../../../orc8r/gateway/python"
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 py_binary(
     name = "subscriberdb",

--- a/lte/gateway/python/magma/subscriberdb/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/tests/BUILD.bazel
@@ -12,9 +12,11 @@
 load("@python_deps//:requirements.bzl", "requirement")
 load("//bazel:python_test.bzl", "pytest_test")
 
-LTE_ROOT = "../../../"
+MAGMA_ROOT = "../../../../../../"
 
-ORC8R_ROOT = LTE_ROOT + "../../../orc8r/gateway/python"
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "client_tests",

--- a/lte/gateway/python/magma/subscriberdb/tests/crypto/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/tests/crypto/BUILD.bazel
@@ -11,7 +11,9 @@
 
 load("//bazel:python_test.bzl", "pytest_test")
 
-LTE_ROOT = "../../../../"
+MAGMA_ROOT = "../../../../../../../"
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "crypto_tests",

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/BUILD.bazel
@@ -13,9 +13,11 @@ load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library")
 load("//bazel:python_test.bzl", "pytest_test")
 
-LTE_ROOT = "../../../../../"
+MAGMA_ROOT = "../../../../../../../../"
 
-ORC8R_ROOT = LTE_ROOT + "../../../orc8r/gateway/python/"
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "avp_tests",

--- a/lte/gateway/python/magma/subscriberdb/tests/store/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/BUILD.bazel
@@ -11,7 +11,9 @@
 
 load("//bazel:python_test.bzl", "pytest_test")
 
-LTE_ROOT = "../../../../"
+MAGMA_ROOT = "../../../../../../../"
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 COMMON_TEST_DEPS = [
     "//lte/gateway/python/magma/subscriberdb:sid",

--- a/orc8r/gateway/python/magma/ctraced/BUILD.bazel
+++ b/orc8r/gateway/python/magma/ctraced/BUILD.bazel
@@ -11,7 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
-ORC8R_ROOT = "../../"
+MAGMA_ROOT = "../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 py_binary(
     name = "ctraced",

--- a/orc8r/gateway/python/magma/directoryd/BUILD.bazel
+++ b/orc8r/gateway/python/magma/directoryd/BUILD.bazel
@@ -11,7 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
-ORC8R_ROOT = "../../"
+MAGMA_ROOT = "../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 py_binary(
     name = "directoryd",

--- a/orc8r/gateway/python/magma/directoryd/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/directoryd/tests/BUILD.bazel
@@ -12,7 +12,9 @@
 load("@python_deps//:requirements.bzl", "requirement")
 load("//bazel:python_test.bzl", "pytest_test")
 
-ORC8R_ROOT = "../../../"
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "rpc_servicer_tests",

--- a/orc8r/gateway/python/magma/eventd/BUILD.bazel
+++ b/orc8r/gateway/python/magma/eventd/BUILD.bazel
@@ -19,9 +19,11 @@ py_library(
     deps = ["//orc8r/protos:eventd_python_grpc"],
 )
 
-ORC8R_ROOT = "../../"
+MAGMA_ROOT = "../../../../../"
 
-LTE_ROOT = ORC8R_ROOT + "../../../lte/gateway/python"
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 DEPS = [
     "//orc8r/gateway/python/magma/common:sentry",

--- a/orc8r/gateway/python/magma/magmad/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/BUILD.bazel
@@ -12,7 +12,9 @@
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
-ORC8R_ROOT = "../../"
+MAGMA_ROOT = "../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 py_binary(
     name = "magmad",

--- a/orc8r/gateway/python/magma/magmad/check/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/BUILD.bazel
@@ -11,7 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-ORC8R_ROOT = "../../../"
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 py_library(
     name = "subprocess_workflow",

--- a/orc8r/gateway/python/magma/magmad/check/kernel_check/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/kernel_check/BUILD.bazel
@@ -11,7 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-ORC8R_ROOT = "../../../../"
+MAGMA_ROOT = "../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 py_library(
     name = "kernel_versions",

--- a/orc8r/gateway/python/magma/magmad/check/machine_check/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/machine_check/BUILD.bazel
@@ -11,7 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-ORC8R_ROOT = "../../../../"
+MAGMA_ROOT = "../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 py_library(
     name = "cpu_info",

--- a/orc8r/gateway/python/magma/magmad/check/network_check/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/BUILD.bazel
@@ -11,7 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-ORC8R_ROOT = "../../../../"
+MAGMA_ROOT = "../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 py_library(
     name = "ping",

--- a/orc8r/gateway/python/magma/magmad/generic_command/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/generic_command/BUILD.bazel
@@ -11,7 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-ORC8R_ROOT = "../../../"
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 py_library(
     name = "command_executor",

--- a/orc8r/gateway/python/magma/magmad/upgrade/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/upgrade/BUILD.bazel
@@ -11,7 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-ORC8R_ROOT = "../../../"
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 py_library(
     name = "upgrader",


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Bazel root definitions are refactored to match the pattern:
```
MAGMA_ROOT = "../../../../../"

ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)

LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
```
- Cf. https://github.com/magma/magma/issues/11743

## Test Plan

- `bazel build //lte/gateway/python/... //orc8r/gateway/python/...`
- `bazel test //lte/gateway/python/... //orc8r/gateway/python/...`
- `bazel run //:buildifier`
- CI

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
