### PR TITLE
chore(mme): Adds newly passing OAI Core test to Bazel configuration

### DIFF
--- a/lte/gateway/c/core/oai/test/nas/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/nas/BUILD.bazel
@@ -1,0 +1,26 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+package(default_visibility = ["//lte/gateway/c/core/oai/test:__subpackages__"])
+
+cc_test(
+    name = "nas_converter_test",
+    srcs = [
+        "test_nas_converter.cpp",
+    ],
+    flaky = True,
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)


### PR DESCRIPTION
Progress on #11656.

Closes #12061.

Filed #12066 to correct the underlying flake.

Adds the unit test of `//lte/gateway/c/core/oai/test/nas:nas_converter_test`.

As noted in #12061 this test is flaky - so we add it to Bazel test suite
now and add the Flaky annotation so that it is run 3 times and any
success is deemed passing.

Test Plan

```
bazel test //lte/gateway/c/core/...
bazel test //lte/gateway/c/core/... --config=lsan
bazel test //lte/gateway/c/core/... --config=lsan
```

Signed-off-by: Scott Moeller <electronjoe@gmail.com>