### PR TITLE
chore: remove libfluid from bazelbase

### DIFF
--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -30,9 +30,6 @@ RUN apt-get update && \
         libidn11-dev \
         libsctp1 \
         libsctp-dev \
-        # dependencies of libfluid_build.sh
-        pkg-config \
-        ruby \
         # dependencies of oai/mme
         libczmq-dev \
         libconfig-dev \
@@ -56,9 +53,6 @@ RUN apt-get update && \
         vim \
         wget \
         zip
-
-# Necessary for execution of libfluid_build.sh
-RUN gem install fpm
 
 # Install bazel
 WORKDIR /usr/sbin
@@ -152,12 +146,6 @@ RUN wget --progress=dot:giga http://ftp.ntua.gr/mirror/gnu/nettle/nettle-2.5.tar
     cd / && \
     rm -rf nettle* && \
     rm -rf gnutls*
-
-#### libfluid is requird to build MME with OVS support
-COPY third_party /tmp/third_party/
-RUN /tmp/third_party/build/bin/libfluid_build.sh && \
-    find . -name magma-libfluid_0.1* -exec dpkg -i {} \; && \
-    rm -rf /tmp/*
 
 ##### FreeDiameter
 COPY lte/gateway/c/core/oai/patches/ /tmp/


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Libfluid is now managed by Bazel directly: https://github.com/magma/magma/blob/master/bazel/cpp_repositories.bzl#L123-L133

Removing the installation steps from bazel-base dockerfile
<!-- Enumerate changes you made and why you made them -->

## Test Plan
docker-compose build
docker-compose run magma-builder bash
bazel test //...
bazel build //...
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
