### PR TITLE
chore(agw): Fix S1ap test names to match file names

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated.py
@@ -32,7 +32,7 @@ class TestAttachDetachDedicated(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated(self):
         """attach/detach + dedicated bearer test with a single UE"""
         num_ues = 1
         detach_type = [

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_activation_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_activation_reject.py
@@ -34,7 +34,7 @@ class TestAttachDetachDedicatedReject(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated_activation_reject(self):
         """attach/detach + dedicated bearer activation reject test with a
         single UE
         """

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_activation_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_activation_timer_expiry.py
@@ -34,7 +34,7 @@ class TestAttachDetachDedicatedActTmrExp(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated_activation_timer_expiry(self):
         """attach/detach + dedicated bearer activation timer expiry test
         with a single UE
         """

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_activation_invalid_imsi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_activation_invalid_imsi.py
@@ -34,7 +34,7 @@ class TestAttachDetachDedicatedInvalidImsi(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated_bearer_activation_invalid_imsi(self):
         """attach/detach + invalid IMSI in dedicated bearer test with a
         single UE
         """

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_activation_invalid_lbi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_activation_invalid_lbi.py
@@ -32,7 +32,7 @@ class TestAttachDetachDedicatedInvalidlbi(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated_bearer_activation_invalid_lbi(self):
         """attach/detach + invalid lbi in dedicated bearer test with
         a single UE
         """

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_ebi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_ebi.py
@@ -34,7 +34,7 @@ class TestAttachDetachDedicatedInvalidEbi(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated_bearer_deactivation_invalid_ebi(self):
         """attach/detach + dedicated bearer deactivation with invalid EBI
         test with a single UE
         """

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_imsi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_imsi.py
@@ -34,7 +34,7 @@ class TestAttachDetachDedicatedDeactInvalidImsi(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated_bearer_deactivation_invalid_imsi(self):
         """attach/detach + dedicated bearer deactivation with invalid IMSI
         test with a single UE
         """

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_lbi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_lbi.py
@@ -34,7 +34,7 @@ class TestAttachDetachDedicatedDeactInvalidLbi(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated_bearer_deactivation_invalid_lbi(self):
         """attach/detach + dedicated bearer deactivation with invalid LBI
         test with a single UE
         """

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py
@@ -34,7 +34,7 @@ class TestAttachDetachDedicatedDeactTmrExp(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated_deactivation_timer_expiry(self):
         """attach/detach + dedicated bearer deactivation timer expiry test
         with a single UE
         """

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_looped.py
@@ -32,7 +32,7 @@ class TestAttachDetachDedicatedLooped(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated_looped(self):
         """attach/detach + dedicated bearer test in loop with a single UE"""
         num_ues = 1
         loop = 3

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_multi_ue.py
@@ -32,7 +32,7 @@ class TestAttachDetachDedicatedMultiUe(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_dedicated_multi_ue(self):
         """attach/detach + dedicated bearer test with 4 UEs"""
         num_ues = 4
         ue_ids = []

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_dedicated.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_dedicated.py
@@ -32,7 +32,7 @@ class TestAttachDetachMultipleDedicated(unittest.TestCase):
         """Cleanup"""
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_multiple_dedicated(self):
         """attach/detach + multiple dedicated bearer test with a single UE"""
         num_dedicated_bearers = 3
         bearer_ids = []

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mme_restart.py
@@ -29,7 +29,7 @@ class TestAttachDetachWithMmeRestart(unittest.TestCase):
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_with_mme_restart(self):
         """
         Basic attach/detach test with two UEs,
         where MME restarts between each attach and detach

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_sctpd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_sctpd_restart.py
@@ -28,7 +28,7 @@ class TestAttachDetachWithSctpdRestart(unittest.TestCase):
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach(self):
+    def test_attach_detach_with_sctpd_restart(self):
         """
         Attach/detach test with two UEs and Sctpd restarting after each attach.
         A new attach has to happen after Sctpd restarts before UE can detach.


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The test name in several S1ap test is simply `test_attach_detach`. This can lead to confusion in error logs. Fixed the names to match the filenames.

## Test Plan

Ran each modified test case individually

