### PR TITLE
fix(magmad): failing magmad tests are fixed

### DIFF
--- a/orc8r/gateway/python/magma/common/BUILD.bazel
+++ b/orc8r/gateway/python/magma/common/BUILD.bazel
@@ -64,6 +64,7 @@ py_library(
         "//orc8r/protos:metricsd_python_proto",
         "//orc8r/protos:service303_python_grpc",
         requirement("prometheus_client"),
+        requirement("setuptools"),
     ],
 )
 


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Failing magmad tests are fixed by adding the setuptools dependency
  - Is relevant for bazel base - the dev-container seems to have the dependency pre-installed

## Test Plan

- Run tests:
  `bazel test //lte/gateway/python/... //orc8r/gateway/python/...`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
