### PR TITLE
fix(orc8r): Fix missing cloud health servicer init

### DIFF
--- a/feg/cloud/go/services/health/health/main.go
+++ b/feg/cloud/go/services/health/health/main.go
@@ -54,6 +54,11 @@ func main() {
 		glog.Fatalf("Error creating health servicer: %+v", err)
 	}
 	protos.RegisterHealthServer(srv.GrpcServer, healthServer)
+	cloudHealthServer, err := servicers.NewCloudHealthServer(store)
+	if err != nil {
+		glog.Fatalf("Error creating cloud health servicer: %+v", err)
+	}
+	protos.RegisterCloudHealthServer(srv.GrpcServer, cloudHealthServer)
 
 	// create a networkHealthStatusReporter to monitor and periodically log metrics
 	// on if all gateways in a network are unhealthy


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

As part of separating out the health servicer into its internal and southbound components, the internal component was not initialized in the main.go. Fix: initialize it in the main.go.

Side note: this is an unfortunate side effect of our current pattern of using non-trivial + un-tested main.go files

## Test Plan

test_in_staging.gif

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->