### PR TITLE
chore: bazel dependencies are cleaned up 

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//bazel:third_party_repositories.bzl", "grpc", "protobuf")
+load("//bazel:third_party_repositories.bzl", "grpc")
 
 http_archive(
     name = "rules_python",
@@ -93,12 +93,6 @@ load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
 rules_cc_dependencies()
 
 ### PROTO / GRPC DEPENDENCIES ###
-protobuf()
-
-load("@protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
-
 grpc()
 
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")

--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -69,6 +69,7 @@ def cpp_repositories():
         commit = "d8326b2bba945a435f299e7526c403d7a1f68c1f",
         remote = "https://github.com/jupp0r/prometheus-cpp.git",
         shallow_since = "1485901529 +0100",
+        repo_mapping = {"@protobuf" : "@com_google_protobuf"},
     )
 
     # cpp_redis dependency

--- a/bazel/third_party_repositories.bzl
+++ b/bazel/third_party_repositories.bzl
@@ -13,22 +13,13 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def protobuf():
-    http_archive(
-        # The name is protobuf here as that is what prometheus-cpp expects
-        # See https://github.com/jupp0r/prometheus-cpp.git @ d8326b2bba945a435f299e7526c403d7a1f68c1f
-        name = "protobuf",
-        strip_prefix = "protobuf-3.15.0",
-        sha256 = "6aff9834fd7c540875e1836967c8d14c6897e3785a2efac629f69860fb7834ff",
-        # TODO(@themarwhal): Upgrade to latest release once we resolve GH8457
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.15.0.tar.gz"],
-    )
-
 def grpc():
     # see https://rules-proto-grpc.aliddell.com/en/latest/index.html
     http_archive(
         name = "rules_proto_grpc",
         sha256 = "7954abbb6898830cd10ac9714fbcacf092299fda00ed2baf781172f545120419",
         strip_prefix = "rules_proto_grpc-3.1.1",
+        # TODO(@themarwhal): Ships with https://github.com/protocolbuffers/protobuf v3.15.3
+        # Upgrade to latest release once we resolve GH8457
         urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/3.1.1.tar.gz"],
     )

--- a/cwf/gateway/docker/c/Dockerfile
+++ b/cwf/gateway/docker/c/Dockerfile
@@ -70,7 +70,7 @@ COPY bazel/ ${MAGMA_ROOT}/bazel
 RUN bazel build \
   @com_github_grpc_grpc//:grpc++ \
   @com_github_google_glog//:glog \
-  @protobuf//:protobuf \
+  @com_google_protobuf//:protobuf \
   @prometheus_cpp//:prometheus-cpp \
   @yaml-cpp//:yaml-cpp \
   @github_nlohmann_json//:json

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -30,7 +30,7 @@ cc_library(
     deps = [
         "//orc8r/gateway/c/common/logging",
         "@com_github_google_glog//:glog",
-        "@protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -48,7 +48,7 @@ cc_library(
     hdrs = ["Utilities.h"],
     # TODO(@themarwhal): Migrate to using full path for includes - GH8494
     strip_include_prefix = "/lte/gateway/c/session_manager",
-    deps = ["@protobuf"],
+    deps = ["@com_google_protobuf//:protobuf"],
 )
 
 cc_library(
@@ -207,7 +207,7 @@ cc_library(
         ":utilities",
         "//lte/protos:spgw_service_cpp_grpc",
         "//orc8r/gateway/c/common/service303",
-        "@protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -380,7 +380,7 @@ cc_library(
         "//lte/protos:mconfigs_cpp_proto",
         "//orc8r/gateway/c/common/logging",
         "@com_github_grpc_grpc//:grpc++",
-        "@protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -444,7 +444,7 @@ cc_library(
         ":session_state_enforcer",
         "//lte/protos:session_manager_cpp_grpc",
         "@com_github_grpc_grpc//:grpc++",
-        "@protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -113,7 +113,7 @@ COPY bazel/ ${MAGMA_ROOT}/bazel
 RUN bazel build \
   @com_github_grpc_grpc//:grpc++ \
   @com_github_google_glog//:glog \
-  @protobuf//:protobuf \
+  @com_google_protobuf//:protobuf \
   @prometheus_cpp//:prometheus-cpp \
   @yaml-cpp//:yaml-cpp \
   @github_nlohmann_json//:json \

--- a/lte/protos/BUILD.bazel
+++ b/lte/protos/BUILD.bazel
@@ -110,7 +110,7 @@ proto_library(
         ":apn_proto",
         "//orc8r/protos:common_proto",
         "//orc8r/protos:digest_proto",
-        "@protobuf//:field_mask_proto",
+        "@com_google_protobuf//:field_mask_proto",
     ],
 )
 
@@ -247,7 +247,7 @@ proto_library(
         ":policydb_proto",
         ":subscriberdb_proto",
         "//orc8r/protos:common_proto",
-        "@protobuf//:timestamp_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
@@ -504,8 +504,8 @@ proto_library(
         "//orc8r/protos:common_proto",
         "//orc8r/protos:digest_proto",
         "//orc8r/protos:service303_proto",
-        "@protobuf//:field_mask_proto",
-        "@protobuf//:timestamp_proto",
+        "@com_google_protobuf//:field_mask_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/lte/protos/oai/BUILD.bazel
+++ b/lte/protos/oai/BUILD.bazel
@@ -80,7 +80,7 @@ proto_library(
         ":nas_state_proto",
         ":spgw_state_proto",
         ":std_3gpp_types_proto",
-        "@protobuf//:timestamp_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
@@ -142,7 +142,7 @@ proto_library(
     name = "all_proto",
     srcs = glob(["*.proto"]),
     visibility = ["//visibility:private"],
-    deps = ["@protobuf//:timestamp_proto"],
+    deps = ["@com_google_protobuf//:timestamp_proto"],
 )
 
 # See comment at :all_proto

--- a/orc8r/gateway/c/common/config/BUILD.bazel
+++ b/orc8r/gateway/c/common/config/BUILD.bazel
@@ -33,7 +33,7 @@ cc_library(
     deps = [
         "//orc8r/gateway/c/common/logging",
         "@github_nlohmann_json//:json",
-        "@protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/orc8r/gateway/c/common/config/test/BUILD.bazel
+++ b/orc8r/gateway/c/common/config/test/BUILD.bazel
@@ -19,7 +19,7 @@ cc_test(
         "//lte/protos:mconfigs_cpp_proto",
         "//orc8r/gateway/c/common/config:mconfig_loader",
         "@com_google_googletest//:gtest_main",
-        "@protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/orc8r/protos/BUILD.bazel
+++ b/orc8r/protos/BUILD.bazel
@@ -51,7 +51,7 @@ proto_library(
     deps = [
         ":common_proto",
         ":mconfig_orc8r_proto",
-        "@protobuf//:struct_proto",
+        "@com_google_protobuf//:struct_proto",
     ],
 )
 
@@ -69,7 +69,7 @@ proto_library(
     name = "mconfig_orc8r_proto",
     srcs = ["mconfig.proto"],
     deps = [
-        "@protobuf//:any_proto",
+        "@com_google_protobuf//:any_proto",
     ],
 )
 
@@ -86,7 +86,7 @@ python_proto_library(
 proto_library(
     name = "digest_proto",
     srcs = ["digest.proto"],
-    deps = ["@protobuf//:any_proto"],
+    deps = ["@com_google_protobuf//:any_proto"],
 )
 
 cpp_proto_library(
@@ -245,8 +245,8 @@ proto_library(
     srcs = ["certifier.proto"],
     deps = [
         ":identity_proto",
-        "@protobuf//:duration_proto",
-        "@protobuf//:timestamp_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
@@ -282,7 +282,7 @@ proto_library(
     deps = [
         ":certifier_proto",
         ":identity_proto",
-        "@protobuf//:timestamp_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
@@ -334,14 +334,14 @@ proto_library(
     deps = [
         ":common_proto",
         ":metricsd_proto",
-        "@protobuf//:wrappers_proto",
+        "@com_google_protobuf//:wrappers_proto",
     ],
 )
 
 proto_library(
     name = "streamer_proto",
     srcs = ["streamer.proto"],
-    deps = ["@protobuf//:any_proto"],
+    deps = ["@com_google_protobuf//:any_proto"],
 )
 
 python_grpc_library(


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

### Problem
* we explicitly use `https://github.com/protocolbuffers/protobuf` v3.15.0
* via `https://github.com/rules-proto-grpc/rules_proto_grpc` we also use v3.15.3
* apart from using different versions, this leads to >100mb extra cache

### Solution Here
* remove explicit dependency of protobuf v3.15.0
* use implicit protobuf v3.15.3 from grpc rules when needed

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
