### PR TITLE
chore: remove folly from bazel oai build

### DIFF
--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1130,7 +1130,6 @@ cc_library(
         "@libfluid_msg//:fluid_msg",
         "@liblfds//:lfds710",
         "@system_libraries//:czmq",
-        "@system_libraries//:folly",
         "@system_libraries//:libconfig",
         "@system_libraries//:libfd",
         "@system_libraries//:libgnutls",


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
OAI no longer depends on Folly
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
