### PR TITLE
fix(mme): Updating state converter's plmn_bytes array to be null-terminated

### DIFF
--- a/lte/gateway/c/core/oai/common/state_converter.cpp
+++ b/lte/gateway/c/core/oai/common/state_converter.cpp
@@ -53,7 +53,7 @@ void StateConverter::guti_to_proto(const guti_t& state_guti,
                                    oai::Guti* guti_proto) {
   guti_proto->Clear();
 
-  char plmn_array[PLMN_BYTES];
+  char plmn_array[PLMN_BYTES + 1];
   plmn_to_chars(state_guti.gummei.plmn, plmn_array);
   guti_proto->set_plmn(plmn_array);
   guti_proto->set_mme_gid(state_guti.gummei.mme_gid);
@@ -74,7 +74,7 @@ void StateConverter::ecgi_to_proto(const ecgi_t& state_ecgi,
                                    oai::Ecgi* ecgi_proto) {
   ecgi_proto->Clear();
 
-  char plmn_array[PLMN_BYTES];
+  char plmn_array[PLMN_BYTES + 1];
   plmn_to_chars(state_ecgi.plmn, plmn_array);
   ecgi_proto->set_plmn(plmn_array);
   ecgi_proto->set_enb_id(state_ecgi.cell_identity.enb_id);

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_converter.cpp
@@ -265,7 +265,7 @@ void S1apStateConverter::supported_tai_item_to_proto(
   supported_tai_item_proto->set_tac(state_supported_tai_item->tac);
   supported_tai_item_proto->set_bplmnlist_count(
       state_supported_tai_item->bplmnlist_count);
-  char plmn_array[PLMN_BYTES] = {0};
+  char plmn_array[PLMN_BYTES + 1] = {0};
   for (int idx = 0; idx < state_supported_tai_item->bplmnlist_count; idx++) {
     plmn_array[0] =
         (char)(state_supported_tai_item->bplmns[idx].mcc_digit1 + ASCII_ZERO);


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- bazel tests untangled a bug where on PLMN char array conversion a heap-buffer overflow is thrown due to the array not being null terminated.
- Fix is done on all state conversion usages under MME tasks

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- `make test_oai OAI_TESTS=".*s1ap\|spgw_state.*"` (with ASAN enabled also for C++)
```
cd  /home/vagrant/build/c/core/oai && ctest --output-on-failure -R  .*s1ap\|spgw_state.*
Test project /home/vagrant/build/c/core/oai
    Start 11: test_s1ap
1/2 Test #11: test_s1ap ........................   Passed   37.96 sec
    Start 19: test_spgw_state_converter
2/2 Test #19: test_spgw_state_converter ........   Passed    0.11 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  38.07 sec
```
- `bazel test //lte/gateway/c/core/oai/test/s1ap_task:s1ap_state_converter_test --config=asan`
- `make integ_test`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
