### PR TITLE
chore(ci): Add a doc check to ensure all files are committed

### DIFF
--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -60,3 +60,24 @@ jobs:
         run: |
             cd ${MAGMA_ROOT}/docs
             make precommit
+
+  markdown-insync:
+    needs: path_filter
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    name: Markdown insync check
+    runs-on: ubuntu-latest
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Run docs `make`
+        run: |
+            cd ${MAGMA_ROOT}/docs
+            make
+      - name: Check all generated files are checked in after running `make -C $MAGMA_ROOT/docs`
+        run: |
+          git status
+          git diff-index --quiet HEAD


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I keep finding that there are leftover doc files on master, adding a new CI check to help developers detect this.
See https://github.com/magma/magma/pull/11875
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Check fails on master (should pass again once the above PR is merged)
<img width="1100" alt="Screen Shot 2022-03-01 at 12 16 44 PM" src="https://user-images.githubusercontent.com/37634144/156216566-17fbf4cc-3cc6-4ff1-8092-1a13d5252206.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
