### PR TITLE
fix(agw): Add typing-extensions as Python dependency

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -131,6 +131,7 @@ setup(
         'ovs>=2.13',
         'prometheus-client>=0.3.1',
         'aioeventlet==0.5.1',  # aioeventlet-build.sh
+        'typing-extensions>=4.1.1',
     ],
     extras_require={
         'dev': [

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -107,6 +107,7 @@ setup(
         "rfc3987>=1.3.0",
         "jsonpointer>=1.14",
         "webcolors>=1.11.1",
+        'typing-extensions>=4.1.1',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
## Summary

The import was introduced as part of #12012 to improve the typing of Python code. Apparently, it causes issues on bare-metal AGWs.

## Test Plan

Executed `make run` on my VM and the Python services started up. Unfortunately, I have no bare-metal AGW available to test it.

## Additional Information

- [ ] This change is backwards-breaking