### PR TITLE
fix(mme): Fix ASAN error in SPGW unit test for IP Alloc Failure

### DIFF
--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
@@ -424,8 +424,9 @@ TEST_F(SPGWAppProcedureTest, TestCreateSessionIPAllocFailure) {
   status_code_e ip_alloc_rc = sgw_handle_ip_allocation_rsp(
       spgw_state, &test_ip_alloc_resp, test_imsi64);
 
-  // check that IP address is not allocated
-  ASSERT_TRUE(eps_bearer_ctxt_p->paa.ipv4_address.s_addr == UNASSIGNED_UE_IP);
+  // Verify that UE context was removed in SPGW state after CSR failure
+  ue_context_p = spgw_get_ue_context(test_imsi64);
+  ASSERT_TRUE(ue_context_p == nullptr);
 
   // Sleep to ensure that messages are received and contexts are released
   std::this_thread::sleep_for(std::chrono::milliseconds(END_OF_TEST_SLEEP_MS));


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Closes https://github.com/magma/magma/issues/12126 

The original test `SPGWAppProcedureTest::TestCreateSessionIPAllocFailure` was checking the IP address of an EPS bearer context structure which had been deleted, prompting a `heap-use-after-free` error from ASAN. This change fixes the check in the test to verify that the entire UE context is deleted after the IP allocation failure.

## Test Plan

Enable ASAN for unit tests by removing the if (NOT BUILD_TESTS) condition in [oai/CMakeLists.txt](https://github.com/magma/magma/blob/master/lte/gateway/c/core/oai/CMakeLists.txt#L48)

Verify that SPGW procedures unit tests succeed
`make test_oai OAI_TESTS=".*spgw_proc.*"`