### PR TITLE
fix: configure and enable systemd-timesyncd

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/files/timesyncd.conf
+++ b/lte/gateway/deploy/roles/dev_common/files/timesyncd.conf
@@ -1,0 +1,19 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See timesyncd.conf(5) for details.
+
+[Time]
+NTP=0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
+#FallbackNTP=ntp.ubuntu.com
+#RootDistanceMaxSec=5
+#PollIntervalMinSec=32
+#PollIntervalMaxSec=2048

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -25,6 +25,17 @@
       - ansible
   retries: 5
 
+- name: Copy over the timesyncd config
+  become: yes
+  copy:
+    src: timesyncd.conf
+    dest: /etc/systemd/timesyncd.conf
+
+- name: Make sure timesyncd is started
+  systemd:
+    name: systemd-timesyncd.service
+    state: started
+
 - name: Copy ssh keepAlive configs
   copy: src={{ item.src }} dest={{ item.dest }}
   become: yes


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Enable `systemd-timesyncd` though ansible on Vagrant dev VM.

Having time properlyt synch may help on building AGW on CI (based on this https://github.com/ninja-build/ninja/issues/1599)

## Test Plan

```
vagrant@magma-dev-focal:~$ timedatectl
               Local time: Wed 2022-03-09 21:13:44 UTC
           Universal time: Wed 2022-03-09 21:13:44 UTC
                 RTC time: Wed 2022-03-09 21:13:45
                Time zone: Etc/UTC (UTC, +0000)
System clock synchronized: yes
              NTP service: active
          RTC in local TZ: no
vagrant@magma-dev-focal:~$ sudo journalctl -fu systemd-timesyncd
-- Logs begin at Thu 2021-06-17 23:23:20 UTC. --
Jun 18 06:09:04 magma-dev-focal systemd[1]: Stopping Network Time Synchronization...
Jun 18 06:09:04 magma-dev-focal systemd[1]: systemd-timesyncd.service: Succeeded.
Jun 18 06:09:04 magma-dev-focal systemd[1]: Stopped Network Time Synchronization.
-- Reboot --
Mar 09 21:08:40 magma-dev-focal systemd[1]: Starting Network Time Synchronization...
Mar 09 21:08:40 magma-dev-focal systemd[1]: Started Network Time Synchronization.
Mar 09 21:08:40 magma-dev-focal systemd-timesyncd[4275]: Initial synchronization to time server 74.6.168.72:123 (0.pool.ntp.org).
Mar 09 21:09:41 magma-dev-focal systemd-timesyncd[4275]: No network connectivity, watching for changes.
Mar 09 21:09:47 magma-dev-focal systemd-timesyncd[4275]: Network configuration changed, trying to establish connection.
Mar 09 21:09:49 magma-dev-focal systemd-timesyncd[4275]: Network configuration changed, trying to establish connection.
Mar 09 21:09:49 magma-dev-focal systemd-timesyncd[4275]: Initial synchronization to time server 137.190.2.4:123 (0.pool.ntp.org).
^C
vagrant@magma-dev-focal:~$
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
