### PR TITLE
fix(amf): PDU session establishment reject with cause DNN not supported

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -678,13 +678,6 @@ int amf_send_registration_accept(amf_context_t* amf_context) {
                    "Started for ue id: " AMF_UE_NGAP_ID_FMT,
                    registration_proc->T3550.id, registration_proc->ue_id);
     }
-
-    // s6a update location request
-    int rc =
-        amf_send_n11_update_location_req(ue_m5gmm_context_p->amf_ue_ngap_id);
-    if (rc == RETURNerror) {
-      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: n11_update_location_req failure\n");
-    }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
@@ -72,10 +72,29 @@ int amf_handle_security_complete_response(
                  smc_proc->T3560.id, ue_id);
     smc_proc->T3560.id = NAS5G_TIMER_INACTIVE_ID;
 
-    /* FSM takes care of sending initial context setup request */
-    ue_state_handle_message_initial(COMMON_PROCEDURE_INITIATED1,
-                                    STATE_EVENT_SEC_MODE_COMPLETE, SESSION_NULL,
-                                    ue_mm_context, amf_ctx);
+    if (amf_ctx && IS_AMF_CTXT_PRESENT_SECURITY(amf_ctx)) {
+      if (M5G_UEContextRequest_requested != ue_mm_context->ue_context_request) {
+        /*
+         * Notify AMF that the authentication procedure successfully completed
+         */
+        amf_sap_t amf_sap = {};
+        amf_sap.primitive = AMFCN_CS_RESPONSE;
+        amf_sap.u.amf_reg.ue_id = ue_id;
+        amf_sap.u.amf_reg.ctx = amf_ctx;
+        amf_sap.u.amf_reg.notify = true;
+        amf_sap.u.amf_reg.free_proc = true;
+        amf_sap.u.amf_reg.u.common_proc = &smc_proc->amf_com_proc;
+        amf_ctx->_security.kenb_ul_count = amf_ctx->_security.ul_count;
+        amf_ctx_set_attribute_valid(amf_ctx, AMF_CTXT_MEMBER_SECURITY);
+        rc = amf_sap_send(&amf_sap);
+      }
+    }
+
+    // s6a update location request
+    int rc = amf_send_n11_update_location_req(ue_mm_context->amf_ue_ngap_id);
+    if (rc == RETURNerror) {
+      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: n11_update_location_req failure\n");
+    }
 
   } else {
     OAILOG_ERROR(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
@@ -72,24 +72,6 @@ int amf_handle_security_complete_response(
                  smc_proc->T3560.id, ue_id);
     smc_proc->T3560.id = NAS5G_TIMER_INACTIVE_ID;
 
-    if (amf_ctx && IS_AMF_CTXT_PRESENT_SECURITY(amf_ctx)) {
-      if (M5G_UEContextRequest_requested != ue_mm_context->ue_context_request) {
-        /*
-         * Notify AMF that the authentication procedure successfully completed
-         */
-        amf_sap_t amf_sap = {};
-        amf_sap.primitive = AMFCN_CS_RESPONSE;
-        amf_sap.u.amf_reg.ue_id = ue_id;
-        amf_sap.u.amf_reg.ctx = amf_ctx;
-        amf_sap.u.amf_reg.notify = true;
-        amf_sap.u.amf_reg.free_proc = true;
-        amf_sap.u.amf_reg.u.common_proc = &smc_proc->amf_com_proc;
-        amf_ctx->_security.kenb_ul_count = amf_ctx->_security.ul_count;
-        amf_ctx_set_attribute_valid(amf_ctx, AMF_CTXT_MEMBER_SECURITY);
-        rc = amf_sap_send(&amf_sap);
-      }
-    }
-
     // Send s6a update location request
     if (amf_send_n11_update_location_req(ue_mm_context->amf_ue_ngap_id) ==
         RETURNerror) {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
@@ -90,10 +90,13 @@ int amf_handle_security_complete_response(
       }
     }
 
-    // s6a update location request
-    int rc = amf_send_n11_update_location_req(ue_mm_context->amf_ue_ngap_id);
-    if (rc == RETURNerror) {
-      OAILOG_INFO(LOG_AMF_APP, "AMF_APP: n11_update_location_req failure\n");
+    // Send s6a update location request
+    if (amf_send_n11_update_location_req(ue_mm_context->amf_ue_ngap_id) ==
+        RETURNerror) {
+      OAILOG_ERROR(LOG_AMF_APP,
+                   "update location request failed for amf_ue_ngap_id "
+                   ": " AMF_UE_NGAP_ID_FMT,
+                   ue_mm_context->amf_ue_ngap_id);
     }
 
   } else {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.hpp
@@ -100,6 +100,6 @@ nas_amf_smc_proc_t* nas5g_new_smc_procedure(amf_context_t* const amf_context);
 nas5g_amf_auth_proc_t* nas5g_new_authentication_procedure(
     amf_context_t* const amf_context);
 
-int amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia);
+imsi64_t amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia);
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.hpp
@@ -76,7 +76,6 @@ int get_decrypt_imsi_suci_extension(amf_context_t* amf_context,
                                     const std::string& ue_pubkey,
                                     const std::string& ciphertext,
                                     const std::string& mac_tag);
-int amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia);
 void amf_copy_plmn_to_supi(const ImsiM5GSMobileIdentity& imsi,
                            supi_as_imsi_t& supi_imsi);
 int amf_copy_plmn_to_context(const ImsiM5GSMobileIdentity& imsi,

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -816,6 +816,7 @@ int amf_nas_proc_authentication_info_answer(
 
 imsi64_t amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia) {
   imsi64_t imsi64 = INVALID_IMSI64;
+  int rc = RETURNerror;
   amf_context_t* amf_ctxt_p = NULL;
   ue_m5gmm_context_s* ue_context = NULL;
 
@@ -897,8 +898,15 @@ imsi64_t amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia) {
    * Execute the requested new UE registration procedure
    * This will initiate identity req in DL.
    */
-  amf_proc_registration_request(aia->ue_id, is_amf_ctx_new, params);
-  OAILOG_FUNC_RETURN(LOG_NAS_AMF, imsi64);
+  rc = amf_proc_registration_request(aia->ue_id, is_amf_ctx_new, params);
+  if (rc == RETURNerror) {
+    OAILOG_ERROR(LOG_AMF_APP,
+                 "processing registration request failed for ue-id "
+                 ": " AMF_UE_NGAP_ID_FMT,
+                 aia->ue_id);
+    OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
+  }
+  OAILOG_FUNC_RETURN(LOG_AMF_APP, imsi64);
 }
 
 int amf_handle_s6a_update_location_ans(

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -891,7 +891,6 @@ imsi64_t amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia) {
 
   ue_context->amf_context.m5_guti.m_tmsi = amf_guti.m_tmsi;
   ue_context->amf_context.m5_guti.guamfi = amf_guti.guamfi;
-  imsi64 = amf_imsi_to_imsi64(params->imsi);
 
   params->decode_status = ue_context->amf_context.decode_status;
   /*
@@ -899,7 +898,7 @@ imsi64_t amf_decrypt_imsi_info_answer(itti_amf_decrypted_imsi_info_ans_t* aia) {
    * This will initiate identity req in DL.
    */
   amf_proc_registration_request(aia->ue_id, is_amf_ctx_new, params);
-  return imsi64;
+  OAILOG_FUNC_RETURN(LOG_NAS_AMF, imsi64);
 }
 
 int amf_handle_s6a_update_location_ans(

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -495,11 +495,11 @@ TEST_F(AMFAppProcedureTest, TestDeRegistration) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -711,11 +711,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -822,17 +822,19 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetupWithoutContext) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  // Send uplink nas message for registration complete response from UE
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
       sizeof(ue_registration_complete_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
-  rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
-
-  // Send uplink nas message for pdu session establishment request from UE
+  /* Send uplink nas message for pdu session establishment request from UE */
   rc = send_uplink_nas_pdu_session_establishment_request(
       amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
       sizeof(ue_pdu_session_est_req_hexbuf));
@@ -932,11 +934,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetupNoDnnNoSlice) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1038,11 +1040,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionFailure_dnn_not_subscribed) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1115,11 +1117,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_missing_dnn) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1198,11 +1200,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_unknown_pdu_session_type) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1288,11 +1290,11 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_Invalid_PDUSession_Identity) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1537,11 +1539,11 @@ TEST_F(AMFAppProcedureTest, TestPDUv6SessionSetup) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1644,11 +1646,11 @@ TEST_F(AMFAppProcedureTest, TestPDUv4v6SessionSetup) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1749,11 +1751,11 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1880,11 +1882,11 @@ TEST_F(AMFAppProcedureTest, ServiceRequestSignalling) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  send_initial_context_response(amf_app_desc_p, ue_id);
-
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1974,6 +1976,10 @@ TEST_F(AMFAppProcedureTest, ImplicitDeregDuplicateSuciReg) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
+
   send_initial_context_response(amf_app_desc_p, init_ue_id);
 
   // Send uplink nas message for registration complete response from UE
@@ -2028,6 +2034,9 @@ TEST_F(AMFAppProcedureTest, ImplicitDeregDuplicateSuciReg) {
                                                plmn, ue_smc_response_hexbuf,
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
+
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
 
   send_initial_context_response(amf_app_desc_p, updated_ue_id);
 
@@ -2132,7 +2141,13 @@ TEST_F(AMFAppProcedureTest, ServiceRequestWrongTMSI) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  // Send uplink nas message for registration complete response from UE
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, init_ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, init_ue_id, plmn, ue_registration_complete_hexbuf,
       sizeof(ue_registration_complete_hexbuf));
@@ -2140,7 +2155,7 @@ TEST_F(AMFAppProcedureTest, ServiceRequestWrongTMSI) {
 
   send_initial_context_response(amf_app_desc_p, init_ue_id);
 
-  // Send uplink nas message for pdu session establishment request from UE
+  /* Send uplink nas message for pdu session establishment request from UE */
   rc = send_uplink_nas_pdu_session_establishment_request(
       amf_app_desc_p, init_ue_id, plmn, ue_pdu_session_est_req_hexbuf,
       sizeof(ue_pdu_session_est_req_hexbuf));
@@ -2195,6 +2210,9 @@ TEST_F(AMFAppProcedureTest, ServiceRequestWrongTMSI) {
                                                plmn, ue_smc_response_hexbuf,
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
+
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
 
   send_initial_context_response(amf_app_desc_p, updated_ue_id);
 
@@ -2261,7 +2279,13 @@ TEST_F(AMFAppProcedureTest, ServiceRequestSignalWithPDU) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  // Send uplink nas message for registration complete response from UE
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
       sizeof(ue_registration_complete_hexbuf));
@@ -2269,7 +2293,7 @@ TEST_F(AMFAppProcedureTest, ServiceRequestSignalWithPDU) {
 
   send_initial_context_response(amf_app_desc_p, ue_id);
 
-  // Send uplink nas message for pdu session establishment request from UE
+  /* Send uplink nas message for pdu session establishment request from UE */
   rc = send_uplink_nas_pdu_session_establishment_request(
       amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
       sizeof(ue_pdu_session_est_req_hexbuf));
@@ -2390,7 +2414,13 @@ TEST_F(AMFAppProcedureTest, SctpShutWithServiceRequest) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  // Send uplink nas message for registration complete response from UE
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
       sizeof(ue_registration_complete_hexbuf));
@@ -2398,7 +2428,7 @@ TEST_F(AMFAppProcedureTest, SctpShutWithServiceRequest) {
 
   send_initial_context_response(amf_app_desc_p, ue_id);
 
-  // Send uplink nas message for pdu session establishment request from UE
+  /* Send uplink nas message for pdu session establishment request from UE */
   rc = send_uplink_nas_pdu_session_establishment_request(
       amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
       sizeof(ue_pdu_session_est_req_hexbuf));
@@ -2529,4 +2559,85 @@ TEST_F(AMFAppProcedureTest, TestAuthFailureFromSubscribeDbLock) {
   amf_free_ue_context(ue_context_p);
 }
 
+TEST_F(AMFAppProcedureTest, TestPDUSession_LocationUpdateFail) {
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Authentication Request to UE
+      NGAP_NAS_DL_DATA_REQ,  // Security Command Mode Request to UE
+      NGAP_NAS_DL_DATA_REQ,  // PDU Session Establishment Request with failure
+                             // sm cause
+      NGAP_NAS_DL_DATA_REQ,  // Deregistaration Accept
+      NGAP_UE_CONTEXT_RELEASE_COMMAND  // UEContextReleaseCommand
+  };
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn,
+                                           initial_ue_message_hexbuf,
+                                           sizeof(initial_ue_message_hexbuf));
+
+  /* Check if UE Context is created with correct imsi */
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  snprintf(ula_ans.imsi, sizeof(ula_ans.imsi), "%s", "123456789012345");
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNerror);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  // ue context should exist
+  ASSERT_NE(ue_context_p, nullptr);
+  memset(&ue_context_p->amf_context.apn_config_profile, 0,
+         sizeof(ue_context_p->amf_context.apn_config_profile));
+
+  /* Send uplink nas message for pdu session establishment request from UE */
+  rc = send_uplink_nas_pdu_session_establishment_request(
+      amf_app_desc_p, ue_id, plmn, ue_pdu_session_est_req_hexbuf,
+      sizeof(ue_pdu_session_est_req_hexbuf));
+  EXPECT_EQ(rc, RETURNok);
+
+  ue_context_p = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  // ue context should exist
+  ASSERT_NE(ue_context_p, nullptr);
+  // smf context should not be present
+  EXPECT_EQ(ue_context_p->amf_context.smf_ctxt_map.size(), 0);
+
+  /* Send uplink nas message for deregistration complete response from UE */
+  rc = send_uplink_nas_ue_deregistration_request(
+      amf_app_desc_p, ue_id, plmn, ue_initiated_dereg_hexbuf,
+      sizeof(ue_initiated_dereg_hexbuf));
+
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_ue_context_release_complete_message(amf_app_desc_p, 1, 1, ue_id);
+  EXPECT_EQ(expected_Ids, AMFClientServicer::getInstance().msgtype_stack);
+}
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -439,7 +439,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcNoTMSI) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -499,7 +499,7 @@ TEST_F(AMFAppProcedureTest, TestDeRegistration) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -588,7 +588,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcGutiBased) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -657,7 +657,7 @@ TEST_F(AMFAppProcedureTest, TestMobileUpdatingRegistrationProcGutiBased) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -715,7 +715,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -936,7 +936,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetupNoDnnNoSlice) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1042,7 +1042,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionFailure_dnn_not_subscribed) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1119,7 +1119,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_missing_dnn) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1202,7 +1202,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_unknown_pdu_session_type) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1292,7 +1292,7 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_Invalid_PDUSession_Identity) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1437,7 +1437,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   // Send uplink nas message for registration complete response from UE
   rc = send_uplink_nas_registration_complete(
@@ -1541,7 +1541,7 @@ TEST_F(AMFAppProcedureTest, TestPDUv6SessionSetup) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1648,7 +1648,7 @@ TEST_F(AMFAppProcedureTest, TestPDUv4v6SessionSetup) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1753,7 +1753,7 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1884,7 +1884,7 @@ TEST_F(AMFAppProcedureTest, ServiceRequestSignalling) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -81,11 +81,10 @@ class AMFAppProcedureTest : public ::testing::Test {
                  .mnc_digit2 = 5,
                  .mnc_digit1 = 4};
 
-  itti_amf_decrypted_imsi_info_ans_t decrypted_imsi = {
-      .imsi = "222456000000001", .imsi_length = 15, .result = 1, .ue_id = 1};
+  itti_amf_decrypted_imsi_info_ans_t decrypted_imsi;
 
   const uint8_t intital_ue_message_suci_ext_hexbuf[65] = {
-      0x7e, 0x00, 0x41, 0x79, 0x00, 0x35, 0x01, 0x09, 0xf1, 0x07, 0x00,
+      0x7e, 0x00, 0x41, 0x79, 0x00, 0x35, 0x01, 0x22, 0x62, 0x54, 0x00,
       0x00, 0x01, 0x04, 0xc8, 0xfc, 0x0c, 0xe5, 0x47, 0x9a, 0x51, 0x5d,
       0xab, 0xf2, 0xf3, 0x45, 0xae, 0xb4, 0x66, 0x92, 0xd6, 0xff, 0x7a,
       0x5f, 0x4f, 0x57, 0x2a, 0x47, 0x99, 0xf2, 0x33, 0x69, 0x35, 0x16,
@@ -438,6 +437,10 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcNoTMSI) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
@@ -493,6 +496,10 @@ TEST_F(AMFAppProcedureTest, TestDeRegistration) {
   EXPECT_TRUE(rc == RETURNok);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -579,6 +586,10 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcGutiBased) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
@@ -644,6 +655,10 @@ TEST_F(AMFAppProcedureTest, TestMobileUpdatingRegistrationProcGutiBased) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
@@ -698,14 +713,14 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetup) {
 
   send_initial_context_response(amf_app_desc_p, ue_id);
 
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
       sizeof(ue_registration_complete_hexbuf));
-  EXPECT_TRUE(rc == RETURNok);
-
-  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
-  rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_TRUE(rc == RETURNok);
 
   /* Send uplink nas message for pdu session establishment request from UE */
@@ -919,6 +934,10 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionSetupNoDnnNoSlice) {
 
   send_initial_context_response(amf_app_desc_p, ue_id);
 
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
@@ -1021,6 +1040,10 @@ TEST_F(AMFAppProcedureTest, TestPDUSessionFailure_dnn_not_subscribed) {
 
   send_initial_context_response(amf_app_desc_p, ue_id);
 
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
@@ -1093,6 +1116,10 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_missing_dnn) {
   EXPECT_TRUE(rc == RETURNok);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1172,6 +1199,10 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_unknown_pdu_session_type) {
   EXPECT_TRUE(rc == RETURNok);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1258,6 +1289,10 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_Invalid_PDUSession_Identity) {
   EXPECT_TRUE(rc == RETURNok);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1348,33 +1383,37 @@ TEST_F(AMFAppProcedureTest, TestPDUSession_Invalid_PDUSession_Identity) {
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
 }
 
-#if 0
 TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
   amf_ue_ngap_id_t ue_id = 0;
 
   // Send the initial UE message
   imsi64_t imsi64 = 0;
-  int rc          = RETURNok;
-  imsi64          = send_initial_ue_message_no_tmsi(
+  int rc = RETURNok;
+  imsi64 = send_initial_ue_message_no_tmsi(
       amf_app_desc_p, 36, 1, 1, 0, plmn, intital_ue_message_suci_ext_hexbuf,
       sizeof(intital_ue_message_suci_ext_hexbuf));
 
-  rc = amf_decrypt_imsi_info_answer(&decrypted_imsi);
-  EXPECT_TRUE(rc == RETURNok);
+  char imsi_h[] = {"\x00\x00\x00\x00\x10"};
+  memset(&decrypted_imsi.imsi, 0, sizeof(decrypted_imsi.imsi));
+  memcpy(&decrypted_imsi.imsi, &imsi_h, sizeof(imsi_h));
+  decrypted_imsi.imsi_length = sizeof(imsi_h) + 1;
+  decrypted_imsi.result = 1;
+  decrypted_imsi.ue_id = 1;
 
-  ue_m5gmm_context_s* context_encrypted_imsi =
-    amf_get_ue_context_from_imsi(decrypted_imsi.imsi);
+  imsi64 = amf_decrypt_imsi_info_answer(&decrypted_imsi);
+  EXPECT_EQ(imsi64, 222456000000001);
 
-  ASSERT_NE(context_encrypted_imsi, nullptr);
+  char imsi[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, imsi, 15);
 
-  ue_id = context_encrypted_imsi->amf_ue_ngap_id;
-  EXPECT_TRUE(ue_id != 0);
+  // Check if UE Context is created with correct imsi
+  bool res = false;
+  res = get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id);
+  EXPECT_TRUE(res == true);
 
   // Send the authentication response message from subscriberdb
   rc = send_proc_authentication_info_answer(imsi, ue_id, true);
   EXPECT_TRUE(rc == RETURNok);
-
-  bool res = false;
 
   // Validate if authentication procedure is initialized as expected
   res = validate_auth_procedure(ue_id, 0);
@@ -1391,9 +1430,13 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
   EXPECT_TRUE(res == true);
 
   // Send uplink nas message for security mode complete response from UE
-  rc = send_uplink_nas_message_ue_smc_response(
-      amf_app_desc_p, ue_id, plmn, ue_smc_response_hexbuf,
-      sizeof(ue_smc_response_hexbuf));
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_TRUE(rc == RETURNok);
 
   // Send uplink nas message for registration complete response from UE
@@ -1404,7 +1447,6 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
 
   amf_app_handle_deregistration_req(ue_id);
 }
-#endif
 
 TEST_F(AMFAppProcedureTest, TestAuthFailureFromSubscribeDb) {
   amf_ue_ngap_id_t ue_id = 0;
@@ -1496,6 +1538,10 @@ TEST_F(AMFAppProcedureTest, TestPDUv6SessionSetup) {
   EXPECT_TRUE(rc == RETURNok);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
 
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
@@ -1600,6 +1646,10 @@ TEST_F(AMFAppProcedureTest, TestPDUv4v6SessionSetup) {
 
   send_initial_context_response(amf_app_desc_p, ue_id);
 
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
@@ -1699,13 +1749,17 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
       sizeof(ue_registration_complete_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
-
-  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for pdu session establishment request from UE */
   rc = send_uplink_nas_pdu_session_establishment_request(
@@ -1826,13 +1880,17 @@ TEST_F(AMFAppProcedureTest, ServiceRequestSignalling) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   /* Send uplink nas message for registration complete response from UE */
   rc = send_uplink_nas_registration_complete(
       amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
       sizeof(ue_registration_complete_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
-
-  send_initial_context_response(amf_app_desc_p, ue_id);
 
   /*Send UE context release request to move to idle mode*/
   send_ue_context_release_request_message(amf_app_desc_p, 1, 1, ue_id);

--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -27,6 +27,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/lib/secu/secu_defs.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_identity.hpp"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GNasEnums.h"
+#include "lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h"
 
 using ::testing::Test;
 
@@ -700,6 +701,10 @@ TEST_F(AMFAppStatelessTest, TestAfterRegistrationComplete) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_EQ(rc, RETURNok);
 
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
@@ -834,6 +839,10 @@ TEST_F(AMFAppStatelessTest, TestAfterPDUSessionEstReq) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_EQ(rc, RETURNok);
 
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
+
   send_initial_context_response(amf_app_desc_p, ue_id);
 
   /* Send uplink nas message for registration complete response from UE */
@@ -967,6 +976,10 @@ TEST_F(AMFAppStatelessTest, TestAfterPDUSessionReleaseComplete) {
                                                ue_smc_response_hexbuf,
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_EQ(rc, RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_TRUE(rc == RETURNok);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
 

--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -703,7 +703,7 @@ TEST_F(AMFAppStatelessTest, TestAfterRegistrationComplete) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
 
@@ -841,7 +841,7 @@ TEST_F(AMFAppStatelessTest, TestAfterPDUSessionEstReq) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
 
@@ -979,7 +979,7 @@ TEST_F(AMFAppStatelessTest, TestAfterPDUSessionReleaseComplete) {
 
   s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
-  EXPECT_TRUE(rc == RETURNok);
+  EXPECT_EQ(rc, RETURNok);
 
   send_initial_context_response(amf_app_desc_p, ue_id);
 

--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -27,7 +27,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/lib/secu/secu_defs.h"
 #include "lte/gateway/c/core/oai/tasks/amf/amf_identity.hpp"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GNasEnums.h"
-#include "lte/gateway/c/core/oai/test/amf/util_s6a_update_location.h"
+#include "lte/gateway/c/core/oai/test/amf/util_s6a_update_location.hpp"
 
 using ::testing::Test;
 

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -87,6 +87,8 @@ setup(
         'scripts/dp_probe_cli.py',
         'scripts/user_trace_cli.py',
         'scripts/icmpv6.py',
+        'scripts/test_supi_profile_cli.py',
+        'scripts/test_supi_decrypt_imsi_cli.py',
         'load_tests/loadtest_sessiond.py',
         'load_tests/loadtest_pipelined.py',
         'load_tests/loadtest_mobilityd.py',

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -87,8 +87,6 @@ setup(
         'scripts/dp_probe_cli.py',
         'scripts/user_trace_cli.py',
         'scripts/icmpv6.py',
-        'scripts/test_supi_profile_cli.py',
-        'scripts/test_supi_decrypt_imsi_cli.py',
         'load_tests/loadtest_sessiond.py',
         'load_tests/loadtest_pipelined.py',
         'load_tests/loadtest_mobilityd.py',


### PR DESCRIPTION
Signed-off-by: chandhu-wavelabs <chandhu.naga@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
In few of the scale tests, s6a response (having APN and AMBR) is send by subscriberdb after getting the PDU session
establishment request which was resulting in session failure.

Code changes are done to initiate the request early on to ensure AMF has all the required information to process
PDU Session creation
 ## Test Plan
 Scale test is passed with this fix. Attached one random UE - AGW message flow from scale test results.
 
![image](https://user-images.githubusercontent.com/84959602/158157664-6458d422-d02d-4c83-86b3-6b1b90de5416.png)

UT cases are passed.
![image](https://user-images.githubusercontent.com/84959602/158156629-456c8722-ff14-441f-9c34-3fa91e660474.png)
![image](https://user-images.githubusercontent.com/84959602/158157786-3c8624b3-8053-420e-aee5-ebb2f436c62c.png)



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
