### PR TITLE
fix(dp): remove unnecesary lookup function from domain proxy helm chart templates

### DIFF
--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/ca.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/ca.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.dp.create -}}
 {{- $fullName := include "domain-proxy.fullname" . -}}
 {{- $secret := printf "%s-%s" $fullName "cc-ca" -}}
-{{- if not (lookup "v1" "Secret" .Release.Namespace $secret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,5 +10,4 @@ data:
 {{- $pathca := printf "%s" .Values.dp.configuration_controller.tlsConfig.paths.ca }}
   ca.crt: |
 {{ (.Files.Get $pathca) | b64enc | indent 4 }}
-{{- end -}}
 {{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/tls.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/tls.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.dp.create -}}
 {{- $fullName := include "domain-proxy.fullname" . -}}
 {{- $secret := printf "%s-%s" $fullName "cc" -}}
-{{- if not (lookup "v1" "Secret" .Release.Namespace $secret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,5 +13,4 @@ data:
 {{ (.Files.Get $pathcrt) | b64enc | indent 4 }}
   tls.key: |
 {{ (.Files.Get $pathkey) | b64enc | indent 4 }}
-{{- end -}}
 {{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/ca.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/ca.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.dp.create -}}
 {{- $fullName := include "domain-proxy.fullname" . -}}
 {{- if .Values.dp.protocol_controller.tlsConfig.paths.ca -}}
-{{- if (empty (lookup "v1" "Secret" .Release.Namespace "${fullName}-pc-ca")) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,6 +10,5 @@ data:
 {{- $pathca := printf "%s" .Values.dp.protocol_controller.tlsConfig.paths.ca }}
   ca.crt: |
 {{ (.Files.Get $pathca) | b64enc | indent 4 }}
-{{- end }}
 {{- end -}}
 {{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/tls.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/protocol_controller/tls.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.dp.create -}}
 {{- $fullName := include "domain-proxy.fullname" . -}}
 {{- if .Values.dp.protocol_controller.tlsConfig -}}
-{{- if (empty (lookup "v1" "Secret" .Release.Namespace "${fullName}-pc")) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,6 +13,5 @@ data:
 {{ (.Files.Get $pathcrt) | b64enc | indent 4 }}
   tls.key: |
 {{ (.Files.Get $pathkey) | b64enc | indent 4 }}
-{{- end }}
 {{- end -}}
 {{- end }}


### PR DESCRIPTION

Signed-off-by: Marcin Trojanowski <marcin.trojanowski@freedomfi.com>

## Summary

This PR removes lookup function from secret helm templates.

## Test Plan

All tests should pass
