### PR TITLE
refactor(magmad): refactor bazel root imports in magmad

### DIFF
--- a/orc8r/gateway/python/magma/magmad/check/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/BUILD.bazel
@@ -11,13 +11,8 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-MAGMA_ROOT = "../../../../../../"
-
-ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
-
 py_library(
     name = "subprocess_workflow",
     srcs = ["subprocess_workflow.py"],
-    imports = [ORC8R_ROOT],
     visibility = ["//visibility:public"],
 )

--- a/orc8r/gateway/python/magma/magmad/check/kernel_check/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/kernel_check/BUILD.bazel
@@ -11,14 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-MAGMA_ROOT = "../../../../../../../"
-
-ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
-
 py_library(
     name = "kernel_versions",
     srcs = ["kernel_versions.py"],
-    imports = [ORC8R_ROOT],
     visibility = ["//visibility:public"],
     deps = ["//orc8r/gateway/python/magma/magmad/check:subprocess_workflow"],
 )

--- a/orc8r/gateway/python/magma/magmad/check/kernel_check/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/kernel_check/tests/BUILD.bazel
@@ -11,9 +11,14 @@
 
 load("//bazel:python_test.bzl", "pytest_test")
 
+MAGMA_ROOT = "../../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "kernel_versions_tests",
     size = "small",
     srcs = ["kernel_versions_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad/check/kernel_check:kernel_versions"],
 )

--- a/orc8r/gateway/python/magma/magmad/check/machine_check/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/machine_check/BUILD.bazel
@@ -11,14 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-MAGMA_ROOT = "../../../../../../../"
-
-ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
-
 py_library(
     name = "cpu_info",
     srcs = ["cpu_info.py"],
-    imports = [ORC8R_ROOT],
     visibility = ["//visibility:public"],
     deps = ["//orc8r/gateway/python/magma/magmad/check:subprocess_workflow"],
 )

--- a/orc8r/gateway/python/magma/magmad/check/machine_check/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/machine_check/tests/BUILD.bazel
@@ -11,9 +11,14 @@
 
 load("//bazel:python_test.bzl", "pytest_test")
 
+MAGMA_ROOT = "../../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "cpu_info_tests",
     size = "small",
     srcs = ["cpu_info_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad/check/machine_check:cpu_info"],
 )

--- a/orc8r/gateway/python/magma/magmad/check/network_check/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/BUILD.bazel
@@ -11,14 +11,9 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-MAGMA_ROOT = "../../../../../../../"
-
-ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
-
 py_library(
     name = "ping",
     srcs = ["ping.py"],
-    imports = [ORC8R_ROOT],
     visibility = ["//visibility:public"],
     deps = [
         ":traceroute",
@@ -29,7 +24,6 @@ py_library(
 py_library(
     name = "routing_table",
     srcs = ["routing_table.py"],
-    imports = [ORC8R_ROOT],
     visibility = ["//visibility:public"],
     deps = ["//orc8r/gateway/python/magma/magmad/check:subprocess_workflow"],
 )
@@ -37,7 +31,6 @@ py_library(
 py_library(
     name = "traceroute",
     srcs = ["traceroute.py"],
-    imports = [ORC8R_ROOT],
     visibility = ["//visibility:public"],
     deps = ["//orc8r/gateway/python/magma/magmad/check:subprocess_workflow"],
 )

--- a/orc8r/gateway/python/magma/magmad/check/network_check/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/tests/BUILD.bazel
@@ -11,10 +11,15 @@
 
 load("//bazel:python_test.bzl", "pytest_test")
 
+MAGMA_ROOT = "../../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "ping_tests",
     size = "small",
     srcs = ["ping_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad/check/network_check:ping"],
 )
 
@@ -22,6 +27,7 @@ pytest_test(
     name = "routing_table_tests",
     size = "small",
     srcs = ["routing_table_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad/check/network_check:routing_table"],
 )
 
@@ -29,5 +35,6 @@ pytest_test(
     name = "traceroute_tests",
     size = "small",
     srcs = ["traceroute_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad/check/network_check:traceroute"],
 )

--- a/orc8r/gateway/python/magma/magmad/check/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/check/tests/BUILD.bazel
@@ -11,9 +11,14 @@
 
 load("//bazel:python_test.bzl", "pytest_test")
 
+MAGMA_ROOT = "../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "subprocess_workflow_tests",
     size = "small",
     srcs = ["subprocess_workflow_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad/check:subprocess_workflow"],
 )

--- a/orc8r/gateway/python/magma/magmad/generic_command/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/generic_command/BUILD.bazel
@@ -11,16 +11,11 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-MAGMA_ROOT = "../../../../../../"
-
-ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
-
 py_library(
     name = "command_executor",
     srcs = [
         "command_executor.py",
         "shell_command_executor.py",
     ],
-    imports = [ORC8R_ROOT],
     visibility = ["//visibility:public"],
 )

--- a/orc8r/gateway/python/magma/magmad/generic_command/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/generic_command/tests/BUILD.bazel
@@ -11,10 +11,15 @@
 
 load("//bazel:python_test.bzl", "pytest_test")
 
+MAGMA_ROOT = "../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "command_executor_test",
     size = "small",
     srcs = ["command_executor_test.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad/generic_command:command_executor"],
 )
 
@@ -22,5 +27,6 @@ pytest_test(
     name = "shell_command_executor_test",
     size = "small",
     srcs = ["shell_command_executor_test.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad/generic_command:command_executor"],
 )

--- a/orc8r/gateway/python/magma/magmad/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/tests/BUILD.bazel
@@ -12,10 +12,15 @@
 load("@python_deps//:requirements.bzl", "requirement")
 load("//bazel:python_test.bzl", "pytest_test")
 
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "bootstrap_manager_tests",
     size = "small",
     srcs = ["bootstrap_manager_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )
 
@@ -23,6 +28,7 @@ pytest_test(
     name = "collector_tests",
     size = "small",
     srcs = ["collector_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = [
         requirement("prometheus_client"),
         "//orc8r/gateway/python/magma/magmad:magmad_lib",
@@ -33,6 +39,7 @@ pytest_test(
     name = "config_manager_tests",
     size = "small",
     srcs = ["config_manager_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = [
         "//orc8r/gateway/python/magma/configuration:mconfig_managers",
         "//orc8r/gateway/python/magma/magmad:magmad_lib",
@@ -43,6 +50,7 @@ pytest_test(
     name = "metrics_tests",
     size = "small",
     srcs = ["metrics_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )
 
@@ -50,6 +58,7 @@ pytest_test(
     name = "proxy_client_tests",
     size = "small",
     srcs = ["proxy_client_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )
 
@@ -57,6 +66,7 @@ pytest_test(
     name = "service_manager_tests",
     size = "small",
     srcs = ["service_manager_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )
 
@@ -64,6 +74,7 @@ pytest_test(
     name = "service_poller_tests",
     size = "small",
     srcs = ["service_poller_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )
 
@@ -71,6 +82,7 @@ pytest_test(
     name = "state_reporter_test",
     size = "small",
     srcs = ["state_reporter_test.py"],
+    imports = [ORC8R_ROOT],
     deps = [
         "//orc8r/gateway/python/magma/common:grpc_client_manager",
         "//orc8r/gateway/python/magma/magmad:magmad_lib",
@@ -81,5 +93,6 @@ pytest_test(
     name = "sync_rpc_client_tests",
     size = "medium",
     srcs = ["sync_rpc_client_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad:magmad_lib"],
 )

--- a/orc8r/gateway/python/magma/magmad/upgrade/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/upgrade/BUILD.bazel
@@ -11,21 +11,15 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-MAGMA_ROOT = "../../../../../../"
-
-ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
-
 py_library(
     name = "upgrader",
     srcs = ["upgrader.py"],
-    imports = [ORC8R_ROOT],
     visibility = ["//visibility:public"],
 )
 
 py_library(
     name = "magma_upgrader",
     srcs = ["magma_upgrader.py"],
-    imports = [ORC8R_ROOT],
     visibility = ["//visibility:public"],
     deps = ["//orc8r/gateway/python/magma/common:misc_utils"],
 )
@@ -33,7 +27,6 @@ py_library(
 py_library(
     name = "upgrader2",
     srcs = ["upgrader2.py"],
-    imports = [ORC8R_ROOT],
     visibility = ["//visibility:public"],
     deps = [
         ":upgrader",

--- a/orc8r/gateway/python/magma/magmad/upgrade/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/upgrade/tests/BUILD.bazel
@@ -11,10 +11,15 @@
 
 load("//bazel:python_test.bzl", "pytest_test")
 
+MAGMA_ROOT = "../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
 pytest_test(
     name = "magma_upgrader_tests",
     size = "small",
     srcs = ["magma_upgrader_tests.py"],
+    imports = [ORC8R_ROOT],
     deps = [
         "//orc8r/gateway/python/magma/magmad/upgrade:magma_upgrader",
         "//orc8r/gateway/python/magma/magmad/upgrade:upgrader",
@@ -25,5 +30,6 @@ pytest_test(
     name = "upgrader2_test",
     size = "small",
     srcs = ["upgrader2_test.py"],
+    imports = [ORC8R_ROOT],
     deps = ["//orc8r/gateway/python/magma/magmad/upgrade:upgrader2"],
 )


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Bazel root imports in `magmad` are refactored to only occur in the `py_binary` and `pytest_test` targets.
- See also https://github.com/magma/magma/issues/11743.

## Test Plan

- Run bazel tests in `dev-container` and `bazel-base`:
  `bazel test //orc8r/gateway/python/magma/magmad/...`
- Run `magmad` service with bazel:
 `bazel run //orc8r/gateway/python/magma/magmad`



## Additional Information

- [ ] This change is backwards-breaking
