### PR TITLE
ci(agw): the agw-workflow is started for bazel related changes

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -38,6 +38,9 @@ jobs:
               - '.github/workflows/agw-workflow.yml'
               - 'orc8r/**'
               - 'lte/**'
+              - '.bazelrc'
+              - 'WORKSPACE.bazel'
+              - 'bazel/**'
       - name: Save should_not_skip output
         if: always()
         run: |


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Problem:  agw-workflow is not starting for bazel related changes
- Solution: bazel related files are added to agw-workflow.yml

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
