### PR TITLE
chore(mme): Adds passing OAI Core tests to Bazel configuration

### DIFF
--- a/lte/gateway/c/core/oai/test/gtpv2-c/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/gtpv2-c/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+package(default_visibility = ["//visibility:private"])
+
+cc_test(
+    name = "gtpv2_fteid_test",
+    srcs = [
+        "test_fteid.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/itti/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/itti/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
+
+cc_test(
+    name = "itti_test",
+    srcs = [
+        "test_itti.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/mock_tasks/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/mock_tasks/BUILD.bazel
@@ -1,0 +1,38 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//lte/gateway/c/core/oai/test:__subpackages__"])
+
+cc_library(
+    name = "mock_tasks",
+    srcs = [
+        "grpc_mock.cpp",
+        "ha_mock.cpp",
+        "mme_app_mock.cpp",
+        "s11_mock.cpp",
+        "s1ap_mock.cpp",
+        "s6a_mock.cpp",
+        "sctp_mock.cpp",
+        "service303_mock.cpp",
+        "sgs_mock.cpp",
+        "sgw_s8_mock.cpp",
+        "sms_orc8r_mock.cpp",
+        "spgw_mock.cpp",
+    ],
+    hdrs = [
+        "mock_tasks.h",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/ngap/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/ngap/BUILD.bazel
@@ -1,0 +1,82 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//visibility:private"])
+
+cc_test(
+    name = "ngap_encode_decode_test",
+    size = "small",
+    srcs = [
+        "test_ngap_encode_decode.cpp",
+    ],
+    deps = [
+        ":ngap_utils",
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "ngap_utils",
+    srcs = [
+        "util_ngap_amf_nas_procedures.cpp",
+        "util_ngap_initiate_ue.cpp",
+        "util_ngap_setup_failure.cpp",
+    ],
+    hdrs = [
+        "mock_utils.h",
+        "util_ngap_pkt.h",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+    ],
+)
+
+cc_test(
+    name = "ngap_flows_test",
+    size = "small",
+    srcs = [
+        "test_ngap_flows.cpp",
+    ],
+    deps = [
+        ":ngap_utils",
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "ngap_handle_new_association_test",
+    size = "small",
+    srcs = [
+        "test_ngap_handle_new_association.cpp",
+    ],
+    deps = [
+        ":ngap_utils",
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "ngap_state_converter_test",
+    size = "small",
+    srcs = [
+        "test_ngap_state_converter.cpp",
+    ],
+    deps = [
+        ":ngap_utils",
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/pipelined_client/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/pipelined_client/BUILD.bazel
@@ -1,0 +1,33 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//visibility:private"])
+
+cc_test(
+    name = "pipelined_client_test",
+    srcs = [
+        "test_pipelined_client.cpp",
+    ],
+    deps = [
+        ":utility_protobuf",
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "utility_protobuf",
+    hdrs = [
+        "utility_protobuf.h",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/s1ap_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/s1ap_task/BUILD.bazel
@@ -1,0 +1,78 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//visibility:private"])
+
+cc_test(
+    name = "s1ap_handle_new_association_test",
+    size = "small",
+    srcs = [
+        "test_s1ap_handle_new_association.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "s1ap_mme_handlers_test",
+    size = "small",
+    srcs = [
+        "test_s1ap_mme_handlers.cpp",
+    ],
+    deps = [
+        ":s1ap_mme_test_utils",
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "s1ap_mme_test_utils",
+    srcs = [
+        "s1ap_mme_test_utils.cpp",
+    ],
+    hdrs = [
+        "s1ap_mme_test_utils.h",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+    ],
+)
+
+cc_test(
+    name = "s1ap_state_converter_test",
+    size = "small",
+    srcs = [
+        "test_s1ap_state_converter.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "s1ap_state_manager_test",
+    size = "small",
+    srcs = [
+        "test_s1ap_state_manager.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)


### PR DESCRIPTION
Progress on #11656.

This subset of OAI core tests (~6 tests) are the only tests that
presently pass ASAN of the ~36 tests that exist. We must fix the ASAN
issues (or disable ASAN from CI Bazel workflow) to commit more.

Test Plan

```
bazel test //lte/gateway/c/core/...
bazel test //lte/gateway/c/core/... --config=lsan
bazel test //lte/gateway/c/core/... --config=lsan
```

Signed-off-by: Scott Moeller <electronjoe@gmail.com>