### PR TITLE
chore: enable amf_encode_decode_test in Bazel test runs

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/amf/BUILD.bazel
@@ -107,8 +107,6 @@ cc_test(
     srcs = [
         "test_amf_encode_decode.cpp",
     ],
-    # TODO: Remove manual tag when fixed: GH12163
-    tags = ["manual"],
     deps = [
         ":amf_app_test_util",
         "//lte/gateway/c/core",


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This test was previously tagged as manual as it had issues when running with ASAN. I'm now removing the manual tag so that it is run by default. (Which closes https://github.com/magma/magma/issues/12163)

I ran the following commands to verify the test
```bash
bazel test //lte/gateway/c/core/oai/test/amf:amf_encode_decode_test --runs_per_test=1000
bazel test //lte/gateway/c/core/oai/test/amf:amf_encode_decode_test --runs_per_test=1000 —config=asan
```

Both pass without any failures.

There are two other tests in this file marked as manual but they both had flakiness issues. It seems that we still have some issues with ASAN occasionally. I'll reopen the corresponding GH issues so that we can have a look. https://github.com/magma/magma/issues/12144 and https://github.com/magma/magma/issues/11826
```bash
# PASSES
bazel test //lte/gateway/c/core/oai/test/amf:amf_procedures_test --runs_per_test=100
# FAILED 11/111
bazel test //lte/gateway/c/core/oai/test/amf:amf_procedures_test --runs_per_test=100 --config=asan

# FAILED 1/101
bazel test //lte/gateway/c/core/oai/test/amf:amf_stateless_test --runs_per_test=100
# FAILED 10/110
bazel test //lte/gateway/c/core/oai/test/amf:amf_stateless_test --runs_per_test=100 —config=asan
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
