### PR TITLE
feat(ci): add mypy linter for Python files

### DIFF
--- a/.github/workflows/python-linter.yml
+++ b/.github/workflows/python-linter.yml
@@ -1,0 +1,59 @@
+# Copyright 2020 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: python-linter
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+      - 'v[0-9]+.[0-9]+.?[0-9]?*'
+      - ci/python-mypy-linter
+  pull_request:
+    branches:
+      - master
+      - 'v[0-9]+.[0-9]+.?[0-9]?*'
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  python_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          base: master
+          list-files: shell
+          filters: |
+            python:
+              - 'lte/gateway/python/**'
+              - 'orc8r/gateway/python/**'
+      - uses: ricardochaves/python-lint@v1.4.0
+        if: steps.changes.outputs.python == 'true'
+        with:
+          python-root-list: ${{ steps.changes.outputs.python_files }}
+          use-pylint: false
+          use-pycodestyle: false
+          use-flake8: false
+          use-black: false
+          use-mypy: true
+          use-isort: false
+          extra-pylint-options: ""
+          extra-pycodestyle-options: ""
+          extra-flake8-options: ""
+          extra-black-options: ""
+          # for packages without __init__.py the option `--namespace-packages` needs to be set.
+          # However, for packages with __init__.py this provokes import errors.
+          extra-mypy-options: "--ignore-missing-imports --follow-imports silent"
+          extra-isort-options: ""


### PR DESCRIPTION
... but only for the ones being touched

## Summary

- Adds a mypy linter as an (optional) check to the CI.
- The check only operates on changed files.
- Non-breaking for now, as there are potentially a lot of errors and warnings atm.

## Test Plan

- local execution with [act](https://github.com/nektos/act)
- CI: https://github.com/magma/magma/actions/workflows/python-linter.yml
  - Pipeline does not run if no Python files were changed -  https://github.com/magma/magma/actions/runs/1952111424
  - Pipeline is green for files without issues - https://github.com/magma/magma/actions/runs/1952153357
  - Pipeline is red for files with issues - https://github.com/magma/magma/actions/runs/1952181625

## Additional Information

- For easy implementation this uses the Github Action [Python Code Quality and Lint](https://github.com/marketplace/actions/python-code-quality-and-lint)

## Out of scope

- Other linters are also supported and could be easily activated, if desired.
- This linter enables to do further cleanup of Python code.
  - https://github.com/magma/magma/pull/11963
  - https://github.com/magma/magma/pull/12012
- Mypy has known issues with `__init__.py` or rather the absence. More specifically it can handle folders with `__init__.py` as well as without `__init__.py` (using the `--namespace-packages` option). Whether this works in all cases and at the same time, is still to be evaluated.