### PR TITLE
feat(agw): Enable Redis integration in Sentry

### DIFF
--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -20,6 +20,7 @@ import sentry_sdk
 import snowflake
 from magma.configuration.service_configs import get_service_config_value
 from orc8r.protos.mconfig import mconfigs_pb2
+from sentry_sdk.integrations.redis import RedisIntegration
 
 Event = Dict[str, Any]
 Hint = Dict[str, Any]
@@ -157,6 +158,9 @@ def sentry_init(service_name: str, sentry_mconfig: mconfigs_pb2.SharedSentryConf
         release=os.getenv(COMMIT_HASH),
         traces_sample_rate=sentry_config.sample_rate,
         before_send=_get_before_send_hook(sentry_config.exclusion_patterns),
+        integrations=[
+            RedisIntegration(),
+        ],
     )
 
     cloud_address = get_service_config_value(


### PR DESCRIPTION
## Summary

Enable Redis integration in Sentry as described here https://docs.sentry.io/platforms/python/configuration/integrations/redis/.

## Test Plan

Sent errors to Sentry test account and saw Redís breadcrumbs (see screenshot).

![Screenshot from 2022-03-15 11-15-04](https://user-images.githubusercontent.com/32741139/158356217-07108076-4da3-47a6-ae85-f135cb0880db.png)

## Additional Information

- [ ] This change is backwards-breaking