### PR TITLE
feat(ci): refine image tagging for docker images

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 		"ryuta46.multi-command",
 		"coolchyni.beyond-debug",
 	],
-	"image": "ghcr.io/magma/magma/devcontainer:master",
+	"image": "ghcr.io/magma/magma/devcontainer:sha-e05d447",
 	"settings": {
 		"search.followSymlinks": false,
 		"terminal.integrated.profiles.linux": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 		"ryuta46.multi-command",
 		"coolchyni.beyond-debug",
 	],
-	"image": "ghcr.io/magma/magma/devcontainer:sha-e05d447",
+	"image": "ghcr.io/magma/magma/devcontainer:latest",
 	"settings": {
 		"search.followSymlinks": false,
 		"terminal.integrated.profiles.linux": {

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:sha-206a67a"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -21,7 +21,7 @@ env:
 
   S3_BUCKET_PATH: s3://magma-cache
 
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:sha-206a67a"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
 
 jobs:
   bazel-build-magma-vm-and-push-cache:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
     # Run four times a day to build bazel cache
     - cron: '0 0,6,12,18 * * *'
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:master"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:sha-206a67a"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
     # Run four times a day to build bazel cache
     - cron: '0 0,6,12,18 * * *'
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:sha-206a67a"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 

--- a/.github/workflows/docker-builder-bazel-base.yml
+++ b/.github/workflows/docker-builder-bazel-base.yml
@@ -23,6 +23,7 @@ on:  # yamllint disable-line rule:truthy
 env:
   REGISTRY: ghcr.io
   IMAGE_STREAM: ${{ github.repository }}/bazel-base
+  IMAGE_TAGS: type=sha
   DOCKERFILE: experimental/bazel-base/Dockerfile
 
 jobs:

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -23,6 +23,7 @@ on:  # yamllint disable-line rule:truthy
 env:
   REGISTRY: ghcr.io
   IMAGE_STREAM: ${{ github.repository }}/devcontainer
+  IMAGE_TAGS: type=sha
   DOCKERFILE: .devcontainer/Dockerfile
 
 jobs:

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -23,6 +23,7 @@ on:  # yamllint disable-line rule:truthy
 env:
   REGISTRY: ghcr.io
   IMAGE_STREAM: ${{ github.repository }}/python-precommit
+  IMAGE_TAGS: type=sha
   DOCKERFILE: lte/gateway/docker/python-precommit/Dockerfile
 
 jobs:

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -22,7 +22,7 @@ on:
       - reopened
       - synchronize
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:sha-206a67a"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
## Summary

- reactivated the unique sha tagging for the images
- retained the rolling release feature by using `latest` tag for devcontainer.

This PR is connected to the changes in
- https://github.com/magma/magma/pull/10711
- https://github.com/magma/magma/pull/11508
- https://github.com/magma/magma/pull/11666

### Reasoning

Within #10711 the possibility of a more divers and telling image tagging was provided. This tagging was activated in #11508 and finally used in #11666.
However, the image tagging behaves slightly different than expected. My expectation was, that any available tag defined in #10711 would be given to images created. That is not the case, but _only one image tag is given_, regarding on some Github internal priority. In addition one has to consider that only images from master branch are (currently) ever pushed, probably due to the restriction in push secrets from PR builds.

What works well though, is that the `latest` tag is always applied to any new image pushed to the image stream.

So the boundary conditions are currently:
- Only images build from master branch will be pushed to the GHCR.
- Master branch builds always get the image stream tag `master`.
- Any newly pushed image always gets the image stream tag `latest`.
  -  The image stream tag `latest` is the only one easily given additionally on every push.

With the boundary conditions above that means that the image stream tag `master` and `latest` will always be in parallel, unless a manual push to the GHCR happens, which is undesired and unlikely. This nullifies the benefit of the `master` tag, but the same functionality can be reached with the `latest` tag.

Thus in within this PR, we are using `latest` instead of master to pull images. This is effectively only a name change and will not result in a change of behaviour. Additionally the `sha-*` is reintroduced to uniquely identify every image build more easily and more visibly in the Github GUI.
(Images can always be identified by their full hash regardless their tagging, but creating an image stream tag for every image it will be more prominently shown in the Github GUI. I am aware that might not be a good pattern to have a separate tag per image, or to optimise image streams for visibility in some GUI, but I think we could make an exception here.)

## Test Plan

- CI
