### PR TITLE
chore(ci): Fix bazel build and test job bug

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -164,19 +164,9 @@ jobs:
         if: github.event_name == 'push'
         env:
           BAZEL_CACHE_DIR: .${{ env.BAZEL_CACHE }}
+          BAZEL_CACHE_CUTOFF_MB: 6000
         run: |
-          # See https://stackoverflow.com/a/27485157 for reference.
-          # We do not care about the repo cache size here because it is handled in bazel.yml
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-
-          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | grep total | cut -f1)
-          echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
-          # Use a 6GB threshold since actions/cache compresses the results, and Bazel caches seem
-          # to only increase by a few hundred megabytes across changes for unrelated branches.
-          if [[ "$CACHE_SIZE_MB" -gt 6000 ]]; then
-            echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
-            rm -rf $EXPANDED_BAZEL_CACHE_PATH
-          fi
+          ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
       - name: Setup Devcontainer Image
         uses: addnab/docker-run-action@v2
         with:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -91,16 +91,7 @@ jobs:
           # Uncompressed cache on master is looking to be around 6GB (from observing jobs on master)
           BAZEL_CACHE_CUTOFF_MB: 6500
         run: |
-          # See https://stackoverflow.com/a/27485157 for reference.
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-
-          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | cut -f1)
-          echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
-
-          if [[ "$CACHE_SIZE_MB" -gt $BAZEL_CACHE_CUTOFF_MB ]]; then
-            echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
-            rm -rf $EXPANDED_BAZEL_CACHE_PATH $EXPANDED_BAZEL_CACHE_REPO_PATH
-          fi
+          ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
       - name: Ensure cache size BAZEL_CACHE_REPO
         # Only run on master to avoid slow build on PRs
         if: github.event_name == 'schedule' || github.event_name == 'push'
@@ -110,15 +101,7 @@ jobs:
           # Uncompressed cache on master is looking to be around 400MB (from observing jobs on master)
           BAZEL_CACHE_REPO_CUTOFF_MB: 600
         run: |
-          # See https://stackoverflow.com/a/27485157 for reference.
-          EXPANDED_BAZEL_CACHE_REPO_PATH="${BAZEL_CACHE_REPO_DIR/#\~/$HOME}"
-
-          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_REPO_PATH | cut -f1)
-          echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
-          if [[ "$CACHE_SIZE_MB" -gt "$BAZEL_CACHE_REPO_CUTOFF_MB" ]]; then
-            echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
-            rm -rf $EXPANDED_BAZEL_CACHE_PATH $EXPANDED_BAZEL_CACHE_REPO_PATH
-          fi
+          ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_REPO_DIR" "$BAZEL_CACHE_REPO_CUTOFF_MB"
       - name: Setup Devcontainer Image
         uses: addnab/docker-run-action@v2
         with:
@@ -180,16 +163,7 @@ jobs:
           # Uncompressed cache on master is looking to be around 6GB (from observing jobs on master)
           BAZEL_CACHE_CUTOFF_MB: 6500
         run: |
-          # See https://stackoverflow.com/a/27485157 for reference.
-          EXPANDED_BAZEL_CACHE_PATH="${BAZEL_CACHE_DIR/#\~/$HOME}"
-
-          CACHE_SIZE_MB=$(du -smc $EXPANDED_BAZEL_CACHE_PATH | cut -f1)
-          echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
-
-          if [[ "$CACHE_SIZE_MB" -gt $BAZEL_CACHE_CUTOFF_MB ]]; then
-            echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
-            rm -rf $EXPANDED_BAZEL_CACHE_PATH $EXPANDED_BAZEL_CACHE_REPO_PATH
-          fi
+          ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
       # Letting the Build job above handle cache clean up for bazel-cache-repo
       - name: Setup Devcontainer Image
         uses: addnab/docker-run-action@v2

--- a/.github/workflows/check-bazel-cache-dir-size.sh
+++ b/.github/workflows/check-bazel-cache-dir-size.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script should be run from $MAGMA_ROOT
+
+# Relative path to cache directory from $MAGMA_ROOT
+RELATIVE_CACHE_DIR=$1
+CUTOFF_MB=$2
+
+# See https://stackoverflow.com/a/27485157 for reference.
+CACHE_SIZE_MB=$(du -smc "$RELATIVE_CACHE_DIR" | grep "$RELATIVE_CACHE_DIR" | cut -f1)
+echo "Total size of Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
+
+if [[ "$CACHE_SIZE_MB" -gt "$CUTOFF_MB" ]]; then
+    echo "Cache exceeds cut-off; resetting it (will result in a slow build)"
+    rm -rf "$RELATIVE_CACHE_DIR"
+fi


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Seeing this error on master: https://github.com/magma/magma/runs/5415604693?check_suite_focus=true#step:7:20
```bash
Total size of Bazel cache (rounded up to MBs): 471
[19](https://github.com/magma/magma/runs/5415604693?check_suite_focus=true#step:7:19)
/home/runner/work/_temp/0e[20](https://github.com/magma/magma/runs/5415604693?check_suite_focus=true#step:7:20)d7a1-b364-4745-a11a-7d4f3ec853bf.sh: line 6: [[: 471
20
471: syntax error in expression (error token is "471")
[21](https://github.com/magma/magma/runs/5415604693?check_suite_focus=true#step:7:21)
471
```

I was too hasty when committing this, forgot when testing that this logic gets skipped for PRs 😅 

Refactoring the jobs so that all cache resetting logic uses the same script for consistency.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran the script locally
```bash
root@957f231d96f1:/magma# ./.github/workflows/reset-bazel-cache-dir.sh .bazel-cache 3000
Total size of Bazel cache (rounded up to MBs): 29576
Cache exceeds cut-off; resetting it (will result in a slow build)
```

Modified the CI job to run on PR temporarily to verify the change
<img width="940" alt="Screen Shot 2022-03-03 at 8 14 08 PM" src="https://user-images.githubusercontent.com/37634144/156680276-4565a5e8-0985-43e7-8717-635269945909.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
