### PR TITLE
fix(feg): Diameter closed connection recovery

### DIFF
--- a/feg/gateway/diameter/connection_manager.go
+++ b/feg/gateway/diameter/connection_manager.go
@@ -153,7 +153,7 @@ func (cm *ConnectionManager) cleanupConnections() {
 	glog.V(2).Info("ConnectionManager: removing all existing connections")
 	for _, c := range cm.connMap {
 		if c != nil {
-			c.cleanupConnection()
+			c.cleanupConnection(true)
 		}
 	}
 	cm.connMap = map[DiameterServerConnConfig]*Connection{}


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>


## Summary

Add connection recovery logic for externally closed diameter connection.
Current connection manager only recovers errored connections. There several scenarios when connennection can be closed 'quietly' without connection manager knowing about it - when diameter watchdog is timed out, it'll close connection unconditionally, protocol stack may closed unhealthy or idle connection, etc.

The fix is relying on diameter Close Notifier channel to detect connection closure & reconnect.

The fix can potentially resolve issue #12067

## Test Plan

unit tests, TVM

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
