### PR TITLE
fix(dp): Fix migration

### DIFF
--- a/dp/cloud/python/magma/db_service/migrations/versions/d5ba47fd26e9_.py
+++ b/dp/cloud/python/magma/db_service/migrations/versions/d5ba47fd26e9_.py
@@ -1,15 +1,15 @@
 """empty message
 
-Revision ID: db5d8e00ddd1
+Revision ID: d5ba47fd26e9
 Revises: d5f1e6f26fd4
-Create Date: 2022-03-22 18:24:08.991313
+Create Date: 2022-03-23 16:38:50.608758
 
 """
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = 'db5d8e00ddd1'
+revision = 'd5ba47fd26e9'
 down_revision = 'd5f1e6f26fd4'
 branch_labels = None
 depends_on = None
@@ -28,8 +28,8 @@ def upgrade():
     )
     op.add_column(
         'cbsds', sa.Column(
-            'preferred_frequencies_mhz',
-            sa.JSON(), server_default='[]', nullable=False,
+            'preferred_frequencies_mhz', sa.JSON(
+            ), server_default=sa.text("'[]'::json"), nullable=False,
         ),
     )
     # ### end Alembic commands ###

--- a/dp/cloud/python/magma/db_service/models.py
+++ b/dp/cloud/python/magma/db_service/models.py
@@ -289,7 +289,7 @@ class DBCbsd(Base):
         Integer, nullable=False, server_default='0',
     )
     preferred_frequencies_mhz = Column(
-        JSON, nullable=False, server_default='[]',
+        JSON, nullable=False, server_default=sa_text("'[]'::json"),
     )
     network_id = Column(String)
     is_deleted = Column(Boolean, nullable=False, server_default='false')


### PR DESCRIPTION
## Summary

In latest migration json default was incorrectly formatted,
And although migration was generated it couldn't have been applied.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>
