### PR TITLE
chore: modify bzl cc compilation db generation target to include all …

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -66,11 +66,8 @@
 		"editor.formatOnSave": true,
 		// Update this field with any new Bazel targets that need compilation database generation
 		"bsv.cc.compdb.targets": [
-			"//lte/gateway/c/session_manager:sessiond",
-			"//lte/gateway/c/sctpd/src:sctpd",
-			"//lte/gateway/c/li_agent/src:liagentd",
-			"//lte/gateway/c/connection_tracker/src:connectiond",
-			"//lte/gateway/c/core:oai_mme",
+			"//orc8r/gateway/c/...",
+			"//lte/gateway/c/...",
 		],
 		"multiCommand.commands": [
 			{

--- a/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
+++ b/vscode-workspaces/workspace.magma-vm-workspace.code-workspace
@@ -41,11 +41,8 @@
 		],
 		// Update this field with any new Bazel targets that need compilation database generation
 		"bsv.cc.compdb.targets": [
-			"//lte/gateway/c/session_manager:sessiond",
-			"//lte/gateway/c/sctpd/src:sctpd",
-			"//lte/gateway/c/li_agent/src:liagentd",
-			"//lte/gateway/c/connection_tracker/src:connectiond",
-			"//lte/gateway/c/core:oai_mme",
+			"//orc8r/gateway/c/...",
+			"//lte/gateway/c/...",
 		],
 		"multiCommand.commands": [
 			{


### PR DESCRIPTION
…C paths

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
The current config only creates compilation db information for the specified binary targets. This works well enough for the most part but excludes all files used for unit testing. This PR modifies the config to just generate everything under `lte/gateway/c/` and `orc8r/gateway/c/`. 

Now all C/C++ paths should resolve by doing the following
1. Run Cmd+Shift+P and Bzl: Bazel/C++: Generate Compilation Database
2. Run Cmd+Shift+P and clangd: Restart language server
## Test Plan
Tested locally with the Magma VM workspace to confirm complation db is produced for test targets
*no more squiggly for MME test files*
<img width="719" alt="Screen Shot 2022-03-22 at 12 41 55 PM" src="https://user-images.githubusercontent.com/37634144/159530940-3652b642-7d20-4dda-a6cc-c482444fad3f.png">

Also spun up a GitHub Codespace off of this PR to test.
<!-- Enumerate changes you made and why you made them -->


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
