### PR TITLE
fix(agw): Creating unique port number for all dedicated bearers

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
@@ -128,20 +128,21 @@ class TestMaximumBearersTwoPdnsPerUe(unittest.TestCase):
 
             print("Sleeping for 5 seconds")
             time.sleep(5)
-            for i in range(loop):
+            num_flows_per_bearer = 4
+            for idx in range(loop):
                 # Add dedicated bearer to 2nd PDN
                 print(
                     "********************** Adding dedicated bearer to ims"
                     " PDN",
                 )
                 flow_lists2.append(
-                    self._spgw_util.create_default_ipv4_flows(port_idx=i),
+                    self._spgw_util.create_default_ipv4_flows(port_idx=(idx * num_flows_per_bearer) + 10),
                 )
                 self._spgw_util.create_bearer(
                     "IMSI" + "".join([str(i) for i in req.imsi]),
                     act_def_bearer_req.m.pdnInfo.epsBearerId,
-                    flow_lists2[i],
-                    qci_val=i + 1,
+                    flow_lists2[idx],
+                    qci_val=idx + 1,
                 )
                 response = self._s1ap_wrapper.s1_util.get_response()
                 self.assertEqual(


### PR DESCRIPTION
fix(agw): Creating unique port number for all dedicated bearers

## Summary
On master code base, test case, test test_attach_detach_maxbearers_twopdns.py was failing because, as part of this TC, first PDN is created as part of attach and the dedicated bearer is created with 4 packet filters with port number 5001, 5002, 5003 and 5004.
In next step, secondary PDN is created along with 8 dedicated bearers starting same port numbers.
Since port numbers are same; most of the packet filters have loaded to secondary PDN's default bearer.
Now added logic to assign unique port number for all packet filters of dedicated bearer
## Test Plan
Executed test_attach_detach_maxbearers_twopdns.py multiple times

## Additional Information
Checking for other test case for which same port numbers are assigned for different dedicated bearer