### PR TITLE
fix(session_proxy): Add Rentransmits field to diam client

### DIFF
--- a/feg/gateway/services/s6a_proxy/servicers/config.go
+++ b/feg/gateway/services/s6a_proxy/servicers/config.go
@@ -59,9 +59,12 @@ func GetS6aProxyConfigs() *S6aProxyConfig {
 		log.Printf("%s Managed Configs Load Error: %v", S6aProxyServiceName, err)
 		return &S6aProxyConfig{
 			ClientCfg: &diameter.DiameterClientConfig{
-				Host:        diameter.GetValueOrEnv(diameter.HostFlag, S6aDiamHostEnv, DefaultS6aDiamHost),
-				Realm:       diameter.GetValueOrEnv(diameter.RealmFlag, S6aDiamRealmEnv, DefaultS6aDiamRealm),
-				ProductName: diameter.GetValueOrEnv(diameter.ProductFlag, S6aDiamProductEnv, diameter.DiamProductName),
+				Host:             diameter.GetValueOrEnv(diameter.HostFlag, S6aDiamHostEnv, DefaultS6aDiamHost),
+				Realm:            diameter.GetValueOrEnv(diameter.RealmFlag, S6aDiamRealmEnv, DefaultS6aDiamRealm),
+				ProductName:      diameter.GetValueOrEnv(diameter.ProductFlag, S6aDiamProductEnv, diameter.DiamProductName),
+				WatchdogInterval: diameter.DefaultWatchdogIntervalSeconds,
+				Retransmits:      uint(10),
+				RetryCount:       uint(5),
 			},
 			ServerCfg: &diameter.DiameterServerConfig{DiameterServerConnConfig: diameter.DiameterServerConnConfig{
 				Addr:      diameter.GetValueOrEnv(diameter.AddrFlag, HSSAddrEnv, ""),

--- a/feg/gateway/services/session_proxy/credit_control/gx/config.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/config.go
@@ -98,6 +98,7 @@ func GetPCRFConfiguration() []*diameter.DiameterServerConfig {
 // GetGxClientConfiguration returns a slice containing all client diameter configuration
 func GetGxClientConfiguration() []*diameter.DiameterClientConfig {
 	var retries uint32 = 1
+	var retransmits uint32 = 1
 	configsPtr := &mconfig.SessionProxyConfig{}
 	err := managed_configs.GetServiceConfigs(credit_control.SessionProxyServiceName, configsPtr)
 	if err != nil {
@@ -110,6 +111,7 @@ func GetGxClientConfiguration() []*diameter.DiameterClientConfig {
 				AppID:              diam.GX_CHARGING_CONTROL_APP_ID,
 				WatchdogInterval:   diameter.DefaultWatchdogIntervalSeconds,
 				RetryCount:         uint(retries),
+				Retransmits:        uint(retransmits),
 				SupportedVendorIDs: diameter.GetValueOrEnv("", GxSupportedVendorIDsEnv, ""),
 			},
 		}
@@ -123,6 +125,11 @@ func GetGxClientConfiguration() []*diameter.DiameterClientConfig {
 			log.Printf("Invalid Gx Server Retry Count for server (%s): %d, must be >0. Will be set to 1", gxCfg.GetAddress(), retries)
 			retries = 1
 		}
+		retransmits = gxCfg.GetRetransmits()
+		if retransmits < 1 {
+			log.Printf("Invalid Gx Retransmit Count for server (%s): %d, must be >0. Will be set to 1", gxCfg.GetAddress(), retransmits)
+			retransmits = 1
+		}
 
 		wdInterval := gxCfg.GetWatchdogInterval()
 		if wdInterval == 0 {
@@ -135,6 +142,7 @@ func GetGxClientConfiguration() []*diameter.DiameterClientConfig {
 			AppID:              diam.GX_CHARGING_CONTROL_APP_ID,
 			WatchdogInterval:   uint(wdInterval),
 			RetryCount:         uint(retries),
+			Retransmits:        uint(retransmits),
 			SupportedVendorIDs: diameter.GetValueOrEnv("", GxSupportedVendorIDsEnv, "", i),
 		}
 		diamClientsConfigs = append(diamClientsConfigs, diamCliCfg)

--- a/feg/gateway/services/session_proxy/credit_control/gy/config.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/config.go
@@ -139,6 +139,7 @@ func GetOCSConfiguration() []*diameter.DiameterServerConfig {
 // GetGyClientConfiguration returns the client diameter configuration
 func GetGyClientConfiguration() []*diameter.DiameterClientConfig {
 	var retries uint32 = 1
+	var retransmits uint32 = 1
 	configsPtr := &mconfig.SessionProxyConfig{}
 	err := managed_configs.GetServiceConfigs(credit_control.SessionProxyServiceName, configsPtr)
 	if err != nil {
@@ -151,6 +152,7 @@ func GetGyClientConfiguration() []*diameter.DiameterClientConfig {
 				AppID:              diam.CHARGING_CONTROL_APP_ID,
 				WatchdogInterval:   diameter.DefaultWatchdogIntervalSeconds,
 				RetryCount:         uint(retries),
+				Retransmits:        uint(retransmits),
 				SupportedVendorIDs: diameter.GetValueOrEnv("", GySupportedVendorIDsEnv, ""),
 				ServiceContextId:   diameter.GetValueOrEnv("", GyServiceContextIdEnv, ""),
 			},
@@ -165,6 +167,11 @@ func GetGyClientConfiguration() []*diameter.DiameterClientConfig {
 			log.Printf("Invalid Gy Server Retry Count for server (%s): %d, must be >0. Will be set to 1", gyCfg.GetAddress(), retries)
 			retries = 1
 		}
+		retransmits = gyCfg.GetRetransmits()
+		if retransmits < 1 {
+			log.Printf("Invalid Gy Retransmit Count for server (%s): %d, must be >0. Will be set to 1", gyCfg.GetAddress(), retransmits)
+			retransmits = 1
+		}
 
 		wdInterval := gyCfg.GetWatchdogInterval()
 		if wdInterval == 0 {
@@ -177,6 +184,7 @@ func GetGyClientConfiguration() []*diameter.DiameterClientConfig {
 			AppID:              diam.CHARGING_CONTROL_APP_ID,
 			WatchdogInterval:   uint(wdInterval),
 			RetryCount:         uint(retries),
+			Retransmits:        uint(retransmits),
 			SupportedVendorIDs: diameter.GetValueOrEnv("", GySupportedVendorIDsEnv, "", i),
 			ServiceContextId:   diameter.GetValueOrEnv("", GyServiceContextIdEnv, "", i),
 		}

--- a/feg/gateway/services/session_proxy/session_proxy/main.go
+++ b/feg/gateway/services/session_proxy/session_proxy/main.go
@@ -100,7 +100,7 @@ func generateClientsConfsAndDiameterConnection() (
 
 	// Each controller will take one entry of PCRF, OCS, and gx/gy clients confs
 	gxCliConfs := gx.GetGxClientConfiguration()
-	gyCLiConfs := gy.GetGyClientConfiguration()
+	gyCliConfs := gy.GetGyClientConfiguration()
 	OCSConfs := gy.GetOCSConfiguration()
 	PCRFConfs := gx.GetPCRFConfiguration()
 
@@ -135,7 +135,7 @@ func generateClientsConfsAndDiameterConnection() (
 		if OCSConfsCopy[i].DiameterServerConnConfig == PCRFConfsCopy[i].DiameterServerConnConfig &&
 			OCSConfsCopy[i] != PCRFConfsCopy[i] {
 			var clientCfg = *gxCliConfs[i]
-			clientCfg.AuthAppID = gyCLiConfs[i].AppID
+			clientCfg.AuthAppID = gyCliConfs[i].AppID
 			diamClient := diameter.NewClient(&clientCfg, OCSConfs[i].LocalAddr)
 			diamClient.BeginConnection(OCSConfsCopy[i])
 			if gyGlobalConf.DisableGy {
@@ -161,14 +161,13 @@ func generateClientsConfsAndDiameterConnection() (
 					gxGlobalConf)
 			}
 		} else {
-
-			glog.Infof("Using distinct Gy: %+v & Gx: %+v connection",
-				OCSConfsCopy[i].DiameterServerConnConfig, PCRFConfsCopy[i].DiameterServerConnConfig)
+			glog.Infof("Using distinct Gx and Gy")
 			if gyGlobalConf.DisableGy {
 				glog.Info("Gy Disabled by configuration, not connecting to OCS")
 			} else {
+				glog.Infof("Gy client: %+v, Gy server: %+v", gyCliConfs[i], OCSConfsCopy[i])
 				controlParam.CreditClient = gy.NewGyClient(
-					gy.GetGyClientConfiguration()[i],
+					gyCliConfs[i],
 					OCSConfsCopy[i],
 					gy.GetGyReAuthHandler(cloudReg),
 					cloudReg,
@@ -177,8 +176,9 @@ func generateClientsConfsAndDiameterConnection() (
 			if gxGlobalConf.DisableGx {
 				glog.Info("Gx Disabled by configuration, not connecting to PCRF")
 			} else {
+				glog.Infof("Gx client: %+v, Gx server: %+v", gxCliConfs[i], PCRFConfsCopy[i])
 				controlParam.PolicyClient = gx.NewGxClient(
-					gx.GetGxClientConfiguration()[i],
+					gxCliConfs[i],
 					PCRFConfsCopy[i],
 					gx.GetGxReAuthHandler(cloudReg, policyDBClient),
 					cloudReg,

--- a/feg/gateway/services/swx_proxy/servicers/config.go
+++ b/feg/gateway/services/swx_proxy/servicers/config.go
@@ -58,9 +58,12 @@ func GetSwxProxyConfig() []*SwxProxyConfig {
 		return []*SwxProxyConfig{
 			{
 				ClientCfg: &diameter.DiameterClientConfig{
-					Host:        diameter.GetValueOrEnv(diameter.HostFlag, SwxDiamHostEnv, DefaultSwxDiamHost),
-					Realm:       diameter.GetValueOrEnv(diameter.RealmFlag, SwxDiamRealmEnv, DefaultSwxDiamRealm),
-					ProductName: diameter.GetValueOrEnv(diameter.ProductFlag, SwxDiamProductEnv, diameter.DiamProductName),
+					Host:             diameter.GetValueOrEnv(diameter.HostFlag, SwxDiamHostEnv, DefaultSwxDiamHost),
+					Realm:            diameter.GetValueOrEnv(diameter.RealmFlag, SwxDiamRealmEnv, DefaultSwxDiamRealm),
+					ProductName:      diameter.GetValueOrEnv(diameter.ProductFlag, SwxDiamProductEnv, diameter.DiamProductName),
+					WatchdogInterval: diameter.DefaultWatchdogIntervalSeconds,
+					Retransmits:      uint(10),
+					RetryCount:       uint(5),
 				},
 				ServerCfg: &diameter.DiameterServerConfig{DiameterServerConnConfig: diameter.DiameterServerConnConfig{
 					Addr:      diameter.GetValueOrEnv(diameter.AddrFlag, HSSAddrEnv, ""),


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Reatempts field was on configuration file but it was never parsed and configured into diameter client

This PR fixes that and adds some logs to provide visibility into the config

This PR is related to https://github.com/magma/magma/pull/12192

## Test Plan

```
session_proxy    | I0317 23:18:56.756850       1 main.go:168] Gy client: &{Host:string Realm:string ProductName:string AppID:4 AuthAppID:0 Retransmits:3 WatchdogInterval:3 RetryCount:5 SupportedVendorIDs: ServiceContextId:}, Gy server: &{DiameterServerConnConfig:{Addr:172
.16.1.14:3868 Protocol:sctp LocalAddr:172.16.1.13:3906} DestHost:magma-fedgw.magma.com DestRealm:magma.com DisableDestHost:false OverwriteDestHost:false}
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
