### PR TITLE
chore(agw): add E1 to autopep8 python formatting

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/nx_actions.py
+++ b/lte/gateway/deploy/roles/magma/files/nx_actions.py
@@ -215,8 +215,8 @@ def generate(ofp_name, ofpp_name):
         def serialize(self, buf, offset):
             data = self.serialize_body()
             payload_offset = (
-                    ofp.OFP_ACTION_EXPERIMENTER_HEADER_SIZE +
-                    struct.calcsize(NXAction._fmt_str)
+                ofp.OFP_ACTION_EXPERIMENTER_HEADER_SIZE +
+                struct.calcsize(NXAction._fmt_str)
             )
             self.len = utils.round_up(payload_offset + len(data), 8)
             super(NXAction, self).serialize(buf, offset)

--- a/lte/gateway/deploy/roles/magma_test/files/c_parser.py
+++ b/lte/gateway/deploy/roles/magma_test/files/c_parser.py
@@ -203,7 +203,7 @@ def extract_enums(in_fname, out_fname):
     )
     enum_list = Group(enum_value + ZeroOrMore(_comma + enum_value))
     enum = _enum + Optional(identifier('enum_prefix')) + _lcurl + \
-           enum_list('list') + _rcurl + Optional(identifier('enum_postfix'))
+        enum_list('list') + _rcurl + Optional(identifier('enum_postfix'))
     enum.ignore(cppStyleComment)
 
     for item, _, _ in enum.scanString(sample):  # item, start, stop
@@ -269,7 +269,7 @@ def extract_inner_struct(parsed_struct, out_fname):
     params = _extract_inner_params(parsed_struct)
     _write_class(out_fname, parsed_struct.inner_struct, params, "Structure")
     return parsed_struct.inner_struct, parsed_struct.inner_param_name, None, \
-           parsed_struct.length
+        parsed_struct.length
 
 
 def extract_inner_union(parsed_union, out_fname):
@@ -287,12 +287,12 @@ def extract_inner_union(parsed_union, out_fname):
     union_type_name = parsed_union.inner_param_name.title()
     _write_class(out_fname, union_type_name, params, "Union")
     return union_type_name, parsed_union.inner_param_name, None, \
-           parsed_union.length
+        parsed_union.length
 
 
 def extract_simple_param(parsed_struct):
     return parsed_struct[0].param_type, parsed_struct[0].param_name, \
-           parsed_struct[0].ptr, parsed_struct[0].length
+        parsed_struct[0].ptr, parsed_struct[0].length
 
 
 def normalize_param(param_type, param_name, ptr, length):
@@ -318,7 +318,7 @@ def normalize_param(param_type, param_name, ptr, length):
     else:
         # Assert we know about this struct or const
         assert p_type in c_struct or p_type in defines or \
-               p_type in anon_types or p_type in enums, \
+            p_type in anon_types or p_type in enums, \
             "{} not in {} or {} or {} or {}".format(
                 p_type, c_struct, defines,
                 anon_types, enums,
@@ -390,8 +390,8 @@ def extract_structs(in_fname, out_fname):
     )
 
     struct = _struct + Optional(identifier('struct_prefix')) + _lcurl + \
-             struct_list('list') + _rcurl + \
-             Optional(identifier('struct_postfix')) + _semi_colon
+        struct_list('list') + _rcurl + \
+        Optional(identifier('struct_postfix')) + _semi_colon
     struct.ignore(cppStyleComment)
 
     for item, _, _ in struct.scanString(sample):  # item, start, stop

--- a/lte/gateway/deploy/roles/trfserver/files/traffic_server.py
+++ b/lte/gateway/deploy/roles/trfserver/files/traffic_server.py
@@ -142,7 +142,7 @@ class TrafficTestServerDispatcher(socketserver.TCPServer):
             if daemon else logging.StreamHandler()
         log_handler.setFormatter(
             logging.Formatter(
-            log_format, log_time_format,
+                log_format, log_time_format,
             ),
         )
 
@@ -395,7 +395,7 @@ class TrafficTestServer(socketserver.StreamRequestHandler):
                     self.log.error(
                         ''.join(
                             traceback.format_exception(
-                            type(e), e, sys.exc_info()[2],
+                                type(e), e, sys.exc_info()[2],
                             ),
                         ),
                     )

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -242,7 +242,7 @@ def federated_integ_test(
     )
 
     vagrant_setup(
-            'magma_test', destroy_vm, force_provision=provision_vm,
+        'magma_test', destroy_vm, force_provision=provision_vm,
     )
     execute(_make_integ_tests)
     execute(run_integ_tests, "federated_tests/s1aptests/test_attach_detach.py")
@@ -601,7 +601,7 @@ def _set_service_config_var(service, var_name, value):
     """ Sets variable in config file by value """
     run(
         "echo '%s: %s' | sudo tee -a /var/opt/magma/configs/%s.yml" % (
-        var_name, str(value), service,
+            var_name, str(value), service,
         ),
     )
 

--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -214,7 +214,7 @@ class IPAddressManager:
             if ipv4_blocks:
                 ipv4_blocks_deleted.extend(
                     self.ip_allocator.remove_ip_blocks(
-                    ipv4_blocks, force=force,
+                        ipv4_blocks, force=force,
                     ),
                 )
             if ipv6_blocks:

--- a/lte/gateway/python/magma/mobilityd/serialize_utils.py
+++ b/lte/gateway/python/magma/mobilityd/serialize_utils.py
@@ -114,7 +114,7 @@ def _ip_desc_from_proto(proto):
     ip_block_addr = ip_address(proto.ip_block.net_address).exploded
     ip_block = ip_network(
         '{}/{}'.format(
-        ip_block_addr, proto.ip_block.prefix_len,
+            ip_block_addr, proto.ip_block.prefix_len,
         ),
     )
     state = _desc_state_proto_to_str(proto.state)

--- a/lte/gateway/python/magma/subscriberdb/protocols/diameter/application/s6a.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/diameter/application/s6a.py
@@ -210,14 +210,14 @@ class S6AApplication(abc.Application):
 
             auth_info = avp.AVP(
                 'Authentication-Info', [
-                avp.AVP(
-                    'E-UTRAN-Vector', [
-                    avp.AVP('RAND', rand),
-                    avp.AVP('XRES', xres),
-                    avp.AVP('AUTN', autn),
-                    avp.AVP('KASME', kasme),
-                    ],
-                ),
+                    avp.AVP(
+                        'E-UTRAN-Vector', [
+                            avp.AVP('RAND', rand),
+                            avp.AVP('XRES', xres),
+                            avp.AVP('AUTN', autn),
+                            avp.AVP('KASME', kasme),
+                        ],
+                    ),
                 ],
             )
 

--- a/lte/gateway/python/magma/subscriberdb/protocols/diameter/application/s6a_relay.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/diameter/application/s6a_relay.py
@@ -143,8 +143,8 @@ class S6ARelayApplication(S6AApplication):
             if answer.error_code:
                 result_info = avp.AVP(
                     'Experimental-Result', [
-                    avp.AVP('Vendor-Id', 10415),
-                    avp.AVP('Experimental-Result-Code', error_code),
+                        avp.AVP('Vendor-Id', 10415),
+                        avp.AVP('Experimental-Result-Code', error_code),
                     ],
                 )
                 resp = self._gen_response(
@@ -160,14 +160,14 @@ class S6ARelayApplication(S6AApplication):
             else:
                 auth_info = avp.AVP(
                     'Authentication-Info', [
-                    avp.AVP(
-                        'E-UTRAN-Vector', [
-                        avp.AVP('RAND', vector.rand),
-                        avp.AVP('XRES', vector.xres),
-                        avp.AVP('AUTN', vector.autn),
-                        avp.AVP('KASME', vector.kasme),
-                        ],
-                    ) for vector in answer.eutran_vectors
+                        avp.AVP(
+                            'E-UTRAN-Vector', [
+                                avp.AVP('RAND', vector.rand),
+                                avp.AVP('XRES', vector.xres),
+                                avp.AVP('AUTN', vector.autn),
+                                avp.AVP('KASME', vector.kasme),
+                            ],
+                        ) for vector in answer.eutran_vectors
                     ],
                 )
 
@@ -252,8 +252,8 @@ class S6ARelayApplication(S6AApplication):
             if error_code:
                 result_info = avp.AVP(
                     'Experimental-Result', [
-                    avp.AVP('Vendor-Id', 10415),
-                    avp.AVP('Experimental-Result-Code', error_code),
+                        avp.AVP('Vendor-Id', 10415),
+                        avp.AVP('Experimental-Result-Code', error_code),
                     ],
                 )
                 resp = self._gen_response(

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -83,11 +83,11 @@ class SqliteStore(BaseStore):
 
     def _create_digest_db_locations(self, db_location: str) -> DigestDBInfo:
         root_digest_db_location = 'file:' + db_location + \
-                             'subscriber-root-digest.db?cache=shared'
+            'subscriber-root-digest.db?cache=shared'
         logging.info("root digest db location: %s", root_digest_db_location)
 
         leaf_digests_db_location = 'file:' + db_location + \
-                                     'subscriber-leaf-digests.db?cache=shared'
+            'subscriber-leaf-digests.db?cache=shared'
         logging.info(
             "leaf digests db location: %s",
             leaf_digests_db_location,
@@ -275,8 +275,8 @@ class SqliteStore(BaseStore):
             if (len(db_parts) == 2) and db_parts[1]:
                 path_str = db_parts[1].split("?")
                 output = subprocess.Popen(
-                        ["/usr/bin/fuser", "-uv", path_str[0]],
-                        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                    ["/usr/bin/fuser", "-uv", path_str[0]],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 )
                 logging.info(output.communicate())
             raise SubscriberServerTooBusy(subscriber_id)

--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -173,10 +173,10 @@ def ovs_reset_bridges():
     else:
         non_nat_sgi_interface = service_config['nat_iface']
         sgi_management_iface_ip_addr = service_config.get(
-           'sgi_management_iface_ip_addr', mconfig.sgi_management_iface_ip_addr,
+            'sgi_management_iface_ip_addr', mconfig.sgi_management_iface_ip_addr,
         )
         sgi_management_iface_gw = service_config.get(
-           'sgi_management_iface_gw', mconfig.sgi_management_iface_gw,
+            'sgi_management_iface_gw', mconfig.sgi_management_iface_gw,
         )
 
     sgi_bridge_name = service_config.get('uplink_bridge', "uplink_br0")

--- a/lte/gateway/python/scripts/packet_ryu_cli.py
+++ b/lte/gateway/python/scripts/packet_ryu_cli.py
@@ -50,23 +50,23 @@ def _simple_get(args):
 
 
 def _simple_add(args):
-        fields = {
-            "dpid": datapath, "table_id": args.table_start,
-            "priority": args.priority, "instructions":
-            [{"type": "GOTO_TABLE", "table_id": args.table_end}],
-        }
-        if args.cookie:
-            fields["cookie"] = args.cookie
-        if args.reg1:
-            reg1 = int(args.reg1, 0)
-            fields["instructions"].append({
-                "type": "APPLY_ACTIONS", "actions":
-                [{
-                    "type": "SET_FIELD", "field":
-                    "reg1", "value": reg1,
-                }],
-            })
-        add_flowentry(fields)
+    fields = {
+        "dpid": datapath, "table_id": args.table_start,
+        "priority": args.priority, "instructions":
+        [{"type": "GOTO_TABLE", "table_id": args.table_end}],
+    }
+    if args.cookie:
+        fields["cookie"] = args.cookie
+    if args.reg1:
+        reg1 = int(args.reg1, 0)
+        fields["instructions"].append({
+            "type": "APPLY_ACTIONS", "actions":
+            [{
+                "type": "SET_FIELD", "field":
+                "reg1", "value": reg1,
+            }],
+        })
+    add_flowentry(fields)
 
 
 def _simple_send(args):

--- a/lte/gateway/python/scripts/pipelined_cli.py
+++ b/lte/gateway/python/scripts/pipelined_cli.py
@@ -79,8 +79,8 @@ def stress_test5g(client, args):
     else:
         print("QOS Enabled")
         apn_ambr = AggregatedMaximumBitrate(
-                max_bandwidth_ul=1000000000,
-                max_bandwidth_dl=1000000000,
+            max_bandwidth_ul=1000000000,
+            max_bandwidth_dl=1000000000,
         )
     print("Starting attaches")
     timestamp = datetime.now()


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
See https://github.com/magma/magma/issues/11816 for details

Trying to add E1 (indentation related formatting to our CI/formatting script). Formatting in advance before pulling the trigger to avoid confusion.

This change is entirely automatically generated by autopep8
`autopep8  --select W191,W291,W292,W293,W391,E131,E2,E3,E1 -r --in-place ./`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
