### PR TITLE
fix(orc8r): lowercase orc8r service names

### DIFF
--- a/feg/cloud/go/services/basic_acct/definitions.go
+++ b/feg/cloud/go/services/basic_acct/definitions.go
@@ -13,4 +13,4 @@ limitations under the License.
 
 package basic_acct
 
-const ServiceName = "BASE_ACCT"
+const ServiceName = "base_acct"

--- a/feg/cloud/go/services/feg_relay/feg_relay.go
+++ b/feg/cloud/go/services/feg_relay/feg_relay.go
@@ -13,4 +13,4 @@ limitations under the License.
 
 package feg_relay
 
-const ServiceName = "FEG_RELAY"
+const ServiceName = "feg_relay"

--- a/feg/gateway/services/aaa/base_acct/client_api.go
+++ b/feg/gateway/services/aaa/base_acct/client_api.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	ServiceName = "BASE_ACCT"
+	ServiceName = "base_acct"
 )
 
 // Get a thin RPC client to the gateway base_acct service.

--- a/lte/cloud/go/services/policydb/client_api.go
+++ b/lte/cloud/go/services/policydb/client_api.go
@@ -16,4 +16,4 @@ limitations under the License.
 // the RPC implementation.
 package policydb
 
-const ServiceName = "POLICYDB"
+const ServiceName = "policydb"

--- a/lte/cloud/go/services/smsd/const.go
+++ b/lte/cloud/go/services/smsd/const.go
@@ -13,4 +13,4 @@
 
 package smsd
 
-const ServiceName = "SMSD"
+const ServiceName = "smsd"

--- a/orc8r/cloud/go/services/accessd/client_api.go
+++ b/orc8r/cloud/go/services/accessd/client_api.go
@@ -27,7 +27,7 @@ import (
 	"magma/orc8r/lib/go/registry"
 )
 
-const ServiceName = "ACCESSD"
+const ServiceName = "accessd"
 
 // getAccessbClient is a utility function to get a RPC connection to the
 // accessd service

--- a/orc8r/cloud/go/services/bootstrapper/const.go
+++ b/orc8r/cloud/go/services/bootstrapper/const.go
@@ -14,7 +14,7 @@ limitations under the License.
 package bootstrapper
 
 const (
-	ServiceName        = "BOOTSTRAPPER"
+	ServiceName        = "bootstrapper"
 	BlobstoreTableName = "bootstrapper"
 	TokenPrefix        = "reg_"
 )

--- a/orc8r/cloud/go/services/certifier/client_api.go
+++ b/orc8r/cloud/go/services/certifier/client_api.go
@@ -29,7 +29,7 @@ import (
 	"magma/orc8r/lib/go/registry"
 )
 
-const ServiceName = "CERTIFIER"
+const ServiceName = "certifier"
 
 // Utility function to get a RPC connection to the certifier service
 func getCertifierClient() (certprotos.CertifierClient, error) {

--- a/orc8r/cloud/go/services/directoryd/client_api.go
+++ b/orc8r/cloud/go/services/directoryd/client_api.go
@@ -29,7 +29,7 @@ import (
 	"magma/orc8r/lib/go/registry"
 )
 
-const ServiceName = "DIRECTORYD"
+const ServiceName = "directoryd"
 
 //-------------------------------
 // Directoryd service client APIs

--- a/orc8r/cloud/go/services/dispatcher/client_api.go
+++ b/orc8r/cloud/go/services/dispatcher/client_api.go
@@ -13,4 +13,4 @@ limitations under the License.
 
 package dispatcher
 
-const ServiceName = "DISPATCHER"
+const ServiceName = "dispatcher"

--- a/orc8r/gateway/go/directoryd/client_api.go
+++ b/orc8r/gateway/go/directoryd/client_api.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	ServiceName = "DIRECTORYD"
+	ServiceName = "directoryd"
 	ImsiPrefix  = "IMSI"
 
 	UseCloudDirectordEnv = "USE_CLOUD_DIRECTORYD"


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

fix(orc8r): lowercase orc8r service names

## Summary

Service names in Go code are standardized to all-lowercase.

This is for issue:
https://github.com/magma/magma/issues/9829

## Test Plan

I ran unit tests in: /magma/orc8r/cloud/docker/ ./build.py -c
