### PR TITLE
feat(nms): Enable federation mapping configuration capability on federated LTE networks

### DIFF
--- a/nms/app/e2e/__tests__/FegLte-test.js
+++ b/nms/app/e2e/__tests__/FegLte-test.js
@@ -44,7 +44,7 @@ describe('Admin component', () => {
     const page = await browser.newPage();
     await page.setViewport({width: 1280, height: 1024});
     try {
-      await page.goto('https://magma-test.localhost/nms');
+      await page.goto('https://magma-test.localhost/nms/test');
       await page.waitForXPath(`//span[text()='Dashboard']`, {
         timeout: 15000,
       });
@@ -92,7 +92,7 @@ describe('NMS', () => {
     const page = await browser.newPage();
     try {
       // test_feg_lte_network is mocked out
-      await page.goto('https://magma-test.localhost/nms');
+      await page.goto('https://magma-test.localhost/nms/test');
       await page.waitForXPath(`//span[text()='Dashboard']`, {
         timeout: 15000,
       });
@@ -194,6 +194,10 @@ describe('NMS', () => {
       const editSelector = '[data-testid="infoEditButton"]';
       await page.waitForSelector(editSelector);
       await page.click(editSelector);
+
+      const fedationTabSelector = '[data-testid="federationTab"]';
+      await page.waitForSelector(fedationTabSelector);
+      await page.click(fedationTabSelector);
 
       const fegPlaceholder = '[placeholder="Enter Federation Network ID"]';
       await page.waitForSelector(fegPlaceholder);

--- a/nms/app/views/network/FederationStyles.js
+++ b/nms/app/views/network/FederationStyles.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import {colors} from '../../theme/default';
+
+export const federationStyles = {
+  input: {
+    display: 'inline-flex',
+    margin: '5px 0',
+    width: '100%',
+  },
+  root: {
+    '&$expanded': {
+      minHeight: 'auto',
+    },
+    marginTop: '0px',
+    marginBottom: '0px',
+  },
+  expanded: {marginTop: '-8px', marginBottom: '-8px'},
+  block: {
+    display: 'block',
+  },
+  flex: {display: 'flex'},
+  panel: {flexGrow: 1},
+  removeIcon: {alignSelf: 'baseline'},
+  dialog: {height: '640px'},
+  title: {textAlign: 'center', margin: 'auto', marginLeft: '0px'},
+  description: {
+    color: colors.primary.mirage,
+  },
+  switch: {margin: 'auto 0px'},
+};

--- a/nms/app/views/network/NetworkFederationConfig.js
+++ b/nms/app/views/network/NetworkFederationConfig.js
@@ -191,7 +191,6 @@ export function NetworkFederationEdit(props: EditProps) {
   const [error, setError] = useState('');
   const enqueueSnackbar = useEnqueueSnackbar();
   const ctx = useContext(LteNetworkContext);
-  //const networkCtx = useContext(NetworkContext);
   const [config, setConfig] = useState<federated_network_configs>(
     props.config == null || Object.keys(props.config).length === 0
       ? {

--- a/nms/app/views/network/NetworkFederationConfig.js
+++ b/nms/app/views/network/NetworkFederationConfig.js
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {
+  federated_network_configs,
+  mode_map_item,
+} from '../../../generated/MagmaAPIBindings';
+
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AddCircleOutline from '@material-ui/icons/AddCircleOutline';
+import Button from '@material-ui/core/Button';
+import DeleteOutline from '@material-ui/icons/DeleteOutline';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import FormLabel from '@material-ui/core/FormLabel';
+import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
+import ListItemText from '@material-ui/core/ListItemText';
+import LteNetworkContext from '../../components/context/LteNetworkContext';
+import MenuItem from '@material-ui/core/MenuItem';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
+import React from 'react';
+import Select from '@material-ui/core/Select';
+import Switch from '@material-ui/core/Switch';
+import Text from '../../theme/design-system/Text';
+
+import {AltFormField, AltFormFieldSubheading} from '../../components/FormField';
+import {federationStyles} from './FederationStyles';
+import {makeStyles} from '@material-ui/styles';
+import {useContext, useState} from 'react';
+import {useEnqueueSnackbar} from '../../hooks/useSnackbar';
+
+const useStyles = makeStyles(() => federationStyles);
+
+type FieldProps = {
+  index: number,
+  mapping: mode_map_item,
+  handleDelete: number => void,
+  onChange: (number, mode_map_item) => void,
+};
+
+function FederationMappingFields(props: FieldProps) {
+  const classes = useStyles();
+  const {mapping} = props;
+
+  const handleFieldChange = (field: string, value: number | string | {}) =>
+    props.onChange(props.index, {
+      ...props.mapping,
+      [field]: value,
+    });
+
+  return (
+    <div className={classes.flex}>
+      <Accordion defaultExpanded className={classes.panel}>
+        <AccordionSummary
+          classes={{
+            root: classes.root,
+            expanded: classes.expanded,
+          }}
+          expandIcon={<ExpandMoreIcon />}>
+          <Grid container justify="space-between">
+            <Grid item className={classes.title}>
+              <Text weight="medium" variant="body2">
+                Mapping {props.index + 1}
+              </Text>
+            </Grid>
+            <Grid item>
+              <IconButton
+                className={classes.removeIcon}
+                onClick={() => props.handleDelete(props.index)}>
+                <DeleteOutline />
+              </IconButton>
+            </Grid>
+          </Grid>
+        </AccordionSummary>
+        <AccordionDetails classes={{root: classes.block}}>
+          <div className={classes.flex}>
+            <Grid container spacing={2}>
+              <Grid item xs={3}>
+                <AltFormFieldSubheading disableGutters label={'APN'}>
+                  <OutlinedInput
+                    data-testid="mappingApn"
+                    placeholder="oai.ipv4"
+                    fullWidth={true}
+                    value={mapping?.apn ?? ''}
+                    onChange={({target}) =>
+                      handleFieldChange('apn', target.value)
+                    }
+                  />
+                </AltFormFieldSubheading>
+              </Grid>
+              <Grid item xs={3}>
+                <AltFormFieldSubheading disableGutters label={'IMSI Range'}>
+                  <OutlinedInput
+                    data-testid="mappingImsiRange"
+                    placeholder="000000:000019"
+                    fullWidth={true}
+                    value={mapping?.imsi_range ?? ''}
+                    onChange={({target}) =>
+                      handleFieldChange('imsi_range', target.value)
+                    }
+                  />
+                </AltFormFieldSubheading>
+              </Grid>
+              <Grid item xs={3}>
+                <AltFormFieldSubheading disableGutters label={'Mode'}>
+                  <Select
+                    fullWidth={true}
+                    variant={'outlined'}
+                    value={mapping.mode}
+                    onChange={({target}) => {
+                      handleFieldChange('mode', target.value);
+                    }}
+                    input={<OutlinedInput id="mode" />}>
+                    <MenuItem value={'local_subscriber'}>
+                      <ListItemText primary={'Local Subscriber'} />
+                    </MenuItem>
+                    <MenuItem value={'s8_subscriber'}>
+                      <ListItemText primary={'S8 Subscriber'} />
+                    </MenuItem>
+                  </Select>
+                </AltFormFieldSubheading>
+              </Grid>
+              <Grid item xs={3}>
+                <AltFormFieldSubheading disableGutters label={'PLMN'}>
+                  <OutlinedInput
+                    data-testid="mappingPlmn"
+                    placeholder="12345"
+                    fullWidth={true}
+                    value={mapping?.plmn ?? ''}
+                    onChange={({target}) =>
+                      handleFieldChange('plmn', target.value)
+                    }
+                  />
+                </AltFormFieldSubheading>
+              </Grid>
+            </Grid>
+          </div>
+        </AccordionDetails>
+      </Accordion>
+    </div>
+  );
+}
+
+/**
+ * Props contains the fields needed to display a federated network's
+ * federation configuration.
+ *
+ * @property {string} saveButtonTitle
+ *    Title of save button, eg. "Continue", or "Save".
+ * @property {string} networkId
+ *    ID of network being modified
+ * @property {federated_network_configs} federatedNetworkConfigs
+ *    Federation configuration.
+ * @property {() => void} onClose
+ *    Callback on closing the config modal.
+ * @property {(federated_network_configs) => void} onSave
+ *    Callback on saving the configs.
+ */
+type EditProps = {
+  saveButtonTitle: string,
+  networkId: string,
+  config: federated_network_configs,
+  onClose: () => void,
+  onSave: federated_network_configs => void,
+};
+
+/**
+ * NetworkFederationEdit provides modal content for editing a
+ * Federated LTE Network's federation configs.
+ *
+ * @param {EditProps} props
+ */
+export function NetworkFederationEdit(props: EditProps) {
+  const classes = useStyles();
+  const [error, setError] = useState('');
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const ctx = useContext(LteNetworkContext);
+  //const networkCtx = useContext(NetworkContext);
+  const [config, setConfig] = useState<federated_network_configs>(
+    props.config == null || Object.keys(props.config).length === 0
+      ? {
+          feg_network_id: '',
+          federated_modes_mapping: {
+            enabled: false,
+            mapping: [],
+          },
+        }
+      : props.config,
+  );
+
+  const handleAddMapping = () => {
+    const mapping: Array<mode_map_item> = [
+      ...(config?.federated_modes_mapping?.mapping || []),
+      {
+        mode: 'local_subscriber',
+        plmn: '',
+        imsi_range: '',
+        apn: '',
+      },
+    ];
+
+    setConfig({
+      ...config,
+      federated_modes_mapping: {...config.federated_modes_mapping, mapping},
+    });
+  };
+
+  const onMappingChange = (index: number, newMapping: mode_map_item) => {
+    const mapping: Array<mode_map_item> = [
+      ...(config?.federated_modes_mapping?.mapping || []),
+    ];
+    mapping[index] = newMapping;
+
+    setConfig({
+      ...config,
+      federated_modes_mapping: {...config.federated_modes_mapping, mapping},
+    });
+  };
+
+  const handleDeleteMapping = (index: number) => {
+    const mapping: Array<mode_map_item> = [
+      ...(config?.federated_modes_mapping?.mapping || []),
+    ];
+    mapping.splice(index, 1);
+    setConfig({
+      ...config,
+      federated_modes_mapping: {...config.federated_modes_mapping, mapping},
+    });
+  };
+
+  /**
+   * onSave handles API calls and context updates when the
+   * "Save" button is clicked on the config modal.
+   */
+  const onSave = async () => {
+    try {
+      await ctx.updateNetworks({
+        networkId: props.networkId,
+        federation: config,
+      });
+      enqueueSnackbar('Federation configs saved successfully', {
+        variant: 'success',
+      });
+      props.onSave(config);
+    } catch (e) {
+      setError(e.response?.data?.message ?? e?.message);
+    }
+  };
+
+  const mappingsList: Array<mode_map_item> = [
+    ...(config?.federated_modes_mapping?.mapping || []),
+  ];
+
+  return (
+    <>
+      <DialogContent data-testid="networkInfoEdit">
+        {error !== '' && (
+          <AltFormField label={''}>
+            <FormLabel error>{error}</FormLabel>
+          </AltFormField>
+        )}
+
+        <AltFormField label={'Federation'}>
+          <OutlinedInput
+            data-testid="fegNetworkId"
+            placeholder="Enter Federation Network ID"
+            fullWidth={true}
+            value={config.feg_network_id ?? ''}
+            onChange={({target}) =>
+              setConfig({
+                ...config,
+                feg_network_id: target.value,
+              })
+            }
+          />
+        </AltFormField>
+        <AltFormField label={'Federated Mapping Mode'}>
+          <Switch
+            data-testid="federatedModeMapping"
+            onChange={({target}) => {
+              setConfig({
+                ...config,
+                federated_modes_mapping: {
+                  ...config?.federated_modes_mapping,
+                  enabled: target.checked,
+                },
+              });
+            }}
+            checked={config?.federated_modes_mapping?.enabled || false}
+          />
+        </AltFormField>
+        {config?.federated_modes_mapping?.enabled === true && (
+          <AltFormField label={'Mappings'}>
+            <Grid container spacing={1}>
+              <Grid item xs={12}>
+                <Text
+                  weight="medium"
+                  variant="subtitle2"
+                  className={classes.description}>
+                  {
+                    'Mappings for PLMN, IMSI ranges, and corresponding gateway modes'
+                  }
+                </Text>
+              </Grid>
+              <Grid item xs={12}>
+                <Grid container spacing={1}>
+                  {mappingsList.slice(0, 30).map((mapping, i) => (
+                    <Grid key={i} item xs={12}>
+                      <FederationMappingFields
+                        key={i}
+                        index={i}
+                        mapping={mapping}
+                        handleDelete={handleDeleteMapping}
+                        onChange={onMappingChange}
+                      />
+                    </Grid>
+                  ))}
+                </Grid>
+              </Grid>
+              <Grid item xs={12}>
+                Add New Mapping
+                <IconButton
+                  data-testid="addFlowButton"
+                  onClick={handleAddMapping}>
+                  <AddCircleOutline />
+                </IconButton>
+              </Grid>
+            </Grid>
+          </AltFormField>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button
+          data-testid="cancelButton"
+          onClick={props.onClose}
+          skin="regular">
+          Cancel
+        </Button>
+        <Button
+          data-testid="saveButton"
+          onClick={onSave}
+          variant="contained"
+          color="primary">
+          {props.saveButtonTitle}
+        </Button>
+      </DialogActions>
+    </>
+  );
+}

--- a/nms/app/views/network/NetworkInfo.js
+++ b/nms/app/views/network/NetworkInfo.js
@@ -65,12 +65,24 @@ export default function NetworkInfo(props: Props) {
     ],
   ];
   if (networkCtx.networkType === FEG_LTE) {
-    kpiData.push([
-      {
-        category: 'Federation',
-        value: props.lteNetwork?.federation?.feg_network_id || '-',
-      },
-    ]);
+    kpiData.push(
+      [
+        {
+          category: 'Federation',
+          value: props.lteNetwork?.federation?.feg_network_id || '-',
+        },
+      ],
+      [
+        {
+          category: 'Federated Mapping Mode',
+          value:
+            props.lteNetwork?.federation?.federated_modes_mapping?.enabled ===
+            true
+              ? 'On'
+              : 'Off',
+        },
+      ],
+    );
   }
   return <DataGrid data={kpiData} testID="info" />;
 }
@@ -86,7 +98,6 @@ export function NetworkInfoEdit(props: EditProps) {
   const [error, setError] = useState('');
   const enqueueSnackbar = useEnqueueSnackbar();
   const ctx = useContext(LteNetworkContext);
-  const networkCtx = useContext(NetworkContext);
   const [lteNetwork, setLteNetwork] = useState<
     $Shape<lte_network & feg_lte_network>,
   >(props.lteNetwork);
@@ -162,22 +173,6 @@ export function NetworkInfoEdit(props: EditProps) {
               }
             />
           </AltFormField>
-          {networkCtx.networkType === FEG_LTE && (
-            <AltFormField label={'Federation'}>
-              <OutlinedInput
-                data-testid="federation"
-                placeholder="Enter Federation Network ID"
-                fullWidth={true}
-                value={lteNetwork.federation?.feg_network_id ?? ''}
-                onChange={({target}) =>
-                  setLteNetwork({
-                    ...lteNetwork,
-                    federation: {feg_network_id: target.value},
-                  })
-                }
-              />
-            </AltFormField>
-          )}
           <AltFormField label={'Add Description'}>
             <OutlinedInput
               data-testid="networkDescription"


### PR DESCRIPTION
## Summary

This bridges a gap in feature parity between the Orc8r API and NMS.

Enables the ability to configure routing for a federated LTE network, as specified [here](https://docs.magmacore.org/docs/next/howtos/inbound_roaming#2-configure-local-access-gateway-network-routing).

This screenshot shows the addition of additional configuration displayed in the network page for a federated LTE network, specifically "Federated Mapping Mode"
![Screen Shot 2022-03-03 at 3 30 49 PM](https://user-images.githubusercontent.com/804385/156671692-75d86d5c-47f4-4edc-8ec3-550647d03a89.png)

Clicking the "Edit" button, opens up a modal for configuring the federated LTE network. A new tab has been added, labeled "Federation":
![Screen Shot 2022-03-03 at 3 30 56 PM](https://user-images.githubusercontent.com/804385/156671689-6674ce74-d86f-4e72-9638-ccbe28e3818c.png)

There is also the capability to configure the routing/mappings for federation purposes:
![Screen Shot 2022-03-03 at 3 33 02 PM](https://user-images.githubusercontent.com/804385/156671685-c92075e0-e23e-4c4d-8d2c-8b3bbabf55e7.png)



## Test Plan

- Checked enabling/disabling mapping mode

- Checked adding/editing/deleting mappings, and persistence across page refreshes, and consistency with direct access through Orc8r API

## Additional Information

- [ ] This change is backwards-breaking
