### PR TITLE
fix(ci): semantic pr check has needed permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -52,6 +52,8 @@ jobs:
     needs: reverted-pr-check
     if: ${{ needs.reverted-pr-check.outputs.is_reverted_pr == 'false' }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

See [slack](https://magmacore.slack.com/archives/C01AWMH0EJW/p1647470676696139) for initial discussion.

In https://github.com/magma/magma/pull/11442 permissions for github actions were revised. The semantic pr checks seems to need write permissions for pull requests.

**Pleas note:** I am new to github actions, i.e., please make sure setting the permissions make sense.

**Update:** I guess there are more jobs having this problem, e.g.,
* https://github.com/magma/magma/runs/5582956635?check_suite_focus=true
* https://github.com/magma/magma/runs/5582956359?check_suite_focus=true

### My understanding:
* `pull_request_target` cause the check to use `semantic-pr.yml` from master, i.e., this change will only have effect if merged. This also implies that this needs to be merged by someone who can override the 'required' restriction.
* Assumption here is that `permissions` on job level supersede global/workflow `permissions` (I did not see this in the [docu](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/)).

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
