### PR TITLE
chore(ci): Enlarges bazel cache generation to include test scenarios

### DIFF
--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -92,6 +92,9 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel build //...
+            bazel test //...
+            bazel test //... --config=asan
+            bazel test //... --config=lsan
       - name: Upload .bazel-cache and .bazel-cache-repo to S3
         run: |
           tar -zcvf ${{ env.BAZEL_CACHE_DEVCONTAINER_TAR }} ${{ env.BAZEL_CACHE }}/


### PR DESCRIPTION
Today we pre-populate remote bazel caches (stored in aws) with `bazel build //...` - but due to flag differences in compilation and linking for c/c++ targets, the cache is minimally re-used for `bazel test` targets of various varieties. This PR increases the cache coverage for these, at a cost of cache size.

## Test Plan

### Size Impact

```
bazel clean --expunge
rm -rf .bazel-cache
rm -rf .bazel-cache-repo
bazel build //...
tar -zcf .bazel-cache.tgz .bazel-cache
tar -zcf .bazel-cache-repo.tgz .bazel-cache-repo
@electronjoe ➜ /workspaces/magma (pr-bazel-cachify-moar ✗) $ ls -lh .bazel*
-rw-rw-rw-  1 vscode vscode 464M Mar  3 20:09 .bazel-cache-repo.tgz
-rw-rw-rw-  1 vscode vscode 1.1G Mar  3 20:08 .bazel-cache.tgz
```

Versus
```
bazel clean --expunge
rm -rf .bazel-cache
rm -rf .bazel-cache-repo
bazel build //... && bazel test //... && bazel test //... --config=asan && bazel test //... --config=lsan
tar -zcf .bazel-cache.tgz .bazel-cache
tar -zcf .bazel-cache-repo.tgz .bazel-cache-repo
@electronjoe ➜ /workspaces/magma (pr-bazel-cachify-moar ✗) $ ls -lh .bazel-*
-rw-rw-rw-  1 vscode vscode 464M Mar  3 21:17 .bazel-cache-repo.tgz
-rw-rw-rw-  1 vscode vscode 2.2G Mar  3 21:16 .bazel-cache.tgz
```

Signed-off-by: Scott Moeller <electronjoe@gmail.com>