### PR TITLE
build(mme): bazel test compiles mme with unit test flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,6 +34,8 @@ build:devcontainer --define=folly_so=1
 #  Bazel test runtime default: PATH=/bin:/usr/bin:/usr/local/bin
 #  Some python tests require access to /usr/sbin binaries (e.g. route, ifconfig)
 build --test_env=PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin
+#  For testing compile mme libraries with unit test flag
+test --copt=-DMME_UNIT_TEST
 
 # CODE COVERAGE CONFIGS
 build --javacopt="-source 8"


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

See #11861 including discussion.

## Test Plan

CI
If respective bazelified tests are merged:
* `bazel test --test_output=all lte/gateway/c/core/oai/test/s1ap_task:s1ap_mme_handlers_test`
* with and without change in  `.bazelrc`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
