### PR TITLE
fix(mme): Fix network address in create bearer packet filter

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.cpp
@@ -351,7 +351,8 @@ bool SpgwServiceImpl::fillIpv4(packet_filter_contents_t* pf_content,
 
   for (int i = (TRAFFIC_FLOW_TEMPLATE_IPV4_ADDR_SIZE - 1); i >= 0; --i) {
     pf_content->ipv4remoteaddr[i].mask = (unsigned char)mask & 0xFF;
-    pf_content->ipv4remoteaddr[i].addr = (unsigned char)ipv4addrHBO & pf_content->ipv4remoteaddr[i].mask;
+    pf_content->ipv4remoteaddr[i].addr =
+        (unsigned char)ipv4addrHBO & pf_content->ipv4remoteaddr[i].mask;
     ipv4addrHBO = ipv4addrHBO >> 8;
     mask = mask >> 8;
   }

--- a/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.cpp
@@ -342,19 +342,20 @@ bool SpgwServiceImpl::fillIpv4(packet_filter_contents_t* pf_content,
   if (!ipv4network.success) {
     return false;
   }
-  uint32_t ipv4addrHBO = ipv4network.addr_hbo;
-  for (int i = (TRAFFIC_FLOW_TEMPLATE_IPV4_ADDR_SIZE - 1); i >= 0; --i) {
-    pf_content->ipv4remoteaddr[i].addr = (unsigned char)ipv4addrHBO & 0xFF;
-    ipv4addrHBO = ipv4addrHBO >> 8;
-  }
+
   uint32_t mask = UINT32_MAX;  // all ones
   mask =
       (mask << (32 -
                 ipv4network.mask_len));  // first mask_len bits are 1s, rest 0s
+  uint32_t ipv4addrHBO = ipv4network.addr_hbo;
+
   for (int i = (TRAFFIC_FLOW_TEMPLATE_IPV4_ADDR_SIZE - 1); i >= 0; --i) {
     pf_content->ipv4remoteaddr[i].mask = (unsigned char)mask & 0xFF;
+    pf_content->ipv4remoteaddr[i].addr = (unsigned char)ipv4addrHBO & pf_content->ipv4remoteaddr[i].mask;
+    ipv4addrHBO = ipv4addrHBO >> 8;
     mask = mask >> 8;
   }
+
   OAILOG_DEBUG(
       LOG_UTIL,
       "Network Address: %d.%d.%d.%d "

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -467,6 +467,8 @@ class S1ApUtil(object):
                     },
                 },
             )
+            print ("Created ", len(total_dl_ovs_flows_created),
+                    "Expected ", total_num_dl_flows_to_be_verified)
             assert (
                 len(total_dl_ovs_flows_created)
                 == total_num_dl_flows_to_be_verified

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -468,7 +468,7 @@ class S1ApUtil(object):
                 },
             )
             print ("Created ", len(total_dl_ovs_flows_created),
-                    "Expected ", total_num_dl_flows_to_be_verified)
+                   "Expected ", total_num_dl_flows_to_be_verified)
             assert (
                 len(total_dl_ovs_flows_created)
                 == total_num_dl_flows_to_be_verified

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -467,8 +467,10 @@ class S1ApUtil(object):
                     },
                 },
             )
-            print ("Created ", len(total_dl_ovs_flows_created),
-                   "Expected ", total_num_dl_flows_to_be_verified)
+            print(
+                "OVS DL flows created ", len(total_dl_ovs_flows_created),
+                "expected ", total_num_dl_flows_to_be_verified,
+            )
             assert (
                 len(total_dl_ovs_flows_created)
                 == total_num_dl_flows_to_be_verified

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
@@ -137,11 +137,12 @@ class TestMaximumBearersTwoPdnsPerUe(unittest.TestCase):
                     " PDN",
                 )
 
-                uniq_port_idx = pdn_count*100 + idx*num_flows_per_bearer
+                uniq_port_idx = pdn_count * 100 + idx * num_flows_per_bearer
 
                 flow_lists2.append(
                     self._spgw_util.create_default_ipv4_flows(
-                        port_idx=uniq_port_idx),
+                        port_idx=uniq_port_idx,
+                    ),
                 )
                 self._spgw_util.create_bearer(
                     "IMSI" + "".join([str(i) for i in req.imsi]),

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
@@ -41,7 +41,7 @@ class TestMaximumBearersTwoPdnsPerUe(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
 
         # 1 oai PDN + 1 dedicated bearer, 1 ims pdn + 8 dedicated bearers
-        loop = 8
+        num_ims_ded_bearers = 8
 
         # APN of the secondary PDN
         ims = {
@@ -129,14 +129,19 @@ class TestMaximumBearersTwoPdnsPerUe(unittest.TestCase):
             print("Sleeping for 5 seconds")
             time.sleep(5)
             num_flows_per_bearer = 4
-            for idx in range(loop):
+            pdn_count = 1
+            for idx in range(num_ims_ded_bearers):
                 # Add dedicated bearer to 2nd PDN
                 print(
                     "********************** Adding dedicated bearer to ims"
                     " PDN",
                 )
+
+                uniq_port_idx = pdn_count*100 + idx*num_flows_per_bearer
+
                 flow_lists2.append(
-                    self._spgw_util.create_default_ipv4_flows(port_idx=(idx * num_flows_per_bearer) + 10),
+                    self._spgw_util.create_default_ipv4_flows(
+                        port_idx=uniq_port_idx),
                 )
                 self._spgw_util.create_bearer(
                     "IMSI" + "".join([str(i) for i in req.imsi]),


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The test case [test_attach_detach_maxbearers_twopdns.py](https://github.com/magma/magma/blob/master/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py) started failing after the changes in https://github.com/magma/magma/commit/b4fc6908954e49e3b9e47fa3cfe0e4ff2c9fdea2 . 
The new `parseIpv4Network` logic behaves differently from `folly::IPAddress::tryCreateNetwork` when the input address is of the form "192.168.129.42/16". Specifically, the output is:

- folly::IPAddress::tryCreateNetwork("192.168.129.42/16") -> (192.168.0.0, 16)
- parseIpv4Network("192.168.129.42/16") -> (192.168.129.42, 16)

Since the default downlink flow rules in `s1ap_utils.py` include rules for "192.168.129.42/32" and "192.168.129.42/16", the above logic , in addition with the overlapping port number range (as highlighted in https://github.com/magma/magma/pull/11969) , was causing an overlap on flow rules. This was causing the number of created rules to be 28, while the expected count was 33 ( = 1 default + 8 bearers * 4 rules_per_bearer). 

This can be seen by dumping all the DL flows from OVS for `test_attach_detach_maxbearers_twopdns.py` on:

https://github.com/magma/magma/commit/2d306616f554475b0af0d357a9a481c53b17e70b , which shows [33 downlink flows ](https://github.com/magma/magma/files/8218894/dlflows_2d30.txt)

https://github.com/magma/magma/commit/b4fc6908954e49e3b9e47fa3cfe0e4ff2c9fdea2, which shows [28 downlink flows](https://github.com/magma/magma/files/8218897/dlflows_b4fc.txt)

The changes in https://github.com/magma/magma/pull/11969 circumvent the issue by expanding the port number range so that the flow rules do not overlap, but the IP address match is still incorrect.

This change:
1. fixes the logic in `fillIpv4` to treat the IP address returned from `parseipv4network` as a string and apply the mask when copying that address into a packet filter.
2. Adds a debug log in `s1ap_utils.py` to print the number of DL flows created vs expected
3. Include the PDN count also in generating the unique port number for each bearer.

## Test Plan

- Functional test with `test_attach_detach_maxbearers_twopdns.py`
Before the change, MME Debug log reports:
```
DEBUG UTIL tasks/grpc_service/SpgwServiceIm:0358  Network Address: 192.168.129.42 Network Mask: 255.255.0.0
```
After the change
```
DEBUG UTIL tasks/grpc_service/SpgwServiceIm:0359  Network Address: 192.168.0.0 Network Mask: 255.255.0.0
```

- Sanity test
`make integ_test`
