### PR TITLE
fix(feg): fix incorrect conversion between integer types

### DIFF
--- a/feg/gateway/tools/swx_cli/main.go
+++ b/feg/gateway/tools/swx_cli/main.go
@@ -236,10 +236,6 @@ func sendSar(addr string, client swxClient) int {
 }
 
 func sendMar(addr string, client swxClient) int {
-	if numVectors > math.MaxUint32 {
-		fmt.Printf("numVectors %d is outside the bounds of unit32 type", numVectors)
-		return 2
-	}
 	req := &protos.AuthenticationRequest{
 		UserName:             imsi,
 		SipNumAuthVectors:    uint32(numVectors),
@@ -392,10 +388,15 @@ func getInteractiveRequestParameters(reader *bufio.Reader, requestType string) e
 			return err
 		}
 		if vectorsStr != "" {
-			numVectors, err = strconv.ParseUint(vectorsStr, 10, 64)
+			numVectors, err = strconv.ParseUint(vectorsStr, 10, 32)
 			if err != nil {
 				fmt.Println(err.Error())
 				return err
+			}
+			if numVectors > math.MaxUint32 {
+				strErrMsg := fmt.Sprintf("number %d is outside the boundaries of uint32 type", numVectors)
+				fmt.Println(strErrMsg)
+				return fmt.Errorf(strErrMsg)
 			}
 		}
 		return nil

--- a/orc8r/cloud/go/services/state/indexer/registry.go
+++ b/orc8r/cloud/go/services/state/indexer/registry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package indexer
 
 import (
+	"math"
 	"strconv"
 	"testing"
 
@@ -79,9 +80,12 @@ func getIndexer(serviceName string) (Indexer, error) {
 	if err != nil {
 		return nil, err
 	}
-	versionInt, err := strconv.ParseInt(versionVal, 10, 64)
+	versionInt, err := strconv.ParseInt(versionVal, 10, 32)
 	if err != nil {
 		return nil, errors.Wrapf(err, "convert indexer version %v to int for service %s", versionVal, serviceName)
+	}
+	if versionInt < 0 || versionInt > math.MaxUint32 {
+		return nil, errors.Wrapf(err, "number %d is outside the boundaries of uint32 type", versionInt)
 	}
 	version, err := NewIndexerVersion(versionInt)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>
fix(feg): fix incorrect conversion between integer types

## Summary

String was parsed into an int using strconv.ParseInt(val, 10, 64) which can cause incorrect conversion if INT is converted into another integer type of a smaller size (uint32). String parsing is changed to parse to 32 byte type and checks are created to see if the number is within the limits for type uint32.

## Test Plan

I ran /magma/feg/gateway/docker/ ./build.py -c and 
/magma/orc8r/cloud/docker/  ./build.py -c

## Additional Information

This is for code scanning alerts “Incorrect conversion between integer types”:
https://github.com/magma/magma/security/code-scanning/19
https://github.com/magma/magma/security/code-scanning/18
