### PR TITLE
chore(dp): add gnu make version to list of prerequsites

### DIFF
--- a/dp/README.md
+++ b/dp/README.md
@@ -1,13 +1,13 @@
 # Magma Domain Proxy
 
-
-This instructions assumes that both minikube, kubectl and skaffold utilities are installed and available on PATH.
-Detailed instruction on how to install utilities can be found here:
+## Prerequsites
+This instructions assumes that mentioned below utilities are installed and available on PATH:
   - [minikube](https://minikube.sigs.k8s.io/docs/start/)
   - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
   - [skaffold](https://skaffold.dev/docs/install/)
   - [helm](https://helm.sh/docs/intro/install/)
   - [kubens/kubectx](https://github.com/ahmetb/kubectx#installation)
+  - [GNU Make version >= 4.2](https://www.gnu.org/software/make/)
 
 ## Local deployment without orc8r.
 


### PR DESCRIPTION
Signed-off-by: Marcin Trojanowski <marcin.trojanowski@freedomfi.com>


## Summary

This pr adds GNU make as a prerequisites for a domain-proxy build, including make version.

## Test Plan

All CI tests should pass


