### PR TITLE
chore: disable W504 and WPS348 from py lint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,9 @@ strictness = short
 
 ignore =
     W503, # line break before binary operator
+    W504, # line break occurred after a binary operator 
     # wemake-python-styleguide warnings
+    # See https://wemake-python-stylegui.de/en/latest/pages/usage/violations/index.html for doc
     WPS102, # Found incorrect module name pattern
     WPS110, # Found wrong variable name
     WPS111, # Found too short name
@@ -38,6 +40,7 @@ ignore =
     WPS336, # Found explicit string concatenation
     WPS337, # Found multiline conditions
     WPS338, # Found incorrect order of methods in a class
+    WPS348, # Found line starting with a dot
     WPS352, # Found multiline loop
     WPS414, # Found incorrect unpacking target
     WPS420, # Found wrong keyword


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
From a comment on PR: https://github.com/magma/magma/pull/11815#discussion_r814968592
<!-- Enumerate changes you made and why you made them -->

## Test Plan
n/a
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
