### PR TITLE
chore(agw): add E1 to s1ap autopep8 python formatting

### DIFF
--- a/lte/gateway/python/integ_tests/common/mobility_service_client.py
+++ b/lte/gateway/python/integ_tests/common/mobility_service_client.py
@@ -125,7 +125,7 @@ class MobilityServiceGrpc(MobilityServiceClient):
                 address = ipaddress.ip_address(address_int)
                 ip_block_list.append(
                     ipaddress.ip_network(
-                    "%s/%d" % (address, block.prefix_len),
+                        "%s/%d" % (address, block.prefix_len),
                     ),
                 )
             if ip_block_list is not None:
@@ -164,7 +164,7 @@ class MobilityServiceGrpc(MobilityServiceClient):
                 address = ipaddress.ip_address(address_int)
                 removed_ip_block_list += (
                     ipaddress.ip_network(
-                    "%s/%d" % (address, block.prefix_len),
+                        "%s/%d" % (address, block.prefix_len),
                     ),
                 )
             return removed_ip_block_list

--- a/lte/gateway/python/integ_tests/common/service303_utils.py
+++ b/lte/gateway/python/integ_tests/common/service303_utils.py
@@ -56,7 +56,7 @@ class GatewayServicesUtil(object):
         # Mobilityd comes up after mme, so wait for this too
         assert(
             self._mobilityd_service.wait_for_healthy_service(
-            after_start_time,
+                after_start_time,
             )
         )
 
@@ -103,7 +103,7 @@ class Service303Util(object):
     @staticmethod
     def _is_metric_type_supported(metric_type):
         return metric_type == metrics_proto.GAUGE \
-               or metric_type == metrics_proto.COUNTER
+            or metric_type == metrics_proto.COUNTER
 
     def get_metric_value(
         self,

--- a/lte/gateway/python/integ_tests/gxgy_tests/session_manager.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/session_manager.py
@@ -81,17 +81,17 @@ def get_standard_update_response(
         for update in args[0].updates:
             charging_responses.append(
                 create_update_response(
-                update.sid, update.usage.charging_key, quota,
-                is_final=is_final, success=success,
+                    update.sid, update.usage.charging_key, quota,
+                    is_final=is_final, success=success,
                 ),
             )
             update_complete.put(update)
         for monitor in args[0].usage_monitors:
             monitor_responses.append(
                 create_monitor_response(
-                monitor.sid, monitor.update.monitoring_key, quota,
-                monitor.update.level, action=monitor_action,
-                success=success,
+                    monitor.sid, monitor.update.monitoring_key, quota,
+                    monitor.update.level, action=monitor_action,
+                    success=success,
                 ),
             )
             monitor_complete.put(monitor)

--- a/lte/gateway/python/integ_tests/gxgy_tests/test_usage_monitors.py
+++ b/lte/gateway/python/integ_tests/gxgy_tests/test_usage_monitors.py
@@ -72,7 +72,7 @@ class UsageMonitorTest(unittest.TestCase):
                 dynamic_rules=[],
                 usage_monitors=[
                     create_monitor_response(
-                    sub1.imsi, "mkey1", quota, session_manager_pb2.PCC_RULE_LEVEL,
+                        sub1.imsi, "mkey1", quota, session_manager_pb2.PCC_RULE_LEVEL,
                     ),
                 ],
             ),

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -409,14 +409,14 @@ class S1ApUtil(object):
         detach_req.ue_Id = ue_id
         detach_req.ueDetType = reason_type
         assert (
-                self.issue_cmd(s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req)
-                == 0
+            self.issue_cmd(s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req)
+            == 0
         )
         if reason_type == s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value:
             response = self.get_response()
             assert (
-                    s1ap_types.tfwCmd.UE_DETACH_ACCEPT_IND.value
-                    == response.msg_type
+                s1ap_types.tfwCmd.UE_DETACH_ACCEPT_IND.value
+                == response.msg_type
             )
 
         # Now wait for the context release response
@@ -468,8 +468,8 @@ class S1ApUtil(object):
                 },
             )
             assert (
-                    len(total_dl_ovs_flows_created)
-                    == total_num_dl_flows_to_be_verified
+                len(total_dl_ovs_flows_created)
+                == total_num_dl_flows_to_be_verified
             )
 
             # Now verify the rules for every flow
@@ -511,7 +511,7 @@ class S1ApUtil(object):
                                 5,
                             )  # sleep for 5 seconds before retrying
                         assert (
-                                len(downlink_flows) >= num_dl_flows
+                            len(downlink_flows) >= num_dl_flows
                         ), "Downlink flow missing for UE"
                         assert downlink_flows[0]["match"][ip_dst] == ue_ip_addr
                         actions = downlink_flows[0]["instructions"][0][
@@ -588,7 +588,7 @@ class S1ApUtil(object):
                     break
                 time.sleep(5)  # sleep for 5 seconds before retrying
             assert (
-                    len(paging_flows) == num_paging_flows_to_be_verified
+                len(paging_flows) == num_paging_flows_to_be_verified
             ), "Paging flow missing for UE"
 
             # TODO - Verify that the action is to send to controller
@@ -916,29 +916,29 @@ class MagmadUtil(object):
             print("MME configuration is updated successfully")
         elif ret_code == 1:
             assert False, (
-                    "Failed to "
-                    + action
-                    + " MME configuration. Error: Invalid command"
+                "Failed to "
+                + action
+                + " MME configuration. Error: Invalid command"
             )
         elif ret_code == 2:
             assert False, (
-                    "Failed to "
-                    + action
-                    + " MME configuration. Error: MME configuration file is "
-                    + "missing"
+                "Failed to "
+                + action
+                + " MME configuration. Error: MME configuration file is "
+                + "missing"
             )
         elif ret_code == 3:
             assert False, (
-                    "Failed to "
-                    + action
-                    + " MME configuration. Error: MME configuration's backup file "
-                    + "is missing"
+                "Failed to "
+                + action
+                + " MME configuration. Error: MME configuration's backup file "
+                + "is missing"
             )
         else:
             assert False, (
-                    "Failed to "
-                    + action
-                    + " MME configuration. Error: Unknown error"
+                "Failed to "
+                + action
+                + " MME configuration. Error: Unknown error"
             )
 
     def update_mme_config_for_non_sanity(self, cmd):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_no_ueContext_release_comp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_no_ueContext_release_comp.py
@@ -38,9 +38,9 @@ class TestAttachDetachNoUeContextReleseComp(unittest.TestCase):
         )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
-                ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
-                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t,
+            ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
         )
 
         # Wait on EMM Information from MME
@@ -54,7 +54,7 @@ class TestAttachDetachNoUeContextReleseComp(unittest.TestCase):
         detach_req.ue_Id = req.ue_id
         detach_req.ueDetType = s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value
         self._s1ap_wrapper._s1_util.issue_cmd(
-             s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req,
         )
         response = self._s1ap_wrapper._s1_util.get_response()
         assert (
@@ -66,7 +66,7 @@ class TestAttachDetachNoUeContextReleseComp(unittest.TestCase):
         sctp_abort = s1ap_types.FwSctpAbortReq_t()
         sctp_abort.cause = 0
         self._s1ap_wrapper.s1_util.issue_cmd(
-             s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort,
+            s1ap_types.tfwCmd.SCTP_ABORT_REQ, sctp_abort,
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
@@ -29,61 +29,61 @@ class TestContinuousRandomAttach(unittest.TestCase):
         self._s1ap_wrapper.cleanup()
 
     def handle_msg(self, msg):
-            if msg.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value:
-                self.auth_req_ind_count += 1
-                m = msg.cast(s1ap_types.ueAuthReqInd_t)
-                print("====> Received UE_AUTH_REQ_IND ue-id", m.ue_Id)
-                auth_res = s1ap_types.ueAuthResp_t()
-                auth_res.ue_Id = m.ue_Id
-                sqn_recvd = s1ap_types.ueSqnRcvd_t()
-                sqn_recvd.pres = 0
-                auth_res.sqnRcvd = sqn_recvd
-                self._s1ap_wrapper._s1_util.issue_cmd(
-                    s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
-                )
-            elif msg.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value:
-                self.sec_mod_cmd_ind_count += 1
-                m = msg.cast(s1ap_types.ueSecModeCmdInd_t)
-                print("============>  Received UE_SEC_MOD_CMD_IND ue-id", m.ue_Id)
-                sec_mode_complete = s1ap_types.ueSecModeComplete_t()
-                sec_mode_complete.ue_Id = m.ue_Id
-                self._s1ap_wrapper._s1_util.issue_cmd(
-                    s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
-                )
-            elif msg.msg_type == s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value:
-                self.attach_accept_ind_count += 1
-                m = msg.cast(s1ap_types.ueAttachAccept_t)
-                print("====================> Received UE_ATTACH_ACCEPT_IND ue-id", m.ue_Id)
-                pdn_type = m.esmInfo.pAddr.pdnType
-                addr = m.esmInfo.pAddr.addrInfo
-                if self._s1ap_wrapper._s1_util.CM_ESM_PDN_IPV4 == pdn_type:
-                    # Cast and cache the IPv4 address
-                    ip = ipaddress.ip_address(bytes(addr[:4]))
-                    with self._s1ap_wrapper._s1_util._lock:
-                        self._s1ap_wrapper._s1_util._ue_ip_map[m.ue_Id] = ip
-                attach_complete = s1ap_types.ueAttachComplete_t()
-                attach_complete.ue_Id = m.ue_Id
-                self._s1ap_wrapper._s1_util.issue_cmd(
-                    s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
-                )
-            elif msg.msg_type == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value:
-                self.identity_req_ind_count += 1
-                m = msg.cast(s1ap_types.ueIdentityReqInd_t)
-                print("=> Received UE_IDENTITY_REQ_IND ue-id", m.ue_Id)
-                us_identity_resp = s1ap_types.ueIdentityResp_t()
-                us_identity_resp.ue_Id = m.ue_Id
-                us_identity_resp.idType = m.idType
-                self._s1ap_wrapper._s1_util.issue_cmd(
-                    s1ap_types.tfwCmd.UE_IDENTITY_RESP, us_identity_resp,
-                )
-            elif msg.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value:
-                self.int_ctx_setup_ind_count += 1
-            elif msg.msg_type == s1ap_types.tfwCmd.UE_EMM_INFORMATION.value:
-                self.ue_emm_information_count += 1
-            elif msg.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value:
-                self.ue_ctx_rel_ind_count += 1
-            else:
-                print("Unhandled msg type", msg.msg_type)
+        if msg.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value:
+            self.auth_req_ind_count += 1
+            m = msg.cast(s1ap_types.ueAuthReqInd_t)
+            print("====> Received UE_AUTH_REQ_IND ue-id", m.ue_Id)
+            auth_res = s1ap_types.ueAuthResp_t()
+            auth_res.ue_Id = m.ue_Id
+            sqn_recvd = s1ap_types.ueSqnRcvd_t()
+            sqn_recvd.pres = 0
+            auth_res.sqnRcvd = sqn_recvd
+            self._s1ap_wrapper._s1_util.issue_cmd(
+                s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
+            )
+        elif msg.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value:
+            self.sec_mod_cmd_ind_count += 1
+            m = msg.cast(s1ap_types.ueSecModeCmdInd_t)
+            print("============>  Received UE_SEC_MOD_CMD_IND ue-id", m.ue_Id)
+            sec_mode_complete = s1ap_types.ueSecModeComplete_t()
+            sec_mode_complete.ue_Id = m.ue_Id
+            self._s1ap_wrapper._s1_util.issue_cmd(
+                s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
+            )
+        elif msg.msg_type == s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value:
+            self.attach_accept_ind_count += 1
+            m = msg.cast(s1ap_types.ueAttachAccept_t)
+            print("====================> Received UE_ATTACH_ACCEPT_IND ue-id", m.ue_Id)
+            pdn_type = m.esmInfo.pAddr.pdnType
+            addr = m.esmInfo.pAddr.addrInfo
+            if self._s1ap_wrapper._s1_util.CM_ESM_PDN_IPV4 == pdn_type:
+                # Cast and cache the IPv4 address
+                ip = ipaddress.ip_address(bytes(addr[:4]))
+                with self._s1ap_wrapper._s1_util._lock:
+                    self._s1ap_wrapper._s1_util._ue_ip_map[m.ue_Id] = ip
+            attach_complete = s1ap_types.ueAttachComplete_t()
+            attach_complete.ue_Id = m.ue_Id
+            self._s1ap_wrapper._s1_util.issue_cmd(
+                s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete,
+            )
+        elif msg.msg_type == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value:
+            self.identity_req_ind_count += 1
+            m = msg.cast(s1ap_types.ueIdentityReqInd_t)
+            print("=> Received UE_IDENTITY_REQ_IND ue-id", m.ue_Id)
+            us_identity_resp = s1ap_types.ueIdentityResp_t()
+            us_identity_resp.ue_Id = m.ue_Id
+            us_identity_resp.idType = m.idType
+            self._s1ap_wrapper._s1_util.issue_cmd(
+                s1ap_types.tfwCmd.UE_IDENTITY_RESP, us_identity_resp,
+            )
+        elif msg.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value:
+            self.int_ctx_setup_ind_count += 1
+        elif msg.msg_type == s1ap_types.tfwCmd.UE_EMM_INFORMATION.value:
+            self.ue_emm_information_count += 1
+        elif msg.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value:
+            self.ue_ctx_rel_ind_count += 1
+        else:
+            print("Unhandled msg type", msg.msg_type)
 
     def send_attach_req(self, ue_id):
         attach_req = s1ap_types.ueAttachRequest_t()

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete_with_mme_restart.py
@@ -108,8 +108,8 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
 
         while response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND:
             print(
-                    "Received Attach Accept retransmission from before restart",
-                    "Ignoring...",
+                "Received Attach Accept retransmission from before restart",
+                "Ignoring...",
             )
             response = self._s1ap_wrapper.s1_util.get_response()
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
@@ -24,7 +24,7 @@ from s1ap_utils import MagmadUtil
 class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-           stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         )
         self.dl_flow_rules = {}
 

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
@@ -169,7 +169,7 @@ class TrafficMessage(object):
 # Enumerated type for TrafficRequest; module-level for pickling purposes
 TrafficRequestType = enum.unique(
     enum.Enum(
-    'TrafficRequestType', 'EXIT SHUTDOWN START TEST',
+        'TrafficRequestType', 'EXIT SHUTDOWN START TEST',
     ),
 )
 
@@ -194,7 +194,7 @@ class TrafficRequest(TrafficMessage):
 # Enumerated type for TrafficResponse; module-level for pickling purposes
 TrafficResponseType = enum.unique(
     enum.Enum(
-    'TrafficResponseType', 'INFO RESULTS SERVER STARTED',
+        'TrafficResponseType', 'INFO RESULTS SERVER STARTED',
     ),
 )
 

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -441,7 +441,7 @@ class TrafficTest(object):
                 # Add arp table entry
                 os.system(
                     '/usr/sbin/arp -s %s %s' % (
-                    server_instance.ip.exploded, server_instance.mac,
+                        server_instance.ip.exploded, server_instance.mac,
                     ),
                 )
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
See https://github.com/magma/magma/issues/11816 for details

Trying to add E1 (indentation related formatting to our CI/formatting script). Formatting in advance before pulling the trigger to avoid confusion.

This change is entirely automatically generated by autopep8
`autopep8  --select W191,W291,W292,W293,W391,E131,E2,E3,E1 -r --in-place ./`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
Ran s1ap tests locally
Followup item? Should we remove the gxgy tests? I've never seen anyone run those
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
