### PR TITLE
fix(mme): Corrects bazel dependencies for amf_app_test_util

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/amf/BUILD.bazel
@@ -55,5 +55,6 @@ cc_library(
     ],
     deps = [
         "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
@@ -23,6 +23,7 @@ cc_library(
     ],
     deps = [
         "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
@@ -26,7 +26,10 @@ cc_library(
         "spgw_test_util.h",
         "state_creators.h",
     ],
-    deps = ["//lte/gateway/c/core"],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest",
+    ],
 )
 
 cc_test(


### PR DESCRIPTION
Per issue detected by @themarwhal at https://github.com/magma/magma/pull/12124#discussion_r827427829

## Test Plan

The following is successful:

```
MAGMA_ROOT=/Users/<username>/Documents/magma/ docker-compose run magma-builder bash
bazel test //lte/gateway/c/core/...
```

Signed-off-by: Scott Moeller <electronjoe@gmail.com>