### PR TITLE
fix(mme): fix SEGV errors in bazel built mme

### DIFF
--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1138,6 +1138,10 @@ cc_binary(
     srcs = [
         "oai/oai_mme/oai_mme.c",
     ],
+    copts = [
+        "-DEMBEDDED_SGW",  # TODO(#11638): Feature flags fixups
+    ],
+    linkstatic = False,
     deps = [
         ":core",
     ],


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>


## Summary

- Bazel built MME is linked **dynamically** and with `EMBEDDED_SGW` set.
- Minimal changes that **make the bazel built MME binary runnable** and fix:
  - #12232 
  -  #12233
- Note: The `glog` dependency needs to be linked dynamically (see https://github.com/google/glog/issues/53), ideally `linkstatic = False` should thus only apply to `glog`. 
- Note: `bazel run` on MME needs runtime options `-c /var/opt/magma/tmp/mme.conf -s /var/opt/magma/tmp/spgw.conf`. Can these be set at the `cc_binary`?

## Test Plan

- Run MME with bazel:
  `bazel run lte/gateway/c/core:oai_mme -- -c /var/opt/magma/tmp/mme.conf -s /var/opt/magma/tmp/spgw.conf`



## Additional Information

- [ ] This change is backwards-breaking
