### PR TITLE
fix: revert type_extensions introduced in 12012

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -27,7 +27,6 @@ from threading import Condition
 from typing import List, Optional, cast
 
 from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
-from typing_extensions import TypeGuard
 
 from .dhcp_client import DHCPClient
 from .dhcp_desc import DHCPDescriptor, DHCPState
@@ -218,5 +217,5 @@ class IPAllocatorDHCP(IPAllocator):
             return cast(DHCPDescriptor, dhcp_desc)
 
 
-def dhcp_allocated_ip(dhcp_desc: Optional[DHCPDescriptor]) -> TypeGuard[DHCPDescriptor]:
+def dhcp_allocated_ip(dhcp_desc: Optional[DHCPDescriptor]) -> bool:
     return dhcp_desc is not None and dhcp_desc.ip_is_allocated()

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -131,7 +131,6 @@ setup(
         'ovs>=2.13',
         'prometheus-client>=0.3.1',
         'aioeventlet==0.5.1',  # aioeventlet-build.sh
-        'typing-extensions',
     ],
     extras_require={
         'dev': [

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -107,7 +107,6 @@ setup(
         "rfc3987>=1.3.0",
         "jsonpointer>=1.14",
         "webcolors>=1.11.1",
-        'typing-extensions',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Type_extensions module introduced here https://github.com/magma/magma/pull/12012 is causing a dependency issue on our build process. We will need to revert this change until we have updated all our code to python 3.8 or 3.10

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
