### PR TITLE
fix(mme): Fix ASAN errors in EMM context conversion unit test

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Attach.c
@@ -541,7 +541,6 @@ status_code_e emm_proc_attach_request(
      */
     new_emm_ctx = &ue_mm_context->emm_context;
 
-    bdestroy(new_emm_ctx->esm_msg);
     emm_init_context(new_emm_ctx, true);
 
     new_emm_ctx->num_attach_request++;
@@ -2504,7 +2503,6 @@ void proc_new_attach_req(mme_ue_context_t* const mme_ue_context_p,
     OAILOG_FUNC_OUT(LOG_NAS_EMM);
   }
 
-  bdestroy(new_emm_ctx->esm_msg);
   emm_init_context(new_emm_ctx, true);
 
   new_emm_ctx->num_attach_request++;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.c
@@ -188,10 +188,6 @@ void clear_emm_ctxt(emm_context_t* emm_context) {
   // Stop T3489 timer
   free_esm_context_content(&emm_context->esm_ctx);
 
-  if (emm_context->esm_msg) {
-    bdestroy(emm_context->esm_msg);
-  }
-
   // Change the FSM state to Deregistered
   if (emm_fsm_get_state(emm_context) != EMM_DEREGISTERED) {
     emm_fsm_set_state(ue_id, emm_context, EMM_DEREGISTERED);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data.h
@@ -300,8 +300,6 @@ typedef struct emm_context_s {
                                      MME24.301R10_5.5.3.2.4_5*/
   eps_network_feature_support_t _eps_network_feature_support;
 
-  // TODO: DO BETTER  WITH BELOW
-  bstring esm_msg; /* ESM message contained within the initial request*/
 #define EMM_CN_SAP_BUFFER_SIZE 4096
 
 #define IS_EMM_CTXT_PRESENT_IMSI(eMmCtXtPtR) \

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
@@ -745,6 +745,16 @@ void emm_init_context(struct emm_context_s* const emm_ctx,
     esm_init_context(&emm_ctx->esm_ctx);
   }
   emm_ctx->emm_procedures = NULL;
+  emm_ctx->t3422_arg = NULL;
+
+  // Initialize flags
+  emm_ctx->is_dynamic = false;
+  emm_ctx->is_attached = false;
+  emm_ctx->is_initial_identity_imsi = true;
+  emm_ctx->is_imsi_only_detach = false;
+  emm_ctx->is_guti_based_attach = false;
+  emm_ctx->is_emergency = false;
+  emm_ctx->additional_update_type = NO_ADDITIONAL_INFORMATION;
 }
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/emm_data_ctx.c
@@ -619,7 +619,6 @@ void free_emm_ctx_memory(emm_context_t* const ctxt,
   }
   nas_delete_all_emm_procedures(ctxt);
   free_esm_context_content(&ctxt->esm_ctx);
-  bdestroy_wrapper(&ctxt->esm_msg);
 }
 
 //------------------------------------------------------------------------------
@@ -746,7 +745,6 @@ void emm_init_context(struct emm_context_s* const emm_ctx,
     esm_init_context(&emm_ctx->esm_ctx);
   }
   emm_ctx->emm_procedures = NULL;
-  emm_ctx->esm_msg = NULL;
 }
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/core/oai/test/nas/test_nas_converter.cpp
+++ b/lte/gateway/c/core/oai/test/nas/test_nas_converter.cpp
@@ -91,15 +91,6 @@ TEST_F(NasStateConverterTest, TestEmmContextConversion) {
   ;
   emm_context.new_attach_info->ies->is_initial = true;
   emm_context.new_attach_info->ies->type = EMM_ATTACH_TYPE_EPS;
-  emm_context.t3422_arg = nullptr; // Timer 3422 is not running
-
-  // Initialize flags
-  emm_context.is_dynamic = false;
-  emm_context.is_attached = false;
-  emm_context.is_initial_identity_imsi = true;
-  emm_context.is_guti_based_attach = false;
-  emm_context.is_emergency = false;
-  emm_context.additional_update_type = NO_ADDITIONAL_INFORMATION;
 
   oai::EmmContext proto_state;
   NasStateConverter::emm_context_to_proto(&emm_context, &proto_state);

--- a/lte/gateway/c/core/oai/test/nas/test_nas_converter.cpp
+++ b/lte/gateway/c/core/oai/test/nas/test_nas_converter.cpp
@@ -93,6 +93,14 @@ TEST_F(NasStateConverterTest, TestEmmContextConversion) {
   emm_context.new_attach_info->ies->type = EMM_ATTACH_TYPE_EPS;
   emm_context.t3422_arg = nullptr; // Timer 3422 is not running
 
+  // Initialize flags
+  emm_context.is_dynamic = false;
+  emm_context.is_attached = false;
+  emm_context.is_initial_identity_imsi = true;
+  emm_context.is_guti_based_attach = false;
+  emm_context.is_emergency = false;
+  emm_context.additional_update_type = NO_ADDITIONAL_INFORMATION;
+
   oai::EmmContext proto_state;
   NasStateConverter::emm_context_to_proto(&emm_context, &proto_state);
 
@@ -128,7 +136,6 @@ TEST_F(NasStateConverterTest, TestEmmContextConversion) {
   free_wrapper((void**)&final_state.new_attach_info->ies);
   free_wrapper((void**)&final_state.new_attach_info);
   free_wrapper((void**)&final_state.esm_ctx.esm_proc_data);
-  free_wrapper((void**)&final_state.t3422_arg);
   clear_emm_ctxt(&final_state);
 }
 

--- a/lte/gateway/c/core/oai/test/nas/test_nas_converter.cpp
+++ b/lte/gateway/c/core/oai/test/nas/test_nas_converter.cpp
@@ -91,6 +91,7 @@ TEST_F(NasStateConverterTest, TestEmmContextConversion) {
   ;
   emm_context.new_attach_info->ies->is_initial = true;
   emm_context.new_attach_info->ies->type = EMM_ATTACH_TYPE_EPS;
+  emm_context.t3422_arg = nullptr; // Timer 3422 is not running
 
   oai::EmmContext proto_state;
   NasStateConverter::emm_context_to_proto(&emm_context, &proto_state);


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Closes https://github.com/magma/magma/issues/12125, https://github.com/magma/magma/issues/12066 and https://github.com/magma/magma/issues/11827 with following fixes:

- Initialize the T3422 argument to null for a new EMM context since no 3422 timer is running
- Initialize the flags in EMM context correctly
- Remove unused member `esm_msg` of `emm_context_t` structure

## Test Plan

- CMake build:

Enable ASAN for unit tests by removing the if (NOT BUILD_TESTS) condition in [oai/CMakeLists.txt](https://github.com/magma/magma/blob/master/lte/gateway/c/core/oai/CMakeLists.txt#L48)

Verify that `make test_oai OAI_TESTS=".*nas_converter.*"` succeeds

- Bazel build:

Follow the steps in https://github.com/magma/magma/issues/11955#issuecomment-1068459181 to setup Bazel dev environment

Apply changes from this PR and then verify that 
`bazel test //lte/gateway/c/core/oai/test/nas:nas_converter_test --config=asan --runs_per_test=30` succeeds

- Integration test:

`make integ_test TESTS=s1aptests/test_attach_detach.py`