### PR TITLE
fix(mme): Fix flaky unit tests

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -1448,10 +1448,10 @@ TEST_F(MmeAppProcedureTest, TestPagingMaxRetx) {
   EXPECT_EQ(mme_state_p->nb_s1u_bearers, 0);
 
   // Constructing and sending Paging Request
-  send_paging_request();
   EXPECT_CALL(*s1ap_handler, s1ap_handle_paging_request())
       .Times(2)
       .WillRepeatedly(ReturnFromAsyncTask(&cv));
+  send_paging_request();
 
   // wait for s1ap_handle_paging_request to arrive twice
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
@@ -1497,19 +1497,19 @@ TEST_F(MmeAppProcedureTest,
   attach_ue(cv, lock, mme_state_p, &guti);
 
   // Send activate dedicated bearer request for lbi 5 mimicing SPGW
-  send_s11_create_bearer_req(5);
   EXPECT_CALL(*s1ap_handler, s1ap_generate_s1ap_e_rab_setup_req()).Times(1);
+  send_s11_create_bearer_req(5);
 
   // Send ERAB Setup Response mimicing S1AP
   send_erab_setup_rsp(6);
 
   // Constructing and sending Activate Dedicated Bearer Accept to mme_app
   // mimicing S1AP
+  EXPECT_CALL(*spgw_handler, sgw_handle_nw_initiated_actv_bearer_rsp())
+      .Times(1);
   send_mme_app_uplink_data_ind(nas_msg_activate_ded_bearer_accept,
                                sizeof(nas_msg_activate_ded_bearer_accept),
                                plmn);
-  EXPECT_CALL(*spgw_handler, sgw_handle_nw_initiated_actv_bearer_rsp())
-      .Times(1);
 
   // Check MME state after Bearer Activation
   send_activate_message_to_mme_app();
@@ -1523,8 +1523,8 @@ TEST_F(MmeAppProcedureTest,
   uint8_t ebi_to_be_deactivated = 6;
   // Constructing and sending deactivate bearer request
   // for dedicated bearer that should trigger ERAB Release Command
-  send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, false);
   EXPECT_CALL(*s1ap_handler, s1ap_generate_s1ap_e_rab_rel_cmd()).Times(1);
+  send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, false);
 
   // Send ERAB Release Response mimicing S1AP
   send_erab_release_rsp();
@@ -1563,8 +1563,8 @@ TEST_F(
   attach_ue(cv, lock, mme_state_p, &guti);
 
   // Send activate dedicated bearer request for lbi 5 mimicing SPGW
-  send_s11_create_bearer_req(5);
   EXPECT_CALL(*s1ap_handler, s1ap_generate_s1ap_e_rab_setup_req()).Times(1);
+  send_s11_create_bearer_req(5);
 
   // Send ERAB Setup Response mimicing S1AP
   send_erab_setup_rsp(6);
@@ -1577,11 +1577,11 @@ TEST_F(
 
   // Constructing and sending Activate Dedicated Bearer Accept to mme_app
   // mimicing S1AP
+  EXPECT_CALL(*spgw_handler, sgw_handle_nw_initiated_actv_bearer_rsp())
+      .Times(1);
   send_mme_app_uplink_data_ind(nas_msg_activate_ded_bearer_accept,
                                sizeof(nas_msg_activate_ded_bearer_accept),
                                plmn);
-  EXPECT_CALL(*spgw_handler, sgw_handle_nw_initiated_actv_bearer_rsp())
-      .Times(1);
 
   // Check MME state after Bearer Activation
   send_activate_message_to_mme_app();
@@ -1595,10 +1595,11 @@ TEST_F(
   uint8_t ebi_to_be_deactivated = 6;
   // Constructing and sending deactivate bearer request
   // for dedicated bearer that should trigger ERAB Release Command
-  send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, false);
   EXPECT_CALL(*s1ap_handler, s1ap_generate_s1ap_e_rab_rel_cmd())
       .Times(5)
       .WillRepeatedly(ReturnFromAsyncTask(&cv));
+
+  send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, false);
 
   // Wait for ERAB Release up to retransmission limit;
   // Deactivate EPS bearer context requests are piggybacked on ERAB Release
@@ -2090,8 +2091,6 @@ TEST_F(MmeAppProcedureTest, TestX2HandoverPathSwitchSuccess) {
   uint32_t new_enb_ue_s1ap_id = DEFAULT_eNB_S1AP_UE_ID + 1;
   uint32_t new_sctp_assoc_id = DEFAULT_SCTP_ASSOC_ID + 1;
   uint32_t new_enb_id = DEFAULT_ENB_ID + 1;
-  send_s1ap_path_switch_req(new_sctp_assoc_id, new_enb_id, new_enb_ue_s1ap_id,
-                            plmn);
 
   // Expect that Path Switch ACK is sent to S1AP from mme_app after modify
   // bearer response is received
@@ -2099,6 +2098,9 @@ TEST_F(MmeAppProcedureTest, TestX2HandoverPathSwitchSuccess) {
                                  check_params_in_path_switch_req_ack(
                                      new_enb_ue_s1ap_id, new_sctp_assoc_id)))
       .Times(1);
+
+  send_s1ap_path_switch_req(new_sctp_assoc_id, new_enb_id, new_enb_ue_s1ap_id,
+                            plmn);
 
   // Constructing and sending Modify Bearer Response to mme_app
   // mimicing SPGW, with same parameters as last one
@@ -2136,8 +2138,6 @@ TEST_F(MmeAppProcedureTest, TestX2HandoverPathSwitchFailure) {
   uint32_t new_enb_ue_s1ap_id = DEFAULT_eNB_S1AP_UE_ID + 1;
   uint32_t new_sctp_assoc_id = DEFAULT_SCTP_ASSOC_ID + 1;
   uint32_t new_enb_id = DEFAULT_ENB_ID + 1;
-  send_s1ap_path_switch_req(new_sctp_assoc_id, new_enb_id, new_enb_ue_s1ap_id,
-                            plmn);
 
   // Expect that Path Switch Failure is sent to S1AP from mme_app after modify
   // bearer response is received
@@ -2145,6 +2145,9 @@ TEST_F(MmeAppProcedureTest, TestX2HandoverPathSwitchFailure) {
                                  check_params_in_path_switch_req_failure(
                                      new_enb_ue_s1ap_id, new_sctp_assoc_id)))
       .Times(1);
+
+  send_s1ap_path_switch_req(new_sctp_assoc_id, new_enb_id, new_enb_ue_s1ap_id,
+                            plmn);
 
   // Constructing and sending Modify Bearer Response to mme_app
   // mimicing SPGW, with empty modify bearer list to trigger failure
@@ -2202,10 +2205,11 @@ TEST_F(MmeAppProcedureTest,
   send_modify_bearer_resp(b_modify, b_rm);
 
   // Add dedicated bearer for LBI 6
-  send_s11_create_bearer_req(DEFAULT_LBI + ebi_idx);
   // s1ap_generate_s1ap_e_rab_setup_req is called twice. Once for default
   // bearer and once for dedicated bearer
   EXPECT_CALL(*s1ap_handler, s1ap_generate_s1ap_e_rab_setup_req()).Times(2);
+
+  send_s11_create_bearer_req(DEFAULT_LBI + ebi_idx);
 
   // Send ERAB Setup Response mimicing S1AP
   send_erab_setup_rsp(7);
@@ -2303,10 +2307,11 @@ TEST_F(MmeAppProcedureTest,
   send_modify_bearer_resp(b_modify, b_rm);
 
   // Add dedicated bearer for LBI 6
-  send_s11_create_bearer_req(DEFAULT_LBI + ebi_idx);
   // s1ap_generate_s1ap_e_rab_setup_req is called twice. Once for default
   // bearer and once for dedicated bearer
   EXPECT_CALL(*s1ap_handler, s1ap_generate_s1ap_e_rab_setup_req()).Times(2);
+
+  send_s11_create_bearer_req(DEFAULT_LBI + ebi_idx);
 
   // Send ERAB Setup Response mimicing S1AP
   send_erab_setup_rsp(7);
@@ -2417,8 +2422,6 @@ TEST_F(MmeAppProcedureTest, TestS1HandoverSuccess) {
 
   // Send Handover Required to mme_app mimicing S1AP, use 1 for all new ids,
   // since Initial UE message is using 0
-  send_s1ap_handover_required(DEFAULT_SCTP_ASSOC_ID, new_enb_id,
-                              new_enb_ue_s1ap_id, mme_ue_s1ap_id);
 
   // Expect that MME Handover Request is sent to S1AP from mme_app
   EXPECT_CALL(*s1ap_handler, s1ap_mme_handle_handover_request(
@@ -2426,16 +2429,19 @@ TEST_F(MmeAppProcedureTest, TestS1HandoverSuccess) {
                                      mme_ue_s1ap_id, DEFAULT_SCTP_ASSOC_ID)))
       .Times(1);
 
-  // Send Handover Request Ack to mme_app mimicing S1AP
-  send_s1ap_handover_request_ack(DEFAULT_SCTP_ASSOC_ID, DEFAULT_ENB_ID,
-                                 new_enb_id, DEFAULT_eNB_S1AP_UE_ID,
-                                 new_enb_ue_s1ap_id, mme_ue_s1ap_id);
+  send_s1ap_handover_required(DEFAULT_SCTP_ASSOC_ID, new_enb_id,
+                              new_enb_ue_s1ap_id, mme_ue_s1ap_id);
 
+  // Send Handover Request Ack to mme_app mimicing S1AP
   // Expect that MME Handover Command is sent to S1AP from mme_app
   EXPECT_CALL(*s1ap_handler, s1ap_mme_handle_handover_command(
                                  check_params_in_mme_app_handover_command(
                                      mme_ue_s1ap_id, new_enb_id)))
       .Times(1);
+  send_s1ap_handover_request_ack(DEFAULT_SCTP_ASSOC_ID, DEFAULT_ENB_ID,
+                                 new_enb_id, DEFAULT_eNB_S1AP_UE_ID,
+                                 new_enb_ue_s1ap_id, mme_ue_s1ap_id);
+
 
   // Send Handover Notify to mme_app mimicing S1AP
   send_s1ap_handover_notify(new_sctp_assoc_id, DEFAULT_ENB_ID, new_enb_id,
@@ -2846,10 +2852,10 @@ TEST_F(MmeAppProcedureTest,
   send_s11_create_bearer_req(5);
 
   // Send ERAB Setup Response mimicing S1AP
-  send_erab_setup_rsp(6);
-
   EXPECT_CALL(*spgw_handler, sgw_handle_nw_initiated_actv_bearer_rsp())
       .Times(1);
+  send_erab_setup_rsp(6);
+
   // Wait for timer expiry.
   for (int i = 1; i < NAS_RETX_LIMIT + 1; ++i) {
     cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -2442,7 +2442,6 @@ TEST_F(MmeAppProcedureTest, TestS1HandoverSuccess) {
                                  new_enb_id, DEFAULT_eNB_S1AP_UE_ID,
                                  new_enb_ue_s1ap_id, mme_ue_s1ap_id);
 
-
   // Send Handover Notify to mme_app mimicing S1AP
   send_s1ap_handover_notify(new_sctp_assoc_id, DEFAULT_ENB_ID, new_enb_id,
                             DEFAULT_eNB_S1AP_UE_ID, new_enb_ue_s1ap_id,


### PR DESCRIPTION
fix(mme): Fix flaky unit tests

## Summary

Moved EXPECT_CALL before calling the function triggering the event in the EXPECT_CALL

## Test Plan

Ran make_test_oai in a loop for half an hour without any failures.

