### PR TITLE
chore(mme): address -Wunused-variable and -Wunused-function

### DIFF
--- a/lte/gateway/c/core/oai/common/state_converter.cpp
+++ b/lte/gateway/c/core/oai/common/state_converter.cpp
@@ -263,7 +263,6 @@ void StateConverter::proto_to_map_uint64_uint64(
     const google::protobuf::Map<uint64_t, uint64_t>& proto_map,
     map_uint64_uint64_t* map) {
   for (auto const& kv : proto_map) {
-    uint64_t id = kv.first;
     uint64_t val = kv.second;
     magma::map_rc_t m_rc = map->insert(kv.first, kv.second);
 

--- a/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -23,6 +23,8 @@ using namespace fluid_msg;
 
 namespace openflow {
 
+static struct in_addr INADDR_ZERO { .s_addr = 0 };
+
 ControllerEvent::ControllerEvent(fluid_base::OFConnection* ofconn,
                                  const ControllerEventType type)
     : ofconn_(ofconn), type_(type) {}

--- a/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.h
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/ControllerEvents.h
@@ -26,8 +26,6 @@ using namespace fluid_msg;
 
 namespace openflow {
 
-static struct in_addr INADDR_ZERO { .s_addr = 0 };
-
 enum ControllerEventType {
   EVENT_PACKET_IN,
   EVENT_SWITCH_DOWN,

--- a/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.cpp
@@ -41,8 +41,6 @@ uint32_t prefix2mask(int prefix) {
 
 void PagingApplication::event_callback(const ControllerEvent& ev,
                                        const OpenflowMessenger& messenger) {
-  struct in6_addr dest_ipv6;
-
   if (ev.get_type() == EVENT_PACKET_IN) {
     const PacketInEvent& pi = static_cast<const PacketInEvent&>(ev);
     of13::PacketIn ofpi;

--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -1169,7 +1169,6 @@ int get_decrypt_imsi_suci_extension(amf_context_t* amf_context,
                                     const std::string& mac_tag) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
 
-  int rc = RETURNerror;
   amf_ue_ngap_id_t ue_id =
       PARENT_STRUCT(amf_context, ue_m5gmm_context_s, amf_context)
           ->amf_ue_ngap_id;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -541,20 +541,6 @@ int amf_app_handle_uplink_nas_message(amf_app_desc_t* amf_app_desc_p,
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 
-static void get_ambr_unit(uint8_t apn_ambr_unit, uint32_t apn_session_ambr,
-                          uint8_t* calc_ambr_unit,
-                          uint16_t* calc_session_ambr) {
-  *calc_ambr_unit = 0;
-
-  while (apn_session_ambr) {
-    *calc_ambr_unit += 1;
-
-    apn_session_ambr >>= 2;
-  }
-
-  *calc_session_ambr = PDU_SESSION_DEFAULT_AMBR;
-}
-
 /* Received the session created response message from SMF. Populate and Send
  * PDU Session Resource Setup Request message to gNB and  PDU Session
  * Establishment Accept Message to UE*/

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -420,7 +420,6 @@ int amf_idle_mode_procedure(amf_context_t* amf_ctx) {
  **                                                                        **
  ***************************************************************************/
 void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p) {
-  hashtable_rc_t h_rc = HASH_TABLE_OK;
   magma::map_rc_t m_rc = magma::MAP_OK;
   amf_app_desc_t* amf_app_desc_p = get_amf_nas_state(false);
   amf_ue_context_t* amf_ue_context_p = &amf_app_desc_p->amf_ue_contexts;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -45,7 +45,6 @@ int amf_handle_service_request(
   amf_sap_t amf_sap;
   tmsi_t tmsi_rcv;
   char imsi[IMSI_BCD_DIGITS_MAX + 1];
-  char ip_str[INET_ADDRSTRLEN];
   uint16_t pdu_session_status = 0;
   uint32_t tmsi_stored;
   paging_context_t* paging_ctx = nullptr;

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -487,7 +487,6 @@ int amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia) {
   int rc = RETURNerror;
   amf_context_t* amf_ctxt_p = NULL;
   ue_m5gmm_context_s* ue_context = NULL;
-  int amf_cause = -1;
 
   // Local imsi to be put in imsi defined in 3gpp_23.003.h
   supi_as_imsi_t supi_imsi;

--- a/lte/gateway/c/core/oai/tasks/async_grpc_service/grpc_async_service_task.cpp
+++ b/lte/gateway/c/core/oai/tasks/async_grpc_service/grpc_async_service_task.cpp
@@ -130,7 +130,6 @@ std::function<void(grpc::Status, ResponseType)> AsyncGRPCRequest<
 void S6aProxyAsyncResponderHandler::CancelLocation(
     ServerContext* context, const CancelLocationRequest* request,
     std::function<void(grpc::Status, CancelLocationAnswer)> response_callback) {
-  auto& request_cpy = *request;
   CancelLocationAnswer ans;
   Status status;
   status = Status::OK;
@@ -152,7 +151,6 @@ void S6aProxyAsyncResponderHandler::CancelLocation(
 void S6aProxyAsyncResponderHandler::Reset(
     ServerContext* context, const ResetRequest* request,
     std::function<void(grpc::Status, ResetAnswer)> response_callback) {
-  auto& request_cpy = *request;
   ResetAnswer ans;
   Status status;
   status = Status::OK;

--- a/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -98,10 +98,6 @@ Status AmfServiceImpl::SetSmfSessionContext(
     ServerContext* context, const SetSMSessionContextAccess* request,
     SmContextVoid* response) {
   struct in_addr ip_addr = {0};
-  char ip_v4_str[INET_ADDRSTRLEN] = {0};
-  char ip_v6_str[INET6_ADDRSTRLEN] = {0};
-
-  uint32_t ip_int = 0;
   OAILOG_INFO(LOG_UTIL,
               "Received GRPC SetSmfSessionContext request from SMF\n");
 
@@ -173,8 +169,6 @@ Status AmfServiceImpl::SetSmfSessionContext(
   if (req_common.ue_ipv4().size() > 0) {
     inet_pton(AF_INET, req_common.ue_ipv4().c_str(),
               &(itti_msg.pdu_address.ipv4_address));
-    uint32_t ip_int = ntohl(ip_addr.s_addr);
-
     itti_msg.pdu_address.pdn_type = IPv4;
   }
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.cpp
@@ -144,7 +144,6 @@ int mme_app_get_imsi_from_ipv6(struct in6_addr ipv6_addr,
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
 
-  struct in6_addr ue_ip6_masked;
   auto itr_map = ueip_imsi_map.find(ipv6);
 
   if (itr_map == ueip_imsi_map.end()) {

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
@@ -215,9 +215,7 @@ int M5GSMobileIdentityMsg::DecodeImsiMobileIdentityMsg(
      coded as std::hexadecimal digits
   */
 
-  int tmp = ielen - decoded;
-  decoded = ielen;
-  return (decoded);
+  return ielen;
 };
 
 // Will be supported POST MVC
@@ -276,10 +274,7 @@ int M5GSMobileIdentityMsg::DecodeTmsiMobileIdentityMsg(
   decoded++;
   memcpy(&tmsi->m5g_tmsi, buffer + decoded, ielen - decoded);
 
-  int tmp = ielen - decoded;
-  decoded = ielen;
-
-  return (decoded);
+  return ielen;
 };
 
 // Decode M5GSMobileIdentity IE

--- a/orc8r/gateway/c/common/ebpf/EbpfMapUtils.h
+++ b/orc8r/gateway/c/common/ebpf/EbpfMapUtils.h
@@ -77,7 +77,6 @@ int bpf_map_update_elem(int fd, void* key, void* value, uint64_t flags) {
 
 int bpf_map_delete_elem(int fd, void* key) {
   union bpf_attr attr;
-  int ret;
 
   memset(&attr, 0, sizeof(attr));
   attr.map_fd = fd;


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I've been noticing a lot of unused* warnings when building MME. The full compile log can be found here: https://github.com/magma/magma/actions/runs/1959156383
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
