### PR TITLE
fix(orc8r): Update gateway device information during registration

### DIFF
--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/registration.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/registration.go
@@ -11,6 +11,7 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/bootstrapper"
+	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/device"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/tenants"
@@ -44,6 +45,12 @@ func (r *RegistrationService) Register(c context.Context, request *protos.Regist
 		return clientErr, nil
 	}
 
+	err = updateGatewayDevice(c, deviceInfo, request.Hwid, request.ChallengeKey)
+	if err != nil {
+		clientErr := makeErr(fmt.Sprintf("error updating gateway: %v", err))
+		return clientErr, nil
+	}
+
 	err = r.RegisterDevice(*deviceInfo, request.Hwid, request.ChallengeKey)
 	if err != nil {
 		clientErr := makeErr(fmt.Sprintf("error registering device: %v", err))
@@ -65,11 +72,7 @@ func (r *RegistrationService) Register(c context.Context, request *protos.Regist
 }
 
 func RegisterDevice(deviceInfo protos.GatewayDeviceInfo, hwid *protos.AccessGatewayID, challengeKey *protos.ChallengeKey) error {
-	challengeKeyBase64 := strfmt.Base64(challengeKey.Key)
-	gatewayRecord := &models.GatewayDevice{
-		HardwareID: hwid.Id,
-		Key:        &models.ChallengeKey{KeyType: challengeKey.KeyType.String(), Key: &challengeKeyBase64},
-	}
+	gatewayRecord := createGatewayDevice(hwid, challengeKey)
 	err := device.RegisterDevice(context.Background(), deviceInfo.NetworkId, orc8r.AccessGatewayRecordType, hwid.Id, gatewayRecord, serdes.Device)
 	return err
 }
@@ -113,4 +116,40 @@ func makeErr(errString string) *protos.RegisterResponse {
 		},
 	}
 	return errRes
+}
+
+// createGatewayDevice creates the gateway device model
+func createGatewayDevice(hwID *protos.AccessGatewayID, challengeKey *protos.ChallengeKey) *models.GatewayDevice {
+	challengeKeyBase64 := strfmt.Base64(challengeKey.Key)
+	return &models.GatewayDevice{
+		HardwareID: hwID.Id,
+		Key:        &models.ChallengeKey{KeyType: challengeKey.KeyType.String(), Key: &challengeKeyBase64},
+	}
+}
+
+// updateGatewayDevice writes to the device information to the gateway entity
+func updateGatewayDevice(ctx context.Context, deviceInfo *protos.GatewayDeviceInfo, hwID *protos.AccessGatewayID, challengeKey *protos.ChallengeKey) error {
+	networkID := deviceInfo.NetworkId
+	gatewayID := deviceInfo.LogicalId
+
+	ent, err := configurator.LoadEntity(
+		ctx,
+		networkID, orc8r.MagmadGatewayType, gatewayID,
+		configurator.EntityLoadCriteria{},
+		serdes.Entity,
+	)
+	if err != nil {
+		return err
+	}
+
+	device := createGatewayDevice(hwID, challengeKey)
+
+	gw := (&models.MagmadGateway{}).FromBackendModels(ent, device, nil)
+
+	_, err = configurator.UpdateEntities(ctx, networkID, gw.ToEntityUpdateCriteria(ent), serdes.Entity)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Previously, the gateway was registered to the device service but the gateway itself did not have the updated device info (i.e. hardware id and challenge key, etc.). This caused checkin_cli.py to fail bc the gateway was half registered.

Fixed so that the device field is updated upon calling register.py

Tested by spinning up orc8r, this was after running the register.py script
<img width="1297" alt="image" src="https://user-images.githubusercontent.com/25142344/157378198-2994efcb-5d02-4bfc-a1d0-f54925833bff.png">
