### PR TITLE
fix(mme): enable sgw_s8_task tests with asan

### DIFF
--- a/lte/gateway/c/core/oai/test/sgw_s8_task/sgw_dedicated_bearer.cpp
+++ b/lte/gateway/c/core/oai/test/sgw_s8_task/sgw_dedicated_bearer.cpp
@@ -305,7 +305,7 @@ TEST_F(SgwS8ConfigAndCreateMock, send_create_bearer_req_to_mme) {
               mme_app_handle_nw_init_ded_bearer_actv_req(check_params_in_cb_req(
                   cb_req.linked_eps_bearer_id, cb_req.bearer_context[0].tft)))
       .Times(1)
-      .WillOnce(ReturnFromAsyncTask(&cv));
+      .WillOnce(ReturnFromAsyncTaskWithReturn(&cv));
 
   EXPECT_NE(
       sgw_s8_handle_create_bearer_request(sgw_state, &cb_req, &cause_value),
@@ -357,7 +357,7 @@ TEST_F(SgwS8ConfigAndCreateMock, recv_create_bearer_response) {
               mme_app_handle_nw_init_ded_bearer_actv_req(check_params_in_cb_req(
                   cb_req.linked_eps_bearer_id, cb_req.bearer_context[0].tft)))
       .Times(1)
-      .WillOnce(ReturnFromAsyncTask(&cv));
+      .WillOnce(ReturnFromAsyncTaskWithReturn(&cv));
   EXPECT_NE(
       sgw_s8_handle_create_bearer_request(sgw_state, &cb_req, &cause_value),
       INVALID_IMSI64);
@@ -472,7 +472,7 @@ TEST_F(SgwS8ConfigAndCreateMock, recv_delete_bearer_req) {
               mme_app_handle_nw_init_bearer_deactv_req(check_params_in_db_req(
                   db_req.num_eps_bearer_id, db_req.eps_bearer_id)))
       .Times(1)
-      .WillOnce(ReturnFromAsyncTask(&cv));
+      .WillOnce(ReturnFromAsyncTaskWithReturn(&cv));
   EXPECT_EQ(sgw_s8_handle_delete_bearer_request(sgw_state, &db_req), RETURNok);
   cv.wait_for(lock, std::chrono::milliseconds(END_OF_TESTCASE_SLEEP_MS));
   free_wrapper(reinterpret_cast<void**>(&cb_req.pgw_cp_address));

--- a/lte/gateway/c/core/oai/test/sgw_s8_task/sgw_s8_test_attach_proc.cpp
+++ b/lte/gateway/c/core/oai/test/sgw_s8_task/sgw_s8_test_attach_proc.cpp
@@ -122,7 +122,6 @@ TEST_F(SgwS8ConfigAndCreateMock, update_pdn_session_on_cs_rsp) {
   EXPECT_EQ(sgw_s8_handle_create_session_response(sgw_state, &csresp, imsi64),
             RETURNok);
   cv.wait_for(lock, std::chrono::milliseconds(END_OF_TESTCASE_SLEEP_MS));
-
   EXPECT_TRUE((sgw_get_sgw_eps_bearer_context(csresp.context_teid)) != nullptr);
   sgw_eps_bearer_ctxt_t* bearer_ctx_p = sgw_cm_get_eps_bearer_entry(
       &sgw_pdn_session->pdn_connection, csresp.eps_bearer_id);
@@ -278,7 +277,7 @@ TEST_F(SgwS8ConfigAndCreateMock, delete_session_req_handling) {
               mme_app_handle_delete_sess_rsp(check_cause_in_ds_rsp(
                   REQUEST_ACCEPTED, session_req.sender_fteid_for_cp.teid)))
       .Times(1)
-      .WillOnce(ReturnFromAsyncTask(&cv));
+      .WillOnce(ReturnFromAsyncTaskWithReturn(&cv));
   EXPECT_EQ(sgw_s8_handle_delete_session_response(sgw_state, &ds_rsp, imsi64),
             RETURNok);
   cv.wait_for(lock, std::chrono::milliseconds(END_OF_TESTCASE_SLEEP_MS));
@@ -323,7 +322,7 @@ TEST_F(SgwS8ConfigAndCreateMock, delete_session_req_handling_invalid_teid) {
               mme_app_handle_delete_sess_rsp(check_cause_in_ds_rsp(
                   CONTEXT_NOT_FOUND, session_req.sender_fteid_for_cp.teid)))
       .Times(1)
-      .WillOnce(ReturnFromAsyncTask(&cv));
+      .WillOnce(ReturnFromAsyncTaskWithReturn(&cv));
   EXPECT_EQ(
       sgw_s8_handle_s11_delete_session_request(sgw_state, &ds_req, imsi64),
       RETURNerror);

--- a/lte/gateway/c/core/oai/test/sgw_s8_task/sgw_s8_utility.h
+++ b/lte/gateway/c/core/oai/test/sgw_s8_task/sgw_s8_utility.h
@@ -68,6 +68,11 @@ bool is_num_s1_bearers_valid(sgw_state_t* sgw_state, imsi64_t imsi64,
 
 ACTION_P(ReturnFromAsyncTask, cv) { cv->notify_all(); }
 
+ACTION_P(ReturnFromAsyncTaskWithReturn, cv) {
+  cv->notify_all();
+  return true;
+}
+
 // Initialize config params
 class SgwS8ConfigAndCreateMock : public ::testing::Test {
  public:


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Problem: Running `bazel test //lte/gateway/c/core/oai/test/sgw_s8_task/...  --config=asan` results in `runtime error: execution reached the end of a value-returning function without returning a value`.
- Solution: split `ACTION_P(ReturnFromAsyncTask...` into two versions, one that returns `true` and one without any return value.
- See:  
  - #11983 
  - https://github.com/magma/magma/issues/12024
  - https://github.com/magma/magma/issues/12025

## Test Plan

- Run bazel tests:
  `bazel test //lte/gateway/c/core/oai/test/sgw_s8_task/...  --config=asan --runs_per_test=10`
- Run `make test_oai` in dev-container
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
