### PR TITLE
chore: modify GDB launcher to handle all C/C++ tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,8 +4,8 @@
         {
             "type": "by-gdb",
             "request": "launch",
-            "name": "(Bazel) Run SessionD test with GDB",
-            "program": "${workspaceFolder}/bazel-bin/lte/gateway/c/session_manager/test/${input:pickSessionDUnitTest}",
+            "name": "(Bazel) Run C/C++ test with GDB",
+            "program": "${workspaceFolder}/bazel-bin/${input:pickCcTest}",
             "cwd": "${workspaceRoot}",
             "commandsBeforeExec": [
                 "enable pretty-printer"
@@ -14,12 +14,16 @@
     ],
     "inputs": [
         {
-            "id": "pickSessionDUnitTest",
+            "id": "pickCcTest",
             "type": "command",
             "command": "shellCommand.execute",
             "args": {
-                // Use bazel query to find all test targets. This will automatically pick up any new tests added.
-                "command": "bazel query 'tests(//lte/gateway/c/session_manager/test/...)' | cut -d ':' -f2",
+                "description": "Pick a Bazel cc_test target",
+                // Use bazel query to find all test targets. This will automatically pick up any new cc_test added
+                // We need to massage the query output to get the output path
+                // 1. remove the initial // (ex: //orc8r/gateway/c/common/config/test:yaml_utils_test -> orc8r/gateway/c/common/config/test:yaml_utils_test)
+                // 2. replace : -> / (ex: orc8r/gateway/c/common/config/test:yaml_utils_test -> orc8r/gateway/c/common/config/test/yaml_utils_test)
+                "command": "bazel query \"kind('cc_test', //...)\" --output=label | sed 's/\\/\\///' | sed 's/:/\\//'",
             },
         }
     ]


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
* The current launch config only handled SessionD unit tests, modify it so that it can handle any cc_test
* This will help us debug MME unit tests faster, I hope
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Select the green button in the debug screen
![Screen Shot 2022-02-28 at 1 18 08 PM](https://user-images.githubusercontent.com/37634144/156036493-7ec934d1-250f-4872-9d1e-96e21aaa5083.png)
Confirmed that it lists all cc targets
![Screen Shot 2022-02-28 at 1 18 44 PM](https://user-images.githubusercontent.com/37634144/156036575-010dafb0-6a5c-48f1-85ec-6e204e4f8fde.png)
Selecting a test launches the debugger
![Screen Shot 2022-02-28 at 1 19 25 PM](https://user-images.githubusercontent.com/37634144/156036658-9793c7e3-2ff2-444d-be70-46679b9ed373.png)
![Screen Shot 2022-02-28 at 1 19 35 PM](https://user-images.githubusercontent.com/37634144/156036676-e6ca6328-1e09-4c25-a0a1-f650a62ae736.png)

We can now insert breakpoints from inside the editor for MME unit tests
![Screen Shot 2022-02-28 at 1 26 42 PM](https://user-images.githubusercontent.com/37634144/156037747-0ee0e9f1-8656-40da-b265-ad9450e83521.png)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
