### PR TITLE
chore(dp): add E1 to autopep8 python formatting

### DIFF
--- a/dp/tools/fake_sas/fake_sas.py
+++ b/dp/tools/fake_sas/fake_sas.py
@@ -86,452 +86,454 @@ INVALID_PARAM = 103
 
 
 class FakeSas(sas_interface.SasInterface):
-  """A fake implementation of SasInterface.
+    """A fake implementation of SasInterface.
 
-  Returns success for all requests with plausible fake values for all required
-  response fields.
+    Returns success for all requests with plausible fake values for all required
+    response fields.
 
-  """
-
-  def __init__(self):
-    self.maximum_batch_size = 100
-    pass
-
-  def Registration(self, request, ssl_cert=None, ssl_key=None):
-    response = {'registrationResponse': []}
-    for req in request['registrationRequest']:
-      if 'fccId' not in req or 'cbsdSerialNumber' not in req:
-        response['registrationResponse'].append({
-            'response': self._GetSuccessResponse(),
-        })
-        continue
-      response['registrationResponse'].append({
-        'cbsdId': req['fccId'] + '/' + req['cbsdSerialNumber'],
-        'response': self._GetSuccessResponse(),
-      })
-    return response
-
-  def SpectrumInquiry(self, request, ssl_cert=None, ssl_key=None):
-    response = {'spectrumInquiryResponse': []}
-    for req in request['spectrumInquiryRequest']:
-      response['spectrumInquiryResponse'].append({
-          'cbsdId': req['cbsdId'],
-          'availableChannel': [{
-              'frequencyRange': {
-                  'lowFrequency': 3620000000,
-                  'highFrequency': 3630000000,
-              },
-              'channelType': 'GAA',
-              'ruleApplied': 'FCC_PART_96',
-              'maxEirp': 37.0,
-          }],
-          'response': self._GetSuccessResponse(),
-      })
-    return response
-
-  def Grant(self, request, ssl_cert=None, ssl_key=None):
-    response = {'grantResponse': []}
-    for req in request['grantRequest']:
-      if ('cbsdId' not in req):
-        response['grantResponse'].append({
-          'response': self._GetMissingParamResponse(),
-        })
-      else:
-        if (('highFrequency' not in req['operationParam']['operationFrequencyRange']) or \
-           ('lowFrequency' not in req['operationParam']['operationFrequencyRange'])):
-           response['grantResponse'].append({
-             'cbsdId': req['cbsdId'],
-             'response': self._GetMissingParamResponse(),
-           })
-        else:
-          response['grantResponse'].append({
-            'cbsdId': req['cbsdId'],
-            'grantId': 'fake_grant_id_%s' % datetime.utcnow().isoformat(),
-            'channelType': 'GAA',
-            'heartbeatInterval': 60,
-            'response': self._GetSuccessResponse(),
-          })
-    return response
-
-  def Heartbeat(self, request, ssl_cert=None, ssl_key=None):
-    response = {'heartbeatResponse': []}
-    for req in request['heartbeatRequest']:
-      transmit_expire_time = datetime.utcnow().replace(
-          microsecond=0,
-      ) + timedelta(minutes=1)
-      response['heartbeatResponse'].append({
-          'cbsdId': req['cbsdId'],
-          'grantId': req['grantId'],
-          'transmitExpireTime': transmit_expire_time.isoformat() + 'Z',
-          'response': self._GetSuccessResponse(),
-      })
-    return response
-
-  def Relinquishment(self, request, ssl_cert=None, ssl_key=None):
-    response = {'relinquishmentResponse': []}
-    for req in request['relinquishmentRequest']:
-      response['relinquishmentResponse'].append({
-          'cbsdId': req['cbsdId'],
-          'grantId': req['grantId'],
-          'response': self._GetSuccessResponse(),
-      })
-    return response
-
-  def Deregistration(self, request, ssl_cert=None, ssl_key=None):
-    response = {'deregistrationResponse': []}
-    for req in request['deregistrationRequest']:
-      if ('cbsdId' not in req):
-        response['deregistrationResponse'].append({
-          'response': self._GetMissingParamResponse(),
-        })
-      else:
-        response['deregistrationResponse'].append({
-          'cbsdId': req['cbsdId'],
-          'response': self._GetSuccessResponse(),
-        })
-    return response
-
-  def GetEscSensorRecord(self, request, ssl_cert=None, ssl_key=None):
-    # Get the Esc Sensor record
-    with open(os.path.join('testcases', 'testdata', 'esc_sensor_record_0.json')) as fd:
-      esc_sensor_record = json.load(fd)
-
-    if request == esc_sensor_record['id']:
-      return esc_sensor_record
-    else:
-      # Return Empty if invalid Id
-      return {}
-
-  def GetFullActivityDump(self, version, ssl_cert=None, ssl_key=None):
-    response = json.loads(
-        json.dumps({
-            'files': [
-              {
-                  'url': 'https://raw.githubusercontent.com/Wireless-Innovation-Forum/' +
-                         'Spectrum-Access-System/master/schema/empty_activity_dump_file.json',
-                  'checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'size': 19,
-                  'version': version, 'recordType': "cbsd",
-              },
-              {
-                'url': 'https://raw.githubusercontent.com/Wireless-Innovation-Forum/Spectrum-Access-System/master/schema/empty_activity_dump_file.json',
-                'checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'size': 19,
-                'version': version, 'recordType': "zone",
-              },
-              {
-                'url': 'https://raw.githubusercontent.com/Wireless-Innovation-Forum/Spectrum-Access-System/master/schema/empty_activity_dump_file.json',
-                'checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'size': 19,
-                'version': version, 'recordType': "esc_sensor",
-              },
-              {
-                'url': 'https://raw.githubusercontent.com/Wireless-Innovation-Forum/Spectrum-Access-System/master/schema/empty_activity_dump_file.json',
-                'checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'size': 19,
-                'version': version, 'recordType': "coordination",
-              },
-            ],
-            'generationDateTime': datetime.utcnow().strftime(
-                  '%Y-%m-%dT%H:%M:%SZ',
-            ),
-            'description': "Full activity dump files",
-        }),
-    )
-    return response
-
-  def _GetSuccessResponse(self):
-    return {'responseCode': 0}
-
-  def _GetMissingParamResponse(self):
-    return {'responseCode': MISSING_PARAM}
-
-  def DownloadFile(self, url, ssl_cert=None, ssl_key=None):
-    """SAS-SAS Get data from json files after generate the
-     Full Activity Dump Message
-    Returns:
-     the message as an "json data" object specified in WINNF-16-S-0096
     """
-    pass
+
+    def __init__(self):
+        self.maximum_batch_size = 100
+        pass
+
+    def Registration(self, request, ssl_cert=None, ssl_key=None):
+        response = {'registrationResponse': []}
+        for req in request['registrationRequest']:
+            if 'fccId' not in req or 'cbsdSerialNumber' not in req:
+                response['registrationResponse'].append({
+                    'response': self._GetSuccessResponse(),
+                })
+                continue
+            response['registrationResponse'].append({
+                'cbsdId': req['fccId'] + '/' + req['cbsdSerialNumber'],
+                'response': self._GetSuccessResponse(),
+            })
+        return response
+
+    def SpectrumInquiry(self, request, ssl_cert=None, ssl_key=None):
+        response = {'spectrumInquiryResponse': []}
+        for req in request['spectrumInquiryRequest']:
+            response['spectrumInquiryResponse'].append({
+                'cbsdId': req['cbsdId'],
+                'availableChannel': [{
+                    'frequencyRange': {
+                        'lowFrequency': 3620000000,
+                        'highFrequency': 3630000000,
+                    },
+                    'channelType': 'GAA',
+                    'ruleApplied': 'FCC_PART_96',
+                    'maxEirp': 37.0,
+                }],
+                'response': self._GetSuccessResponse(),
+            })
+        return response
+
+    def Grant(self, request, ssl_cert=None, ssl_key=None):
+        response = {'grantResponse': []}
+        for req in request['grantRequest']:
+            if ('cbsdId' not in req):
+                response['grantResponse'].append({
+                    'response': self._GetMissingParamResponse(),
+                })
+            else:
+                if (('highFrequency' not in req['operationParam']['operationFrequencyRange']) or \
+                   ('lowFrequency' not in req['operationParam']['operationFrequencyRange'])):
+                    response['grantResponse'].append({
+                        'cbsdId': req['cbsdId'],
+                        'response': self._GetMissingParamResponse(),
+                    })
+                else:
+                    response['grantResponse'].append({
+                        'cbsdId': req['cbsdId'],
+                        'grantId': 'fake_grant_id_%s' % datetime.utcnow().isoformat(),
+                        'channelType': 'GAA',
+                        'heartbeatInterval': 60,
+                        'response': self._GetSuccessResponse(),
+                    })
+        return response
+
+    def Heartbeat(self, request, ssl_cert=None, ssl_key=None):
+        response = {'heartbeatResponse': []}
+        for req in request['heartbeatRequest']:
+            transmit_expire_time = datetime.utcnow().replace(
+                microsecond=0,
+            ) + timedelta(minutes=1)
+            response['heartbeatResponse'].append({
+                'cbsdId': req['cbsdId'],
+                'grantId': req['grantId'],
+                'transmitExpireTime': transmit_expire_time.isoformat() + 'Z',
+                'response': self._GetSuccessResponse(),
+            })
+        return response
+
+    def Relinquishment(self, request, ssl_cert=None, ssl_key=None):
+        response = {'relinquishmentResponse': []}
+        for req in request['relinquishmentRequest']:
+            response['relinquishmentResponse'].append({
+                'cbsdId': req['cbsdId'],
+                'grantId': req['grantId'],
+                'response': self._GetSuccessResponse(),
+            })
+        return response
+
+    def Deregistration(self, request, ssl_cert=None, ssl_key=None):
+        response = {'deregistrationResponse': []}
+        for req in request['deregistrationRequest']:
+            if ('cbsdId' not in req):
+                response['deregistrationResponse'].append({
+                    'response': self._GetMissingParamResponse(),
+                })
+            else:
+                response['deregistrationResponse'].append({
+                    'cbsdId': req['cbsdId'],
+                    'response': self._GetSuccessResponse(),
+                })
+        return response
+
+    def GetEscSensorRecord(self, request, ssl_cert=None, ssl_key=None):
+        # Get the Esc Sensor record
+        with open(os.path.join('testcases', 'testdata', 'esc_sensor_record_0.json')) as fd:
+            esc_sensor_record = json.load(fd)
+
+        if request == esc_sensor_record['id']:
+            return esc_sensor_record
+        else:
+            # Return Empty if invalid Id
+            return {}
+
+    def GetFullActivityDump(self, version, ssl_cert=None, ssl_key=None):
+        response = json.loads(
+            json.dumps({
+                'files': [
+                    {
+                        'url': 'https://raw.githubusercontent.com/Wireless-Innovation-Forum/' +
+                        'Spectrum-Access-System/master/schema/empty_activity_dump_file.json',
+                        'checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'size': 19,
+                        'version': version, 'recordType': "cbsd",
+                    },
+                    {
+                        'url': 'https://raw.githubusercontent.com/Wireless-Innovation-Forum/Spectrum-Access-System/master/schema/empty_activity_dump_file.json',
+                        'checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'size': 19,
+                        'version': version, 'recordType': "zone",
+                    },
+                    {
+                        'url': 'https://raw.githubusercontent.com/Wireless-Innovation-Forum/Spectrum-Access-System/master/schema/empty_activity_dump_file.json',
+                        'checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'size': 19,
+                        'version': version, 'recordType': "esc_sensor",
+                    },
+                    {
+                        'url': 'https://raw.githubusercontent.com/Wireless-Innovation-Forum/Spectrum-Access-System/master/schema/empty_activity_dump_file.json',
+                        'checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'size': 19,
+                        'version': version, 'recordType': "coordination",
+                    },
+                ],
+                'generationDateTime': datetime.utcnow().strftime(
+                    '%Y-%m-%dT%H:%M:%SZ',
+                ),
+                'description': "Full activity dump files",
+            }),
+        )
+        return response
+
+    def _GetSuccessResponse(self):
+        return {'responseCode': 0}
+
+    def _GetMissingParamResponse(self):
+        return {'responseCode': MISSING_PARAM}
+
+    def DownloadFile(self, url, ssl_cert=None, ssl_key=None):
+        """SAS-SAS Get data from json files after generate the
+         Full Activity Dump Message
+        Returns:
+         the message as an "json data" object specified in WINNF-16-S-0096
+        """
+        pass
 
 
 class FakeSasAdmin(sas_interface.SasAdminInterface):
-  """Implementation of SAS Admin for Fake SAS."""
+    """Implementation of SAS Admin for Fake SAS."""
 
-  def Reset(self):
-    pass
+    def Reset(self):
+        pass
 
-  def InjectFccId(self, request):
-    pass
+    def InjectFccId(self, request):
+        pass
 
-  def InjectUserId(self, request):
-    pass
+    def InjectUserId(self, request):
+        pass
 
-  def InjectCpiUser(self, request):
-    pass
+    def InjectCpiUser(self, request):
+        pass
 
-  def BlacklistByFccId(self, request):
-    pass
+    def BlacklistByFccId(self, request):
+        pass
 
-  def BlacklistByFccIdAndSerialNumber(self, request):
-    pass
+    def BlacklistByFccIdAndSerialNumber(self, request):
+        pass
 
-  def PreloadRegistrationData(self, request):
-    pass
+    def PreloadRegistrationData(self, request):
+        pass
 
-  def InjectExclusionZone(self, request, ssl_cert=None, ssl_key=None):
-    pass
+    def InjectExclusionZone(self, request, ssl_cert=None, ssl_key=None):
+        pass
 
-  def InjectZoneData(self, request, ssl_cert=None, ssl_key=None):
-    return request['record']['id']
+    def InjectZoneData(self, request, ssl_cert=None, ssl_key=None):
+        return request['record']['id']
 
-  def InjectPalDatabaseRecord(self, request):
-    pass
+    def InjectPalDatabaseRecord(self, request):
+        pass
 
-  def InjectFss(self, request):
-    pass
+    def InjectFss(self, request):
+        pass
 
-  def InjectWisp(self, request):
-    pass
+    def InjectWisp(self, request):
+        pass
 
-  def InjectSasAdministratorRecord(self, request):
-    pass
+    def InjectSasAdministratorRecord(self, request):
+        pass
 
-  def InjectEscSensorDataRecord(self, request):
-    pass
+    def InjectEscSensorDataRecord(self, request):
+        pass
 
-  def InjectPeerSas(self, request):
-    pass
+    def InjectPeerSas(self, request):
+        pass
 
-  def TriggerMeasurementReportRegistration(self):
-    pass
+    def TriggerMeasurementReportRegistration(self):
+        pass
 
-  def TriggerMeasurementReportHeartbeat(self):
-    pass
+    def TriggerMeasurementReportHeartbeat(self):
+        pass
 
-  def TriggerPpaCreation(self, request, ssl_cert=None, ssl_key=None):
-    return 'zone/ppa/fake_sas/%s/%s' % (
-        request['palIds'][0],
-        uuid.uuid4().hex,
-    )
+    def TriggerPpaCreation(self, request, ssl_cert=None, ssl_key=None):
+        return 'zone/ppa/fake_sas/%s/%s' % (
+            request['palIds'][0],
+            uuid.uuid4().hex,
+        )
 
-  def TriggerDailyActivitiesImmediately(self):
-    pass
+    def TriggerDailyActivitiesImmediately(self):
+        pass
 
-  def TriggerEnableNtiaExclusionZones(self):
-    pass
+    def TriggerEnableNtiaExclusionZones(self):
+        pass
 
-  def TriggerEnableScheduledDailyActivities(self):
-    pass
+    def TriggerEnableScheduledDailyActivities(self):
+        pass
 
-  def QueryPropagationAndAntennaModel(self, request):
-    from testcases.WINNF_FT_S_PAT_testcase import computePropagationAntennaModel
-    return computePropagationAntennaModel(request)
+    def QueryPropagationAndAntennaModel(self, request):
+        from testcases.WINNF_FT_S_PAT_testcase import (
+            computePropagationAntennaModel,
+        )
+        return computePropagationAntennaModel(request)
 
-  def GetDailyActivitiesStatus(self):
-    return {'completed': True}
+    def GetDailyActivitiesStatus(self):
+        return {'completed': True}
 
-  def GetPpaCreationStatus(self):
-    return {'completed': True, 'withError': False}
+    def GetPpaCreationStatus(self):
+        return {'completed': True, 'withError': False}
 
-  def GetDailyActivitiesStatus(self):
-    return {'completed': True}
+    def GetDailyActivitiesStatus(self):
+        return {'completed': True}
 
-  def TriggerLoadDpas(self):
-    pass
+    def TriggerLoadDpas(self):
+        pass
 
-  def TriggerBulkDpaActivation(self, request):
-    pass
+    def TriggerBulkDpaActivation(self, request):
+        pass
 
-  def TriggerDpaActivation(self, request):
-    pass
+    def TriggerDpaActivation(self, request):
+        pass
 
-  def TriggerFullActivityDump(self):
-    pass
+    def TriggerFullActivityDump(self):
+        pass
 
-  def TriggerDpaDeactivation(self, request):
-    pass
+    def TriggerDpaDeactivation(self, request):
+        pass
 
-  def TriggerEscDisconnect(self):
-    pass
+    def TriggerEscDisconnect(self):
+        pass
 
-  def InjectDatabaseUrl(self, request):
-    pass
+    def InjectDatabaseUrl(self, request):
+        pass
 
 
 class FakeSasHandler(BaseHTTPRequestHandler):
-  @classmethod
-  def SetVersion(cls, cbsd_sas_version, sas_sas_version):
-    cls.cbsd_sas_version = cbsd_sas_version
-    cls.sas_sas_version = sas_sas_version
+    @classmethod
+    def SetVersion(cls, cbsd_sas_version, sas_sas_version):
+        cls.cbsd_sas_version = cbsd_sas_version
+        cls.sas_sas_version = sas_sas_version
 
-  def _parseUrl(self, url):
-    """Parse the Url into the path and value."""
-    splitted_url = url.split('/')[1:]
-    # Returns path and value
-    return '/'.join(splitted_url[0:2]), '/'.join(splitted_url[2:])
+    def _parseUrl(self, url):
+        """Parse the Url into the path and value."""
+        splitted_url = url.split('/')[1:]
+        # Returns path and value
+        return '/'.join(splitted_url[0:2]), '/'.join(splitted_url[2:])
 
-  def do_POST(self):
-    """Handles POST requests."""
+    def do_POST(self):
+        """Handles POST requests."""
 
-    length = int(self.headers.getheader('content-length'))
-    if length > 0:
-      request = json.loads(self.rfile.read(length))
-    if self.path == '/%s/registration' % self.cbsd_sas_version:
-      response = FakeSas().Registration(request)
-    elif self.path == '/%s/spectrumInquiry' % self.cbsd_sas_version:
-      response = FakeSas().SpectrumInquiry(request)
-    elif self.path == '/%s/grant' % self.cbsd_sas_version:
-      response = FakeSas().Grant(request)
-    elif self.path == '/%s/heartbeat' % self.cbsd_sas_version:
-      response = FakeSas().Heartbeat(request)
-    elif self.path == '/%s/relinquishment' % self.cbsd_sas_version:
-      response = FakeSas().Relinquishment(request)
-    elif self.path == '/%s/deregistration' % self.cbsd_sas_version:
-      response = FakeSas().Deregistration(request)
-    elif self.path == '/admin/injectdata/zone':
-      response = FakeSasAdmin().InjectZoneData(request)
-    elif self.path == '/admin/trigger/create_ppa':
-      response = FakeSasAdmin().TriggerPpaCreation(request)
-    elif self.path == '/admin/get_daily_activities_status':
-      response = FakeSasAdmin().GetDailyActivitiesStatus()
-    elif self.path == '/admin/get_daily_activities_status':
-      response = FakeSasAdmin().GetDailyActivitiesStatus()
-    elif self.path == '/admin/get_ppa_status':
-      response = FakeSasAdmin().GetPpaCreationStatus()
-    elif self.path == '/admin/query/propagation_and_antenna_model':
-      try:
-        response = FakeSasAdmin().QueryPropagationAndAntennaModel(request)
-      except ValueError:
-        self.send_response(400)
-      return
-    elif self.path in (
-        '/admin/reset', '/admin/injectdata/fcc_id',
-        '/admin/injectdata/user_id',
-        '/admin/injectdata/conditional_registration',
-        '/admin/injectdata/blacklist_fcc_id',
-        '/admin/injectdata/blacklist_fcc_id_and_serial_number',
-        '/admin/injectdata/fss',
-        '/admin/injectdata/wisp',
-        '/admin/injectdata/peer_sas',
-        '/admin/injectdata/pal_database_record',
-        '/admin/injectdata/sas_admin',
-        '/admin/injectdata/sas_impl',
-        '/admin/injectdata/esc_sensor',
-        '/admin/injectdata/cpi_user',
-        '/admin/trigger/meas_report_in_registration_response',
-        '/admin/trigger/meas_report_in_heartbeat_response',
-        '/admin/trigger/daily_activities_immediately',
-        '/admin/trigger/enable_scheduled_daily_activities',
-        '/admin/trigger/load_dpas',
-        '/admin/trigger/dpa_activation',
-        '/admin/trigger/dpa_deactivation',
-        '/admin/trigger/bulk_dpa_activation',
-        '/admin/injectdata/exclusion_zone',
-        '/admin/trigger/create_full_activity_dump',
-        '/admin/injectdata/database_url',
-    ):
-      response = ''
-    else:
-      self.send_response(404)
-      return
-    self.send_response(200)
-    self.send_header('Content-type', 'application/json')
-    self.end_headers()
-    self.wfile.write(json.dumps(response))
+        length = int(self.headers.getheader('content-length'))
+        if length > 0:
+            request = json.loads(self.rfile.read(length))
+        if self.path == '/%s/registration' % self.cbsd_sas_version:
+            response = FakeSas().Registration(request)
+        elif self.path == '/%s/spectrumInquiry' % self.cbsd_sas_version:
+            response = FakeSas().SpectrumInquiry(request)
+        elif self.path == '/%s/grant' % self.cbsd_sas_version:
+            response = FakeSas().Grant(request)
+        elif self.path == '/%s/heartbeat' % self.cbsd_sas_version:
+            response = FakeSas().Heartbeat(request)
+        elif self.path == '/%s/relinquishment' % self.cbsd_sas_version:
+            response = FakeSas().Relinquishment(request)
+        elif self.path == '/%s/deregistration' % self.cbsd_sas_version:
+            response = FakeSas().Deregistration(request)
+        elif self.path == '/admin/injectdata/zone':
+            response = FakeSasAdmin().InjectZoneData(request)
+        elif self.path == '/admin/trigger/create_ppa':
+            response = FakeSasAdmin().TriggerPpaCreation(request)
+        elif self.path == '/admin/get_daily_activities_status':
+            response = FakeSasAdmin().GetDailyActivitiesStatus()
+        elif self.path == '/admin/get_daily_activities_status':
+            response = FakeSasAdmin().GetDailyActivitiesStatus()
+        elif self.path == '/admin/get_ppa_status':
+            response = FakeSasAdmin().GetPpaCreationStatus()
+        elif self.path == '/admin/query/propagation_and_antenna_model':
+            try:
+                response = FakeSasAdmin().QueryPropagationAndAntennaModel(request)
+            except ValueError:
+                self.send_response(400)
+            return
+        elif self.path in (
+            '/admin/reset', '/admin/injectdata/fcc_id',
+            '/admin/injectdata/user_id',
+            '/admin/injectdata/conditional_registration',
+            '/admin/injectdata/blacklist_fcc_id',
+            '/admin/injectdata/blacklist_fcc_id_and_serial_number',
+            '/admin/injectdata/fss',
+            '/admin/injectdata/wisp',
+            '/admin/injectdata/peer_sas',
+            '/admin/injectdata/pal_database_record',
+            '/admin/injectdata/sas_admin',
+            '/admin/injectdata/sas_impl',
+            '/admin/injectdata/esc_sensor',
+            '/admin/injectdata/cpi_user',
+            '/admin/trigger/meas_report_in_registration_response',
+            '/admin/trigger/meas_report_in_heartbeat_response',
+            '/admin/trigger/daily_activities_immediately',
+            '/admin/trigger/enable_scheduled_daily_activities',
+            '/admin/trigger/load_dpas',
+            '/admin/trigger/dpa_activation',
+            '/admin/trigger/dpa_deactivation',
+            '/admin/trigger/bulk_dpa_activation',
+            '/admin/injectdata/exclusion_zone',
+            '/admin/trigger/create_full_activity_dump',
+            '/admin/injectdata/database_url',
+        ):
+            response = ''
+        else:
+            self.send_response(404)
+            return
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(response))
 
-  def do_GET(self):
-    """Handles GET requests."""
-    path, value = self._parseUrl(self.path)
-    if path == '%s/esc_sensor' % self.sas_sas_version:
-      response = FakeSas().GetEscSensorRecord(value)
-    elif path == '%s/dump' % self.sas_sas_version:
-      response = FakeSas().GetFullActivityDump(self.sas_sas_version)
-    else:
-      self.send_response(404)
-      return
-    self.send_response(200)
-    self.send_header('Content-type', 'application/json')
-    self.end_headers()
-    self.wfile.write(json.dumps(response))
+    def do_GET(self):
+        """Handles GET requests."""
+        path, value = self._parseUrl(self.path)
+        if path == '%s/esc_sensor' % self.sas_sas_version:
+            response = FakeSas().GetEscSensorRecord(value)
+        elif path == '%s/dump' % self.sas_sas_version:
+            response = FakeSas().GetFullActivityDump(self.sas_sas_version)
+        else:
+            self.send_response(404)
+            return
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(response))
 
 
 def ParseCrlIndex(index_filename):
-  """Returns the list of CRL filenames from a CRL index file."""
-  dirname = os.path.dirname(index_filename)
-  return [
-      os.path.join(dirname, line.rstrip())
-      for line in open(index_filename)
-  ]
+    """Returns the list of CRL filenames from a CRL index file."""
+    dirname = os.path.dirname(index_filename)
+    return [
+        os.path.join(dirname, line.rstrip())
+        for line in open(index_filename)
+    ]
 
 
 def RunFakeServer(cbsd_sas_version, sas_sas_version, is_ecc, crl_index):
-  FakeSasHandler.SetVersion(cbsd_sas_version, sas_sas_version)
-  if is_ecc:
-    assert ssl.HAS_ECDH
-  server = HTTPServer((HOST, PORT), FakeSasHandler)
+    FakeSasHandler.SetVersion(cbsd_sas_version, sas_sas_version)
+    if is_ecc:
+        assert ssl.HAS_ECDH
+    server = HTTPServer((HOST, PORT), FakeSasHandler)
 
-  ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-  ssl_context.options |= ssl.CERT_REQUIRED
+    ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ssl_context.options |= ssl.CERT_REQUIRED
 
-  # If CRLs were provided, then enable revocation checking.
-  if crl_index is not None:
-    ssl_context.verify_flags = ssl.VERIFY_CRL_CHECK_CHAIN
+    # If CRLs were provided, then enable revocation checking.
+    if crl_index is not None:
+        ssl_context.verify_flags = ssl.VERIFY_CRL_CHECK_CHAIN
 
-    try:
-      crl_files = ParseCrlIndex(crl_index)
-    except IOError as e:
-      print("Failed to parse CRL index file %r: %s" % (crl_index, e))
+        try:
+            crl_files = ParseCrlIndex(crl_index)
+        except IOError as e:
+            print("Failed to parse CRL index file %r: %s" % (crl_index, e))
 
-    # https://tools.ietf.org/html/rfc5280#section-4.2.1.13 specifies that
-    # CRLs MUST be DER-encoded, but SSLContext expects the name of a PEM-encoded
-    # file, so we must convert it first.
-    for f in crl_files:
-      try:
-        with file(f) as handle:
-          der = handle.read()
-          try:
-            crl = crypto.load_crl(crypto.FILETYPE_ASN1, der)
-          except crypto.Error as e:
-            print("Failed to parse CRL file %r as DER format: %s" % (f, e))
-            return
-          with tempfile.NamedTemporaryFile() as tmp:
-            tmp.write(crypto.dump_crl(crypto.FILETYPE_PEM, crl))
-            tmp.flush()
-            ssl_context.load_verify_locations(cafile=tmp.name)
-        print("Loaded CRL file: %r" % f)
-      except IOError as e:
-        print("Failed to load CRL file %r: %s" % (f, e))
-        return
+        # https://tools.ietf.org/html/rfc5280#section-4.2.1.13 specifies that
+        # CRLs MUST be DER-encoded, but SSLContext expects the name of a PEM-encoded
+        # file, so we must convert it first.
+        for f in crl_files:
+            try:
+                with file(f) as handle:
+                    der = handle.read()
+                    try:
+                        crl = crypto.load_crl(crypto.FILETYPE_ASN1, der)
+                    except crypto.Error as e:
+                        print("Failed to parse CRL file %r as DER format: %s" % (f, e))
+                        return
+                    with tempfile.NamedTemporaryFile() as tmp:
+                        tmp.write(crypto.dump_crl(crypto.FILETYPE_PEM, crl))
+                        tmp.flush()
+                        ssl_context.load_verify_locations(cafile=tmp.name)
+                print("Loaded CRL file: %r" % f)
+            except IOError as e:
+                print("Failed to load CRL file %r: %s" % (f, e))
+                return
 
-  ssl_context.load_verify_locations(cafile=CA_CERT)
-  ssl_context.load_cert_chain(
-      certfile=ECC_CERT_FILE if is_ecc else CERT_FILE,
-      keyfile=ECC_KEY_FILE if is_ecc else KEY_FILE,
-  )
-  ssl_context.set_ciphers(':'.join(ECC_CIPHERS if is_ecc else CIPHERS))
-  ssl_context.verify_mode = ssl.CERT_REQUIRED
-  server.socket = ssl_context.wrap_socket(server.socket, server_side=True)
-  print('Will start server at %s:%d, use <Ctrl-C> to stop.' % (HOST, PORT))
-  server.serve_forever()
+    ssl_context.load_verify_locations(cafile=CA_CERT)
+    ssl_context.load_cert_chain(
+        certfile=ECC_CERT_FILE if is_ecc else CERT_FILE,
+        keyfile=ECC_KEY_FILE if is_ecc else KEY_FILE,
+    )
+    ssl_context.set_ciphers(':'.join(ECC_CIPHERS if is_ecc else CIPHERS))
+    ssl_context.verify_mode = ssl.CERT_REQUIRED
+    server.socket = ssl_context.wrap_socket(server.socket, server_side=True)
+    print('Will start server at %s:%d, use <Ctrl-C> to stop.' % (HOST, PORT))
+    server.serve_forever()
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '--ecc', help='Use ECDSA certificate', action='store_true',
-  )
-  parser.add_argument(
-      '--crl_index',
-      help=(
-          'Read a text file containing one DER-encoded CRL file per line, '
-          'and enable revocation checking.'
-      ),
-      dest='crl_index', action='store',
-  )
-  try:
-    args = parser.parse_args()
-  except:
-    parser.print_help()
-    sys.exit(0)
-  config_parser = configparser.RawConfigParser()
-  config_parser.read(['sas.cfg'])
-  cbsd_sas_version = config_parser.get('SasConfig', 'CbsdSasVersion')
-  sas_sas_version = config_parser.get('SasConfig', 'SasSasVersion')
-  RunFakeServer(cbsd_sas_version, sas_sas_version, args.ecc, args.crl_index)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--ecc', help='Use ECDSA certificate', action='store_true',
+    )
+    parser.add_argument(
+        '--crl_index',
+        help=(
+            'Read a text file containing one DER-encoded CRL file per line, '
+            'and enable revocation checking.'
+        ),
+        dest='crl_index', action='store',
+    )
+    try:
+        args = parser.parse_args()
+    except:
+        parser.print_help()
+        sys.exit(0)
+    config_parser = configparser.RawConfigParser()
+    config_parser.read(['sas.cfg'])
+    cbsd_sas_version = config_parser.get('SasConfig', 'CbsdSasVersion')
+    sas_sas_version = config_parser.get('SasConfig', 'SasSasVersion')
+    RunFakeServer(cbsd_sas_version, sas_sas_version, args.ecc, args.crl_index)

--- a/dp/tools/fake_sas/sas_interface.py
+++ b/dp/tools/fake_sas/sas_interface.py
@@ -22,513 +22,513 @@ import six
 
 
 class SasInterface(six.with_metaclass(abc.ABCMeta, object)):
-  """WinnForum standardized interfaces.
+    """WinnForum standardized interfaces.
 
-  Includes SAS-CBSD interface and (will include) SAS-SAS interface.
+    Includes SAS-CBSD interface and (will include) SAS-SAS interface.
 
-  """
-
-  @abc.abstractmethod
-  def Registration(self, request, ssl_cert=None, ssl_key=None):
-    """SAS-CBSD Registration interface.
-
-    Registers CBSDs.
-
-    Request and response are both lists of dictionaries. Each dictionary
-    contains all fields of a single request/response.
-
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "registrationRequest" and the value is a list of individual CBSD
-        registration requests (each of which is itself a dictionary).
-      ssl_cert: Path to SSL cert file, if None, will use default cert file.
-      ssl_key: Path to SSL key file, if None, will use default key file.
-    Returns:
-      A dictionary with a single key-value pair where the key is
-      "registrationResponse" and the value is a list of individual CBSD
-      registration responses (each of which is itself a dictionary).
     """
-    pass
 
-  @abc.abstractmethod
-  def SpectrumInquiry(self, request, ssl_cert=None, ssl_key=None):
-    """SAS-CBSD SpectrumInquiry interface.
+    @abc.abstractmethod
+    def Registration(self, request, ssl_cert=None, ssl_key=None):
+        """SAS-CBSD Registration interface.
 
-    Performs spectrum inquiry for CBSDs.
+        Registers CBSDs.
 
-    Request and response are both lists of dictionaries. Each dictionary
-    contains all fields of a single request/response.
+        Request and response are both lists of dictionaries. Each dictionary
+        contains all fields of a single request/response.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "spectrumInquiryRequest" and the value is a list of individual CBSD
-        spectrum inquiry requests (each of which is itself a dictionary).
-      ssl_cert: Path to SSL cert file, if None, will use default cert file.
-      ssl_key: Path to SSL key file, if None, will use default key file.
-    Returns:
-      A dictionary with a single key-value pair where the key is
-      "spectrumInquiryResponse" and the value is a list of individual CBSD
-      spectrum inquiry responses (each of which is itself a dictionary).
-    """
-    pass
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "registrationRequest" and the value is a list of individual CBSD
+            registration requests (each of which is itself a dictionary).
+          ssl_cert: Path to SSL cert file, if None, will use default cert file.
+          ssl_key: Path to SSL key file, if None, will use default key file.
+        Returns:
+          A dictionary with a single key-value pair where the key is
+          "registrationResponse" and the value is a list of individual CBSD
+          registration responses (each of which is itself a dictionary).
+        """
+        pass
 
-  @abc.abstractmethod
-  def Grant(self, request, ssl_cert=None, ssl_key=None):
-    """SAS-CBSD Grant interface.
+    @abc.abstractmethod
+    def SpectrumInquiry(self, request, ssl_cert=None, ssl_key=None):
+        """SAS-CBSD SpectrumInquiry interface.
 
-    Request and response are both lists of dictionaries. Each dictionary
-    contains all fields of a single request/response.
+        Performs spectrum inquiry for CBSDs.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "grantRequest" and the value is a list of individual CBSD
-        grant requests (each of which is itself a dictionary).
-      ssl_cert: Path to SSL cert file, if None, will use default cert file.
-      ssl_key: Path to SSL key file, if None, will use default key file.
-    Returns:
-      A dictionary with a single key-value pair where the key is
-      "grantResponse" and the value is a list of individual CBSD
-      grant responses (each of which is itself a dictionary).
-    """
-    pass
+        Request and response are both lists of dictionaries. Each dictionary
+        contains all fields of a single request/response.
 
-  @abc.abstractmethod
-  def Heartbeat(self, request, ssl_cert=None, ssl_key=None):
-    """SAS-CBSD Heartbeat interface.
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "spectrumInquiryRequest" and the value is a list of individual CBSD
+            spectrum inquiry requests (each of which is itself a dictionary).
+          ssl_cert: Path to SSL cert file, if None, will use default cert file.
+          ssl_key: Path to SSL key file, if None, will use default key file.
+        Returns:
+          A dictionary with a single key-value pair where the key is
+          "spectrumInquiryResponse" and the value is a list of individual CBSD
+          spectrum inquiry responses (each of which is itself a dictionary).
+        """
+        pass
 
-    Requests heartbeat for a grant for CBSDs.
+    @abc.abstractmethod
+    def Grant(self, request, ssl_cert=None, ssl_key=None):
+        """SAS-CBSD Grant interface.
 
-    Request and response are both lists of dictionaries. Each dictionary
-    contains all fields of a single request/response.
+        Request and response are both lists of dictionaries. Each dictionary
+        contains all fields of a single request/response.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "heartbeatRequest" and the value is a list of individual CBSD
-        heartbeat requests (each of which is itself a dictionary).
-      ssl_cert: Path to SSL cert file, if None, will use default cert file.
-      ssl_key: Path to SSL key file, if None, will use default key file.
-    Returns:
-      A dictionary with a single key-value pair where the key is
-      "heartbeatResponse" and the value is a list of individual CBSD
-      heartbeat responses (each of which is itself a dictionary).
-    """
-    pass
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "grantRequest" and the value is a list of individual CBSD
+            grant requests (each of which is itself a dictionary).
+          ssl_cert: Path to SSL cert file, if None, will use default cert file.
+          ssl_key: Path to SSL key file, if None, will use default key file.
+        Returns:
+          A dictionary with a single key-value pair where the key is
+          "grantResponse" and the value is a list of individual CBSD
+          grant responses (each of which is itself a dictionary).
+        """
+        pass
 
-  @abc.abstractmethod
-  def Relinquishment(self, request, ssl_cert=None, ssl_key=None):
-    """SAS-CBSD Relinquishment interface.
+    @abc.abstractmethod
+    def Heartbeat(self, request, ssl_cert=None, ssl_key=None):
+        """SAS-CBSD Heartbeat interface.
 
-    Relinquishes grant for CBSDs.
+        Requests heartbeat for a grant for CBSDs.
 
-    Request and response are both lists of dictionaries. Each dictionary
-    contains all fields of a single request/response.
+        Request and response are both lists of dictionaries. Each dictionary
+        contains all fields of a single request/response.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "relinquishmentRequest" and the value is a list of individual CBSD
-        relinquishment requests (each of which is itself a dictionary).
-      ssl_cert: Path to SSL cert file, if None, will use default cert file.
-      ssl_key: Path to SSL key file, if None, will use default key file.
-    Returns:
-      A dictionary with a single key-value pair where the key is
-      "relinquishmentResponse" and the value is a list of individual CBSD
-      relinquishment responses (each of which is itself a dictionary).
-    """
-    pass
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "heartbeatRequest" and the value is a list of individual CBSD
+            heartbeat requests (each of which is itself a dictionary).
+          ssl_cert: Path to SSL cert file, if None, will use default cert file.
+          ssl_key: Path to SSL key file, if None, will use default key file.
+        Returns:
+          A dictionary with a single key-value pair where the key is
+          "heartbeatResponse" and the value is a list of individual CBSD
+          heartbeat responses (each of which is itself a dictionary).
+        """
+        pass
 
-  @abc.abstractmethod
-  def Deregistration(self, request, ssl_cert=None, ssl_key=None):
-    """SAS-CBSD Deregistration interface.
+    @abc.abstractmethod
+    def Relinquishment(self, request, ssl_cert=None, ssl_key=None):
+        """SAS-CBSD Relinquishment interface.
 
-    Deregisters CBSDs.
+        Relinquishes grant for CBSDs.
 
-    Request and response are both lists of dictionaries. Each dictionary
-    contains all fields of a single request/response.
+        Request and response are both lists of dictionaries. Each dictionary
+        contains all fields of a single request/response.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "deregistrationRequest" and the value is a list of individual CBSD
-        deregistration requests (each of which is itself a dictionary).
-      ssl_cert: Path to SSL cert file, if None, will use default cert file.
-      ssl_key: Path to SSL key file, if None, will use default key file.
-    Returns:
-      A dictionary with a single key-value pair where the key is
-      "deregistrationResponse" and the value is a list of individual CBSD
-      deregistration responses (each of which is itself a dictionary).
-    """
-    pass
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "relinquishmentRequest" and the value is a list of individual CBSD
+            relinquishment requests (each of which is itself a dictionary).
+          ssl_cert: Path to SSL cert file, if None, will use default cert file.
+          ssl_key: Path to SSL key file, if None, will use default key file.
+        Returns:
+          A dictionary with a single key-value pair where the key is
+          "relinquishmentResponse" and the value is a list of individual CBSD
+          relinquishment responses (each of which is itself a dictionary).
+        """
+        pass
 
-  @abc.abstractmethod
-  def GetEscSensorRecord(self, request, ssl_cert=None, ssl_key=None):
-    """SAS-SAS ESC Sensor Record Exchange interface
+    @abc.abstractmethod
+    def Deregistration(self, request, ssl_cert=None, ssl_key=None):
+        """SAS-CBSD Deregistration interface.
 
-    Requests a Pull Command to get the ESC Sensor Data Message
+        Deregisters CBSDs.
 
-    Args:
-      request: A string containing Esc Sensor Record Id
-      ssl_cert: Path to SSL cert file, if None, will use default cert file.
-      ssl_key: Path to SSL key file, if None, will use default key file.
-    Returns:
-      A dictionary of Esc Sensor Data Message object specified in
-      WINNF-16-S-0096
-    """
-    pass
+        Request and response are both lists of dictionaries. Each dictionary
+        contains all fields of a single request/response.
 
-  @abc.abstractmethod
-  def GetFullActivityDump(self, ssl_cert=None, ssl_key=None):
-    """SAS-SAS Full Activity Dump interface.
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "deregistrationRequest" and the value is a list of individual CBSD
+            deregistration requests (each of which is itself a dictionary).
+          ssl_cert: Path to SSL cert file, if None, will use default cert file.
+          ssl_key: Path to SSL key file, if None, will use default key file.
+        Returns:
+          A dictionary with a single key-value pair where the key is
+          "deregistrationResponse" and the value is a list of individual CBSD
+          deregistration responses (each of which is itself a dictionary).
+        """
+        pass
 
-    Requests a Pull Command to get Full Activity Dump Message.
+    @abc.abstractmethod
+    def GetEscSensorRecord(self, request, ssl_cert=None, ssl_key=None):
+        """SAS-SAS ESC Sensor Record Exchange interface
 
-    Args:
-      ssl_cert: Path to SSL cert file, if None, will use default cert file.
-      ssl_key: Path to SSL key file, if None, will use default key file.
-    Returns:
-      A dictionary containing the FullActivityDump object specified in WINNF-16-S-0096
-    """
-    pass
+        Requests a Pull Command to get the ESC Sensor Data Message
 
-  @abc.abstractmethod
-  def DownloadFile(self, url, ssl_cert=None, ssl_key=None):
-    """SAS-SAS Get data from json files after generate the
-     Full Activity Dump Message
-    Returns:
-     the message as an "json data" object specified in WINNF-16-S-0096
-    """
-    pass
+        Args:
+          request: A string containing Esc Sensor Record Id
+          ssl_cert: Path to SSL cert file, if None, will use default cert file.
+          ssl_key: Path to SSL key file, if None, will use default key file.
+        Returns:
+          A dictionary of Esc Sensor Data Message object specified in
+          WINNF-16-S-0096
+        """
+        pass
+
+    @abc.abstractmethod
+    def GetFullActivityDump(self, ssl_cert=None, ssl_key=None):
+        """SAS-SAS Full Activity Dump interface.
+
+        Requests a Pull Command to get Full Activity Dump Message.
+
+        Args:
+          ssl_cert: Path to SSL cert file, if None, will use default cert file.
+          ssl_key: Path to SSL key file, if None, will use default key file.
+        Returns:
+          A dictionary containing the FullActivityDump object specified in WINNF-16-S-0096
+        """
+        pass
+
+    @abc.abstractmethod
+    def DownloadFile(self, url, ssl_cert=None, ssl_key=None):
+        """SAS-SAS Get data from json files after generate the
+         Full Activity Dump Message
+        Returns:
+         the message as an "json data" object specified in WINNF-16-S-0096
+        """
+        pass
 
 
 class SasAdminInterface(six.with_metaclass(abc.ABCMeta, object)):
-  """Minimal test control interface for the SAS under test."""
+    """Minimal test control interface for the SAS under test."""
 
-  @abc.abstractmethod
-  def Reset(self):
-    """SAS admin interface to reset the SAS between test cases."""
-    pass
+    @abc.abstractmethod
+    def Reset(self):
+        """SAS admin interface to reset the SAS between test cases."""
+        pass
 
-  @abc.abstractmethod
-  def InjectFccId(self, request):
-    """SAS admin interface to inject fcc id information into SAS under test.
+    @abc.abstractmethod
+    def InjectFccId(self, request):
+        """SAS admin interface to inject fcc id information into SAS under test.
 
-    Args:
-      request: A dictionary with the following key-value pairs:
-        "fccId": (string) valid fccId to be injected into SAS under test
-        "fccMaxEirp": (double) optional; default value of 47 dBm/10 MHz
-    """
-    pass
+        Args:
+          request: A dictionary with the following key-value pairs:
+            "fccId": (string) valid fccId to be injected into SAS under test
+            "fccMaxEirp": (double) optional; default value of 47 dBm/10 MHz
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectUserId(self, request):
-    """SAS admin interface to whitelist a user ID in the SAS under test.
+    @abc.abstractmethod
+    def InjectUserId(self, request):
+        """SAS admin interface to whitelist a user ID in the SAS under test.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "userId" and the value is a string of valid userId to be whitelisted by
-        the SAS under test.
-    """
-    pass
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "userId" and the value is a string of valid userId to be whitelisted by
+            the SAS under test.
+        """
+        pass
 
-  @abc.abstractmethod
-  def BlacklistByFccId(self, request):
-    """Inject an FCC ID which will be blacklisted by the SAS under test.
+    @abc.abstractmethod
+    def BlacklistByFccId(self, request):
+        """Inject an FCC ID which will be blacklisted by the SAS under test.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "fccId" and the value is the FCC ID (string) to be blacklisted.
-    """
-    pass
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "fccId" and the value is the FCC ID (string) to be blacklisted.
+        """
+        pass
 
-  @abc.abstractmethod
-  def BlacklistByFccIdAndSerialNumber(self, request):
-    """Inject an (FCC ID, serial number) pair which will be blacklisted by the
-       SAS under test.
+    @abc.abstractmethod
+    def BlacklistByFccIdAndSerialNumber(self, request):
+        """Inject an (FCC ID, serial number) pair which will be blacklisted by the
+           SAS under test.
 
-    Args:
-      request: A dictionary with the following key-value pairs:
-        "fccId": (string) blacklisted FCC ID
-        "serialNumber": (string) blacklisted serial number
-    """
-    pass
+        Args:
+          request: A dictionary with the following key-value pairs:
+            "fccId": (string) blacklisted FCC ID
+            "serialNumber": (string) blacklisted serial number
+        """
+        pass
 
-  @abc.abstractmethod
-  def PreloadRegistrationData(self, request):
-    """SAS admin interface to preload registration data into SAS under test.
+    @abc.abstractmethod
+    def PreloadRegistrationData(self, request):
+        """SAS admin interface to preload registration data into SAS under test.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "registrationData" and the value is a list of individual CBSD
-        registration data which need to be preloaded into SAS (each of which is
-        itself a dictionary). The dictionary is a RegistrationRequest object,
-        the fccId and cbsdSerialNumber fields are required, other fields are
-        optional.
-    """
-    pass
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "registrationData" and the value is a list of individual CBSD
+            registration data which need to be preloaded into SAS (each of which is
+            itself a dictionary). The dictionary is a RegistrationRequest object,
+            the fccId and cbsdSerialNumber fields are required, other fields are
+            optional.
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectExclusionZone(self, request):
-    """Inject exclusion zone information into SAS under test.
+    @abc.abstractmethod
+    def InjectExclusionZone(self, request):
+        """Inject exclusion zone information into SAS under test.
 
-    Args:
-      request: A dictionary with the following key-value pairs:
-        "zone": A GeoJSON object defining the exclusion zone to be injected to SAS UUT.
-        "frequencyRanges": A list of frequency ranges for the exclusion zone.
-    """
-    pass
+        Args:
+          request: A dictionary with the following key-value pairs:
+            "zone": A GeoJSON object defining the exclusion zone to be injected to SAS UUT.
+            "frequencyRanges": A list of frequency ranges for the exclusion zone.
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectZoneData(self, request):
-    """Inject PPA or NTIA zone information into SAS under test.
+    @abc.abstractmethod
+    def InjectZoneData(self, request):
+        """Inject PPA or NTIA zone information into SAS under test.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "record" and the value is ZoneData object to be injected into
-        SAS under test. For more information about ZoneData please see
-        the SAS-SAS TS (WINNF-16-S-0096).
-    """
-    pass
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "record" and the value is ZoneData object to be injected into
+            SAS under test. For more information about ZoneData please see
+            the SAS-SAS TS (WINNF-16-S-0096).
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectPalDatabaseRecord(self, request):
-    """Inject a PAL Database record into the SAS under test.
+    @abc.abstractmethod
+    def InjectPalDatabaseRecord(self, request):
+        """Inject a PAL Database record into the SAS under test.
 
-    Args:
-      request:
-      For the contents of this request, please refer to the PAL Database TS
-      (WINNF-16-S-0245).
-    """
-    pass
+        Args:
+          request:
+          For the contents of this request, please refer to the PAL Database TS
+          (WINNF-16-S-0245).
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectFss(self, request):
-    """SAS admin interface to inject FSS information into SAS under test.
+    @abc.abstractmethod
+    def InjectFss(self, request):
+        """SAS admin interface to inject FSS information into SAS under test.
 
-    Args:
-        request: A dictionary with a single key-value pair where the key is
-        "record" and the value is a fixed satellite service object
-        (which is itself a dictionary). The dictionary is an
-        IncumbentProtectionData object (specified in SAS-SAS TS).
-    """
-    pass
+        Args:
+            request: A dictionary with a single key-value pair where the key is
+            "record" and the value is a fixed satellite service object
+            (which is itself a dictionary). The dictionary is an
+            IncumbentProtectionData object (specified in SAS-SAS TS).
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectWisp(self, request):
-    """SAS admin interface to inject WISP information into SAS under test.
+    @abc.abstractmethod
+    def InjectWisp(self, request):
+        """SAS admin interface to inject WISP information into SAS under test.
 
-    Args:
-      request: A dictionary with two key-value pairs where the keys are
-        "record" and "zone" with the values IncumbentProtectionData
-        object (specified in SAS-SAS TS) and a GeoJSON Object respectively
-    Note: Required Field in IncumbentProtectionData are id, type,
-    deploymentParam->operationParam->operationFrequencyRange->
-    lowFrequency, highFrequency
-    """
-    pass
+        Args:
+          request: A dictionary with two key-value pairs where the keys are
+            "record" and "zone" with the values IncumbentProtectionData
+            object (specified in SAS-SAS TS) and a GeoJSON Object respectively
+        Note: Required Field in IncumbentProtectionData are id, type,
+        deploymentParam->operationParam->operationFrequencyRange->
+        lowFrequency, highFrequency
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectSasAdministratorRecord(self, request):
-    """SAS admin interface to inject SAS Administrator Record into SAS under test.
+    @abc.abstractmethod
+    def InjectSasAdministratorRecord(self, request):
+        """SAS admin interface to inject SAS Administrator Record into SAS under test.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "record" and the value is a SAS Administrator information (which is
-        itself a dictionary). The dictionary is an SASAdministrator object
-        (Specified in SAS-SAS TS WINNF-16-S-0096)
-    """
-    pass
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "record" and the value is a SAS Administrator information (which is
+            itself a dictionary). The dictionary is an SASAdministrator object
+            (Specified in SAS-SAS TS WINNF-16-S-0096)
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectEscSensorDataRecord(self, request):
-    """SAS admin interface to inject ESC Sensor Data Record into SAS under test.
+    @abc.abstractmethod
+    def InjectEscSensorDataRecord(self, request):
+        """SAS admin interface to inject ESC Sensor Data Record into SAS under test.
 
-    Args:
-      request: A dictionary with a single key-value pair where the key is
-        "record" and the value is a EscSensorData object (which is
-        itself a dictionary specified in SAS-SAS TS WINNF-16-S-0096)
-    Behavior: SAS should act as if it is connected to an ESC sensor with
-    the provided parameters.
-    """
-    pass
+        Args:
+          request: A dictionary with a single key-value pair where the key is
+            "record" and the value is a EscSensorData object (which is
+            itself a dictionary specified in SAS-SAS TS WINNF-16-S-0096)
+        Behavior: SAS should act as if it is connected to an ESC sensor with
+        the provided parameters.
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerMeasurementReportRegistration(self):
-    """SAS admin interface to trigger measurement report request for all subsequent
-    registration request
+    @abc.abstractmethod
+    def TriggerMeasurementReportRegistration(self):
+        """SAS admin interface to trigger measurement report request for all subsequent
+        registration request
 
-    Note: The SAS should request a measurement report in the RegistrationResponse
-    (if status == 0)
-    """
-    pass
+        Note: The SAS should request a measurement report in the RegistrationResponse
+        (if status == 0)
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerMeasurementReportHeartbeat(self):
-    """SAS admin interface to trigger measurement report request for all subsequent
-    heartbeat request
+    @abc.abstractmethod
+    def TriggerMeasurementReportHeartbeat(self):
+        """SAS admin interface to trigger measurement report request for all subsequent
+        heartbeat request
 
-    Note: The SAS should request a measurement report in the HeartbeatResponse
-    (if status == 0)
-    """
-    pass
+        Note: The SAS should request a measurement report in the HeartbeatResponse
+        (if status == 0)
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerPpaCreation(self, request):
-    """SAS admin interface to trigger PPA creation based on the CBSD Ids,
-    Pal Ids and Provided Contour
+    @abc.abstractmethod
+    def TriggerPpaCreation(self, request):
+        """SAS admin interface to trigger PPA creation based on the CBSD Ids,
+        Pal Ids and Provided Contour
 
-    Args:
-      request: A dictionary with multiple key-value pairs where the keys are
-        cbsdIds: array of string containing CBSD Id
-        palIds: array of string containing PAL Id
-        providedContour(optional): GeoJSON Object
+        Args:
+          request: A dictionary with multiple key-value pairs where the keys are
+            cbsdIds: array of string containing CBSD Id
+            palIds: array of string containing PAL Id
+            providedContour(optional): GeoJSON Object
 
-    Returns:
-      PPA Id in string format
-    """
-    pass
+        Returns:
+          PPA Id in string format
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerDailyActivitiesImmediately(self):
-    """SAS admin interface to trigger daily activities immediately which will
-    execute the following activities:
-      1. Pull from all External Database and other SASes (URLs will be injected to
-      SAS UUT using another RPC Call)
-      2. Run IAP and DPA Calculations
-      3. Apply EIRP updates to devices
-    """
-    pass
+    @abc.abstractmethod
+    def TriggerDailyActivitiesImmediately(self):
+        """SAS admin interface to trigger daily activities immediately which will
+        execute the following activities:
+          1. Pull from all External Database and other SASes (URLs will be injected to
+          SAS UUT using another RPC Call)
+          2. Run IAP and DPA Calculations
+          3. Apply EIRP updates to devices
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerEnableNtiaExclusionZones(self):
-    """SAS admin interface to trigger enforcement of the NTIA exclusion zones 
-    """
-    pass
+    @abc.abstractmethod
+    def TriggerEnableNtiaExclusionZones(self):
+        """SAS admin interface to trigger enforcement of the NTIA exclusion zones 
+        """
+        pass
 
-  @abc.abstractmethod
-  def GetDailyActivitiesStatus(self):
-    """SAS admin interface to get the daily activities status
-    Returns:
-      A dictionary with a single key-value pair where the key is "completed" and the
-      value is a boolean with value as true if the daily activities is completed and
-      false if the daily activities is running/failing.
-    """
-    pass
+    @abc.abstractmethod
+    def GetDailyActivitiesStatus(self):
+        """SAS admin interface to get the daily activities status
+        Returns:
+          A dictionary with a single key-value pair where the key is "completed" and the
+          value is a boolean with value as true if the daily activities is completed and
+          false if the daily activities is running/failing.
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerEnableScheduledDailyActivities(self):
-    """SAS admin interface to trigger the daily activities according to the 
-       schedule agreed upon by SAS admins.                         
-    """
-    pass
+    @abc.abstractmethod
+    def TriggerEnableScheduledDailyActivities(self):
+        """SAS admin interface to trigger the daily activities according to the 
+           schedule agreed upon by SAS admins.                         
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectCpiUser(self, request):
-    """SAS admin interface to add a CPI User as if it came directly from the CPI database.
+    @abc.abstractmethod
+    def InjectCpiUser(self, request):
+        """SAS admin interface to add a CPI User as if it came directly from the CPI database.
 
-    Args:
-      request: A dictionary with the following key-value pairs:
-        "cpiId": (string) valid cpiId to be injected into SAS under test
-        "cpiName": (string) valid name for cpi user to be injected into SAS under test
-        "cpiPublicKey": (string) public key value for cpi user to be injected into SAS under test
-    """
-    pass
+        Args:
+          request: A dictionary with the following key-value pairs:
+            "cpiId": (string) valid cpiId to be injected into SAS under test
+            "cpiName": (string) valid name for cpi user to be injected into SAS under test
+            "cpiPublicKey": (string) public key value for cpi user to be injected into SAS under test
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerLoadDpas(self):
-    """SAS admin interface to load all ESC-monitored DPAs and immediately activate all of them.
-    """
-    pass
+    @abc.abstractmethod
+    def TriggerLoadDpas(self):
+        """SAS admin interface to load all ESC-monitored DPAs and immediately activate all of them.
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerBulkDpaActivation(self, request):
-    """SAS admin interface to bulk DPA activation/deactivation
-     Args:
-      request: A dictionary with the following key-value pairs:
-        "activate": (boolean) if True, activate all ESC-monitored DPAs on all channels
-            else deactivate all ESC-monitored DPAs on all channels
-    """
-    pass
+    @abc.abstractmethod
+    def TriggerBulkDpaActivation(self, request):
+        """SAS admin interface to bulk DPA activation/deactivation
+         Args:
+          request: A dictionary with the following key-value pairs:
+            "activate": (boolean) if True, activate all ESC-monitored DPAs on all channels
+                else deactivate all ESC-monitored DPAs on all channels
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerDpaActivation(self, request):
-    """SAS admin interface to activate specific DPA on specific channel
-     Args:
-      request: A dictionary with the following key-value pairs:
-        "dpaId": (string) it represents the field "name" in the kml file of DPAs
-        "frequencyRange": frequencyRange of DPA Channel with lowFrequency, highFrequency
+    @abc.abstractmethod
+    def TriggerDpaActivation(self, request):
+        """SAS admin interface to activate specific DPA on specific channel
+         Args:
+          request: A dictionary with the following key-value pairs:
+            "dpaId": (string) it represents the field "name" in the kml file of DPAs
+            "frequencyRange": frequencyRange of DPA Channel with lowFrequency, highFrequency
 
-    """
-    pass
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerDpaDeactivation(self, request):
-    """SAS admin interface to deactivate specific DPA on specific channel
-     Args:
-      request: A dictionary with the following key-value pairs:
-        "dpaId": (string) it represents the field "name" in the kml file of DPAs
-        "frequencyRange": frequencyRange of DPA Channel with lowFrequency, highFrequency
-    """
-    pass
+    @abc.abstractmethod
+    def TriggerDpaDeactivation(self, request):
+        """SAS admin interface to deactivate specific DPA on specific channel
+         Args:
+          request: A dictionary with the following key-value pairs:
+            "dpaId": (string) it represents the field "name" in the kml file of DPAs
+            "frequencyRange": frequencyRange of DPA Channel with lowFrequency, highFrequency
+        """
+        pass
 
-  @abc.abstractmethod
-  def TriggerEscDisconnect(self):
-    """Simulates the ESC (ESC-DE) being disconnected from the SAS UUT."""
-    pass
+    @abc.abstractmethod
+    def TriggerEscDisconnect(self):
+        """Simulates the ESC (ESC-DE) being disconnected from the SAS UUT."""
+        pass
 
-  @abc.abstractmethod
-  def TriggerFullActivityDump(self):
-    """SAS admin interface to trigger generation of a Full Activity Dump.
+    @abc.abstractmethod
+    def TriggerFullActivityDump(self):
+        """SAS admin interface to trigger generation of a Full Activity Dump.
 
-    Note: SAS does not need to complete generation before returning HTTP 200.
-    See the testing API specification for more details.
-    """
-    pass
+        Note: SAS does not need to complete generation before returning HTTP 200.
+        See the testing API specification for more details.
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectPeerSas(self, request):
-    """SAS admin interface to inject a peer SAS into the SAS UUT.
+    @abc.abstractmethod
+    def InjectPeerSas(self, request):
+        """SAS admin interface to inject a peer SAS into the SAS UUT.
 
-    Args:
-      request: A dictionary with the following key-value pairs:
-        "certificateHash": the sha1 fingerprint of the certificate
-        "url": base URL of the peer SAS.
-    """
-    pass
+        Args:
+          request: A dictionary with the following key-value pairs:
+            "certificateHash": the sha1 fingerprint of the certificate
+            "url": base URL of the peer SAS.
+        """
+        pass
 
-  @abc.abstractmethod
-  def QueryPropagationAndAntennaModel(self, request):
-    """SAS admin interface to query propagation and antenna gains for CBSD and FSS  or Provided PPA Contour
+    @abc.abstractmethod
+    def QueryPropagationAndAntennaModel(self, request):
+        """SAS admin interface to query propagation and antenna gains for CBSD and FSS  or Provided PPA Contour
 
-    Args:
-      request: A dictionary with multiple key-value pairs where the keys are
-        reliabilityLevel: (permitted values: -1, 0.05, 0.95)
-        cbsd: dictionary defining cbsd
-        fss(optional): dictionary defining fss
-        ppa(optional): GeoJSON Object
+        Args:
+          request: A dictionary with multiple key-value pairs where the keys are
+            reliabilityLevel: (permitted values: -1, 0.05, 0.95)
+            cbsd: dictionary defining cbsd
+            fss(optional): dictionary defining fss
+            ppa(optional): GeoJSON Object
 
-    Returns:
-      double pathlossDb (pathloss in dB)
-      double txAntennaGainDbi (transmitter antenna gain in dBi in the direction of the receiver)
-      double rxAntennaGainDbi (optional) (receiver antenna gain in dBi in the direction of the transmitter)
+        Returns:
+          double pathlossDb (pathloss in dB)
+          double txAntennaGainDbi (transmitter antenna gain in dBi in the direction of the receiver)
+          double rxAntennaGainDbi (optional) (receiver antenna gain in dBi in the direction of the transmitter)
 
-    """
-    pass
+        """
+        pass
 
-  @abc.abstractmethod
-  def GetPpaCreationStatus(self):
-    """SAS admin interface to get the most recent PPA creation status
-    Returns:
-      A dictionary with a two key-value pairs where the keys are "completed" and
-      "withError". The values are of boolean type. The value for "completed" flag
-      set to True if the ppa creation(for the most recent ppa creation) has completed or
-      to False if the PPA creation is still in progress. The value for "withError" flag is
-      is set to True if the PPA creation has completed with error(s) else it is set to False.
-    """
-    pass
+    @abc.abstractmethod
+    def GetPpaCreationStatus(self):
+        """SAS admin interface to get the most recent PPA creation status
+        Returns:
+          A dictionary with a two key-value pairs where the keys are "completed" and
+          "withError". The values are of boolean type. The value for "completed" flag
+          set to True if the ppa creation(for the most recent ppa creation) has completed or
+          to False if the PPA creation is still in progress. The value for "withError" flag is
+          is set to True if the PPA creation has completed with error(s) else it is set to False.
+        """
+        pass
 
-  @abc.abstractmethod
-  def InjectDatabaseUrl(self, request):
-    """Inject the Database URL into SAS.
+    @abc.abstractmethod
+    def InjectDatabaseUrl(self, request):
+        """Inject the Database URL into SAS.
 
-    Args:
-      request: Contains database url to be injected.
-    """
-    pass
+        Args:
+          request: Contains database url to be injected.
+        """
+        pass


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
See https://github.com/magma/magma/issues/11816 for details

Trying to add E1 (indentation related formatting to our CI/formatting script). Formatting in advance before pulling the trigger to avoid confusion.

This change is entirely automatically generated by autopep8
`autopep8  --select W191,W291,W292,W293,W391,E131,E2,E3,E1 -r --in-place ./dp`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
