### PR TITLE
fix(pipelined): Catch error and log warning if mtr setup fails

### DIFF
--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -152,8 +152,10 @@ def main():
     # monitoring related configuration
     mtr_interface = service.config.get('mtr_interface', None)
     if mtr_interface:
-        mtr_ip = get_ip_from_if(mtr_interface)
-        service.config['mtr_ip'] = mtr_ip
+        try:
+            service.config['mtr_ip'] = get_ip_from_if(mtr_interface)
+        except ValueError:
+            logging.warning("Unable to set up mtr interface", exc_info=True)
 
     # Load the ryu apps
     service_manager = ServiceManager(service)


### PR DESCRIPTION
## Summary

The mtr interface is not essential for AGW functionality.

Fixes #11830.

## Additional Information

- [ ] This change is backwards-breaking