### PR TITLE
fix(mme): Fix typing_extensions version dependency on magma_test

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -131,7 +131,7 @@ setup(
         'ovs>=2.13',
         'prometheus-client>=0.3.1',
         'aioeventlet==0.5.1',  # aioeventlet-build.sh
-        'typing-extensions>=4.1.1',
+        'typing-extensions',
     ],
     extras_require={
         'dev': [

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -107,7 +107,7 @@ setup(
         "rfc3987>=1.3.0",
         "jsonpointer>=1.14",
         "webcolors>=1.11.1",
-        'typing-extensions>=4.1.1',
+        'typing-extensions',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- magma_test `make` compile fails due to using python3.5, which does not find typing_extensions latest version 
- removing version declaration on both `setup.py` 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- before:
```
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache --no-build-isolation -e .[dev]
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
ERROR: Could not find a version that satisfies the requirement typing-extensions>=4.1.1 (from lte[dev])
ERROR: No matching distribution found for typing-extensions>=4.1.1
/home/vagrant/magma/orc8r/gateway/python/python.mk:139: recipe for target 'install_egg' failed
make[2]: *** [install_egg] Error 1
```
- after:
```
make[1]: Leaving directory '/home/vagrant/magma/lte/gateway/python'
#@echo "Installing swagger-codegen requirements"
#/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache -r /home/vagrant/api-bindings/requirements.txt
Copying s1aptester config files
cp /home/vagrant/magma/lte/gateway/python/integ_tests/data/s1ap_tester_cfg/* /home/vagrant/s1ap-tester
Install MySQL for upstreaming
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache mysqlclient==1.3.13
/usr/lib/python3/dist-packages/secretstorage/dhcrypto.py:15: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
  from cryptography.utils import int_from_bytes
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
Install flaky for test retries support
/home/vagrant/build/python/bin/pip3 install -q -U --cache-dir ~/.pipcache flaky
/usr/lib/python3/dist-packages/secretstorage/dhcrypto.py:15: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
  from cryptography.utils import int_from_bytes
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
touch /home/vagrant/build/python/setupinteg_env
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
