### PR TITLE
chore: bazel file linter is applied in ci

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -185,3 +185,12 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel test //... --test_output=errors --cache_test_results=no
+      - name: Run `bazel run //:check_starlark_format`
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/
+          run: |
+            cd /workspaces/magma
+            bazel run //:check_starlark_format

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,7 @@ buildifier_test(
     timeout = "short",
     srcs = ["//:starlark_files"],
     lint_mode = "warn",
-    lint_warnings = ["all"],
+    lint_warnings = ["-unused-variable"],
     verbose = True,
 )
 

--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -69,7 +69,7 @@ def cpp_repositories():
         commit = "d8326b2bba945a435f299e7526c403d7a1f68c1f",
         remote = "https://github.com/jupp0r/prometheus-cpp.git",
         shallow_since = "1485901529 +0100",
-        repo_mapping = {"@protobuf" : "@com_google_protobuf"},
+        repo_mapping = {"@protobuf": "@com_google_protobuf"},
     )
 
     # cpp_redis dependency

--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -1,6 +1,21 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Load external go repositories. """
+
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 def go_repositories():
+    """ Declares all go dependencies. """
+
     go_repository(
         name = "co_honnef_go_tools",
         importpath = "honnef.co/go/tools",

--- a/orc8r/gateway/c/common/config/BUILD.bazel
+++ b/orc8r/gateway/c/common/config/BUILD.bazel
@@ -32,8 +32,8 @@ cc_library(
     strip_include_prefix = "/orc8r/gateway/c/common/config",
     deps = [
         "//orc8r/gateway/c/common/logging",
-        "@github_nlohmann_json//:json",
         "@com_google_protobuf//:protobuf",
+        "@github_nlohmann_json//:json",
     ],
 )
 


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Forgot again to apply the buildifier in a previous PR :/
Should we add a check to the Bazel CI workflow?
Added a check in the test job - I would see it as a test, but are open to move it to a separate job.

![linterFail](https://user-images.githubusercontent.com/42540177/158596539-52b9e36f-902b-497a-be2c-1a96adc8bd1b.png)

## Test Plan

CI
* see first commit fith failure run https://github.com/magma/magma/runs/5570173878?check_suite_focus=true
* second commit with fixes TBD

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
