### PR TITLE
fix(dp): Make reqest order deterministic

### DIFF
--- a/dp/cloud/go/active_mode_controller/internal/message_generator/message_generator_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/message_generator_test.go
@@ -2,7 +2,6 @@ package message_generator_test
 
 import (
 	"context"
-	"sort"
 	"testing"
 	"time"
 
@@ -353,28 +352,16 @@ func TestGenerateMessages(t *testing.T) {
 			for _, msg := range msgs {
 				_ = msg.Send(context.Background(), p)
 			}
-			thenRequestsAreEqual(t, tt.expectedRequests, p.requests)
+			require.Len(t, p.requests, len(tt.expectedRequests))
+			for i := range tt.expectedRequests {
+				assert.JSONEq(t, tt.expectedRequests[i].Payload, p.requests[i].Payload)
+			}
 			require.Len(t, p.actions, len(tt.expectedActions))
 			for i := range tt.expectedActions {
 				assert.Equal(t, tt.expectedActions[i], p.actions[i])
 			}
 		})
 	}
-}
-
-func thenRequestsAreEqual(t *testing.T, expected, actual []*requests.RequestPayload) {
-	require.Len(t, actual, len(expected))
-	sortRequests(expected)
-	sortRequests(actual)
-	for i := range expected {
-		assert.JSONEq(t, expected[i].Payload, actual[i].Payload)
-	}
-}
-
-func sortRequests(requests []*requests.RequestPayload) {
-	sort.Slice(requests, func(i, j int) bool {
-		return requests[i].Payload < requests[j].Payload
-	})
 }
 
 func getSpectrumInquiryRequest() []*requests.RequestPayload {

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/request.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/request.go
@@ -15,6 +15,7 @@ const (
 	Heartbeat
 	Relinquishment
 	Deregistration
+	RequestTypeCount
 )
 
 func (r RequestType) String() string {

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas_helpers/builder.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas_helpers/builder.go
@@ -7,13 +7,15 @@ import (
 )
 
 func Build(reqs []*sas.Request) []string {
-	byType := map[sas.RequestType][]json.RawMessage{}
+	byType := [sas.RequestTypeCount][]json.RawMessage{}
 	for _, r := range reqs {
 		byType[r.Type] = append(byType[r.Type], r.Data)
 	}
 	payloads := make([]string, 0, len(byType))
 	for k, v := range byType {
-		payloads = append(payloads, toRequest(k, v))
+		if len(v) != 0 {
+			payloads = append(payloads, toRequest(sas.RequestType(k), v))
+		}
 	}
 	return payloads
 }

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas_helpers/builder_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas_helpers/builder_test.go
@@ -14,6 +14,7 @@ func TestBuild(t *testing.T) {
 	const someDeregistrationRequest = `{"cbsdId":"someId"}`
 	const otherDeregistrationRequest = `{"cbsdId":"otherId"}`
 	const someHeartbeatRequest = `{"cbsdId":"someId","grantId":"grantId"}`
+	const someRegistrationRequest = `{"key":"value"}`
 	requests := []*sas.Request{{
 		Type: sas.Deregistration,
 		Data: []byte(someDeregistrationRequest),
@@ -23,12 +24,16 @@ func TestBuild(t *testing.T) {
 	}, {
 		Type: sas.Deregistration,
 		Data: []byte(otherDeregistrationRequest),
+	}, {
+		Type: sas.Registration,
+		Data: []byte(someRegistrationRequest),
 	}}
 	actual := sas_helpers.Build(requests)
 	expected := []string{
+		fmt.Sprintf(`{"%s":[%s]}`, sas.Registration, someRegistrationRequest),
 		fmt.Sprintf(`{"%s":[%s]}`, sas.Heartbeat, someHeartbeatRequest),
 		fmt.Sprintf(`{"%s":[%s,%s]}`, sas.Deregistration,
 			someDeregistrationRequest, otherDeregistrationRequest),
 	}
-	assert.ElementsMatch(t, expected, actual)
+	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
## Summary

Iteration through map is not deterministic and can lead to flaky tests.
Now it is fixed.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>