### PR TITLE
fix(nms): make node versions in dockerfile consistent

### DIFF
--- a/nms/packages/magmalte/Dockerfile
+++ b/nms/packages/magmalte/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:12.18-alpine as builder
+FROM node:16.14-alpine as builder
 
-RUN apk add python g++ make libx11 glew-dev libxi-dev ca-certificates
+RUN apk add python3 g++ make libx11 glew-dev libxi-dev ca-certificates
 
 WORKDIR /usr/src/
 
@@ -17,7 +17,7 @@ COPY packages packages
 WORKDIR /usr/src/packages/magmalte
 RUN yarn run build
 
-FROM node:10-alpine
+FROM node:16.14-alpine
 
 # Install required binaries
 RUN apk add ca-certificates curl bash

--- a/nms/packages/magmalte/mock/Dockerfile
+++ b/nms/packages/magmalte/mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18-alpine as builder
+FROM node:16.14-alpine as builder
 
 WORKDIR /usr/src/
 
@@ -12,7 +12,7 @@ RUN yarn install --mutex network --frozen-lockfile && yarn cache clean
 # Build our static files
 COPY packages packages
 
-FROM node:10-alpine
+FROM node:16.14-alpine
 
 # Install required binaries
 RUN apk add ca-certificates curl bash

--- a/nms/packages/magmalte/wait-for-it.sh
+++ b/nms/packages/magmalte/wait-for-it.sh
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 #   Use this script to test if a given TCP host/port are available
 
+# url: https://github.com/vishnubob/wait-for-it
+
+# The MIT License (MIT)
+# Copyright (c) 2016 Giles Hall
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 WAITFORIT_cmdname=${0##*/}
 
 echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }


### PR DESCRIPTION
## Summary

The commit 32dc1c261db10a4052761da088f6248443cb4763 missed to update the
actual node version, and just bumped the builder. This makes both
versions consistent and also bumps to latest minor version.

It was necessary to change `python` -> `python3` for apk to find it. This looks like something that should already previously have been an issue. There is no CI job that builds this container?

## Test Plan


## Additional Information

- [ ] This change is backwards-breaking
