### PR TITLE
fix(orc8r): Fixed simple gateway registration cli

### DIFF
--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/registration.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/registration.go
@@ -2,6 +2,7 @@ package registration
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	"github.com/go-openapi/strfmt"
@@ -67,8 +68,11 @@ func (r *RegistrationService) Register(c context.Context, request *protos.Regist
 }
 
 func RegisterDevice(deviceInfo protos.GatewayDeviceInfo, hwid *protos.AccessGatewayID, challengeKey *protos.ChallengeKey) error {
-	gatewayRecord := createGatewayDevice(hwid, challengeKey)
-	err := device.RegisterDevice(context.Background(), deviceInfo.NetworkId, orc8r.AccessGatewayRecordType, hwid.Id, gatewayRecord, serdes.Device)
+	gatewayRecord, err := createGatewayDevice(hwid, challengeKey)
+	if err != nil {
+		return err
+	}
+	err = device.RegisterDevice(context.Background(), deviceInfo.NetworkId, orc8r.AccessGatewayRecordType, hwid.Id, gatewayRecord, serdes.Device)
 	return err
 }
 
@@ -114,12 +118,17 @@ func makeErr(errString string) *protos.RegisterResponse {
 }
 
 // createGatewayDevice creates the gateway device model
-func createGatewayDevice(hwID *protos.AccessGatewayID, challengeKey *protos.ChallengeKey) *models.GatewayDevice {
-	challengeKeyBase64 := strfmt.Base64(challengeKey.Key)
-	return &models.GatewayDevice{
+func createGatewayDevice(hwID *protos.AccessGatewayID, challengeKey *protos.ChallengeKey) (*models.GatewayDevice, error) {
+	decodedKey, err := base64.StdEncoding.DecodeString(string(challengeKey.Key))
+	if err != nil {
+		return nil, err
+	}
+	challengeKeyBase64 := strfmt.Base64(decodedKey)
+	gatewayDevice := &models.GatewayDevice{
 		HardwareID: hwID.Id,
 		Key:        &models.ChallengeKey{KeyType: challengeKey.KeyType.String(), Key: &challengeKeyBase64},
 	}
+	return gatewayDevice, nil
 }
 
 // updateGatewayDevice writes to the device information to the gateway entity
@@ -137,7 +146,10 @@ func updateGatewayDevice(ctx context.Context, deviceInfo *protos.GatewayDeviceIn
 		return err
 	}
 
-	device := createGatewayDevice(hwID, challengeKey)
+	device, err := createGatewayDevice(hwID, challengeKey)
+	if err != nil {
+		return err
+	}
 
 	gw := (&models.MagmadGateway{}).FromBackendModels(ent, device, nil)
 

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/registration_test.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/registration_test.go
@@ -42,10 +42,11 @@ var (
 			Id: hardwareID,
 		},
 		ChallengeKey: &protos.ChallengeKey{
-			KeyType: 0,
-			Key:     []byte("key"),
+			KeyType: protos.ChallengeKey_ECHO,
+			Key:     challengeKey,
 		},
 	}
+	challengeKey       = []byte("MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQrZVdmuZpvciEXdznTErWUelOcgdBwPKQfOZDL7Wkl8ALSBtKvJWDPyhS6rkW9/xJdgPD4QK3Jqc4Eox5NT6SVYYuHWLv7b28493rwFvuC2+YurmfYj+LZh9VBVTvlwk")
 	controlProxy       = "controlProxy"
 	nextTenantID int64 = 0
 	hardwareID         = "foo-bar-hardware-id"


### PR DESCRIPTION
* added function save_root_ca to use the provided value of the root ca from the command line argument
* added function save_control_proxy because previously save_override_config was assuming that the control proxy was json decoded which formatted the writing incorrectly
* fixed the challenge key, before it was being base64 encoded twice
* added a sleep so that the bootstrapper manager has sufficient time to run bootstrap before running checkin cli


* manually tested 