### PR TITLE
fix(mme): Fix to pass test_ngap_state_converter in Bazel testing

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_state_converter.cpp
@@ -45,6 +45,7 @@ void NgapStateConverter::state_to_proto(ngap_state_t* state, NgapState* proto) {
   hashtable_rc_t ht_rc;
   amf_ue_ngap_id_t amfid;
   sctp_assoc_id_t associd;
+  void* associd_ptr = nullptr;
   auto amfid2associd = proto->mutable_amfid2associd();
 
   hashtable_key_array_t* keys = hashtable_ts_get_keys(&state->amfid2associd);
@@ -54,10 +55,13 @@ void NgapStateConverter::state_to_proto(ngap_state_t* state, NgapState* proto) {
     for (int i = 0; i < keys->num_keys; i++) {
       amfid = (amf_ue_ngap_id_t)keys->keys[i];
       ht_rc = hashtable_ts_get(&state->amfid2associd, (hash_key_t)amfid,
-                               (void**)&associd);
+                               reinterpret_cast<void**>(&associd_ptr));
       AssertFatal(ht_rc == HASH_TABLE_OK, "amfid not in amfid2associd");
 
-      (*amfid2associd)[amfid] = associd;
+      if (associd_ptr) {
+        associd = (sctp_assoc_id_t)(uintptr_t)associd_ptr;
+        (*amfid2associd)[amfid] = associd;
+      }
     }
     FREE_HASHTABLE_KEY_ARRAY(keys);
   }
@@ -215,7 +219,7 @@ void NgapStateConverter::supported_tai_item_to_proto(
   supported_tai_item_proto->set_tac(state_supported_tai_item->tac);
   supported_tai_item_proto->set_bplmnlist_count(
       state_supported_tai_item->bplmnlist_count);
-  char plmn_array[PLMN_BYTES] = {0};
+  char plmn_array[PLMN_BYTES + 1] = {0};
   for (int idx = 0; idx < state_supported_tai_item->bplmnlist_count; idx++) {
     plmn_array[0] = static_cast<char>(
         state_supported_tai_item->bplmn_list[idx].plmn_id.mcc_digit1 +


### PR DESCRIPTION
Signed-off-by: sreedharkumartn <sreedhar.kumar@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
**Issue 1:**
- Issue reported by @themarwhal in issue #11676.

Fix:
- Increase the size of ``plmn_array`` by +1 to include null pointer.

**Issue 2:**
- After above fix, while running the below command
``bazel test //lte/gateway/c/core/oai/test/ngap:ngap_state_converter_test --config=asan --compilation_mode=dbg --runs_per_test=10``
got this error
![image](https://user-images.githubusercontent.com/89978170/156195524-2863b254-5f63-4aa2-bf82-07943a53e712.png)

Fix:
- Introduction of additional pointer for associd.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Bazel testing using (@electronjoe  repo)
![ngap_state_converter_bazel](https://user-images.githubusercontent.com/89978170/156195790-bf02a684-ad5a-4eb2-80e8-a3ccb419e671.png)

- Validated with Unit test
![UT](https://user-images.githubusercontent.com/89978170/156195852-5ac37c15-9580-4297-869b-6b1091b46d7e.png)

- Verified basic sanity with UERANSIM

PCAP Snap:
![image](https://user-images.githubusercontent.com/89978170/156209351-49c13ebb-aada-430b-a434-99b20559902d.png)

MME Log:
[mme.log](https://github.com/magma/magma/files/8163223/mme.log)



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
