### PR TITLE
chore: fix Bazel build on Magma VM

### DIFF
--- a/lte/gateway/c/core/oai/test/mock_tasks/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/mock_tasks/BUILD.bazel
@@ -34,5 +34,6 @@ cc_library(
     ],
     deps = [
         "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Saw this issue with Magma build inside the VM and also bazel-base container (when running `bazel test //lte/gateway/c/core/...`)
![Screen Shot 2022-03-10 at 10 12 29 AM](https://user-images.githubusercontent.com/37634144/157691861-bbec46da-b03c-4993-a056-bc9042616908.png)

I wonder why we didn't see this in devcontainer? (checking inside the bazel-base too.. edit: same behavior for bazel-base :o )
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
