### PR TITLE
fix(mme): Fix spgw_procedures test for Bazel

### DIFF
--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures.cpp
@@ -342,14 +342,6 @@ void SPGWAppProcedureTest ::deactivate_dedicated_bearer(
       &sample_gx_nw_init_ded_bearer_deactv_req, test_imsi_str,
       DEFAULT_EPS_BEARER_ID, ded_eps_bearer_id);
 
-  // check that MME gets a bearer deactivation request
-  EXPECT_CALL(*mme_app_handler,
-              mme_app_handle_nw_init_bearer_deactv_req(
-                  check_params_in_deactv_bearer_req(
-                      sample_gx_nw_init_ded_bearer_deactv_req.no_of_bearers,
-                      sample_gx_nw_init_ded_bearer_deactv_req.ebi)))
-      .Times(1);
-
   return_code = spgw_handle_nw_initiated_bearer_deactv_req(
       &sample_gx_nw_init_ded_bearer_deactv_req, test_imsi64);
 
@@ -634,6 +626,14 @@ TEST_F(SPGWAppProcedureTest, TestDedicatedBearerDeactivation) {
   // Activate dedicated bearer
   ebi_t ded_eps_bearer_id = activate_dedicated_bearer(
       spgw_state, spgw_eps_bearer_ctxt_info_p, ue_sgw_teid);
+
+  // check that MME gets a bearer deactivation request
+  uint32_t expected_no_of_bearers = 1;
+  ebi_t expected_ebi[] = {6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  EXPECT_CALL(*mme_app_handler, mme_app_handle_nw_init_bearer_deactv_req(
+                                    check_params_in_deactv_bearer_req(
+                                        expected_no_of_bearers, expected_ebi)))
+      .Times(1);
 
   // Deactivate dedicated bearer
   deactivate_dedicated_bearer(spgw_state, ue_sgw_teid, ded_eps_bearer_id);


### PR DESCRIPTION
Fixes #11984

## Summary

Moved one `EXPECT_CALL` from the `deactivate_dedicated_bearer` to the `TestDedicatedBearerDeactivation` `TEST_F` macro. We found that this fixes the test when run with Bazel. Also works with `asan` and `lsan` options.

## Test Plan

The `bazel test` commands have to be run on the `pr-giant-bazel-mme-rebase` branch (with these changes cherry-picked).

```
bazel test lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_test --runs_per_test=100
bazel test lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_test --config=asan
bazel test lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_test --config=lsan
cd $MAGMA_ROOT/lte/gateway && make test_oai
```

## Additional Information

- [ ] This change is backwards-breaking

We have not understood why `bazel test` fails without this change. With `print` debugging, we were able to see that the `MATCHER_P2` doesn't seem to get the parameters that we would expect. Out of curiosity, we tested if we can outsource the `EXPECT_CALL` to another function, but that also fails (with the same error as without this change). It seems we have to call it directly from the `TEST_F` macro.

