### PR TITLE
fix(mme): Wait for ICS request to be sent in MME unit tests before decoding for GUTI

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h
@@ -36,7 +36,7 @@ extern task_zmq_ctx_t task_zmq_ctx_main;
 #define DEFAULT_LBI 5
 
 #define DEFAULT_eNB_S1AP_UE_ID 0
-#define DEFAULT_SCTP_ASSOC_ID 0
+#define DEFAULT_SCTP_ASSOC_ID 0U
 #define DEFAULT_ENB_ID 0
 
 #define MME_APP_EXPECT_CALLS(dlNas, connEstConf, ctxRel, air, ulr, purgeReq,   \
@@ -48,7 +48,8 @@ extern task_zmq_ctx_t task_zmq_ctx_main;
                                        ReturnFromAsyncTask(&cv)));             \
     EXPECT_CALL(*s1ap_handler, s1ap_handle_conn_est_cnf(testing::_))           \
         .Times(connEstConf)                                                    \
-        .WillRepeatedly(testing::SaveArg<0>(&nas_msg));                        \
+        .WillRepeatedly(                                                       \
+            DoAll(testing::SaveArg<0>(&nas_msg), ReturnFromAsyncTask(&cv)));   \
     EXPECT_CALL(*s1ap_handler, s1ap_handle_ue_context_release_command())       \
         .Times(ctxRel)                                                         \
         .WillRepeatedly(ReturnFromAsyncTask(&cv));                             \

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -922,6 +922,9 @@ TEST_F(MmeAppProcedureTest, TestPagingMaxRetx) {
   send_mme_app_initial_ue_msg(nas_msg_service_req, sizeof(nas_msg_service_req),
                               plmn, guti, 1);
 
+  // Wait for ICS request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -119,6 +119,9 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachEpsOnlyDetach) {
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
   send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
 
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
 
@@ -512,6 +515,9 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachExpiredIdentity) {
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
   send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
 
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
 
@@ -616,6 +622,9 @@ TEST_F(MmeAppProcedureTest, TestIcsRequestTimeout) {
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
   send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
 
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
   // Wait for ICS Request timeout
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
@@ -671,6 +680,9 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachIcsFailure) {
 
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
   send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
+
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Send ICS failure to mme_app mimicing S1AP
   send_ics_failure();
@@ -838,6 +850,9 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleServiceReqDetach) {
   send_mme_app_initial_ue_msg(nas_msg_service_req, sizeof(nas_msg_service_req),
                               plmn, guti, 1);
 
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
 
@@ -968,6 +983,9 @@ TEST_F(MmeAppProcedureTest, TestAttachIdlePeriodicTauReqWithActiveFlag) {
                               sizeof(nas_msg_periodic_tau_req_with_actv_flag),
                               plmn, guti, 1);
 
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
 
@@ -1086,6 +1104,9 @@ TEST_F(MmeAppProcedureTest, TestAttachIdleNormalTauReqWithActiveFlag) {
   send_mme_app_initial_ue_msg(nas_msg_normal_tau_req_with_actv_flag,
                               sizeof(nas_msg_normal_tau_req_with_actv_flag),
                               plmn, guti, 1);
+
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
@@ -1401,6 +1422,9 @@ TEST_F(MmeAppProcedureTest,
   cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
   send_delete_session_resp(DEFAULT_LBI + ebi_idx);
 
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
 
@@ -1503,6 +1527,9 @@ TEST_F(MmeAppProcedureTest,
   // Constructing and sending deactivate bearer request
   uint8_t ebi_to_be_deactivated = 7;
   send_s11_deactivate_bearer_req(1, &ebi_to_be_deactivated, false);
+
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
@@ -1650,6 +1677,9 @@ TEST_F(MmeAppProcedureTest, TestDuplicateAttach) {
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
   send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
 
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
 
@@ -1740,6 +1770,9 @@ TEST_F(MmeAppProcedureTest, TestDuplicateAttach) {
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
   send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
 
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
 
@@ -1808,6 +1841,9 @@ TEST_F(MmeAppProcedureTest, TestCLRNwInitiatedDetach) {
 
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
   send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
+
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
@@ -1905,6 +1941,9 @@ TEST_F(MmeAppProcedureTest, TestS6aReset) {
 
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
   send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
+
+  // Wait for ICS Request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
 
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_nas_timer.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_nas_timer.cpp
@@ -64,6 +64,9 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachExpiredNasTimers) {
   // Constructing and sending Create Session Response to mme_app mimicing SPGW
   send_create_session_resp(REQUEST_ACCEPTED, DEFAULT_LBI);
 
+  // Wait for ICS request to be sent
+  cv.wait_for(lock, std::chrono::milliseconds(STATE_MAX_WAIT_MS));
+
   // Constructing and sending ICS Response to mme_app mimicing S1AP
   send_ics_response();
 


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Partly fixes https://github.com/magma/magma/issues/12166 

- Flakiness in expected length of nas_decoded message: This change adds a notify action to the Expect call to make sure the MME test thread waits for nas_msg to be received at mock S1AP task before extracting GUTI

## Test Plan

- Correctness test:
`bazel test //lte/gateway/c/core/oai/test/...`

- Flakiness test:
`bazel test //lte/gateway/c/core/oai/test/mme_app_task:mme_procedures_test --runs_per_test=50` does not these failures any more

```
 EXPECT_EQ(nas_msg->slen, 67);
 EXPECT_EQ(decoder_rc, nas_msg->slen);
  ```

**TODO:**
The failures such as these are still present and will be addressed in a future PR.
```
lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp:740: Failure
Mock function called more times than expected - returning directly.
    Function call: s1ap_generate_downlink_nas_transport(16-byte object <01-00 00-00 00-00 00-00 70-92 04-8C 68-7F 00-00>)
         Expected: to be called twice
           Actual: called 3 times - over-saturated and active
  ```
