### PR TITLE
fix(amf): PCO encoding and other fixes

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -428,6 +428,8 @@ imsi64_t amf_app_handle_initial_ue_message(
       OAILOG_FUNC_RETURN(LOG_AMF_APP, imsi64);
     }
 
+    is_mm_ctx_new = true;
+
     // Allocate new amf_ue_ngap_id
     amf_ue_ngap_id = amf_app_ctx_get_new_ue_id(
         &amf_app_desc_p->amf_app_ue_ngap_id_generator);
@@ -471,7 +473,6 @@ imsi64_t amf_app_handle_initial_ue_message(
                  "(" AMF_UE_NGAP_ID_FMT ")",
                  ue_context_p->amf_ue_ngap_id);
   }
-  is_mm_ctx_new = true;
 
   OAILOG_DEBUG(LOG_AMF_APP,
                " Sending NAS Establishment Indication to NAS for ue_id = "
@@ -945,8 +946,9 @@ int amf_app_handle_pdu_session_accept(
   new_qos_rule_pkt_filter.pkt_filter_id = 0x1;
   new_qos_rule_pkt_filter.len = 0x1;
   uint8_t contents = 0x1;
-  memcpy(new_qos_rule_pkt_filter.contents, &contents,
-         new_qos_rule_pkt_filter.len);
+
+  new_qos_rule_pkt_filter.contents = contents;
+
   memcpy(qos_rule.new_qos_rule_pkt_filter, &new_qos_rule_pkt_filter,
          1 * sizeof(NewQOSRulePktFilter));
   memcpy(smf_msg->msg.pdu_session_estab_accept.qos_rules.qos_rule, &qos_rule,
@@ -978,20 +980,27 @@ int amf_app_handle_pdu_session_accept(
   -------------------------------------- */
   smf_msg->msg.pdu_session_estab_accept.nssai.iei =
       static_cast<uint8_t>(M5GIei::S_NSSAI);
-  if (smf_ctx->requested_nssai.sst) {
-    if (smf_ctx->requested_nssai.sd[0]) {
-      smf_msg->msg.pdu_session_estab_accept.nssai.len = SST_LENGTH + SD_LENGTH;
-      smf_msg->msg.pdu_session_estab_accept.nssai.sst =
-          smf_ctx->requested_nssai.sst;
-      memcpy(smf_msg->msg.pdu_session_estab_accept.nssai.sd,
-             smf_ctx->requested_nssai.sd, 3);
-    } else {
-      smf_msg->msg.pdu_session_estab_accept.nssai.len = SST_LENGTH;
-      smf_msg->msg.pdu_session_estab_accept.nssai.sst =
-          smf_ctx->requested_nssai.sst;
-    }
-    buf_len = smf_msg->msg.pdu_session_estab_accept.nssai.len + 2;
+
+  s_nssai_t slice_information = {};
+  amf_smf_get_slice_configuration(smf_ctx, &(slice_information));
+  if (!slice_information.sst) {
+    OAILOG_ERROR(LOG_AMF_APP,
+                 "Slice Configuration does not exist:" AMF_UE_NGAP_ID_FMT,
+                 ue_id);
+
+    return M5G_AS_FAILURE;
   }
+
+  if (slice_information.sd[0]) {
+    smf_msg->msg.pdu_session_estab_accept.nssai.len = SST_LENGTH + SD_LENGTH;
+    smf_msg->msg.pdu_session_estab_accept.nssai.sst = slice_information.sst;
+    memcpy(smf_msg->msg.pdu_session_estab_accept.nssai.sd, slice_information.sd,
+           SD_LENGTH);
+  } else {
+    smf_msg->msg.pdu_session_estab_accept.nssai.len = SST_LENGTH;
+    smf_msg->msg.pdu_session_estab_accept.nssai.sst = slice_information.sst;
+  }
+  buf_len = smf_msg->msg.pdu_session_estab_accept.nssai.len + 2;
 
   /* DNN
   -------------------------------------
@@ -1044,11 +1053,15 @@ int amf_app_handle_pdu_session_accept(
     bdestroy_wrapper(&buffer);
   }
 
-  /* Clean up the PCO contents */
+  /* Clean up the pco of smf_ctx as its only filled by establishment request */
+  protocol_configuration_options_t* context_pco = &(smf_ctx->pco);
+  sm_free_protocol_configuration_options(&context_pco);
+
+  /* Clean up the pco of pdu session establishment accept message */
   sm_free_protocol_configuration_options(&msg_accept_pco);
 
   return rc;
-}
+}  // namespace magma5g
 
 /* Handling PDU Session Resource Setup Response sent from gNB*/
 void amf_app_handle_resource_setup_response(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_identity.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_identity.cpp
@@ -119,7 +119,7 @@ int amf_proc_identification_complete(const amf_ue_ngap_id_t ue_id,
                                      uint32_t* const tmsi,
                                      guti_m5_t* amf_ctx_guti) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  int rc = RETURNok;
   amf_sap_t amf_sap = {};
   amf_context_t* amf_ctx = NULL;
 
@@ -136,10 +136,13 @@ int amf_proc_identification_complete(const amf_ue_ngap_id_t ue_id,
     nas_amf_ident_proc_t* ident_proc =
         get_5g_nas_common_procedure_identification(amf_ctx);
 
-    // if (ident_proc) {
-    /*
-     * Stop timer T3570
-     */
+    if (ident_proc == NULL) {
+      OAILOG_ERROR(LOG_AMF_APP,
+                   "Failed to start identity procedure for "
+                   "ue_id " AMF_UE_NGAP_ID_FMT "\n",
+                   ue_id);
+      OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+    }
 
     OAILOG_DEBUG(LOG_AMF_APP, "Timer: Stopping Identity timer with ID %lu\n",
                  ident_proc->T3570.id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -256,6 +256,30 @@ int amf_copy_plmn_to_context(const ImsiM5GSMobileIdentity& imsi,
   return RETURNok;
 }
 
+void amf_get_registration_type_request(
+    uint8_t received_reg_type, amf_proc_registration_type_t* params_reg_type) {
+  std::string reg_type;
+
+  if (received_reg_type == AMF_REGISTRATION_TYPE_INITIAL) {
+    reg_type = "INITIAL REGISTRATION TYPE";
+  } else if (received_reg_type == AMF_REGISTRATION_TYPE_MOBILITY_UPDATING) {
+    reg_type = "MOBILITY UPDATING REGISTRATION TYPE";
+  } else if (received_reg_type == AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
+    reg_type = "PERIODIC UPDATING REGISTRATION TYPE";
+  } else if (received_reg_type == AMF_REGISTRATION_TYPE_EMERGENCY) {
+    reg_type = "EMERGENCY TYPE REGISTRATION";
+  } else if (received_reg_type == AMF_REGISTRATION_TYPE_RESERVED) {
+    reg_type = "RESERVED REGISTRATION TYPE";
+  } else {
+    reg_type = "UNKNOWN REGISTRATION TYPE";
+  }
+
+  *params_reg_type =
+      static_cast<amf_proc_registration_type_t>(received_reg_type);
+
+  OAILOG_INFO(LOG_AMF_APP, "Received registration type %s", reg_type.c_str());
+}
+
 /* Identifies 5GS Registration type and processes the Message accordingly */
 int amf_handle_registration_request(
     amf_ue_ngap_id_t ue_id, tai_t* originating_tai, ecgi_t* originating_ecgi,
@@ -275,37 +299,32 @@ int amf_handle_registration_request(
     rc = amf_proc_registration_reject(ue_id, amf_cause);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
   }
-  amf_registration_request_ies_t* params =
-      new (amf_registration_request_ies_t)();
-  /*
-   * Message processing
-   */
-  /*
-   * Get the 5GS Registration type
-   */
-  params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_RESERVED;
-  if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_INITIAL) {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_INITIAL;
-  } else if (msg->m5gs_reg_type.type_val ==
-             AMF_REGISTRATION_TYPE_MOBILITY_UPDATING) {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_MOBILITY_UPDATING;
-  } else if (msg->m5gs_reg_type.type_val ==
-             AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_PERIODIC_UPDATING;
-  } else if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_EMERGENCY) {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_EMERGENCY;
-  } else if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_RESERVED) {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_RESERVED;
-  } else {
-    params->m5gsregistrationtype = AMF_REGISTRATION_TYPE_INITIAL;
+
+  // Get the 5GS Registration type
+  amf_proc_registration_type_t m5gsregistrationtype =
+      AMF_REGISTRATION_TYPE_RESERVED;
+
+  amf_get_registration_type_request(msg->m5gs_reg_type.type_val,
+                                    &m5gsregistrationtype);
+
+  if (m5gsregistrationtype > AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
+    OAILOG_ERROR(LOG_AMF_APP, "Registration type not supported \n");
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
 
   ue_m5gmm_context_s* ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   if (ue_context == NULL) {
     OAILOG_ERROR(LOG_AMF_APP,
                  "UE context is null for UE ID: " AMF_UE_NGAP_ID_FMT, ue_id);
-    return RETURNerror;
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
+
+  amf_registration_request_ies_t* params =
+      new (amf_registration_request_ies_t)();
+
+  // Store the registration type in params
+  params->m5gsregistrationtype = m5gsregistrationtype;
+
   // Save the UE Security Capability into AMF's UE Context
   memcpy(&(ue_context->amf_context.ue_sec_capability),
          &(msg->ue_sec_capability), sizeof(UESecurityCapabilityMsg));
@@ -314,7 +333,11 @@ int amf_handle_registration_request(
 
   ue_context->amf_context.decode_status = decode_status;
 
-  if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_INITIAL) {
+  // If registration type is initial registration or
+  // Context is new and registration type is mobile updating start registration
+  if ((params->m5gsregistrationtype == AMF_REGISTRATION_TYPE_INITIAL) ||
+      ((is_amf_ctx_new == true) && (params->m5gsregistrationtype ==
+                                    AMF_REGISTRATION_TYPE_MOBILITY_UPDATING))) {
     OAILOG_DEBUG(LOG_NAS_AMF, "New REGISTRATION_REQUEST processing\n");
     // Check integrity and ciphering algorithm bits
     // If all bits are zero it means integrity and ciphering algorithms are not
@@ -457,9 +480,8 @@ int amf_handle_registration_request(
       params->guti = new (guti_m5_t)();
       ue_context->amf_context.reg_id_type = M5GSMobileIdentityMsg_GUTI;
     }
-  }  // end of AMF_REGISTRATION_TYPE_INITIAL
-
-  if (msg->m5gs_reg_type.type_val == AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
+  } else if (params->m5gsregistrationtype ==
+             AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
     /*
      * This request for periodic registration update
      * For registered UE, is_amf_ctx_new = False
@@ -526,10 +548,11 @@ int amf_handle_registration_request(
           LOG_AMF_APP,
           "UE context was not existing or UE identity type is not GUTI "
           "Periodic Registration Update failed and sending reject message\n");
-      // TODO Implement Reject message
-      return RETURNerror;
+      OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
     }
-  }  // end of AMF_REGISTRATION_TYPE_PERIODIC_UPDATING
+  } else {
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
+  }
 
   params->decode_status = decode_status;
   /*

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -487,16 +487,13 @@ int amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ue_id,
       amf_smf_msg.u.establish.gnb_gtp_teid =
           smf_ctx->gtp_tunnel_id.gnb_gtp_teid;
 
-      // Initialize DNN
-      char* default_dnn = bstr2cstr(amf_config.default_dnn, '?');
-
       int index_dnn = 0;
       bool ue_sent_dnn = true;
       std::string dnn_string;
 
       if (msg->dnn.len <= 1) {
         ue_sent_dnn = false;
-        dnn_string = default_dnn;
+        dnn_string.assign(bdata(amf_config.default_dnn));
       } else {
         dnn_string.assign(reinterpret_cast<char*>(msg->dnn.dnn),
                           msg->dnn.len - 1);
@@ -504,7 +501,6 @@ int amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ue_id,
 
       int validate = amf_validate_dnn(&ue_context->amf_context, dnn_string,
                                       &index_dnn, ue_sent_dnn);
-      free(default_dnn);
 
       if (validate == RETURNok) {
         smf_dnn_ambr_select(smf_ctx, ue_context, index_dnn);
@@ -833,8 +829,8 @@ int amf_smf_handle_ip_address_response(
                                                   response_p->pdu_session_id);
   if (NULL == smf_ctx) {
     OAILOG_ERROR(LOG_AMF_APP,
-                 "Smf Context not found for pdu session id: [%s] \n",
-                 reinterpret_cast<char*>(response_p->pdu_session_id));
+                 "Smf Context not found for pdu session id: [%u] \n",
+                 response_p->pdu_session_id);
     return rc;
   }
 

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_smf_session_context.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_smf_session_context.h
@@ -27,4 +27,7 @@ status_code_e amf_smf_context_ue_aggregate_max_bit_rate_set(
 status_code_e amf_smf_context_ue_aggregate_max_bit_rate_get(
     const amf_context_s* amf_ctxt_p, bit_rate_t* subscriber_ambr_dl,
     bit_rate_t* subscriber_ambr_ul);
+
+void amf_smf_get_slice_configuration(std::shared_ptr<smf_context_t> smf_ctx,
+                                     s_nssai_t* slice_config);
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -369,6 +369,8 @@ int amf_proc_identification(amf_context_t* const amf_context,
       ident_proc->identity_type = type;
       ident_proc->retransmission_count = 0;
       ident_proc->ue_id = ue_id;
+      (reinterpret_cast<nas5g_base_proc_t*>(ident_proc))->parent =
+          reinterpret_cast<nas5g_base_proc_t*>(amf_proc);
       ident_proc->amf_com_proc.amf_proc.delivered = NULL;
       ident_proc->amf_com_proc.amf_proc.base_proc.success_notif = success;
       ident_proc->amf_com_proc.amf_proc.base_proc.failure_notif = failure;

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQOSRules.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQOSRules.h
@@ -22,8 +22,7 @@ class NewQOSRulePktFilter {
   uint8_t pkt_filter_dir : 2;
   uint8_t pkt_filter_id : 4;
   uint8_t len;
-  uint8_t contents[1 * ONE_K];  // need to revisit if the QOS rules occupy more
-                                // space than 4k.
+  uint8_t contents;
   NewQOSRulePktFilter();
   ~NewQOSRulePktFilter();
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQOSRules.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQOSRules.cpp
@@ -70,7 +70,7 @@ int QOSRulesMsg::DecodeQOSRulesMsg(QOSRulesMsg* qos_rules, uint8_t iei,
 
       IES_DECODE_U8(buffer, decoded,
                     qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len);
-      memcpy(qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].contents,
+      memcpy(&(qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].contents),
              buffer + decoded,
              qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len);
       decoded += qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len;
@@ -127,7 +127,7 @@ int QOSRulesMsg::EncodeQOSRulesMsg(QOSRulesMsg* qos_rules, uint8_t iei,
           qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len;
       encoded++;
       memcpy(buffer + encoded,
-             qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].contents,
+             &(qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].contents),
              qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len);
       encoded = encoded + qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len;
     }

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -38,11 +38,25 @@ imsi64_t send_initial_ue_message_no_tmsi(
     amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, const uint8_t* nas_msg,
     uint8_t nas_msg_length);
 
-imsi64_t send_initial_ue_message_service_request_with_pdu(
+/* For guti based registration */
+uint64_t send_initial_ue_message_with_tmsi(
+    amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,
+    uint32_t gnb_id, gnb_ue_ngap_id_t gnb_ue_ngap_id,
+    amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, uint32_t m_tmsi,
+    const uint8_t* nas_msg, uint8_t nas_msg_length);
+
+/* For generating the identity response message */
+int send_uplink_nas_identity_response_message(amf_app_desc_t* amf_app_desc_p,
+                                              amf_ue_ngap_id_t ue_id,
+                                              const plmn_t& plmn,
+                                              const uint8_t* nas_msg,
+                                              uint8_t nas_msg_length);
+
+imsi64_t send_initial_ue_message_service_request(
     amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,
     uint32_t gnb_id, gnb_ue_ngap_id_t gnb_ue_ngap_id,
     amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, const uint8_t* nas_msg,
-    uint8_t nas_msg_length);
+    uint8_t nas_msg_length, uint8_t tmsi_offset);
 
 int send_uplink_nas_message_service_request_with_pdu(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t amf_ue_ngap_id,

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -967,7 +967,7 @@ TEST(test_dnn, test_amf_handle_s6a_update_location_ans) {
   // Building s6a_update_location_ans_t
   std::string imsi = "901700000000001";
   s6a_update_location_ans_t ula_ans;
-  ula_ans = amf_send_s6a_ula(imsi);
+  ula_ans = util_amf_send_s6a_ula(imsi);
 
   // Building key value pair for amf_supi_guti_map and ue_context_map
   uint64_t imsi_64 = 901700000000001;
@@ -1014,7 +1014,7 @@ TEST(test_dnn, test_amf_validate_dnn) {
   s6a_update_location_ans_t ula_ans;
 
   // mock handling ans received from s6a_update_location_request
-  ula_ans = amf_send_s6a_ula(imsi);
+  ula_ans = util_amf_send_s6a_ula(imsi);
   memcpy(&amf_ctx.apn_config_profile,
          &ula_ans.subscription_data.apn_config_profile,
          sizeof(apn_config_profile_t));

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.h"
 #include "lte/gateway/c/core/oai/test/amf/amf_app_test_util.h"
+#include "lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h"
 
 using ::testing::Test;
 
@@ -45,6 +46,20 @@ class AMFAppProcedureTest : public ::testing::Test {
 
     init_task_context(TASK_MAIN, nullptr, 0, NULL, &amf_app_task_zmq_ctx);
 
+    char dnn[] = "internet";
+    amf_config.default_dnn = bfromcstr(dnn);
+    inet_aton("8.8.8.8", &(amf_config.ipv4.default_dns));
+    inet_aton("8.8.10.10", &(amf_config.ipv4.default_dns_sec));
+
+    /* Initialize the plmn */
+    amf_config.guamfi.nb = 1;
+    amf_config.guamfi.guamfi[0].plmn = {.mcc_digit2 = 2,
+                                        .mcc_digit1 = 2,
+                                        .mnc_digit3 = 6,
+                                        .mcc_digit3 = 2,
+                                        .mnc_digit2 = 5,
+                                        .mnc_digit1 = 4};
+
     amf_app_desc_p = get_amf_nas_state(false);
     AMFClientServicer::getInstance().msgtype_stack.clear();
   }
@@ -60,12 +75,12 @@ class AMFAppProcedureTest : public ::testing::Test {
  protected:
   amf_app_desc_t* amf_app_desc_p;
   std::string imsi = "222456000000001";
-  plmn_t plmn = {.mcc_digit2 = 0,
-                 .mcc_digit1 = 0,
-                 .mnc_digit3 = 0x0f,
-                 .mcc_digit3 = 1,
-                 .mnc_digit2 = 1,
-                 .mnc_digit1 = 0};
+  plmn_t plmn = {.mcc_digit2 = 2,
+                 .mcc_digit1 = 2,
+                 .mnc_digit3 = 6,
+                 .mcc_digit3 = 2,
+                 .mnc_digit2 = 5,
+                 .mnc_digit1 = 4};
 
   itti_amf_decrypted_imsi_info_ans_t decrypted_imsi = {
       .imsi = "222456000000001", .imsi_length = 15, .result = 1, .ue_id = 1};
@@ -82,6 +97,34 @@ class AMFAppProcedureTest : public ::testing::Test {
       0x7e, 0x00, 0x41, 0x79, 0x00, 0x0d, 0x01, 0x22, 0x62,
       0x54, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
       0x01, 0x2e, 0x04, 0xf0, 0xf0, 0xf0, 0xf0};
+
+  /* Guti based initial registration message */
+  const uint8_t guti_initial_ue_message_hexbuf[98] = {
+      0x7e, 0x01, 0x67, 0xb7, 0x6f, 0xc6, 0x03, 0x7e, 0x00, 0x41, 0x09,
+      0x00, 0x0b, 0xf2, 0x22, 0x62, 0x54, 0x01, 0x00, 0x40, 0x12, 0x70,
+      0x41, 0x77, 0x2e, 0x04, 0x80, 0xe0, 0x80, 0xe0, 0x71, 0x00, 0x41,
+      0x7e, 0x00, 0x41, 0x09, 0x00, 0x0b, 0xf2, 0x22, 0x62, 0x54, 0x01,
+      0x00, 0x40, 0x12, 0x70, 0x41, 0x77, 0x10, 0x01, 0x03, 0x2e, 0x04,
+      0x80, 0xe0, 0x80, 0xe0, 0x2f, 0x02, 0x01, 0x01, 0x52, 0x22, 0x62,
+      0x54, 0x00, 0x00, 0x01, 0x17, 0x07, 0x80, 0xe0, 0xe0, 0x60, 0x00,
+      0x1c, 0x30, 0x18, 0x01, 0x00, 0x74, 0x00, 0x0a, 0x09, 0x08, 0x69,
+      0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74, 0x53, 0x01, 0x01};
+
+  /* Mobile Termination as the initial ue message */
+  const uint8_t mu_initial_ue_message_hexbuf[93] = {
+      0x7e, 0x01, 0xa3, 0xcf, 0x4c, 0x7e, 0xd1, 0x7e, 0x00, 0x41, 0x02, 0x00,
+      0x0b, 0xf2, 0x22, 0x62, 0x54, 0x01, 0x00, 0x40, 0x8f, 0x71, 0x9f, 0x0e,
+      0x2e, 0x04, 0xf0, 0x70, 0xf0, 0x70, 0x71, 0x00, 0x3c, 0x7e, 0x00, 0x41,
+      0x02, 0x00, 0x0b, 0xf2, 0x22, 0x62, 0x54, 0x01, 0x00, 0x40, 0x8f, 0x71,
+      0x9f, 0x0e, 0x10, 0x01, 0x03, 0x2e, 0x04, 0xf0, 0x70, 0xf0, 0x70, 0x2f,
+      0x02, 0x01, 0x01, 0x52, 0x22, 0x62, 0x54, 0x00, 0x00, 0x01, 0x17, 0x07,
+      0xf0, 0x70, 0x00, 0x00, 0x18, 0x80, 0xb0, 0x50, 0x02, 0x00, 0x00, 0x18,
+      0x01, 0x01, 0x74, 0x00, 0x00, 0x90, 0x53, 0x01, 0x01};
+
+  const uint8_t identity_response[25] = {
+      0x7e, 0x01, 0xe2, 0x1d, 0xd9, 0xe5, 0x04, 0x7e, 0x00,
+      0x5c, 0x00, 0x0d, 0x01, 0x22, 0x62, 0x54, 0xf0, 0xff,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
 
   const uint8_t ue_auth_response_hexbuf[21] = {
       0x7e, 0x0,  0x57, 0x2d, 0x10, 0x25, 0x70, 0x6f, 0x9a, 0x5b, 0x90,
@@ -108,6 +151,14 @@ class AMFAppProcedureTest : public ::testing::Test {
       0xff, 0x91, 0xa1, 0x28, 0x01, 0x00, 0x7b, 0x00, 0x07, 0x80, 0x00,
       0x0a, 0x00, 0x00, 0x0d, 0x00, 0x12, 0x01, 0x81, 0x22, 0x01, 0x01,
       0x25, 0x09, 0x08, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74};
+
+  const uint8_t ue_pdu_session_est_req_no_dnn_no_slice_hexbuf[67] = {
+      0x7e, 0x00, 0x67, 0x01, 0x00, 0x3a, 0x2e, 0x01, 0x01, 0xc1, 0x00, 0x00,
+      0x91, 0x28, 0x01, 0x00, 0x7b, 0x00, 0x2d, 0x80, 0x80, 0x21, 0x10, 0x01,
+      0x00, 0x00, 0x10, 0x81, 0x06, 0x00, 0x00, 0x00, 0x00, 0x83, 0x06, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x05, 0x00,
+      0x00, 0x10, 0x00, 0x00, 0x11, 0x00, 0x00, 0x17, 0x01, 0x01, 0x00, 0x23,
+      0x00, 0x00, 0x24, 0x00, 0x12, 0x01, 0x81};
 
   const uint8_t ue_pdu_session_v6_est_req_hexbuf[44] = {
       0x7e, 0x00, 0x67, 0x01, 0x00, 0x15, 0x2e, 0x01, 0x01, 0xc1, 0xff,
@@ -168,6 +219,12 @@ class AMFAppProcedureTest : public ::testing::Test {
       0xff, 0xff, 0xff, 0xff,
       // Uplink data status and pdu session status
       0x40, 0x02, 0x20, 0x00, 0x50, 0x02, 0x20, 0x00};
+
+  const uint8_t initial_ue_msg_service_request_signaling[40] = {
+      0x7e, 0x01, 0x30, 0x6f, 0xf2, 0xae, 0x03, 0x7e, 0x00, 0x4c,
+      0x00, 0x00, 0x07, 0xf4, 0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b,
+      0x71, 0x00, 0x11, 0x7e, 0x00, 0x4c, 0x00, 0x00, 0x07, 0xf4,
+      0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b, 0x50, 0x02, 0x20, 0x00};
 };
 
 amf_context_t* get_amf_context_by_ueid(amf_ue_ngap_id_t ue_id) {
@@ -182,6 +239,31 @@ amf_context_t* get_amf_context_by_ueid(amf_ue_ngap_id_t ue_id) {
   amf_context_t* amf_ctx = &ue_m5gmm_context->amf_context;
 
   return amf_ctx;
+}
+
+bool validate_identification_procedure(amf_ue_ngap_id_t ue_id,
+                                       uint32_t expected_retransmission_count) {
+  amf_context_t* amf_ctx = get_amf_context_by_ueid(ue_id);
+  if (amf_ctx == NULL) {
+    return false;
+  }
+
+  /* Fetch security mode control procedure */
+  nas_amf_ident_proc_t* ident_proc =
+      get_5g_nas_common_procedure_identification(amf_ctx);
+  if (ident_proc == NULL) {
+    return false;
+  }
+
+  if (ident_proc->retransmission_count != expected_retransmission_count) {
+    return false;
+  }
+
+  if (ident_proc->ue_id != ue_id) {
+    return false;
+  }
+
+  return true;
 }
 
 bool validate_auth_procedure(amf_ue_ngap_id_t ue_id,
@@ -400,7 +482,246 @@ TEST_F(AMFAppProcedureTest, TestDeRegistration) {
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
 }
 
+TEST_F(AMFAppProcedureTest, TestRegistrationProcGutiBased) {
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
+      NGAP_NAS_DL_DATA_REQ,  // Security Command Mode Request to UE
+      NGAP_NAS_DL_DATA_REQ,
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
+      NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
+  };
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  uint32_t m_tmsi = 0x12704177;
+  ue_id = send_initial_ue_message_with_tmsi(
+      amf_app_desc_p, 36, 1, 1, 0, plmn, m_tmsi, guti_initial_ue_message_hexbuf,
+      sizeof(guti_initial_ue_message_hexbuf));
+
+  EXPECT_TRUE(validate_identification_procedure(ue_id, 0));
+
+  int rc = RETURNok;
+  rc = send_uplink_nas_identity_response_message(amf_app_desc_p, ue_id, plmn,
+                                                 identity_response,
+                                                 sizeof(identity_response));
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  ASSERT_NE(ue_context_p, nullptr);
+  EXPECT_TRUE(ue_context_p->amf_context.imsi64 == stoul(imsi));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Validate if authentication procedure is initialized as expected */
+  EXPECT_TRUE(validate_auth_procedure(ue_id, 0));
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Check whether security mode procedure is initiated */
+  EXPECT_TRUE(validate_smc_procedure(ue_id, 0));
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  amf_app_handle_deregistration_req(ue_id);
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
+TEST_F(AMFAppProcedureTest, TestMobileUpdatingRegistrationProcGutiBased) {
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
+      NGAP_NAS_DL_DATA_REQ,  // Security Command Mode Request to UE
+      NGAP_NAS_DL_DATA_REQ,
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
+      NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
+  };
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  uint32_t m_tmsi = 0x8f719f0e;
+  ue_id = send_initial_ue_message_with_tmsi(
+      amf_app_desc_p, 36, 1, 1, 0, plmn, m_tmsi, mu_initial_ue_message_hexbuf,
+      sizeof(mu_initial_ue_message_hexbuf));
+
+  EXPECT_TRUE(validate_identification_procedure(ue_id, 0));
+
+  int rc = RETURNok;
+  rc = send_uplink_nas_identity_response_message(amf_app_desc_p, ue_id, plmn,
+                                                 identity_response,
+                                                 sizeof(identity_response));
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  ASSERT_NE(ue_context_p, nullptr);
+  EXPECT_TRUE(ue_context_p->amf_context.imsi64 == stoul(imsi));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Validate if authentication procedure is initialized as expected */
+  EXPECT_TRUE(validate_auth_procedure(ue_id, 0));
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Check whether security mode procedure is initiated */
+  EXPECT_TRUE(validate_smc_procedure(ue_id, 0));
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  amf_app_handle_deregistration_req(ue_id);
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
 TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
+      NGAP_NAS_DL_DATA_REQ,            // Security Command Mode Request to UE
+      NGAP_INITIAL_CONTEXT_SETUP_REQ,  // Initial Conext Setup Request to UE &
+                                       // Registration Accept
+      NGAP_PDUSESSION_RESOURCE_SETUP_REQ,  // PDU Resource Setup Request to GNB
+                                           // & PDU Session Establishment Accept
+      NGAP_PDUSESSIONRESOURCE_REL_REQ,  // PDU Session Resource Release Command
+      NGAP_NAS_DL_DATA_REQ,             // Deregistaration Accept
+      NGAP_UE_CONTEXT_RELEASE_COMMAND   // UEContextReleaseCommand
+  };
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn,
+                                           initial_ue_message_hexbuf,
+                                           sizeof(initial_ue_message_hexbuf));
+
+  /* Check if UE Context is created with correct imsi */
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for pdu session establishment request from UE */
+  rc = send_uplink_nas_pdu_session_establishment_request(
+      amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
+      sizeof(ue_pdu_session_est_req_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send ip address response  from pipelined */
+  rc = send_ip_address_response_itti(IPv4);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send pdu session setup response  from smf */
+  rc = send_pdu_session_response_itti(IPv4);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send pdu resource setup response  from UE */
+  rc = send_pdu_resource_setup_response(ue_id);
+  EXPECT_TRUE(rc == RETURNok);
+
+  rc = send_pdu_notification_response();
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  ASSERT_NE(ue_context_p, nullptr);
+
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 1);
+  std::shared_ptr<smf_context_t> smf_ctxt =
+      ue_context_p->amf_context.smf_ctxt_map.begin()->second;
+
+  /* Send uplink nas message for pdu session release request from UE */
+  rc = send_uplink_nas_pdu_session_release_message(
+      amf_app_desc_p, ue_id, plmn, pdu_sess_release_hexbuf,
+      sizeof(pdu_sess_release_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for pdu session release complete from UE */
+  rc = send_uplink_nas_pdu_session_release_message(
+      amf_app_desc_p, ue_id, plmn, pdu_sess_release_complete_hexbuf,
+      sizeof(pdu_sess_release_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 0);
+
+  rc = send_pdu_notification_response();
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for deregistration complete response from UE */
+  rc = send_uplink_nas_ue_deregistration_request(
+      amf_app_desc_p, ue_id, plmn, ue_initiated_dereg_hexbuf,
+      sizeof(ue_initiated_dereg_hexbuf));
+
+  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
+TEST_F(AMFAppProcedureTest, TestPDUSessionSetupNoDnnNoSlice) {
   int rc = RETURNerror;
   amf_ue_ngap_id_t ue_id = 0;
   std::vector<MessagesIds> expected_Ids{
@@ -452,8 +773,9 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
 
   /* Send uplink nas message for pdu session establishment request from UE */
   rc = send_uplink_nas_pdu_session_establishment_request(
-      amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
-      sizeof(ue_pdu_session_est_req_hexbuf));
+      amf_app_desc_p, ue_id, plmn,
+      ue_pdu_session_est_req_no_dnn_no_slice_hexbuf,
+      sizeof(ue_pdu_session_est_req_no_dnn_no_slice_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
   /* Send ip address response  from pipelined */
@@ -1178,7 +1500,6 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
                                         AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
                                         AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
                                         NGAP_INITIAL_CONTEXT_SETUP_REQ,
-                                        NGAP_NAS_DL_DATA_REQ,
                                         NGAP_PDUSESSIONRESOURCE_REL_REQ,
                                         NGAP_NAS_DL_DATA_REQ,
                                         NGAP_UE_CONTEXT_RELEASE_COMMAND};
@@ -1245,13 +1566,19 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
 
   /*Send initial UE message Service Request with PDU*/
   imsi64 = 0;
-  imsi64 = send_initial_ue_message_service_request_with_pdu(
-      amf_app_desc_p, 36, 1, 1, ue_id, plmn,
+  imsi64 = send_initial_ue_message_service_request(
+      amf_app_desc_p, 36, 1, 2, ue_id, plmn,
       initial_ue_msg_service_request_with_pdu,
-      sizeof(initial_ue_msg_service_request_with_pdu));
+      sizeof(initial_ue_msg_service_request_with_pdu), 8);
 
   EXPECT_EQ(REGISTERED_IDLE, ue_context->mm_state);
   EXPECT_EQ(true, ue_context->pending_service_response);
+
+  // Ue id will be freshly generated
+  EXPECT_NE(ue_context->amf_ue_ngap_id, ue_id);
+
+  // Update the ue_id
+  ue_id = ue_context->amf_ue_ngap_id;
 
   /* Send pdu session setup response  from smf */
   rc = send_pdu_session_response_itti(IPv4);
@@ -1260,13 +1587,6 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
   EXPECT_EQ(false, ue_context->pending_service_response);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
-
-  /*Send Uplink NAS transport Service request with PDU*/
-  rc = send_uplink_nas_message_service_request_with_pdu(
-      amf_app_desc_p, ue_id, plmn, initial_ue_msg_service_request_with_pdu,
-      sizeof(initial_ue_msg_service_request_with_pdu));
-  EXPECT_TRUE(rc == RETURNok);
-  EXPECT_EQ(false, ue_context->pending_service_response);
 
   /* Send uplink nas message for pdu session release request from UE */
   rc = send_uplink_nas_pdu_session_release_message(
@@ -1292,4 +1612,85 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
 
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
 }
+
+TEST_F(AMFAppProcedureTest, ServiceRequestSignalling) {
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND,
+                                        AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND};
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn,
+                                           initial_ue_message_hexbuf,
+                                           sizeof(initial_ue_message_hexbuf));
+
+  /* Check if UE Context is created with correct imsi */
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /*Send UE context release request to move to idle mode*/
+  send_ue_context_release_request_message(amf_app_desc_p, 1, 1, ue_id);
+  ue_m5gmm_context_s* ue_context = nullptr;
+  ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  EXPECT_EQ(REGISTERED_IDLE, ue_context->mm_state);
+
+  /*Send initial UE message Service Request with PDU*/
+  imsi64 = 0;
+  imsi64 = send_initial_ue_message_service_request(
+      amf_app_desc_p, 36, 1, 2, ue_id, plmn,
+      initial_ue_msg_service_request_signaling,
+      sizeof(initial_ue_msg_service_request_signaling), 4);
+
+  EXPECT_EQ(REGISTERED_CONNECTED, ue_context->mm_state);
+
+  // Ue id will be freshly generated
+  EXPECT_NE(ue_context->amf_ue_ngap_id, ue_id);
+
+  // Update the ue_id
+  ue_id = ue_context->amf_ue_ngap_id;
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for deregistration complete response from UE */
+  rc = send_uplink_nas_ue_deregistration_request(
+      amf_app_desc_p, ue_id, plmn, ue_initiated_dereg_hexbuf,
+      sizeof(ue_initiated_dereg_hexbuf));
+
+  EXPECT_TRUE(rc == RETURNok);
+
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.cpp
+++ b/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.cpp
@@ -19,7 +19,7 @@
 namespace magma5g {
 // api to mock handling of s6a_update_location_ans
 
-s6a_update_location_ans_t amf_send_s6a_ula(const std::string& imsi) {
+s6a_update_location_ans_t util_amf_send_s6a_ula(const std::string& imsi) {
   s6a_update_location_ans_t itti_msg = {};
 
   // building s6a_update_location_ans_t
@@ -41,6 +41,8 @@ s6a_update_location_ans_t amf_send_s6a_ula(const std::string& imsi) {
   itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
       .context_identifier = 0;
 
+  itti_msg.subscription_data.apn_config_profile.nb_apns = 1;
+
   memset(&itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
               .ambr.br_unit,
          0, sizeof(apn_ambr_bitrate_unit_t));
@@ -60,6 +62,18 @@ s6a_update_location_ans_t amf_send_s6a_ula(const std::string& imsi) {
       strlen("internet") + 1,
       sizeof(itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
                  .service_selection_length));
+
+  itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+      .subscribed_qos.qci = 8;
+  itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+      .subscribed_qos.allocation_retention_priority.priority_level = 8;
+  itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+      .subscribed_qos.allocation_retention_priority.pre_emp_vulnerability =
+      static_cast<pre_emption_vulnerability_t>(
+          PRE_EMPTION_VULNERABILITY_ENABLED);
+  itti_msg.subscription_data.apn_config_profile.apn_configuration[0]
+      .subscribed_qos.allocation_retention_priority.pre_emp_capability =
+      static_cast<pre_emption_capability_t>(PRE_EMPTION_CAPABILITY_ENABLED);
 
   return itti_msg;
 }

--- a/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h
+++ b/lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h
@@ -18,6 +18,6 @@
 namespace magma5g {
 // api to mock handling s6a_update_location_ans
 
-s6a_update_location_ans_t amf_send_s6a_ula(const std::string& imsi);
+s6a_update_location_ans_t util_amf_send_s6a_ula(const std::string& imsi);
 
 }  // namespace magma5g


### PR DESCRIPTION
Signed-off-by: LKishor123 <laawanya.kishor@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
1. Fix for handling the PCO options when both IPCP and DNS request is coming.
-  Existing change assumed either IPCP or DNS will come but not both. With real UE both options were
   coming and hence code needs to handle both and provide appropriate response. 
   Changes are done in `sm_process_pco_request` to parse the option and adjust length accordingly (Issue: [#11538](https://github.com/magma/magma/issues/11538))

2. Added the code for handling the mobile updating scenario for initial registration.
-  Mobile Updating scenario was not handled correctly in the code. When the GNB gets restarted due to some reason
   UE can send Mobile Updating also. Code changes done in `amf_handle_registration_request` to handle
   the Mobile Updating option

3. Selecting default slice information update in PDU Session Establishment request if not received in PDU Session Establishment accept.
-  In PDU Session Establishment Req, UE might not send any slice information. In such case AMF needs to get the default slice
   and put it in the PDU Session Establishment Accept message. Changes are done in `amf_app_handle_pdu_session_accept`
   to get the slice information using `amf_config_get_default_slice_config`.

4. The QoS management in amf_app_handle_pdu_session_accept
- Buffer management for QoS contents was not consistent. Simplified the buffer management changes for pdu session accept 

5. Added the unit testcases for Guti registration and mobile updating based registration.
-  Following unit testcases are added for sanity check
     - Guti Registration is working as expected : TestRegistrationProcGutiBased (added)
     - S6aUpdate location response emulated for covering DNN scenarion : TestPDUSessionSetup (modified)
     - Changes to cover slice missing in PDU session request : TestPDUSessionSetupNoDnnNoSlice (added)
     - Additional UT for handling Service Request for signalling : ServiceRequestSignalling
 
6. Changes in ngap_handle_conn_est_cnf : Minor re-alignment to put sequence of ie in ICS according to 3gpp spec

<!-- Enumerate changes you made and why you made them -->

## Test Plan

**Unit testing**
  1. For multiple DNS option in  PCO  
      - unit tested added : TestPDUSessionSetupNoDnnNoSlice
      - Pcap snapshot from real equipment testing : 

<img width="960" alt="Multiple-DNS-Option-PCO-Session-Accept" src="https://user-images.githubusercontent.com/52399057/155876862-9893f1fc-1002-479a-9c4f-dd57726ec602.png">

      
  2. For Mobile Updating
      - Added a unit testcase  TestMobileUpdatingRegistrationProcGutiBased
  
  3. For default slice related
      - Unit testcase added : TestPDUSessionSetupNoDnnNoSlice
      - Pcap snapshot from real equipment testing
      
<img width="957" alt="Default-Slice-Info-Added" src="https://user-images.githubusercontent.com/52399057/155876920-dcbc9526-dd31-4ae9-bea9-9245ab1b3523.png">

  
  4. For QoS buffer update
      - Existing Unit testcase TestPDUSessionSetup updated having default ambr values
      - Pcap snapshot from real equipment
      
<img width="960" alt="QoS-Buffer-Update-Logs" src="https://user-images.githubusercontent.com/52399057/155876949-71086bca-472f-4f27-96a2-bc02fa7d63d4.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
