### PR TITLE
chore(mme): Adds newly passing OAI Core tests to Bazel configuration

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/amf/BUILD.bazel
@@ -1,0 +1,59 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
+
+cc_test(
+    name = "amf_algorithm_selection_test",
+    size = "small",
+    srcs = [
+        "test_amf_algorithm_selection.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "amf_map_test",
+    size = "small",
+    srcs = [
+        "test_amf_map.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "amf_app_test_util",
+    srcs = [
+        "amf_app_test_util.cpp",
+        "util_nas5g_auth_fail_pkt.cpp",
+        "util_nas5g_registration_pkt.cpp",
+        "util_nas5g_security_mode_reject_pkt.cpp",
+        "util_nas5g_service_request_pkt.cpp",
+        "util_nas5g_ul_nas_pdu_decode.cpp",
+        "util_s6a_update_location.cpp",
+    ],
+    hdrs = [
+        "amf_app_test_util.h",
+        "util_nas5g_pkt.h",
+        "util_s6a_update_location.h",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
@@ -1,0 +1,105 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
+
+cc_library(
+    name = "mme_app_test_core",
+    srcs = [
+        "mme_app_test_util.cpp",
+    ],
+    hdrs = [
+        "mme_app_test_util.h",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+    ],
+)
+
+cc_test(
+    name = "sgw_config_test",
+    srcs = [
+        "test_sgw_config.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "mme_app_config_test",
+    srcs = [
+        "test_mme_app_config.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "mme_app_esm_encode_decode_test",
+    srcs = [
+        "test_mme_app_esm_encode_decode.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "mme_app_emm_encode_decode_test",
+    srcs = [
+        "test_mme_app_emm_encode_decode.cpp",
+    ],
+    deps = [
+        ":mme_app_test_core",
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "apn_aggregate_maximum_bit_rate_test",
+    srcs = [
+        "test_ApnAggregateMaximumBitRate.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "eps_quality_of_service_test",
+    srcs = [
+        "test_EPSQualityOfService.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "mme_app_nas_encode_decode_test",
+    srcs = [
+        "test_mme_app_nas_encode_decode.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
@@ -1,0 +1,56 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
+
+cc_library(
+    name = "spgw_test_core",
+    srcs = [
+        "mock_spgw_op.cpp",
+        "spgw_test.cpp",
+        "spgw_test_util.cpp",
+        "state_creators.cpp",
+    ],
+    hdrs = [
+        "mock_spgw_op.h",
+        "spgw_test_util.h",
+        "state_creators.h",
+    ],
+    deps = ["//lte/gateway/c/core"],
+)
+
+cc_test(
+    name = "pgw_pco_test",
+    srcs = [
+        "test_pgw_pco.cpp",
+    ],
+    deps = [
+        ":spgw_test_core",
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "spgw_procedures_with_injected_state_test",
+    srcs = [
+        "test_spgw_procedures_with_injected_state.cpp",
+    ],
+    data = ["//lte/gateway/c/core/oai/test/spgw_task/data"],
+    deps = [
+        ":spgw_test_core",
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/spgw_task/data/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/spgw_task/data/BUILD.bazel
@@ -1,0 +1,18 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//lte/gateway/c/core/oai/test/spgw_task:__pkg__"])
+
+filegroup(
+    name = "data",
+    testonly = 1,
+    srcs = glob(["*"]),
+)


### PR DESCRIPTION
Working towards #11656.  All these unit tests now pass on Master for all of `nominal test`, `--config=asan` and `--config=lsan`.

## Test Plan

CI workflow and...

Local execution from GitHub Codespace of:

```
bazel test //lte/gateway/c/core/...
bazel test //lte/gateway/c/core/... --config=asan
bazel test //lte/gateway/c/core/... --config=lsan
```

Signed-off-by: Scott Moeller <electronjoe@gmail.com>