### PR TITLE
fix(mme): Fix gtp_app_test with ASAN enabled

### DIFF
--- a/lte/gateway/c/core/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/GTPApplication.cpp
@@ -291,7 +291,7 @@ static void add_downlink_match(of13::FlowMod& downlink_fm,
 
 static void mask_ipv6_address(uint8_t* dst, const uint8_t* src,
                               const uint8_t* mask) {
-  for (int i = 0; i < INET6_ADDRSTRLEN; i++) {
+  for (int i = 0; i < sizeof(struct in6_addr); i++) {
     dst[i] = src[i] & mask[i];
   }
 }

--- a/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.cpp
@@ -110,7 +110,7 @@ void PagingApplication::handle_paging_message(
 
 static void mask_ipv6_address(uint8_t* dst, const uint8_t* src,
                               const uint8_t* mask) {
-  for (int i = 0; i < INET6_ADDRSTRLEN; i++) {
+  for (int i = 0; i < sizeof(struct in6_addr); i++) {
     dst[i] = src[i] & mask[i];
   }
 }


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Fix a typo to change the iteration size from 46 to 16. (Synched with @pshelar on the issue, he said it's a simple typing error)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
```bash
bazel test //lte/gateway/c/core/oai/test/openflow/... --config=asan --runs_per_test=10
...
INFO: Build completed successfully, 31 total actions
//lte/gateway/c/core/oai/test/openflow:gtp_app_test                      PASSED in 1.6s
  Stats over 10 runs: max = 1.6s, min = 1.4s, avg = 1.5s, dev = 0.1s
//lte/gateway/c/core/oai/test/openflow:imsi_encoder_test                 PASSED in 1.6s
  Stats over 10 runs: max = 1.6s, min = 1.3s, avg = 1.5s, dev = 0.1s
//lte/gateway/c/core/oai/test/openflow:openflow_controller_test          PASSED in 1.6s
  Stats over 10 runs: max = 1.6s, min = 1.5s, avg = 1.6s, dev = 0.0s
```

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
