### PR TITLE
chore: Migrate PACKAGE_* compile defs to be handled with per_file_copt

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,8 +37,16 @@ build --test_env=PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin
 # Use MAGMA_ROOT from the host system in tests.
 # Needed by python tests (e.g. freedomfi_one_tests in enodebd)
 build --test_env=MAGMA_ROOT
+
+# MME specific compile time defines
 # Compile mme libraries with unit test flag
 test --per_file_copt=^lte/gateway/c/core/.*$@-DMME_UNIT_TEST
+# TODO: deprecate these flags used for logging if possible
+build --per_file_copt=^lte/gateway/c/core/.*$@-DPACKAGE_BUGREPORT=\"TBD\"
+build --per_file_copt=^lte/gateway/c/core/.*$@-DPACKAGE_VERSION=\"0.1\"
+build --per_file_copt=^lte/gateway/c/core/oai/tasks/amf/.*$@-DPACKAGE_NAME=\"AMF\"
+build --per_file_copt=^lte/gateway/c/core/oai/tasks/mme_app/.*$@-DPACKAGE_NAME=\"MME\"
+build --per_file_copt=^lte/gateway/c/core/oai/tasks/sgw/.*$@-DPACKAGE_NAME=\"S/P-GW\"
 
 # CODE COVERAGE CONFIGS
 build --javacopt="-source 8"

--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1077,9 +1077,6 @@ cc_library(
     copts = [
         "-DEMBEDDED_SGW",  # TODO(#11638): Feature flags fixups
         "-DS6A_OVER_GRPC",  # TODO(#11638): Feature flags fixups
-        "-DPACKAGE_BUGREPORT=\\\"PACKAGE_BUGREPORT\\\"",  # TODO(#11591): needs deprecation
-        "-DPACKAGE_NAME=\\\"PACKAGE_NAME\\\"",  # TODO(#11591): needs deprecation
-        "-DPACKAGE_VERSION=\\\"0.1\\\"",  # TODO(#11591): needs deprecation
         "-DCMAKE_BUILD_TYPE=\\\"CMAKE_BUILD_TYPE\\\"",  # TODO(#11897): needs alternative approach or deprecation
     ],
     deps = [


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Address https://github.com/magma/magma/issues/11591

This PR moves out the copts that set PACKAGE_BUGREPORT, PACKAGE_VERSION, and PACKAGE_NAME from oai's BUILD.bazel to bazelrc. Ideally, we would handle these by creating libraries for each task and setting the copts there. As that is not feasible for the initial MME bazelification due to cyclic dependencies, per_file_copt gives us an easy way to set copts depending on the file path. 

I'm limiting this PR to Bazel related changes only, but I am thinking these define variables can be cleaned up a little bit more. We can probably get rid of PACKAGE_BUGREPORT and PACKAGE_VERSION as they don't seem to contain useful values.  
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run `bazel build //lte/gateway/c/core/... -s` and visibly confirm the compilation flags are correct. 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
