### PR TITLE
chore: Push test cache for Magma VM to S3

### DIFF
--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -65,6 +65,14 @@ jobs:
         run: |
           cd lte/gateway
           vagrant ssh -c 'cd ~/magma; bazel build //...' magma
+      - name: Test all with Bazel `bazel test //... --cache_test_results=no`
+        run: |
+          cd lte/gateway
+          vagrant ssh -c 'cd ~/magma; bazel test //... --cache_test_results=no' magma
+      - name: Test C/C++ with ASAN `bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan`
+        run: |
+          cd lte/gateway
+          vagrant ssh -c 'cd ~/magma; bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan --cache_test_results=no' magma
       - name: Upload .bazel-cache and .bazel-cache-repo to S3
         run: |
           tar -zcvf ${{ env.BAZEL_CACHE_MAGMA_VM_TAR }} ${{ env.BAZEL_CACHE }}/

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -57,22 +57,22 @@ jobs:
         run: |
           cd lte/gateway
           vagrant up magma
-      - name: Build all with Bazel from scratch `bazel build //... --config=production`
+      - name: Build all with production config `bazel build //... --config=production`
         run: |
           cd lte/gateway
           vagrant ssh -c 'cd ~/magma; bazel build //... --config=production' magma
-      - name: Build all with Bazel from scratch `bazel build //...`
+      - name: Build all `bazel build //...`
         run: |
           cd lte/gateway
           vagrant ssh -c 'cd ~/magma; bazel build //...' magma
-      - name: Test all with Bazel `bazel test //... --cache_test_results=no`
+      - name: Test all `bazel test //...`
         run: |
           cd lte/gateway
-          vagrant ssh -c 'cd ~/magma; bazel test //... --cache_test_results=no' magma
+          vagrant ssh -c 'cd ~/magma; bazel test //...' magma
       - name: Test C/C++ with ASAN `bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan`
         run: |
           cd lte/gateway
-          vagrant ssh -c 'cd ~/magma; bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan --cache_test_results=no' magma
+          vagrant ssh -c 'cd ~/magma; bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan' magma
       - name: Upload .bazel-cache and .bazel-cache-repo to S3
         run: |
           tar -zcvf ${{ env.BAZEL_CACHE_MAGMA_VM_TAR }} ${{ env.BAZEL_CACHE }}/
@@ -91,18 +91,33 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_AMI_BAZEL_CACHE_S3 }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_AMI_BAZEL_CACHE_S3 }}
           aws-region: us-east-1
-      - name: Build all with Bazel from scratch `bazel build //...`
+      - name: Build all `bazel build //...`
         uses: addnab/docker-run-action@v2
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma -e ABC=123
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
             cd /workspaces/magma
             bazel build //...
+      - name: Test all  `bazel test //...`
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma
             bazel test //...
-            bazel test //... --config=asan
-            bazel test //... --config=lsan
+      - name: Test C/C++ with ASAN  `bazel build //...`
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma
+            bazel test //lte/gateway/c/... //orc8r/gateway/c/... --config=asan
       - name: Upload .bazel-cache and .bazel-cache-repo to S3
         run: |
           tar -zcvf ${{ env.BAZEL_CACHE_DEVCONTAINER_TAR }} ${{ env.BAZEL_CACHE }}/


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Magma VM cache: Improve Magma VM cache hosted on S3 by including test cache as well.
Devconainer cache:  Python tests do not pass when run with --config=asan/lsan. Modifying the cache population to only include C/C++ targets


https://github.com/magma/magma/runs/5473144787?check_suite_focus=true

![Screen Shot 2022-03-09 at 11 56 35 AM](https://user-images.githubusercontent.com/37634144/157491346-d6a4fa4c-2939-41fc-9030-a9f0bf0b7a48.png)
## Test Plan
Tested commands locally with magma VM
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
