### PR TITLE
fix(sessiond): Generalizing the behavior for enable5g_features flags …

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -194,6 +194,8 @@ ovs_internal_conntrack_port_number: 15579
 ovs_internal_conntrack_fwd_tbl_number: 202
 
 # For 5G Functionality Support flag
+# Commenting local config parameter for enable5g_features to give
+# precedence to Orc8r streamed config parameter in gateway.mcofnig file
 # enable5g_features: false
 
 upf_node_identifier: 192.168.200.1

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -194,7 +194,7 @@ ovs_internal_conntrack_port_number: 15579
 ovs_internal_conntrack_fwd_tbl_number: 202
 
 # For 5G Functionality Support flag
-enable5g_features: false
+# enable5g_features: false
 
 upf_node_identifier: 192.168.200.1
 

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -52,6 +52,8 @@ sessions_table: sessiond:sessions
 
 # Set to true if converged access set message support is required or 5g access
 # support is required
+# Commenting local config parameter for enable5g_features to give precedence
+# to Orc8r streamed config parameter in gateway.mcofnig file
 # enable5g_features: false
 
 # Sets the amount of octets that will be requested on the CCR-I for credit if

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -52,7 +52,7 @@ sessions_table: sessiond:sessions
 
 # Set to true if converged access set message support is required or 5g access
 # support is required
-enable5g_features: false
+# enable5g_features: false
 
 # Sets the amount of octets that will be requested on the CCR-I for credit if
 # credit is given. If unset, defaults to 10Mb


### PR DESCRIPTION


Signed-off-by: khansiddiquekc <khan.siddique@wavelabs.in>



## Summary
enable5g_features: false in yml files to be commented out in all modules.
By default orc8r should drive the behavior.

The behavior can be over-ridden by configurations in local yaml files.

So as part of this task :

Comment enable5g_features flag from all yaml files.
Ensure orc8r is dictating the behavior.
To override local yaml can be used.


## Test Plan
1) Tested with stub CLI `smf_upf_integration_cli.py` with swagger UI.


## Additional Information
1) corresponding Zenhub task is #11363 
2) Please find the logs in the following comment session.

