### PR TITLE
fix(orc8r): Rename lib_errors to lib_merrors

### DIFF
--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
@@ -37,7 +37,7 @@ import (
 	orc8rModels "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/cwf/cloud/go/services/cwf/obsidian/models/conversion.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/conversion.go
@@ -31,7 +31,7 @@ import (
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/handlers"
 	orc8rModels "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func (m *CwfNetwork) GetEmptyNetwork() handlers.NetworkModel {

--- a/cwf/cloud/go/services/cwf/servicers/protected/builder_servicer.go
+++ b/cwf/cloud/go/services/cwf/servicers/protected/builder_servicer.go
@@ -31,7 +31,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	orc8r_mconfig "magma/orc8r/lib/go/protos/mconfig"
 )

--- a/dp/cloud/go/services/dp/obsidian/handlers/handlers.go
+++ b/dp/cloud/go/services/dp/obsidian/handlers/handlers.go
@@ -31,7 +31,7 @@ import (
 	dp_service "magma/dp/cloud/go/services/dp"
 	"magma/dp/cloud/go/services/dp/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/registry"
 )
 

--- a/dp/cloud/go/services/dp/servicers/cbsd_manager.go
+++ b/dp/cloud/go/services/dp/servicers/cbsd_manager.go
@@ -25,7 +25,7 @@ import (
 	"magma/dp/cloud/go/services/dp/storage"
 	"magma/dp/cloud/go/services/dp/storage/db"
 	"magma/orc8r/cloud/go/clock"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 type cbsdManager struct {

--- a/dp/cloud/go/services/dp/servicers/cbsd_manager_test.go
+++ b/dp/cloud/go/services/dp/servicers/cbsd_manager_test.go
@@ -28,7 +28,7 @@ import (
 	"magma/dp/cloud/go/services/dp/storage"
 	"magma/dp/cloud/go/services/dp/storage/db"
 	"magma/orc8r/cloud/go/clock"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func TestCbsdManager(t *testing.T) {

--- a/dp/cloud/go/services/dp/storage/cbsd_manager.go
+++ b/dp/cloud/go/services/dp/storage/cbsd_manager.go
@@ -20,7 +20,7 @@ import (
 
 	"magma/dp/cloud/go/services/dp/storage/db"
 	"magma/orc8r/cloud/go/sqorc"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 type CbsdManager interface {

--- a/dp/cloud/go/services/dp/storage/cbsd_manager_test.go
+++ b/dp/cloud/go/services/dp/storage/cbsd_manager_test.go
@@ -24,7 +24,7 @@ import (
 	"magma/dp/cloud/go/services/dp/storage/db"
 	"magma/dp/cloud/go/services/dp/storage/dbtest"
 	"magma/orc8r/cloud/go/sqorc"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func TestCbsdManager(t *testing.T) {

--- a/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
+++ b/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testcontroller
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
+	"magma/fbinternal/cloud/go/services/testcontroller/protos"
+	"magma/fbinternal/cloud/go/services/testcontroller/statemachines"
+	"magma/fbinternal/cloud/go/services/testcontroller/storage"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/lib/go/merrors"
+	"magma/orc8r/lib/go/registry"
+)
+
+// UnmarshalledTestCase encapsulates a TestCase and the unmarshaled
+// representation of its TestConfig field.
+type UnmarshalledTestCase struct {
+	*storage.TestCase
+	UnmarshaledConfig interface{}
+}
+
+func getE2EClient() (protos.TestControllerClient, error) {
+	conn, err := registry.GetConnection(ServiceName)
+	if err != nil {
+		initErr := merrors.NewInitError(err, ServiceName)
+		glog.Error(initErr)
+		return nil, initErr
+	}
+	return protos.NewTestControllerClient(conn), nil
+}
+
+func ExecuteNextTestCase(testMachines map[string]statemachines.TestMachine, store storage.TestControllerStorage, serdes serde.Registry) error {
+	tc, err := store.GetNextTestForExecution()
+	if err != nil {
+		return err
+	}
+	if tc == nil {
+		return nil
+	}
+
+	machine, ok := testMachines[tc.TestCaseType]
+	if !ok {
+		return errors.Errorf("no test state machine found matching %s", tc.TestCaseType)
+	}
+	unmarshalledConfig, err := serde.Deserialize(tc.TestConfig, tc.TestCaseType, serdes)
+	if err != nil {
+		return errors.Wrapf(err, "could not deserialize test %s config", tc.TestCaseType)
+	}
+	var prevErr error
+	if tc.Error != "" {
+		prevErr = errors.New(tc.Error)
+	}
+
+	nextState, nextDuration, err := machine.Run(tc.State, unmarshalledConfig, prevErr)
+	var newErr *string
+	if err != nil {
+		newErr = strPtr(err.Error())
+	}
+	err = store.ReleaseTest(tc.Pk, nextState, newErr, nextDuration)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func GetTestCases(ctx context.Context, pks []int64, serdes serde.Registry) (map[int64]*UnmarshalledTestCase, error) {
+	client, err := getE2EClient()
+	if err != nil {
+		return nil, err
+	}
+	res, err := client.GetTestCases(ctx, &protos.GetTestCasesRequest{Pks: pks})
+	if err != nil {
+		return nil, err
+	}
+
+	ret := map[int64]*UnmarshalledTestCase{}
+	for pk, tc := range res.Tests {
+		unmarshalledConfig, err := serde.Deserialize(tc.TestConfig, tc.TestCaseType, serdes)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to deserialize test case of type %s", tc.TestCaseType)
+		}
+		ret[pk] = &UnmarshalledTestCase{
+			TestCase:          tc,
+			UnmarshaledConfig: unmarshalledConfig,
+		}
+	}
+	return ret, nil
+}
+
+func CreateOrUpdateTestCase(ctx context.Context, pk int64, testCaseType string, testCaseConfig interface{}, serdes serde.Registry) error {
+	marshaledConfig, err := serde.Serialize(testCaseConfig, testCaseType, serdes)
+	if err != nil {
+		return errors.Wrap(err, "failed to serialize config")
+	}
+
+	client, err := getE2EClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.CreateOrUpdateTestCase(
+		ctx,
+		&protos.CreateTestCaseRequest{
+			Test: &storage.MutableTestCase{
+				Pk:           pk,
+				TestCaseType: testCaseType,
+				TestConfig:   marshaledConfig,
+			},
+		},
+	)
+	return err
+}
+
+func DeleteTestCase(pk int64) error {
+	client, err := getE2EClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.DeleteTestCase(context.Background(), &protos.DeleteTestCaseRequest{Pk: pk})
+	return err
+}

--- a/fbinternal/cloud/go/services/testcontroller/node_client_api.go
+++ b/fbinternal/cloud/go/services/testcontroller/node_client_api.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testcontroller
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/ptypes/wrappers"
+
+	"magma/fbinternal/cloud/go/services/testcontroller/protos"
+	"magma/fbinternal/cloud/go/services/testcontroller/storage"
+	"magma/orc8r/lib/go/merrors"
+	"magma/orc8r/lib/go/registry"
+)
+
+func getNodeClient() (protos.NodeLeasorClient, error) {
+	conn, err := registry.GetConnection(ServiceName)
+	if err != nil {
+		initErr := merrors.NewInitError(err, ServiceName)
+		glog.Error(initErr)
+		return nil, initErr
+	}
+	return protos.NewNodeLeasorClient(conn), nil
+}
+
+func GetNodes(ctx context.Context, ids []string, tag *string) (map[string]*storage.CINode, error) {
+	client, err := getNodeClient()
+	if err != nil {
+		return nil, err
+	}
+	res, err := client.GetNodes(ctx, &protos.GetNodesRequest{Ids: ids, Tag: asStringValue(tag)})
+	if err != nil {
+		return nil, err
+	}
+	return res.Nodes, nil
+}
+
+func CreateOrUpdateNode(ctx context.Context, node *storage.MutableCINode) error {
+	client, err := getNodeClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.CreateOrUpdateNode(ctx, &protos.CreateOrUpdateNodeRequest{Node: node})
+	return err
+}
+
+func DeleteNode(ctx context.Context, id string) error {
+	client, err := getNodeClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.DeleteNode(ctx, &protos.DeleteNodeRequest{Id: id})
+	return err
+}
+
+func ReserveNode(ctx context.Context, id string) (*storage.NodeLease, error) {
+	client, err := getNodeClient()
+	if err != nil {
+		return nil, err
+	}
+	res, err := client.ReserveNode(ctx, &protos.ReserveNodeRequest{Id: id})
+	if err != nil {
+		return nil, err
+	}
+	return res.Lease, nil
+}
+
+func LeaseNode(ctx context.Context, tag string) (*storage.NodeLease, error) {
+	client, err := getNodeClient()
+	if err != nil {
+		return nil, err
+	}
+	res, err := client.LeaseNode(ctx, &protos.LeaseNodeRequest{Tag: tag})
+	if err != nil {
+		return nil, err
+	}
+	return res.Lease, nil
+}
+
+func ReleaseNode(ctx context.Context, id string, leaseID string) error {
+	client, err := getNodeClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.ReleaseNode(ctx, &protos.ReleaseNodeRequest{NodeID: id, LeaseID: leaseID})
+	return err
+}
+
+func asStringValue(s *string) *wrappers.StringValue {
+	if s == nil {
+		return nil
+	}
+	return &wrappers.StringValue{Value: *s}
+}

--- a/fbinternal/cloud/go/services/vpnservice/client_api.go
+++ b/fbinternal/cloud/go/services/vpnservice/client_api.go
@@ -1,0 +1,59 @@
+package vpnservice
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+
+	fbprotos "magma/fbinternal/cloud/go/protos"
+	"magma/orc8r/lib/go/merrors"
+	"magma/orc8r/lib/go/protos"
+	"magma/orc8r/lib/go/registry"
+)
+
+const ServiceName = "VPNSERVICE"
+
+// Utility function to get a RPC connection to the VPN service
+func getVPNServiceClient() (fbprotos.VPNServiceClient, error) {
+	conn, err := registry.GetConnection(ServiceName)
+	if err != nil {
+		initErr := merrors.NewInitError(err, ServiceName)
+		glog.Error(initErr)
+		return nil, initErr
+	}
+
+	return fbprotos.NewVPNServiceClient(conn), err
+}
+
+// Get the VPN CA certificate
+func GetVPNCA(ctx context.Context) (cert []byte, err error) {
+	client, err := getVPNServiceClient()
+	if err != nil {
+		return nil, err
+	}
+
+	caMsg, err := client.GetCA(ctx, &protos.Void{})
+	if err != nil {
+		glog.Errorf("Failed to get VPN CA: %s", err)
+		return nil, err
+	}
+
+	return caMsg.Cert, nil
+}
+
+// Return a certificate signed by the VPN CA, with serial number.
+// CSR is in ASN.1 DER encoding.
+func RequestSignedCert(ctx context.Context, csr []byte) (sn string, cert []byte, err error) {
+	client, err := getVPNServiceClient()
+	if err != nil {
+		return "", nil, err
+	}
+
+	req := &fbprotos.VPNCertRequest{Request: csr}
+	certMsg, err := client.RequestCert(ctx, req)
+	if err != nil {
+		glog.Errorf("Failed to retrieve signed VPN cert: %s", err)
+		return "", nil, err
+	}
+	return certMsg.Serial, certMsg.Cert, nil
+}

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
@@ -32,7 +32,7 @@ import (
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/handlers"
 	orc8rModels "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/feg/cloud/go/services/feg/obsidian/models/conversion.go
+++ b/feg/cloud/go/services/feg/obsidian/models/conversion.go
@@ -32,7 +32,7 @@ import (
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/handlers"
 	orc8rModels "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/feg/cloud/go/services/feg/servicers/protected/builder_servicer.go
+++ b/feg/cloud/go/services/feg/servicers/protected/builder_servicer.go
@@ -28,7 +28,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/feg/cloud/go/services/feg_relay/servicers/southbound/cancel_location.go
+++ b/feg/cloud/go/services/feg_relay/servicers/southbound/cancel_location.go
@@ -19,7 +19,7 @@ import (
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 // CancelLocation relays the CancelLocationRequest to a corresponding
@@ -44,7 +44,7 @@ func (srv *FegToGwRelayServer) CancelLocationUnverified(
 	hwId, err := getHwIDFromIMSI(ctx, req.UserName)
 	if err != nil {
 		fmt.Printf("unable to get HwID from IMSI %v. err: %v", req.UserName, err)
-		if _, ok := err.(errors.ClientInitError); ok {
+		if _, ok := err.(merrors.ClientInitError); ok {
 			return &fegprotos.CancelLocationAnswer{ErrorCode: fegprotos.ErrorCode_UNABLE_TO_DELIVER}, nil
 		}
 		return &fegprotos.CancelLocationAnswer{ErrorCode: fegprotos.ErrorCode_USER_UNKNOWN}, nil

--- a/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
+++ b/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
@@ -30,7 +30,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/device"
 	orc8rModels "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/feg/cloud/go/services/health/client_api.go
+++ b/feg/cloud/go/services/health/client_api.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/glog"
 
 	"magma/feg/cloud/go/protos"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/registry"
 )
 
@@ -32,7 +32,7 @@ import (
 func getHealthClient() (protos.HealthClient, error) {
 	conn, err := registry.GetConnection(ServiceName)
 	if err != nil {
-		initErr := errors.NewInitError(err, ServiceName)
+		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
 		return nil, initErr
 	}

--- a/feg/gateway/service_health/client_api.go
+++ b/feg/gateway/service_health/client_api.go
@@ -22,7 +22,7 @@ import (
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	orcprotos "magma/orc8r/lib/go/protos"
 )
 
@@ -31,7 +31,7 @@ import (
 func getClient(service string) (protos.ServiceHealthClient, error) {
 	conn, err := registry.GetConnection(service)
 	if err != nil {
-		initErr := errors.NewInitError(err, service)
+		initErr := merrors.NewInitError(err, service)
 		glog.Error(initErr)
 		return nil, initErr
 	}

--- a/feg/gateway/services/aaa/base_acct/client_api.go
+++ b/feg/gateway/services/aaa/base_acct/client_api.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc"
 
 	"magma/feg/cloud/go/protos"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	platformregistry "magma/orc8r/lib/go/registry"
 )
 
@@ -39,7 +39,7 @@ func getBaseAcctClient() (protos.AccountingClient, error) {
 	)
 	conn, err = platformregistry.Get().GetSharedCloudConnection(strings.ToLower(ServiceName))
 	if err != nil {
-		initErr := errors.NewInitError(err, ServiceName)
+		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
 		return nil, initErr
 	}

--- a/feg/gateway/services/gateway_health/gateway_client_api.go
+++ b/feg/gateway/services/gateway_health/gateway_client_api.go
@@ -25,7 +25,7 @@ import (
 
 	"magma/feg/cloud/go/protos"
 	"magma/gateway/service_registry"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 // getHealthClient is a utility function to get an RPC connection to the
@@ -36,7 +36,7 @@ func getHealthClient(cloudRegistry service_registry.GatewayRegistry) (protos.Hea
 	}
 	conn, err := cloudRegistry.GetCloudConnection("HEALTH")
 	if err != nil {
-		initErr := errors.NewInitError(err, "HEALTH")
+		initErr := merrors.NewInitError(err, "HEALTH")
 		glog.Error(initErr)
 		return nil, nil, initErr
 	}

--- a/feg/gateway/services/session_proxy/servicers/multiple_session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/multiple_session_controller.go
@@ -26,7 +26,7 @@ import (
 	"magma/feg/gateway/services/session_proxy/credit_control/gx"
 	"magma/feg/gateway/services/session_proxy/credit_control/gy"
 	"magma/lte/cloud/go/protos"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	orcprotos "magma/orc8r/lib/go/protos"
 )
 
@@ -219,7 +219,7 @@ func (srv *CentralSessionControllers) Enable(
 	ctx context.Context,
 	void *orcprotos.Void,
 ) (*orcprotos.Void, error) {
-	multiError := errors.NewMulti()
+	multiError := merrors.NewMulti()
 	for i, controller := range srv.centralControllers {
 		_, err := controller.Enable(ctx, void)
 		multiError = multiError.AddFmt(err, "error(%d):", i+1)

--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -30,7 +30,7 @@ import (
 	"magma/feg/gateway/services/session_proxy/credit_control/gy"
 	"magma/feg/gateway/services/session_proxy/metrics"
 	"magma/lte/cloud/go/protos"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	orcprotos "magma/orc8r/lib/go/protos"
 )
 
@@ -339,7 +339,7 @@ func (srv *CentralSessionController) Enable(
 	ctx context.Context,
 	void *orcprotos.Void,
 ) (*orcprotos.Void, error) {
-	multiError := errors.NewMulti()
+	multiError := merrors.NewMulti()
 	if !srv.cfg.DisableGx {
 		err := srv.policyClient.EnableConnections()
 		if err != nil {

--- a/feg/gateway/services/swx_proxy/servicers/multiple_swx_proxy.go
+++ b/feg/gateway/services/swx_proxy/servicers/multiple_swx_proxy.go
@@ -19,7 +19,7 @@ import (
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/multiplex"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	orcprotos "magma/orc8r/lib/go/protos"
 )
 
@@ -129,7 +129,7 @@ func (s *SwxProxies) Disable(ctx context.Context, req *fegprotos.DisableMessage)
 
 // Calls Enable on each swx proxy
 func (s *SwxProxies) Enable(ctx context.Context, req *orcprotos.Void) (*orcprotos.Void, error) {
-	multiError := errors.NewMulti()
+	multiError := merrors.NewMulti()
 	for i, proxy := range s.proxies {
 		proxy.connMan.Enable()
 		_, err := proxy.connMan.GetConnection(proxy.smClient, proxy.config.ServerCfg)

--- a/lte/cloud/go/services/lte/client_api.go
+++ b/lte/cloud/go/services/lte/client_api.go
@@ -24,7 +24,7 @@ import (
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
 	"magma/lte/cloud/go/services/lte/protos"
 	"magma/orc8r/cloud/go/serde"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/registry"
 )
 

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
@@ -34,7 +34,7 @@ import (
 	orc8r_models "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -32,7 +32,7 @@ import (
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/handlers"
 	orc8rModels "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func (m *LteNetwork) GetEmptyNetwork() handlers.NetworkModel {

--- a/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
@@ -40,7 +40,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/lte/cloud/go/services/lte/servicers/protected/lookup.go
+++ b/lte/cloud/go/services/lte/servicers/protected/lookup.go
@@ -22,7 +22,7 @@ import (
 
 	"magma/lte/cloud/go/services/lte/protos"
 	lte_storage "magma/lte/cloud/go/services/lte/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 // lookupServicer stores reported enodeb state with additional gatewayID as

--- a/lte/cloud/go/services/lte/storage/enodeb_state_lookup.go
+++ b/lte/cloud/go/services/lte/storage/enodeb_state_lookup.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 type EnodebStateLookup interface {

--- a/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
@@ -29,7 +29,7 @@ import (
 	"magma/lte/cloud/go/services/nprobe/storage"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/services/configurator"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
@@ -27,7 +27,7 @@ import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
@@ -25,7 +25,7 @@ import (
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/services/configurator"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/lte/cloud/go/services/policydb/streamer/providers.go
+++ b/lte/cloud/go/services/policydb/streamer/providers.go
@@ -28,7 +28,7 @@ import (
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/lte/cloud/go/services/subscriberdb/client_api.go
+++ b/lte/cloud/go/services/subscriberdb/client_api.go
@@ -21,7 +21,7 @@ import (
 	"github.com/thoas/go-funk"
 
 	"magma/lte/cloud/go/services/subscriberdb/protos"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/registry"
 )
 
@@ -49,7 +49,7 @@ func ListMSISDNs(ctx context.Context, networkID string) (map[string]string, erro
 }
 
 // GetIMSIForMSISDN returns the IMSI associated with the passed MSISDN.
-// If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If not found, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func GetIMSIForMSISDN(ctx context.Context, networkID, msisdn string) (string, error) {
 	client, err := getClient()
 	if err != nil {

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -41,7 +41,7 @@ import (
 	"magma/orc8r/cloud/go/services/state"
 	state_types "magma/orc8r/cloud/go/services/state/types"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/lte/cloud/go/services/subscriberdb/servicers/protected/lookup.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/protected/lookup.go
@@ -25,7 +25,7 @@ import (
 	subscriberdb_storage "magma/lte/cloud/go/services/subscriberdb/storage"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 // lookupServicer translates subscriber aliases to their IMSI.

--- a/orc8r/cloud/go/blobstore/blobstore.go
+++ b/orc8r/cloud/go/blobstore/blobstore.go
@@ -64,7 +64,7 @@ type Store interface {
 
 	// Get loads a specific blob from storage.
 	// If there is no blob matching the given ID, ErrNotFound from
-	// magma/orc8r/lib/go/errors will be returned.
+	// magma/orc8r/lib/go/merrors will be returned.
 	Get(networkID string, id storage.TK) (Blob, error)
 
 	// GetMany loads and returns a collection of blobs matching the

--- a/orc8r/cloud/go/blobstore/blobstore_integ_test.go
+++ b/orc8r/cloud/go/blobstore/blobstore_integ_test.go
@@ -22,7 +22,7 @@ import (
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
-	magmaerrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func integration(t *testing.T, fact blobstore.StoreFactory) {
@@ -36,7 +36,7 @@ func integration(t *testing.T, fact blobstore.StoreFactory) {
 	assert.Empty(t, listActual)
 
 	getActual, err := store.Get("network", storage.TK{Type: "t", Key: "k"})
-	assert.True(t, err == magmaerrors.ErrNotFound)
+	assert.True(t, err == merrors.ErrNotFound)
 	assert.Equal(t, blobstore.Blob{}, getActual)
 
 	getManyActual, err := store.GetMany(

--- a/orc8r/cloud/go/blobstore/blobstore_migration_test.go
+++ b/orc8r/cloud/go/blobstore/blobstore_migration_test.go
@@ -21,7 +21,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/storage"
-	magmaerrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func TestBlobstoreImplMigrations(t *testing.T) {
@@ -135,7 +135,7 @@ func checkWriteBlobs(
 	err = store.Delete(networkID, storage.TKs{expectedBlobs[1].TK()})
 	assert.NoError(t, err)
 	_, err = store.Get(networkID, expectedBlobs[1].TK())
-	assert.Equal(t, magmaerrors.ErrNotFound, err)
+	assert.Equal(t, merrors.ErrNotFound, err)
 
 	err = store.Write(networkID, blobstore.Blobs{
 		expectedBlobs[1],
@@ -149,7 +149,7 @@ func checkWriteBlobs(
 	err = store.Delete(networkID, storage.TKs{blobNotInFact.TK()})
 	assert.NoError(t, err)
 	_, err = store.Get(networkID, blobNotInFact.TK())
-	assert.Equal(t, magmaerrors.ErrNotFound, err)
+	assert.Equal(t, merrors.ErrNotFound, err)
 
 	err = store.Commit()
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/blobstore/blobstore_sql.go
+++ b/orc8r/cloud/go/blobstore/blobstore_sql.go
@@ -26,7 +26,7 @@ import (
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/storage"
-	magmaerrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (
@@ -129,7 +129,7 @@ func (store *sqlStore) Get(networkID string, id storage.TK) (Blob, error) {
 		return Blob{}, err
 	}
 	if len(multiRet) == 0 {
-		return Blob{}, magmaerrors.ErrNotFound
+		return Blob{}, merrors.ErrNotFound
 	}
 	return multiRet[0], nil
 }

--- a/orc8r/cloud/go/blobstore/blobstore_sql_test.go
+++ b/orc8r/cloud/go/blobstore/blobstore_sql_test.go
@@ -24,7 +24,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func TestSQLStore_Get(t *testing.T) {

--- a/orc8r/cloud/go/obsidian/access/operator.go
+++ b/orc8r/cloud/go/obsidian/access/operator.go
@@ -21,7 +21,7 @@ import (
 
 	"magma/orc8r/cloud/go/identity"
 	"magma/orc8r/cloud/go/services/certifier"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 
@@ -39,7 +39,7 @@ func getOperator(req *http.Request, decorate logDecorator) (*protos.Identity, er
 	}
 	certInfo, err := certifier.GetCertificateIdentity(req.Context(), csn)
 	if err != nil {
-		if _, ok := err.(errors.ClientInitError); ok {
+		if _, ok := err.(merrors.ClientInitError); ok {
 			glog.Error(decorate("Certificate SN '%s' lookup error '%s'", csn, err))
 			return nil, err
 		}

--- a/orc8r/cloud/go/obsidian/access/rest_middleware.go
+++ b/orc8r/cloud/go/obsidian/access/rest_middleware.go
@@ -28,7 +28,7 @@ import (
 	"magma/orc8r/cloud/go/services/certifier"
 	"magma/orc8r/cloud/go/services/certifier/constants"
 	certprotos "magma/orc8r/cloud/go/services/certifier/protos"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 var unprotectedPaths = map[string]bool{

--- a/orc8r/cloud/go/obsidian/swagger/remote_spec.go
+++ b/orc8r/cloud/go/obsidian/swagger/remote_spec.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golang/glog"
 
 	"magma/orc8r/cloud/go/obsidian/swagger/protos"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/registry"
 )
 

--- a/orc8r/cloud/go/services/accessd/client_api.go
+++ b/orc8r/cloud/go/services/accessd/client_api.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/glog"
 
 	accessprotos "magma/orc8r/cloud/go/services/accessd/protos"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
 )

--- a/orc8r/cloud/go/services/accessd/storage/storage_blobstore_test.go
+++ b/orc8r/cloud/go/services/accessd/storage/storage_blobstore_test.go
@@ -27,7 +27,7 @@ import (
 	accessprotos "magma/orc8r/cloud/go/services/accessd/protos"
 	astorage "magma/orc8r/cloud/go/services/accessd/storage"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/orc8r/cloud/go/services/bootstrapper/client_api.go
+++ b/orc8r/cloud/go/services/bootstrapper/client_api.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
 )

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/storage.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/storage.go
@@ -19,7 +19,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/services/bootstrapper"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/orc8r/cloud/go/services/certifier/client_api.go
+++ b/orc8r/cloud/go/services/certifier/client_api.go
@@ -24,7 +24,7 @@ import (
 
 	"magma/orc8r/cloud/go/clock"
 	certprotos "magma/orc8r/cloud/go/services/certifier/protos"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
 )

--- a/orc8r/cloud/go/services/certifier/servicers/protected/certifier.go
+++ b/orc8r/cloud/go/services/certifier/servicers/protected/certifier.go
@@ -36,7 +36,7 @@ import (
 	certprotos "magma/orc8r/cloud/go/services/certifier/protos"
 	"magma/orc8r/cloud/go/services/certifier/storage"
 	"magma/orc8r/cloud/go/services/tenants"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/security/cert"
 	unarylib "magma/orc8r/lib/go/service/middleware/unary"
@@ -297,7 +297,7 @@ func (srv *CertifierServer) CollectGarbageImpl(ctx context.Context) (int, error)
 	if err != nil {
 		return 0, err
 	}
-	var multiErr *errors.Multi
+	var multiErr *merrors.Multi
 	count := 0
 	for _, sn := range snList.Sns {
 		certInfo, err := srv.getCertInfo(sn)

--- a/orc8r/cloud/go/services/certifier/storage/storage.go
+++ b/orc8r/cloud/go/services/certifier/storage/storage.go
@@ -31,7 +31,7 @@ type CertificateStorage interface {
 	ListSerialNumbers() ([]string, error)
 
 	// GetCertInfo returns the certificate info associated with the serial number.
-	// If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
+	// If not found, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 	GetCertInfo(serialNumber string) (*protos.CertificateInfo, error)
 
 	// GetManyCertInfo maps the passed serial numbers to their associated certificate info.

--- a/orc8r/cloud/go/services/certifier/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/certifier/storage/storage_blobstore.go
@@ -25,7 +25,7 @@ import (
 	"magma/orc8r/cloud/go/services/certifier/constants"
 	"magma/orc8r/cloud/go/services/certifier/protos"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/orc8r/cloud/go/services/certifier/storage/storage_blobstore_test.go
+++ b/orc8r/cloud/go/services/certifier/storage/storage_blobstore_test.go
@@ -28,7 +28,7 @@ import (
 	"magma/orc8r/cloud/go/services/certifier/protos"
 	cstorage "magma/orc8r/cloud/go/services/certifier/storage"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func TestCertifierBlobstore_GetCertInfo(t *testing.T) {

--- a/orc8r/cloud/go/services/certifier/storage/storage_integ_test.go
+++ b/orc8r/cloud/go/services/certifier/storage/storage_integ_test.go
@@ -25,7 +25,7 @@ import (
 	"magma/orc8r/cloud/go/services/certifier/protos"
 	"magma/orc8r/cloud/go/services/certifier/storage"
 	"magma/orc8r/cloud/go/sqorc"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func TestCertifierStorageBlobstore_Integation(t *testing.T) {

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -25,7 +25,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator/protos"
 	"magma/orc8r/cloud/go/services/configurator/storage"
 	storage2 "magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	commonProtos "magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
 )
@@ -218,7 +218,7 @@ func LoadNetworksOfType(ctx context.Context, typeVal string, loadMetadata bool, 
 }
 
 // LoadNetwork loads the network identified by the network ID.
-// If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If not found, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func LoadNetwork(ctx context.Context, networkID string, loadMetadata bool, loadConfigs bool, serdes serde.Registry) (Network, error) {
 	networks, _, err := LoadNetworks(ctx, []string{networkID}, loadMetadata, loadConfigs, serdes)
 	if err != nil {
@@ -231,7 +231,7 @@ func LoadNetwork(ctx context.Context, networkID string, loadMetadata bool, loadC
 }
 
 // LoadNetworkConfig loads network config of type configType registered under the network ID.
-// If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If not found, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func LoadNetworkConfig(ctx context.Context, networkID, configType string, serdes serde.Registry) (interface{}, error) {
 	network, err := LoadNetwork(ctx, networkID, false, true, serdes)
 	if err != nil {
@@ -413,7 +413,7 @@ func DeleteInternalEntity(ctx context.Context, entityType, entityKey string) err
 }
 
 // GetPhysicalIDOfEntity gets the physicalID associated with the entity identified by (networkID, entityType, entityKey)
-// If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If not found, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func GetPhysicalIDOfEntity(ctx context.Context, networkID, entityType, entityKey string) (string, error) {
 	entity, err := LoadSerializedEntity(ctx, networkID, entityType, entityKey, EntityLoadCriteria{})
 	if err != nil {
@@ -457,7 +457,7 @@ func ListInternalEntityKeys(ctx context.Context, entityType string) ([]string, e
 }
 
 // LoadEntity loads the network entity identified by (network ID, entity type, entity key).
-// If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If not found, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func LoadEntity(ctx context.Context, networkID string, entityType string, entityKey string, criteria EntityLoadCriteria, serdes serde.Registry) (NetworkEntity, error) {
 	ret := NetworkEntity{}
 	loaded, notFound, err := LoadEntities(
@@ -478,7 +478,7 @@ func LoadEntity(ctx context.Context, networkID string, entityType string, entity
 }
 
 // LoadEntityConfig loads the config for the entity identified by (network ID, entity type, entity key).
-// If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If not found, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func LoadEntityConfig(ctx context.Context, networkID, entityType, entityKey string, serdes serde.Registry) (interface{}, error) {
 	entity, err := LoadEntity(ctx, networkID, entityType, entityKey, EntityLoadCriteria{LoadConfig: true}, serdes)
 	if err != nil {
@@ -491,7 +491,7 @@ func LoadEntityConfig(ctx context.Context, networkID, entityType, entityKey stri
 }
 
 // LoadEntityForPhysicalID loads the network entity identified by the physical ID.
-// If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If not found, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func LoadEntityForPhysicalID(ctx context.Context, physicalID string, criteria EntityLoadCriteria, serdes serde.Registry) (NetworkEntity, error) {
 	ret := NetworkEntity{}
 	loaded, _, err := LoadEntities(
@@ -532,7 +532,7 @@ func LoadEntities(ctx context.Context, networkID string, typeFilter *string, key
 
 // LoadSerializedEntity is same as LoadEntity, but doesn't deserialize the
 // loaded entity.
-// If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If not found, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func LoadSerializedEntity(ctx context.Context, networkID string, entityType string, entityKey string, criteria EntityLoadCriteria) (NetworkEntity, error) {
 	ret := NetworkEntity{}
 	loaded, notFound, err := LoadSerializedEntities(
@@ -605,7 +605,7 @@ func loadEntities(
 }
 
 // LoadInternalEntity calls LoadEntity with the internal network ID.
-// If not found, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If not found, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func LoadInternalEntity(ctx context.Context, entityType string, entityKey string, criteria EntityLoadCriteria, serdes serde.Registry) (NetworkEntity, error) {
 	return LoadEntity(ctx, storage.InternalNetworkID, entityType, entityKey, criteria, serdes)
 }

--- a/orc8r/cloud/go/services/configurator/graph.go
+++ b/orc8r/cloud/go/services/configurator/graph.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 // why pointer receivers here? we can cache intermediate computation steps

--- a/orc8r/cloud/go/services/configurator/mconfig/remote_builder.go
+++ b/orc8r/cloud/go/services/configurator/mconfig/remote_builder.go
@@ -21,7 +21,7 @@ import (
 
 	"magma/orc8r/cloud/go/services/configurator/mconfig/protos"
 	"magma/orc8r/cloud/go/services/configurator/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/registry"
 )
 

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/gateway_api.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/gateway_api.go
@@ -39,7 +39,7 @@ func NewGwCtracedClient() GwCtracedClient {
 }
 
 // getGWCtracedClient gets a GRPC client to the ctraced service running on the gateway specified by (network ID, gateway ID).
-// If gateway not found by configurator, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If gateway not found by configurator, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func getGWCtracedClient(ctx context.Context, networkID string, gatewayID string) (protos.CallTraceServiceClient, context.Context, error) {
 	hwID, err := configurator.GetPhysicalIDOfEntity(ctx, networkID, orc8r.MagmadGatewayType, gatewayID)
 	if err != nil {
@@ -55,7 +55,7 @@ func getGWCtracedClient(ctx context.Context, networkID string, gatewayID string)
 }
 
 // StartCallTrace starts a call trace on the specified gateway
-// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func (c gwCtracedClientImpl) StartCallTrace(ctx context.Context, networkId string, gatewayId string, req *protos.StartTraceRequest) (*protos.StartTraceResponse, error) {
 	client, gatewayCtx, err := getGWCtracedClient(ctx, networkId, gatewayId)
 	if err != nil {
@@ -69,7 +69,7 @@ func (c gwCtracedClientImpl) StartCallTrace(ctx context.Context, networkId strin
 }
 
 // EndCallTrace ends a call trace on the specified gateway
-// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func (c gwCtracedClientImpl) EndCallTrace(ctx context.Context, networkId string, gatewayId string, req *protos.EndTraceRequest) (*protos.EndTraceResponse, error) {
 	client, gatewayCtx, err := getGWCtracedClient(ctx, networkId, gatewayId)
 	if err != nil {

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
@@ -27,7 +27,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/ctraced/obsidian/models"
 	"magma/orc8r/cloud/go/services/ctraced/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/orc8r/cloud/go/services/ctraced/servicers/southbound/trace_servicer.go
+++ b/orc8r/cloud/go/services/ctraced/servicers/southbound/trace_servicer.go
@@ -25,7 +25,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/ctraced/obsidian/models"
 	"magma/orc8r/cloud/go/services/ctraced/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
@@ -20,7 +20,7 @@ import (
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore_test.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore_test.go
@@ -24,7 +24,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore/mocks"
 	cstorage "magma/orc8r/cloud/go/services/ctraced/storage"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/orc8r/cloud/go/services/device/client_api.go
+++ b/orc8r/cloud/go/services/device/client_api.go
@@ -23,7 +23,7 @@ import (
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/device/protos"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/registry"
 )
 

--- a/orc8r/cloud/go/services/directoryd/client_api.go
+++ b/orc8r/cloud/go/services/directoryd/client_api.go
@@ -25,7 +25,7 @@ import (
 	"magma/orc8r/cloud/go/services/directoryd/protos"
 	"magma/orc8r/cloud/go/services/directoryd/types"
 	"magma/orc8r/cloud/go/services/state"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/registry"
 )
 

--- a/orc8r/cloud/go/services/directoryd/servicers/protected/id_gen.go
+++ b/orc8r/cloud/go/services/directoryd/servicers/protected/id_gen.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/golang/glog"
 
-	magmaerrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (
@@ -57,7 +57,7 @@ func (g *IdGenerator) GetUniqueId(network string, doesExistFunc doesExistInDatab
 	for i := 0; i < g.maxAttempts; i++ {
 		newID := g.getRandomFromOneToMaxUint32()
 		_, err := doesExistFunc(network, fmt.Sprint(newID))
-		if err == magmaerrors.ErrNotFound {
+		if err == merrors.ErrNotFound {
 			return newID, nil
 		}
 		if err != nil {

--- a/orc8r/cloud/go/services/directoryd/servicers/protected/id_gen_test.go
+++ b/orc8r/cloud/go/services/directoryd/servicers/protected/id_gen_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	servicers "magma/orc8r/cloud/go/services/directoryd/servicers/protected"
-	magmaerrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 type MockStore struct {
@@ -41,13 +41,13 @@ func (m *MockStore) getIDOnDatabaseWithExistingMatch(networkId string, id string
 		m.previous_seen = id
 		return "hw_id_1", nil
 	}
-	return "", magmaerrors.ErrNotFound
+	return "", merrors.ErrNotFound
 }
 
 func (m *MockStore) getIDOnDatabaseNotExistingMatch(networkId string, id string) (string, error) {
 	m.Hits += 1
 	m.previous_seen = id
-	return "", magmaerrors.ErrNotFound
+	return "", merrors.ErrNotFound
 }
 
 func (m *MockStore) getIDOnDatabaseAlwaysError(networkId string, id string) (string, error) {

--- a/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
@@ -21,7 +21,7 @@ import (
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/orc8r/cloud/go/services/directoryd/storage/storage_blobstore_test.go
+++ b/orc8r/cloud/go/services/directoryd/storage/storage_blobstore_test.go
@@ -24,7 +24,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore/mocks"
 	dstorage "magma/orc8r/cloud/go/services/directoryd/storage"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (

--- a/orc8r/cloud/go/services/directoryd/storage/storage_integ_test.go
+++ b/orc8r/cloud/go/services/directoryd/storage/storage_integ_test.go
@@ -22,7 +22,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/services/directoryd/storage"
 	"magma/orc8r/cloud/go/sqorc"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func TestDirectorydStorageBlobstore_Integation(t *testing.T) {

--- a/orc8r/cloud/go/services/magmad/gateway_api.go
+++ b/orc8r/cloud/go/services/magmad/gateway_api.go
@@ -28,7 +28,7 @@ import (
 )
 
 // getGWMagmadClient gets a GRPC client to the magmad service running on the gateway specified by (network ID, gateway ID).
-// If gateway not found by configurator, returns ErrNotFound from magma/orc8r/lib/go/errors.
+//  If gateway not found by configurator, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func getGWMagmadClient(ctx context.Context, networkID string, gatewayID string) (protos.MagmadClient, context.Context, error) {
 	hwID, err := configurator.GetPhysicalIDOfEntity(ctx, networkID, orc8r.MagmadGatewayType, gatewayID)
 	if err != nil {
@@ -44,7 +44,7 @@ func getGWMagmadClient(ctx context.Context, networkID string, gatewayID string) 
 }
 
 // GatewayReboot reboots a gateway.
-// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func GatewayReboot(ctx context.Context, networkId string, gatewayId string) error {
 	client, gatewayCtx, err := getGWMagmadClient(ctx, networkId, gatewayId)
 	if err != nil {
@@ -55,7 +55,7 @@ func GatewayReboot(ctx context.Context, networkId string, gatewayId string) erro
 }
 
 // GatewayRestartServices restarts services at a gateway.
-// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func GatewayRestartServices(ctx context.Context, networkId string, gatewayId string, services []string) error {
 	client, gatewayCtx, err := getGWMagmadClient(ctx, networkId, gatewayId)
 	if err != nil {
@@ -66,7 +66,7 @@ func GatewayRestartServices(ctx context.Context, networkId string, gatewayId str
 }
 
 // GatewayPing sends pings from a gateway to a set of hosts.
-// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func GatewayPing(ctx context.Context, networkId string, gatewayId string, packets int32, hosts []string) (*protos.NetworkTestResponse, error) {
 	client, gatewayCtx, err := getGWMagmadClient(ctx, networkId, gatewayId)
 	if err != nil {
@@ -81,7 +81,7 @@ func GatewayPing(ctx context.Context, networkId string, gatewayId string, packet
 }
 
 // GatewayGenericCommand runs a generic command at a gateway.
-// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func GatewayGenericCommand(ctx context.Context, networkId string, gatewayId string, params *protos.GenericCommandParams) (*protos.GenericCommandResponse, error) {
 	client, gatewayCtx, err := getGWMagmadClient(ctx, networkId, gatewayId)
 	if err != nil {
@@ -92,7 +92,7 @@ func GatewayGenericCommand(ctx context.Context, networkId string, gatewayId stri
 }
 
 // TailGatewayLogs
-// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If gateway not registered, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func TailGatewayLogs(ctx context.Context, networkId string, gatewayId string, service string) (protos.Magmad_TailLogsClient, error) {
 	client, gatewayCtx, err := getGWMagmadClient(ctx, networkId, gatewayId)
 	if err != nil {

--- a/orc8r/cloud/go/services/metricsd/client_api.go
+++ b/orc8r/cloud/go/services/metricsd/client_api.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/golang/glog"
 
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	service_registry "magma/orc8r/lib/go/registry"
 )

--- a/orc8r/cloud/go/services/metricsd/exporters/remote_exporter.go
+++ b/orc8r/cloud/go/services/metricsd/exporters/remote_exporter.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/glog"
 
 	"magma/orc8r/cloud/go/services/metricsd/protos"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/registry"
 )
 

--- a/orc8r/cloud/go/services/orchestrator/analytics/calculations/state.go
+++ b/orc8r/cloud/go/services/orchestrator/analytics/calculations/state.go
@@ -28,7 +28,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state/wrappers"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/metrics"
 )
 

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/entity_handler_factory.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/entity_handler_factory.go
@@ -22,7 +22,7 @@ import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 // PartialEntityModel describe models that represents a portion of network
@@ -74,7 +74,7 @@ func GetPartialReadEntityHandler(path string, paramName string, model PartialEnt
 			}
 
 			err := model.FromBackendModels(c.Request().Context(), networkID, key)
-			if err == errors.ErrNotFound {
+			if err == merrors.ErrNotFound {
 				return obsidian.MakeHTTPError(err, http.StatusNotFound)
 			} else if err != nil {
 				return obsidian.MakeHTTPError(err, http.StatusInternalServerError)

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_command_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_command_handlers.go
@@ -23,7 +23,7 @@ import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/services/magmad"
 	magmadModels "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory.go
@@ -28,7 +28,7 @@ import (
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state/wrappers"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 // GatewayModel describes models that represent a certain type of gateway.

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers.go
@@ -35,7 +35,7 @@ import (
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state/wrappers"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 // MagmadEncompassingGateway represents a subtype of the Magmad gateway.

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory.go
@@ -25,7 +25,7 @@ import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 // NetworkModel describes models that represent a certain type of network.

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory_test.go
@@ -28,7 +28,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/handlers"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 type (
@@ -238,7 +238,7 @@ func TestGetDeleteNetworkConfigHandler(t *testing.T) {
 	tests.RunUnitTest(t, e, deleteTestConfig)
 
 	_, err := configurator.LoadNetworkConfig(context.Background(), networkID, "test", networkSerdes)
-	assert.EqualError(t, err, errors.ErrNotFound.Error())
+	assert.EqualError(t, err, merrors.ErrNotFound.Error())
 }
 
 func (m *ID) Validate(_ strfmt.Registry) error {

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers.go
@@ -25,7 +25,7 @@ import (
 	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func listNetworks(c echo.Context) error {

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers.go
@@ -27,7 +27,7 @@ import (
 	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func listChannelsHandler(c echo.Context) error {

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/conversion.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/conversion.go
@@ -27,7 +27,7 @@ import (
 	"magma/orc8r/cloud/go/services/bootstrapper"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func (m *Network) ToConfiguratorNetwork() configurator.Network {

--- a/orc8r/cloud/go/services/orchestrator/servicers/protected/builder_servicer.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/protected/builder_servicer.go
@@ -29,7 +29,7 @@ import (
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
 	"magma/orc8r/cloud/go/services/configurator/storage"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	mconfig_protos "magma/orc8r/lib/go/protos/mconfig"
 )

--- a/orc8r/cloud/go/services/orchestrator/servicers/protected/indexer_servicer.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/protected/indexer_servicer.go
@@ -28,7 +28,7 @@ import (
 	"magma/orc8r/cloud/go/services/state/indexer"
 	"magma/orc8r/cloud/go/services/state/protos"
 	state_types "magma/orc8r/cloud/go/services/state/types"
-	multierrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (
@@ -117,7 +117,7 @@ func setSecondaryStates(ctx context.Context, networkID string, states state_type
 	if len(sessionIDToIMSI) == 0 && len(cTeidToHwId) == 0 {
 		return stateErrors, nil
 	}
-	multiError := multierrors.NewMulti()
+	multiError := merrors.NewMulti()
 	if len(sessionIDToIMSI) != 0 {
 		err := directoryd.MapSessionIDsToIMSIs(ctx, networkID, sessionIDToIMSI)
 		multiError = multiError.AddFmt(err, "failed to update directoryd mapping of session IDs to IMSIs %+v", sessionIDToIMSI)
@@ -138,7 +138,7 @@ func setSecondaryStates(ctx context.Context, networkID string, states state_type
 // unsetSecondaryStates removes {sessionID -> IMSI} and {TEID -> HWID} mappings
 func unsetSecondaryStates(ctx context.Context, networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
 	sessionIDToIMSI, cTeidToHwId, uTeidToHwId, stateErrors := getMappings(states)
-	multiError := multierrors.NewMulti()
+	multiError := merrors.NewMulti()
 
 	err := unsetTeids(ctx, controlPlaneTeid, networkID, cTeidToHwId)
 	multiError = multiError.Add(err)

--- a/orc8r/cloud/go/services/state/client_api.go
+++ b/orc8r/cloud/go/services/state/client_api.go
@@ -21,7 +21,7 @@ import (
 
 	"magma/orc8r/cloud/go/serde"
 	state_types "magma/orc8r/cloud/go/services/state/types"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
 )

--- a/orc8r/cloud/go/services/state/indexer/reindex/queue_sql.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue_sql.go
@@ -26,7 +26,7 @@ import (
 	"magma/orc8r/cloud/go/clock"
 	"magma/orc8r/cloud/go/services/state/indexer"
 	"magma/orc8r/cloud/go/sqorc"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (
@@ -381,7 +381,7 @@ func (s *sqlJobQueue) getExistingIncompleteJobs(tx *sql.Tx) (map[string]*reindex
 	return jobs, nil
 }
 
-// If no job available, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If no job available, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func (s *sqlJobQueue) claimAvailableJob() (*reindexJob, error) {
 	txFn := func(tx *sql.Tx) (interface{}, error) {
 		now := clock.Now()
@@ -448,7 +448,7 @@ func (s *sqlJobQueue) selectAll() squirrel.SelectBuilder {
 	return s.builder.Select(idCol, fromCol, toCol, statusCol, attemptsCol, errorCol, lastChangeCol)
 }
 
-// If no job available, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If no job available, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func scanJob(rows *sql.Rows) (*reindexJob, error) {
 	jobs, err := scanJobs(rows)
 	if err != nil {

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue.go
@@ -23,7 +23,7 @@ import (
 	"magma/orc8r/cloud/go/services/state/indexer"
 	"magma/orc8r/cloud/go/services/state/indexer/metrics"
 	state_types "magma/orc8r/cloud/go/services/state/types"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/util"
 )
 
@@ -90,7 +90,7 @@ func (r *reindexerQueue) GetIndexerVersions() ([]*indexer.Versions, error) {
 	return r.queue.GetIndexerVersions()
 }
 
-// If no job available, returns ErrNotFound from magma/orc8r/lib/go/errors.
+// If no job available, returns ErrNotFound from magma/orc8r/lib/go/merrors.
 func (r *reindexerQueue) claimAndReindexOne(ctx context.Context, batches []reindexBatch) error {
 	defer TestHookReindexDone()
 

--- a/orc8r/cloud/go/services/state/indexer/remote_indexer.go
+++ b/orc8r/cloud/go/services/state/indexer/remote_indexer.go
@@ -21,7 +21,7 @@ import (
 
 	state_protos "magma/orc8r/cloud/go/services/state/protos"
 	state_types "magma/orc8r/cloud/go/services/state/types"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/registry"
 )
 

--- a/orc8r/cloud/go/services/state/metrics/gateway_status_reporter.go
+++ b/orc8r/cloud/go/services/state/metrics/gateway_status_reporter.go
@@ -24,7 +24,7 @@ import (
 	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/state/wrappers"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func PeriodicallyReportGatewayStatus(dur time.Duration) {
@@ -61,7 +61,7 @@ func reportGatewayStatus() error {
 			gatewayID := gatewayEntity.Key
 			status, err := wrappers.GetGatewayStatus(context.Background(), networkID, gatewayEntity.PhysicalID)
 			if err != nil {
-				if err != errors.ErrNotFound {
+				if err != merrors.ErrNotFound {
 					glog.Errorf("Error getting gateway state for network:%v, gateway:%v, %v", networkID, gatewayID, err)
 				}
 				continue

--- a/orc8r/cloud/go/services/state/wrappers/wrappers.go
+++ b/orc8r/cloud/go/services/state/wrappers/wrappers.go
@@ -23,7 +23,7 @@ import (
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/services/state/types"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 // GetGatewayStatus returns the status for an indicated gateway.
@@ -33,7 +33,7 @@ func GetGatewayStatus(ctx context.Context, networkID string, deviceID string) (*
 		return nil, err
 	}
 	if st.ReportedState == nil {
-		return nil, errors.ErrNotFound
+		return nil, merrors.ErrNotFound
 	}
 	return fillInGatewayStatusState(st), nil
 }

--- a/orc8r/cloud/go/services/streamer/providers/servicers/protected/remote_provider.go
+++ b/orc8r/cloud/go/services/streamer/providers/servicers/protected/remote_provider.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 
 	streamer_protos "magma/orc8r/cloud/go/services/streamer/protos"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
 )

--- a/orc8r/cloud/go/services/tenants/client_api.go
+++ b/orc8r/cloud/go/services/tenants/client_api.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	tenant_protos "magma/orc8r/cloud/go/services/tenants/protos"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	srvRegistry "magma/orc8r/lib/go/registry"
 )

--- a/orc8r/cloud/go/services/tenants/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/tenants/obsidian/handlers/handlers.go
@@ -25,7 +25,7 @@ import (
 	"magma/orc8r/cloud/go/services/tenants"
 	"magma/orc8r/cloud/go/services/tenants/obsidian/models"
 	"magma/orc8r/cloud/go/services/tenants/protos"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (
@@ -208,7 +208,7 @@ func CreateOrUpdateControlProxyHandler(c echo.Context) error {
 
 func mapErr(err error, notFoundErr error, nonNilErr error) error {
 	switch {
-	case err == errors.ErrNotFound:
+	case err == merrors.ErrNotFound:
 		return echo.NewHTTPError(http.StatusNotFound, notFoundErr)
 	case err != nil:
 		return echo.NewHTTPError(http.StatusInternalServerError, nonNilErr)

--- a/orc8r/cloud/go/services/tenants/servicers/protected/servicer.go
+++ b/orc8r/cloud/go/services/tenants/servicers/protected/servicer.go
@@ -22,7 +22,7 @@ import (
 
 	tenant_protos "magma/orc8r/cloud/go/services/tenants/protos"
 	"magma/orc8r/cloud/go/services/tenants/servicers/storage"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 
@@ -51,7 +51,7 @@ func (s *tenantsServicer) CreateTenant(c context.Context, request *tenant_protos
 	switch {
 	case err == nil:
 		return nil, status.Errorf(codes.AlreadyExists, "Tenant with Id %d already exists", request.Id)
-	case err != errors.ErrNotFound:
+	case err != merrors.ErrNotFound:
 		return nil, status.Errorf(codes.Internal, "Error getting existing tenants: %v", err)
 	}
 
@@ -88,7 +88,7 @@ func (s *tenantsServicer) SetTenant(c context.Context, request *tenant_protos.ID
 func (s *tenantsServicer) DeleteTenant(c context.Context, request *tenant_protos.GetTenantRequest) (*protos.Void, error) {
 	err := s.store.DeleteTenant(request.Id)
 	switch {
-	case err == errors.ErrNotFound:
+	case err == merrors.ErrNotFound:
 		return nil, status.Errorf(codes.NotFound, "Tenant %d not found", request.Id)
 	case err != nil:
 		return nil, status.Errorf(codes.Internal, "Error deleting tenant %d: %v", request.Id, err)
@@ -126,7 +126,7 @@ func (s *tenantsServicer) CreateOrUpdateControlProxy(c context.Context, request 
 
 func mapErrForGet(err error, id int64, getType string) error {
 	switch {
-	case err == errors.ErrNotFound:
+	case err == merrors.ErrNotFound:
 		return status.Errorf(codes.NotFound, "%s %d not found", getType, id)
 	case err != nil:
 		return status.Errorf(codes.Internal, "Error %s getting %d: %v", getType, id, err)

--- a/orc8r/cloud/go/syncstore/store_reader.go
+++ b/orc8r/cloud/go/syncstore/store_reader.go
@@ -27,7 +27,7 @@ import (
 	configurator_storage "magma/orc8r/cloud/go/services/configurator/storage"
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/storage"
-	merrors "magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/orc8r/gateway/go/directoryd/client_api.go
+++ b/orc8r/gateway/go/directoryd/client_api.go
@@ -20,10 +20,11 @@ import (
 	"strings"
 
 	"context"
+
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
 
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	platformregistry "magma/orc8r/lib/go/registry"
 	"magma/orc8r/lib/go/util"
@@ -50,7 +51,7 @@ func GetGatewayDirectorydClient() (protos.GatewayDirectoryServiceClient, error) 
 		conn, err = platformregistry.Get().GetConnection(ServiceName)
 	}
 	if err != nil {
-		initErr := errors.NewInitError(err, ServiceName)
+		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
 		return nil, initErr
 	}

--- a/orc8r/gateway/go/eventd/client_api.go
+++ b/orc8r/gateway/go/eventd/client_api.go
@@ -20,7 +20,7 @@ import (
 	"github.com/golang/glog"
 
 	"magma/gateway/mconfig"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	mcfgprotos "magma/orc8r/lib/go/protos/mconfig"
 	platformregistry "magma/orc8r/lib/go/registry"
@@ -63,7 +63,7 @@ func (v Verbosity) Log(request *protos.Event) error {
 func getEventdClient() (protos.EventServiceClient, error) {
 	conn, err := platformregistry.GetConnection(ServiceName)
 	if err != nil {
-		initErr := errors.NewInitError(err, ServiceName)
+		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
 		return nil, initErr
 	}

--- a/orc8r/gateway/go/services/magmad/service/magmad.go
+++ b/orc8r/gateway/go/services/magmad/service/magmad.go
@@ -33,7 +33,7 @@ import (
 	"magma/gateway/services/magmad/service/ping"
 	"magma/gateway/services/magmad/service_manager"
 	"magma/orc8r/lib/go/definitions"
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/service"
 )
@@ -43,7 +43,7 @@ type magmadService struct {
 }
 
 func (m *magmadService) StartServices(context.Context, *protos.Void) (*protos.Void, error) {
-	resErrs := errors.NewMulti()
+	resErrs := merrors.NewMulti()
 	sm := service_manager.Get()
 	for _, srv := range getServices() {
 		glog.Infof("Starting service '%s'", srv)
@@ -53,7 +53,7 @@ func (m *magmadService) StartServices(context.Context, *protos.Void) (*protos.Vo
 }
 
 func (m *magmadService) StopServices(context.Context, *protos.Void) (*protos.Void, error) {
-	resErrs := errors.NewMulti()
+	resErrs := merrors.NewMulti()
 	sm := service_manager.Get()
 	for _, srv := range getServices() {
 		glog.Infof("Stopping service '%s'", srv)
@@ -69,7 +69,7 @@ func (m *magmadService) Reboot(context.Context, *protos.Void) (*protos.Void, err
 }
 
 func (m *magmadService) RestartServices(context.Context, *protos.RestartServicesRequest) (*protos.Void, error) {
-	resErrs := errors.NewMulti()
+	resErrs := merrors.NewMulti()
 	sm := service_manager.Get()
 	for _, srv := range getServices() {
 		glog.Infof("Restarting service '%s'", srv)

--- a/orc8r/lib/go/merrors/client_errors.go
+++ b/orc8r/lib/go/merrors/client_errors.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package errors
+package merrors
 
 import (
 	"errors"

--- a/orc8r/lib/go/merrors/grpc_to_http.go
+++ b/orc8r/lib/go/merrors/grpc_to_http.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package errors
+package merrors
 
 import (
 	"net/http"

--- a/orc8r/lib/go/merrors/multi.go
+++ b/orc8r/lib/go/merrors/multi.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package errors
+package merrors
 
 import (
 	"bytes"

--- a/orc8r/lib/go/merrors/multi_error_test.go
+++ b/orc8r/lib/go/merrors/multi_error_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package errors_test
+package merrors_test
 
 import (
 	"fmt"
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 )
 
 func TestMultiError(t *testing.T) {
@@ -30,7 +30,7 @@ func TestMultiError(t *testing.T) {
 	if returnNilMulti().AsError() != nil {
 		t.Error("'if err == nil' check should succeed for returned MultiError")
 	}
-	me := errors.NewMulti()
+	me := merrors.NewMulti()
 	assert.Nil(t, me)
 	var e error = nil
 	me = me.Add(e)
@@ -41,25 +41,25 @@ func TestMultiError(t *testing.T) {
 	if me.AsError() != nil {
 		t.Error("'if err == nil' check should succeed for converted error")
 	}
-	me = me.Add(errors.ErrNotFound)
-	me = me.Add(errors.ErrNotFound)
+	me = me.Add(merrors.ErrNotFound)
+	me = me.Add(merrors.ErrNotFound)
 	assert.NotNil(t, me)
 	assert.NotNil(t, me.AsError())
 	assert.GreaterOrEqual(t, len(me.AsError().Error()), 20)
 	assert.Equal(t, me.AsError().Error(), me.Error())
 	assert.Equal(t, 2, len(me.Get()))
 
-	multi := returnMulti(errors.ErrNotFound, errors.ErrAlreadyExists, nil)
+	multi := returnMulti(merrors.ErrNotFound, merrors.ErrAlreadyExists, nil)
 	assert.NotNil(t, multi)
 	assert.Equal(t, 2, len(multi.Get()))
 	assert.NotEmpty(t, multi.Error())
 
-	multiErr := returnMultiError(errors.ErrNotFound, nil, errors.ErrAlreadyExists)
+	multiErr := returnMultiError(merrors.ErrNotFound, nil, merrors.ErrAlreadyExists)
 	assert.NotNil(t, multiErr)
 	assert.NotEmpty(t, multiErr.Error())
 
 	// test AddFmt
-	me = errors.NewMulti().AddFmt(fmt.Errorf("foo bar"), "Multi error has %s (%d)", "one", 1)
+	me = merrors.NewMulti().AddFmt(fmt.Errorf("foo bar"), "Multi error has %s (%d)", "one", 1)
 	assert.Len(t, me.Get(), 1)
 	assert.Equal(t, "Multi error has one (1) foo bar", me.Get()[0].Error())
 	assert.Equal(t, "Multi error has one (1) foo bar", me.Error())
@@ -68,24 +68,24 @@ func TestMultiError(t *testing.T) {
 	assert.Equal(t, "Multi error has two (2) foo bars", me.Get()[1].Error())
 	assert.Equal(t, "errors: [0: Multi error has one (1) foo bar; 1: Multi error has two (2) foo bars]", me.Error())
 
-	var nilMulti *errors.Multi
+	var nilMulti *merrors.Multi
 	nilMulti = nilMulti.AddFmt(fmt.Errorf("just an error"), "")
 	assert.NotNil(t, nilMulti)
 	assert.Error(t, nilMulti.AsError())
 }
 
 func returnNil() error {
-	return errors.NewMulti().AsError()
+	return merrors.NewMulti().AsError()
 }
 
-func returnNilMulti() *errors.Multi {
-	return errors.NewMulti()
+func returnNilMulti() *merrors.Multi {
+	return merrors.NewMulti()
 }
 
-func returnMulti(e1, e2, e3 error) *errors.Multi {
-	return errors.NewMulti(e1, e2, e3)
+func returnMulti(e1, e2, e3 error) *merrors.Multi {
+	return merrors.NewMulti(e1, e2, e3)
 }
 
 func returnMultiError(e1, e2, e3 error) error {
-	return errors.NewMulti(e1, e2, e3)
+	return merrors.NewMulti(e1, e2, e3)
 }

--- a/orc8r/lib/go/service/client/client_api.go
+++ b/orc8r/lib/go/service/client/client_api.go
@@ -15,9 +15,10 @@ package client
 
 import (
 	"context"
+
 	"github.com/golang/glog"
 
-	"magma/orc8r/lib/go/errors"
+	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
 )
@@ -25,7 +26,7 @@ import (
 func getClient(service string) (protos.Service303Client, error) {
 	conn, err := registry.GetConnection(service)
 	if err != nil {
-		initErr := errors.NewInitError(err, "SERVICE303")
+		initErr := merrors.NewInitError(err, "SERVICE303")
 		glog.Error(initErr)
 		return nil, initErr
 	}


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

fix(orc8r): Rename lib_errors to lib_merrors

## Summary

I renamed package orc8r/lib/go/errors to orc8r/lib/go/merrors and removed all the occasions where we perform that alias.

## Test Plan

ran /magma/feg/gateway/docker/ ./build.py -c and /magma/orc8r/cloud/docker/ ./build.py -c

Tihs is PR for: #9827
