### PR TITLE
fix(mme): Adds mme_config initialization to s1ap_state_converter tests

### DIFF
--- a/lte/gateway/c/core/oai/test/s1ap_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/s1ap_task/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(s1ap_test
         test_s1ap_state_converter.cpp)
 
 target_link_libraries(s1ap_test
-        TASK_S1AP MOCK_TASKS
+        TASK_S1AP MOCK_TASKS TASK_AMF_APP
         gtest gtest_main
         )
 

--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_state_converter.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_state_converter.cpp
@@ -15,11 +15,13 @@
 extern "C" {
 #include "lte/gateway/c/core/oai/common/log.h"
 #include "S1ap_S1AP-PDU.h"
+#include "lte/gateway/c/core/oai/include/amf_config.h"
 #include "lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.h"
 }
 
 #include "lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_converter.h"
 #include "lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_manager.h"
+#include "lte/gateway/c/core/oai/test/mock_tasks/mock_tasks.h"
 
 using ::testing::Test;
 
@@ -27,9 +29,19 @@ namespace magma {
 namespace lte {
 
 class S1APStateConverterTest : public ::testing::Test {
-  virtual void SetUp() {}
+  void SetUp() {
+    itti_init(TASK_MAX, THREAD_MAX, MESSAGES_ID_MAX, tasks_info, messages_info,
+              NULL, NULL);
+    mme_config_init(&mme_config);
+    s1ap_state_init(amf_config.max_ues, amf_config.max_gnbs,
+                    amf_config.use_stateless);
+  }
 
-  virtual void TearDown() {}
+  void TearDown() {
+    s1ap_state_exit();
+    free_mme_config(&mme_config);
+    itti_free_desc_threads();
+  }
 };
 
 TEST_F(S1APStateConverterTest, S1apStateConversionSuccess) {


### PR DESCRIPTION
Closes #11823.

Without this the size of some hashtables is uninitialized, causing
test failure.

## Test Plan

- Successful execution of Bazel test on experimental branch
- CI test phases of `make test_oai` and `make build_oai`

Signed-off-by: Scott Moeller <electronjoe@gmail.com>