### PR TITLE
chore(mme): add unit test for fillIpv4

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.h
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/SpgwServiceImpl.h
@@ -87,24 +87,27 @@ class SpgwServiceImpl final : public SpgwService::Service {
 
   ipv4_network_t parseIpv4Network(const std::string& ipv4network_str);
 
- private:
-  /*
-   * Fill up the packet filter contents such as flags and flow tuple fields
-   * @param pf_content: packet filter content to be filled
-   * @param flow_match_rule: pf_content is filled based on flow match rule
-   * @return bool: Return true if sueccessful, false if not
-   */
-  bool fillUpPacketFilterContents(packet_filter_contents_t* pf_content,
-                                  const FlowMatch* flow_match_rule);
-
   /*
    * Fill up the ipv4 remote address field in packet filter
    * @param pf_content: packet filter object to be filled
    * @param ipv4addr: IPv4 address in string form (e.g, "172.12.0.1")
    * @return bool: Return true if successful, false if not
+   *
+   * Visible for testing only.
+   * This function should not be used outside of this class.
    */
   bool fillIpv4(packet_filter_contents_t* pf_content,
                 const std::string& ipv4addr);
+
+ private:
+  /*
+   * Fill up the packet filter contents such as flags and flow tuple fields
+   * @param pf_content: packet filter content to be filled
+   * @param flow_match_rule: pf_content is filled based on flow match rule
+   * @return bool: Return true if successful, false if not
+   */
+  bool fillUpPacketFilterContents(packet_filter_contents_t* pf_content,
+                                  const FlowMatch* flow_match_rule);
 
   /*
    * Fill up the ipv6 remote address field in packet filter


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
- Unit test for `SpgwServiceImpl::fillIpv4` is added (see  #12038)
  - `SpgwServiceImpl::fillIpv4` is a private function. The only public function that can lead to calls in `fillIpv4` is `SpgwServiceImpl::CreateBearer` and several conditions need to be fulfilled in order to lead to `fillIpv4` calls. 
  - It seems that the `SpgwServiceImpl::fillIpv4` function is not called in the existing unit tests - all OAI unit tests succeed even if e.g. `raise(SIGSEGV);` is added to the `SpgwServiceImpl::fillIpv4` function. The same if true for the `SpgwServiceImpl::CreateBearer` function which is the only C/C++ function that can lead to calls of the `fillIpv4` function (via `fillUpPacketFilterContents`).
  - `SpgwServiceImpl::fillIpv4` is made public in order to enable direct testing and to limit extensive overhead from indirect testing via `SpgwServiceImpl::CreateBearer`.

## Test Plan
- Run tests `make test_oai`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
