### PR TITLE
chore(feg): add E1 to autopep8 python formatting

### DIFF
--- a/feg/gateway/fabfile.py
+++ b/feg/gateway/fabfile.py
@@ -58,7 +58,7 @@ def check_feg_cloud_connectivity(timeout=5):
     local("cd docker")
     local("pwd")
     dev_utils.local_command_with_repetition(
-            "cd docker; docker-compose exec magmad checkin_cli.py", timeout,
+        "cd docker; docker-compose exec magmad checkin_cli.py", timeout,
     )
 
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
See https://github.com/magma/magma/issues/11816 for details

Trying to add E1 (indentation related formatting to our CI/formatting script). Formatting in advance before pulling the trigger to avoid confusion.

This change is entirely automatically generated by autopep8
`autopep8  --select W191,W291,W292,W293,W391,E131,E2,E3,E1 -r --in-place ./`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
