### PR TITLE
fix(mme): fix asan error in mme_app_ip_imsi

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.cpp
@@ -191,7 +191,8 @@ void mme_app_remove_ue_ipv4_addr(uint32_t ipv4_addr, imsi64_t imsi64) {
         break;
       }
     }
-    if (vec_it == itr_map->second.end()) {
+    if (ueip_imsi_map.find(ipv4) != ueip_imsi_map.end() &&
+        vec_it == itr_map->second.end()) {
       OAILOG_ERROR(
           LOG_MME_APP,
           "Failed to remove an entry for ue_ip:%x from ipv4_imsi map \n",


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Fix asan error in mme_app_ip_imsi 
- Note: Can be applied to current master
- Note: This fixes one of the asan errors found in https://github.com/magma/magma/issues/11955 when running 
  `bazel test //lte/gateway/c/core/oai/test/mme_app_task:mme_procedures_test --test_output=all --config=asan`
  on the `scott/pr-giant-bazel-mme-rebase` branch

### Details
The asan error (`ERROR: AddressSanitizer: heap-use-after-free`) originates from accessing `itr_map->second.end()` after `ueip_imsi_map.erase(ipv4)` has been carried out. In `mme_app_ip_imsi.cpp` line 174 and after:
```
auto itr_map = ueip_imsi_map.find(ipv4);
```
```
if (itr_map->second.empty()) {
          ueip_imsi_map.erase(ipv4);
 }
```
```
if (vec_it == itr_map->second.end()) {...
```


## Test Plan

- Run `make test_oai`
- CI

## Additional Information


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
