### PR TITLE
fix(mme): Fix bytes_to_hex stack-buffer-overflow on log.c

### DIFF
--- a/lte/gateway/c/core/oai/common/conversions.c
+++ b/lte/gateway/c/core/oai/common/conversions.c
@@ -358,3 +358,12 @@ void bstring_to_paa(const bstring bstr, paa_t* paa) {
     }
   }
 }
+
+// Return the hex representation of a char array
+char* bytes_to_hex(char* byte_array, int length, char* hex_array) {
+  int i;
+  for (i = 0; i < length; i++) {
+    snprintf(hex_array + i * 3, 3, " %02x", (unsigned char)byte_array[i]);
+  }
+  return hex_array;
+}

--- a/lte/gateway/c/core/oai/common/conversions.h
+++ b/lte/gateway/c/core/oai/common/conversions.h
@@ -754,4 +754,7 @@ void bstring_to_paa(bstring bstr, paa_t* paa);
 void copy_paa(paa_t* paa_dst, paa_t* paa_src);
 bstring paa_to_bstring(const paa_t* paa);
 
+// Return the hex representation of a char array
+char* bytes_to_hex(char* byte_array, int length, char* hex_array);
+
 #endif /* FILE_CONVERSIONS_SEEN */

--- a/lte/gateway/c/core/oai/common/log.c
+++ b/lte/gateway/c/core/oai/common/log.c
@@ -1507,14 +1507,3 @@ const char* get_short_file_name(const char* const source_file_nameP) {
 
   return root_startP + strlen(LOG_MAGMA_REPO_ROOT);
 }
-
-// Return the hex representation of a char array
-
-char* bytes_to_hex(char* byte_array, int length, char* hex_array) {
-  int i;
-  for (i = 0; i < length; i++) {
-    sprintf(hex_array + i * 3, " %02x", (unsigned char)byte_array[i]);
-  }
-  hex_array[3 * length + 1] = '\0';
-  return hex_array;
-}

--- a/lte/gateway/c/core/oai/common/log.h
+++ b/lte/gateway/c/core/oai/common/log.h
@@ -388,9 +388,6 @@ int append_log_ctx_info_prefix_id(
 
 const char* get_short_file_name(const char* const source_file_nameP);
 
-// Return the hex representation of a char array
-char* bytes_to_hex(char* byte_array, int length, char* hex_array);
-
 #define OAILOG_LOG_CONFIGURE log_configure
 #define OAILOG_LEVEL_STR2INT log_level_str2int
 #define OAILOG_LEVEL_INT2STR log_level_int2str

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -18,14 +18,13 @@
 #include <grpcpp/impl/codegen/status.h>
 #include <cstring>
 #include <string>
-#include "lte/gateway/c/core/oai/common/conversions.h"
-#include "lte/gateway/c/core/oai/common/common_defs.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include "lte/gateway/c/core/oai/common/common_defs.h"
+#include "lte/gateway/c/core/oai/common/conversions.h"
 #include "lte/gateway/c/core/oai/common/log.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Fixes #11970 
- Replace `sprintf` on bytes_to_hex array to `snprintf`
- https://www.cplusplus.com/reference/cstdio/snprintf/ `snprintf` already leaves space for the terminating null character.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- `make integ_test` 
- `make integ_test` with https://github.com/magma/magma/pull/11883 changes

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
