### PR TITLE
fix(mme): Fix mme_app_remove_ue_ipv6_addr and get_msisdn_from_session…

### DIFF
--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -333,6 +333,10 @@ static int get_uli_from_session_req(
 int get_msisdn_from_session_req(
     const itti_s11_create_session_request_t* saved_req, char* msisdn) {
   int len = saved_req->msisdn.length;
+  if (len == 0) {
+    return len;
+  }
+
   int i, j;
 
   for (i = 0; i < len; ++i) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.cpp
@@ -178,17 +178,18 @@ void mme_app_remove_ue_ipv4_addr(uint32_t ipv4_addr, imsi64_t imsi64) {
     OAILOG_FUNC_OUT(LOG_MME_APP);
   } else {
     auto vec_it = itr_map->second.begin();
-    for (; vec_it != itr_map->second.end(); ++vec_it) {
+    while (vec_it != itr_map->second.end()) {
       if (*vec_it == imsi64) {
         OAILOG_DEBUG_UE(LOG_MME_APP, imsi64,
                         "Deleted ue ipv4:%x from ipv4_imsi map \n", ipv4_addr);
-        itr_map->second.erase(vec_it);
-        vec_it--;
+        vec_it = itr_map->second.erase(vec_it);
         if (itr_map->second.empty()) {
           ueip_imsi_map.erase(ipv4);
         }
         MmeNasStateManager::getInstance().write_mme_ueip_imsi_map_to_db();
         break;
+      } else {
+        vec_it++;
       }
     }
     if (ueip_imsi_map.find(ipv4) != ueip_imsi_map.end() &&
@@ -217,20 +218,22 @@ void mme_app_remove_ue_ipv6_addr(struct in6_addr ipv6_addr, imsi64_t imsi64) {
     OAILOG_FUNC_OUT(LOG_MME_APP);
   } else {
     auto vec_it = itr_map->second.begin();
-    for (; vec_it != itr_map->second.end(); ++vec_it) {
+    while (vec_it != itr_map->second.end()) {
       if (*vec_it == imsi64) {
         OAILOG_DEBUG_UE(LOG_MME_APP, imsi64,
                         "Deleted ue ipv6:%s from ipv6_imsi map \n", ipv6);
-        itr_map->second.erase(vec_it);
-        vec_it--;
+        vec_it = itr_map->second.erase(vec_it);
         if (itr_map->second.empty()) {
           ueip_imsi_map.erase(ipv6);
         }
         MmeNasStateManager::getInstance().write_mme_ueip_imsi_map_to_db();
         break;
+      } else {
+        vec_it++;
       }
     }
-    if (vec_it == itr_map->second.end()) {
+    if (ueip_imsi_map.find(ipv6) != ueip_imsi_map.end() &&
+        vec_it == itr_map->second.end()) {
       OAILOG_ERROR(
           LOG_MME_APP,
           "Failed to remove an entry for ue_ipv6:%s from ipv6_imsi map \n",


### PR DESCRIPTION
…_req length

Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Closes #12019 and #12021
- Updates `mme_app_remove_ue_ipv6_addr` with extra check for non-existing lookup and also updates `vec_it` traversal on the for loop for both `mme_app_remove_ue_...` ipv4/v6 versions
- Adds check for zero length msisdn in case it's empty 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- `make integ_test` with and without https://github.com/magma/magma/pull/11883 changes applied

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
