### PR TITLE
chore: remove LOG_WITH_GLOG compilation flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,7 +9,6 @@ build:production --config=lsan --compilation_mode=dbg --strip=never --copt=-O3
 
 # C/C++ CONFIGS
 build --cxxopt=-std=c++14
-build --cxxopt=-DLOG_WITH_GLOG=1
 build --experimental_strict_action_env
 
 # MAGMA VM CONFIGS

--- a/lte/gateway/c/connection_tracker/src/BUILD.bazel
+++ b/lte/gateway/c/connection_tracker/src/BUILD.bazel
@@ -14,9 +14,6 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 cc_binary(
     name = "connectiond",
     srcs = ["main.cpp"],
-    copts = [
-        "-DLOG_WITH_GLOG",
-    ],
     deps = [
         ":event_tracker",
         "//lte/protos:mconfigs_cpp_proto",

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -16,9 +16,6 @@ package(default_visibility = ["//lte/gateway/c/li_agent/src:__subpackages__"])
 cc_binary(
     name = "liagentd",
     srcs = ["main.cpp"],
-    copts = [
-        "-DLOG_WITH_GLOG",
-    ],
     deps = [
         ":interface_monitor",
         "//orc8r/gateway/c/common/config:mconfig_loader",

--- a/lte/gateway/c/sctpd/src/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/BUILD.bazel
@@ -16,9 +16,6 @@ package(default_visibility = ["//lte/gateway/c/sctpd/src:__subpackages__"])
 cc_binary(
     name = "sctpd",
     srcs = ["sctpd.cpp"],
-    copts = [
-        "-DLOG_WITH_GLOG",
-    ],
     linkstatic = True,
     deps = [
         ":config",

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -480,9 +480,6 @@ cc_library(
 cc_binary(
     name = "sessiond",
     srcs = ["sessiond_main.cpp"],
-    copts = [
-        "-DLOG_WITH_GLOG",
-    ],
     # Make the binary as static as possible to allow for more reliable behavior when moving binaries around
     # From bazel doc: this flag makes it so all user libraries are linked statically (if a static version is available),
     #                 but where system libraries (excluding C/C++ runtime libraries) are linked dynamically

--- a/orc8r/gateway/c/common/logging/magma_logging.h
+++ b/orc8r/gateway/c/common/logging/magma_logging.h
@@ -19,23 +19,7 @@
 #define MDEBUG 4
 
 // GLOG LOGGING
-#ifdef LOG_WITH_GLOG
 #include <glog/logging.h>
 
 #define MLOG(VERBOSITY) VLOG(VERBOSITY)
 #define MLOG_IF(VERBOSITY, CONDITION) VLOG_IF(VERBOSITY, CONDITION)
-
-#endif
-
-// NON GLOG LOGGING
-#ifndef LOG_WITH_GLOG
-#include <iostream>
-
-// for non glog use cases, just log to std cout
-struct _MLOG_NEWLINE {
-  ~_MLOG_NEWLINE() { std::cout << std::endl; }
-};
-#define MLOG(VERBOSITY) \
-  (_MLOG_NEWLINE(), std::cout << "[" << __FILE__ << ":" << __LINE__ << "] ")
-
-#endif

--- a/orc8r/gateway/c/common/logging/magma_logging_init.h
+++ b/orc8r/gateway/c/common/logging/magma_logging_init.h
@@ -16,8 +16,6 @@
 
 #include "orc8r/gateway/c/common/logging/magma_logging.h"
 
-// GLOG LOGGING
-#ifdef LOG_WITH_GLOG
 #include <glog/logging.h>
 
 namespace magma {
@@ -43,24 +41,3 @@ static void init_logging(const char* service_name) {
   FLAGS_logtostderr = 1;
 }
 }  // namespace magma
-#endif
-
-// NON GLOG LOGGING
-#ifndef LOG_WITH_GLOG
-#include <iostream>
-
-namespace magma {
-static void set_verbosity(__attribute__((unused)) uint32_t verbosity) {
-  (void)set_verbosity;  // casting to void to suppress unused reference warning
-}
-// get_verbosity gets the the global logging verbosity
-static uint32_t get_verbosity() {
-  (void)get_verbosity;  // casting to void to suppress unused reference warning
-  return 0;
-}
-static void init_logging(__attribute__((unused)) const char* service_name) {
-  (void)init_logging;  // casting to void to suppress unused reference warning
-}
-
-}  // namespace magma
-#endif


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
https://github.com/magma/magma/pull/10759 removed OAI's dependency to magma_logging, which means that we can just log with GLOG by default. (Which was already the case for sctpd/liagentd/sessiond...)

This PR removes the conditional flag to toggle between glog and std::cout to avoid creating a dependency like OAI had to the library before in the future. (Before the aforementioned PR, OAI was not able to compile with LOG_WITH_GLOG set to 1)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
