### PR TITLE
chore: remove python specific formatOnSave setting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -92,7 +92,6 @@
 			"--select=W191,W291,W292,W293,W391,E131,E2,E3"
 		],
 		"[python]": {
-			"editor.formatOnSave": true,
 			"editor.codeActionsOnSave": {
 				"source.organizeImports": true
 			}


### PR DESCRIPTION
## Summary

Remove language specific `formatOnSave` setting for Python, since it is available globally now. https://github.com/magma/magma/blob/287e5dbd2fb0f2d6549457a95a23381c7bd8b086/.devcontainer/devcontainer.json#L65

## Test Plan

Tested locally that python code is still formatted.