### PR TITLE
chore(mme): Adds newly passing OAI Core tests to Bazel configuration

### DIFF
--- a/lte/gateway/c/core/oai/test/lib/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/lib/BUILD.bazel
@@ -1,0 +1,36 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
+
+cc_test(
+    name = "lib_3gpp_test",
+    srcs = [
+        "test_3gpp.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "lib_bstr_test",
+    srcs = [
+        "test_bstr.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/n11/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/n11/BUILD.bazel
@@ -1,0 +1,36 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
+
+cc_test(
+    name = "n11_auth_service_client_test",
+    srcs = [
+        "test_auth_service_client.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "n11_smf_service_client_test",
+    srcs = [
+        "test_smf_service_client.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/openflow/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/openflow/BUILD.bazel
@@ -1,0 +1,58 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
+
+cc_library(
+    name = "openflow_mocks",
+    hdrs = [
+        "openflow_mocks.h",
+    ],
+)
+
+cc_test(
+    name = "gtp_app_test",
+    srcs = [
+        "test_gtp_app.cpp",
+    ],
+    deps = [
+        ":openflow_mocks",
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "imsi_encoder_test",
+    srcs = [
+        "test_imsi_encoder.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "openflow_controller_test",
+    srcs = [
+        "test_openflow_controller.cpp",
+    ],
+    deps = [
+        ":openflow_mocks",
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/sgw_s8_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/sgw_s8_task/BUILD.bazel
@@ -1,0 +1,65 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
+
+cc_test(
+    name = "sgw_dedicated_bearer_test",
+    srcs = [
+        "sgw_dedicated_bearer.cpp",
+    ],
+    deps = [
+        ":sgw_s8_utility",
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "sgw_s8_utility",
+    srcs = [
+        "sgw_s8_utility.cpp",
+    ],
+    hdrs = [
+        "sgw_s8_utility.h",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+    ],
+)
+
+cc_test(
+    name = "sgw_s8_recv_grpc_messages_test",
+    srcs = [
+        "sgw_s8_recv_grpc_messages.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "sgw_s8_test_attach_proc_test",
+    srcs = [
+        "sgw_s8_test_attach_proc.cpp",
+    ],
+    deps = [
+        ":sgw_s8_utility",
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)


### PR DESCRIPTION
Progress on #11656.

This subset of OAI core tests (~6 tests) are the only tests that
presently pass ASAN of the ~36 tests that exist. We must fix the ASAN
issues (or disable ASAN from CI Bazel workflow) to commit more.

Test Plan

```
bazel test //lte/gateway/c/core/...
bazel test //lte/gateway/c/core/... --config=lsan
bazel test //lte/gateway/c/core/... --config=lsan
```

Signed-off-by: Scott Moeller <electronjoe@gmail.com>