### PR TITLE
docs: update postgres upgrade instructions

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/upgrade_1_6.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/upgrade_1_6.md
@@ -79,7 +79,7 @@ terraform apply  # check this output VERY carefully
 
 [AWS is terminating support for Postgres 9.6 on November 11, 2021](https://aws.amazon.com/blogs/database/upgrading-from-amazon-rds-for-postgresql-version-9-5/), in accordance with the [Postgres versioning policy](https://www.postgresql.org/support/versioning/). Postgres 9.6 was the default Orc8r DB target for the past several Magma releases.
 
-[We will provide forthcoming guidance on performing the DB upgrade](https://github.com/magma/magma/issues/7871), which [will require minor DB downtime](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html).
+To upgrade your Postgres database to the correct version follow [these instructions](https://docs.magmacore.org/docs/orc8r/rds_upgrade#logs-and-validation).
 
 ### Host custom artifacts
 

--- a/docs/readmes/orc8r/upgrade_1_6.md
+++ b/docs/readmes/orc8r/upgrade_1_6.md
@@ -78,7 +78,7 @@ terraform apply  # check this output VERY carefully
 
 [AWS is terminating support for Postgres 9.6 on November 11, 2021](https://aws.amazon.com/blogs/database/upgrading-from-amazon-rds-for-postgresql-version-9-5/), in accordance with the [Postgres versioning policy](https://www.postgresql.org/support/versioning/). Postgres 9.6 was the default Orc8r DB target for the past several Magma releases.
 
-[We will provide forthcoming guidance on performing the DB upgrade](https://github.com/magma/magma/issues/7871), which [will require minor DB downtime](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html).
+To upgrade your Postgres database to the correct version follow [these instructions](https://docs.magmacore.org/docs/orc8r/rds_upgrade#logs-and-validation).
 
 ### Host custom artifacts
 


### PR DESCRIPTION
Signed-off-by: Jared Mullane <jmullane@fb.com>


## Summary

Updated orchestrator upgrade documentation with a link to the latest postgres upgrade documentation. 

## Test Plan
![Screen Shot 2022-03-17 at 2 19 56 PM](https://user-images.githubusercontent.com/61836831/158897836-b9456783-abab-481e-bac3-05019c5ba89c.png)

