### PR TITLE
chore: all python tests are (mandatory) categorized by size

### DIFF
--- a/bazel/python_test.bzl
+++ b/bazel/python_test.bzl
@@ -92,7 +92,7 @@ _pytest_runner = rule(
     },
 )
 
-def pytest_test(name, srcs, deps = [], args = [], data = [], imports = [], python_version = None, **kwargs):
+def pytest_test(name, srcs, size, deps = [], args = [], data = [], imports = [], python_version = None, **kwargs):
     runner_target = "%s-runner.py" % name
 
     _pytest_runner(
@@ -113,5 +113,6 @@ def pytest_test(name, srcs, deps = [], args = [], data = [], imports = [], pytho
         main = runner_target,
         legacy_create_init = False,
         imports = imports + ["."],
+        size = size,
         **kwargs
     )

--- a/lte/gateway/python/magma/enodebd/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/enodebd/tests/BUILD.bazel
@@ -20,6 +20,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "baicells_old_tests",
+    size = "small",
     srcs = ["baicells_old_tests.py"],
     imports = [
         LTE_ROOT,
@@ -35,6 +36,7 @@ pytest_test(
 
 pytest_test(
     name = "baicells_qafb_tests",
+    size = "small",
     srcs = ["baicells_qafb_tests.py"],
     imports = [
         LTE_ROOT,
@@ -50,6 +52,7 @@ pytest_test(
 
 pytest_test(
     name = "baicells_qrtb_tests",
+    size = "small",
     srcs = ["baicells_qrtb_tests.py"],
     imports = [
         LTE_ROOT,
@@ -68,6 +71,7 @@ pytest_test(
 
 pytest_test(
     name = "baicells_tests",
+    size = "small",
     srcs = ["baicells_tests.py"],
     imports = [
         LTE_ROOT,
@@ -84,6 +88,7 @@ pytest_test(
 
 pytest_test(
     name = "cavium_tests",
+    size = "small",
     srcs = ["cavium_tests.py"],
     imports = [
         LTE_ROOT,
@@ -100,6 +105,7 @@ pytest_test(
 
 pytest_test(
     name = "configuration_init_tests",
+    size = "small",
     srcs = ["configuration_init_tests.py"],
     imports = [
         LTE_ROOT,
@@ -115,6 +121,7 @@ pytest_test(
 
 pytest_test(
     name = "data_model_tests",
+    size = "small",
     srcs = ["data_model_tests.py"],
     imports = [
         LTE_ROOT,
@@ -128,6 +135,7 @@ pytest_test(
 
 pytest_test(
     name = "device_utils_tests",
+    size = "small",
     srcs = ["device_utils_tests.py"],
     imports = [LTE_ROOT],
     deps = [
@@ -138,6 +146,7 @@ pytest_test(
 
 pytest_test(
     name = "enb_acs_manager_tests",
+    size = "small",
     srcs = ["enb_acs_manager_tests.py"],
     imports = [
         LTE_ROOT,
@@ -153,6 +162,7 @@ pytest_test(
 
 pytest_test(
     name = "enodeb_acs_states_tests",
+    size = "small",
     srcs = ["enodeb_acs_states_tests.py"],
     imports = [
         LTE_ROOT,
@@ -169,6 +179,7 @@ pytest_test(
 
 pytest_test(
     name = "enodeb_configuration_tests",
+    size = "small",
     srcs = ["enodeb_configuration_tests.py"],
     imports = [
         LTE_ROOT,
@@ -183,6 +194,7 @@ pytest_test(
 
 pytest_test(
     name = "enodeb_status_tests",
+    size = "small",
     srcs = ["enodeb_status_tests.py"],
     imports = [
         LTE_ROOT,
@@ -200,6 +212,7 @@ pytest_test(
 
 pytest_test(
     name = "freedomfi_one_tests",
+    size = "small",
     srcs = ["freedomfi_one_tests.py"],
     imports = [
         LTE_ROOT,
@@ -225,6 +238,7 @@ pytest_test(
 
 pytest_test(
     name = "get_params_tests",
+    size = "small",
     srcs = ["get_params_tests.py"],
     imports = [
         LTE_ROOT,
@@ -242,6 +256,7 @@ pytest_test(
 
 pytest_test(
     name = "spyne_mods_tests",
+    size = "small",
     srcs = ["spyne_mods_tests.py"],
     imports = [LTE_ROOT],
     deps = ["//lte/gateway/python/magma/enodebd/tr069:models"],
@@ -249,6 +264,7 @@ pytest_test(
 
 pytest_test(
     name = "stats_manager_tests",
+    size = "small",
     srcs = ["stats_manager_tests.py"],
     data = ["pm_file_example.xml"],
     imports = [
@@ -268,6 +284,7 @@ pytest_test(
 
 pytest_test(
     name = "timer_tests",
+    size = "small",
     srcs = ["timer_tests.py"],
     imports = [LTE_ROOT],
     deps = ["//lte/gateway/python/magma/enodebd/state_machines:timer"],
@@ -275,6 +292,7 @@ pytest_test(
 
 pytest_test(
     name = "tr069_tests",
+    size = "small",
     srcs = ["tr069_tests.py"],
     imports = [
         LTE_ROOT,
@@ -289,6 +307,7 @@ pytest_test(
 
 pytest_test(
     name = "transform_for_enb_tests",
+    size = "small",
     srcs = ["transform_for_enb_tests.py"],
     imports = [LTE_ROOT],
     deps = ["//lte/gateway/python/magma/enodebd/data_models:transform_for"],
@@ -296,6 +315,7 @@ pytest_test(
 
 pytest_test(
     name = "transform_for_magma_tests",
+    size = "small",
     srcs = ["transform_for_magma_tests.py"],
     imports = [LTE_ROOT],
     deps = ["//lte/gateway/python/magma/enodebd/data_models:transform_for"],

--- a/lte/gateway/python/magma/mobilityd/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/tests/BUILD.bazel
@@ -21,6 +21,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "ip_alloc_dhcp_test",
+    size = "small",
     srcs = ["ip_alloc_dhcp_test.py"],
     imports = [
         LTE_ROOT,
@@ -37,6 +38,7 @@ pytest_test(
 
 pytest_test(
     name = "ip_allocator_dhcp_mac_addr_test",
+    size = "small",
     srcs = ["ip_allocator_dhcp_mac_addr_test.py"],
     imports = [LTE_ROOT],
     deps = [
@@ -47,6 +49,7 @@ pytest_test(
 
 pytest_test(
     name = "test_dhcp_client",
+    size = "small",
     srcs = ["test_dhcp_client.py"],
     imports = [LTE_ROOT],
     tags = TAG_SUDO_TEST,
@@ -59,6 +62,7 @@ pytest_test(
 
 pytest_test(
     name = "test_ipv6_allocator",
+    size = "small",
     srcs = ["test_ipv6_allocator.py"],
     imports = [
         LTE_ROOT,
@@ -72,6 +76,7 @@ pytest_test(
 
 pytest_test(
     name = "test_multi_apn_ip_alloc",
+    size = "small",
     srcs = ["test_multi_apn_ip_alloc.py"],
     imports = [
         LTE_ROOT,
@@ -85,6 +90,7 @@ pytest_test(
 
 pytest_test(
     name = "test_static_ip_alloc",
+    size = "small",
     srcs = ["test_static_ip_alloc.py"],
     imports = [LTE_ROOT],
     deps = [
@@ -95,6 +101,7 @@ pytest_test(
 
 pytest_test(
     name = "test_static_ipv6_alloc",
+    size = "small",
     srcs = ["test_static_ipv6_alloc.py"],
     imports = [LTE_ROOT],
     deps = [
@@ -105,6 +112,7 @@ pytest_test(
 
 pytest_test(
     name = "test_uplink_gw",
+    size = "small",
     srcs = ["test_uplink_gw.py"],
     imports = [LTE_ROOT],
     deps = ["//lte/gateway/python/magma/mobilityd:mobilityd_lib"],
@@ -112,6 +120,7 @@ pytest_test(
 
 pytest_test(
     name = "ip_allocator_tests",
+    size = "small",
     srcs = ["ip_allocator_tests.py"],
     imports = [
         LTE_ROOT,

--- a/lte/gateway/python/magma/monitord/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/monitord/tests/BUILD.bazel
@@ -19,6 +19,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "test_icmp_monitor",
+    size = "small",
     srcs = ["test_icmp_monitor.py"],
     imports = [
         LTE_ROOT,

--- a/lte/gateway/python/magma/policydb/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/tests/BUILD.bazel
@@ -21,6 +21,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "test_policy_servicer",
+    size = "small",
     srcs = ["test_policy_servicer.py"],
     imports = [
         LTE_ROOT,
@@ -37,6 +38,7 @@ pytest_test(
 
 pytest_test(
     name = "test_reauth_handler",
+    size = "small",
     srcs = ["test_reauth_handler.py"],
     imports = [
         LTE_ROOT,
@@ -51,6 +53,7 @@ pytest_test(
 
 pytest_test(
     name = "test_session_servicer",
+    size = "small",
     srcs = ["test_session_servicer.py"],
     imports = [
         LTE_ROOT,
@@ -66,6 +69,7 @@ pytest_test(
 
 pytest_test(
     name = "test_streamer_callback",
+    size = "small",
     srcs = ["test_streamer_callback.py"],
     imports = [
         LTE_ROOT,

--- a/lte/gateway/python/magma/redirectd/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/redirectd/tests/BUILD.bazel
@@ -19,6 +19,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "test_redirect",
+    size = "small",
     srcs = ["test_redirect.py"],
     imports = [
         LTE_ROOT,

--- a/lte/gateway/python/magma/subscriberdb/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/tests/BUILD.bazel
@@ -20,6 +20,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "client_tests",
+    size = "small",
     srcs = ["client_tests.py"],
     imports = [
         LTE_ROOT,
@@ -37,6 +38,7 @@ pytest_test(
 
 pytest_test(
     name = "processor_tests",
+    size = "medium",
     srcs = ["processor_tests.py"],
     imports = [LTE_ROOT],
     deps = [
@@ -49,6 +51,7 @@ pytest_test(
 
 pytest_test(
     name = "rpc_tests",
+    size = "small",
     srcs = ["rpc_tests.py"],
     imports = [
         LTE_ROOT,
@@ -63,6 +66,7 @@ pytest_test(
 
 pytest_test(
     name = "sid_utils_tests",
+    size = "small",
     srcs = ["sid_utils_tests.py"],
     imports = [LTE_ROOT],
     deps = [

--- a/lte/gateway/python/magma/subscriberdb/tests/crypto/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/tests/crypto/BUILD.bazel
@@ -17,6 +17,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "crypto_tests",
+    size = "small",
     srcs = ["crypto_tests.py"],
     imports = [LTE_ROOT],
     deps = ["//lte/gateway/python/magma/subscriberdb/crypto:gsm"],
@@ -24,6 +25,7 @@ pytest_test(
 
 pytest_test(
     name = "milenage_tests",
+    size = "small",
     srcs = ["milenage_tests.py"],
     imports = [LTE_ROOT],
     deps = ["//lte/gateway/python/magma/subscriberdb/crypto:milenage"],
@@ -31,6 +33,7 @@ pytest_test(
 
 pytest_test(
     name = "test_ECIES",
+    size = "small",
     srcs = ["test_ECIES.py"],
     imports = [LTE_ROOT],
     deps = ["//lte/gateway/python/magma/subscriberdb/crypto:ECIES"],

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/BUILD.bazel
@@ -21,6 +21,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "avp_tests",
+    size = "small",
     srcs = ["avp_tests.py"],
     imports = [LTE_ROOT],
     deps = ["//lte/gateway/python/magma/subscriberdb/protocols/diameter"],
@@ -28,6 +29,7 @@ pytest_test(
 
 pytest_test(
     name = "base_application_tests",
+    size = "small",
     srcs = ["base_application_tests.py"],
     imports = [
         LTE_ROOT,
@@ -42,6 +44,7 @@ pytest_test(
 
 pytest_test(
     name = "message_tests",
+    size = "small",
     srcs = ["message_tests.py"],
     imports = [LTE_ROOT],
     deps = ["//lte/gateway/python/magma/subscriberdb/protocols/diameter"],
@@ -49,6 +52,7 @@ pytest_test(
 
 pytest_test(
     name = "s6a_application_tests",
+    size = "small",
     srcs = ["s6a_application_tests.py"],
     imports = [
         LTE_ROOT,
@@ -66,6 +70,7 @@ pytest_test(
 
 pytest_test(
     name = "s6a_relay_tests",
+    size = "small",
     srcs = ["s6a_relay_tests.py"],
     imports = [
         LTE_ROOT,
@@ -83,6 +88,7 @@ pytest_test(
 
 pytest_test(
     name = "server_tests",
+    size = "small",
     srcs = ["server_tests.py"],
     imports = [LTE_ROOT],
     deps = [

--- a/lte/gateway/python/magma/subscriberdb/tests/store/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/tests/store/BUILD.bazel
@@ -17,6 +17,7 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "onready_test",
+    size = "medium",
     srcs = ["onready_test.py"],
     imports = [LTE_ROOT],
     deps = [
@@ -29,6 +30,7 @@ pytest_test(
 
 pytest_test(
     name = "store_tests",
+    size = "medium",
     srcs = ["store_tests.py"],
     imports = [LTE_ROOT],
     deps = [

--- a/orc8r/gateway/python/magma/directoryd/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/directoryd/tests/BUILD.bazel
@@ -18,6 +18,7 @@ ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "rpc_servicer_tests",
+    size = "small",
     srcs = ["rpc_servicer_tests.py"],
     imports = [ORC8R_ROOT],
     deps = [

--- a/orc8r/gateway/python/magma/eventd/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/eventd/tests/BUILD.bazel
@@ -17,6 +17,7 @@ ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "event_validation_tests",
+    size = "small",
     srcs = ["event_validation_tests.py"],
     imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/eventd:eventd_lib"],

--- a/orc8r/gateway/python/magma/magmad/check/kernel_check/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/kernel_check/tests/BUILD.bazel
@@ -13,6 +13,7 @@ load("//bazel:python_test.bzl", "pytest_test")
 
 pytest_test(
     name = "kernel_versions_tests",
+    size = "small",
     srcs = ["kernel_versions_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad/check/kernel_check:kernel_versions"],
 )

--- a/orc8r/gateway/python/magma/magmad/check/machine_check/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/machine_check/tests/BUILD.bazel
@@ -13,6 +13,7 @@ load("//bazel:python_test.bzl", "pytest_test")
 
 pytest_test(
     name = "cpu_info_tests",
+    size = "small",
     srcs = ["cpu_info_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad/check/machine_check:cpu_info"],
 )

--- a/orc8r/gateway/python/magma/magmad/check/network_check/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/tests/BUILD.bazel
@@ -13,18 +13,21 @@ load("//bazel:python_test.bzl", "pytest_test")
 
 pytest_test(
     name = "ping_tests",
+    size = "small",
     srcs = ["ping_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad/check/network_check:ping"],
 )
 
 pytest_test(
     name = "routing_table_tests",
+    size = "small",
     srcs = ["routing_table_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad/check/network_check:routing_table"],
 )
 
 pytest_test(
     name = "traceroute_tests",
+    size = "small",
     srcs = ["traceroute_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad/check/network_check:traceroute"],
 )

--- a/orc8r/gateway/python/magma/magmad/check/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/tests/BUILD.bazel
@@ -13,6 +13,7 @@ load("//bazel:python_test.bzl", "pytest_test")
 
 pytest_test(
     name = "subprocess_workflow_tests",
+    size = "small",
     srcs = ["subprocess_workflow_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad/check:subprocess_workflow"],
 )

--- a/orc8r/gateway/python/magma/magmad/generic_command/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/generic_command/tests/BUILD.bazel
@@ -13,12 +13,14 @@ load("//bazel:python_test.bzl", "pytest_test")
 
 pytest_test(
     name = "command_executor_test",
+    size = "small",
     srcs = ["command_executor_test.py"],
     deps = ["//orc8r/gateway/python/magma/magmad/generic_command:command_executor"],
 )
 
 pytest_test(
     name = "shell_command_executor_test",
+    size = "small",
     srcs = ["shell_command_executor_test.py"],
     deps = ["//orc8r/gateway/python/magma/magmad/generic_command:command_executor"],
 )

--- a/orc8r/gateway/python/magma/magmad/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/tests/BUILD.bazel
@@ -14,12 +14,14 @@ load("//bazel:python_test.bzl", "pytest_test")
 
 pytest_test(
     name = "bootstrap_manager_tests",
+    size = "small",
     srcs = ["bootstrap_manager_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )
 
 pytest_test(
     name = "collector_tests",
+    size = "small",
     srcs = ["collector_tests.py"],
     deps = [
         requirement("prometheus_client"),
@@ -29,6 +31,7 @@ pytest_test(
 
 pytest_test(
     name = "config_manager_tests",
+    size = "small",
     srcs = ["config_manager_tests.py"],
     deps = [
         "//orc8r/gateway/python/magma/configuration:mconfig_managers",
@@ -38,30 +41,35 @@ pytest_test(
 
 pytest_test(
     name = "metrics_tests",
+    size = "small",
     srcs = ["metrics_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )
 
 pytest_test(
     name = "proxy_client_tests",
+    size = "small",
     srcs = ["proxy_client_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )
 
 pytest_test(
     name = "service_manager_tests",
+    size = "small",
     srcs = ["service_manager_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )
 
 pytest_test(
     name = "service_poller_tests",
+    size = "small",
     srcs = ["service_poller_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )
 
 pytest_test(
     name = "state_reporter_test",
+    size = "small",
     srcs = ["state_reporter_test.py"],
     deps = [
         "//orc8r/gateway/python/magma/common:grpc_client_manager",
@@ -71,6 +79,7 @@ pytest_test(
 
 pytest_test(
     name = "sync_rpc_client_tests",
+    size = "medium",
     srcs = ["sync_rpc_client_tests.py"],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )

--- a/orc8r/gateway/python/magma/magmad/upgrade/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/upgrade/tests/BUILD.bazel
@@ -13,6 +13,7 @@ load("//bazel:python_test.bzl", "pytest_test")
 
 pytest_test(
     name = "magma_upgrader_tests",
+    size = "small",
     srcs = ["magma_upgrader_tests.py"],
     deps = [
         "//orc8r/gateway/python/magma/magmad/upgrade:magma_upgrader",
@@ -22,6 +23,7 @@ pytest_test(
 
 pytest_test(
     name = "upgrader2_test",
+    size = "small",
     srcs = ["upgrader2_test.py"],
     deps = ["//orc8r/gateway/python/magma/magmad/upgrade:upgrader2"],
 )

--- a/orc8r/gateway/python/magma/state/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/state/tests/BUILD.bazel
@@ -18,6 +18,7 @@ ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 pytest_test(
     name = "garbage_collector_test",
+    size = "small",
     srcs = ["garbage_collector_test.py"],
     imports = [ORC8R_ROOT],
     deps = [
@@ -32,6 +33,7 @@ pytest_test(
 
 pytest_test(
     name = "state_replicator_test",
+    size = "small",
     srcs = ["state_replicator_test.py"],
     imports = [ORC8R_ROOT],
     deps = [


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Technical debt task from https://github.com/magma/magma/issues/11743.

Bazel uses `size = "medium"` as default, i.e., a test times out after five minutes. See [docu](https://bazel.build/reference/be/common-definitions). This should be set to more granular values so that regression of runtime is tested as well.

Notes:
* I made the `size` property mandatory - this is possible because we are using a wrapper rule (`pytest_test`)  for `py_test`. I think this is reasonable, but I can remove this restriction if there are valid arguments.
* From the current test set the majority of tests can be set to "small" (one minute time out). Exceptions with "medium" are following.
* `processor_tests` "medium" - had locally actually 2/10 runs >1 minute
* `onready_test`, `store_tests`, `sync_rpc_client_tests` had an average of >25 seconds. Here I just want to make sure that there are no time outs on less powerful setups.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
