### PR TITLE
chore(mme): Moves libnettle and libgnutls installation directories

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -142,7 +142,7 @@ RUN wget --progress=dot:giga https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz &&
     cd nettle-2.5 && \
     mkdir build && \
     cd build/ && \
-    ../configure --disable-openssl --enable-shared --libdir=/usr/local/lib && \
+    ../configure --disable-openssl --enable-shared --libdir=/usr/lib && \
     make -j"$(nproc)" && \
     make install && \
     ldconfig -v && \
@@ -151,7 +151,7 @@ RUN wget --progress=dot:giga https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz &&
     tar xf gnutls-3.1.23.tar.xz && \
     cd gnutls-3.1.23 && \
     mkdir build && cd build && \
-    CFLAGS=-D_IO_ftrylockfile ../configure --with-libnettle-prefix=/usr/local && \
+    CFLAGS=-D_IO_ftrylockfile ../configure --libdir=/usr/lib --with-libnettle-prefix=/usr && \
     make -j"$(nproc)" && \
     make install && \
     ldconfig -v && \

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -136,7 +136,7 @@ RUN wget --progress=dot:giga http://ftp.ntua.gr/mirror/gnu/nettle/nettle-2.5.tar
     cd nettle-2.5 && \
     mkdir build && \
     cd build/ && \
-    ../configure --disable-openssl --enable-shared --libdir=/usr/local/lib && \
+    ../configure --disable-openssl --enable-shared --libdir=/usr/lib && \
     make -j"$(nproc)" && \
     make install && \
     ldconfig -v && \
@@ -145,7 +145,7 @@ RUN wget --progress=dot:giga http://ftp.ntua.gr/mirror/gnu/nettle/nettle-2.5.tar
     tar xf gnutls-3.1.23.tar.xz && \
     cd gnutls-3.1.23 && \
     mkdir build && cd build && \
-    CFLAGS=-D_IO_ftrylockfile ../configure --with-libnettle-prefix=/usr/local && \
+    CFLAGS=-D_IO_ftrylockfile ../configure --libdir=/usr/lib --with-libnettle-prefix=/usr && \
     make -j"$(nproc)" && \
     make install && \
     ldconfig -v && \


### PR DESCRIPTION
To match Magma Dev VM paths. [Solutions](https://magmacore.slack.com/archives/C02HRAXJEBB/p1646144090525289?thread_ts=1646137599.328289&cid=C02HRAXJEBB) suggestion by @nstng.

## Test Plan

- Validated successful Bazel build of #11862 with modified
system_libraries.build to match path migration
- Validated success of `make test_oai` within devcontainer (did not break CMake)

Signed-off-by: Scott Moeller <electronjoe@gmail.com>