### PR TITLE
fix(feg): Adjust diameter config logs to v=1

### DIFF
--- a/feg/gateway/diameter/diameter_client.go
+++ b/feg/gateway/diameter/diameter_client.go
@@ -176,7 +176,7 @@ func NewClient(clientCfg *DiameterClientConfig, localAddresses ...string) *Clien
 		cfg:            clientCfg,
 		originStateID:  originStateID,
 	}
-	glog.V(3).Infof("new diam client::\n\t%s", client.String())
+	glog.V(1).Infof("new diam client::\n\t%s", client.String())
 
 	go client.handleErrors(mux.ErrorReports())
 	return client


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Adjust diameter config logs to v=1.
new diameter client configuration logs are printed only once during the client instantiation, so it's safe to reduce log level to 1 from current 3 for them.

## Test Plan

unit tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
