### PR TITLE
chore: temporarily reduce workload on Bazel cache population job

### DIFF
--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -112,15 +112,7 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel test //...
-      - name: Test C/C++ with ASAN  `bazel build //...`
-        uses: addnab/docker-run-action@v2
-        with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
-          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
-          run: |
-            cd /workspaces/magma
-            bazel test //lte/gateway/c/... //orc8r/gateway/c/... --config=asan
+      # TODO: It would be good to also populate cache for `bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan` GH12210
       - name: Upload .bazel-cache and .bazel-cache-repo to S3
         run: |
           tar -zcvf ${{ env.BAZEL_CACHE_DEVCONTAINER_TAR }} ${{ env.BAZEL_CACHE }}/


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
The bazel cache push job for devcontainer has been failing for the past few days due to disk issues :( We might need a different approach for this. But for now, I'm modifying the job so that we only populate cache for the plain build and test. With our recent change in the ASAN/lSAN copt config, running with --config=asan will only trigger a rebuild in the Magma C/C++ targets, which is not great but not awful.

Issue is tracked here; https://github.com/magma/magma/issues/12210
<!-- Enumerate changes you made and why you made them -->

## Test Plan
master
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
