### PR TITLE
fix(agw): fix the MAGMA-MME build in OAI variant

### DIFF
--- a/ci-scripts/docker/Dockerfile.mme.ci.rhel8
+++ b/ci-scripts/docker/Dockerfile.mme.ci.rhel8
@@ -5,7 +5,7 @@ FROM magma-dev-mme:ci-base-image as magma-mme-builder
 
 ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
-ENV BUILD_TYPE=Debug
+ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c
 
 # Remove any old CI artifact
@@ -20,7 +20,9 @@ RUN export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig/ && \
     echo $FEATURES && \
     make build_oai && \
     make build_sctpd && \
-    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme
+    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme && \
+    ldd $C_BUILD/core/oai/oai_mme/oai_mme && \
+    ldd $C_BUILD/sctpd/src/sctpd
 
 # Prepare config file
 RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
@@ -129,7 +131,9 @@ COPY --from=magma-mme-builder \
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml && \
-    openssl rand -out /root/.rnd 128
+    openssl rand -out /root/.rnd 128 && \
+    ldd /magma-mme/bin/oai_mme && \
+    ldd /magma-mme/bin/sctpd
 
 WORKDIR /etc/magma
 COPY --from=magma-mme-builder \

--- a/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
+++ b/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
@@ -19,7 +19,9 @@ RUN cd $MAGMA_ROOT/lte/gateway && \
     echo $FEATURES && \
     make build_oai && \
     make build_sctpd && \
-    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme
+    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme && \
+    ldd $C_BUILD/core/oai/oai_mme/oai_mme && \
+    ldd $C_BUILD/sctpd/src/sctpd
 
 # Prepare config file
 RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
@@ -73,26 +75,13 @@ RUN apt-get update && \
 # Copy pre-built shared object files
 COPY --from=magma-mme-builder \
     /usr/lib/x86_64-linux-gnu/liblsan.so.0 \
-    /usr/lib/x86_64-linux-gnu/libasan.so.4 \
-    /usr/lib/x86_64-linux-gnu/libubsan.so.0 \
     /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 \
     /usr/lib/x86_64-linux-gnu/libconfig.so.9 \
     /usr/lib/x86_64-linux-gnu/libglog.so.0  \
     /usr/lib/x86_64-linux-gnu/libyaml-cpp.so.0.5 \
     /usr/lib/x86_64-linux-gnu/libsctp.so.1 \
     /usr/lib/x86_64-linux-gnu/libunwind.so.8 \
-    /usr/lib/x86_64-linux-gnu/libboost_context.so.1.65.1 \
-    /usr/lib/x86_64-linux-gnu/libboost_filesystem.so.1.65.1 \
-    /usr/lib/x86_64-linux-gnu/libboost_program_options.so.1.65.1 \
-    /usr/lib/x86_64-linux-gnu/libboost_regex.so.1.65.1 \
-    /usr/lib/x86_64-linux-gnu/libboost_system.so.1.65.1 \
-    /usr/lib/x86_64-linux-gnu/libdouble-conversion.so.1 \
-    /usr/lib/x86_64-linux-gnu/libevent-2.1.so.6 \
     /usr/lib/x86_64-linux-gnu/libssl.so.1.1 \
-    /usr/lib/x86_64-linux-gnu/libsnappy.so.1 \
-    /usr/lib/x86_64-linux-gnu/libicui18n.so.60 \
-    /usr/lib/x86_64-linux-gnu/libicuuc.so.60 \
-    /usr/lib/x86_64-linux-gnu/libicudata.so.60 \
     /usr/lib/x86_64-linux-gnu/libczmq.so.4.1.0 \
     /usr/lib/x86_64-linux-gnu/libzmq.so.5.1.5 \
     /usr/lib/x86_64-linux-gnu/libsodium.so.23.1.0 \
@@ -137,7 +126,9 @@ COPY --from=magma-mme-builder \
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml && \
-    openssl rand -out /root/.rnd 128
+    openssl rand -out /root/.rnd 128 && \
+    ldd /magma-mme/bin/oai_mme && \
+    ldd /magma-mme/bin/sctpd
 
 WORKDIR /etc/magma
 COPY --from=magma-mme-builder \

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -6,7 +6,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest as magma-mme-builder
 ARG GIT_PROXY
 ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
-ENV BUILD_TYPE=Debug
+ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c
 ENV TZ=Europe/Paris
 # Copy RHEL certificates for builder image
@@ -75,6 +75,11 @@ RUN yum install -y \
     # Install FMT lib requirements
     elfutils-libelf-devel-static \
     libdwarf-devel \
+    # Install double-conversion and unwind requirements
+    boost \
+    boost-devel \
+    glog-devel \
+    binutils-devel \
     # Install FreeDiameter requirements
     lksctp-tools \
     lksctp-tools-devel \
@@ -264,6 +269,24 @@ RUN cd asn1c && \
     make -j`nproc` && \
     make install
 
+##### Unwind and Double-Conversion
+RUN echo "Install Double Conversion" && \
+    # Moved git clone --depth=1 --branch=v3.1.5 https://github.com/google/double-conversion.git && \
+    cd double-conversion && \
+    cmake3 -DBUILD_SHARED_LIBS=ON . && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig && \
+    cd / && \
+    echo "Install Unwind" && \
+    # Moved git clone --depth=1 --branch=v1.2.1 https://github.com/libunwind/libunwind.git && \
+    cd libunwind && \
+    ./autogen.sh && \
+    ./configure && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig
+
 ##### FreeDiameter
 RUN cd freediameter && \
     # Moved git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
@@ -327,7 +350,9 @@ RUN ldconfig --verbose && \
     echo $FEATURES && \
     make build_oai && \
     make build_sctpd && \
-    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme
+    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme && \
+    ldd $C_BUILD/core/oai/oai_mme/oai_mme && \
+    ldd $C_BUILD/sctpd/src/sctpd
 
 # Prepare config file
 RUN yum install -y python3-pip && \
@@ -475,7 +500,9 @@ COPY --from=magma-mme-builder \
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml && \
-    openssl rand -out /root/.rnd 128
+    openssl rand -out /root/.rnd 128 && \
+    ldd /magma-mme/bin/oai_mme && \
+    ldd /magma-mme/bin/sctpd
 
 WORKDIR /etc/magma
 COPY --from=magma-mme-builder \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -192,7 +192,9 @@ RUN ldconfig && \
     echo $FEATURES && \
     make build_oai && \
     make build_sctpd && \
-    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme
+    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme && \
+    ldd $C_BUILD/core/oai/oai_mme/oai_mme && \
+    ldd $C_BUILD/sctpd/src/sctpd
 
 # Prepare config file
 RUN apt-get install -y python3-pip && \
@@ -278,26 +280,13 @@ RUN apt-get update && \
 # Copy pre-built shared object files
 COPY --from=magma-mme-builder \
     /usr/lib/x86_64-linux-gnu/liblsan.so.0 \
-    /usr/lib/x86_64-linux-gnu/libasan.so.4 \
-    /usr/lib/x86_64-linux-gnu/libubsan.so.0 \
     /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 \
     /usr/lib/x86_64-linux-gnu/libconfig.so.9 \
     /usr/lib/x86_64-linux-gnu/libglog.so.0  \
     /usr/lib/x86_64-linux-gnu/libyaml-cpp.so.0.5 \
     /usr/lib/x86_64-linux-gnu/libsctp.so.1 \
     /usr/lib/x86_64-linux-gnu/libunwind.so.8 \
-    /usr/lib/x86_64-linux-gnu/libboost_context.so.1.65.1 \
-    /usr/lib/x86_64-linux-gnu/libboost_filesystem.so.1.65.1 \
-    /usr/lib/x86_64-linux-gnu/libboost_program_options.so.1.65.1 \
-    /usr/lib/x86_64-linux-gnu/libboost_regex.so.1.65.1 \
-    /usr/lib/x86_64-linux-gnu/libboost_system.so.1.65.1 \
-    /usr/lib/x86_64-linux-gnu/libdouble-conversion.so.1 \
-    /usr/lib/x86_64-linux-gnu/libevent-2.1.so.6 \
     /usr/lib/x86_64-linux-gnu/libssl.so.1.1 \
-    /usr/lib/x86_64-linux-gnu/libsnappy.so.1 \
-    /usr/lib/x86_64-linux-gnu/libicui18n.so.60 \
-    /usr/lib/x86_64-linux-gnu/libicuuc.so.60 \
-    /usr/lib/x86_64-linux-gnu/libicudata.so.60 \
     /usr/lib/x86_64-linux-gnu/libczmq.so.4.1.0 \
     /usr/lib/x86_64-linux-gnu/libzmq.so.5.1.5 \
     /usr/lib/x86_64-linux-gnu/libsodium.so.23.1.0 \
@@ -346,7 +335,9 @@ COPY --from=magma-mme-builder \
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml && \
-    openssl rand -out /root/.rnd 128
+    openssl rand -out /root/.rnd 128 && \
+    ldd /magma-mme/bin/oai_mme && \
+    ldd /magma-mme/bin/sctpd
 
 WORKDIR /etc/magma
 COPY --from=magma-mme-builder \


### PR DESCRIPTION

Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

After PR merge (https://github.com/magma/magma/pull/11811), both U18 and RHEL8 builds from scratch are broken.

[Today's Master Build Check](https://jenkins-oai.eurecom.fr/job/MAGMA-MME-production/12597/)

CI passed on the Pull Request because CI uses a base image with previously needed packages still installed.

I've fixed both CI and from scratch docker files.
You were a bit too fast on removing `unwind` and `double-conversion` on RHEL8.

I've added also some verbosity on the required packages for the executables.

I did not see the PR last week but when touching these files, DM on `slack`. It's better I've got a look.

## Test Plan

All 4 dockerfiles were tested manually.

I will re-create base images once it's merged.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
