### PR TITLE
fix(mme): fix asan error in test_3gpp

### DIFF
--- a/lte/gateway/c/core/oai/test/lib/test_3gpp.cpp
+++ b/lte/gateway/c/core/oai/test/lib/test_3gpp.cpp
@@ -247,7 +247,7 @@ TEST_F(m3GppTest, TestImsiMobileIdentity) {
 
 TEST_F(m3GppTest, TestMobileStationClassmark2) {
   mobile_station_classmark2_t msclassmark2 = {0};
-  mobile_station_classmark2_t msclassmark2_decoded;
+  mobile_station_classmark2_t msclassmark2_decoded = {0};
 
   msclassmark2.revisionlevel = 3;
   msclassmark2.esind = 1;


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Problem: The `lib_3gpp_test` is failing with bazel (on `scott/pr-giant-bazel-mme-rebase` ) when `--config=asan` is set
- Solution: Initialize struct
- Note: Can be applied to current master

## Test Plan

- On `scott/pr-giant-bazel-mme-rebase` run bazel test:
  `bazel test //lte/gateway/c/core/oai/test/lib:lib_3gpp_test --config=asan --compilation_mode=dbg`
  `bazel test //lte/gateway/c/core/oai/test/lib:lib_3gpp_test --config=lsan --compilation_mode=dbg`
- Run `make test_oai`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
