### PR TITLE
fix(orc8r): remove old server parameter from mconfig at GX/GY/SWX

### DIFF
--- a/feg/cloud/go/services/feg/servicers/protected/builder_servicer.go
+++ b/feg/cloud/go/services/feg/servicers/protected/builder_servicer.go
@@ -107,10 +107,6 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 				Servers:         models.ToMultipleServersMconfig(gxc.Server, gxc.Servers),
 				VirtualApnRules: models.ToVirtualApnRuleMconfig(gxc.VirtualApnRules),
 			}
-			// TODO(uri200): 5/7/20 remove this once backwards compatibility is not needed for the field server, remove server from swagger and mconfig
-			if len(mc.Gx.Servers) > 0 {
-				mc.Gx.Server = mc.Gx.Servers[0]
-			}
 		}
 		if gyc != nil {
 			mc.Gy = &feg_mconfig.GyConfig{
@@ -119,10 +115,6 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 				OverwriteApn:    gyc.OverwriteApn,
 				Servers:         models.ToMultipleServersMconfig(gyc.Server, gyc.Servers),
 				VirtualApnRules: models.ToVirtualApnRuleMconfig(gyc.VirtualApnRules),
-			}
-			// TODO(uri200): 5/7/20 remove this once backwards compatibility is not needed for the field server, remove server from swagger and mconfig
-			if len(mc.Gy.Servers) > 0 {
-				mc.Gy.Server = mc.Gy.Servers[0]
 			}
 		}
 		vals["session_proxy"] = mc
@@ -144,8 +136,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 	if swxc != nil {
 		mc := &feg_mconfig.SwxConfig{LogLevel: protos.LogLevel_INFO}
 		protos.FillIn(swxc, mc)
-
-		// TODO(uri200): 5/7/20 remove this once backwards compatibility is not needed for the field server, remove server from swagger and mconfig
+		mc.Server = nil
 		mc.Servers = models.ToMultipleServersMconfig(swxc.Server, swxc.Servers)
 		vals["swx_proxy"] = mc
 	}

--- a/feg/cloud/go/services/feg/servicers/protected/builder_servicer_test.go
+++ b/feg/cloud/go/services/feg/servicers/protected/builder_servicer_test.go
@@ -105,16 +105,6 @@ func TestBuilder_Build(t *testing.T) {
 			LogLevel: 1,
 			Gx: &feg_mconfig.GxConfig{
 				DisableGx: true,
-				Server: &feg_mconfig.DiamClientConfig{
-					Protocol:         "tcp",
-					Address:          "",
-					Retransmits:      0x3,
-					WatchdogInterval: 0x1,
-					RetryCount:       0x5,
-					ProductName:      "magma",
-					Realm:            "magma.com",
-					Host:             "magma-fedgw.magma.com",
-				},
 				// Expect 2, one coming from server and one from serverS
 				Servers: []*feg_mconfig.DiamClientConfig{
 					{
@@ -128,7 +118,7 @@ func TestBuilder_Build(t *testing.T) {
 						Host:             "magma-fedgw.magma.com",
 					},
 					{
-						Protocol:         "tcp",
+						Protocol:         "stcp",
 						Address:          "",
 						Retransmits:      0x3,
 						WatchdogInterval: 0x1,
@@ -149,16 +139,6 @@ func TestBuilder_Build(t *testing.T) {
 			},
 			Gy: &feg_mconfig.GyConfig{
 				DisableGy: true,
-				Server: &feg_mconfig.DiamClientConfig{
-					Protocol:         "tcp",
-					Address:          "",
-					Retransmits:      0x3,
-					WatchdogInterval: 0x1,
-					RetryCount:       0x5,
-					ProductName:      "magma",
-					Realm:            "magma.com",
-					Host:             "magma-fedgw.magma.com",
-				},
 				// Expect 2, one coming from server and one from serverS
 				Servers: []*feg_mconfig.DiamClientConfig{
 					{
@@ -172,7 +152,7 @@ func TestBuilder_Build(t *testing.T) {
 						Host:             "magma-fedgw.magma.com",
 					},
 					{
-						Protocol:         "tcp",
+						Protocol:         "stcp",
 						Address:          "",
 						Retransmits:      0x3,
 						WatchdogInterval: 0x1,
@@ -197,20 +177,10 @@ func TestBuilder_Build(t *testing.T) {
 		},
 		"swx_proxy": &feg_mconfig.SwxConfig{
 			LogLevel: 1,
-			Server: &feg_mconfig.DiamClientConfig{
-				Protocol:         "sctp",
-				Address:          "",
-				Retransmits:      0x3,
-				WatchdogInterval: 0x1,
-				RetryCount:       0x5,
-				ProductName:      "magma",
-				Realm:            "magma.com",
-				Host:             "magma-fedgw.magma.com",
-			},
 			// Expect 2, one coming from server and one from serverS
 			Servers: []*feg_mconfig.DiamClientConfig{
 				{
-					Protocol:         "sctp",
+					Protocol:         "tcp",
 					Address:          "",
 					Retransmits:      0x3,
 					WatchdogInterval: 0x1,
@@ -334,7 +304,7 @@ var defaultConfig = &models.NetworkFederationConfigs{
 		},
 		Servers: []*models.DiameterClientConfigs{
 			{
-				Protocol:         "tcp",
+				Protocol:         "stcp",
 				Retransmits:      3,
 				WatchdogInterval: 1,
 				RetryCount:       5,
@@ -365,7 +335,7 @@ var defaultConfig = &models.NetworkFederationConfigs{
 		},
 		Servers: []*models.DiameterClientConfigs{
 			{
-				Protocol:         "tcp",
+				Protocol:         "stcp",
 				Retransmits:      3,
 				WatchdogInterval: 1,
 				RetryCount:       5,
@@ -401,7 +371,7 @@ var defaultConfig = &models.NetworkFederationConfigs{
 	},
 	Swx: &models.Swx{
 		Server: &models.DiameterClientConfigs{
-			Protocol:         "sctp",
+			Protocol:         "tcp",
 			Retransmits:      3,
 			WatchdogInterval: 1,
 			RetryCount:       5,

--- a/feg/gateway/services/session_proxy/credit_control/gx/config.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/config.go
@@ -54,7 +54,6 @@ var (
 		DisableEUIIPv6IfNoIPFlag, false, "Don't use MAC based EUI-64 IPv6 address for Gx CCR if IP is not provided")
 )
 
-// TODO: refactor those functions to make it more simple
 // GetPCRFConfiguration returns a slice containing all configuration for all known PCRF
 func GetPCRFConfiguration() []*diameter.DiameterServerConfig {
 	configsPtr := &mconfig.SessionProxyConfig{}
@@ -77,20 +76,9 @@ func GetPCRFConfiguration() []*diameter.DiameterServerConfig {
 	}
 
 	gxConfigs := configsPtr.GetGx().GetServers()
-	//TODO: remove this once backwards compatibility is not needed for the field server
-	if len(gxConfigs) == 0 {
-		server := configsPtr.GetGx().GetServer()
-		if server == nil {
-			log.Print("Server configuration for Gx servers not found!!")
-		} else {
-			gxConfigs = append(gxConfigs, server)
-			log.Print("Gx Server configuration using legacy swagger attribute Server (not Servers)")
-		}
-	}
-
-	// Iterate over the slice of servers. VarEnv will apply only to index 0
-	diamServerConfigs := []*diameter.DiameterServerConfig{}
+	var diamServerConfigs []*diameter.DiameterServerConfig
 	for i, gxCfg := range gxConfigs {
+		// Iterate over the slice of servers. VarEnv will apply only to index 0
 		diamSrvCfg := &diameter.DiameterServerConfig{
 			DiameterServerConnConfig: diameter.DiameterServerConnConfig{
 				Addr:      diameter.GetValueOrEnv(diameter.AddrFlag, PCRFAddrEnv, gxCfg.GetAddress(), i),
@@ -104,9 +92,7 @@ func GetPCRFConfiguration() []*diameter.DiameterServerConfig {
 		}
 		diamServerConfigs = append(diamServerConfigs, diamSrvCfg)
 	}
-
 	return diamServerConfigs
-
 }
 
 // GetGxClientConfiguration returns a slice containing all client diameter configuration
@@ -129,19 +115,8 @@ func GetGxClientConfiguration() []*diameter.DiameterClientConfig {
 		}
 	}
 
-	diamClientsConfigs := []*diameter.DiameterClientConfig{}
+	var diamClientsConfigs []*diameter.DiameterClientConfig
 	gxConfigs := configsPtr.GetGx().GetServers()
-	//TODO: remove this once backwards compatibility is not needed for the field server
-	if len(gxConfigs) == 0 {
-		server := configsPtr.GetGx().GetServer()
-		if server == nil {
-			log.Print("Client configuration for Gx servers not found!!")
-		} else {
-			gxConfigs = append(gxConfigs, server)
-			log.Print("Gx Client configuration using legacy swagger attribute Server (not Servers)")
-		}
-	}
-
 	for i, gxCfg := range gxConfigs {
 		retries = gxCfg.GetRetryCount()
 		if retries < 1 {
@@ -165,7 +140,6 @@ func GetGxClientConfiguration() []*diameter.DiameterClientConfig {
 		diamClientsConfigs = append(diamClientsConfigs, diamCliCfg)
 	}
 	return diamClientsConfigs
-
 }
 
 func GetGxGlobalConfig() *GxGlobalConfig {

--- a/feg/gateway/services/session_proxy/credit_control/gy/config.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/config.go
@@ -95,7 +95,6 @@ func GetInitMethod() InitMethod {
 	return initMethod
 }
 
-// TODO: refactor those functions to make it more simple
 // GetOCSConfiguration returns the server configuration for the set OCS
 func GetOCSConfiguration() []*diameter.DiameterServerConfig {
 	configsPtr := &mconfig.SessionProxyConfig{}
@@ -118,20 +117,9 @@ func GetOCSConfiguration() []*diameter.DiameterServerConfig {
 	}
 
 	gyConfigs := configsPtr.GetGy().GetServers()
-	//TODO: remove this once backwards compatibility is not needed for the field server
-	if len(gyConfigs) == 0 {
-		server := configsPtr.GetGy().GetServer()
-		if server == nil {
-			log.Print("Server configuration for Gy servers not found!!")
-		} else {
-			gyConfigs = append(gyConfigs, server)
-			log.Print("Gy Server configuration using legacy swagger attribute Server (not Servers)")
-		}
-	}
-
-	// Iterate over the slice of servers. VarEnv will apply only to index 0
-	diamServerConfigs := []*diameter.DiameterServerConfig{}
+	var diamServerConfigs []*diameter.DiameterServerConfig
 	for i, gyCfg := range gyConfigs {
+		// Iterate over the slice of servers. VarEnv will apply only to index 0
 		diamSrvCfg := &diameter.DiameterServerConfig{
 			DiameterServerConnConfig: diameter.DiameterServerConnConfig{
 				Addr:      diameter.GetValueOrEnv(diameter.AddrFlag, OCSAddrEnv, gyCfg.GetAddress(), i),
@@ -169,18 +157,8 @@ func GetGyClientConfiguration() []*diameter.DiameterClientConfig {
 		}
 	}
 
-	diamClientsConfigs := []*diameter.DiameterClientConfig{}
+	var diamClientsConfigs []*diameter.DiameterClientConfig
 	gyConfigs := configsPtr.GetGy().GetServers()
-	//TODO: remove this once backwards compatibility is not needed for the field server
-	if len(gyConfigs) == 0 {
-		server := configsPtr.GetGy().GetServer()
-		if server == nil {
-			log.Print("Client configuration for Gy servers not found!!")
-		} else {
-			gyConfigs = append(gyConfigs, server)
-			log.Print("Gy Client configuration using legacy swagger attribute Server (not Servers)")
-		}
-	}
 	for i, gyCfg := range gyConfigs {
 		retries = gyCfg.GetRetryCount()
 		if retries < 1 {

--- a/feg/gateway/services/swx_proxy/servicers/conf_test.go
+++ b/feg/gateway/services/swx_proxy/servicers/conf_test.go
@@ -35,17 +35,6 @@ func TestSwxProxyMultipleConfigurationMconfig(t *testing.T) {
 	assert.Equal(t, "magma_test2", confs[1].ClientCfg.ProductName)
 }
 
-// TODO: remove  once backwards compatibility is not needed for the field server
-func TestSwxProxyLegacyConfigurationMconfig(t *testing.T) {
-	confs := generateSwxProxyConfigFromString(t, legacyServerMconfigGen)
-	assertHLRClients(t, confs)
-	// server on "server" tag should not appear
-	assert.Equal(t, 1, len(confs))
-	assert.Equal(t, "10.0.0.0:0", confs[0].ServerCfg.DiameterServerConnConfig.Addr)
-	assert.Equal(t, "magma_test0", confs[0].ClientCfg.ProductName)
-
-}
-
 func TestSwxProxyService_ValidateConfig(t *testing.T) {
 	err := servicers.ValidateSwxProxyConfig(nil)
 	assert.EqualError(t, err, "Nil SwxProxyConfig provided")

--- a/feg/gateway/services/swx_proxy/servicers/config.go
+++ b/feg/gateway/services/swx_proxy/servicers/config.go
@@ -88,22 +88,11 @@ func GetSwxProxyConfig() []*SwxProxyConfig {
 	if ttl < uint32(cache.DefaultGcInterval.Seconds()) {
 		ttl = uint32(cache.DefaultTtl.Seconds())
 	}
+
 	swxConfigs := configsPtr.GetServers()
-
-	//TODO: remove this once backwards compatibility is not needed for the field server
-	if len(swxConfigs) == 0 {
-		server := configsPtr.GetServer()
-		if server == nil {
-			glog.V(2).Infof("Server configuration for Swx servers not found!!")
-		} else {
-			swxConfigs = append(swxConfigs, server)
-			glog.V(2).Infof("Swx Server configuration using legacy swagger attribute Server (not Servers)")
-		}
-	}
-
-	// Iterate over the slice of servers. VarEnv will apply only to index 0
-	diamServerConfigs := []*SwxProxyConfig{}
+	var diamServerConfigs []*SwxProxyConfig
 	for i, swxConfig := range swxConfigs {
+		// Iterate over the slice of servers. VarEnv will apply only to index 0
 		diamSrvCfg := &SwxProxyConfig{
 			ClientCfg: &diameter.DiameterClientConfig{
 				Host:             diameter.GetValueOrEnv(diameter.HostFlag, SwxDiamHostEnv, swxConfig.GetHost(), i),


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Removing some old code that was added to provide support older versions of FEG

This removes `server` field from mconfig at GX/GY/SWX.  GX/GY/SWX uses parameter `servers` (plural) instead of `server`

## Test Plan

TerraVM
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
