### PR TITLE
chore(magmad): Exclude config errors from Sentry

### DIFF
--- a/orc8r/gateway/python/magma/magmad/bootstrap_manager.py
+++ b/orc8r/gateway/python/magma/magmad/bootstrap_manager.py
@@ -185,7 +185,7 @@ class BootstrapManager(SDWatchdogTask):
         try:
             chan = ServiceRegistry.get_bootstrap_rpc_channel()
         except ValueError as exp:
-            logging.error('Failed to get rpc channel: %s', exp)
+            logging.error('Failed to get rpc channel: %s', exp, extra=EXCLUDE_FROM_ERROR_MONITORING)
             self._schedule_next_bootstrap(hard_failure=False)
             return
 
@@ -263,7 +263,7 @@ class BootstrapManager(SDWatchdogTask):
         try:
             chan = ServiceRegistry.get_bootstrap_rpc_channel()
         except ValueError as exp:
-            logging.error('Failed to get rpc channel: %s', exp)
+            logging.error('Failed to get rpc channel: %s', exp, extra=EXCLUDE_FROM_ERROR_MONITORING)
             BOOTSTRAP_EXCEPTION.labels(cause='RequestSignGetRPC').inc()
             self._schedule_next_bootstrap(hard_failure=False)
             return


### PR DESCRIPTION
## Summary

Excludes errors logged frequently recently with Sentry due to SSL certificate not being found.

Closes https://github.com/magma/magma/issues/11756

## Additional Information

- [ ] This change is backwards-breaking