### PR TITLE
chore: testonly attribute is added to some python bazel targets

### DIFF
--- a/lte/gateway/python/magma/policydb/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/tests/BUILD.bazel
@@ -45,5 +45,6 @@ pytest_test(
 
 py_library(
     name = "mock_stubs",
+    testonly = True,
     srcs = ["mock_stubs.py"],
 )

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/BUILD.bazel
@@ -94,5 +94,6 @@ pytest_test(
 
 py_library(
     name = "common",
+    testonly = True,
     srcs = ["common.py"],
 )


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- `testonly = True` attribute is added to some python bazel targets that are only needed for tests
- Cf. #11743 

## Test Plan

- `bazel build //lte/gateway/python/... //orc8r/gateway/python/...`
- `bazel test //lte/gateway/python/... //orc8r/gateway/python/...`
- `bazel run //:buildifier`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
