### PR TITLE
fix(subscriberdb): Add missing proto library with Bazel

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/protocols/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/protocols/BUILD.bazel
@@ -17,6 +17,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//lte/gateway/python/magma/subscriberdb/crypto:ECIES",
+        "//lte/protos:diam_errors_python_proto",
         "//lte/protos:subscriberauth_python_grpc",
     ],
 )

--- a/lte/protos/BUILD.bazel
+++ b/lte/protos/BUILD.bazel
@@ -359,6 +359,11 @@ proto_library(
     srcs = ["diam_errors.proto"],
 )
 
+python_proto_library(
+    name = "diam_errors_python_proto",
+    protos = [":diam_errors_proto"],
+)
+
 cpp_proto_library(
     name = "diam_errors_cpp_proto",
     protos = [":diam_errors_proto"],


### PR DESCRIPTION
## Summary

This fixes a missing dependency in `subscriberdb` built with Bazel (introduced in #11858). 

## Test Plan

```
bazel run '//lte/gateway/python/magma/subscriberdb:subscriberdb'
```

## Additional Information

- [ ] This change is backwards-breaking