### PR TITLE
test(agw): Update S1AP repo source in provisioning script

### DIFF
--- a/lte/gateway/deploy/roles/magma_test/files/clone_s1_tester.sh
+++ b/lte/gateway/deploy/roles/magma_test/files/clone_s1_tester.sh
@@ -11,15 +11,16 @@
 # limitations under the License.
 #
 
+git_src="https://github.com/magma/S1APTester.git"
+
 if [ -d "$S1AP_TESTER_SRC" ]; then
     cd "$S1AP_TESTER_SRC" || exit
     echo "Syncing repo"
-    git pull --rebase https://github.com/facebookexperimental/S1APTester.git
+    git pull --rebase $git_src
 else
     # Git clone
     echo "cloning repo"
-    git clone https://github.com/facebookexperimental/S1APTester.git \
-        "$S1AP_TESTER_SRC"
+    git clone $git_src "$S1AP_TESTER_SRC"
 
     cd "$S1AP_TESTER_SRC" || exit
 


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The `magma_test` VM clones S1APTester source code every time it is provisioned. Since the S1APTester repo moved from `facebookexternal` to `magma` GitHub organization, this script needs to be updated.

## Test Plan

- `vagrant destroy magma_test`
- `vagrant provision magma_test`
- In test VM:
-- Check Git source
```
vagrant@magma-test:~$ cd S1APTester/
vagrant@magma-test:~/S1APTester$ git remote -v
origin	https://github.com/magma/S1APTester.git (fetch)
origin	https://github.com/magma/S1APTester.git (push)
```
-- Verify sanity test
`make integ_test TESTS=s1aptests/test_attach_detach.py`