### PR TITLE
chore(ci): remove lsan from agw-workflow

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -200,23 +200,6 @@ jobs:
             echo "Copying out test result XMLs for testing with ASAN"
             find bazel-out/k8-dbg/testlogs/ -name "*.xml" | while IFS= read -r f; do cp "$f" "c-cpp-test-results/asan_${f//\//_}"; done
             exit $TEST_RESULT
-      - name: Run `bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* --config=lsan`
-        uses: addnab/docker-run-action@v2
-        with:
-          shell: bash
-          image: ${{ env.DEVCONTAINER_IMAGE }}
-          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
-          run: |
-            cd /workspaces/magma
-            # Clean so that test XML outputs are wiped from the previous run
-            bazel clean
-            bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* --config=lsan --test_output=errors --cache_test_results=no
-            TEST_RESULT=$?
-            # copy out test results
-            echo "Copying out test result XMLs for testing with LSAN"
-            find bazel-out/k8-dbg/testlogs/ -name "*.xml" | while IFS= read -r f; do cp "$f" "c-cpp-test-results/lsan_${f//\//_}"; done
-            exit $TEST_RESULT
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Noticing that the C/C++ bazel unit tests are occasionally failing due to `(No space left on device)` (See https://github.com/magma/magma/runs/5455876165?check_suite_focus=true) This is bad because this check is required! 

To get around this, I'm removing the step to run unit tests with LSAN. This should be fine because the ASAN configuration that we have actually enables LSAN as well. So we *should* not be losing leak coverage here. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
