### PR TITLE
chore(orc8r): Upgrade addressable package to v2.8.0

### DIFF
--- a/orc8r/cloud/docker/fluentd_daemon/Gemfile.lock
+++ b/orc8r/cloud/docker/fluentd_daemon/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     concurrent-ruby (1.1.5)
     cool.io (1.5.4)
@@ -88,7 +88,7 @@ GEM
     oj (3.8.1)
     prometheus-client (0.9.0)
       quantile (~> 0.2.1)
-    public_suffix (4.0.1)
+    public_suffix (4.0.6)
     quantile (0.2.1)
     recursive-open-struct (1.1.0)
     rest-client (2.1.0)


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

chore(orc8r): Upgrade addressable package to v2.8.0

## Summary

Within the URI template implementation in Addressable, a maliciously crafted template may result in uncontrolled resource consumption. The vulnerability is fixed in version 2.8.0, so addressable package was upgraded to v2.8.0

## Test Plan

I ran /magma/orc8r/cloud/docker/  ./build.py -c

## Additional Information

For dependabot alert: https://github.com/magma/magma/security/dependabot/94