### PR TITLE
fix(amf): fix for test_amf_stateless in Bazel test

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
@@ -190,7 +190,7 @@ int nas5g_message_decode(const unsigned char* const buffer,
                get_message_type_str(
                    static_cast<uint8_t>(msg->plain.amf.header.message_type))
                    .c_str(),
-               bytes, uint8_to_hex_string(buffer, bytes).c_str());
+               bytes, uint8_to_hex_string(buffer, length).c_str());
 
   OAILOG_INFO(LOG_AMF_APP, "Decoded msg(nas5g) id: [%x]-name [%s]",
               static_cast<uint8_t>(msg->plain.amf.header.message_type),

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GServiceRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GServiceRequest.cpp
@@ -101,9 +101,8 @@ int ServiceRequestMsg::DecodeServiceRequestMsg(ServiceRequestMsg* svc_req,
           decoded += decoded_result;
       } break;
       case NAS_MESSAGE_CONTAINER: {
-        len = len - decoded + 3;
         if ((decoded_result = DecodeServiceRequestMsg(
-                 svc_req, buffer + (decoded + 3), len)) < 0) {
+                 svc_req, buffer + (decoded + 3), len - (decoded + 3))) < 0) {
           return decoded_result;
         } else {
           decoded += (decoded_result + 3);

--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -736,14 +736,9 @@ TEST_F(AMFAppStatelessTest, TestAfterRegistrationComplete) {
 
   // Calling pseudo_amf_restart() and SetUp() simulates a service restart.
   AMFAppStatelessTest::pseudo_amf_restart();
+  EXPECT_TRUE(AmfNasStateManager::getInstance().get_ue_state_map()->isEmpty());
+  EXPECT_EQ(get_amf_nas_state(false), nullptr);
 
-  EXPECT_TRUE(amf_state_ue_id_ht->isEmpty());
-  EXPECT_TRUE(
-      amf_app_desc_p->amf_ue_contexts.gnb_ue_ngap_id_ue_context_htbl.isEmpty());
-
-  EXPECT_TRUE(amf_app_desc_p->amf_ue_contexts.imsi_amf_ue_id_htbl.isEmpty());
-  EXPECT_TRUE(amf_app_desc_p->amf_ue_contexts.tun11_ue_context_htbl.isEmpty());
-  EXPECT_TRUE(amf_app_desc_p->amf_ue_contexts.guti_ue_context_htbl.isEmpty());
   // Internally reads back the state
   AMFAppStatelessTest::SetUp();
   amf_state_ue_id_ht = AmfNasStateManager::getInstance().get_ue_state_map();
@@ -873,13 +868,8 @@ TEST_F(AMFAppStatelessTest, TestAfterPDUSessionEstReq) {
 
   // Calling pseudo_amf_restart() and SetUp() simulates a service restart.
   AMFAppStatelessTest::pseudo_amf_restart();
-
-  EXPECT_TRUE(amf_state_ue_id_ht->isEmpty());
-  EXPECT_TRUE(
-      amf_app_desc_p->amf_ue_contexts.gnb_ue_ngap_id_ue_context_htbl.isEmpty());
-  EXPECT_TRUE(amf_app_desc_p->amf_ue_contexts.imsi_amf_ue_id_htbl.isEmpty());
-  EXPECT_TRUE(amf_app_desc_p->amf_ue_contexts.tun11_ue_context_htbl.isEmpty());
-  EXPECT_TRUE(amf_app_desc_p->amf_ue_contexts.guti_ue_context_htbl.isEmpty());
+  EXPECT_TRUE(AmfNasStateManager::getInstance().get_ue_state_map()->isEmpty());
+  EXPECT_EQ(get_amf_nas_state(false), nullptr);
 
   // Internally reads back the state
   AMFAppStatelessTest::SetUp();
@@ -1034,13 +1024,8 @@ TEST_F(AMFAppStatelessTest, TestAfterPDUSessionReleaseComplete) {
 
   // Calling pseudo_amf_restart() and SetUp() simulates a service restart.
   AMFAppStatelessTest::pseudo_amf_restart();
-
-  EXPECT_TRUE(amf_state_ue_id_ht->isEmpty());
-  EXPECT_TRUE(
-      amf_app_desc_p->amf_ue_contexts.gnb_ue_ngap_id_ue_context_htbl.isEmpty());
-  EXPECT_TRUE(amf_app_desc_p->amf_ue_contexts.imsi_amf_ue_id_htbl.isEmpty());
-  EXPECT_TRUE(amf_app_desc_p->amf_ue_contexts.tun11_ue_context_htbl.isEmpty());
-  EXPECT_TRUE(amf_app_desc_p->amf_ue_contexts.guti_ue_context_htbl.isEmpty());
+  EXPECT_TRUE(AmfNasStateManager::getInstance().get_ue_state_map()->isEmpty());
+  EXPECT_EQ(get_amf_nas_state(false), nullptr);
 
   // Internally reads back the state
   AMFAppStatelessTest::SetUp();

--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -611,8 +611,8 @@ class AMFAppStatelessTest : public ::testing::Test {
     AMFClientServicer::getInstance().map_imsi_ue_proto_str.clear();
   }
 
-  // This Function mocks AMF task restart.
-  void pseudo_amf_restart() {
+  // This Function mocks AMF task stop.
+  void pseudo_amf_stop() {
     for (auto it = ue_context_map.begin(); it != ue_context_map.end();) {
       delete it->second;
       it = ue_context_map.erase(it);
@@ -734,8 +734,9 @@ TEST_F(AMFAppStatelessTest, TestAfterRegistrationComplete) {
   put_amf_ue_state(amf_app_desc_p, imsi64, false);
   EXPECT_EQ(AMFClientServicer::getInstance().map_imsi_ue_proto_str.size(), 1);
 
-  // Calling pseudo_amf_restart() and SetUp() simulates a service restart.
-  AMFAppStatelessTest::pseudo_amf_restart();
+  // Calling pseudo_amf_stop() and SetUp() simulates a service restart.
+  AMFAppStatelessTest::pseudo_amf_stop();
+  // Check if state data is cleared in AMF after pseudo_amf_stop()
   EXPECT_TRUE(AmfNasStateManager::getInstance().get_ue_state_map()->isEmpty());
   EXPECT_EQ(get_amf_nas_state(false), nullptr);
 
@@ -866,8 +867,9 @@ TEST_F(AMFAppStatelessTest, TestAfterPDUSessionEstReq) {
   put_amf_ue_state(amf_app_desc_p, imsi64, false);
   EXPECT_EQ(AMFClientServicer::getInstance().map_imsi_ue_proto_str.size(), 1);
 
-  // Calling pseudo_amf_restart() and SetUp() simulates a service restart.
-  AMFAppStatelessTest::pseudo_amf_restart();
+  // Calling pseudo_amf_stop() and SetUp() simulates a service restart.
+  AMFAppStatelessTest::pseudo_amf_stop();
+  // Check if state data is cleared in AMF after pseudo_amf_stop()
   EXPECT_TRUE(AmfNasStateManager::getInstance().get_ue_state_map()->isEmpty());
   EXPECT_EQ(get_amf_nas_state(false), nullptr);
 
@@ -1022,8 +1024,9 @@ TEST_F(AMFAppStatelessTest, TestAfterPDUSessionReleaseComplete) {
   put_amf_ue_state(amf_app_desc_p, imsi64, false);
   EXPECT_EQ(AMFClientServicer::getInstance().map_imsi_ue_proto_str.size(), 1);
 
-  // Calling pseudo_amf_restart() and SetUp() simulates a service restart.
-  AMFAppStatelessTest::pseudo_amf_restart();
+  // Calling pseudo_amf_stop() and SetUp() simulates a service restart.
+  AMFAppStatelessTest::pseudo_amf_stop();
+  // Check if state data is cleared in AMF after pseudo_amf_stop()
   EXPECT_TRUE(AmfNasStateManager::getInstance().get_ue_state_map()->isEmpty());
   EXPECT_EQ(get_amf_nas_state(false), nullptr);
 


### PR DESCRIPTION
Signed-off-by: shashidhar-patil <shashidhar.patil@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Fixes the following issues :
1)  heap-use-after-free in the test_amf_stateless UT. 
     Issue #11826 
2)  Fixing the above led to heap-buffer-overflow at `DecodeServiceRequestMsg`. The NasContainer was not being decoded in the right way. Fixed by `len - (decoded + 3)`. Issue #12144
<!-- Enumerate changes you made and why you made them -->

## Test Plan

- Bazel testing using (@electronjoe repo)   [Updated: 16/03/2022]
![bazel_test](https://user-images.githubusercontent.com/89975652/158547112-ec935b84-c9dd-4856-b054-f162ff3f465a.png)


- Validated with Unit test  [Updated: 16/03/2022]
![bazel_oai_test](https://user-images.githubusercontent.com/89975652/158547215-a3e74962-c3cc-465e-8746-3e589e649748.png)

- Verified basic sanity with UERANSIM
   PCAP Snap shot: [Updated: 16/03/2022]
![bazel_pcap](https://user-images.githubusercontent.com/89975652/158547310-ddbd1d9e-a4f4-4227-bb3f-b36cdb80179e.png)


   mme log: [Updated: 16/03/2022]
[mme.log](https://github.com/magma/magma/files/8260152/mme.log)



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
