### PR TITLE
chore(mme): Bazelify spgw_service_impl test

### DIFF
--- a/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
@@ -72,3 +72,13 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "spgw_service_impl_test",
+    size = "small",
+    srcs = ["test_spgw_service_impl.cpp"],
+    deps = [
+        "//lte/gateway/c/core",
+        "@com_google_googletest//:gtest_main",
+    ],
+)


### PR DESCRIPTION
Closes #12105

## Summary

Add  `cc_test` target for `test_spgw_service_impl.cpp`

## Test Plan

```
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_service_impl_test --runs_per_test=100
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_service_impl_test --runs_per_test=100 --config=asan
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_service_impl_test --runs_per_test=10 --config=lsan
```

## Additional Information

- [ ] This change is backwards-breaking
