### PR TITLE
chore: POC only apply asan and lsan to magma libs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,7 +35,7 @@ build:devcontainer --define=folly_so=1
 #  Some python tests require access to /usr/sbin binaries (e.g. route, ifconfig)
 build --test_env=PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin
 #  For testing compile mme libraries with unit test flag
-test --copt=-DMME_UNIT_TEST
+test --define=set_test_env=1
 
 # CODE COVERAGE CONFIGS
 build --javacopt="-source 8"
@@ -50,18 +50,10 @@ build:coverage --combined_report=lcov
 build:coverage --instrumentation_filter="//(orc8r|lte)/gateway/(c|python)[/:],-//(orc8r|lte)/protos[/:],-/*/test[/:]"
 
 # ASAN
-build:asan --copt=-fsanitize=address
-build:asan --copt=-fsanitize=undefined
-build:asan --copt=-O0
-build:asan --copt=-fno-omit-frame-pointer
-build:asan --linkopt=-fsanitize=address
-build:asan --linkopt=-fsanitize=undefined
-build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
+build:asan --define=enable_asan=1
 
 # LSAN
-build:lsan --copt=-fsanitize=leak
-build:lsan --copt=-fno-omit-frame-pointer
-build:lsan --linkopt=-fsanitize=leak
+build:lsan --define=enable_lsan=1
 
 # system bazelrc should include config specific to different build envs (--config=vm, --config=devcontainer, etc.)
 try-import /etc/bazelrc

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -12,3 +12,25 @@
 load(":python_toolchain.bzl", "configure_python_toolchain")
 
 configure_python_toolchain()
+
+config_setting(
+    name = "enable_asan",
+    values = {
+        "define": "enable_asan=1",
+    },
+)
+
+config_setting(
+    name = "enable_lsan",
+    values = {
+        "define": "enable_lsan=1",
+    },
+)
+
+config_setting(
+    name = "set_test_flag",
+    values = {
+        "define": "set_test_flag=1",
+    },
+)
+

--- a/bazel/magma_cc.bzl
+++ b/bazel/magma_cc.bzl
@@ -1,0 +1,120 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
+ASAN_COPTS = ["-fsanitize=address", "-fsanitize=undefined", "-O0", "-fno-omit-frame-pointer"]
+ASAN_LINKOPTS = ["-fsanitize=address", "-fsanitize=undefined"]
+ASAN_DEFINES = ["ASAN_OPTIONS=detect_leaks=1:color=always"]
+
+LSAN_COPTS = ["-fsanitize=leak", "-fno-omit-frame-pointer"]
+LSAN_LINKOPTS = ["-fsanitize=leak"]
+
+MAGMA_TEST_DEFINES = ["MME_UNIT_TEST"]
+
+def _magma_copts(copts):
+    return copts + select({
+        "//bazel:enable_asan": ASAN_COPTS,
+        "//conditions:default": [],
+    }) + select({
+        "//bazel:enable_lsan": LSAN_COPTS,
+        "//conditions:default": [],
+    }) 
+
+def _magma_linkopts(linkopts):
+    return linkopts + select({
+        "//bazel:enable_asan": ASAN_LINKOPTS,
+        "//conditions:default": [],
+    }) + select({
+        "//bazel:enable_lsan": LSAN_LINKOPTS,
+        "//conditions:default": [],
+    })
+
+def _magma_defines(defines):
+    return defines + select({
+        "//bazel:enable_asan": ASAN_DEFINES,
+        "//conditions:default": [],
+    })+ select ({
+         "//bazel:set_test_flag": MAGMA_TEST_DEFINES,
+         "//conditions:default": [],
+    })
+
+def magma_cc_library(
+        name,
+        srcs = [],
+        hdrs = [],
+        copts = [],
+        linkopts = [],
+        visibility = None,
+        tags = [],
+        deps = [],
+        strip_include_prefix = None,
+        include_prefix = None,
+        defines = []):
+    """TODO: add doc"""
+    cc_library(
+        name = name,
+        srcs = srcs,
+        hdrs = hdrs,
+        copts = _magma_copts(copts),
+        linkopts = _magma_linkopts(linkopts),
+        visibility = visibility,
+        tags = tags,
+        deps = deps,
+        strip_include_prefix = strip_include_prefix,
+        include_prefix = include_prefix,
+        defines = _magma_defines(defines),
+    )
+
+def magma_cc_binary(
+        name,
+        srcs = [],
+        copts = [],
+        linkopts = [],
+        visibility = None,
+        tags = [],
+        deps = [],
+        strip_include_prefix = None,
+        include_prefix = None,
+        defines = [],
+        linkstatic = True):
+    """TODO: add doc"""
+    cc_binary(
+        name = name,
+        srcs = srcs,
+        copts = _magma_copts(copts),
+        linkopts = _magma_linkopts(linkopts),
+        visibility = visibility,
+        tags = tags,
+        deps = deps,
+        strip_include_prefix = strip_include_prefix,
+        include_prefix = include_prefix,
+        defines = _magma_defines(defines),
+        linkstatic = linkstatic,
+    )
+
+def magma_cc_test(
+        name,
+        srcs = [],
+        copts = [],
+        linkopts = [],
+        visibility = None,
+        tags = [],
+        deps = [],
+        strip_include_prefix = None,
+        include_prefix = None,
+        defines = [],
+        size = None,
+        flaky = None):
+    """TODO: add doc"""
+    cc_test(
+        name = name,
+        srcs = srcs,
+        copts = _magma_copts(copts),
+        linkopts = _magma_linkopts(linkopts),
+        visibility = visibility,
+        tags = tags,
+        deps = deps,
+        size = size,
+        flaky = None,
+        strip_include_prefix = strip_include_prefix,
+        include_prefix = include_prefix,
+        defines = _magma_defines(defines),
+    )

--- a/lte/gateway/c/connection_tracker/src/BUILD.bazel
+++ b/lte/gateway/c/connection_tracker/src/BUILD.bazel
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_binary", "magma_cc_library")
 
-cc_binary(
+magma_cc_binary(
     name = "connectiond",
     srcs = ["main.cpp"],
     deps = [
@@ -23,7 +23,7 @@ cc_binary(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "event_tracker",
     srcs = ["EventTracker.cpp"],
     hdrs = ["EventTracker.h"],
@@ -33,7 +33,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "packet_generator",
     srcs = ["PacketGenerator.cpp"],
     hdrs = ["PacketGenerator.h"],

--- a/lte/gateway/c/core/oai/common/glogwrapper/BUILD.bazel
+++ b/lte/gateway/c/core/oai/common/glogwrapper/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
-cc_library(
+magma_cc_library(
     name = "glog_logging",
     srcs = ["glog_logging.cpp"],
     hdrs = ["glog_logging.h"],

--- a/lte/gateway/c/core/oai/lib/bstr/BUILD.bazel
+++ b/lte/gateway/c/core/oai/lib/bstr/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
-cc_library(
+magma_cc_library(
     name = "bstrlib",
     srcs = ["bstrlib.c"],
     hdrs = ["bstrlib.h"],

--- a/lte/gateway/c/core/oai/lib/directoryd/BUILD.bazel
+++ b/lte/gateway/c/core/oai/lib/directoryd/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
-cc_library(
+magma_cc_library(
     name = "directoryd_client",
     srcs = [
         "GatewayDirectorydClient.cpp",

--- a/lte/gateway/c/core/oai/lib/event_client/BUILD.bazel
+++ b/lte/gateway/c/core/oai/lib/event_client/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
-cc_library(
+magma_cc_library(
     name = "eventd_client",
     srcs = ["EventClientAPI.cpp"],
     hdrs = ["EventClientAPI.h"],

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_binary", "magma_cc_library")
 
 package(default_visibility = ["//lte/gateway/c/li_agent/src:__subpackages__"])
 
-cc_binary(
+magma_cc_binary(
     name = "liagentd",
     srcs = ["main.cpp"],
     deps = [
@@ -25,7 +25,7 @@ cc_binary(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "interface_monitor",
     srcs = ["InterfaceMonitor.cpp"],
     hdrs = ["InterfaceMonitor.h"],
@@ -35,7 +35,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "pdu_generator",
     srcs = ["PDUGenerator.cpp"],
     hdrs = ["PDUGenerator.h"],
@@ -50,7 +50,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "proxy_connector",
     srcs = ["ProxyConnector.cpp"],
     hdrs = ["ProxyConnector.h"],
@@ -59,7 +59,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "mobilityd_client",
     srcs = ["MobilitydClient.cpp"],
     hdrs = ["MobilitydClient.h"],
@@ -70,7 +70,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "utilities",
     srcs = ["Utilities.cpp"],
     hdrs = ["Utilities.h"],

--- a/lte/gateway/c/li_agent/src/test/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/test/BUILD.bazel
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bazel:magma_cc.bzl", "magma_cc_library", "magma_cc_test")
 
-cc_test(
+magma_cc_test(
     name = "pdu_generator_test",
     size = "small",
     srcs = [
@@ -29,7 +29,7 @@ cc_test(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "li_agentd_mocks",
     hdrs = ["LIAgentdMocks.h"],
 )

--- a/lte/gateway/c/sctpd/src/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_binary", "magma_cc_library")
 
 package(default_visibility = ["//lte/gateway/c/sctpd/src:__subpackages__"])
 
-cc_binary(
+magma_cc_binary(
     name = "sctpd",
     srcs = ["sctpd.cpp"],
     linkstatic = True,
@@ -29,7 +29,7 @@ cc_binary(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "sctpd_event_handler",
     srcs = ["sctpd_event_handler.cpp"],
     hdrs = ["sctpd_event_handler.h"],
@@ -39,7 +39,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "sctpd_uplink_client",
     srcs = ["sctpd_uplink_client.cpp"],
     hdrs = ["sctpd_uplink_client.h"],
@@ -49,7 +49,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "sctpd_downlink_impl",
     srcs = ["sctpd_downlink_impl.cpp"],
     hdrs = ["sctpd_downlink_impl.h"],
@@ -59,7 +59,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "sctp_connection",
     srcs = ["sctp_connection.cpp"],
     hdrs = ["sctp_connection.h"],
@@ -69,7 +69,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "sctp_desc",
     srcs = ["sctp_desc.cpp"],
     hdrs = ["sctp_desc.h"],
@@ -78,7 +78,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "sctp_assoc",
     srcs = ["sctp_assoc.cpp"],
     hdrs = ["sctp_assoc.h"],
@@ -87,7 +87,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "util",
     srcs = ["util.cpp"],
     hdrs = ["util.h"],
@@ -99,7 +99,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "config",
     hdrs = ["sctpd.h"],
 )

--- a/lte/gateway/c/sctpd/src/test/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/test/BUILD.bazel
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//bazel:magma_cc.bzl", "magma_cc_test")
 
-cc_test(
+magma_cc_test(
     name = "event_handler_test",
     size = "small",
     srcs = ["test_event_handler.cpp"],
@@ -23,7 +23,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "sctp_desc_test",
     size = "small",
     srcs = ["test_sctp_desc.cpp"],

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_binary", "magma_cc_library")
 
 package(default_visibility = ["//lte/gateway/c/session_manager/test:__pkg__"])
 
-cc_library(
+magma_cc_library(
     name = "diameter_codes",
     srcs = ["DiameterCodes.cpp"],
     hdrs = ["DiameterCodes.h"],
@@ -21,7 +21,7 @@ cc_library(
     strip_include_prefix = "/lte/gateway/c/session_manager",
 )
 
-cc_library(
+magma_cc_library(
     name = "grpc_magma_utils",
     srcs = ["GrpcMagmaUtils.cpp"],
     hdrs = ["GrpcMagmaUtils.h"],
@@ -34,7 +34,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "session_id",
     srcs = ["SessionID.cpp"],
     hdrs = ["SessionID.h"],
@@ -42,7 +42,7 @@ cc_library(
     strip_include_prefix = "/lte/gateway/c/session_manager",
 )
 
-cc_library(
+magma_cc_library(
     name = "utilities",
     srcs = ["Utilities.cpp"],
     hdrs = ["Utilities.h"],
@@ -51,7 +51,7 @@ cc_library(
     deps = ["@protobuf"],
 )
 
-cc_library(
+magma_cc_library(
     name = "credit_key",
     hdrs = ["CreditKey.h"],
     # TODO(@themarwhal): Migrate to using full path for includes - GH8494
@@ -62,7 +62,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "types",
     hdrs = ["Types.h"],
     # TODO(@themarwhal): Migrate to using full path for includes - GH8494
@@ -74,7 +74,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "service_action",
     hdrs = ["ServiceAction.h"],
     # TODO(@themarwhal): Migrate to using full path for includes - GH8494
@@ -86,7 +86,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "policy_loader",
     srcs = [
         "PolicyLoader.cpp",
@@ -111,7 +111,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "session_reporter",
     srcs = ["SessionReporter.cpp"],
     hdrs = ["SessionReporter.h"],
@@ -127,7 +127,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "stored_state",
     srcs = ["StoredState.cpp"],
     hdrs = ["StoredState.h"],
@@ -144,7 +144,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "rule_store",
     srcs = ["RuleStore.cpp"],
     hdrs = ["RuleStore.h"],
@@ -159,7 +159,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "session_credit",
     srcs = [
         "ChargingGrant.cpp",
@@ -185,7 +185,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "shard_tracker",
     srcs = ["ShardTracker.cpp"],
     hdrs = ["ShardTracker.h"],
@@ -193,7 +193,7 @@ cc_library(
     strip_include_prefix = "/lte/gateway/c/session_manager",
 )
 
-cc_library(
+magma_cc_library(
     name = "session_state",
     srcs = ["SessionState.cpp"],
     hdrs = ["SessionState.h"],
@@ -211,7 +211,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "metering_reporter",
     srcs = ["MeteringReporter.cpp"],
     hdrs = ["MeteringReporter.h"],
@@ -224,7 +224,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "session_store",
     srcs = [
         "MemoryStoreClient.cpp",
@@ -248,7 +248,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "aaa_client",
     srcs = ["AAAClient.cpp"],
     hdrs = ["AAAClient.h"],
@@ -262,7 +262,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "directoryd_client",
     srcs = ["DirectorydClient.cpp"],
     hdrs = ["DirectorydClient.h"],
@@ -275,7 +275,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "mobilityd_client",
     srcs = ["MobilitydClient.cpp"],
     hdrs = ["MobilitydClient.h"],
@@ -290,7 +290,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "pipelined_client",
     srcs = ["PipelinedClient.cpp"],
     hdrs = ["PipelinedClient.h"],
@@ -304,7 +304,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "spgw_service_client",
     srcs = ["SpgwServiceClient.cpp"],
     hdrs = ["SpgwServiceClient.h"],
@@ -319,7 +319,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "amf_service_client",
     srcs = ["AmfServiceClient.cpp"],
     hdrs = ["AmfServiceClient.h"],
@@ -334,7 +334,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "session_events",
     srcs = ["SessionEvents.cpp"],
     hdrs = ["SessionEvents.h"],
@@ -347,7 +347,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "local_enforcer",
     srcs = ["LocalEnforcer.cpp"],
     hdrs = ["LocalEnforcer.h"],
@@ -365,7 +365,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "session_state_enforcer",
     srcs = ["SessionStateEnforcer.cpp"],
     hdrs = ["SessionStateEnforcer.h"],
@@ -384,7 +384,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "stats_poller",
     srcs = ["StatsPoller.cpp"],
     hdrs = ["StatsPoller.h"],
@@ -393,21 +393,21 @@ cc_library(
     deps = [":local_enforcer"],
 )
 
-cc_library(
+magma_cc_library(
     name = "operational_states_handler",
     srcs = ["OperationalStatesHandler.cpp"],
     hdrs = ["OperationalStatesHandler.h"],
     deps = [":session_store"],
 )
 
-cc_library(
+magma_cc_library(
     name = "restart_handler",
     srcs = ["RestartHandler.cpp"],
     hdrs = ["RestartHandler.h"],
     deps = [":local_enforcer"],
 )
 
-cc_library(
+magma_cc_library(
     name = "session_proxy_responder_handler",
     srcs = ["SessionProxyResponderHandler.cpp"],
     hdrs = ["SessionProxyResponderHandler.h"],
@@ -420,7 +420,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "local_session_manager_handler",
     srcs = ["LocalSessionManagerHandler.cpp"],
     hdrs = ["LocalSessionManagerHandler.h"],
@@ -433,7 +433,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "set_message_manager_handler",
     srcs = ["SetMessageManagerHandler.cpp"],
     hdrs = ["SetMessageManagerHandler.h"],
@@ -448,7 +448,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "upf_msg_manage_handler",
     srcs = ["UpfMsgManageHandler.cpp"],
     hdrs = ["UpfMsgManageHandler.h"],
@@ -463,7 +463,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "session_manager_server",
     srcs = ["SessionManagerServer.cpp"],
     hdrs = ["SessionManagerServer.h"],
@@ -477,7 +477,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+magma_cc_binary(
     name = "sessiond",
     srcs = ["sessiond_main.cpp"],
     # Make the binary as static as possible to allow for more reliable behavior when moving binaries around

--- a/lte/gateway/c/session_manager/test/BUILD.bazel
+++ b/lte/gateway/c/session_manager/test/BUILD.bazel
@@ -9,19 +9,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//bazel:magma_cc.bzl", "magma_cc_library", "magma_cc_test")
 
-cc_library(
+magma_cc_library(
     name = "consts",
     hdrs = ["Consts.h"],
 )
 
-cc_library(
+magma_cc_library(
     name = "matchers",
     hdrs = ["Matchers.h"],
 )
 
-cc_library(
+magma_cc_library(
     name = "sessiond_mocks",
     hdrs = ["SessiondMocks.h"],
     deps = [
@@ -30,12 +30,12 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "session_state_tester",
     hdrs = ["SessionStateTester.h"],
 )
 
-cc_library(
+magma_cc_library(
     name = "protobuf_creators",
     srcs = ["ProtobufCreators.cpp"],
     hdrs = ["ProtobufCreators.h"],
@@ -51,7 +51,7 @@ cc_library(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "session_store_test",
     size = "small",
     srcs = ["test_session_store.cpp"],
@@ -69,7 +69,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "polling_pipelined_test",
     size = "small",
     srcs = ["test_polling_pipelined.cpp"],
@@ -83,7 +83,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "session_credit_test",
     size = "small",
     srcs = ["test_session_credit.cpp"],
@@ -95,7 +95,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "charging_grant_test",
     size = "small",
     srcs = ["test_charging_grant.cpp"],
@@ -106,7 +106,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "usage_monitor_test",
     size = "small",
     srcs = ["test_usage_monitor.cpp"],
@@ -119,7 +119,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "local_enforcer_test",
     size = "small",
     srcs = ["test_local_enforcer.cpp"],
@@ -133,7 +133,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "local_enforcer_wallet_exhaust_test",
     size = "small",
     srcs = ["test_local_enforcer_wallet_exhaust.cpp"],
@@ -147,7 +147,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "cloud_reporter_test",
     size = "small",
     srcs = ["test_cloud_reporter.cpp"],
@@ -160,7 +160,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "session_manager_handler_test",
     size = "small",
     srcs = ["test_session_manager_handler.cpp"],
@@ -174,7 +174,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "sessiond_integ_test",
     size = "small",
     srcs = ["test_sessiond_integ.cpp"],
@@ -194,7 +194,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "session_state_test",
     size = "small",
     srcs = ["test_session_state.cpp"],
@@ -208,7 +208,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "store_client_test",
     size = "small",
     srcs = ["test_store_client.cpp"],
@@ -222,7 +222,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "stored_state_test",
     size = "small",
     srcs = ["test_stored_state.cpp"],
@@ -234,7 +234,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "proxy_responder_handler_test",
     size = "small",
     srcs = ["test_proxy_responder_handler.cpp"],
@@ -248,7 +248,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "metering_reporter_test",
     size = "small",
     srcs = ["test_metering_reporter.cpp"],
@@ -258,7 +258,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "upf_node_state_test",
     size = "small",
     srcs = ["test_upf_node_state.cpp"],
@@ -270,7 +270,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "set_session_manager_handler_test",
     size = "small",
     srcs = ["test_set_session_manager_handler.cpp"],

--- a/orc8r/gateway/c/common/async_grpc/BUILD.bazel
+++ b/orc8r/gateway/c/common/async_grpc/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+magma_cc_library(
     # TODO(@themarwhal) The library name will match the file names once we resolve GH8467
     name = "async_grpc_receiver",
     srcs = ["GRPCReceiver.cpp"],

--- a/orc8r/gateway/c/common/config/BUILD.bazel
+++ b/orc8r/gateway/c/common/config/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+magma_cc_library(
     name = "yaml_utils",
     srcs = ["YAMLUtils.cpp"],
     hdrs = ["YAMLUtils.h"],
@@ -24,7 +24,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "mconfig_loader",
     srcs = ["MConfigLoader.cpp"],
     hdrs = ["includes/MConfigLoader.h"],
@@ -37,7 +37,7 @@ cc_library(
     ],
 )
 
-cc_library(
+magma_cc_library(
     name = "service_config_loader",
     srcs = ["ServiceConfigLoader.cpp"],
     # TODO(@themarwhal): Remove includes/ project directories - GH8446

--- a/orc8r/gateway/c/common/config/test/BUILD.bazel
+++ b/orc8r/gateway/c/common/config/test/BUILD.bazel
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//bazel:magma_cc.bzl", "magma_cc_test")
 
-cc_test(
+magma_cc_test(
     name = "mconfig_loader_test",
     size = "small",
     srcs = ["test_mconfig_loader.cpp"],
@@ -23,7 +23,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "yaml_utils_test",
     size = "small",
     srcs = ["test_yaml_utils.cpp"],

--- a/orc8r/gateway/c/common/ebpf/BUILD.bazel
+++ b/orc8r/gateway/c/common/ebpf/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+magma_cc_library(
     name = "ebpf",
     hdrs = [
         "EbpfMap.h",

--- a/orc8r/gateway/c/common/eventd/BUILD.bazel
+++ b/orc8r/gateway/c/common/eventd/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+magma_cc_library(
     name = "eventd_client",
     srcs = ["EventdClient.cpp"],
     # TODO(@themarwhal): Remove includes/ project directories - GH8446

--- a/orc8r/gateway/c/common/logging/BUILD.bazel
+++ b/orc8r/gateway/c/common/logging/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+magma_cc_library(
     name = "logging",
     hdrs = [
         "magma_logging.h",

--- a/orc8r/gateway/c/common/sentry/BUILD.bazel
+++ b/orc8r/gateway/c/common/sentry/BUILD.bazel
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -23,7 +23,7 @@ sentry_deps = [
     "@yaml-cpp//:yaml-cpp",
 ]
 
-cc_library(
+magma_cc_library(
     name = "sentry_wrapper",
     srcs = ["SentryWrapper.cpp"],
     hdrs = ["includes/SentryWrapper.h"],

--- a/orc8r/gateway/c/common/service303/BUILD.bazel
+++ b/orc8r/gateway/c/common/service303/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+magma_cc_library(
     name = "service303",
     srcs = [
         "MagmaService.cpp",

--- a/orc8r/gateway/c/common/service303/test/BUILD.bazel
+++ b/orc8r/gateway/c/common/service303/test/BUILD.bazel
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//bazel:magma_cc.bzl", "magma_cc_test")
 
-cc_test(
+magma_cc_test(
     name = "magma_service_test",
     size = "small",
     srcs = ["test_magma_service.cpp"],
@@ -21,7 +21,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "metrics_test",
     size = "small",
     srcs = ["test_metrics.cpp"],
@@ -31,7 +31,7 @@ cc_test(
     ],
 )
 
-cc_test(
+magma_cc_test(
     name = "service303_test",
     size = "small",
     srcs = ["test_service303.cpp"],

--- a/orc8r/gateway/c/common/service_registry/BUILD.bazel
+++ b/orc8r/gateway/c/common/service_registry/BUILD.bazel
@@ -9,11 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:magma_cc.bzl", "magma_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+magma_cc_library(
     name = "service_registry",
     srcs = ["ServiceRegistrySingleton.cpp"],
     hdrs = ["includes/ServiceRegistrySingleton.h"],

--- a/orc8r/gateway/c/common/service_registry/test/BUILD.bazel
+++ b/orc8r/gateway/c/common/service_registry/test/BUILD.bazel
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//bazel:magma_cc.bzl", "magma_cc_test")
 
-cc_test(
+magma_cc_test(
     name = "service_registry_test",
     size = "small",
     srcs = ["test_service_registry.cpp"],


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Notes:
* This does not enable LSAN/ASAN for generated protobuf code
* This option might give us flexibility on overriding ASAN/LSAN configs for select test targets (as we work on fixes)

### Cache stats
Here we will compare how the cache size differs between the current approach and the approach outlined in this PR.
To compute the cache size, I've run the following commands **in sequence**. Running them in sequence is important as it lets us see how much cache is shared.
1. bazel expunge --clean
2. rm .bazel-cache*
3. bazel build //...
4. bazel test //...
5. bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=lsan
6. bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan


Used `du -sh .bazel-cache` to compute the size of .bazel-cache
Used `tar -zcvf cache.tar.gz .bazel-cache && ls -l --block-size=M` to get tar size


| Command  | bazel-cache raw (PR) | bazel-cache compressed (PR) |  bazel-cache raw (master) |  bazel-cache compressed (master) |
| - | - | - | - | - |
| bazel build //... | 4.1GB | 1030MB | 4.1GB | 1030MB |
| bazel test //... | 4.1GB | 1030MB | 4.6GB | 1177MB |
| bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=lsan | 5.8GB | 1508MB | 7.9GB | 2014MB |
| bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan | 8.3GB | 2066MB | 15GB | 3304MB |
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
