### PR TITLE
chore(mme): enable LSAN for C++ MME files for production

### DIFF
--- a/lte/gateway/c/core/oai/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/CMakeLists.txt
@@ -59,6 +59,11 @@ set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fprofile-arcs
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
 set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
 
+# Some unit tests do not pass with LSAN enabled. Only enable LSAN for production non-test builds as a workaround.
+if (NOT BUILD_TESTS)
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
+endif ()
+
 ################################################################
 # Set proto directory for state proto definitions
 ################################################################


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
To enable LSAN for C++ files, we need to also add this following line
```
  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
```

Avoid adding LSAN for production builds when building for test, as some tests do not pass.
```bash
cd  /workspaces/magma/build/c/core/oai && ctest --output-on-failure -R  ".*"
Test project /workspaces/magma/build/c/core/oai
      Start  1: test_mme_app_ue_context
 1/25 Test  #1: test_mme_app_ue_context ....................   Passed    0.03 sec
      Start  2: test_mme_app_nas_encode_decode
 2/25 Test  #2: test_mme_app_nas_encode_decode .............   Passed    0.01 sec
      Start  3: test_nas_eps_quality_of_service
 3/25 Test  #3: test_nas_eps_quality_of_service ............   Passed    0.01 sec
      Start  4: test_nas_apn_ambr
 4/25 Test  #4: test_nas_apn_ambr ..........................   Passed    0.01 sec
      Start  5: test_mme_app
 5/25 Test  #5: test_mme_app ...............................   Passed   40.48 sec
      Start  6: test_ngap
 6/25 Test  #6: test_ngap ..................................   Passed    0.05 sec
      Start  7: test_itti
 7/25 Test  #7: test_itti ..................................   Passed    4.22 sec
      Start  8: test_amf_app
 8/25 Test  #8: test_amf_app ...............................   Passed    0.14 sec
      Start  9: test_smf_service_client
 9/25 Test  #9: test_smf_service_client ....................   Passed    0.04 sec
      Start 10: test_auth_service_client
10/25 Test #10: test_auth_service_client ...................   Passed    0.04 sec
      Start 11: test_s1ap
11/25 Test #11: test_s1ap ..................................   Passed   36.96 sec
      Start 12: test_nas_converter
12/25 Test #12: test_nas_converter .........................   Passed    0.03 sec
      Start 13: test_bstr
13/25 Test #13: test_bstr ..................................   Passed    0.01 sec
      Start 14: test_3gpp
14/25 Test #14: test_3gpp ..................................   Passed    0.01 sec
      Start 15: test_openflow_controller
15/25 Test #15: test_openflow_controller ...................   Passed    0.02 sec
      Start 16: test_imsi_encoder
16/25 Test #16: test_imsi_encoder ..........................   Passed    0.01 sec
      Start 17: test_gtp_app
17/25 Test #17: test_gtp_app ...............................   Passed    0.02 sec
      Start 18: test_spgw_service_impl
18/25 Test #18: test_spgw_service_impl .....................   Passed    0.04 sec
      Start 19: test_spgw_state_converter
19/25 Test #19: test_spgw_state_converter ..................Child aborted***Exception:   0.14 sec
Initializing OAI Logging
Initializing OAI Logging to syslog
Could not create logging file: Permission denied
COULD NOT CREATE A LOGGINGFILE 20220304-153557.562![==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from SPGWStateConverterTest
[ RUN      ] SPGWStateConverterTest.TestSPGWStateConversion
[       OK ] SPGWStateConverterTest.TestSPGWStateConversion (0 ms)
[ RUN      ] SPGWStateConverterTest.TestUEContextConversion
*** buffer overflow detected ***: terminated

      Start 20: test_spgw_procedures
20/25 Test #20: test_spgw_procedures .......................   Passed   45.12 sec
      Start 21: test_pgw_pco
21/25 Test #21: test_pgw_pco ...............................   Passed    0.04 sec
      Start 22: test_spgw_procedures_with_injected_state
22/25 Test #22: test_spgw_procedures_with_injected_state ...Child aborted***Exception:   0.14 sec
Initializing OAI Logging
Initializing OAI Logging to syslog
Could not create logging file: Permission denied
COULD NOT CREATE A LOGGINGFILE 20220304-153642.932![==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from SPGWAppInjectedStateProcedureTest
[ RUN      ] SPGWAppInjectedStateProcedureTest.TestDeleteSessionSuccess
Running setup
*** buffer overflow detected ***: terminated

      Start 23: test_pipelined_client
23/25 Test #23: test_pipelined_client ......................   Passed    0.02 sec
      Start 24: test_sgw_s8
24/25 Test #24: test_sgw_s8 ................................***Failed    6.58 sec
Initializing OAI Logging
Initializing OAI Logging to syslog
Could not create logging file: Permission denied
COULD NOT CREATE A LOGGINGFILE 20220304-153642.942![==========] Running 21 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 19 tests from SgwS8ConfigAndCreateMock
[ RUN      ] SgwS8ConfigAndCreateMock.create_context_on_cs_req_success
TASK_SGW_S8 terminated
[       OK ] SgwS8ConfigAndCreateMock.create_context_on_cs_req_success (1012 ms)
[ RUN      ] SgwS8ConfigAndCreateMock.create_context_on_cs_req
Could not create logging file: Permission denied
COULD NOT CREATE A LOGGINGFILE 20220304-153644.942!TASK_SGW_S8 terminated
[       OK ] SgwS8ConfigAndCreateMock.create_context_on_cs_req (1002 ms)
[ RUN      ] SgwS8ConfigAndCreateMock.update_pdn_session_on_cs_rsp
Directoryd RPC failed with code 14, msg: failed to connect to all addresses
Directoryd RPC failed with code 14, msg: failed to connect to all addresses
TASK_SGW_S8 terminated
[       OK ] SgwS8ConfigAndCreateMock.update_pdn_session_on_cs_rsp (1004 ms)
[ RUN      ] SgwS8ConfigAndCreateMock.recv_different_temporary_create_session_procedure_id_on_cs_rsp
TASK_SGW_S8 terminated
[       OK ] SgwS8ConfigAndCreateMock.recv_different_temporary_create_session_procedure_id_on_cs_rsp (1001 ms)
[ RUN      ] SgwS8ConfigAndCreateMock.recv_different_sgw_s8_teid
Could not create logging file: Permission denied
COULD NOT CREATE A LOGGINGFILE 20220304-153647.942!Directoryd RPC failed with code 14, msg: failed to connect to all addresses

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: mme_app_handle_create_sess_resp()
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
Directoryd RPC failed with code 14, msg: failed to connect to all addresses
TASK_SGW_S8 terminated
[       OK ] SgwS8ConfigAndCreateMock.recv_different_sgw_s8_teid (1002 ms)
[ RUN      ] SgwS8ConfigAndCreateMock.failed_to_get_bearer_context_on_cs_rsp
TASK_SGW_S8 terminated
[       OK ] SgwS8ConfigAndCreateMock.failed_to_get_bearer_context_on_cs_rsp (1002 ms)
[ RUN      ] SgwS8ConfigAndCreateMock.delete_session_req_handling
Directoryd RPC failed with code 14, msg: failed to connect to all addresses
Directoryd RPC failed with code 14, msg: failed to connect to all addresses
LeakSanitizer:DEADLYSIGNAL
==942==ERROR: LeakSanitizer: stack-overflow on address 0x7fd65eddea70 (pc 0x7fd65eddea70 bp 0x7fd65edde830 sp 0x7fd65edde838 T40)
TASK_SGW_S8 terminated
    #0 0x7fd65eddea70  (<unknown module>)

SUMMARY: LeakSanitizer: stack-overflow (<unknown module>) 
==942==ABORTING

      Start 25: test_s6a
25/25 Test #25: test_s6a ...................................   Passed    2.54 sec

88% tests passed, 3 tests failed out of 25

Total Test time (real) = 136.74 sec

The following tests FAILED:
         19 - test_spgw_state_converter (Child aborted)
         22 - test_spgw_procedures_with_injected_state (Child aborted)
         24 - test_sgw_s8 (Failed)
Errors while running CTest
make: *** [Makefile:218: test_oai] Error 8
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI 
Will trigger a LTE integ test job on CI (https://github.com/themarwhal/magma/actions/runs/1934507853  ) (Edit: Actually realized that this does not test what I want as CI builds all services with BUILD_TYPE=Debug)
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
