### PR TITLE
feat(agw): Makfile changes to build magma with the new grpc and prometheus c++ artifacts

### DIFF
--- a/lte/gateway/c/connection_tracker/src/CMakeLists.txt
+++ b/lte/gateway/c/connection_tracker/src/CMakeLists.txt
@@ -69,10 +69,27 @@ add_library(CONNECTION_TRACKER
     ${PROTO_SRCS}
     ${PROTO_HDRS})
 
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(CONNECTION_TRACKER
+    -Wl,--start-group
     SERVICE303_LIB SERVICE_REGISTRY MAGMA_LOGGING MAGMA_CONFIG MAGMA_SENTRY
-    glog gflags folly pthread ${GCOV_LIB} grpc++ grpc yaml-cpp protobuf cpp_redis
+    glog gflags folly pthread ${GCOV_LIB} grpc++ grpc yaml-cpp cpp_redis
     prometheus-cpp tacopie mnl tins
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+    -Wl,--end-group
     )
 
 target_include_directories(CONNECTION_TRACKER PUBLIC
@@ -94,8 +111,3 @@ add_executable(connectiond
     main.cpp)
 
 target_link_libraries(connectiond CONNECTION_TRACKER)
-
-if (BUILD_TESTS)
-  ENABLE_TESTING()
-  ADD_SUBDIRECTORY(test)
-endif (BUILD_TESTS)

--- a/lte/gateway/c/core/oai/common/redis_utils/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/common/redis_utils/CMakeLists.txt
@@ -12,7 +12,21 @@
 cmake_minimum_required(VERSION 3.7.2)
 
 add_library(redis_utils redis_client.cpp)
-target_link_libraries(redis_utils MAGMA_CONFIG COMMON cpp_redis tacopie protobuf)
+
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
+target_link_libraries(redis_utils MAGMA_CONFIG COMMON cpp_redis tacopie 
+    ssl crypto z gpr
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    upb
+    re2
+    cares
+    address_sorting
+	/usr/local/lib/libprotobuf.a
+    )
 
 
 target_include_directories(redis_utils PUBLIC

--- a/lte/gateway/c/core/oai/lib/directoryd/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/lib/directoryd/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(LIB_DIRECTORYD
     )
 
 target_link_libraries(LIB_DIRECTORYD
-    grpc grpc++
+    grpc++ grpc
     LIB_MOBILITY_CLIENT ASYNC_GRPC SERVICE_REGISTRY
     MAGMA_CONFIG
     )

--- a/lte/gateway/c/core/oai/lib/n11/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/lib/n11/CMakeLists.txt
@@ -21,15 +21,31 @@ add_library(LIB_N11
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     )
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
 
 
 target_link_libraries(LIB_N11
+    -Wl,--start-group
     COMMON
     LIB_MOBILITY_CLIENT
     SERVICE_REGISTRY
     LIB_S6A_PROXY
     ASYNC_GRPC
     MAGMA_CONFIG
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+    -Wl,--end-group
     )
 
 target_include_directories(LIB_N11 PUBLIC

--- a/lte/gateway/c/core/oai/lib/pipelined_client/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/lib/pipelined_client/CMakeLists.txt
@@ -37,7 +37,7 @@ add_library(LIB_PIPELINED_CLIENT
 target_link_libraries(LIB_PIPELINED_CLIENT
     COMMON
     TASK_GTPV1U
-    grpc grpc++
+    grpc++ grpc
     MAGMA_CONFIG
     )
 

--- a/lte/gateway/c/core/oai/oai_mme/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/oai_mme/CMakeLists.txt
@@ -25,7 +25,6 @@ if ("${LFDS}" STREQUAL "LFDS-NOTFOUND")
 endif ()
 
 add_executable(mme ${PROJECT_SOURCE_DIR}/oai_mme/oai_mme.c)
-
 # compile the needed macros
 
 create_proto_dir("orc8r" ORC8R_CPP_OUT_DIR)
@@ -39,28 +38,42 @@ generate_cpp_protos("${SMGR_ORC8R_CPP_PROTOS}" "${PROTO_SRCS}"
 
 find_package(MAGMA_LOGGING REQUIRED)
 find_package(MAGMA_SENTRY REQUIRED)
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
 
 target_link_libraries(mme
     -Wl,--start-group
     COMMON
     MAGMA_LOGGING MAGMA_SENTRY
+    TASK_ASYNC_GRPC_SERVICE
     LIB_3GPP LIB_S1AP LIB_NGAP LIB_SECU LIB_DIRECTORYD LIB_SGS_CLIENT LIB_BSTR
     LIB_HASHTABLE LIB_S6A_PROXY
     TASK_S1AP TASK_NGAP TASK_SCTP_SERVER TASK_SGS TASK_SMS_ORC8R
     TASK_S6A TASK_MME_APP TASK_AMF_APP TASK_GRPC_SERVICE TASK_NAS TASK_HA
-    TASK_ASYNC_GRPC_SERVICE
     ${ITTI_LIB} ${GCOV_LIB}
-    -Wl,--end-group
     ${LFDS} pthread m sctp rt crypt ${CRYPTO_LIBRARIES} ${OPENSSL_LIBRARIES}
     ${NETTLE_LIBRARIES} ${CONFIG_LIBRARIES} gnutls
-    prometheus-cpp grpc grpc++ yaml-cpp
+    prometheus-cpp grpc++  grpc yaml-cpp
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    -Wl,--end-group
     )
 
 if (NOT EMBEDDED_SGW)
   target_link_libraries(mme
       LIB_GTPV2C TASK_UDP)
 else (EMBEDDED_SGW)
-  target_link_libraries(mme TASK_SGW TASK_SGW_S8)
+  target_link_libraries(mme 
+	  TASK_SGW TASK_SGW_S8)
 endif (NOT EMBEDDED_SGW)
 
 if (NOT S6A_OVER_GRPC)

--- a/lte/gateway/c/core/oai/tasks/amf/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/amf/CMakeLists.txt
@@ -67,12 +67,15 @@ target_compile_definitions(TASK_AMF_APP PRIVATE
   PACKAGE_BUGREPORT=\"TBD\"
 )
 
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(TASK_AMF_APP 
-  ${CONFIG_LIBRARIES}
-  COMMON
-  LIB_BSTR LIB_HASHTABLE LIB_DIRECTORYD LIB_SECU LIB_EVENT_CLIENT LIB_NAS5G LIB_N11
-  TASK_GRPC_SERVICE TASK_NGAP TASK_SERVICE303 LIB_S6A_PROXY
-  protobuf cpp_redis yaml-cpp redis_utils
+   ${CONFIG_LIBRARIES}
+   COMMON
+   LIB_BSTR LIB_HASHTABLE LIB_DIRECTORYD LIB_SECU LIB_EVENT_CLIENT LIB_NAS5G LIB_N11
+   TASK_GRPC_SERVICE TASK_NGAP TASK_SERVICE303 LIB_S6A_PROXY
+   cpp_redis yaml-cpp redis_utils
+   /usr/local/lib/libprotobuf.a
 )
 
 target_include_directories(TASK_AMF_APP PUBLIC

--- a/lte/gateway/c/core/oai/tasks/async_grpc_service/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/async_grpc_service/CMakeLists.txt
@@ -34,16 +34,33 @@ add_library(TASK_ASYNC_GRPC_SERVICE
     ${PROTO_HDRS}
     )
 
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(TASK_ASYNC_GRPC_SERVICE
+    -Wl,--start-group
     COMMON
-    LIB_BSTR protobuf
+    LIB_BSTR /usr/local/lib/libprotobuf.a
     LIB_HASHTABLE
     ${PROTOBUF_LIBRARIES}
     pthread
     gpr
-    grpc
     grpc++
+    grpc
     TASK_S6A
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+	-Wl,--end-group
     )
 target_include_directories(TASK_ASYNC_GRPC_SERVICE PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/lte/gateway/c/core/oai/tasks/grpc_service/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/CMakeLists.txt
@@ -132,15 +132,33 @@ add_library(TASK_GRPC_SERVICE
     )
 endif (EMBEDDED_SGW)
 
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(TASK_GRPC_SERVICE
-    COMMON
-    LIB_BSTR protobuf
+    -Wl,--start-group
+	COMMON
+    LIB_BSTR 
     LIB_HASHTABLE
     ${PROTOBUF_LIBRARIES}
     grpc++
+    grpc
     TASK_SGS
     TASK_S6A
     TASK_SMS_ORC8R
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+    -Wl,--end-group
     )
 target_include_directories(TASK_GRPC_SERVICE PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/lte/gateway/c/core/oai/tasks/ha/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/ha/CMakeLists.txt
@@ -26,12 +26,15 @@ add_library(TASK_HA
     ${PROTO_HDRS}
     )
 
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(TASK_HA
     COMMON
-    LIB_BSTR LIB_HASHTABLE protobuf
+    LIB_BSTR LIB_HASHTABLE 
     ${PROTOBUF_LIBRARIES}
     TASK_MME_APP
     TASK_S1AP
+    /usr/local/lib/libprotobuf.a
     )
 
 target_include_directories(TASK_HA PUBLIC

--- a/lte/gateway/c/core/oai/tasks/mme_app/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/mme_app/CMakeLists.txt
@@ -79,7 +79,7 @@ target_link_libraries(TASK_MME_APP
     COMMON
     LIB_BSTR LIB_HASHTABLE LIB_DIRECTORYD LIB_SECU LIB_EVENT_CLIENT
     TASK_NAS TASK_S1AP TASK_SERVICE303 TASK_SCTP_SERVER TASK_S6A TASK_SGS
-    protobuf cpp_redis yaml-cpp redis_utils
+    /usr/local/lib/libprotobuf.a cpp_redis yaml-cpp redis_utils
     )
 
 if (EMBEDDED_SGW)

--- a/lte/gateway/c/core/oai/tasks/sctp/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/sctp/CMakeLists.txt
@@ -21,10 +21,28 @@ add_library(TASK_SCTP_SERVER
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     )
+
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(TASK_SCTP_SERVER
+    -Wl,--start-group
     COMMON
     LIB_BSTR LIB_HASHTABLE
-    grpc++ grpc protobuf
+    grpc++ grpc
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+	-Wl,--end-group
     )
 target_include_directories(TASK_SCTP_SERVER PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/lte/gateway/c/core/oai/tasks/sgw/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/sgw/CMakeLists.txt
@@ -35,12 +35,16 @@ target_compile_definitions(TASK_SGW PRIVATE
     PACKAGE_VERSION=\"0.1\"
     PACKAGE_BUGREPORT=\"TBD\"
     )
+
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(TASK_SGW
     COMMON
     ${GTPNL_LIBRARIES}
     LIB_BSTR LIB_HASHTABLE LIB_MOBILITY_CLIENT LIB_PCEF
     TASK_GTPV1U
-    cpp_redis tacopie protobuf
+    cpp_redis tacopie
+    /usr/local/lib/libprotobuf.a
     )
 target_include_directories(TASK_SGW PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/CMakeLists.txt
@@ -20,11 +20,14 @@ set(SGW_S8_SRC
     )
 add_library(TASK_SGW_S8 ${SGW_S8_SRC})
 
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(TASK_SGW_S8
     COMMON
     LIB_BSTR LIB_HASHTABLE LIB_S8_PROXY
     LIB_OPENFLOW_CONTROLLER TASK_SERVICE303
-    cpp_redis tacopie protobuf
+    cpp_redis tacopie
+    /usr/local/lib/libprotobuf.a
     )
 
 target_include_directories(TASK_SGW_S8 PUBLIC

--- a/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/amf/CMakeLists.txt
@@ -56,5 +56,4 @@ target_link_libraries(amf_app_test
     LIB_BSTR LIB_ITTI MOCK_TASKS gtest gtest_main crypt ${CRYPTO_LIBRARIES} ${OPENSSL_LIBRARIES}
     ${NETTLE_LIBRARIES}
     )
-
 add_test(NAME test_amf_app COMMAND amf_app_test)

--- a/lte/gateway/c/core/oai/test/mme_app_task/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/mme_app_task/CMakeLists.txt
@@ -89,7 +89,8 @@ target_link_libraries(test_nas_eps_quality_of_service
     )
 
 target_link_libraries(mme_app_test
-    TASK_MME_APP TASK_NAS TASK_AMF_APP ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
+    TASK_MME_APP TASK_NAS TASK_AMF_APP  
+    ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
     LIB_BSTR LIB_ITTI MOCK_TASKS gtest gtest_main ${CRYPTO_LIBRARIES} ${OPENSSL_LIBRARIES}
     ${NETTLE_LIBRARIES}
     )

--- a/lte/gateway/c/core/oai/test/n11/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/n11/CMakeLists.txt
@@ -4,11 +4,28 @@ include_directories("${PROJECT_SOURCE_DIR}/n11")
 add_executable(smf_service_client test_smf_service_client.cpp)
 add_executable(auth_service_client test_auth_service_client.cpp)
 
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(smf_service_client
-	LIB_N11 gtest gtest_main pthread protobuf rt yaml-cpp
+    LIB_N11 gtest gtest_main pthread rt yaml-cpp
+    /usr/local/lib/libprotobuf.a
     )
 target_link_libraries(auth_service_client
-	LIB_N11 TASK_AMF_APP gtest gtest_main pthread protobuf grpc++ dl m rt yaml-cpp
+    LIB_N11 TASK_AMF_APP -Wl,--start-group gtest gtest_main pthread  grpc++ grpc dl m rt yaml-cpp
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+    -Wl,--end-group
     )
 
 add_test(test_smf_service_client smf_service_client)

--- a/lte/gateway/c/li_agent/src/CMakeLists.txt
+++ b/lte/gateway/c/li_agent/src/CMakeLists.txt
@@ -76,10 +76,27 @@ add_library(LI_AGENT
     ${PROTO_SRCS}
     ${PROTO_HDRS})
 
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(LI_AGENT
+    -Wl,--start-group
     SERVICE303_LIB SERVICE_REGISTRY MAGMA_CONFIG ASYNC_GRPC MAGMA_LOGGING MAGMA_SENTRY
-    glog gflags folly pthread ${GCOV_LIB} grpc++ grpc yaml-cpp protobuf cpp_redis
+    glog gflags folly pthread ${GCOV_LIB} grpc++ grpc yaml-cpp cpp_redis
     prometheus-cpp tacopie mnl tins pcap ssl crypto uuid
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+    -Wl,--end-group
     )
 
 target_include_directories(LI_AGENT PUBLIC

--- a/lte/gateway/c/sctpd/src/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/src/CMakeLists.txt
@@ -57,8 +57,25 @@ add_library(SCTPD_LIB
 
 target_compile_definitions(SCTPD_LIB PUBLIC LOG_WITH_GLOG)
 
-target_link_libraries(SCTPD_LIB MAGMA_LOGGING MAGMA_CONFIG MAGMA_SENTRY
-    sctp pthread grpc++ grpc protobuf glog yaml-cpp
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
+
+target_link_libraries(SCTPD_LIB -Wl,--start-group MAGMA_LOGGING MAGMA_CONFIG MAGMA_SENTRY
+    sctp pthread grpc++ grpc glog yaml-cpp
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+    -Wl,--end-group
     )
 
 target_include_directories(SCTPD_LIB PUBLIC

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -202,10 +202,26 @@ add_library(SESSION_MANAGER
 find_package(MAGMA_LOGGING REQUIRED)
 find_package(MAGMA_SENTRY REQUIRED)
 
-target_link_libraries(SESSION_MANAGER
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*")
+
+target_link_libraries(SESSION_MANAGER -Wl,--start-group
   SERVICE303_LIB SERVICE_REGISTRY ASYNC_GRPC MAGMA_CONFIG MAGMA_LOGGING EVENTD MAGMA_SENTRY
-  glog gflags folly pthread ${GCOV_LIB} gpr grpc++ grpc yaml-cpp protobuf cpp_redis
+  glog gflags folly pthread ${GCOV_LIB} grpc++ grpc yaml-cpp cpp_redis
   prometheus-cpp tacopie
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+    -Wl,--end-group
   )
 
 if (CLANG_FORMAT)

--- a/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
+++ b/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
@@ -86,7 +86,7 @@ folly::dynamic get_dynamic_active_policies(
         policy, &json_policy, options);
     if (!status.ok()) {
       MLOG(MERROR) << "Error serializing PolicyRule " << policy.id()
-                   << " to JSON: " << status.error_message();
+                   << " to JSON: " << status.message();
       continue;
     }
     policies.push_back(json_policy);

--- a/orc8r/gateway/c/common/config/CMakeLists.txt
+++ b/orc8r/gateway/c/common/config/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(MAGMA_CONFIG
     )
 target_link_libraries(MAGMA_CONFIG PRIVATE MAGMA_LOGGING)
 target_link_libraries(MAGMA_CONFIG PRIVATE glog)
+target_link_libraries(MAGMA_CONFIG PRIVATE /usr/local/lib/libprotobuf.a)
 
 if (BUILD_TESTS)
   ENABLE_TESTING()

--- a/orc8r/gateway/c/common/protobuf/CMakeLists.txt
+++ b/orc8r/gateway/c/common/protobuf/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 file(GLOB PROTO_SRCS "orc8r/protos/*.pb.*")
 file(GLOB MCONFIG_SRCS "orc8r/protos/mconfig/*.pb.*")
 file(GLOB PROMETHEUS_SRCS "orc8r/protos/prometheus/*.pb.*")
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
 
 include_directories(".")
 
@@ -27,7 +28,22 @@ add_library(MAGMA_PROTOBUF
     ${PROMETHEUS_SRCS}
     )
 target_link_libraries(MAGMA_PROTOBUF
-    protobuf grpc++ grpc dl prometheus-cpp
+    -Wl,--start-group 
+    grpc++ grpc dl prometheus-cpp
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+    -Wl,--end-group 
     )
 target_include_directories(MAGMA_PROTOBUF SYSTEM PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/orc8r/gateway/c/common/service303/CMakeLists.txt
+++ b/orc8r/gateway/c/common/service303/CMakeLists.txt
@@ -50,7 +50,7 @@ add_library(SERVICE303_LIB
     )
 
 target_link_libraries(SERVICE303_LIB PRIVATE
-    prometheus-cpp protobuf grpc grpc++
+	prometheus-cpp grpc++ grpc
     SERVICE_REGISTRY
     )
 target_link_libraries(SERVICE303_LIB PRIVATE MAGMA_LOGGING)

--- a/orc8r/gateway/c/common/service303/test/CMakeLists.txt
+++ b/orc8r/gateway/c/common/service303/test/CMakeLists.txt
@@ -19,13 +19,31 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include_directories("/usr/src/googletest/googlemock/include/")
 link_directories("/usr/src/googletest/googlemock/lib/")
 
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 foreach (service303_test magma_service service303 metrics)
   add_executable(${service303_test}_test test_${service303_test}.cpp)
   target_link_libraries(${service303_test}_test
-      SERVICE303_LIB
-      SERVICE_REGISTRY
-      gmock_main gtest gtest_main gmock
-      yaml-cpp pthread rt
-      ${GCOV_LIB})
+    -Wl,--start-group
+    SERVICE303_LIB
+    SERVICE_REGISTRY
+    gmock_main gtest gtest_main gmock
+    yaml-cpp pthread rt
+    ${GCOV_LIB}
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+    -Wl,--end-group 
+  )
   add_test(test_${service303_test} ${service303_test}_test)
 endforeach (service303_test)

--- a/orc8r/gateway/c/common/service_registry/CMakeLists.txt
+++ b/orc8r/gateway/c/common/service_registry/CMakeLists.txt
@@ -25,8 +25,25 @@ add_library(SERVICE_REGISTRY
 find_package(MAGMA_CONFIG REQUIRED)
 find_package(MAGMA_LOGGING REQUIRED)
 
+file(GLOB ABSL_LIBS "/usr/local/lib/libabsl*.a")
+
 target_link_libraries(SERVICE_REGISTRY MAGMA_CONFIG
-    grpc++ dl yaml-cpp
+    -Wl,--start-group
+    grpc++ grpc dl yaml-cpp
+    ${ABSL_LIBS}
+    ${ABSL_LIBS}
+    absl_debugging_internal
+    absl_demangle_internal
+    z
+    gpr
+    upb
+    re2
+    cares
+    ssl
+    crypto
+    address_sorting
+    /usr/local/lib/libprotobuf.a
+    -Wl,--end-group  
     )
 
 # copy headers to build directory so they can be shared with OAI,


### PR DESCRIPTION
**BUILD WILL FAIL** Till change are made to source list in the magma vm, so that the new packages, already uploaded to artifactory can be downloaded to the new/and existing magma VMs. Blocked on @tmdzk  for that.

## Summary
changed makefiles to build magma with the new grpc-dev(v1.43.2) artifact, and prometheus-cpp-dev which has a dependency on the grpc.

## Test Plan
uploaded the new artifacts to the artifactory and installed the artifacts locally using dpkg command, and built magma, and also the tests.
https://artifactory.magmacore.org/ui/repos/tree/General/debian-test%2Fpool%2Ffocal-ci%2Fgrpc-dev_1.43.2-3_amd64.deb
https://artifactory.magmacore.org/ui/repos/tree/General/debian-test%2Fpool%2Ffocal-ci%2Fprometheus-cpp-dev_1.0.3-d8326b2_amd64.deb

![274323912_502067151280175_5027768534335549975_n](https://user-images.githubusercontent.com/12483853/159356990-a03d16df-5378-4036-9d27-7af904beef46.png)
[make2.log](https://github.com/magma/magma/files/8319015/make2.log)
[make3.log](https://github.com/magma/magma/files/8319016/make3.log)


## Additional Information

- [x] This change is backwards-breaking

Upgrade Steps:-
1) Upload the new grpc-dev, and prometheus-cpp-dev packages to https://artifactory.magmacore.org (Already Done).

2) add a new role to upgrade the grpc-dev, and prometheus-cpp-dev packages in new magma VMs, when doing vagrant up magma

3) change the source list in the vagrant vm, so that user can get the new  grpc-dev, and prometheus-cpp-dev packages, by doing sudo apt upgrade in the existing magma vms, so as to not disrupt the work already in progress.

4) Once this is done, and magma build is stable remove the old  grpc-dev, and prometheus-cpp-dev packages.