### PR TITLE
chore: enable //lte/gateway/c/core/oai/test/spgw_task:spgw_procedures…

### DIFF
--- a/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/spgw_task/BUILD.bazel
@@ -49,8 +49,6 @@ cc_test(
     srcs = [
         "test_spgw_procedures.cpp",
     ],
-    # TODO: Remove manual tag when fixed: GH11984
-    tags = ["manual"],
     deps = [
         ":spgw_test_core",
         "//lte/gateway/c/core",


### PR DESCRIPTION
…_test for CI runs

Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This test no longer has issues with ASAN or plain mode. Removing the manual tag will add the test to the suite of tests that gets run in CI.

This fully closes out https://github.com/magma/magma/issues/11984
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran the following commands to make sure the test is not flaky
```bash
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_test --runs_per_test=100
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_test --runs_per_test=100 --config=asan
bazel test //lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_test --config=lsan --runs_per_test=100
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
