### PR TITLE
docs: Add stale.yml file for stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -18,3 +18,4 @@ closeComment: >
   This pull request has exceeded its lifecylce and will be closed.
   Should you wish to continue working on this, please reopen it or start a new pull request.
   Thank you again for your contributions.
+  

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 45
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - status: willfix
+# Label to use when marking an issue as stale
+staleLabel: status: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This pull request has been automatically marked as stale because it has not 
+  had any recent activity by the author or maintainer in the past 45 days. 
+  It will be closed if no further activity occurs in the next 7 days. 
+  Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This pull request has exceeded its lifecylce and will be closed.
+  Should you wish to continue working on this, please reopen it or start a new pull request.
+  Thank you again for your contributions.


### PR DESCRIPTION
Signed-off-by: Ekow Taylor <ekowtaylor@gmail.com>

This implements the config file for a GitHub App built with Probot that closes abandoned Issues and Pull Requests after a period of inactivity.

## Summary
Adding .github/stale.yml file to enable configuration for stalebot

## Test Plan
Tested on another repo

## Additional Information
