### PR TITLE
chore: Add --compilation_mode=dbg by default to bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,12 +4,15 @@ startup --output_base=/tmp/bazel
 build --announce_rc
 build --color=yes
 
-build:development --compilation_mode=fastbuild
-build:production --config=lsan --compilation_mode=dbg --strip=never --copt=-O3
+build:production --config=lsan --strip=never --copt=-O3
 
 # C/C++ CONFIGS
 build --cxxopt=-std=c++14
 build --experimental_strict_action_env
+build --compilation_mode=dbg
+
+# Default test configuration
+test --test_output=errors
 
 # MAGMA VM CONFIGS
 build:specify_vm_cc --action_env=CC=/usr/bin/gcc

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -61,10 +61,10 @@ jobs:
         run: |
           cd lte/gateway
           vagrant ssh -c 'cd ~/magma; bazel build //... --config=production' magma
-      - name: Build all with Bazel from scratch `bazel build //... --config=development`
+      - name: Build all with Bazel from scratch `bazel build //...`
         run: |
           cd lte/gateway
-          vagrant ssh -c 'cd ~/magma; bazel build //... --config=development' magma
+          vagrant ssh -c 'cd ~/magma; bazel build //...' magma
       - name: Upload .bazel-cache and .bazel-cache-repo to S3
         run: |
           tar -zcvf ${{ env.BAZEL_CACHE_MAGMA_VM_TAR }} ${{ env.BAZEL_CACHE }}/


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
* --compilation_mode=dbg adds the compilation flag (-g) to include debug information. We include the debug symbols for production, so we would benefit from having this for development as well. 
* One thing that is note worthy is that this will enable -g for building dependencies as well. 
* Also adding `--test_output=errors` as default. This behavior is usually what we want 
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
