### PR TITLE
fix(orc8r): Enable EPS Auth unit tests & fix affected components

### DIFF
--- a/lte/cloud/go/services/eps_authentication/servicers/ai_test.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ai_test.go
@@ -76,7 +76,8 @@ func (suite *EpsAuthTestSuite) TestAuthenticationInformation_UnknownSubscriber()
 
 	aia, err := suite.AuthenticationInformation(air)
 	suite.EqualError(
-		err, "rpc error: code = NotFound desc = Error fetching subscriber: IMSIsub_unknown, No record for query")
+		err,
+		"rpc error: code = NotFound desc = error loading subscriber entity for NID: test, SID: sub_unknown: Not found")
 	suite.checkAIA(aia, protos.ErrorCode_USER_UNKNOWN, 0)
 }
 
@@ -103,8 +104,7 @@ func (suite *EpsAuthTestSuite) TestAuthenticationInformation_MissingSubscriberSt
 
 	aia, err := suite.AuthenticationInformation(air)
 	suite.EqualError(
-		err,
-		"rpc error: code = Unauthenticated desc = Authentication rejected: Subscriber data missing LTE subscription")
+		err, "rpc error: code = Unauthenticated desc = Authentication rejected: Subscriber data missing LTE subscription")
 	suite.checkAIA(aia, protos.ErrorCode_AUTHORIZATION_REJECTED, 0)
 }
 

--- a/lte/cloud/go/services/eps_authentication/servicers/pur_test.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/pur_test.go
@@ -19,7 +19,8 @@ func (suite *EpsAuthTestSuite) TestPurgeUE_UnknownSubscriber() {
 	purge := &protos.PurgeUERequest{UserName: "sub_unknown"}
 	answer, err := suite.PurgeUE(purge)
 	suite.EqualError(
-		err, "rpc error: code = NotFound desc = Error fetching subscriber: IMSIsub_unknown, No record for query")
+		err,
+		"rpc error: code = NotFound desc = error loading subscriber entity for NID: test, SID: sub_unknown: Not found")
 	suite.Equal(protos.ErrorCode_USER_UNKNOWN, answer.ErrorCode)
 }
 

--- a/lte/cloud/go/services/eps_authentication/servicers/server.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/server.go
@@ -39,8 +39,9 @@ func NewEPSAuthServer(store storage.SubscriberDBStorage) (*EPSAuthServer, error)
 // lookupSubscriber returns a subscriber's data or an error.
 func (srv *EPSAuthServer) lookupSubscriber(
 	userName, networkID string) (*lteprotos.SubscriberData, lteprotos.ErrorCode, error) {
-	subscriber, err :=
-		srv.store.GetSubscriberData(&lteprotos.SubscriberID{Id: userName}, &protos.NetworkID{Id: networkID})
+	subscriber, err := srv.store.GetSubscriberData(
+		&lteprotos.SubscriberID{Id: userName}, &protos.NetworkID{Id: networkID})
+
 	if err != nil {
 		if status.Convert(err).Code() == codes.NotFound {
 			return nil, lteprotos.ErrorCode_USER_UNKNOWN, err

--- a/lte/cloud/go/services/eps_authentication/servicers/ul_test.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ul_test.go
@@ -71,7 +71,8 @@ func (suite *EpsAuthTestSuite) TestUpdateLocation_UnknownSubscriber() {
 
 	ula, err := suite.UpdateLocation(ulr)
 	suite.EqualError(
-		err, "rpc error: code = NotFound desc = Error fetching subscriber: IMSIsub_unknown, No record for query")
+		err,
+		"rpc error: code = NotFound desc = error loading subscriber entity for NID: test, SID: sub_unknown: Not found")
 	suite.Equal(protos.ErrorCode_USER_UNKNOWN, ula.ErrorCode)
 }
 


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Enable disabled EPS Authentication unit tests & fix affected components.

## Test Plan
Enable, fix & run unit tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
