### PR TITLE
feat(orc8r): Cache network configs in EPS Authentication implementation.

### DIFF
--- a/lte/cloud/go/services/eps_authentication/servicers/config.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/config.go
@@ -15,6 +15,8 @@ package servicers
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -25,15 +27,34 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 )
 
+const ConfigCacheTTL = time.Minute * 10
+
 // EpsAuthConfig stores all the configs needed to run the service.
 type EpsAuthConfig struct {
 	LteAuthOp   []byte
 	LteAuthAmf  []byte
 	SubProfiles map[string]models.NetworkEpcConfigsSubProfilesAnon
+	lastUpdate  time.Time
 }
+
+type epsCfgCache struct {
+	sync.RWMutex
+	configs map[string]*EpsAuthConfig
+}
+
+var cfgCache = epsCfgCache{configs: map[string]*EpsAuthConfig{}}
 
 // getConfig returns the EpsAuthConfig config for a given networkId.
 func getConfig(networkID string) (*EpsAuthConfig, error) {
+	now := time.Now()
+	cfgCache.RLock()
+	cfg, found := cfgCache.configs[networkID]
+	cfgCache.RUnlock()
+
+	if found && cfg != nil && now.Before(cfg.lastUpdate.Add(ConfigCacheTTL)) {
+		return cfg, nil
+	}
+
 	iCellularConfigs, err := configurator.LoadNetworkConfig(
 		context.Background(), networkID, lte.CellularNetworkConfigType, serdes.Network)
 	if err != nil {
@@ -47,10 +68,16 @@ func getConfig(networkID string) (*EpsAuthConfig, error) {
 		return nil, status.Error(codes.FailedPrecondition, "failed to convert config")
 	}
 	epc := cellularConfig.Epc
-	result := &EpsAuthConfig{
+	cfg = &EpsAuthConfig{
 		LteAuthOp:   epc.LteAuthOp,
 		LteAuthAmf:  epc.LteAuthAmf,
 		SubProfiles: epc.SubProfiles,
+		lastUpdate:  now,
 	}
-	return result, nil
+
+	cfgCache.Lock()
+	cfgCache.configs[networkID] = cfg
+	cfgCache.Unlock()
+
+	return cfg, nil
 }


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Cache network configs in EPS Authentication implementation.

Current implementation of EPS Auth loads network configs on every AI or UL call, network configs rarely change & we can improve efficiency of EPS Auth service and reduce load to configurator by caching the config.

## Test Plan

unit tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
