### PR TITLE
chore: Use per_file_copt for MME unit test flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,14 +31,14 @@ common:devcontainer --repository_cache=/workspaces/magma/.bazel-cache-repo
 build:devcontainer --define=folly_so=1
 
 # TEST CONFIGS
-#  Bazel test runtime default: PATH=/bin:/usr/bin:/usr/local/bin
-#  Some python tests require access to /usr/sbin binaries (e.g. route, ifconfig)
+# Bazel test runtime default: PATH=/bin:/usr/bin:/usr/local/bin
+# Some python tests require access to /usr/sbin binaries (e.g. route, ifconfig)
 build --test_env=PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin
-#  Use MAGMA_ROOT from the host system in tests.
-#  Needed by python tests (e.g. freedomfi_one_tests in enodebd)
+# Use MAGMA_ROOT from the host system in tests.
+# Needed by python tests (e.g. freedomfi_one_tests in enodebd)
 build --test_env=MAGMA_ROOT
-#  For testing compile mme libraries with unit test flag
-test --copt=-DMME_UNIT_TEST
+# Compile mme libraries with unit test flag
+test --per_file_copt=^lte/gateway/c/core/.*$@-DMME_UNIT_TEST
 
 # CODE COVERAGE CONFIGS
 build --javacopt="-source 8"


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Moving the MME unit test compile flag to be handled with --per_file_copt (Thanks TNG team (edit: @ajahl :) ) for finding this!)

I've run `bazel build //...` and then `bazel test //...`  successively with NO CACHE and Bazel seems to build less with this PR. Visibly, I was able to see that this PR leads to only the OAI directory being rebuilt with the test flag. Curiously, the cache size does not change between master and this PR. However, the build time seems to differ by some amount.

| branch | bazel build //... fresh | bazel test //... after build all | du -sh .bazel-cache after build and test |
|-|-|-|-|
| master | 415.338s | 344.743s | 5.8G |
| this PR | 399.585s | 158.011s | 5.8G |

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
