### PR TITLE
chore: fix cwf-integ-test job by allowing write permissions

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -15,8 +15,6 @@ on:  # yamllint disable-line rule:truthy
 env:
   SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
 
-permissions: read-all
-
 jobs:
   docker-build:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Noticing that the CWF integration test is failing to update status since permission changes made last night https://github.com/magma/magma/pull/11442 .
<img width="1704" alt="Screen Shot 2022-03-17 at 2 02 10 PM" src="https://user-images.githubusercontent.com/37634144/158866714-9e2c62b1-b7d0-4683-946c-7f1333c8d351.png">


## Test Plan
test in master?
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
