### PR TITLE
feat(dp): Add library for frequency selection

### DIFF
--- a/dp/cloud/go/active_mode_controller/internal/containers/min_queue.go
+++ b/dp/cloud/go/active_mode_controller/internal/containers/min_queue.go
@@ -1,0 +1,29 @@
+package containers
+
+type MinQueue []*minQueueItem
+
+func (m *MinQueue) Push(value int) {
+	i := len(*m) - 1
+	cnt := 1
+	for ; i >= 0 && (*m)[i].value >= value; i-- {
+		cnt += (*m)[i].count
+	}
+	item := &minQueueItem{value: value, count: cnt}
+	*m = append((*m)[:i+1], item)
+}
+
+func (m *MinQueue) Pop() {
+	(*m)[0].count--
+	if (*m)[0].count == 0 {
+		*m = (*m)[1:]
+	}
+}
+
+func (m MinQueue) Top() int {
+	return m[0].value
+}
+
+type minQueueItem struct {
+	value int
+	count int
+}

--- a/dp/cloud/go/active_mode_controller/internal/containers/min_queue_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/containers/min_queue_test.go
@@ -1,0 +1,39 @@
+package containers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/containers"
+)
+
+func TestMinQueue_PushLess(t *testing.T) {
+	m := &containers.MinQueue{}
+	m.Push(2)
+	m.Push(1)
+	assert.Equal(t, 1, m.Top())
+}
+
+func TestMinQueue_PushGreater(t *testing.T) {
+	m := &containers.MinQueue{}
+	m.Push(1)
+	m.Push(2)
+	assert.Equal(t, 1, m.Top())
+}
+
+func TestMinQueue_PopLess(t *testing.T) {
+	m := &containers.MinQueue{}
+	m.Push(1)
+	m.Push(2)
+	m.Pop()
+	assert.Equal(t, 2, m.Top())
+}
+
+func TestMinQueue_PopGreater(t *testing.T) {
+	m := &containers.MinQueue{}
+	m.Push(2)
+	m.Push(1)
+	m.Pop()
+	assert.Equal(t, 1, m.Top())
+}

--- a/dp/cloud/go/active_mode_controller/internal/containers/priority_queue.go
+++ b/dp/cloud/go/active_mode_controller/internal/containers/priority_queue.go
@@ -1,0 +1,58 @@
+package containers
+
+import "container/heap"
+
+type PriorityQueue struct {
+	h items
+}
+
+func (p *PriorityQueue) Top() int {
+	return p.h[0].value
+}
+
+func (p *PriorityQueue) Push(value int) *Item {
+	item := &Item{value: value}
+	heap.Push(&p.h, item)
+	return item
+}
+
+func (p *PriorityQueue) Delete(key *Item) {
+	heap.Remove(&p.h, key.index)
+}
+
+type Item struct {
+	value int
+	index int
+}
+
+type items []*Item
+
+func (h items) Len() int {
+	return len(h)
+}
+
+func (h items) Less(i, j int) bool {
+	return h[i].value > h[j].value
+}
+
+func (h items) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+
+func (h *items) Push(x interface{}) {
+	n := len(*h)
+	item := x.(*Item)
+	item.index = n
+	*h = append(*h, item)
+}
+
+func (h *items) Pop() interface{} {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	item.index = -1
+	*h = old[:n-1]
+	return item
+}

--- a/dp/cloud/go/active_mode_controller/internal/containers/priority_queue_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/containers/priority_queue_test.go
@@ -1,0 +1,38 @@
+package containers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/containers"
+)
+
+func TestPriorityQueue_Insert(t *testing.T) {
+	p := &containers.PriorityQueue{}
+	p.Push(2)
+	p.Push(3)
+	p.Push(1)
+
+	assert.Equal(t, 3, p.Top())
+}
+
+func TestPriorityQueue_DeleteMax(t *testing.T) {
+	p := &containers.PriorityQueue{}
+	key := p.Push(2)
+	p.Push(1)
+	p.Delete(key)
+
+	assert.Equal(t, 1, p.Top())
+}
+
+func TestPriorityQueue_Delete(t *testing.T) {
+	p := containers.PriorityQueue{}
+	key1 := p.Push(3)
+	key2 := p.Push(2)
+	p.Push(1)
+	p.Delete(key2)
+	p.Delete(key1)
+
+	assert.Equal(t, 1, p.Top())
+}

--- a/dp/cloud/go/active_mode_controller/internal/ranges/checker.go
+++ b/dp/cloud/go/active_mode_controller/internal/ranges/checker.go
@@ -1,0 +1,31 @@
+package ranges
+
+import "sort"
+
+func CheckIfContain(ranges []Range, points []int) []bool {
+	res := make([]bool, len(points))
+	ordered := make([]indexedPoint, len(points))
+	for i, p := range points {
+		ordered[i] = indexedPoint{id: i, pos: p}
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].pos < ordered[j].pos
+	})
+	j := 0
+	for _, p := range ordered {
+		for ; j < len(ranges) && p.pos > ranges[j].End; j++ {
+		}
+		if j == len(ranges) {
+			break
+		}
+		if p.pos >= ranges[j].Begin {
+			res[p.id] = true
+		}
+	}
+	return res
+}
+
+type indexedPoint struct {
+	id  int
+	pos int
+}

--- a/dp/cloud/go/active_mode_controller/internal/ranges/checker_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/ranges/checker_test.go
@@ -1,0 +1,21 @@
+package ranges_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/ranges"
+)
+
+func TestCheckIfContain(t *testing.T) {
+	rs := []ranges.Range{
+		{Begin: 35700, End: 35800},
+		{Begin: 36000, End: 36000},
+		{Begin: 36200, End: 36300},
+	}
+	points := []int{36500, 36250, 35500, 36000, 35850}
+	expected := []bool{false, true, false, true, false}
+	actual := ranges.CheckIfContain(rs, points)
+	assert.Equal(t, expected, actual)
+}

--- a/dp/cloud/go/active_mode_controller/internal/ranges/decomposer.go
+++ b/dp/cloud/go/active_mode_controller/internal/ranges/decomposer.go
@@ -1,0 +1,77 @@
+package ranges
+
+import (
+	"sort"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/containers"
+)
+
+type Range struct {
+	Begin int
+	End   int
+	Value int
+}
+
+type Point struct {
+	Value int
+	Pos   int
+}
+
+func Decompose(ranges []Range, minValue int) []Point {
+	var res []Point
+	points, values := getEndsAndValues(ranges)
+	pq := &containers.PriorityQueue{}
+	pq.Push(minValue)
+	for _, p := range points {
+		res = addPoint(res, Point{
+			Value: pq.Top(),
+			Pos:   p.pos,
+		})
+		if p.isEnd {
+			pq.Delete(values[p.id].item)
+		} else {
+			values[p.id].item = pq.Push(values[p.id].val)
+		}
+	}
+	return res
+}
+
+func getEndsAndValues(ranges []Range) ([]*rangeEnd, []rangeValue) {
+	points := make([]*rangeEnd, 2*len(ranges))
+	values := make([]rangeValue, len(ranges))
+	for i, r := range ranges {
+		points[2*i] = &rangeEnd{id: i, pos: r.Begin, isEnd: false}
+		points[2*i+1] = &rangeEnd{id: i, pos: r.End, isEnd: true}
+		values[i] = rangeValue{val: r.Value}
+	}
+	sort.Slice(points, func(i, j int) bool {
+		if points[i].pos == points[j].pos {
+			return points[i].isEnd
+		}
+		return points[i].pos < points[j].pos
+	})
+	return points, values
+}
+
+func addPoint(points []Point, p Point) []Point {
+	i := len(points) - 1
+	if i >= 0 && p.Pos == points[i].Pos {
+		return points
+	}
+	if i >= 0 && p.Value == points[i].Value {
+		points[i].Pos = p.Pos
+		return points
+	}
+	return append(points, p)
+}
+
+type rangeValue struct {
+	val  int
+	item *containers.Item
+}
+
+type rangeEnd struct {
+	id    int
+	pos   int
+	isEnd bool
+}

--- a/dp/cloud/go/active_mode_controller/internal/ranges/decomposer_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/ranges/decomposer_test.go
@@ -1,0 +1,111 @@
+package ranges_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/ranges"
+)
+
+func TestDecompose(t *testing.T) {
+	const minValue = -200
+	testData := []struct {
+		name     string
+		ranges   []ranges.Range
+		expected []ranges.Point
+	}{{
+		name: "Should convert single channel to points",
+		ranges: []ranges.Range{
+			{Begin: 35600, End: 35700, Value: 30},
+		},
+		expected: []ranges.Point{
+			{Pos: 35600, Value: minValue},
+			{Pos: 35700, Value: 30},
+		},
+	}, {
+		name: "Should join connected ranges with same eirp",
+		ranges: []ranges.Range{
+			{Begin: 35600, End: 35700, Value: 30},
+			{Begin: 35700, End: 35800, Value: 30},
+		},
+		expected: []ranges.Point{
+			{Pos: 35600, Value: minValue},
+			{Pos: 35800, Value: 30},
+		},
+	}, {
+		name: "Should join connected ranges with different eirp",
+		ranges: []ranges.Range{
+			{Begin: 35600, End: 35700, Value: 30},
+			{Begin: 35700, End: 35800, Value: 20},
+		},
+		expected: []ranges.Point{
+			{Pos: 35600, Value: minValue},
+			{Pos: 35700, Value: 30},
+			{Pos: 35800, Value: 20},
+		},
+	}, {
+		name: "Should handle nested ranges",
+		ranges: []ranges.Range{
+			{Begin: 35600, End: 35800, Value: 20},
+			{Begin: 35650, End: 35750, Value: 30},
+		},
+		expected: []ranges.Point{
+			{Pos: 35600, Value: minValue},
+			{Pos: 35650, Value: 20},
+			{Pos: 35750, Value: 30},
+			{Pos: 35800, Value: 20},
+		},
+	}, {
+		name: "Should handle overlapping ranges",
+		ranges: []ranges.Range{
+			{Begin: 35600, End: 35800, Value: 20},
+			{Begin: 35700, End: 35900, Value: 30},
+		},
+		expected: []ranges.Point{
+			{Pos: 35600, Value: minValue},
+			{Pos: 35700, Value: 20},
+			{Pos: 35900, Value: 30},
+		},
+	}, {
+		name: "Should handle disjoint ranges",
+		ranges: []ranges.Range{
+			{Begin: 35600, End: 35700, Value: 30},
+			{Begin: 35800, End: 35900, Value: 30},
+		},
+		expected: []ranges.Point{
+			{Pos: 35600, Value: minValue},
+			{Pos: 35700, Value: 30},
+			{Pos: 35800, Value: minValue},
+			{Pos: 35900, Value: 30},
+		},
+	}, {
+		name: "Should handle complex case",
+		ranges: []ranges.Range{
+			{Begin: 35500, End: 36300, Value: 10},
+			{Begin: 35600, End: 36000, Value: 20},
+			{Begin: 35800, End: 36200, Value: 25},
+			{Begin: 36000, End: 36100, Value: 30},
+			{Begin: 36500, End: 36700, Value: 25},
+			{Begin: 36600, End: 36800, Value: 20},
+		},
+		expected: []ranges.Point{
+			{Pos: 35500, Value: minValue},
+			{Pos: 35600, Value: 10},
+			{Pos: 35800, Value: 20},
+			{Pos: 36000, Value: 25},
+			{Pos: 36100, Value: 30},
+			{Pos: 36200, Value: 25},
+			{Pos: 36300, Value: 10},
+			{Pos: 36500, Value: minValue},
+			{Pos: 36700, Value: 25},
+			{Pos: 36800, Value: 20},
+		},
+	}}
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ranges.Decompose(tt.ranges, minValue)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/dp/cloud/go/active_mode_controller/internal/ranges/finder.go
+++ b/dp/cloud/go/active_mode_controller/internal/ranges/finder.go
@@ -1,0 +1,51 @@
+package ranges
+
+import "magma/dp/cloud/go/active_mode_controller/internal/containers"
+
+func FindAvailable(points []Point, length int, minValue int) []Range {
+	var res []Range
+	i, j := -1, 0
+	last := points[len(points)-1].Pos
+	pos := points[0].Pos - length
+	mq := &containers.MinQueue{}
+	mq.Push(points[0].Value)
+	for {
+		moveBegin := points[i+1].Pos <= points[j].Pos-length
+		delta := 0
+		if moveBegin {
+			i++
+			delta = points[i].Pos - pos
+		} else {
+			delta = points[j].Pos - pos - length
+			j++
+		}
+		if v := mq.Top(); v >= minValue {
+			res = addRange(res, Range{
+				Begin: pos,
+				End:   pos + delta,
+				Value: v,
+			})
+		}
+		pos += delta
+		if !moveBegin && pos+length == last {
+			break
+		}
+		if moveBegin {
+			mq.Pop()
+		} else {
+			mq.Push(points[j].Value)
+		}
+	}
+	return res
+}
+
+func addRange(ranges []Range, r Range) []Range {
+	i := len(ranges) - 1
+	if i >= 0 &&
+		ranges[i].End == r.Begin &&
+		r.Value == ranges[i].Value {
+		ranges[i].End = r.End
+		return ranges
+	}
+	return append(ranges, r)
+}

--- a/dp/cloud/go/active_mode_controller/internal/ranges/finder_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/ranges/finder_test.go
@@ -1,0 +1,81 @@
+package ranges_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/ranges"
+)
+
+func TestFindAvailable(t *testing.T) {
+	const minValue = -200
+	testData := []struct {
+		name     string
+		points   []ranges.Point
+		length   int
+		value    int
+		expected []ranges.Range
+	}{{
+		name: "Should get ranges spanning across two points",
+		points: []ranges.Point{
+			{Pos: 36000, Value: minValue},
+			{Pos: 36500, Value: 20},
+		},
+		length: 100,
+		value:  10,
+		expected: []ranges.Range{
+			{Begin: 36000, End: 36400, Value: 20},
+		},
+	}, {
+		name: "Should get ranges spanning across multiple points",
+		points: []ranges.Point{
+			{Pos: 36000, Value: minValue},
+			{Pos: 36100, Value: 20},
+			{Pos: 36200, Value: 15},
+		},
+		length: 200,
+		value:  10,
+		expected: []ranges.Range{
+			{Begin: 36000, End: 36000, Value: 15},
+		},
+	}, {
+		name: "Should handle skip ranges with too low value",
+		points: []ranges.Point{
+			{Pos: 36000, Value: minValue},
+			{Pos: 36100, Value: 20},
+			{Pos: 36200, Value: 5},
+			{Pos: 36300, Value: 20},
+		},
+		length: 50,
+		value:  10,
+		expected: []ranges.Range{
+			{Begin: 36000, End: 36050, Value: 20},
+			{Begin: 36200, End: 36250, Value: 20},
+		},
+	}, {
+		name: "Should handle complex case",
+		points: []ranges.Point{
+			{Pos: 35500, Value: minValue},
+			{Pos: 35600, Value: 30},
+			{Pos: 35800, Value: 20},
+			{Pos: 35900, Value: 25},
+			{Pos: 36000, Value: 20},
+			{Pos: 36200, Value: 10},
+			{Pos: 36500, Value: 15},
+			{Pos: 36600, Value: 10},
+		},
+		length: 200,
+		value:  15,
+		expected: []ranges.Range{
+			{Begin: 35500, End: 35800, Value: 20},
+			{Begin: 36200, End: 36300, Value: 15},
+		},
+	}}
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ranges.FindAvailable(tt.points, tt.length, tt.value)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/dp/cloud/go/active_mode_controller/internal/ranges/selector.go
+++ b/dp/cloud/go/active_mode_controller/internal/ranges/selector.go
@@ -1,0 +1,21 @@
+package ranges
+
+func SelectPoint(ranges []Range, provider indexProvider) Point {
+	sum := 0
+	for _, r := range ranges {
+		sum += r.End - r.Begin + 1
+	}
+	n := provider.Intn(sum)
+	i := 0
+	for ; n > ranges[i].End-ranges[i].Begin; i++ {
+		n -= ranges[i].End - ranges[i].Begin + 1
+	}
+	return Point{
+		Value: ranges[i].Value,
+		Pos:   ranges[i].Begin + n,
+	}
+}
+
+type indexProvider interface {
+	Intn(int) int
+}

--- a/dp/cloud/go/active_mode_controller/internal/ranges/selector_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/ranges/selector_test.go
@@ -1,0 +1,53 @@
+package ranges_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/ranges"
+)
+
+func TestSelectPoint(t *testing.T) {
+	rs := []ranges.Range{
+		{Begin: 35500, End: 35600, Value: 4},
+		{Begin: 35700, End: 35900, Value: 6},
+		{Begin: 36000, End: 36000, Value: 8},
+	}
+	testData := []struct {
+		name     string
+		index    int
+		expected ranges.Point
+	}{{
+		name:     "Should pick first point in range",
+		index:    101,
+		expected: ranges.Point{Value: 6, Pos: 35700},
+	}, {
+		name:     "Should pick last point in range",
+		index:    100,
+		expected: ranges.Point{Value: 4, Pos: 35600},
+	}, {
+		name:     "Should pick middle point in range",
+		index:    201,
+		expected: ranges.Point{Value: 6, Pos: 35800},
+	}, {
+		name:     "Should pick point from one point range",
+		index:    302,
+		expected: ranges.Point{Value: 8, Pos: 36000},
+	}}
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &stubIndexProvider{index: tt.index}
+			actual := ranges.SelectPoint(rs, r)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+type stubIndexProvider struct {
+	index int
+}
+
+func (s *stubIndexProvider) Intn(n int) int {
+	return s.index % n
+}


### PR DESCRIPTION
## Summary

The library allows 4 operations:
- decomposing SAS channels into non intersecting intervals
- selecting valid intervals for given bandwidth
- checking for given bandwidth which frequencies are valid
- selecting random frequency with uniform distribution

Note: for different bandwidth valid channels may be different,
since power depends not only on eirp, but also on bandwidth,
eirp has to be higher for lower bandwidths.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>
