### PR TITLE
fix(mobilityd): Update vlan param type on ip_allocator_dhcp

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -89,7 +89,7 @@ class DHCPClient:
         self._monitor_thread_event.set()
 
     def send_dhcp_packet(
-        self, mac: MacAddress, vlan: str,
+        self, mac: MacAddress, vlan: int,
         state: DHCPState,
         dhcp_desc: Optional[DHCPDescriptor] = None,
     ) -> None:
@@ -142,7 +142,7 @@ class DHCPClient:
         dhcp_opts.append("end")  # type: ignore[arg-type]
         dhcp_desc.xid = pkt_xid
         with self._dhcp_notify:
-            self.dhcp_client_state[mac.as_redis_key(vlan)] = dhcp_desc
+            self.dhcp_client_state[mac.as_redis_key(str(vlan))] = dhcp_desc
 
         pkt = Ether(src=str(mac), dst="ff:ff:ff:ff:ff:ff")
         if vlan and vlan != "0":

--- a/lte/gateway/python/magma/mobilityd/dhcp_desc.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_desc.py
@@ -36,7 +36,7 @@ class DHCPState(IntEnum):
 class DHCPDescriptor:
     def __init__(
         self, mac: MacAddress, ip: str,
-        state_requested: DHCPState, vlan: str,
+        state_requested: DHCPState, vlan: int,
         state: DHCPState = DHCPState.UNKNOWN,
         subnet: str = None, server_ip: str = None,
         router_ip: str = None, lease_expiration_time: int = 0,

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -206,7 +206,7 @@ class IPAllocatorDHCP(IPAllocator):
 
                 if retry_count % DEFAULT_DHCP_REQUEST_RETRY_FREQUENCY == 0:
                     self._dhcp_client.send_dhcp_packet(
-                        mac, str(vlan),
+                        mac, vlan,
                         DHCPState.DISCOVER,
                     )
                 self.dhcp_wait.wait(timeout=DEFAULT_DHCP_REQUEST_RETRY_DELAY)


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Changes on https://github.com/magma/magma/pull/12012 updated vlan param to be passed as `str` rather than `int`
- This PR corrects type hints of `vlan` param as well as passing it as `int`

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- `make test` locally on VM 
- `make integ_test`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
