### PR TITLE
chore(agw): Add OVS test automation.

### DIFF
--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0016-datapath-gtp-add-segmentation-offloads.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0016-datapath-gtp-add-segmentation-offloads.patch
@@ -1,13 +1,13 @@
-From bb0d5d4b0af53829c83a7dcc9e1a8e69b8019c3d Mon Sep 17 00:00:00 2001
+From f8c31deaf5c7f6a2caf68b1b4c5ae21fa78e8e6c Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 8 Jun 2021 01:44:33 +0000
-Subject: [PATCH 16/22] datapath: gtp: add segmentation offloads
+Subject: [PATCH 16/23] datapath: gtp: add segmentation offloads
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
  datapath/linux/compat/gtp.c    | 22 +++++++++++++++++++---
- tests/system-layer3-tunnels.at |  4 ++--
- 2 files changed, 21 insertions(+), 5 deletions(-)
+ tests/system-layer3-tunnels.at | 10 +++++-----
+ 2 files changed, 24 insertions(+), 8 deletions(-)
 
 diff --git a/datapath/linux/compat/gtp.c b/datapath/linux/compat/gtp.c
 index 75c5c547c..5046bd63a 100644
@@ -64,18 +64,26 @@ index 75c5c547c..5046bd63a 100644
  
  	/* Assume largest header, ie. GTPv0. */
 diff --git a/tests/system-layer3-tunnels.at b/tests/system-layer3-tunnels.at
-index 90a330281..7fcc785cb 100644
+index 90a330281..bcf5df411 100644
 --- a/tests/system-layer3-tunnels.at
 +++ b/tests/system-layer3-tunnels.at
-@@ -412,7 +412,7 @@ dnl sleep 1000
- OVS_WAIT_UNTIL([cat p1.pcap | egrep "IP 172.31.1.100.2152 > 172.31.1.1.2152: UDP, length 12" 2>&1 1>/dev/null])
+@@ -409,12 +409,12 @@ Tunnel port: at_gtp0
+ RX: 2 TX: 2 remote ip: 172.31.1.1, seq 3, pending send 0
+ ])
+ dnl sleep 1000
+-OVS_WAIT_UNTIL([cat p1.pcap | egrep "IP 172.31.1.100.2152 > 172.31.1.1.2152: UDP, length 12" 2>&1 1>/dev/null])
++OVS_WAIT_UNTIL([cat p1.pcap | egrep "IP 172.31.1.100.2152 > 172.31.1.1.2152: UDP, length 14" 2>&1 1>/dev/null])
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0000:.*0800 4500"                                     2>&1 1>/dev/null])
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0010:.*ac1f 0164 ac1f"       2>&1 1>/dev/null])
 -OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0020:  0101 0868 0868 0014 5ac9 3202 0004 0000"       2>&1 1>/dev/null])
-+OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0020:  0101 0868 0868 0014 0000 3202 0004 0000"       2>&1 1>/dev/null])
- OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0030:  0000 0003 0e00"                                2>&1 1>/dev/null])
- 
+-OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0030:  0000 0003 0e00"                                2>&1 1>/dev/null])
+-
++OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0020:  0101 0868 0868 0016 0000 3202 0006 0000"       2>&1 1>/dev/null])
++OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0030:  0000 0003 0000 0e00"                           2>&1 1>/dev/null])
++ 
  OVS_TRAFFIC_VSWITCHD_STOP
+ AT_CLEANUP
+ 
 @@ -554,7 +554,7 @@ sleep 2
  
  OVS_WAIT_UNTIL([cat p1.pcap | egrep "0x0000:.*0800 4500"                                2>&1 1>/dev/null])

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0023-Set-Default-QFI-Value.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0023-Set-Default-QFI-Value.patch
@@ -1,3 +1,9 @@
+From 98e875b18456608a1668e7a9ffeaf88f266e0a86 Mon Sep 17 00:00:00 2001
+From: Nick Yurchenko <urchennko@gmail.com>
+Date: Mon, 13 Sep 2021 18:44:22 +0000
+Subject: [PATCH 23/23] Set Default QFI
+
+---
 diff --git a/datapath/linux/compat/gtp.c b/datapath/linux/compat/gtp.c
 index 725db82d2..a7033031d 100644
 --- a/datapath/linux/compat/gtp.c

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/README.md
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/README.md
@@ -6,11 +6,20 @@ There are couple of difference from existing GTP module:
    to insert gtp.ko
 2. GTP tunnel type is changed to 'gtpu'
 
-These patches should work on following kernel version:
-1. 4.9.214
-2. 4.14.171
-3. 4.19.110
-4. 5.4.50
-5. 5.6.19
+These patches works on ubuntu 20.04 kernels.
 
-Use build.sh to build OVS debian packages.
+
+1. Use build.sh to build OVS debian packages.
+
+2. To setup DEV environment run following command on magma dev VM
+`sudo bash ~/magma/third_party/gtp_ovs/ovs-gtp-patches/2.15/dev.sh setup`
+
+3. To Run OVS GTP tests on OVS kernel datapath:
+`sudo bash ~/magma/third_party/gtp_ovs/ovs-gtp-patches/2.15/dev.sh build_test`
+
+4. For OVS development, use following ovs sources
+```
+sudo su -
+cd ovs-build/ovs/
+bash /home/vagrant/magma/third_party/gtp_ovs/ovs-gtp-patches/2.15/dev.sh build_test
+```

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/dev.sh
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/dev.sh
@@ -1,0 +1,78 @@
+#! /bin/bash
+
+set -x
+OVS_VER='2.15'
+DIR="/root/ovs-build"
+
+MAGMA_ROOT="/home/vagrant/magma"
+
+function setup() {
+
+  set -e
+  apt install -y build-essential linux-headers-generic
+  apt install -y dh-make debhelper dh-python devscripts python3-dev
+  apt install -y graphviz libssl-dev python3-all python3-sphinx libunbound-dev libunwind-dev
+  apt install -y linux-modules-extra-`uname -r`
+  pip3 install scapy
+
+  rm -rf $DIR
+  mkdir $DIR
+  cd $DIR
+
+  git clone  https://github.com/openvswitch/ovs
+  cd ovs/
+  git checkout 31288dc725be6bc8eaa4e8641ee28895c9d0fd7a
+  git am "$MAGMA_ROOT/third_party/gtp_ovs/ovs-gtp-patches/$OVS_VER"/00*
+
+  cd ../
+  git clone git://git.osmocom.org/libgtpnl
+  cd libgtpnl
+  autoreconf -fi && ./configure && make && make install
+  cp ./src/.libs/libgtpnl.so.0.1.1 /lib/libgtpnl.so.0
+}
+
+
+function  build_test() {
+  service magma@* stop
+
+  sleep 1
+  ifdown gtp_br0
+  ifdown uplink_br0
+  sleep 1
+  ovs-dpctl del-dp ovs-system
+  
+  set -e
+  cd $DIR/ovs
+
+  ./boot.sh
+  ./configure  --with-linux=/lib/modules/`uname -r`/build
+  make clean
+  make -j 10
+  make -j 10 install
+
+  sudo sysctl -w kernel.core_pattern=core.%u.%p.%t
+
+  # insert required modules.
+  modprobe udp_tunnel
+  modprobe udp_tunnel
+  modprobe nf_nat
+  modprobe nf_defrag_ipv6
+  modprobe nf_defrag_ipv4
+  modprobe nf_conntrack
+  modprobe tunnel6
+  modprobe nf_defrag_ipv6
+  modprobe nft_connlimit
+  modprobe nft_counter
+  modprobe gtp
+  cp datapath/linux/*.ko /lib/modules/`uname -r`/kernel/net/openvswitch/
+  cp datapath/linux/*.ko /lib/modules/`uname -r`/updates/dkms/
+  sync
+  depmod -a
+
+  make check-kmod TESTSUITEFLAGS="144-155"
+  RET=$?
+  exit $RET
+}
+
+$1
+


### PR DESCRIPTION
Adds script to build and run OVS GTP tests for kernel datapath.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
