### PR TITLE
chore(cwg): removing vulnerable github.com/moby/moby package version

### DIFF
--- a/cwf/k8s/cwf_operator/go.mod
+++ b/cwf/k8s/cwf_operator/go.mod
@@ -29,6 +29,7 @@ module magma/cwf/k8s/cwf_operator
 go 1.13
 
 require (
+	github.com/docker/docker v20.10.13+incompatible // indirect
 	github.com/garyburd/redigo v1.6.2 // indirect
 	github.com/go-logr/glogr v0.1.0
 	github.com/go-redis/redis v6.15.8+incompatible // indirect


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

chore(cwg): removing vulnerable github.com/moby/moby package version

## Summary

Currently using package github.com/moby/moby v0.7.3, for which there is an dependabot alert:

Path traversal vulnerability in Docker before 1.3.3 allows remote attackers to write to arbitrary files and bypass a container protection mechanism via a full pathname in a symlink in an (1) image or (2) build in a Dockerfile. Upgrade package to pathced version 1.3.3.

When you try to upgrade from v0.7.3 to v1.3.3, many errors occur. However, if package github.com/moby/moby is replaced by package github.com/docker/docker v20.10.13, there are no errors and all tests pass. 


## Test Plan

I ran /magma/feg/gateway/docker/ ./build.py -c and
/magma/orc8r/cloud/docker/  ./build.py -c

## Additional Information

This is for dependabot alert:
https://github.com/magma/magma/security/dependabot/141
