### PR TITLE
chore: remove unused main from C++ unit tests

### DIFF
--- a/lte/gateway/c/li_agent/src/test/test_pdu_generator.cpp
+++ b/lte/gateway/c/li_agent/src/test/test_pdu_generator.cpp
@@ -127,11 +127,5 @@ TEST_F(PDUGeneratorTest, test_generator_non_ip_packet) {
   free(pdata);
   free(phdr);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/sctpd/src/test/test_event_handler.cpp
+++ b/lte/gateway/c/sctpd/src/test/test_event_handler.cpp
@@ -138,10 +138,3 @@ TEST_F(EventHandlerTest, test_event_handler_send_ul) {
 
 }  // namespace sctpd
 }  // namespace magma
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  FLAGS_logtostderr = 1;
-  FLAGS_v = 10;
-  return RUN_ALL_TESTS();
-}

--- a/lte/gateway/c/sctpd/src/test/test_sctp_desc.cpp
+++ b/lte/gateway/c/sctpd/src/test/test_sctp_desc.cpp
@@ -101,10 +101,3 @@ TEST_F(SctpdDescTest, test_sctpd_desc) {
 
 }  // namespace sctpd
 }  // namespace magma
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  FLAGS_logtostderr = 1;
-  FLAGS_v = 10;
-  return RUN_ALL_TESTS();
-}

--- a/lte/gateway/c/session_manager/test/test_async_service.cpp
+++ b/lte/gateway/c/session_manager/test/test_async_service.cpp
@@ -166,10 +166,4 @@ TEST_F(AsyncServiceTest, test_multi_thread) {
   result1.get();
   result2.get();
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -342,10 +342,4 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
   // Since this is the final grant, we should not report anything
   EXPECT_FALSE(grant.get_update_type(&update_type));
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_cloud_reporter.cpp
+++ b/lte/gateway/c/session_manager/test/test_cloud_reporter.cpp
@@ -173,10 +173,4 @@ TEST_F(SessionReporterTest, test_multi_call) {
   // wait for callback
   evb->loopForever();
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -3458,11 +3458,4 @@ TEST_F(LocalEnforcerTest, test_sharding_of_sessions) {
   }
 }
 
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  FLAGS_logtostderr = 1;
-  FLAGS_v = 10;
-  return RUN_ALL_TESTS();
-}
-
 };  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -295,12 +295,4 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_update) {
   local_enforcer->update_session_credits_and_rules(session_map, update_response,
                                                    update);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  FLAGS_logtostderr = 1;
-  FLAGS_v = 10;
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_metering_reporter.cpp
+++ b/lte/gateway/c/session_manager/test/test_metering_reporter.cpp
@@ -86,10 +86,4 @@ TEST_F(MeteringReporterTest, test_reporting) {
     }
   }
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_polling_pipelined.cpp
+++ b/lte/gateway/c/session_manager/test/test_polling_pipelined.cpp
@@ -146,12 +146,4 @@ TEST_F(LocalEnforcerStatsPollerTest, test_poll_stats) {
       .Times(1);
   local_enforcer->poll_stats_enforcer(cookie, cookie_mask);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  FLAGS_logtostderr = 1;
-  FLAGS_v = 10;
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -285,10 +285,4 @@ TEST_F(SessionProxyResponderHandlerTest, test_abort_session) {
   session_map = session_store->read_sessions(read_req);
   EXPECT_EQ(session_map[IMSI1].size(), 0);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_session_credit.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_credit.cpp
@@ -433,10 +433,4 @@ TEST(test_get_credit_summary, test_session_credit) {
   EXPECT_NE(summary.time_of_last_usage, time_of_first_usage);
   EXPECT_GT(summary.time_of_last_usage, summary.time_of_first_usage);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -499,10 +499,4 @@ TEST_F(SessionManagerHandlerTest, test_end_session) {
   session_map = session_store->read_sessions({IMSI1});
   EXPECT_EQ(session_map[IMSI1].size(), 0);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -1094,12 +1094,4 @@ TEST_F(SessionStateTest, test_process_dynamic_rule_installs) {
   EXPECT_EQ(2, pending_activation.size());
   EXPECT_EQ(2, pending_bearer_setup.size());
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  FLAGS_logtostderr = 1;
-  FLAGS_v = 10;
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_session_state_5g.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state_5g.cpp
@@ -309,12 +309,4 @@ TEST_F(SessionStateTest5G, test_marshal_unmarshal) {
   EXPECT_EQ(unmarshaled->is_static_rule_installed("rule1"), true);
   EXPECT_EQ(unmarshaled->is_dynamic_rule_installed("rule2"), false);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  FLAGS_logtostderr = 1;
-  FLAGS_v = 10;
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -631,10 +631,4 @@ TEST_F(SessionStoreTest, test_get_session) {
   auto optional_it7 = session_store->find_session(session_map, id7_success_sid);
   EXPECT_FALSE(optional_it7);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -572,13 +572,4 @@ TEST_F(SessiondTest, end_to_end_cloud_down) {
   set_timeout(5000, end_promise);
   end_promise->get_future().get();
 }
-
-int main(int argc, char** argv) {
-  google::InitGoogleLogging(argv[0]);
-  FLAGS_logtostderr = 1;
-  FLAGS_v = 10;
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -1129,9 +1129,4 @@ TEST_F(SessionManagerHandlerTest, test_update_session_credits_and_rules_5g) {
                 .ssc_mode(),
             magma::SscMode::SSC_MODE_2);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -165,10 +165,4 @@ TEST_F(StoreClientTest, test_lambdas) {
       };
   callback();
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -399,10 +399,4 @@ TEST_F(StoredStateTest, test_policy_stats_map) {
   // Check that the value is empty by default
   EXPECT_FALSE(get_default_update_criteria().policy_version_and_stats);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_upf_node_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_upf_node_state.cpp
@@ -145,10 +145,4 @@ TEST_F(SetUPFNodeState, test_upf_session_config) {
   // Validating UPF periodic report config missmatch session
   EXPECT_EQ(ses_config.upf_session_state_size(), count);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
+++ b/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
@@ -84,10 +84,4 @@ TEST_F(SessionStateTest, test_remove_monitor) {
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 0);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 }  // namespace magma

--- a/orc8r/gateway/c/common/config/test/test_yaml_utils.cpp
+++ b/orc8r/gateway/c/common/config/test/test_yaml_utils.cpp
@@ -65,9 +65,4 @@ TEST(test_nested_overrides, test_yaml_utils) {
   EXPECT_EQ("e", merge["nest"]["a"].as<std::string>());
   EXPECT_EQ("d", merge["nest"]["c"].as<std::string>());
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
 }  // namespace magma

--- a/orc8r/gateway/c/common/service303/test/test_magma_service.cpp
+++ b/orc8r/gateway/c/common/service303/test/test_magma_service.cpp
@@ -106,10 +106,5 @@ TEST(test_magma_service, test_ReloadServiceConfig) {
   magma_service.ReloadServiceConfig(nullptr, nullptr, &response);
   EXPECT_EQ(response.result(), ReloadConfigResponse::RELOAD_UNSUPPORTED);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
 }  // namespace service303
 }  // namespace magma

--- a/orc8r/gateway/c/common/service303/test/test_metrics.cpp
+++ b/orc8r/gateway/c/common/service303/test/test_metrics.cpp
@@ -49,9 +49,4 @@ TEST_F(Test, test_metrics_registry) {
   EXPECT_EQ(registry.SizeFamilies(), 2);
   EXPECT_EQ(registry.SizeMetrics(), 4);
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
 }  // namespace magma

--- a/orc8r/gateway/c/common/service303/test/test_service303.cpp
+++ b/orc8r/gateway/c/common/service303/test/test_service303.cpp
@@ -322,9 +322,4 @@ TEST_F(Service303Test, test_enum_conversions) {
   EXPECT_EQ(second_label.name(), "gateway");
   EXPECT_EQ(second_label.value(), "1234");
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
 }  // namespace magma

--- a/orc8r/gateway/c/common/service_registry/test/test_service_registry.cpp
+++ b/orc8r/gateway/c/common/service_registry/test/test_service_registry.cpp
@@ -41,9 +41,4 @@ TEST(TestServiceRegistry, test_get_local_channel_args) {
   EXPECT_EQ(args.port, "60051");
   EXPECT_EQ(args.authority, "mobilityd.local");
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
 }  // namespace magma


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
As far as I can see, these main functions are not needed. (All tests run without them) In fact in SessionD and orc8r/gateway/c/common, about a third of the tests already don't have them. 


<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
