### PR TITLE
chore(mme): Address GCC warning seen on PR11865

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.cpp
@@ -61,7 +61,7 @@ static void handle_decrypted_imsi_info_ans(
   if (!status.ok() || (response.ue_msin_recv().length() == 0)) {
     OAILOG_ERROR(LOG_AMF_APP,
                  "get_decrypt_imsi_info fails with code %d, Message : %s",
-                 status.error_code(), status.error_message());
+                 status.error_code(), status.error_message().c_str());
     OAILOG_ERROR(LOG_AMF_APP,
                  "Deconcealing IMSI Failed, sending Registration Reject");
     int amf_cause = AMF_UE_ILLEGAL;


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Address (seen on [PR11865](https://github.com/magma/magma/pull/11865/) but unrelated to the PR)
<img width="1194" alt="Screen Shot 2022-03-01 at 1 34 56 PM" src="https://user-images.githubusercontent.com/37634144/156229062-1960b4c1-54dd-406f-8ba3-9c6715209cb4.png">

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
