### PR TITLE
fix(mme): Fix pointer misalignment on handle_paging_message

### DIFF
--- a/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.cpp
@@ -70,14 +70,13 @@ void PagingApplication::handle_paging_message(
     fluid_base::OFConnection* ofconn, uint8_t* data,
     const OpenflowMessenger& messenger) {
   // send paging request to MME
-  struct ip* ip_header = (struct ip*)(data + ETH_HEADER_LENGTH);
-  struct in_addr* dest_ipv4 = NULL;
+  struct ip ip_header;
+  memcpy(&ip_header, data + ETH_HEADER_LENGTH, sizeof(ip_header));
 
-  if ((ip_header->ip_v == 6)) {
+  if (ip_header.ip_v == 6) {
     handle_paging_ipv6_message(ofconn, data, messenger);
-
   } else {
-    dest_ipv4 = &ip_header->ip_dst;
+    struct in_addr* dest_ipv4 = &ip_header.ip_dst;
     char* dest_ip_str = inet_ntoa(*dest_ipv4);
 
     OAILOG_DEBUG(LOG_GTPV1U, "Initiating paging procedure for IP %s\n",
@@ -116,17 +115,16 @@ static void mask_ipv6_address(uint8_t* dst, const uint8_t* src,
 void PagingApplication::handle_paging_ipv6_message(
     fluid_base::OFConnection* ofconn, uint8_t* data,
     const OpenflowMessenger& messenger) {
-  // send paging request to MME
-  struct ip6_hdr* ipv6_header = (struct ip6_hdr*)(data + ETH_HEADER_LENGTH);
-  struct in6_addr* dest_ipv6 = NULL;
-  char ip6_str[INET6_ADDRSTRLEN];
-
-  if (!ipv6_header) {
+  if (!data) {
     OAILOG_ERROR(LOG_GTPV1U, "IPv6 header is NULL\n");
     return;
   }
-  dest_ipv6 = &ipv6_header->ip6_dst;
+  // send paging request to MME
+  struct ip6_hdr ipv6_header;
+  memcpy(&ipv6_header, data + ETH_HEADER_LENGTH, sizeof(ipv6_header));
 
+  char ip6_str[INET6_ADDRSTRLEN];
+  struct in6_addr* dest_ipv6 = &ipv6_header.ip6_dst;
   inet_ntop(AF_INET6, dest_ipv6, ip6_str, INET6_ADDRSTRLEN);
 
   OAILOG_DEBUG(LOG_GTPV1U, "Initiating paging procedure for IPv6 %s\n",


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- `handle_paging_message` and `handle_ipv6_paging_message` while running S1AP integ test run a pointer misalignment error was being raised:
```
Mar 09 05:13:08 magma-dev-focal mme[1166150]: /home/vagrant/magma/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.cpp:78:24: runtime error: member access within misaligned address 0x606000068cce for type 'struct ip', which requires 4 byte alignment
Mar 09 05:13:08 magma-dev-focal mme[1166150]: 0x606000068cce: note: pointer points here
Mar 09 05:13:08 magma-dev-focal mme[1166150]:  e1 00 86 dd 60 00  00 00 00 08 3a 40 20 01  00 00 00 00 00 00 00 00  00 00 00 00 00 02 fd ee  00 05
Mar 09 05:13:08 magma-dev-focal mme[1166150]:              ^
Mar 09 05:13:08 magma-dev-focal mme[1166150]: /home/vagrant/magma/lte/gateway/c/core/oai/lib/openflow/controller/PagingApplication.cpp:130:13: runtime error: member access within misaligned address 0x606000068cce for type 'struct ip6_hdr', which requires 4 byte alignment
Mar 09 05:13:08 magma-dev-focal mme[1166150]: 0x606000068cce: note: pointer points here
Mar 09 05:13:08 magma-dev-focal mme[1166150]:  e1 00 86 dd 60 00  00 00 00 08 3a 40 20 01  00 00 00 00 00 00 00 00  00 00 00 00 00 02 fd ee  00 05
Mar 09 05:13:08 magma-dev-focal mme[1166150]:   
```
- This updates the `ip` and `ip_6` headers struct to use `memcpy` to copy exact size of data to the struct
- Closes #12030 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- `make integ_test` with https://github.com/magma/magma/pull/11883 changes applied 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
