### PR TITLE
chore(mme): Commits failing Bazel core oai tests with manual tag

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/amf/BUILD.bazel
@@ -37,6 +37,49 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "amf_procedures_test",
+    size = "small",
+    srcs = [
+        "test_amf_procedures.cpp",
+    ],
+    # TODO: Remove manual tag when fixed: GH12144
+    tags = ["manual"],
+    deps = [
+        ":amf_app_test_util",
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "amf_stateless_test",
+    size = "small",
+    srcs = [
+        "test_amf_stateless.cpp",
+    ],
+    # TODO: Remove manual tag when fixed: GH11826
+    tags = ["manual"],
+    deps = [
+        ":amf_app_test_util",
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "amf_common_utils_test",
+    size = "small",
+    srcs = ["test_amf_common_utils.cpp"],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+
+)
+
 cc_library(
     name = "amf_app_test_util",
     srcs = [

--- a/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
@@ -103,3 +103,18 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "mme_procedures_test",
+    srcs = [
+        "test_mme_procedures.cpp",
+    ],
+    # TODO: Remove manual tag when fixed: GH11955
+    tags = ["manual"],
+    deps = [
+        ":mme_app_test_core",
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
@@ -42,6 +42,21 @@ cc_test(
 )
 
 cc_test(
+    name = "spgw_procedures_test",
+    srcs = [
+        "test_spgw_procedures.cpp",
+    ],
+    # TODO: Remove manual tag when fixed: GH11984
+    tags = ["manual"],
+    deps = [
+        ":spgw_test_core",
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "spgw_procedures_with_injected_state_test",
     srcs = [
         "test_spgw_procedures_with_injected_state.cpp",


### PR DESCRIPTION
## Summary

Work towards #11656.

This PR commits four oai core tests as Bazel test targets, but
as each of them fail in some manner across `vanilla`, `asan` or `lsan`
configurations we use the `manual` tag so that they are not run in CI.

Manual tag use is not best practice generally, as it can lead to hidden
tests that are broken and don't get attention. But since we have a
focused team working on fixing these tests - and it seems valuable to
have the team working on master and not my branch - here we propose
committing them with a `manual` tag.

## Missing Coverage

I executed the script provided by @nstng in https://github.com/magma/magma/issues/11767#issuecomment-1055742007 with the following output:

```
@electronjoe ➜ /workspaces/magma (pr-giant-bazel-mme-rebase ✗) $ /tmp/script.sh 
Source files not found in BUILD.bazel:
mme_app_serialization.cpp
mme_app_serialization.h
test_mme_app_ue_context.c
mme_app_test.cpp
s6a_test.cpp
s6a_recv_async_grpc_messages.cpp
ngap_test.cpp
test_spgw_state_converter.cpp
test_spgw_service_impl.cpp
sgw_s8_test.cpp
s1ap_test.cpp
amf_app_test.cpp
test_amf_encode_decode.cpp
```

Note that some of these files are "wrapper" gtest files that CMake uses and we do not use in Bazel, covered in #11736.

Others are tests that need to be brought into Bazel:
- test_amf_encode_decode.cpp #12146
- test_spgw_service_impl.cpp #12105
- test_mme_app_ue_context.c #12147
- s6a_recv_async_grpc_messages.cpp #12174

Are these dead code @ssanadhya?

- mme_app_serialization.cpp
- mme_app_serialization.h

We will want to re-run the script after a number of these have been dealt with.

## Test Plan

Validated that we do not break any Bazel build or test with this PR.
Validated that tests can be run manually and fail per their GH Issues.

Signed-off-by: Scott Moeller <electronjoe@gmail.com>
