### PR TITLE
fix(mme): Update handle_ue_context_rel_timer_expiry to return gracefully

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/grpc_service_task.c
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/grpc_service_task.c
@@ -62,7 +62,10 @@ static void* grpc_service_thread(__attribute__((unused)) void* args) {
   start_grpc_service(grpc_service_config->server_address);
   zloop_start(grpc_service_task_zmq_ctx.event_loop);
   AssertFatal(
-      0, "Asserting as grpc_service_thread should not be exiting on its own!");
+      0,
+      "Asserting as grpc_service_thread should not be exiting on its own! "
+      "This is likely due to a timer handler function returning -1 "
+      "(RETURNerror) on one of the conditions.");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_main.c
@@ -515,7 +515,9 @@ static void* mme_app_thread(__attribute__((unused)) void* args) {
 
   zloop_start(mme_app_task_zmq_ctx.event_loop);
   AssertFatal(0,
-              "Asserting as mme_app_thread should not be exiting on its own!");
+              "Asserting as mme_app_thread should not be exiting on its own! "
+              "This is likely due to a timer handler function returning -1 "
+              "(RETURNerror) on one of the conditions.");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
@@ -220,7 +220,9 @@ static void* ngap_amf_thread(__attribute__((unused)) void* args) {
   }
   zloop_start(ngap_task_zmq_ctx.event_loop);
   AssertFatal(0,
-              "Asserting as ngap_amf_thread should not be exiting on its own!");
+              "Asserting as ngap_amg_thread should not be exiting on its own! "
+              "This is likely due to a timer handler function returning -1 "
+              "(RETURNerror) on one of the conditions.");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
+++ b/lte/gateway/c/core/oai/tasks/s11/s11_tasks.c
@@ -349,7 +349,9 @@ static void* s11_mme_thread(void* args) {
 
   zloop_start(s11_task_zmq_ctx.event_loop);
   AssertFatal(0,
-              "Asserting as s11_mme_thread should not be exiting on its own!");
+              "Asserting as s11_mme_thread should not be exiting on its own! "
+              "This is likely due to a timer handler function returning -1 "
+              "(RETURNerror) on one of the conditions.");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.c
@@ -316,7 +316,9 @@ static void* s1ap_mme_thread(__attribute__((unused)) void* args) {
 
   zloop_start(s1ap_task_zmq_ctx.event_loop);
   AssertFatal(0,
-              "Asserting as s1ap_mme_thread should not be exiting on its own!");
+              "Asserting as s1ap_mme_thread should not be exiting on its own! "
+              "This is likely due to a timer handler function returning -1 "
+              "(RETURNerror) on one of the conditions.");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -5309,14 +5309,16 @@ static int handle_ue_context_rel_timer_expiry(zloop_t* loop, int timer_id,
   if (!s1ap_pop_timer_arg_ue_id(timer_id, &mme_ue_s1ap_id)) {
     OAILOG_WARNING(LOG_S1AP, "Invalid Timer Id expiration, Timer Id: %u\n",
                    timer_id);
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
+    // Timer handlers need to return 0 to avoid triggering ZMQ thread exit
+    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
   }
   if ((ue_ref_p = s1ap_state_get_ue_mmeid(mme_ue_s1ap_id)) == NULL) {
     OAILOG_ERROR(
         LOG_S1AP,
         "Failed to find UE context for mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT,
         mme_ue_s1ap_id);
-    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
+    // Timer handlers need to return 0 to avoid triggering ZMQ thread exit
+    OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
   }
 
   state = get_s1ap_state(false);

--- a/lte/gateway/c/core/oai/tasks/s6a/s6a_task.c
+++ b/lte/gateway/c/core/oai/tasks/s6a/s6a_task.c
@@ -136,7 +136,10 @@ static void* s6a_thread(void* args) {
   }
 
   zloop_start(s6a_task_zmq_ctx.event_loop);
-  AssertFatal(0, "Asserting as s6a_thread should not be exiting on its own!");
+  AssertFatal(0,
+              "Asserting as s6a_thread should not be exiting on its own! "
+              "This is likely due to a timer handler function returning -1 "
+              "(RETURNerror) on one of the conditions.");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/sgs/sgs_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgs/sgs_task.c
@@ -181,7 +181,10 @@ static void* sgs_thread(__attribute__((unused)) void* args_p) {
                     task_zmq_ctx_p);
 
   zloop_start(task_zmq_ctx_p->event_loop);
-  AssertFatal(0, "Asserting as sgs_thread should not be exiting on its own!");
+  AssertFatal(0,
+              "Asserting as sgs_thread should not be exiting on its own! "
+              "This is likely due to a timer handler function returning -1 "
+              "(RETURNerror) on one of the conditions.");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_task.c
@@ -226,7 +226,9 @@ static void* spgw_app_thread(__attribute__((unused)) void* args) {
 
   zloop_start(spgw_app_task_zmq_ctx.event_loop);
   AssertFatal(0,
-              "Asserting as spgw_app_thread should not be exiting on its own!");
+              "Asserting as spgw_app_thread should not be exiting on its own! "
+              "This is likely due to a timer handler function returning -1 "
+              "(RETURNerror) on one of the conditions.");
   return NULL;
 }
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_task.c
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_task.c
@@ -34,7 +34,9 @@ static void* sgw_s8_thread(void* args) {
 
   zloop_start(sgw_s8_task_zmq_ctx.event_loop);
   AssertFatal(0,
-              "Asserting as sgw_s8_thread should not be exiting on its own!");
+              "Asserting as sgw_s8_thread should not be exiting on its own! "
+              "This is likely due to a timer handler function returning -1 "
+              "(RETURNerror) on one of the conditions.");
   return NULL;
 }
 


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
-  Changes on https://github.com/magma/magma/pull/11245 creates an issue discovered while running `test_attach_auth_failure.py` due to the timer handler returning `RETURNerror` (-1) which triggers an exit on the S1AP's ZMQ thread. 
- This PR fixes the issue by gracefully handling the return of the handler by returning `RETURNok` (0) instead.
- Updates all potential zmq's AssertFatal messages to indicate possible source of crash.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- `make precommit` runs successfully 
- `make integ_test`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
