### PR TITLE
fix(mme): Expired timer recovery on service restart

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -1951,13 +1951,19 @@ status_code_e mme_app_handle_mobile_reachability_timer_expiry(zloop_t* loop,
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
-    OAILOG_WARNING(LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n",
-                   timer_id);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
+  struct ue_mm_context_s* ue_context_p = NULL;
+  if (timer_id == MME_APP_TIMER_INACTIVE_ID) {
+    // Expiry handler was called as part of timer recovery on service restart
+    ue_context_p = (struct ue_mm_context_s*)args;
+  } else {
+    if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+      OAILOG_WARNING(LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n",
+                     timer_id);
+      OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
+    }
+    ue_context_p = mme_app_get_ue_context_for_timer(
+        mme_ue_s1ap_id, "Mobile reachability timer");
   }
-  struct ue_mm_context_s* ue_context_p = mme_app_get_ue_context_for_timer(
-      mme_ue_s1ap_id, "Mobile reachability timer");
   if (ue_context_p == NULL) {
     OAILOG_ERROR(
         LOG_MME_APP,
@@ -2008,13 +2014,20 @@ status_code_e mme_app_handle_implicit_detach_timer_expiry(zloop_t* loop,
                                                           void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
-    OAILOG_WARNING(LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n",
-                   timer_id);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
+  struct ue_mm_context_s* ue_context_p = NULL;
+  if (timer_id == MME_APP_TIMER_INACTIVE_ID) {
+    // Expiry handler was called as part of timer recovery on service restart
+    ue_context_p = (struct ue_mm_context_s*)args;
+  } else {
+    if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+      OAILOG_WARNING(LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n",
+                     timer_id);
+      OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
+    }
+    ue_context_p = mme_app_get_ue_context_for_timer(mme_ue_s1ap_id,
+                                                    "Implicit detach timer");
   }
-  struct ue_mm_context_s* ue_context_p =
-      mme_app_get_ue_context_for_timer(mme_ue_s1ap_id, "Implicit detach timer");
+
   if (ue_context_p == NULL) {
     OAILOG_ERROR(
         LOG_MME_APP,
@@ -2040,6 +2053,7 @@ status_code_e mme_app_handle_initial_context_setup_rsp_timer_expiry(
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
   struct ue_mm_context_s* ue_context_p = NULL;
   if (timer_id == MME_APP_TIMER_INACTIVE_ID) {
+    // Expiry handler was called as part of timer recovery on service restart
     ue_context_p = (struct ue_mm_context_s*)args;
   } else {
     if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
@@ -2437,14 +2451,19 @@ status_code_e mme_app_handle_paging_timer_expiry(zloop_t* loop, int timer_id,
                                                  void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
-    OAILOG_WARNING(LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n",
-                   timer_id);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
+  struct ue_mm_context_s* ue_context_p = NULL;
+  if (timer_id == MME_APP_TIMER_INACTIVE_ID) {
+    // Expiry handler was called as part of timer recovery on service restart
+    ue_context_p = (struct ue_mm_context_s*)args;
+  } else {
+    if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+      OAILOG_WARNING(LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n",
+                     timer_id);
+      OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
+    }
+    ue_context_p =
+        mme_app_get_ue_context_for_timer(mme_ue_s1ap_id, "Paging timer");
   }
-  struct ue_mm_context_s* ue_context_p =
-      mme_app_get_ue_context_for_timer(mme_ue_s1ap_id, "Paging timer");
-
   if (ue_context_p == NULL) {
     OAILOG_ERROR(
         LOG_MME_APP,

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -2038,13 +2038,19 @@ status_code_e mme_app_handle_initial_context_setup_rsp_timer_expiry(
     zloop_t* loop, int timer_id, void* args) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   mme_ue_s1ap_id_t mme_ue_s1ap_id = 0;
-  if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
-    OAILOG_ERROR(LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n",
-                 timer_id);
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
+  struct ue_mm_context_s* ue_context_p = NULL;
+  if (timer_id == MME_APP_TIMER_INACTIVE_ID) {
+    ue_context_p = (struct ue_mm_context_s*)args;
+  } else {
+    if (!mme_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
+      OAILOG_NOTICE(LOG_MME_APP, "Invalid Timer Id expiration, Timer Id: %u\n",
+                    timer_id);
+      OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
+    }
+    ue_context_p = mme_app_get_ue_context_for_timer(
+        mme_ue_s1ap_id, "Initial context setup response timer");
   }
-  struct ue_mm_context_s* ue_context_p = mme_app_get_ue_context_for_timer(
-      mme_ue_s1ap_id, "Initial context setup response timer");
+
   if (ue_context_p == NULL) {
     OAILOG_ERROR(
         LOG_MME_APP,

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -914,6 +914,7 @@ void mme_ue_context_update_ue_sig_connection_state(
         MME_APP_TIMER_INACTIVE_ID) {
       mme_app_stop_timer(ue_context_p->mobile_reachability_timer.id);
       ue_context_p->mobile_reachability_timer.id = MME_APP_TIMER_INACTIVE_ID;
+      ue_context_p->time_mobile_reachability_timer_started = 0;
     }
     // Stop Implicit detach timer,if running
     if (ue_context_p->implicit_detach_timer.id != MME_APP_TIMER_INACTIVE_ID) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
@@ -59,7 +59,10 @@ void mme_app_resume_timer(struct ue_mm_context_s* const ue_mm_context_pP,
    * from restart, so MME shall handle as timer expiry
    */
   if (timer->msec <= elapsed_time_in_ms) {
-    timer_expiry_handler(mme_app_task_zmq_ctx.event_loop, timer->id, NULL);
+    // In this case, the timer has no id since it is just getting resumed, pass
+    // the UE context to expiry handler
+    timer_expiry_handler(mme_app_task_zmq_ctx.event_loop,
+                         MME_APP_TIMER_INACTIVE_ID, (void*)ue_mm_context_pP);
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
   uint32_t remaining_time_in_msecs = timer->msec - elapsed_time_in_ms;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
@@ -61,8 +61,8 @@ void mme_app_resume_timer(struct ue_mm_context_s* const ue_mm_context_pP,
   if (timer->msec <= elapsed_time_in_ms) {
     // In this case, the timer has no id since it is just getting resumed, pass
     // the UE context to expiry handler
-    timer_expiry_handler(mme_app_task_zmq_ctx.event_loop,
-                         MME_APP_TIMER_INACTIVE_ID, (void*)ue_mm_context_pP);
+    timer_expiry_handler(mme_app_task_zmq_ctx.event_loop, timer->id,
+                         reinterpret_cast<void*>(ue_mm_context_pP));
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
   uint32_t remaining_time_in_msecs = timer->msec - elapsed_time_in_ms;

--- a/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_with_mme_restart.py
@@ -115,6 +115,7 @@ class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
             print("Waiting for", j, "seconds")
             time.sleep(1)
 
+        print("************************* Waiting for response from MME")
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,


### PR DESCRIPTION
## Summary

As stated in https://github.com/magma/magma/issues/11902, if MME restarts with a pending ICS timer, the timer recovery was not triggering a UE context release. Instead MME was starting the Mobile Reachability Timer, leading to implicit detach of UE over 10 minutes. This change fixes the logic by:
- sending an inactive timer id and  UE context to timer expiry handler on timer recovery
- modifying the following timer expiry handlers to skip MME UE ID look up when the expiry handler is called after service restart
-- ICS response timer
-- Mobile reachability timer
-- Implicit Detach timer
-- Paging response timer

Based on offline discussion with @rsarwad , also fixed an error where mobile reachability timer was not getting reset when UE state was switched from ECM_IDLE to ECM_CONNECTED.

## Test Plan

- Test `test_ics_timer_expiry_with_mme_restart.py`
Before the change, MME log shows the following and test runs for over 600 seconds
```
000566 Wed Mar 02 19:19:50 2022 7FA60F346700 DEBUG MME-AP tasks/mme_app/mme_app_timer_mana:0056         Handling :Initial Context Setup Response timer
000567 Wed Mar 02 19:19:50 2022 7FA60F346700 TRACE MME-AP tasks/mme_app/mme_app_bearer.c  :2039         Entering mme_app_handle_initial_context_setup_rsp_timer_expiry()
000568 Wed Mar 02 19:19:50 2022 7FA60F346700 ERROR MME-AP tasks/mme_app/mme_app_bearer.c  :2042            Invalid Timer Id expiration, Timer Id: 4294967295
000569 Wed Mar 02 19:19:50 2022 7FA60F346700 TRACE MME-AP tasks/mme_app/mme_app_bearer.c  :2044         Leaving mme_app_handle_initial_context_setup_rsp_timer_expiry() 
```

After the change, MME log shows the following and test completes in less than 60 seconds
```
000566 Wed Mar 02 21:09:43 2022 7FE94D698700 DEBUG MME-AP tasks/mme_app/mme_app_timer_mana:0056         Handling :Initial Context Setup Response timer
000567 Wed Mar 02 21:09:43 2022 7FE94D698700 TRACE MME-AP tasks/mme_app/mme_app_bearer.c  :2039         Entering mme_app_handle_initial_context_setup_rsp_timer_expiry()
000568 Wed Mar 02 21:09:43 2022 7FE94D698700 TRACE MME-AP tasks/mme_app/mme_app_bearer.c  :4554            Entering handle_ics_failure()
000569 Wed Mar 02 21:09:43 2022 7FE94D698700 ERROR MME-AP tasks/mme_app/mme_app_bearer.c  :4566   [1010000000001]            handle ics failure
000570 Wed Mar 02 21:09:43 2022 7FE94D698700 TRACE MME-AP tasks/mme_app/mme_app_itti_messa:0121               Entering mme_app_send_s11_release_access_bearers_req()
000571 Wed Mar 02 21:09:43 2022 7FE94D698700 INFO  MME-AP tasks/mme_app/mme_app_itti_messa:0178   [1010000000001]               Send Release Access Bearer Req for teid to spgw task 1 for ue id 1
000572 Wed Mar 02 21:09:43 2022 7FE94D698700 TRACE MME-AP tasks/mme_app/mme_app_itti_messa:0186               Leaving mme_app_send_s11_release_access_bearers_req() (rc=0)
000573 Wed Mar 02 21:09:43 2022 7FE94D698700 TRACE MME-AP tasks/mme_app/mme_app_bearer.c  :4587            Leaving handle_ics_failure()
000574 Wed Mar 02 21:09:43 2022 7FE94D698700 TRACE MME-AP tasks/mme_app/mme_app_bearer.c  :2072         Leaving mme_app_handle_initial_context_setup_rsp_timer_expiry() (rc=0)
```

- `make test_oai`
-  `make integ_test`

- TODO: Test cases for non-ICS timers modified in this PR will be added as part of https://github.com/magma/magma/issues/11910

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
