### PR TITLE
chore(mme): enable bazel and CMAKE build for spgw_task tests

### DIFF
--- a/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/spgw_task/CMakeLists.txt
@@ -13,6 +13,9 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Needed to determine if build with CMAKE or Bazel
+set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -DCMAKE_BUILD")
+
 set(SPGW_LIB_DIR $ENV{C_BUILD}/oai/tasks/sgw)
 
 include_directories("/usr/src/googletest/googlemock/include/")

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures_with_injected_state.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures_with_injected_state.cpp
@@ -124,10 +124,14 @@ class SPGWAppInjectedStateProcedureTest : public ::testing::Test {
     spgw_app_init(&spgw_config, mme_config.use_stateless);
 
     // add injection of state loaded in SPGW state manager
+#ifdef CMAKE_BUILD  // if CMAKE is used the absolute path is needed
     std::string magma_root = std::getenv("MAGMA_ROOT");
-    name_of_ue_samples = load_file_into_vector_of_line_content(
-        magma_root + "/" + DEFAULT_SPGW_CONTEXT_DATA_PATH,
-        magma_root + "/" + DEFAULT_SPGW_CONTEXT_DATA_PATH + "data_list.txt");
+    std::string path = magma_root + "/" + DEFAULT_SPGW_CONTEXT_DATA_PATH;
+#else  // if bazel is used the relative path is used
+    std::string path = DEFAULT_SPGW_CONTEXT_DATA_PATH;
+#endif
+    name_of_ue_samples =
+        load_file_into_vector_of_line_content(path, path + "data_list.txt");
     mock_read_spgw_ue_state_db(name_of_ue_samples);
 
     std::this_thread::sleep_for(


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Enable bazel and CMAKE build for spgw_task tests
- Note: This PR will work on current master and will fix https://github.com/magma/magma/issues/11712
- Note: If CMAKE is phased out completely the changes in `test_spgw_procedures_with_injected_state.cpp` should be adapted. See https://github.com/magma/magma/issues/11959.

## Test Plan

- Run OAI make tests:
  `make test_oai`
- Run bazel tests (when bazelified), in particular for `test_spgw_procedures_with_injected_state`:
  `bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_with_injected_state_test`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
