### PR TITLE
chore: nas state converter test is no longer flaky or fails with ASAN

### DIFF
--- a/lte/gateway/c/core/oai/test/nas/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/nas/BUILD.bazel
@@ -18,9 +18,6 @@ cc_test(
     srcs = [
         "test_nas_converter.cpp",
     ],
-    flaky = True,
-    # TODO: This test fails with ASAN and is flaky when run plainly: GH12066, GH11827
-    tags = ["manual"],
     deps = [
         "//lte/gateway/c/core",
         "@com_google_googletest//:gtest_main",


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
The flakiness and ASAN failure was addressed by https://github.com/magma/magma/issues/12125
Remove the flaky and manual tag from the job so that it is run by default with no retries.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
