### PR TITLE
chore(ci): modify Bazel build and test job so that we only start from…

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -81,20 +81,41 @@ jobs:
         # thereby only ever using the last successful cache version. This solution will result in a
         # few slower CI actions around the time cache is detected to be too large, but it should
         # incrementally improve thereafter.
-        - name: Ensure cache size
+        - name: Ensure cache size BAZEL_CACHE
+          # Only run on master to avoid slow build on PRs
+          if: github.event_name == 'push'
           env:
             BAZEL_CACHE_DIR: .${{ env.BAZEL_CACHE }}
-            BAZEL_CACHE_REPO_DIR: .${{ env.BAZEL_CACHE_REPO }}
+            # Use a 7GB threshold since actions/cache compresses the results, and Bazel caches seem
+            # to only increase by a few hundred megabytes across changes for unrelated branches.
+            # Uncompressed cache on master is looking to be around 6GB (from observing jobs on master)
+            BAZEL_CACHE_CUTOFF_MB: 7000
           run: |
             # See https://stackoverflow.com/a/27485157 for reference.
             EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
+
+            CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | cut -f1)
+            echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
+            
+            if [[ "$CACHE_SIZE_MB" -gt $BAZEL_CACHE_CUTOFF_MB ]]; then
+              echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
+              rm -rf $EXPANDED_BAZEL_CACHE_PATH $EXPANDED_BAZEL_CACHE_REPO_PATH
+            fi
+        - name: Ensure cache size BAZEL_CACHE_REPO
+          # Only run on master to avoid slow build on PRs
+          if: github.event_name == 'push'
+          env:
+            BAZEL_CACHE_REPO_DIR: .${{ env.BAZEL_CACHE_REPO }}
+            # Use a 600 threshold since actions/cache compresses the results, and the repository cache should not increase unless we add more dependencies
+            # Uncompressed cache on master is looking to be around 400MB (from observing jobs on master)
+            BAZEL_CACHE_REPO_CUTOFF_MB: 600
+          run: |
+            # See https://stackoverflow.com/a/27485157 for reference.
             EXPANDED_BAZEL_CACHE_REPO_PATH="${BAZEL_CACHE_REPO_DIR/#\~/$HOME}"
 
-            CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH $EXPANDED_BAZEL_CACHE_REPO_PATH | grep total | cut -f1)
+            CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_REPO_PATH | cut -f1)
             echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
-            # Use a 4.5GB threshold since actions/cache compresses the results, and Bazel caches seem
-            # to only increase by a few hundred megabytes across changes for unrelated branches.
-            if [[ "$CACHE_SIZE_MB" -gt 4500 ]]; then
+            if [[ "$CACHE_SIZE_MB" -gt "$BAZEL_CACHE_REPO_CUTOFF_MB" ]]; then
               echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
               rm -rf $EXPANDED_BAZEL_CACHE_PATH $EXPANDED_BAZEL_CACHE_REPO_PATH
             fi


### PR DESCRIPTION
… scratch on master

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
1. Noticed that the Bazel build and test job was starting from scratch very often on master. This is probably because the cutoff value to remove the cache is now too small. (Maybe due to all the python dependencies we're adding). 
2. Modified the logic so that we only rebuild the cache on master. This change makes it so that PR authors are not affected by the occasional slow build.
3. Separated out the cache wiping logic for Bazel-cache-repo and bazel-cache. Bazel-cache-repo should rarely need a cache wipe as it only holds the source code of our dependencies, which should not change frequently.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI (will monitor master)
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
