### PR TITLE
chore(pipelined): add E1 to autopep8 python formatting

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/classifier.py
+++ b/lte/gateway/python/magma/pipelined/app/classifier.py
@@ -67,12 +67,12 @@ class Classifier(MagmaController):
     APP_TYPE = ControllerType.SPECIAL
     SESSIOND_RPC_TIMEOUT = 5
     ClassifierConfig = namedtuple(
-            'ClassifierConfig',
-            [
-                'gtp_port', 'mtr_ip', 'mtr_port', 'internal_sampling_port',
-                'internal_sampling_fwd_tbl', 'multi_tunnel_flag',
-                'internal_conntrack_port', 'internal_conntrack_fwd_tbl', 'paging_timeout', 'classifier_controller_id',
-            ],
+        'ClassifierConfig',
+        [
+            'gtp_port', 'mtr_ip', 'mtr_port', 'internal_sampling_port',
+            'internal_sampling_fwd_tbl', 'multi_tunnel_flag',
+            'internal_conntrack_port', 'internal_conntrack_fwd_tbl', 'paging_timeout', 'classifier_controller_id',
+        ],
     )
 
     def __init__(self, *args, **kwargs):
@@ -85,7 +85,7 @@ class Classifier(MagmaController):
         self._datapath = None
         self._clean_restart = kwargs['config']['clean_restart']
         self._sessiond_setinterface = \
-                   kwargs['rpc_stubs']['sessiond_setinterface']
+            kwargs['rpc_stubs']['sessiond_setinterface']
         if self.config.multi_tunnel_flag:
             self._ovs_multi_tunnel_init()
         self.paging_flag = 0
@@ -237,12 +237,12 @@ class Classifier(MagmaController):
         """
         paging_message = UPFPagingInfo(local_f_teid=local_f_teid, ue_ip_addr=ue_ip_add)
         future = self._sessiond_setinterface.SendPagingRequest.future(
-                            paging_message, self.SESSIOND_RPC_TIMEOUT,
+            paging_message, self.SESSIOND_RPC_TIMEOUT,
         )
         future.add_done_callback(
-                              lambda future: self.loop.call_soon_threadsafe(
-                                  self._paging_msg_sent_callback, future,
-                              ),
+            lambda future: self.loop.call_soon_threadsafe(
+                self._paging_msg_sent_callback, future,
+            ),
         )
 
     def _paging_msg_sent_callback(self, future):
@@ -721,8 +721,8 @@ class Classifier(MagmaController):
 
         if ip_flow_dl.dest_ip.address:
             addr_str = socket.inet_ntop(
-               socket.AF_INET,
-               ip_flow_dl.dest_ip.address,
+                socket.AF_INET,
+                ip_flow_dl.dest_ip.address,
             )
             dest_ip = IPAddress(
                 version=IPAddress.IPV4,
@@ -731,8 +731,8 @@ class Classifier(MagmaController):
 
         if ip_flow_dl.src_ip.address:
             addr_str = socket.inet_ntop(
-                  socket.AF_INET,
-                  ip_flow_dl.src_ip.address,
+                socket.AF_INET,
+                ip_flow_dl.src_ip.address,
             )
             src_ip = IPAddress(
                 version=IPAddress.IPV4,
@@ -963,8 +963,8 @@ class Classifier(MagmaController):
 
         if request.ue_ipv4_address.address:
             addr_str = socket.inet_ntop(
-               socket.AF_INET,
-               request.ue_ipv4_address.address,
+                socket.AF_INET,
+                request.ue_ipv4_address.address,
             )
             ue_ipv4_address = IPAddress(
                 version=IPAddress.IPV4,
@@ -973,7 +973,7 @@ class Classifier(MagmaController):
 
         if request.ue_ipv6_address.address:
             addr_str6 = socket.inet_ntop(
-                       socket.AF_INET6, request.ue_ipv6_address.address,
+                socket.AF_INET6, request.ue_ipv6_address.address,
             )
             ue_ipv6_address = IPAddress(
                 version=IPAddress.IPV6,
@@ -1067,7 +1067,7 @@ class Classifier(MagmaController):
             return False
 
         if ((tunnel_msg.ue_ipv4_address is None) and \
-              (tunnel_msg.ue_ipv6_address is None)):
+                (tunnel_msg.ue_ipv6_address is None)):
             return False
 
         if tunnel_msg.enb_ip_address is None:

--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -99,8 +99,8 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
     MAX_DELAY_INTERVALS = 20
 
     ng_config = namedtuple(
-            'ng_config',
-            ['ng_service_enabled', 'sessiond_setinterface'],
+        'ng_config',
+        ['ng_service_enabled', 'sessiond_setinterface'],
     )
     _CONTEXTS = {
         'dpset': dpset.DPSet,
@@ -643,7 +643,7 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
                 ip_addr = convert_ipv6_str_to_ip_proto(record.ue_ipv6)
 
             current_ver = self._session_rule_version_mapper.get_version(
-                    record.sid, ip_addr, record.rule_id,
+                record.sid, ip_addr, record.rule_id,
             )
             local_f_teid_ng = 0
             if record.teid:
@@ -782,11 +782,11 @@ class EnforcementStatsController(PolicyMixin, RestartMixin, MagmaController):
                     continue
 
                 session_config_dict[local_f_teid_ng] = \
-                                             UPFSessionState(
-                                                 subscriber_id=sid,
-                                                 session_version=rule_version,
-                                                 local_f_teid=local_f_teid_ng,
-                                             )
+                    UPFSessionState(
+                    subscriber_id=sid,
+                    session_version=rule_version,
+                    local_f_teid=local_f_teid_ng,
+                    )
 
         SessionStateManager.report_session_config_state(
             session_config_dict,

--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -342,7 +342,7 @@ class InOutController(RestartMixin, MagmaController):
         if mac_addr == "":
             mac_addr = self._current_upstream_mac_map.get(vlan, "")
         if mac_addr == "" and self.config.enable_nat is False and \
-            self.config.setup_type == 'LTE':
+                self.config.setup_type == 'LTE':
             mac_addr = self.config.uplink_gw_mac
 
         if mac_addr != "":

--- a/lte/gateway/python/magma/pipelined/app/ue_mac.py
+++ b/lte/gateway/python/magma/pipelined/app/ue_mac.py
@@ -67,7 +67,7 @@ class UEMacAddressController(MagmaController):
             self._li_port = \
                 BridgeTools.get_ofport(kwargs['config']['li_local_iface'])
         self._dpi_port = \
-                BridgeTools.get_ofport(kwargs['config']['dpi']['mon_port'])
+            BridgeTools.get_ofport(kwargs['config']['dpi']['mon_port'])
 
     def initialize_on_connect(self, datapath):
         self.delete_all_flows(datapath)

--- a/lte/gateway/python/magma/pipelined/ng_manager/node_state_manager.py
+++ b/lte/gateway/python/magma/pipelined/ng_manager/node_state_manager.py
@@ -110,23 +110,23 @@ class NodeStateManager:
     def send_association_setup_message(self):
 
         teid_range_indicate, teid_range_value =\
-                  self._get_teid_pool_range()
+            self._get_teid_pool_range()
 
         # Create Node association setup message
         assoc_message = \
-           UPFAssociationState(
-                           state_version=self._smf_assoc_version,
-                           assoc_state=UPFAssociationState.ESTABLISHED,
-                           feature_set=UPFFeatureSet(f_teid=True),
-                           recovery_time_stamp=self._recovery_timestamp.GetCurrentTime(),
-                           ip_resource_schema=[
-                               UserPlaneIPResourceSchema(
-                                   ipv4_address=self.config.downlink_ip,
-                                   teid_range_indication=teid_range_indicate,
-                                   teid_range=teid_range_value,
-                               ),
-                           ],
-           )
+            UPFAssociationState(
+                state_version=self._smf_assoc_version,
+                assoc_state=UPFAssociationState.ESTABLISHED,
+                feature_set=UPFFeatureSet(f_teid=True),
+                recovery_time_stamp=self._recovery_timestamp.GetCurrentTime(),
+                ip_resource_schema=[
+                    UserPlaneIPResourceSchema(
+                        ipv4_address=self.config.downlink_ip,
+                        teid_range_indication=teid_range_indicate,
+                        teid_range=teid_range_value,
+                    ),
+                ],
+            )
 
         self._assoc_mon_thread = hub.spawn(self._monitor_association, assoc_message)
 
@@ -139,7 +139,7 @@ class NodeStateManager:
 
         while assoc_established == False:
             assoc_established =\
-                    self._send_association_request_message(assoc_message)
+                self._send_association_request_message(assoc_message)
 
             if assoc_established == False:
                 retry_count += 1
@@ -158,8 +158,8 @@ class NodeStateManager:
 
         # Create Node association release message
         assoc_message = UPFAssociationState(
-                            state_version=self._smf_assoc_version + 1,
-                            assoc_state=UPFAssociationState.RELEASE,
+            state_version=self._smf_assoc_version + 1,
+            assoc_state=UPFAssociationState.RELEASE,
         )
 
         self._send_association_request_message(assoc_message)
@@ -171,23 +171,23 @@ class NodeStateManager:
         node_message = UPFNodeState(upf_id=self._node_id)
 
         teid_range_indicate, teid_range_value =\
-                         self._get_teid_pool_range()
+            self._get_teid_pool_range()
 
         # Create Node association setup message
         assoc_message = \
-           UPFAssociationState(
-                           state_version=self._smf_assoc_version,
-                           assoc_state=UPFAssociationState.ESTABLISHED,
-                           feature_set=UPFFeatureSet(f_teid=True),
-                           recovery_time_stamp=self._recovery_timestamp.GetCurrentTime(),
-                           ip_resource_schema=[
-                               UserPlaneIPResourceSchema(
-                                   ipv4_address=self.config.downlink_ip,
-                                   teid_range_indication=teid_range_indicate,
-                                   teid_range=teid_range_value,
-                               ),
-                           ],
-           )
+            UPFAssociationState(
+                state_version=self._smf_assoc_version,
+                assoc_state=UPFAssociationState.ESTABLISHED,
+                feature_set=UPFFeatureSet(f_teid=True),
+                recovery_time_stamp=self._recovery_timestamp.GetCurrentTime(),
+                ip_resource_schema=[
+                    UserPlaneIPResourceSchema(
+                        ipv4_address=self.config.downlink_ip,
+                        teid_range_indication=teid_range_indicate,
+                        teid_range=teid_range_value,
+                    ),
+                ],
+            )
 
         node_message.associaton_state.CopyFrom(assoc_message)
         return node_message

--- a/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager.py
+++ b/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager.py
@@ -31,11 +31,11 @@ from magma.pipelined.set_interface_client import send_periodic_session_update
 
 # Help to build failure report
 MsgParseOutput = NamedTuple(
-                   'MsgParseOutput',
-                   [
-                       ('offending_ie', OffendingIE),
-                       ('cause_info', int),
-                   ],
+    'MsgParseOutput',
+    [
+        ('offending_ie', OffendingIE),
+        ('cause_info', int),
+    ],
 )
 
 
@@ -76,7 +76,7 @@ class SessionStateManager:
 
             # If session is creted or activiated FAR_IDs cann't be 0
             if len(pdr_entry.set_gr_far.ListFields()) == 0 and \
-                     pdr_entry.pdr_state == PdrState.Value('INSTALL'):
+                    pdr_entry.pdr_state == PdrState.Value('INSTALL'):
                 offending_ie = OffendingIE(
                     identifier=pdr_entry.pdr_id,
                     version=pdr_entry.pdr_version,
@@ -117,17 +117,17 @@ class SessionStateManager:
 
         # Assume things are green
         context_response =\
-             UPFSessionContextState(
-                 cause_info=CauseIE(cause_ie=CauseIE.REQUEST_ACCEPTED),
-                 session_snapshot=UPFSessionState(
-                     subscriber_id=new_session.subscriber_id,
-                     local_f_teid=new_session.local_f_teid,
-                     session_version=new_session.session_version,
-                 ),
-             )
+            UPFSessionContextState(
+                cause_info=CauseIE(cause_ie=CauseIE.REQUEST_ACCEPTED),
+                session_snapshot=UPFSessionState(
+                    subscriber_id=new_session.subscriber_id,
+                    local_f_teid=new_session.local_f_teid,
+                    session_version=new_session.session_version,
+                ),
+            )
 
         context_response.cause_info.cause_ie = \
-                  SessionStateManager.validate_session_msg(new_session)
+            SessionStateManager.validate_session_msg(new_session)
         if context_response.cause_info.cause_ie != CauseIE.REQUEST_ACCEPTED:
             self.logger.warning(
                 "Error : Parsing Error in SetInterface Message %d",

--- a/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager_util.py
+++ b/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager_util.py
@@ -18,28 +18,28 @@ from lte.protos.pipelined_pb2 import (
 )
 
 FARRuleEntry = NamedTuple(
-                   'FARRuleEntry',
-                    [
-                        ('apply_action', int),
-                        ('o_teid', int),
-                        ('gnb_ip_addr', str),
-                    ],
+    'FARRuleEntry',
+    [
+        ('apply_action', int),
+        ('o_teid', int),
+        ('gnb_ip_addr', str),
+    ],
 )
 
 PDRRuleEntry = NamedTuple(
-                'PDRRuleEntry',
-                [
-                    ('pdr_id', int),
-                    ('pdr_version', int),
-                    ('pdr_state', int),
-                    ('precedence', int),
-                    ('local_f_teid', int),
-                    ('ue_ip_addr', str),
-                    ('del_qos_enforce_rule', DeactivateFlowsRequest),
-                    ('add_qos_enforce_rule', ActivateFlowsRequest),
-                    ('far_action', FARRuleEntry),
-                    ('ue_ipv6_addr', str),
-                ],
+    'PDRRuleEntry',
+    [
+        ('pdr_id', int),
+        ('pdr_version', int),
+        ('pdr_state', int),
+        ('precedence', int),
+        ('local_f_teid', int),
+        ('ue_ip_addr', str),
+        ('del_qos_enforce_rule', DeactivateFlowsRequest),
+        ('add_qos_enforce_rule', ActivateFlowsRequest),
+        ('far_action', FARRuleEntry),
+        ('ue_ipv6_addr', str),
+    ],
 )
 
 # Create the Named tuple for the FAR entry

--- a/lte/gateway/python/magma/pipelined/ng_set_session_msg.py
+++ b/lte/gateway/python/magma/pipelined/ng_set_session_msg.py
@@ -37,8 +37,8 @@ from magma.pipelined.policy_converters import convert_ipv4_str_to_ip_proto
 from magma.subscriberdb.sid import SIDUtils
 
 QoSEnforceRuleEntry = namedtuple(
-                         'QoSEnforceRuleEntry',
-                         ['imsi', 'rule_id', 'ipv4_dst', 'allow', 'priority', 'hard_timeout', 'direction'],
+    'QoSEnforceRuleEntry',
+    ['imsi', 'rule_id', 'ipv4_dst', 'allow', 'priority', 'hard_timeout', 'direction'],
 )
 
 
@@ -50,12 +50,12 @@ class CreateSessionUtil:
         This will anchor point for create sessions with PDR, FAR & QER.
         """
         self._set_session = \
-                  SessionSet(
-                      subscriber_id=subscriber_id, local_f_teid=local_f_teid,\
-                      session_version=session_version,\
-                      node_id=NodeID(node_id_type=NodeID.IPv4, node_id=node_id),\
-                      state=Fsm_state(state=Fsm_state.CREATED),
-                  )
+            SessionSet(
+                subscriber_id=subscriber_id, local_f_teid=local_f_teid,\
+                session_version=session_version,\
+                node_id=NodeID(node_id_type=NodeID.IPv4, node_id=node_id),\
+                state=Fsm_state(state=Fsm_state.CREATED),
+            )
 
     @staticmethod
     def CreateAddQERinPDR(
@@ -96,19 +96,19 @@ class CreateSessionUtil:
                 ),
             ]
         qos_enforce_rule = ActivateFlowsRequest(
-                                  sid=SIDUtils.to_pb(qos_enforce_rule.imsi),
-                                  ip_addr=ue_ip_addr,
-                                  policies=[
-                                      VersionedPolicy(
-                                          rule=PolicyRule(
-                                            id=qos_enforce_rule.rule_id,
-                                            priority=qos_enforce_rule.priority,
-                                            hard_timeout=qos_enforce_rule.hard_timeout,
-                                            flow_list=flow_list,
-                                          ), version=1,
-                                      ), ],
-                                  request_origin=RequestOriginType(type=RequestOriginType.N4),
-                                  apn_ambr=apn_ambr,
+            sid=SIDUtils.to_pb(qos_enforce_rule.imsi),
+            ip_addr=ue_ip_addr,
+            policies=[
+                VersionedPolicy(
+                    rule=PolicyRule(
+                        id=qos_enforce_rule.rule_id,
+                        priority=qos_enforce_rule.priority,
+                        hard_timeout=qos_enforce_rule.hard_timeout,
+                        flow_list=flow_list,
+                    ), version=1,
+                ), ],
+            request_origin=RequestOriginType(type=RequestOriginType.N4),
+            apn_ambr=apn_ambr,
         )
         return qos_enforce_rule
 
@@ -119,10 +119,10 @@ class CreateSessionUtil:
     ) -> DeactivateFlowsRequest:
 
         qos_enforce_rule = DeactivateFlowsRequest(
-                                  sid=SIDUtils.to_pb(qos_enforce_rule.imsi),
-                                  ip_addr=ue_ip_addr,
-                                  policies=[VersionedPolicyID(rule_id=qos_enforce_rule.rule_id)],
-                                  request_origin=RequestOriginType(type=RequestOriginType.N4),
+            sid=SIDUtils.to_pb(qos_enforce_rule.imsi),
+            ip_addr=ue_ip_addr,
+            policies=[VersionedPolicyID(rule_id=qos_enforce_rule.rule_id)],
+            request_origin=RequestOriginType(type=RequestOriginType.N4),
         )
 
         return qos_enforce_rule
@@ -137,7 +137,7 @@ class CreateSessionUtil:
                 fwd_parm=FwdParam(
                     dest_iface=0,
                     outr_head_cr=OuterHeaderCreation(
-                                 o_teid=o_teid, gnb_ipv4_adr=gnb_ip_addr,
+                        o_teid=o_teid, gnb_ipv4_adr=gnb_ip_addr,
                     ),
                 ),
             )
@@ -156,9 +156,9 @@ class CreateSessionUtil:
                 pdr_state=pdr_state,\
                 precedence=precedence,\
                 pdi=PDI(
-                                   src_interface=0,\
-                                   local_f_teid=local_f_teid,\
-                                   ue_ipv4=ue_ip_addr,
+                    src_interface=0,\
+                    local_f_teid=local_f_teid,\
+                    ue_ipv4=ue_ip_addr,
                 ), \
                 o_h_remo_desc=0,
             )

--- a/lte/gateway/python/magma/pipelined/openflow/flows.py
+++ b/lte/gateway/python/magma/pipelined/openflow/flows.py
@@ -148,8 +148,8 @@ def add_flow(
     if actions is None:
         actions = []
     reset_scratch_reg_actions = [
-             parser.NXActionRegLoad2(dst=reg, value=REG_ZERO_VAL)
-             for reg in SCRATCH_REGS
+        parser.NXActionRegLoad2(dst=reg, value=REG_ZERO_VAL)
+        for reg in SCRATCH_REGS
     ]
     actions = actions + reset_scratch_reg_actions
 

--- a/lte/gateway/python/magma/pipelined/openflow/messages.py
+++ b/lte/gateway/python/magma/pipelined/openflow/messages.py
@@ -318,7 +318,7 @@ class MessageHub(object):
         flow_match = strip_common(match_flow) == strip_common(match_msg)
 
         return flow_match and reg_loads_match and resubmits_match and \
-               outputs_match
+            outputs_match
 
     def _get_msg_index_in_flow_list(self, dp, msg, flow_list):
         for i in range(len(flow_list)):

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -548,7 +548,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
         self._log_grpc_payload(request)
         if not self._service_manager.is_app_enabled(
-              Classifier.APP_NAME,
+            Classifier.APP_NAME,
         ):
             context.set_code(grpc.StatusCode.UNAVAILABLE)
             context.set_details('Service not enabled!')
@@ -556,7 +556,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
         fut = Future()
         self._loop.call_soon_threadsafe(\
-                      self._setup_pg_tunnel_update, request, fut,
+            self._setup_pg_tunnel_update, request, fut,
         )
         try:
             return fut.result(timeout=self._call_timeout)
@@ -908,7 +908,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
         fut = Future()
         self._loop.call_soon_threadsafe(\
-                      self.ng_update_session_flows, request, fut,
+            self.ng_update_session_flows, request, fut,
         )
         try:
             return fut.result(timeout=self._call_timeout)
@@ -947,14 +947,14 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
                 if ret:
                     # Install the Rules
                     failed_policy_rule_results =\
-                            self._ng_qer_update(request, pdr_entries)
+                        self._ng_qer_update(request, pdr_entries)
 
                 if (not ret or failed_policy_rule_results):
                     offending_ie = OffendingIE(
                         identifier=pdr_entries.pdr_id,
                         version=pdr_entries.pdr_version,
                         qos_enforce_rule_results=ActivateFlowsResult(\
-                                               policy_results=[failed_policy_rule_results],
+                            policy_results=[failed_policy_rule_results],
                         ),
                     )
 
@@ -1048,20 +1048,20 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
                 ipv4 = convert_ip_str_to_ip_proto(qos_enforce_rule.ip_addr)
 
                 enforcement_res = \
-                      self._ng_activate_qer_flow(
-                          ipv4, local_f_teid_ng,
-                          qos_enforce_rule,
-                      )
+                    self._ng_activate_qer_flow(
+                        ipv4, local_f_teid_ng,
+                        qos_enforce_rule,
+                    )
                 failed_policy_rules_results = \
                     _retrieve_failed_results(enforcement_res)
 
             if qos_enforce_rule.ipv6_addr:
                 ipv6 = convert_ipv6_bytes_to_ip_proto(qos_enforce_rule.ipv6_addr)
                 enforcement_res = \
-                      self._ng_activate_qer_flow(
-                          ipv6, local_f_teid_ng,
-                          qos_enforce_rule,
-                      )
+                    self._ng_activate_qer_flow(
+                        ipv6, local_f_teid_ng,
+                        qos_enforce_rule,
+                    )
                 failed_policy_rules_results = \
                     _retrieve_failed_results(enforcement_res)
 

--- a/lte/gateway/python/magma/pipelined/set_interface_client.py
+++ b/lte/gateway/python/magma/pipelined/set_interface_client.py
@@ -71,7 +71,7 @@ def send_paging_intiated_notification(
     setinterface_stub: SetInterfaceForUserPlaneStub,
 ):
     """
-	Make RPC call to send paging initiated notification to sessionD
+        Make RPC call to send paging initiated notification to sessionD
     """
     try:
         setinterface_stub.SetPagingInitiated(paging_info, DEFAULT_GRPC_TIMEOUT)

--- a/lte/gateway/python/magma/pipelined/tests/ng_node_rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/tests/ng_node_rpc_servicer.py
@@ -28,17 +28,17 @@ from ryu.lib import hub
 
 class SMFAssociationServerTest(session_manager_pb2_grpc.SetInterfaceForUserPlaneServicer):
 
-     def __init__(self, loop):
-         self._loop = loop
+    def __init__(self, loop):
+        self._loop = loop
 
-     def add_to_server(self, server):
+    def add_to_server(self, server):
         """
         Add the servicer to a gRPC server
         """
         session_manager_pb2_grpc.add_SetInterfaceForUserPlaneServicer_to_server(self, server)
 
-     def SetUPFNodeState(self, request, context):
-         return (Void())
+    def SetUPFNodeState(self, request, context):
+        return (Void())
 
 
 class RpcTests(unittest.TestCase):
@@ -75,11 +75,11 @@ class RpcTests(unittest.TestCase):
         sessiod_interface_stub = SetInterfaceForUserPlaneStub(channel)
 
         config_mock = {
-                   'enodeb_iface': 'eth1',
-                   'clean_restart': True,
-                   'enable5g_features': True,
-                   'upf_node_identifier': '192.168.220.1',
-                   'bridge_name': self.BRIDGE,
+            'enodeb_iface': 'eth1',
+            'clean_restart': True,
+            'enable5g_features': True,
+            'upf_node_identifier': '192.168.220.1',
+            'bridge_name': self.BRIDGE,
         }
 
         self._ng_node_mgr = NodeStateManager(loop_mock, sessiod_interface_stub, config_mock)

--- a/lte/gateway/python/magma/pipelined/tests/test_access_control.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_access_control.py
@@ -588,9 +588,9 @@ class AccessControlTestLocalIpBlockLTE(unittest.TestCase):
 
 def _build_default_ip_packet(mac, dst, src):
     return IPPacketBuilder() \
-            .set_ip_layer(dst, src) \
-            .set_ether_layer(mac, "00:00:00:00:00:00") \
-            .build()
+        .set_ip_layer(dst, src) \
+        .set_ether_layer(mac, "00:00:00:00:00:00") \
+        .build()
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/magma/pipelined/tests/test_classifier_mme_flow_dl.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_classifier_mme_flow_dl.py
@@ -109,12 +109,12 @@ class ClassifierMmeTest(unittest.TestCase):
         self.test_detach_default_tunnel_flows()
 
         dest_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.128.12"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.128.12"),
         )
         src_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.129.64"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.129.64"),
         )
         ip_flow_dl = IPFlowDL(
             set_params=71, tcp_dst_port=0,
@@ -131,12 +131,12 @@ class ClassifierMmeTest(unittest.TestCase):
         )
 
         dest_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.128.111"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.128.111"),
         )
         src_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.129.4"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.129.4"),
         )
 
         ip_flow_dl = IPFlowDL(
@@ -163,12 +163,12 @@ class ClassifierMmeTest(unittest.TestCase):
     def test_delete_tunnel_ip_flow_dl(self):
 
         dest_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.128.12"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.128.12"),
         )
         src_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.129.64"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.129.64"),
         )
 
         ip_flow_dl = IPFlowDL(
@@ -186,12 +186,12 @@ class ClassifierMmeTest(unittest.TestCase):
         )
 
         dest_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.128.111"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.128.111"),
         )
         src_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.129.4"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.129.4"),
         )
 
         ip_flow_dl = IPFlowDL(
@@ -218,12 +218,12 @@ class ClassifierMmeTest(unittest.TestCase):
     def test_discard_tunnel_ip_flow_dl(self):
 
         dest_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.128.12"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.128.12"),
         )
         src_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.129.64"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.129.64"),
         )
 
         ip_flow_dl = IPFlowDL(
@@ -255,12 +255,12 @@ class ClassifierMmeTest(unittest.TestCase):
     def test_resume_tunnel_ip_flow_dl(self):
 
         dest_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.128.12"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.128.12"),
         )
         src_ip = IPAddress(
-                version=IPAddress.IPV4,
-                address=socket.inet_pton(socket.AF_INET, "192.168.129.64"),
+            version=IPAddress.IPV4,
+            address=socket.inet_pton(socket.AF_INET, "192.168.129.64"),
         )
         ip_flow_dl = IPFlowDL(
             set_params=71, tcp_dst_port=0,

--- a/lte/gateway/python/magma/pipelined/tests/test_enforcement.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_enforcement.py
@@ -498,7 +498,7 @@ class EnforcementTableTest(unittest.TestCase):
         )
 
         with s1.isolator, s1.context, s2.isolator, s2.context, flow_verifier, \
-             snapshot_verifier:
+                snapshot_verifier:
             for pkt in pkts_to_send:
                 pkt_sender.send(pkt.pkt, pkt.num)
 

--- a/lte/gateway/python/magma/pipelined/tests/test_enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_enforcement_stats.py
@@ -465,7 +465,7 @@ class EnforcementStatsTest(unittest.TestCase):
         with isolator, sub_context, snapshot_verifier:
             pkt_sender.send(packet)
         enf_stat_name = imsi + '|' + self.DEFAULT_DROP_FLOW_NAME + '|' \
-                        + sub_ip + '|' + "0"
+            + sub_ip + '|' + "0"
         wait_for_enforcement_stats(
             self.enforcement_stats_controller,
             [enf_stat_name],


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
See https://github.com/magma/magma/issues/11816 for details

Trying to add E1 (indentation related formatting to our CI/formatting script). Formatting in advance before pulling the trigger to avoid confusion.

This change is entirely automatically generated by autopep8
`autopep8  --select W191,W291,W292,W293,W391,E131,E2,E3,E1 -r --in-place ./`
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
Ran the affected S1AP tests

Followup item? Should we remove the gxgy tests? I've never seen anyone run those
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
