### PR TITLE
chore(orc8r): add E1 to autopep8 python formatting

### DIFF
--- a/orc8r/gateway/python/magma/common/health/health_service.py
+++ b/orc8r/gateway/python/magma/common/health/health_service.py
@@ -85,8 +85,8 @@ class GenericHealthChecker:
         }
         res = {
             service_name: Errors(
-            log_level=configs[service_name].get('logLevel', 'INFO'),
-            error_count=0,
+                log_level=configs[service_name].get('logLevel', 'INFO'),
+                error_count=0,
             )
             for service_name in service_names
         }

--- a/orc8r/gateway/python/magma/common/misc_utils.py
+++ b/orc8r/gateway/python/magma/common/misc_utils.py
@@ -285,8 +285,8 @@ def call_process(cmd, callback, loop):
     loop = loop or asyncio.get_event_loop()
     loop.create_task(
         loop.subprocess_shell(
-        lambda: SubprocessProtocol(callback), "nohup " + cmd,
-        preexec_fn=os.setsid,
+            lambda: SubprocessProtocol(callback), "nohup " + cmd,
+            preexec_fn=os.setsid,
         ),
     )
 

--- a/orc8r/gateway/python/magma/common/tests/cert_utils_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/cert_utils_tests.py
@@ -77,7 +77,7 @@ class CertUtilsTest(TestCase):
             cert_file = os.path.join(temp_dir, 'test.cert')
             cu.write_cert(
                 cert.public_bytes(
-                serialization.Encoding.DER,
+                    serialization.Encoding.DER,
                 ), cert_file,
             )
             cert_load = cu.load_cert(cert_file)

--- a/orc8r/gateway/python/magma/common/tests/metrics_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/metrics_tests.py
@@ -128,7 +128,7 @@ class Service303MetricTests(unittest.TestCase):
         # Add a summary with a label to the regisry
         c = Summary(
             'process_max_fds', 'A summary', [
-            'result',
+                'result',
             ], registry=self.registry,
         )
         c.labels('success').observe(1.23)

--- a/orc8r/gateway/python/magma/eventd/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/eventd/rpc_servicer.py
@@ -71,8 +71,8 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
         try:
             with closing(
                 socket.create_connection(
-                ('localhost', self._fluent_bit_port),
-                timeout=self._tcp_timeout,
+                    ('localhost', self._fluent_bit_port),
+                    timeout=self._tcp_timeout,
                 ),
             ) as sock:
                 logging.debug('Sending log to FluentBit')

--- a/orc8r/gateway/python/magma/magmad/tests/collector_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/collector_tests.py
@@ -371,17 +371,17 @@ class MetricsCollectorTests(unittest.TestCase):
                 self.assertEqual(3, len(proto.metric[0].histogram.bucket))
                 self.assertEqual(
                     1, proto.metric[0].histogram.bucket[
-                    0
+                        0
                     ].cumulative_count,
                 )
                 self.assertEqual(
                     2, proto.metric[0].histogram.bucket[
-                    1
+                        1
                     ].cumulative_count,
                 )
                 self.assertEqual(
                     3, proto.metric[0].histogram.bucket[
-                    2
+                        2
                     ].cumulative_count,
                 )
             else:
@@ -391,17 +391,17 @@ class MetricsCollectorTests(unittest.TestCase):
                 self.assertEqual(3, len(proto.metric[0].histogram.bucket))
                 self.assertEqual(
                     2, proto.metric[0].histogram.bucket[
-                    0
+                        0
                     ].cumulative_count,
                 )
                 self.assertEqual(
                     3, proto.metric[0].histogram.bucket[
-                    1
+                        1
                     ].cumulative_count,
                 )
                 self.assertEqual(
                     4, proto.metric[0].histogram.bucket[
-                    2
+                        2
                     ].cumulative_count,
                 )
 

--- a/orc8r/gateway/python/magma/magmad/upgrade/tests/upgrader2_test.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/tests/upgrader2_test.py
@@ -110,7 +110,7 @@ class Upgrader2Test(unittest.TestCase):
             {self.version_a},
             upgrader2.VersionInfo(
                 self.version_none, {
-                self.version_a,
+                    self.version_a,
                 },
             ).all_versions,
         )

--- a/orc8r/gateway/python/magma/magmad/upgrade/upgrader2.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/upgrader2.py
@@ -150,7 +150,7 @@ class UpgradeIntent(
         available_versions = version_info.all_versions
         preference = [
             version for version in (
-            self.stable, self.canary,
+                self.stable, self.canary,
             ) if version
         ]
         for version in preference:

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -298,7 +298,7 @@ class StateReplicator(SDWatchdogTask):
 
     async def _cleanup_deleted_keys(self):
         deleted_keys = set(self._state_versions) - \
-                       self._state_keys_from_current_iteration
+            self._state_keys_from_current_iteration
         for key in deleted_keys:
             del self._state_versions[key]
         self._state_keys_from_current_iteration = set()

--- a/orc8r/gateway/python/scripts/config_cli.py
+++ b/orc8r/gateway/python/scripts/config_cli.py
@@ -104,7 +104,7 @@ def set_streamer_status(_, args):
     if invalid_keys:
         print(
             '%s does not have the following streamer config keys: %s' % (
-            service, invalid_keys,
+                service, invalid_keys,
             ),
         )
         return

--- a/orc8r/gateway/python/scripts/generate_service_config.py
+++ b/orc8r/gateway/python/scripts/generate_service_config.py
@@ -87,7 +87,7 @@ def generate_template_config(service, template, out_dirname, context):
     out_filename = _get_template_out_filename(template, out_dirname)
     logging.info(
         "Generating config file: [%s] using template: [%s]" % (
-        out_filename, template_filename,
+            out_filename, template_filename,
         ),
     )
     template_context = {}

--- a/orc8r/gateway/python/scripts/verify_streamed_mconfigs.py
+++ b/orc8r/gateway/python/scripts/verify_streamed_mconfigs.py
@@ -40,11 +40,11 @@ def main():
             return 0
         else:
             key_difference = gw_configs_json_deser['configsByKey'].keys() ^\
-                             streamed_gw_configs['configsByKey'].keys()
+                streamed_gw_configs['configsByKey'].keys()
             if key_difference:
                 print(
                     'Symmetric difference of mconfig keys: {}'.format(
-                    key_difference,
+                        key_difference,
                     ),
                 )
 

--- a/orc8r/tools/fab/dev_utils.py
+++ b/orc8r/tools/fab/dev_utils.py
@@ -336,8 +336,8 @@ def cloud_get(
     """
     url = url or PORTAL_URL
     admin_cert = admin_cert or types.ClientCert(
-            cert='./../../.cache/test_certs/admin_operator.pem',
-            key='./../../.cache/test_certs/admin_operator.key.pem',
+        cert='./../../.cache/test_certs/admin_operator.pem',
+        key='./../../.cache/test_certs/admin_operator.key.pem',
     )
 
     if resource.startswith("/"):
@@ -370,8 +370,8 @@ def cloud_post(
     """
     url = url or PORTAL_URL
     admin_cert = admin_cert or types.ClientCert(
-            cert='./../../.cache/test_certs/admin_operator.pem',
-            key='./../../.cache/test_certs/admin_operator.key.pem',
+        cert='./../../.cache/test_certs/admin_operator.pem',
+        key='./../../.cache/test_certs/admin_operator.key.pem',
     )
     resp = requests.post(
         url + resource,

--- a/orc8r/tools/fab/vagrant.py
+++ b/orc8r/tools/fab/vagrant.py
@@ -38,7 +38,7 @@ def setup_env_vagrant(machine='magma', apply_to_env=True, force_provision=False)
 
     # Ensure that VM is running
     isUp = local('vagrant status %s' % machine, capture=True) \
-               .find('running') < 0
+        .find('running') < 0
     if isUp:
         # The machine isn't running. Most likely it's just not up. Let's
         # first try the simple thing of bringing it up, and if that doesn't
@@ -98,7 +98,7 @@ def teardown_vagrant(machine):
 
     # Destroy if vm if it exists
     created = local('vagrant status %s' % machine, capture=True) \
-                  .find('not created') < 0
+        .find('not created') < 0
 
     if created:
         local('vagrant destroy -f %s' % machine)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
See https://github.com/magma/magma/issues/11816 for details

Trying to add E1 (indentation related formatting to our CI/formatting script). Formatting in advance before pulling the trigger to avoid confusion.

This change is entirely automatically generated by autopep8
`autopep8  --select W191,W291,W292,W293,W391,E131,E2,E3,E1 -r --in-place ./`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
