### PR TITLE
fix(mme): Null terminates string to stop buffer overflow

### DIFF
--- a/lte/gateway/c/core/oai/common/state_converter.cpp
+++ b/lte/gateway/c/core/oai/common/state_converter.cpp
@@ -53,7 +53,7 @@ void StateConverter::guti_to_proto(const guti_t& state_guti,
                                    oai::Guti* guti_proto) {
   guti_proto->Clear();
 
-  char plmn_array[PLMN_BYTES + 1];
+  char plmn_array[PLMN_BYTES] = {0};
   plmn_to_chars(state_guti.gummei.plmn, plmn_array);
   guti_proto->set_plmn(plmn_array);
   guti_proto->set_mme_gid(state_guti.gummei.mme_gid);
@@ -74,7 +74,7 @@ void StateConverter::ecgi_to_proto(const ecgi_t& state_ecgi,
                                    oai::Ecgi* ecgi_proto) {
   ecgi_proto->Clear();
 
-  char plmn_array[PLMN_BYTES + 1];
+  char plmn_array[PLMN_BYTES] = {0};
   plmn_to_chars(state_ecgi.plmn, plmn_array);
   ecgi_proto->set_plmn(plmn_array);
   ecgi_proto->set_enb_id(state_ecgi.cell_identity.enb_id);

--- a/lte/gateway/c/core/oai/include/state_converter.h
+++ b/lte/gateway/c/core/oai/include/state_converter.h
@@ -44,7 +44,7 @@ namespace magma {
 namespace lte {
 
 #define ASCII_ZERO 0x30
-#define PLMN_BYTES 6
+#define PLMN_BYTES 7
 #define BSTRING_TO_STRING(bstr, str_ptr)                \
   do {                                                  \
     *str_ptr = std::string(bdata(bstr), blength(bstr)); \

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_converter.cpp
@@ -294,7 +294,7 @@ void AmfNasStateConverter::tai_to_proto(const tai_t* state_tai,
                                         magma::lte::oai::Tai* tai_proto) {
   OAILOG_DEBUG(LOG_MME_APP, "State PLMN " PLMN_FMT "to proto",
                PLMN_ARG(&state_tai->plmn));
-  char plmn_array[PLMN_BYTES];
+  char plmn_array[PLMN_BYTES] = {0};
   plmn_array[0] = static_cast<char>(state_tai->plmn.mcc_digit1 + ASCII_ZERO);
   plmn_array[1] = static_cast<char>(state_tai->plmn.mcc_digit2 + ASCII_ZERO);
   plmn_array[2] = static_cast<char>(state_tai->plmn.mcc_digit3 + ASCII_ZERO);
@@ -327,7 +327,7 @@ void AmfNasStateConverter::proto_to_tai(const magma::lte::oai::Tai& tai_proto,
 void AmfNasStateConverter::guti_m5_to_proto(
     const guti_m5_t& state_guti_m5, magma::lte::oai::Guti_m5* guti_m5_proto) {
   guti_m5_proto->Clear();
-  char plmn_array[PLMN_BYTES];
+  char plmn_array[PLMN_BYTES] = {0};
   AmfNasStateConverter::plmn_to_chars(state_guti_m5.guamfi.plmn, plmn_array);
   guti_m5_proto->set_plmn(plmn_array);
   guti_m5_proto->set_amf_regionid(state_guti_m5.guamfi.amf_regionid);

--- a/lte/gateway/c/core/oai/tasks/nas/nas_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_state_converter.cpp
@@ -53,7 +53,7 @@ void NasStateConverter::partial_tai_list_to_proto(
           partial_tai_list_proto->mutable_tai_one_plmn_consecutive_tacs());
     } break;
     case TRACKING_AREA_IDENTITY_LIST_ONE_PLMN_NON_CONSECUTIVE_TACS: {
-      char plmn_array[PLMN_BYTES];
+      char plmn_array[PLMN_BYTES] = {0};
       plmn_array[0] =
           (char)(state_partial_tai_list->u.tai_one_plmn_non_consecutive_tacs
                      .plmn.mcc_digit1 +
@@ -153,7 +153,7 @@ void NasStateConverter::tai_to_proto(const tai_t* state_tai,
                                      oai::Tai* tai_proto) {
   OAILOG_DEBUG(LOG_MME_APP, "State PLMN " PLMN_FMT "to proto",
                PLMN_ARG(&state_tai->plmn));
-  char plmn_array[PLMN_BYTES];
+  char plmn_array[PLMN_BYTES] = {0};
   plmn_array[0] = (char)(state_tai->plmn.mcc_digit1 + ASCII_ZERO);
   plmn_array[1] = (char)(state_tai->plmn.mcc_digit2 + ASCII_ZERO);
   plmn_array[2] = (char)(state_tai->plmn.mcc_digit3 + ASCII_ZERO);

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_state_converter.cpp
@@ -219,7 +219,7 @@ void NgapStateConverter::supported_tai_item_to_proto(
   supported_tai_item_proto->set_tac(state_supported_tai_item->tac);
   supported_tai_item_proto->set_bplmnlist_count(
       state_supported_tai_item->bplmnlist_count);
-  char plmn_array[PLMN_BYTES + 1] = {0};
+  char plmn_array[PLMN_BYTES] = {0};
   for (int idx = 0; idx < state_supported_tai_item->bplmnlist_count; idx++) {
     plmn_array[0] = static_cast<char>(
         state_supported_tai_item->bplmn_list[idx].plmn_id.mcc_digit1 +

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_state_converter.cpp
@@ -265,7 +265,7 @@ void S1apStateConverter::supported_tai_item_to_proto(
   supported_tai_item_proto->set_tac(state_supported_tai_item->tac);
   supported_tai_item_proto->set_bplmnlist_count(
       state_supported_tai_item->bplmnlist_count);
-  char plmn_array[PLMN_BYTES + 1] = {0};
+  char plmn_array[PLMN_BYTES] = {0};
   for (int idx = 0; idx < state_supported_tai_item->bplmnlist_count; idx++) {
     plmn_array[0] =
         (char)(state_supported_tai_item->bplmns[idx].mcc_digit1 + ASCII_ZERO);


### PR DESCRIPTION
Addresses one finding (more exist) of #11826.

Zero-initialized all instances of `plmn_array[PLMN_BYTES]` (so that they will be null terminated) and enlarged the array by one char to accommodate the null termination.

Fixes the finding:

```
[ RUN      ] TestAMFStateConverter.TestUEm5gmmContextToProto
=================================================================
==15482==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffee811fc86 at pc 0x7f3038dada6d bp 0x7ffee811faa0 sp 0x7ffee811f248
READ of size 7 at 0x7ffee811fc86 thread T0
    #0 0x7f3038dada6c  (/lib/x86_64-linux-gnu/libasan.so.5+0x67a6c)
    #1 0x7f302e641e9b in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (/lib/x86_64-linux-gnu/libstdc++.so.6+0x145e9b)
    #2 0x7f30383b85f6 in magma::lte::oai::Tai::set_mcc_mnc(char const*) bazel-out/k8-dbg/bin/lte/protos/oai/nas_state_cpp_proto_pb/lte/protos/oai/nas_state.pb.h:11239
```

## Test Plan

Using prototype Bazel build with `--config=asan` validated ASAN finding
is resolved.

Signed-off-by: Scott Moeller <electrojoe@gmail.com>