### PR TITLE
chore: -fsanitize=undefined option is added to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -51,9 +51,11 @@ build:coverage --instrumentation_filter="//(orc8r|lte)/gateway/(c|python)[/:],-/
 
 # ASAN
 build:asan --copt=-fsanitize=address
+build:asan --copt=-fsanitize=undefined
 build:asan --copt=-O0
 build:asan --copt=-fno-omit-frame-pointer
 build:asan --linkopt=-fsanitize=address
+build:asan --linkopt=-fsanitize=undefined
 build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
 
 # LSAN


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- In analogy to CMake the `-fsanitize=undefined` option is added to `build:asan` in the `.bazelrc` to detect undefined behavior at compile-time.
- Follow up to https://github.com/magma/magma/pull/11903

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
