### PR TITLE
chore: experiment with only applying ASAN and LSAN to Magma C files

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -53,18 +53,14 @@ build:coverage --combined_report=lcov
 build:coverage --instrumentation_filter="//(orc8r|lte)/gateway/(c|python)[/:],-//(orc8r|lte)/protos[/:],-/*/test[/:]"
 
 # ASAN
-build:asan --copt=-fsanitize=address
-build:asan --copt=-fsanitize=undefined
-build:asan --copt=-O0
-build:asan --copt=-fno-omit-frame-pointer
 build:asan --linkopt=-fsanitize=address
 build:asan --linkopt=-fsanitize=undefined
 build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
+build:asan --per_file_copt=^.*/gateway/c/.*$@-fsanitize=address,-fsanitize=undefined,-O0,-fno-omit-frame-pointer
 
 # LSAN
-build:lsan --copt=-fsanitize=leak
-build:lsan --copt=-fno-omit-frame-pointer
 build:lsan --linkopt=-fsanitize=leak
+build:lsan --per_file_copt=^.*/gateway/c/.*$@-fsanitize=leak,-fno-omit-frame-pointer
 
 # system bazelrc should include config specific to different build envs (--config=vm, --config=devcontainer, etc.)
 try-import /etc/bazelrc


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Just experimenting to see how the selective ASAN/LSAN enablement affects cache size

Master cache size after running `bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan` and `bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=lsan`: 13G
PR cache size after running `bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan` and `bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=lsan`: 8.4G

@nstng  / @LKreutzer I think reducing ASAN/LSAN instrumentalization scope will help the cache size as well. (for CI, at least)

I've also found some repos in sourcegraph use per_file_copt to exclude dependencies from enabling it. https://sourcegraph.com/github.com/google/oss-fuzz/-/blob/projects/envoy/build.sh?L73:10


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
