### PR TITLE
fix(subscriberdb): Update error code import

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/protocols/m5g_auth_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/m5g_auth_servicer.py
@@ -15,6 +15,7 @@ import logging
 
 from grpc import StatusCode
 from lte.protos import (
+    diam_errors_pb2,
     subscriberauth_pb2,
     subscriberauth_pb2_grpc,
     subscriberdb_pb2,
@@ -79,7 +80,7 @@ class M5GAuthRpcServicer(subscriberauth_pb2_grpc.M5GSubscriberAuthenticationServ
             metrics.M5G_AUTH_SUCCESS_TOTAL.inc()
 
             # Generate and return response message
-            aia.error_code = subscriberauth_pb2.SUCCESS
+            aia.error_code = diam_errors_pb2.SUCCESS
             m5gauth_vector = aia.m5gauth_vectors.add()
             m5gauth_vector.rand = bytes(m5g_ran_auth_vectors.rand)
             m5gauth_vector.xres_star = m5g_ran_auth_vectors.xres_star[16:]


### PR DESCRIPTION
## Summary

Fixes broken import introduced by https://github.com/magma/magma/pull/11773, which was flagged up by Sentry

Closes https://github.com/magma/magma/issues/11855

## Test Plan

```
>>> from lte.protos import subscriberauth_pb2
>>> subscriberauth_pb2.SUCCESS
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'lte.protos.subscriberauth_pb2' has no attribute 'SUCCESS'
>>> from lte.protos import diam_errors_pb2
>>> diam_errors_pb2.SUCCESS
2001
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
