### PR TITLE
chore: remove manual tags from mme and spgw procedure tests

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
@@ -110,8 +110,8 @@ cc_test(
     srcs = [
         "test_mme_procedures.cpp",
     ],
-    # TODO: Remove manual tag when fixed: GH11955
-    tags = ["manual"],
+    # TODO: Address flaky test GH12166
+    flaky = True,
     deps = [
         ":mme_app_test_core",
         "//lte/gateway/c/core",

--- a/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
@@ -49,8 +49,6 @@ cc_test(
     srcs = [
         "test_spgw_procedures.cpp",
     ],
-    # TODO: Remove manual tag when fixed: GH11984
-    tags = ["manual"],
     deps = [
         ":spgw_test_core",
         "//lte/gateway/c/core",


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
https://github.com/magma/magma/issues/11955 and https://github.com/magma/magma/issues/11984 have recently been resolved. Now they can be run by default for both the CI jobs we have (plain test all and test C/C++ with --config=asan)

I've filed https://github.com/magma/magma/issues/12166 to track that mme_procedures_test is flaky. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI

I also ran 
```bash
# PASSES
bazel test //lte/gateway/c/core/... --runs_per_test=50 --config=asan 
# mme_procedures_test FAILED in 6 out of 50 in 45.7s 
bazel test //lte/gateway/c/core/... --runs_per_test=50 
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
