### PR TITLE
fix(feg): fix incorrect conversion between integer types

### DIFF
--- a/feg/gateway/policydb/flow_parser.go
+++ b/feg/gateway/policydb/flow_parser.go
@@ -15,6 +15,7 @@ package policydb
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -168,13 +169,13 @@ func parseAddress(addr string) (*address, error) {
 		return &address{ip: ipAddr, version: version, port: 0}, nil
 	}
 
-	// Don't support port ranges for now
-	portInt, err := strconv.Atoi(matches[1])
+	portInt, err := strconv.ParseUint(matches[1], 10, 32)
 	if err != nil {
 		return nil, err
 	}
-	if portInt < 0 || portInt > 4294967295 {
-		return nil, fmt.Errorf("Number %d is outside the boundaries of unit32 type", portInt)
+	if portInt > math.MaxUint32 {
+		return nil, fmt.Errorf("number %d is outside the boundaries of unit32 type", portInt)
 	}
+
 	return &address{ip: ipAddr, version: version, port: uint32(portInt)}, nil
 }

--- a/feg/gateway/tgpp/utils.go
+++ b/feg/gateway/tgpp/utils.go
@@ -13,6 +13,7 @@ limitations under the License.
 package tgpp
 
 import (
+	"math"
 	"strconv"
 
 	"github.com/golang/glog"
@@ -33,12 +34,14 @@ func GetPlmnID(imsi string, mncLen int) []byte {
 	}
 	imsiBytes := [6]byte{}
 	for i := 0; i < 6; i++ {
-		v, err := strconv.Atoi(imsi[i : i+1])
+		v, err := strconv.ParseUint(imsi[i:i+1], 10, 8)
 		if err != nil {
-			glog.Errorf("Invalid Digit '%s' in IMSI '%s': %v", imsi[i:i+1], imsi, err)
+			glog.Errorf("invalid Digit '%s' in IMSI '%s': %v", imsi[i:i+1], imsi, err)
+			return []byte{}
 		}
-		if v < 0 || v > 255 {
-			glog.Errorf("Digit '%d' in IMSI '%s' is outside the bounds of byte type", v, imsi)
+		if v > math.MaxUint8 {
+			glog.Errorf("digit '%d' in IMSI '%s' is outside the bounds of byte type", v, imsi)
+			return []byte{}
 		}
 		imsiBytes[i] = byte(v)
 	}

--- a/feg/gateway/tools/gw_csfb_service_cli/main.go
+++ b/feg/gateway/tools/gw_csfb_service_cli/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 
@@ -157,12 +158,12 @@ func marshalLocationUpdateAccept() (decode.SGsMessageType, *any.Any, error) {
 func marshalLocationUpdateReject() (decode.SGsMessageType, *any.Any, error) {
 	var rejectCause []byte
 	if len(flag.Args()) == 2 {
-		rejectCauseCode, err := strconv.Atoi(flag.Arg(1))
+		rejectCauseCode, err := strconv.ParseUint(flag.Arg(1), 10, 8)
 		if err != nil {
 			return decode.SGsAPLocationUpdateReject, nil, err
 		}
-		if rejectCauseCode < 0 || rejectCauseCode > 255 {
-			return decode.SGsAPLocationUpdateReject, nil, fmt.Errorf("Number %d is outside the bounds of byte type", rejectCauseCode)
+		if rejectCauseCode > math.MaxUint8 {
+			return decode.SGsAPLocationUpdateReject, nil, fmt.Errorf("number %d is outside the bounds of byte type", rejectCauseCode)
 		}
 		rejectCause = []byte{byte(rejectCauseCode)}
 	} else {

--- a/feg/gateway/tools/hello_cli/main.go
+++ b/feg/gateway/tools/hello_cli/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -37,7 +38,14 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	code, _ := strconv.Atoi(flag.Arg(1))
+	code, err := strconv.ParseUint(flag.Arg(1), 10, 32)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if code > math.MaxUint32 {
+		log.Fatal(fmt.Errorf("code %d is outside the bounds of unit32 type", code))
+	}
+
 	conn, err := registry.Get().GetCloudConnection(strings.ToLower(registry.FEG_HELLO))
 	if err != nil {
 		log.Fatal(err)
@@ -45,9 +53,6 @@ func main() {
 	defer conn.Close()
 	cl := protos.NewHelloClient(conn)
 	fmt.Printf("Sending  Greeting: '%s', Code: %d\n", msg, code)
-	if code < 0 || code > 4294967295 {
-		log.Fatal(fmt.Errorf("Code %d is outside the bounds of unit32 type", code))
-	}
 	res, err := cl.SayHello(context.Background(), &protos.HelloRequest{Greeting: msg, GrpcErrCode: uint32(code)})
 	if err != nil {
 		log.Fatal(err)

--- a/feg/gateway/tools/s6a_cli/main.go
+++ b/feg/gateway/tools/s6a_cli/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -317,12 +318,12 @@ func air(cmd *commands.Command, args []string) int {
 func getPlmnID(imsi string, mncLen int) ([3]byte, error) {
 	imsiBytes := [6]byte{}
 	for i := 0; i < 6; i++ {
-		v, err := strconv.Atoi(imsi[i : i+1])
+		v, err := strconv.ParseUint(imsi[i:i+1], 10, 8)
 		if err != nil {
-			return [3]byte{}, fmt.Errorf("Invalid Digit '%s' in IMSI '%s': %v", imsi[i:i+1], imsi, err)
+			return [3]byte{}, fmt.Errorf("invalid Digit '%s' in IMSI '%s': %v", imsi[i:i+1], imsi, err)
 		}
-		if v < 0 || v > 255 {
-			return [3]byte{}, fmt.Errorf("Number %d is outside the boundaries of byte type", v)
+		if v > math.MaxUint8 {
+			return [3]byte{}, fmt.Errorf("number %d is outside the boundaries of byte type", v)
 		}
 		imsiBytes[i] = byte(v)
 	}


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

fix(feg): fix incorrect conversion between integer types

## Summary

String was parsed into an int using strconv.Atoi() which can cause incorrect conversion if INT is converted into another integer type of a smaller size. The function strconv.Atoi() has been replaced by the function strconv.ParseUint() and checks are created to see if the number is within the limits for types uint8 and uint32.

## Test Plan

I ran /magma/feg/gateway/docker/ ./build.py -c

## Additional Information

This is for code scanning alerts “Incorrect conversion between integer types”:
https://github.com/magma/magma/security/code-scanning/17
https://github.com/magma/magma/security/code-scanning/16
https://github.com/magma/magma/security/code-scanning/15
https://github.com/magma/magma/security/code-scanning/14
https://github.com/magma/magma/security/code-scanning/12
