### PR TITLE
chore(agw): Remove manual tag

### DIFF
--- a/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
@@ -49,8 +49,6 @@ cc_test(
     srcs = [
         "test_spgw_procedures.cpp",
     ],
-    # TODO: Remove manual tag when fixed: GH11984
-    tags = ["manual"],
     deps = [
         ":spgw_test_core",
         "//lte/gateway/c/core",


### PR DESCRIPTION
## Summary

#12142 introduced the `cc_test` with the `manual` tag, and #12150 removed the need for the manual tag. This PR removes the manual tag.

## Test Plan

tests for #12150 should be sufficient

## Additional Information

- [ ] This change is backwards-breaking