### PR TITLE
chore(mme): Cleanup irrelevant logs and unused variable

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -294,7 +294,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
     } break;
 
     default: {
-      OAILOG_ERROR(LOG_S1AP, "Unknown message ID %d:%s\n",
+      OAILOG_DEBUG(LOG_S1AP, "Unknown message ID %d:%s\n",
                    ITTI_MSG_ID(received_message_p),
                    ITTI_MSG_NAME(received_message_p));
     } break;

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state.cpp
@@ -42,8 +42,6 @@ spgw_state_t* get_spgw_state(bool read_from_db) {
 }
 
 hash_table_ts_t* get_spgw_ue_state() {
-  OAILOG_DEBUG(LOG_SPGW_APP, "get_spgw_ue_state called by thread id %lu",
-               pthread_self());
   return SpgwStateManager::getInstance().get_ue_state_ht();
 }
 

--- a/lte/gateway/c/core/oai/test/spgw_task/test_pgw_pco.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_pgw_pco.cpp
@@ -83,7 +83,6 @@ class SPGWPcoTest : public ::testing::Test {
     poc_id->id = PCO_PI_IPCP;
     poc_id->length = PCO_PI_IPCP_LEN;
 
-    int poc_idx = 0;
     char poc_content[PCO_PI_IPCP_LEN];
 
     poc_content[0] = 0x01;  // Code = 01 , i.e. Config Request


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Remove some irrelevant logs, such as:
- Recovery message is not handled by S1ap task since it does not have any pending timers at restart, downgrading the error to debug
` ERROR S1AP   tasks/s1ap/s1ap_mme.c           :0297    Unknown message ID 11:RECOVERY_MESSAGE`
- Thread id reading SPGW task 
- Unused variable in `test_pgw_pco.cpp`

## Test Plan

`make test_oai`
