### PR TITLE
fix(pipelined): backport: 1.7: he: move proxy-dev setup to main module

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/he.py
+++ b/lte/gateway/python/magma/pipelined/app/he.py
@@ -135,9 +135,6 @@ class HeaderEnrichmentController(MagmaController):
         uplink_port = config_dict.get('uplink_port', None)
         proxy_port_name = config_dict.get('proxy_port_name')
 
-        bridge = config_dict.get('bridge_name')
-        BridgeTools.add_ovs_port(bridge, proxy_port_name, PROXY_OF_PORT)
-
         try:
             he_proxy_port = BridgeTools.get_ofport(proxy_port_name)
         except DatapathLookupError:

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -26,7 +26,7 @@ from magma.common.sentry import sentry_init
 from magma.common.service import MagmaService
 from magma.configuration import environment
 from magma.pipelined.app import of_rest_server
-from magma.pipelined.app.he import PROXY_PORT_NAME
+from magma.pipelined.app.he import PROXY_OF_PORT, PROXY_PORT_NAME
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.check_quota_server import run_flask
 from magma.pipelined.datapath_setup import (
@@ -140,6 +140,10 @@ def main():
     he_enabled_flag = False
     if service.mconfig.he_config:
         he_enabled_flag = service.mconfig.he_config.enable_header_enrichment
+        if he_enabled_flag:
+            bridge = service.config.get('bridge_name')
+            BridgeTools.add_ovs_port(bridge, PROXY_PORT_NAME, PROXY_OF_PORT)
+
     he_enabled = service.config.get('he_enabled', he_enabled_flag)
     service.config['he_enabled'] = he_enabled
 

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_invalid_subscriber.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_invalid_subscriber.snapshot
@@ -1,5 +1,5 @@
  cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ip,nw_src=192.168.128.45 actions=load:0xd->OXM_OF_METADATA[],load:0x1->NXM_NX_REG1[],resubmit(,enforcement(main_table))
  cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ip,nw_dst=192.168.128.45 actions=load:0xd->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
- cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=1,in_port=15 actions=drop
+ cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=1,in_port=16 actions=drop
  cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0xfffffffffffffffe, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_subscriber_ipv6_policy.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_subscriber_ipv6_policy.snapshot
@@ -1,6 +1,6 @@
  cookie=0x0, table=mme(main_table), n_packets=1, n_bytes=54, priority=65535,ipv6,ipv6_src=de34:431d:1bc:: actions=load:0x48c2739fd9c3->OXM_OF_METADATA[],load:0x1->NXM_NX_REG1[],resubmit(,enforcement(main_table))
  cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ipv6,ipv6_dst=de34:431d:1bc:: actions=load:0x48c2739fd9c3->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
- cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=1,in_port=15 actions=drop
+ cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=1,in_port=16 actions=drop
  cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x2, table=enforcement(main_table), n_packets=1, n_bytes=54, priority=65533,ipv6,reg1=0x1,metadata=0x48c2739fd9c3,ipv6_src=de34:431d:1bc::/64,ipv6_dst=f333:432::dbca actions=note:b'simple_match',set_field:0x2->reg2,set_field:0x1->reg4,set_field:0->reg11,resubmit(,enforcement_stats(main_table)),resubmit(,egress(main_table))
  cookie=0xfffffffffffffffe, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_subscriber_policy.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_subscriber_policy.snapshot
@@ -1,6 +1,6 @@
  cookie=0x0, table=mme(main_table), n_packets=4096, n_bytes=139264, priority=65535,ip,nw_src=192.168.128.74 actions=load:0x48c2739fd9c3->OXM_OF_METADATA[],load:0x1->NXM_NX_REG1[],resubmit(,enforcement(main_table))
  cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ip,nw_dst=192.168.128.74 actions=load:0x48c2739fd9c3->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
- cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=1,in_port=15 actions=drop
+ cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=1,in_port=16 actions=drop
  cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x2, table=enforcement(main_table), n_packets=256, n_bytes=8704, priority=65533,ip,reg1=0x1,metadata=0x48c2739fd9c3,nw_src=192.168.128.74,nw_dst=45.10.0.0/24 actions=note:b'simple_match',set_field:0x2->reg2,set_field:0x1->reg4,set_field:0->reg11,resubmit(,enforcement_stats(main_table)),resubmit(,egress(main_table))
  cookie=0xfffffffffffffffe, table=enforcement(main_table), n_packets=3840, n_bytes=130560, priority=0 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_subscriber_two_policies.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_subscriber_two_policies.snapshot
@@ -1,6 +1,6 @@
  cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ip,nw_src=192.168.128.74 actions=load:0x5f04fb434e009->OXM_OF_METADATA[],load:0x1->NXM_NX_REG1[],resubmit(,enforcement(main_table))
  cookie=0x0, table=mme(main_table), n_packets=42, n_bytes=1428, priority=65535,ip,nw_dst=192.168.128.74 actions=load:0x5f04fb434e009->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
- cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=1,in_port=15 actions=drop
+ cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=1,in_port=16 actions=drop
  cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x3, table=enforcement(main_table), n_packets=42, n_bytes=1428, priority=65533,ip,reg1=0x10,metadata=0x5f04fb434e009,nw_src=15.0.0.0/24,nw_dst=192.168.128.74 actions=note:b'match',set_field:0x2->reg3,resubmit(,enforcement_stats(main_table))
  cookie=0x4, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=65533,tcp,reg1=0x1,metadata=0x5f04fb434e009,nw_src=192.168.128.74 actions=note:b'no_match',set_field:0x4->reg2,set_field:0x1->reg4,set_field:0->reg11,resubmit(,enforcement_stats(main_table)),resubmit(,egress(main_table))

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_two_subscribers.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_two_subscribers.snapshot
@@ -2,7 +2,7 @@
  cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ip,nw_src=192.168.128.100 actions=load:0x19e809e4df0089->OXM_OF_METADATA[],load:0x1->NXM_NX_REG1[],resubmit(,enforcement(main_table))
  cookie=0x0, table=mme(main_table), n_packets=29, n_bytes=986, priority=65535,ip,nw_dst=192.168.128.5 actions=load:0x5f04fb4bc8239->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
  cookie=0x0, table=mme(main_table), n_packets=18, n_bytes=972, priority=65535,ip,nw_dst=192.168.128.100 actions=load:0x19e809e4df0089->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
- cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=1,in_port=15 actions=drop
+ cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=1,in_port=16 actions=drop
  cookie=0x0, table=proxy(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x5, table=enforcement(main_table), n_packets=29, n_bytes=986, priority=65533,ip,reg1=0x10,metadata=0x5f04fb4bc8239,nw_src=8.8.8.0/24,nw_dst=192.168.128.5 actions=note:b't',set_field:0x2->reg3,resubmit(,enforcement_stats(main_table))
  cookie=0x6, table=enforcement(main_table), n_packets=18, n_bytes=972, priority=65533,tcp,reg1=0x10,metadata=0x19e809e4df0089,nw_dst=192.168.128.100 actions=note:b'qqq',set_field:0x2->reg3,resubmit(,enforcement_stats(main_table))

--- a/lte/gateway/python/magma/pipelined/tests/test_he.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_he.py
@@ -99,7 +99,7 @@ class HeTableTest(unittest.TestCase):
 
         BridgeTools.create_veth_pair(cls.VETH, cls.VETH_NS)
         BridgeTools.create_bridge(cls.BRIDGE, cls.IFACE)
-        # BridgeTools.add_ovs_port(cls.BRIDGE, cls.VETH, cls.PROXY_PORT)
+        BridgeTools.add_ovs_port(cls.BRIDGE, cls.VETH, cls.PROXY_PORT)
 
         he_controller_reference = Future()
         testing_controller_reference = Future()
@@ -463,7 +463,7 @@ class EnforcementTableHeTest(unittest.TestCase):
     he_controller_reference = Future()
     VETH = 'tveth1'
     VETH_NS = 'tveth1_ns'
-    PROXY_PORT = '16'
+    PROXY_PORT = '15'
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This would avoid race between inout and he apps.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
backports PR #12216