### PR TITLE
chore: migrate gcc-warnings job to use per_file_copts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -62,5 +62,8 @@ build:asan --per_file_copt=^.*/gateway/c/.*$@-fsanitize=address,-fsanitize=undef
 build:lsan --linkopt=-fsanitize=leak
 build:lsan --per_file_copt=^.*/gateway/c/.*$@-fsanitize=leak,-fno-omit-frame-pointer
 
+# Config for turning up more GCC warnings
+build:max_gcc_warnings --per_file_copt=^.*/gateway/c/.*$@-Wextra,-Wshadow,-Wimplicit-fallthrough,-Wduplicated-cond,-Wduplicated-branches,-Wlogical-op,-Wnull-dereference,-Wformat=2,-Wstrict-overflow=4,-Wuninitialized,-Wshift-overflow=2
+
 # system bazelrc should include config specific to different build envs (--config=vm, --config=devcontainer, etc.)
 try-import /etc/bazelrc

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -56,9 +56,6 @@ jobs:
       - path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Build all Bazelified C/C++ targets
-    env:
-      C_CPP_FLAGS: "-Wextra -Wshadow -Wimplicit-fallthrough -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wformat=2 -Wstrict-overflow=4 -Wuninitialized -Wshift-overflow=2"
-      C_ONLY_FLAGS: "-Wjump-misses-init"
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
@@ -108,7 +105,7 @@ jobs:
           options: -v ${{ github.workspace }}:/workspaces/magma
           run: |
             cd /workspaces/magma
-            ./.github/workflows/generate-gcc-warnings.sh "${{ steps.changed_files.outputs.all }}" "$C_CPP_FLAGS" "$C_ONLY_FLAGS"
+            ./.github/workflows/generate-gcc-warnings.sh "${{ steps.changed_files.outputs.all }}"
       - name: Load problem matcher
         # If needed https://github.com/microsoft/vscode-cpptools/issues/2266 for path fixups
         #

--- a/.github/workflows/generate-gcc-warnings.sh
+++ b/.github/workflows/generate-gcc-warnings.sh
@@ -3,25 +3,12 @@
 # List of files or paths to grep for in the compilation log
 # Ex: .github/workflows/gcc-problems.yml,.github/workflows/generate-gcc-warnings.sh,lte/gateway/c/sctpd/src/sctpd.cpp,lte/gateway/c/session_manager/AAAClient.cpp
 FILES=$1
-# Applied to both C and C++. 
-# Ex: "-Wextra -Wshadow -Wimplicit-fallthrough"
-C_CPP_FLAGS=$2
-# Applied to C only. 
-# Ex: "-Wjump-misses-init"
-C_ONLY_FLAGS=$3
 
 # We want the full compilation log everytime the script is run
 bazel clean
 
-# Massage some of our external build files so that we can bypass -Werror
-bazel fetch //orc8r/gateway/c/... //lte/gateway/c/...
-sed -i 's/"-Werror",/#"-Werror",/g' /tmp/bazel/external/boringssl/BUILD
-
-COPTS=${C_CPP_FLAGS//'-W'/'--copt=-W'}
-CONLY_OPTS=${C_ONLY_FLAGS//'-W'/'--conlyopt=-W'}
-
 # shellcheck disable=SC2086
-bazel build --color=no //orc8r/gateway/c/... //lte/gateway/c/... $COPTS $CONLY_OPTS 2>&1 | tee compile.log
+bazel build --color=no //orc8r/gateway/c/... //lte/gateway/c/... --config=max_gcc_warnings 2>&1 | tee compile.log
 
 rm -f filtered-compile.log
 echo "$FILES" | tr , '\n' | while read f


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This PR adds a max_gcc_warnings config to bump up GCC warnings flags for CI annotation. In the previous iteration, I had to manually modify the boringssl source file to remove -Werror so that build did not fail. With this approach, we do not have to touch external dependencies as we only apply the expanded set of GCC flags to Magma C/C++ files. This is also nice in terms of cache bloating.

This provides a quicker workflow of just adding `--config=max_gcc_warnings` to any target. 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran `bazel build //lte/gateway/c/... --config=max_gcc_warnings` locally to see more warning output
Checking the compile log uploaded by the CI job.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
