### PR TITLE
fix(mme): Fix smf_service_client test with ASAN

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
@@ -101,7 +101,8 @@ SetSMSessionContext create_sm_pdu_session(
   req_rat_specific->mutable_gnode_endpoint()->set_end_ipv4_addr(ipv4_str);
 
   // Set the PTI
-  req_rat_specific->set_procedure_trans_identity((const char*)(&(pti)));
+  req_rat_specific->set_procedure_trans_identity((const char*)(&pti),
+                                                 sizeof(uint8_t));
 
   // qos_info
   qos_info.set_qos_class_id(static_cast<magma::lte::QCI>(qos_profile.qci));

--- a/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
+++ b/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
@@ -67,25 +67,23 @@ TEST(test_create_sm_pdu_session_v4, create_sm_pdu_session_v4) {
       request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
   auto* req_cmn = request.mutable_common_context();
 
-  EXPECT_TRUE(imsi == req_cmn->sid().id().substr(4));
-  EXPECT_TRUE(magma::lte::SubscriberID_IDType::SubscriberID_IDType_IMSI ==
-              req_cmn->sid().type());
-  EXPECT_TRUE(apn == req_cmn->apn());
-  EXPECT_TRUE(magma::lte::RATType::TGPP_NR == req_cmn->rat_type());
-  EXPECT_TRUE(magma::lte::SMSessionFSMState::CREATING_0 ==
-              req_cmn->sm_session_state());
-  EXPECT_TRUE(0 == req_cmn->sm_session_version());
-  EXPECT_TRUE(pdu_session_id == rat_req->pdu_session_id());
-  EXPECT_TRUE(magma::lte::RequestType::INITIAL_REQUEST ==
-              rat_req->request_type());
+  EXPECT_EQ(imsi, req_cmn->sid().id().substr(4));
+  EXPECT_EQ(magma::lte::SubscriberID_IDType::SubscriberID_IDType_IMSI,
+            req_cmn->sid().type());
+  EXPECT_EQ(apn, req_cmn->apn());
+  EXPECT_EQ(magma::lte::RATType::TGPP_NR, req_cmn->rat_type());
+  EXPECT_EQ(magma::lte::SMSessionFSMState::CREATING_0,
+            req_cmn->sm_session_state());
+  EXPECT_EQ(0, req_cmn->sm_session_version());
+  EXPECT_EQ(pdu_session_id, rat_req->pdu_session_id());
+  EXPECT_EQ(magma::lte::RequestType::INITIAL_REQUEST, rat_req->request_type());
 
-  EXPECT_TRUE(magma::lte::PduSessionType::IPV4 == rat_req->pdu_session_type());
-  EXPECT_TRUE(1 == rat_req->mutable_gnode_endpoint()->teid());
-  EXPECT_TRUE(gnb_ip_addr ==
-              rat_req->mutable_gnode_endpoint()->end_ipv4_addr());
+  EXPECT_EQ(magma::lte::PduSessionType::IPV4, rat_req->pdu_session_type());
+  EXPECT_EQ(1, rat_req->mutable_gnode_endpoint()->teid());
+  EXPECT_EQ(gnb_ip_addr, rat_req->mutable_gnode_endpoint()->end_ipv4_addr());
   uint8_t* pti_decoded = (uint8_t*)rat_req->procedure_trans_identity().c_str();
-  EXPECT_TRUE(pti == *pti_decoded);
-  EXPECT_TRUE(ue_ipv4_addr == req_cmn->ue_ipv4());
+  EXPECT_EQ(pti, *pti_decoded);
+  EXPECT_EQ(ue_ipv4_addr, req_cmn->ue_ipv4());
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Addresses https://github.com/magma/magma/issues/11993

When running the smf_service_client test with ASAN, we currently get a stack-buffer-overflow error that looks like this
```
�[1m�[31m==24848==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffb3478ee1 at pc 0x7f30b6b83a6d bp 0x7fffb3478c90 sp 0x7fffb3478438
�[1m�[0m�[1m�[34mREAD of size 3 at 0x7fffb3478ee1 thread T0�[1m�[0m
    #0 0x7f30b6b83a6c  (/lib/x86_64-linux-gnu/libasan.so.5+0x67a6c)
    #1 0x7f3088c2ee9b in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (/lib/x86_64-linux-gnu/libstdc++.so.6+0x145e9b)
    #2 0x7f30b3f80259 in magma::lte::M5GSMSessionContext::set_procedure_trans_identity(char const*) bazel-out/k8-dbg/bin/lte/protos/session_manager_cpp_proto_pb/lte/protos/session_manager.pb.h:30430
    #3 0x7f30b3f73c86 in magma5g::create_sm_pdu_session(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned char*, unsigned int, unsigned int, unsigned int, unsigned char, unsigned char*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, ambr_t const&, unsigned int, eps_subscribed_qos_profile_s const&) lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp:104
    #4 0x55af4e7d808f in magma::lte::test_create_sm_pdu_session_v4_create_sm_pdu_session_v4_Test::TestBody() lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp:61
    #5 0x7f30897c6c8d in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*
```

My current hypothesis is that when we convert pti of type uint8 to char*, we read too much of the stack as we do not specify how long to read it. The error seems to go away if I specify sizeof(uint8). This checks out in my head, but I would love an expert look at it.

I also cleaned up the unit test to use EXPECT_EQ instead of EXPECT_TRUE. (This gives a much more helpful error message when the assertion fails)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make test_oai
```
bazel test //lte/gateway/c/core/oai/test/n11:n11_smf_service_client_test --test_output=all --config=asan --runs_per_test=10
...
INFO: Build completed successfully, 13 total actions
//lte/gateway/c/core/oai/test/n11:n11_smf_service_client_test            PASSED in 1.4s
  Stats over 10 runs: max = 1.4s, min = 1.0s, avg = 1.1s, dev = 0.2s
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
