### PR TITLE
refactor: Refactor bazel binaries to only include main.py

### DIFF
--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -34,6 +34,7 @@ pycryptodome
 spyne
 aiohttp
 lxml==4.7.1
+typing_extensions
 
 # bazelbase container requirements
 hiredis

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -818,7 +818,7 @@ priority==1.3.0 \
     --hash=sha256:6bc1961a6d7fcacbfc337769f1a382c8e746566aaa365e78047abe9f66b2ffbe \
     --hash=sha256:be4fcb94b5e37cdeb40af5533afe6dd603bd665fe9c8b3052610fc1001d5d1eb
     # via -r requirements.in
-prometheus-client==0.3.1 \
+prometheus_client==0.3.1 \
     --hash=sha256:17bc24c09431644f7c65d7bce9f4237252308070b6395d6d8e87767afe867e24
     # via -r requirements.in
 protobuf==3.19.4 \
@@ -1145,6 +1145,10 @@ tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via pytest
+typing-extensions==4.1.1 \
+    --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42 \
+    --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
+    # via -r requirements.in
 urllib3==1.26.8 \
     --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed \
     --hash=sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c

--- a/lte/gateway/python/magma/mobilityd/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/BUILD.bazel
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 load("@python_deps//:requirements.bzl", "requirement")
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -20,6 +20,28 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 py_binary(
     name = "mobilityd",
+    srcs = ["main.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    # legacy_create_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
+    legacy_create_init = False,
+    main = "main.py",
+    python_version = "PY3",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":mobilityd_lib",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:subscriberdb_python_grpc",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
+        "//orc8r/gateway/python/magma/common/redis:client",
+    ],
+)
+
+py_library(
+    name = "mobilityd_lib",
     srcs = [
         "dhcp_client.py",
         "dhcp_desc.py",
@@ -33,7 +55,6 @@ py_binary(
         "ip_descriptor_map.py",
         "ipv6_allocator_pool.py",
         "mac.py",
-        "main.py",
         "metrics.py",
         "mobility_store.py",
         "rpc_servicer.py",
@@ -42,26 +63,18 @@ py_binary(
         "uplink_gw.py",
         "utils.py",
     ],
-    imports = [
-        LTE_ROOT,
-        ORC8R_ROOT,
-    ],
-    # legacy_create_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
-    legacy_create_init = False,
-    main = "main.py",
-    python_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         "//lte/gateway/python/magma/subscriberdb:sid",
         "//lte/protos:keyval_python_proto",
-        "//lte/protos:mconfigs_python_proto",
         "//lte/protos:mobilityd_python_grpc",
+        "//lte/protos:mobilityd_python_proto",
         "//lte/protos:subscriberdb_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
-        "//orc8r/gateway/python/magma/common:sentry",
-        "//orc8r/gateway/python/magma/common:service",
         "//orc8r/gateway/python/magma/common/redis:client",
         requirement("netifaces"),
         requirement("scapy"),
+        requirement("typing_extensions"),
+        requirement("prometheus_client"),
     ],
 )

--- a/lte/gateway/python/magma/mobilityd/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/tests/BUILD.bazel
@@ -13,22 +13,34 @@ load("@python_deps//:requirements.bzl", "requirement")
 load("//bazel:python_test.bzl", "pytest_test")
 load("//bazel:test_constants.bzl", "TAG_SUDO_TEST")
 
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "ip_alloc_dhcp_test",
     srcs = ["ip_alloc_dhcp_test.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
     tags = TAG_SUDO_TEST,
     deps = [
-        "//lte/gateway/python/magma/mobilityd",
-        requirement("fakeredis"),
+        "//lte/gateway/python/magma/mobilityd:mobilityd_lib",
         "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//orc8r/gateway/python/magma/common/redis:client",
+        requirement("fakeredis"),
     ],
 )
 
 pytest_test(
     name = "ip_allocator_dhcp_mac_addr_test",
     srcs = ["ip_allocator_dhcp_mac_addr_test.py"],
+    imports = [LTE_ROOT],
     deps = [
-        "//lte/gateway/python/magma/mobilityd",
+        "//lte/gateway/python/magma/mobilityd:mobilityd_lib",
         requirement("fakeredis"),
     ],
 )
@@ -36,19 +48,24 @@ pytest_test(
 pytest_test(
     name = "test_dhcp_client",
     srcs = ["test_dhcp_client.py"],
+    imports = [LTE_ROOT],
     tags = TAG_SUDO_TEST,
     deps = [
-        "//lte/gateway/python/magma/mobilityd",
-        requirement("freezegun"),
+        "//lte/gateway/python/magma/mobilityd:mobilityd_lib",
         "//lte/gateway/python/magma/pipelined:bridge_util",
+        requirement("freezegun"),
     ],
 )
 
 pytest_test(
     name = "test_ipv6_allocator",
     srcs = ["test_ipv6_allocator.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
     deps = [
-        "//lte/gateway/python/magma/mobilityd",
+        "//lte/gateway/python/magma/mobilityd:mobilityd_lib",
         requirement("fakeredis"),
     ],
 )
@@ -56,8 +73,12 @@ pytest_test(
 pytest_test(
     name = "test_multi_apn_ip_alloc",
     srcs = ["test_multi_apn_ip_alloc.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
     deps = [
-        "//lte/gateway/python/magma/mobilityd",
+        "//lte/gateway/python/magma/mobilityd:mobilityd_lib",
         requirement("fakeredis"),
     ],
 )
@@ -65,32 +86,39 @@ pytest_test(
 pytest_test(
     name = "test_static_ip_alloc",
     srcs = ["test_static_ip_alloc.py"],
+    imports = [LTE_ROOT],
     deps = [
         ":test_multi_apn_ip_alloc",
-        "//lte/gateway/python/magma/mobilityd",
+        "//lte/gateway/python/magma/mobilityd:mobilityd_lib",
     ],
 )
 
 pytest_test(
     name = "test_static_ipv6_alloc",
     srcs = ["test_static_ipv6_alloc.py"],
+    imports = [LTE_ROOT],
     deps = [
         ":test_multi_apn_ip_alloc",
-        "//lte/gateway/python/magma/mobilityd",
+        "//lte/gateway/python/magma/mobilityd:mobilityd_lib",
     ],
 )
 
 pytest_test(
     name = "test_uplink_gw",
     srcs = ["test_uplink_gw.py"],
-    deps = ["//lte/gateway/python/magma/mobilityd"],
+    imports = [LTE_ROOT],
+    deps = ["//lte/gateway/python/magma/mobilityd:mobilityd_lib"],
 )
 
 pytest_test(
     name = "ip_allocator_tests",
     srcs = ["ip_allocator_tests.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
     deps = [
+        "//lte/gateway/python/magma/mobilityd:mobilityd_lib",
         requirement("fakeredis"),
-        "//lte/gateway/python/magma/mobilityd",
     ],
 )

--- a/lte/gateway/python/magma/policydb/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/BUILD.bazel
@@ -19,16 +19,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 py_binary(
     name = "policydb",
-    srcs = [
-        "apn_rule_map_store.py",
-        "basename_store.py",
-        "main.py",
-        "rating_group_store.py",
-        "reauth_handler.py",
-        "rule_map_store.py",
-        "rule_store.py",
-        "streamer_callback.py",
-    ],
+    srcs = ["main.py"],
     imports = [
         LTE_ROOT,
         ORC8R_ROOT,
@@ -37,15 +28,37 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
     deps = [
+        ":policydb_lib",
         "//lte/gateway/python/magma/policydb/servicers:policy_servicer",
         "//lte/gateway/python/magma/policydb/servicers:session_servicer",
         "//lte/protos:mconfigs_python_proto",
         "//lte/protos:policydb_python_grpc",
         "//lte/protos:session_manager_python_grpc",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
+        "//orc8r/gateway/python/magma/common:streamer",
+    ],
+)
+
+py_library(
+    name = "policydb_lib",
+    srcs = [
+        "apn_rule_map_store.py",
+        "basename_store.py",
+        "rating_group_store.py",
+        "reauth_handler.py",
+        "rule_map_store.py",
+        "rule_store.py",
+        "streamer_callback.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":default_rules",
         "//orc8r/gateway/python/magma/common:rpc_utils",
         "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:serialization_utils",
         "//orc8r/gateway/python/magma/common:service",
         "//orc8r/gateway/python/magma/common:streamer",
         "//orc8r/gateway/python/magma/common/redis:client",

--- a/lte/gateway/python/magma/policydb/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/tests/BUILD.bazel
@@ -13,11 +13,24 @@ load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library")
 load("//bazel:python_test.bzl", "pytest_test")
 
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "test_policy_servicer",
     srcs = ["test_policy_servicer.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
     deps = [
-        "//lte/gateway/python/magma/policydb",
+        "//lte/gateway/python/magma/policydb:policydb_lib",
+        "//lte/gateway/python/magma/policydb/servicers:policy_servicer",
+        "//lte/protos:policydb_python_grpc",
+        "//lte/protos:session_manager_python_grpc",
         requirement("grpcio"),
     ],
 )
@@ -25,21 +38,44 @@ pytest_test(
 pytest_test(
     name = "test_reauth_handler",
     srcs = ["test_reauth_handler.py"],
-    deps = ["//lte/gateway/python/magma/policydb"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = [
+        "//lte/gateway/python/magma/policydb:policydb_lib",
+        "//lte/protos:policydb_python_grpc",
+        "//lte/protos:session_manager_python_grpc",
+    ],
 )
 
 pytest_test(
     name = "test_session_servicer",
     srcs = ["test_session_servicer.py"],
-    deps = ["//lte/gateway/python/magma/policydb"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = [
+        "//lte/gateway/python/magma/policydb:policydb_lib",
+        "//lte/gateway/python/magma/policydb/servicers:session_servicer",
+        "//lte/protos:policydb_python_grpc",
+        "//lte/protos:session_manager_python_grpc",
+    ],
 )
 
 pytest_test(
     name = "test_streamer_callback",
     srcs = ["test_streamer_callback.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
     deps = [
         ":mock_stubs",
-        "//lte/gateway/python/magma/policydb",
+        "//lte/gateway/python/magma/policydb:policydb_lib",
+        "//lte/protos:policydb_python_grpc",
+        "//lte/protos:session_manager_python_grpc",
     ],
 )
 

--- a/lte/gateway/python/magma/redirectd/BUILD.bazel
+++ b/lte/gateway/python/magma/redirectd/BUILD.bazel
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 load("@python_deps//:requirements.bzl", "requirement")
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -20,15 +20,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 py_binary(
     name = "redirectd",
-    srcs = [
-        "main.py",
-        "redirect_server.py",
-        "redirect_store.py",
-    ],
-    data = [
-        "templates/404.html",
-        "templates/layout.html",
-    ],
+    srcs = ["main.py"],
     imports = [
         LTE_ROOT,
         ORC8R_ROOT,
@@ -37,21 +29,31 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
     deps = [
+        ":redirectd_lib",
         "//lte/protos:mconfigs_python_proto",
-        "//lte/protos:policydb_python_proto",
         "//orc8r/gateway/python/magma/common:sentry",
         "//orc8r/gateway/python/magma/common:service",
-        "//orc8r/gateway/python/magma/common/redis:client",
         "//orc8r/gateway/python/magma/configuration:service_configs",
-        "//orc8r/protos:eventd_python_grpc",
-        "//orc8r/protos:mconfig_python_proto",
-        "//orc8r/protos:mconfigs_python_proto",
-        "//orc8r/protos:metricsd_python_proto",
-        "//orc8r/protos:service303_python_grpc",
-        requirement("grpcio"),
-        requirement("wsgiserver"),
+    ],
+)
+
+py_library(
+    name = "redirectd_lib",
+    srcs = [
+        "redirect_server.py",
+        "redirect_store.py",
+    ],
+    data = [
+        "templates/404.html",
+        "templates/layout.html",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lte/protos:policydb_python_proto",
+        "//orc8r/gateway/python/magma/common/redis:client",
         requirement("flask"),
+        requirement("wsgiserver"),
     ],
 )

--- a/lte/gateway/python/magma/redirectd/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/redirectd/tests/BUILD.bazel
@@ -11,11 +11,21 @@
 
 load("//bazel:python_test.bzl", "pytest_test")
 
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "test_redirect",
     srcs = ["test_redirect.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
     deps = [
-        "//lte/gateway/python/magma/redirectd",
+        "//lte/gateway/python/magma/redirectd:redirectd_lib",
         "//lte/protos:policydb_python_proto",
     ],
 )

--- a/orc8r/gateway/python/magma/common/BUILD.bazel
+++ b/orc8r/gateway/python/magma/common/BUILD.bazel
@@ -87,7 +87,10 @@ py_library(
 py_library(
     name = "streamer",
     srcs = ["streamer.py"],
-    deps = ["//orc8r/protos:streamer_python_grpc"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/protos:streamer_python_grpc",
+    ],
 )
 
 py_library(

--- a/orc8r/gateway/python/magma/eventd/BUILD.bazel
+++ b/orc8r/gateway/python/magma/eventd/BUILD.bazel
@@ -12,16 +12,6 @@
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
-py_library(
-    name = "eventd_client",
-    srcs = ["eventd_client.py"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//orc8r/gateway/python/magma/common:service_registry",
-        "//orc8r/protos:eventd_python_grpc",
-    ],
-)
-
 MAGMA_ROOT = "../../../../../"
 
 ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
@@ -30,11 +20,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 py_binary(
     name = "eventd",
-    srcs = [
-        "event_validator.py",
-        "main.py",
-        "rpc_servicer.py",
-    ],
+    srcs = ["main.py"],
     imports = [
         LTE_ROOT,
         ORC8R_ROOT,
@@ -43,13 +29,35 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":eventd_lib",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
+    ],
+)
+
+py_library(
+    name = "eventd_lib",
+    srcs = [
+        "event_validator.py",
+        "rpc_servicer.py",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//lte/swagger:lte_swagger_specs",
         "//orc8r/gateway/python/magma/common:rpc_utils",
-        "//orc8r/gateway/python/magma/common:sentry",
-        "//orc8r/gateway/python/magma/common:service",
         "//orc8r/swagger:orc8r_swagger_specs",
         requirement("bravado_core"),
+    ],
+)
+
+py_library(
+    name = "eventd_client",
+    srcs = ["eventd_client.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:service_registry",
+        "//orc8r/protos:eventd_python_grpc",
     ],
 )

--- a/orc8r/gateway/python/magma/eventd/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/eventd/tests/BUILD.bazel
@@ -11,8 +11,13 @@
 
 load("//bazel:python_test.bzl", "pytest_test")
 
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "event_validation_tests",
     srcs = ["event_validation_tests.py"],
-    deps = ["//orc8r/gateway/python/magma/eventd"],
+    imports = [ORC8R_ROOT],
+    deps = ["//orc8r/gateway/python/magma/eventd:eventd_lib"],
 )


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The `py_binary`s of `eventd`, `redirectd`, `policydb` and `mobilityd` are refactored to only include the `main.py`. 
- Other source files are moved to separate `py_library`s.
- See https://github.com/magma/magma/issues/11743
- Note: Review on commit by commit basis

## Test Plan

- Run tests with bazel in `dev-container` and in `bazel-base`:
`bazel test  //orc8r/gateway/python/... //lte/gateway/python/...`

- Run services with bazel in `dev-container` and in `bazel-base`:
```
bazel run //lte/gateway/python/magma/redirectd:redirectd
bazel run //lte/gateway/python/magma/policydb:policydb
bazel run //lte/gateway/python/magma/mobilityd:mobilityd
bazel run //orc8r/gateway/python/magma/eventd:eventd
```


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
