### PR TITLE
chore: add OAI Bazel target for remaining test files

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/amf/BUILD.bazel
@@ -77,7 +77,6 @@ cc_test(
         "//lte/gateway/c/core",
         "@com_google_googletest//:gtest_main",
     ],
-
 )
 
 cc_library(
@@ -99,5 +98,21 @@ cc_library(
     deps = [
         "//lte/gateway/c/core",
         "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "amf_encode_decode_test",
+    size = "small",
+    srcs = [
+        "test_amf_encode_decode.cpp",
+    ],
+    # TODO: Remove manual tag when fixed: GH12163
+    tags = ["manual"],
+    deps = [
+        ":amf_app_test_util",
+        "//lte/gateway/c/core",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
@@ -119,3 +119,15 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "mme_app_ue_context_test",
+    size = "small",
+    srcs = [
+        "test_mme_app_ue_context.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
@@ -72,3 +72,28 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "spgw_service_impl_test",
+    size = "small",
+    srcs = [
+        "test_spgw_service_impl.cpp",
+    ],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "spgw_state_converter_test",
+    size = "small",
+    srcs = [
+        "test_spgw_state_converter.cpp",
+    ],
+    deps = [
+        ":spgw_test_core",
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Address
*  https://github.com/magma/magma/issues/12147
*  https://github.com/magma/magma/issues/12146
*  https://github.com/magma/magma/issues/12105
*  https://github.com/magma/magma/issues/12103

Bazelify test files tracked by the above four issues. `amf_encode_decode` does not pass with ASAN, so I've filed a follow up task for this and marked the test as 'manual' for now.  https://github.com/magma/magma/issues/12163

This PR combined with https://github.com/magma/magma/pull/12148 addresses all the untracked files pointed out by @nstng 's script in https://github.com/magma/magma/issues/11767

<!-- Enumerate changes you made and why you made them -->

## Test Plan
These all pass and CI

```bash
bazel test //lte/gateway/c/core/oai/test/mme_app_task:mme_app_ue_context --runs_per_test=100
bazel test //lte/gateway/c/core/oai/test/mme_app_task:mme_app_ue_context --runs_per_test=100 --config=asan
bazel test //lte/gateway/c/core/oai/test/mme_app_task:mme_app_ue_context --runs_per_test=100 --config=lsan
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_service_impl  --runs_per_test=100
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_service_impl --config=asan --runs_per_test=100
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_service_impl --config=lsan --runs_per_test=100
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_state_converter  --runs_per_test=100
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_state_converter  --runs_per_test=100 --config=asan
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_state_converter  --runs_per_test=100 --config=lsan
```


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
