### PR TITLE
chore(mobilityd): Fix type errors shown by mypy

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_desc.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_desc.py
@@ -94,6 +94,7 @@ class DHCPDescriptor:
         if self.state == DHCPState.OFFER or self.state == DHCPState.REQUEST \
                 or self.state == DHCPState.ACK:
             return self.ip
+        return None
 
     def ip_is_allocated(self) -> bool:
         """

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
@@ -19,10 +19,10 @@ from __future__ import (
 )
 
 from abc import ABC, abstractmethod
-from ipaddress import ip_address, ip_network
 from typing import List
 
 from magma.mobilityd.ip_descriptor import IPDesc
+from magma.mobilityd.utils import IPAddress, IPNetwork
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 
@@ -30,23 +30,23 @@ DEFAULT_IP_RECYCLE_INTERVAL = 15
 class IPAllocator(ABC):
 
     @abstractmethod
-    def add_ip_block(self, ipblock: ip_network):
+    def add_ip_block(self, ipblock: IPNetwork):
         ...
 
     @abstractmethod
     def remove_ip_blocks(
         self,
-        ipblocks: List[ip_network],
+        ipblocks: List[IPNetwork],
         force: bool,
-    ) -> List[ip_network]:
+    ) -> List[IPNetwork]:
         ...
 
     @abstractmethod
-    def list_added_ip_blocks(self) -> List[ip_network]:
+    def list_added_ip_blocks(self) -> List[IPNetwork]:
         ...
 
     @abstractmethod
-    def list_allocated_ips(self, ipblock: ip_network) -> List[ip_address]:
+    def list_allocated_ips(self, ipblock: IPNetwork) -> List[IPAddress]:
         ...
 
     @abstractmethod

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -33,6 +33,7 @@ from .dhcp_desc import DHCPDescriptor, DHCPState
 from .ip_allocator_base import IPAllocator, NoAvailableIPError
 from .mac import MacAddress, create_mac_from_sid
 from .mobility_store import MobilityStore
+from .utils import IPAddress, IPNetwork
 
 DEFAULT_DHCP_REQUEST_RETRY_FREQUENCY = 10
 DEFAULT_DHCP_REQUEST_RETRY_DELAY = 1
@@ -69,7 +70,7 @@ class IPAllocatorDHCP(IPAllocator):
         self._retry_limit = retry_limit  # default wait for two minutes
         self._dhcp_client.run()
 
-    def add_ip_block(self, ipblock: ip_network):
+    def add_ip_block(self, ipblock: IPNetwork):
         logging.warning(
             "No need to allocate block for DHCP allocator: %s",
             ipblock,
@@ -77,19 +78,19 @@ class IPAllocatorDHCP(IPAllocator):
 
     def remove_ip_blocks(
         self,
-        ipblocks: List[ip_network],
+        ipblocks: List[IPNetwork],
         force: bool = False,
-    ) -> List[ip_network]:
+    ) -> List[IPNetwork]:
         logging.warning(
             "Trying to delete ipblock from DHCP allocator: %s",
             ipblocks,
         )
         return []
 
-    def list_added_ip_blocks(self) -> List[ip_network]:
+    def list_added_ip_blocks(self) -> List[IPNetwork]:
         return list(deepcopy(self._store.assigned_ip_blocks))
 
-    def list_allocated_ips(self, ipblock: ip_network) -> List[ip_address]:
+    def list_allocated_ips(self, ipblock: IPNetwork) -> List[IPAddress]:
         """ List IP addresses allocated from a given IP block
 
         Args:

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
@@ -22,13 +22,13 @@ from __future__ import (
     unicode_literals,
 )
 
-from ipaddress import ip_address, ip_network
 from typing import List
 
 from magma.mobilityd.ip_allocator_base import IPAllocator
 from magma.mobilityd.ip_descriptor import IPDesc
 from magma.mobilityd.mobility_store import MobilityStore
 from magma.mobilityd.subscriberdb_client import SubscriberDbClient
+from magma.mobilityd.utils import IPAddress, IPNetwork
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 
@@ -51,27 +51,27 @@ class IPAllocatorMultiAPNWrapper(IPAllocator):
         self._subscriber_client = SubscriberDbClient(subscriberdb_rpc_stub)
         self._ip_allocator = ip_allocator
 
-    def add_ip_block(self, ipblock: ip_network):
+    def add_ip_block(self, ipblock: IPNetwork):
         """ Add a block of IP addresses to the free IP list
         """
         self._ip_allocator.add_ip_block(ipblock)
 
     def remove_ip_blocks(
-        self, ipblocks: List[ip_network],
+        self, ipblocks: List[IPNetwork],
         force: bool = False,
-    ) -> List[ip_network]:
+    ) -> List[IPNetwork]:
         """ Remove allocated IP blocks.
         """
         return self._ip_allocator.remove_ip_blocks(ipblocks, force)
 
-    def list_added_ip_blocks(self) -> List[ip_network]:
+    def list_added_ip_blocks(self) -> List[IPNetwork]:
         """ List IP blocks added to the IP allocator
         Return:
              copy of the list of assigned IP blocks
         """
         return self._ip_allocator.list_added_ip_blocks()
 
-    def list_allocated_ips(self, ipblock: ip_network) -> List[ip_address]:
+    def list_allocated_ips(self, ipblock: IPNetwork) -> List[IPAddress]:
         """ List IP addresses allocated from a given IP block
         """
         return self._ip_allocator.list_allocated_ips(ipblock)

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
@@ -24,7 +24,6 @@ from __future__ import (
 
 import logging
 from copy import deepcopy
-from ipaddress import ip_address, ip_network
 from typing import List
 
 from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
@@ -36,6 +35,7 @@ from .ip_allocator_base import (
     OverlappedIPBlocksError,
 )
 from .mobility_store import MobilityStore
+from .utils import IPAddress, IPNetwork
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 
@@ -47,7 +47,7 @@ class IpAllocatorPool(IPAllocator):
         """
         self._store = store  # mobilityd storage instance
 
-    def add_ip_block(self, ipblock: ip_network):
+    def add_ip_block(self, ipblock: IPNetwork):
         """ Add a block of IP addresses to the free IP list
 
         IP blocks should not overlap.
@@ -81,9 +81,9 @@ class IpAllocatorPool(IPAllocator):
                 num_reserved_addresses -= 1
 
     def remove_ip_blocks(
-        self, ipblocks: List[ip_network],
+        self, ipblocks: List[IPNetwork],
         force: bool = False,
-    ) -> List[ip_network]:
+    ) -> List[IPNetwork]:
         """ Makes the indicated block(s) unavailable for allocation
 
         If force is False, blocks that have any addresses currently allocated
@@ -169,7 +169,7 @@ class IpAllocatorPool(IPAllocator):
             logging.info('Removed IP block %s from IPv4 address pool', block)
         return list(remove_blocks)
 
-    def list_added_ip_blocks(self) -> List[ip_network]:
+    def list_added_ip_blocks(self) -> List[IPNetwork]:
         """ List IP blocks added to the IP allocator
 
         Return:
@@ -181,7 +181,7 @@ class IpAllocatorPool(IPAllocator):
                 ret.append(ipblock)
         return list(deepcopy(ret))
 
-    def list_allocated_ips(self, ipblock: ip_network) -> List[ip_address]:
+    def list_allocated_ips(self, ipblock: IPNetwork) -> List[IPAddress]:
         """ List IP addresses allocated from a given IP block
 
         Args:

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -23,7 +23,7 @@ from __future__ import (
 )
 
 import logging
-from ipaddress import ip_address, ip_network
+from ipaddress import ip_network
 from typing import List, Optional
 
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
@@ -34,7 +34,7 @@ from magma.mobilityd.ip_allocator_base import (
 from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
 from magma.mobilityd.mobility_store import MobilityStore
 from magma.mobilityd.subscriberdb_client import SubscriberDbClient
-from magma.mobilityd.utils import log_error_and_raise
+from magma.mobilityd.utils import IPAddress, IPNetwork, log_error_and_raise
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 
@@ -60,27 +60,27 @@ class IPAllocatorStaticWrapper(IPAllocator):
         else:
             self._ip_version = 4
 
-    def add_ip_block(self, ipblock: ip_network):
+    def add_ip_block(self, ipblock: IPNetwork):
         """ Add a block of IP addresses to the free IP list
         """
         self._ip_allocator.add_ip_block(ipblock)
 
     def remove_ip_blocks(
-        self, ipblocks: List[ip_network],
+        self, ipblocks: List[IPNetwork],
         force: bool = False,
-    ) -> List[ip_network]:
+    ) -> List[IPNetwork]:
         """ Remove allocated IP blocks.
         """
         return self._ip_allocator.remove_ip_blocks(ipblocks, force)
 
-    def list_added_ip_blocks(self) -> List[ip_network]:
+    def list_added_ip_blocks(self) -> List[IPNetwork]:
         """ List IP blocks added to the IP allocator
         Return:
              copy of the list of assigned IP blocks
         """
         return self._ip_allocator.list_added_ip_blocks()
 
-    def list_allocated_ips(self, ipblock: ip_network) -> List[ip_address]:
+    def list_allocated_ips(self, ipblock: IPNetwork) -> List[IPAddress]:
         """ List IP addresses allocated from a given IP block
         """
         return self._ip_allocator.list_allocated_ips(ipblock)

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor.py
@@ -10,8 +10,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import ipaddress
 from enum import Enum
+
+from magma.mobilityd.utils import IPAddress, IPNetwork
 
 
 class IPState(Enum):
@@ -47,8 +48,8 @@ class IPDesc:
     """
 
     def __init__(
-        self, ip: ipaddress.ip_address = None, state: IPState = None,
-        sid: str = None, ip_block: ipaddress.ip_network = None,
+        self, ip: IPAddress = None, state: IPState = None,
+        sid: str = None, ip_block: IPNetwork = None,
         ip_type: IPType = None, vlan_id: int = 0,
     ):
         self.ip = ip

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
@@ -39,10 +39,11 @@ from __future__ import (
     unicode_literals,
 )
 
-from ipaddress import ip_address, ip_network
+from ipaddress import ip_address
 from typing import Dict, List, MutableMapping, Optional, Set
 
 from magma.mobilityd.ip_descriptor import IPDesc, IPState
+from magma.mobilityd.utils import IPAddress, IPNetwork
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 
@@ -58,7 +59,7 @@ class IpDescriptorMap:
         self.ip_states = ip_states
 
     def add_ip_to_state(
-        self, ip: ip_address, ip_desc: IPDesc,
+        self, ip: IPAddress, ip_desc: IPDesc,
         state: IPState,
     ):
         """ Add ip=>ip_desc pairs to a internal dict """
@@ -69,7 +70,7 @@ class IpDescriptorMap:
 
         self.ip_states[state][ip.exploded] = ip_desc
 
-    def remove_ip_from_state(self, ip: ip_address, state: IPState) -> IPDesc:
+    def remove_ip_from_state(self, ip: IPAddress, state: IPState) -> IPDesc:
         """ Remove an IP from a internal dict """
         assert state in IPState, "unknown state %s" % state
 
@@ -97,26 +98,26 @@ class IpDescriptorMap:
 
         return bool(self.ip_states[state]) == False
 
-    def test_ip_state(self, ip: ip_address, state: IPState) -> bool:
+    def test_ip_state(self, ip: IPAddress, state: IPState) -> bool:
         """ check if IP is in state X """
         assert state in IPState, "unknown state %s" % state
 
         return ip.exploded in self.ip_states[state]
 
-    def get_ip_state(self, ip: ip_address) -> IPState:
+    def get_ip_state(self, ip: IPAddress) -> IPState:
         """ return the state of an IP """
         for state in IPState:
             if self.test_ip_state(ip, state):
                 return state
         raise AssertionError("IP %s not found in any states" % ip)
 
-    def list_ips(self, state: IPState) -> List[ip_address]:
+    def list_ips(self, state: IPState) -> List[IPAddress]:
         """ return a list of IPs in state X """
         assert state in IPState, "unknown state %s" % state
 
         return [ip_address(ip) for ip in self.ip_states[state]]
 
-    def mark_ip_state(self, ip: ip_address, state: IPState) -> IPDesc:
+    def mark_ip_state(self, ip: IPAddress, state: IPState) -> IPDesc:
         """ Remove, mark, add: move IP to a new state """
         assert state in IPState, "unknown state %s" % state
 
@@ -141,7 +142,7 @@ class IpDescriptorMap:
         self.add_ip_to_state(ip, ip_desc, state)
         return ip_desc
 
-    def get_allocated_ip_block_set(self) -> Set[ip_network]:
+    def get_allocated_ip_block_set(self) -> Set[IPNetwork]:
         """ A IP block is allocated if ANY IP is allocated from it """
         allocated_ips = self.ip_states[IPState.ALLOCATED]
         return {ip_desc.ip_block for ip_desc in allocated_ips.values()}

--- a/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
@@ -13,10 +13,9 @@ limitations under the License.
 import logging
 import random
 from copy import deepcopy
-from ipaddress import ip_address, ip_network
 from typing import List, Optional
 
-from magma.mobilityd.utils import log_error_and_raise
+from magma.mobilityd.utils import IPAddress, IPNetwork, log_error_and_raise
 
 from .ip_allocator_base import (
     IPAllocator,
@@ -48,7 +47,7 @@ class IPv6AllocatorPool(IPAllocator):
             else MAX_IPV6_CONF_PREFIX_LEN
         )
 
-    def add_ip_block(self, ipblock: ip_network):
+    def add_ip_block(self, ipblock: IPNetwork):
         """
         Adds IP block to the assigned IP block of the IPv6 allocator
 
@@ -73,9 +72,9 @@ class IPv6AllocatorPool(IPAllocator):
         self._store.assigned_ip_blocks.add(ipblock)
 
     def remove_ip_blocks(
-        self, ipblocks: List[ip_network],
+        self, ipblocks: List[IPNetwork],
         force: bool = False,
-    ) -> List[ip_network]:
+    ) -> List[IPNetwork]:
         """
         Removes assigned IP block (as it only supports one for now)
 
@@ -98,7 +97,7 @@ class IPv6AllocatorPool(IPAllocator):
             if allocated_ip_block_set:
                 return []
 
-        removed_blocks = []
+        removed_blocks: List[IPNetwork] = []
         # Clear allocated session prefix and IID store
         self._store.allocated_iid.clear()
         self._store.sid_session_prefix_allocated.clear()
@@ -240,7 +239,7 @@ class IPv6AllocatorPool(IPAllocator):
                     return session_prefix_part
         return None
 
-    def list_added_ip_blocks(self) -> List[ip_network]:
+    def list_added_ip_blocks(self) -> List[IPNetwork]:
         """
         Returns: assigned IP blocks on the allocator
         """
@@ -250,7 +249,7 @@ class IPv6AllocatorPool(IPAllocator):
                 ret.append(ipblock)
         return list(deepcopy(ret))
 
-    def list_allocated_ips(self, ipblock: ip_network) -> List[ip_address]:
+    def list_allocated_ips(self, ipblock: IPNetwork) -> List[IPAddress]:
         raise NotImplementedError
 
 

--- a/lte/gateway/python/magma/mobilityd/mac.py
+++ b/lte/gateway/python/magma/mobilityd/mac.py
@@ -20,7 +20,7 @@ class MacAddress:
     def __init__(self, mac: str):
         self.mac_address = mac
 
-    def as_hex(self) -> str:
+    def as_hex(self) -> bytes:
         """
         Covert Mac address string to binary number format.
         Returns: packed binary number.

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -15,6 +15,7 @@ import logging
 from typing import Any, Optional
 
 from lte.protos.mconfig import mconfigs_pb2
+from lte.protos.mconfig.mconfigs_pb2 import MobilityD
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
 from magma.common.redis.client import get_default_client
 from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING, sentry_init
@@ -29,6 +30,7 @@ from magma.mobilityd.ip_allocator_static import IPAllocatorStaticWrapper
 from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool
 from magma.mobilityd.mobility_store import MobilityStore
 from magma.mobilityd.rpc_servicer import MobilityServiceRpcServicer
+from magma.mobilityd.utils import IPNetwork
 
 DEFAULT_IPV6_PREFIX_ALLOC_MODE = 'RANDOM'
 RETRY_LIMIT = 300
@@ -80,7 +82,7 @@ def _get_ipv4_allocator(
 
 def _get_ipv6_allocator(
         store: MobilityStore, allocator_type: int,
-        static_ip_enabled: bool, mconfig: any,
+        static_ip_enabled: bool, mconfig: MobilityD,
         ipv6_prefixlen: Optional[int],
         subscriberdb_rpc_stub: SubscriberDBStub = None,
 ):
@@ -112,7 +114,7 @@ def _get_ipv6_allocator(
 def _get_ip_block(
     ip_block_str: str,
     ip_type: str,
-) -> Optional[ipaddress.ip_network]:
+) -> Optional[IPNetwork]:
     """Convert string into ipaddress.ip_network
 
     Support both IPv4 or IPv6 addresses

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -68,8 +68,9 @@ class UplinkGatewayInfo:
         vlan_key = _get_vlan_key(vlan_id, version)
         if vlan_key in self._backing_map:
             gw_info = self._backing_map.get(vlan_key)
-            ip = ipaddress.ip_address(gw_info.ip.address)
-            return str(ip)
+            if gw_info:
+                return str(ipaddress.ip_address(gw_info.ip.address))
+        return None
 
     def read_default_gw(self):
         self._do_read_default_gw()
@@ -159,10 +160,10 @@ class UplinkGatewayInfo:
             vlan_id: vlan of the gw, None if GW is not in a vlan.
         """
         vlan_key = _get_vlan_key(vlan_id, version)
-        if vlan_key in self._backing_map:
-            return self._backing_map.get(vlan_key).mac
-        else:
-            return None
+        gw_info = self._backing_map.get(vlan_key)
+        if gw_info:
+            return gw_info.mac
+        return None
 
     def update_mac(
         self, ip: Optional[str], mac: Optional[str], vlan_id=None,

--- a/lte/gateway/python/magma/mobilityd/utils.py
+++ b/lte/gateway/python/magma/mobilityd/utils.py
@@ -12,6 +12,11 @@ limitations under the License.
 """
 
 import logging
+from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
+from typing import Union
+
+IPAddress = Union[IPv4Address, IPv6Address]
+IPNetwork = Union[IPv4Network, IPv6Network]
 
 
 def log_error_and_raise(exception_class: type, message_template: str, *args):


### PR DESCRIPTION
## Summary

I tried static type checking of mobilityd using mypy and fixed some of the errors it found. Mostly these were minor issues (missing return statements or null checks).

The only bigger change is the introduction of dedicated types for IP addresses and networks. Before this PR, they referred to functions as variable types, which is not a valid type hint.

## Test Plan

Install mypy in a virtualenv and execute it via
```
cd $MAGMA_ROOT/lte/gateway
mypy --ignore-missing-imports python/magma/mobilityd/
```

Error count on master:
```
Found 108 errors in 16 files (checked 31 source files)
```

Error count after the changes:
```
Found 24 errors in 5 files (checked 31 source files)
```

## Additional Information

- [ ] This change is backwards-breaking