### PR TITLE
fix(feg): FeG diameter handler blocking fix and additional logging for diameter & session_proxy

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
@@ -139,7 +139,7 @@ func (gxClient *GxClient) SendCreditControlRequest(
 		return err
 	}
 
-	glog.V(2).Infof("Sending Gx CCR message\n%s\n", message)
+	glog.V(3).Infof("Sending Gx CCR message\n%s\n", message)
 	key := credit_control.GetRequestKey(credit_control.Gx, request.SessionID, request.RequestNumber)
 	return gxClient.diamClient.SendRequest(server, done, message, key)
 }

--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
@@ -144,7 +144,7 @@ func (gyClient *GyClient) SendCreditControlRequest(
 		return err
 	}
 
-	glog.V(2).Infof("Sending Gy CCR message:\n%s\n", message)
+	glog.V(3).Infof("Sending Gy CCR message:\n%s\n", message)
 	key := credit_control.GetRequestKey(credit_control.Gy, request.SessionID, request.RequestNumber)
 	return gyClient.diamClient.SendRequest(server, done, message, key)
 }
@@ -184,7 +184,7 @@ func (gyClient *GyClient) DisableConnections(period time.Duration) {
 // messages received from the OCS
 func registerReAuthHandler(reAuthHandler ChargingReAuthHandler, diamClient *diameter.Client) {
 	reqHandler := func(conn diam.Conn, message *diam.Message) {
-		glog.V(2).Infof("Received Gy reauth message:\n%s\n", message)
+		glog.V(3).Infof("Received Gy reauth message:\n%s\n", message)
 		rar := &ChargingReAuthRequest{}
 		if err := message.Unmarshal(rar); err != nil {
 			glog.Errorf("Received unparseable RAR over Gy %s\n%s", message, err)
@@ -399,7 +399,7 @@ func getMSCCAVP(requestType credit_control.CreditRequestType, credits *UsedCredi
 		avpGroup = append(avpGroup, diam.NewAVP(avp.RequestedServiceUnit, avp.Mbit, 0, &diam.GroupedAVP{AVP: usuGrp}))
 	}
 
-	if serviceIdentifier >= 0 && serviceIdentifier <= 4294967295 { //check if is in bounds of Unsigned32 type
+	if serviceIdentifier >= 0 && serviceIdentifier <= 4294967295 { // check if is in bounds of Unsigned32 type
 		avpGroup = append(
 			avpGroup,
 			diam.NewAVP(avp.ServiceIdentifier, avp.Mbit, 0, datatype.Unsigned32(serviceIdentifier)))
@@ -466,7 +466,7 @@ func getReceivedCredits(cca *CCADiameterMessage) []*ReceivedCredits {
 // Output: diam.HandlerFunc
 func getCCAHandler() diameter.AnswerHandler {
 	return func(message *diam.Message) diameter.KeyAndAnswer {
-		glog.V(2).Infof("Received Gy CCA message:\n%s\n", message)
+		glog.V(3).Infof("Received Gy CCA message:\n%s\n", message)
 		var cca CCADiameterMessage
 		if err := message.Unmarshal(&cca); err != nil {
 			metrics.GyUnparseableMsg.Inc()


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>


## Summary

Additional logging for diameter, session_proxy also a fix for long standing [bug](https://github.com/magma/magma/blame/v1.6.1/feg/gateway/diameter/diameter_client.go#L302-L303) in FeG diameter client which could block response handle indefinitely on mismatch/lost diameter response (answer).

The fix should resolve issue https://github.com/magma/magma/issues/12067

## Test Plan

unit tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
