### PR TITLE
fix(ci): workflow permissions for merge runs are set as required

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,6 +30,8 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -14,8 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event.workflow.name }}
   cancel-in-progress: true
 
-permissions: read-all
-
 jobs:
   skip_check:
     name: Job to check if the workflow ${{ github.event.workflow.name }} can be skipped

--- a/.github/workflows/deploy-build-from-pr.yml
+++ b/.github/workflows/deploy-build-from-pr.yml
@@ -8,8 +8,6 @@ on:  # yamllint disable-line rule:truthy
     types:
       - completed
 
-permissions: read-all
-
 # Replace registries with new test registries reserved for PR builds
 jobs:
   deploy:

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -450,6 +450,9 @@ jobs:
     needs: integration_tests
     name: Integration test results
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
     if: always()
     steps:
       - name: Download artifact

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -59,6 +59,9 @@ jobs:
     name: Upload unit test for ${{ github.event.workflow.name }}
     needs: skip_check
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
     if: >
       github.event.workflow_run.conclusion != 'skipped' &&
         github.event.workflow_run.head_repository.full_name != github.repository &&


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

See [slack](https://magmacore.slack.com/archives/C01AWMH0EJW/p1647470676696139) for general discussion.

In https://github.com/magma/magma/pull/11442 permissions for github actions were revised. Some workflows with actions that run after a merge to master need more detailed restrictions.

The following list might not be complete but is the scope of this change.
* .github/workflows/unit-test-workflow.yml/Upload unit test for feg-workflow [example](https://github.com/magma/magma/runs/5589839710?check_suite_focus=true)
* .github/workflows/deploy-build-from-pr.yml/Deploy artifacts from PR [example](https://github.com/magma/magma/runs/5589517414?check_suite_focus=true)
* .github/workflows/comment-pr-on-check-failure.yml/Comment on PR for check DCO check [example](https://github.com/magma/magma/runs/5589645484?check_suite_focus=true)
* .github/workflows/codeql-analysis.yml/ all jobs [example](https://github.com/magma/magma/runs/5589611508?check_suite_focus=true)
* .github/workflows/dp-workflow.yml/Integration test results [example](https://github.com/magma/magma/runs/5589965548?check_suite_focus=true)

I tried to set permissions as restrictive as possible. For specific actions see documentation at:
* https://github.com/github/codeql-action
* https://github.com/EnricoMi/publish-unit-test-result-action

For workflows that are using the native github API I removed the general read-all restriction. Here more granular restrictions might be possible.

## Test Plan

My current understanding is that this can only be tested by merging the change to master. If this does not work, the change should be reverted and https://github.com/magma/magma/pull/11442  be revised.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
