### PR TITLE
chore(pipelined): Migrate pipelined

### DIFF
--- a/bazel/external/aioeventlet.BUILD
+++ b/bazel/external/aioeventlet.BUILD
@@ -1,0 +1,21 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "aioeventlet",
+    srcs = ["aioeventlet.py"],
+    deps = [requirement("eventlet")],
+)

--- a/bazel/external/bcc.BUILD
+++ b/bazel/external/bcc.BUILD
@@ -1,0 +1,18 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "bcc",
+    srcs = glob(["bcc/**/*.py"]),
+    visibility = ["//visibility:public"],
+)

--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -30,11 +30,22 @@ h2>=3,<4
 #  priority==1.3.0 is requirement of aioh2 (loaded via bazel)
 priority==1.3.0
 requests
-pycryptodome
+pycryptodome>=3.9.9
 spyne
 aiohttp
 lxml==4.7.1
 typing_extensions
+eventlet==0.30.2
+aiodns>=1.1.1
+pymemoize>=1.0.2
+pyroute2==0.5.14
+#  oslo-config, routes, tinyrpc, webob, ovs are requirements
+#  of ryu (loaded with bazel)
+oslo-config==8.8.0
+routes==2.5.1
+tinyrpc==1.1.4
+webob==1.8.7
+ovs==2.16.0
 
 # bazelbase container requirements
 hiredis

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
 #
+aiodns==3.0.0 \
+    --hash=sha256:2b19bc5f97e5c936638d28e665923c093d8af2bf3aa88d35c43417fa25d136a2 \
+    --hash=sha256:946bdfabe743fceeeb093c8a010f5d1645f708a241be849e17edfb0e49e08cd6
+    # via -r requirements.in
 aiohttp==3.8.1 \
     --hash=sha256:01d7bdb774a9acc838e6b8f1d114f45303841b89b95984cbb7d80ea41172a9e3 \
     --hash=sha256:03a6d5349c9ee8f79ab3ff3694d6ce1cfc3ced1c9d36200cb8f08ba06bd3b782 \
@@ -155,7 +159,9 @@ cffi==1.15.0 \
     --hash=sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc \
     --hash=sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997 \
     --hash=sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796
-    # via cryptography
+    # via
+    #   cryptography
+    #   pycares
 charset-normalizer==2.0.12 \
     --hash=sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597 \
     --hash=sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df
@@ -250,12 +256,24 @@ cryptography==36.0.1 \
     --hash=sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1 \
     --hash=sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee
     # via -r requirements.in
+debtcollector==2.5.0 \
+    --hash=sha256:1393a527d2c72f143ffa6a629e9c33face6642634eece475b48cab7b04ba61f3 \
+    --hash=sha256:dc9d1ad3f745c43f4bbedbca30f9ffe8905a8c028c9926e61077847d5ea257ab
+    # via oslo-config
 deprecated==1.2.13 \
     --hash=sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d \
     --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
     # via
     #   -r requirements.in
     #   redis
+dnspython==1.16.0 \
+    --hash=sha256:36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01 \
+    --hash=sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d
+    # via eventlet
+eventlet==0.30.2 \
+    --hash=sha256:1811b122d9a45eb5bafba092d36911bca825f835cb648a862bbf984030acff9d \
+    --hash=sha256:89cc6dbfef47c4629cefead5fde21c5f2b33464d57f7df5fc5148f8b4de3fbb5
+    # via -r requirements.in
 fakeredis==1.7.1 \
     --hash=sha256:7c2c4ba1b42e0a75337c54b777bf0671056b4569650e3ff927e4b9b385afc8ec \
     --hash=sha256:be3668e50f6b57d5fc4abfd27f9f655bed07a2c5aecfc8b15d0aad59f997c1ba
@@ -331,6 +349,63 @@ frozenlist==1.3.0 \
     # via
     #   aiohttp
     #   aiosignal
+greenlet==1.1.2 \
+    --hash=sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3 \
+    --hash=sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711 \
+    --hash=sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd \
+    --hash=sha256:049fe7579230e44daef03a259faa24511d10ebfa44f69411d99e6a184fe68073 \
+    --hash=sha256:14d4f3cd4e8b524ae9b8aa567858beed70c392fdec26dbdb0a8a418392e71708 \
+    --hash=sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67 \
+    --hash=sha256:17ff94e7a83aa8671a25bf5b59326ec26da379ace2ebc4411d690d80a7fbcf23 \
+    --hash=sha256:1e12bdc622676ce47ae9abbf455c189e442afdde8818d9da983085df6312e7a1 \
+    --hash=sha256:21915eb821a6b3d9d8eefdaf57d6c345b970ad722f856cd71739493ce003ad08 \
+    --hash=sha256:288c6a76705dc54fba69fbcb59904ae4ad768b4c768839b8ca5fdadec6dd8cfd \
+    --hash=sha256:2bde6792f313f4e918caabc46532aa64aa27a0db05d75b20edfc5c6f46479de2 \
+    --hash=sha256:32ca72bbc673adbcfecb935bb3fb1b74e663d10a4b241aaa2f5a75fe1d1f90aa \
+    --hash=sha256:356b3576ad078c89a6107caa9c50cc14e98e3a6c4874a37c3e0273e4baf33de8 \
+    --hash=sha256:40b951f601af999a8bf2ce8c71e8aaa4e8c6f78ff8afae7b808aae2dc50d4c40 \
+    --hash=sha256:572e1787d1460da79590bf44304abbc0a2da944ea64ec549188fa84d89bba7ab \
+    --hash=sha256:58df5c2a0e293bf665a51f8a100d3e9956febfbf1d9aaf8c0677cf70218910c6 \
+    --hash=sha256:64e6175c2e53195278d7388c454e0b30997573f3f4bd63697f88d855f7a6a1fc \
+    --hash=sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b \
+    --hash=sha256:7418b6bfc7fe3331541b84bb2141c9baf1ec7132a7ecd9f375912eca810e714e \
+    --hash=sha256:7cbd7574ce8e138bda9df4efc6bf2ab8572c9aff640d8ecfece1b006b68da963 \
+    --hash=sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3 \
+    --hash=sha256:833e1551925ed51e6b44c800e71e77dacd7e49181fdc9ac9a0bf3714d515785d \
+    --hash=sha256:8639cadfda96737427330a094476d4c7a56ac03de7265622fcf4cfe57c8ae18d \
+    --hash=sha256:8c5d5b35f789a030ebb95bff352f1d27a93d81069f2adb3182d99882e095cefe \
+    --hash=sha256:8c790abda465726cfb8bb08bd4ca9a5d0a7bd77c7ac1ca1b839ad823b948ea28 \
+    --hash=sha256:8d2f1fb53a421b410751887eb4ff21386d119ef9cde3797bf5e7ed49fb51a3b3 \
+    --hash=sha256:903bbd302a2378f984aef528f76d4c9b1748f318fe1294961c072bdc7f2ffa3e \
+    --hash=sha256:93f81b134a165cc17123626ab8da2e30c0455441d4ab5576eed73a64c025b25c \
+    --hash=sha256:95e69877983ea39b7303570fa6760f81a3eec23d0e3ab2021b7144b94d06202d \
+    --hash=sha256:9633b3034d3d901f0a46b7939f8c4d64427dfba6bbc5a36b1a67364cf148a1b0 \
+    --hash=sha256:97e5306482182170ade15c4b0d8386ded995a07d7cc2ca8f27958d34d6736497 \
+    --hash=sha256:9f3cba480d3deb69f6ee2c1825060177a22c7826431458c697df88e6aeb3caee \
+    --hash=sha256:aa5b467f15e78b82257319aebc78dd2915e4c1436c3c0d1ad6f53e47ba6e2713 \
+    --hash=sha256:abb7a75ed8b968f3061327c433a0fbd17b729947b400747c334a9c29a9af6c58 \
+    --hash=sha256:aec52725173bd3a7b56fe91bc56eccb26fbdff1386ef123abb63c84c5b43b63a \
+    --hash=sha256:b11548073a2213d950c3f671aa88e6f83cda6e2fb97a8b6317b1b5b33d850e06 \
+    --hash=sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88 \
+    --hash=sha256:b336501a05e13b616ef81ce329c0e09ac5ed8c732d9ba7e3e983fcc1a9e86965 \
+    --hash=sha256:b8c008de9d0daba7b6666aa5bbfdc23dcd78cafc33997c9b7741ff6353bafb7f \
+    --hash=sha256:b92e29e58bef6d9cfd340c72b04d74c4b4e9f70c9fa7c78b674d1fec18896dc4 \
+    --hash=sha256:be5f425ff1f5f4b3c1e33ad64ab994eed12fc284a6ea71c5243fd564502ecbe5 \
+    --hash=sha256:dd0b1e9e891f69e7675ba5c92e28b90eaa045f6ab134ffe70b52e948aa175b3c \
+    --hash=sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a \
+    --hash=sha256:e6a36bb9474218c7a5b27ae476035497a6990e21d04c279884eb10d9b290f1b1 \
+    --hash=sha256:e859fcb4cbe93504ea18008d1df98dee4f7766db66c435e4882ab35cf70cac43 \
+    --hash=sha256:eb6ea6da4c787111adf40f697b4e58732ee0942b5d3bd8f435277643329ba627 \
+    --hash=sha256:ec8c433b3ab0419100bd45b47c9c8551248a5aee30ca5e9d399a0b57ac04651b \
+    --hash=sha256:eff9d20417ff9dcb0d25e2defc2574d10b491bf2e693b4e491914738b7908168 \
+    --hash=sha256:f0214eb2a23b85528310dad848ad2ac58e735612929c8072f6093f3585fd342d \
+    --hash=sha256:f276df9830dba7a333544bd41070e8175762a7ac20350786b322b714b0e654f5 \
+    --hash=sha256:f3acda1924472472ddd60c29e5b9db0cec629fbe3c5c5accb74d6d6d14773478 \
+    --hash=sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf \
+    --hash=sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce \
+    --hash=sha256:fa877ca7f6b48054f847b61d6fa7bed5cebb663ebc55e018fda12db09dcc664c \
+    --hash=sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b
+    # via eventlet
 grpcio==1.44.0 \
     --hash=sha256:05467acd391e3fffb05991c76cb2ed2fa1309d0e3815ac379764bc5670b4b5d4 \
     --hash=sha256:0ac72d4b953b76924f8fa21436af060d7e6d8581e279863f30ee14f20751ac27 \
@@ -767,6 +842,10 @@ multidict==6.0.2 \
     # via
     #   aiohttp
     #   yarl
+netaddr==0.8.0 \
+    --hash=sha256:9666d0232c32d2656e5e5f8d735f58fd6c7457ce52fc21c98d45f2af78f990ac \
+    --hash=sha256:d6cc57c7a07b1d9d2e917aa8b36ae8ce61c35ba3fcd1b83ca31c5a0ee2b5a243
+    # via oslo-config
 netifaces==0.11.0 \
     --hash=sha256:043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32 \
     --hash=sha256:08e3f102a59f9eaef70948340aeb6c89bd09734e0dca0f3b82720305729f63ea \
@@ -799,6 +878,17 @@ netifaces==0.11.0 \
     --hash=sha256:e76c7f351e0444721e85f975ae92718e21c1f361bda946d60a214061de1f00a1 \
     --hash=sha256:eb4813b77d5df99903af4757ce980a98c4d702bbcb81f32a0b305a1537bdf0b1
     # via -r requirements.in
+oslo-config==8.8.0 \
+    --hash=sha256:96933d3011dae15608a11616bfb00d947e22da3cb09b6ff37ddd7576abd4764c \
+    --hash=sha256:b1e2a398450ea35a8e5630d8b23057b8939838c4433cd25a20cc3a36d5df9e3b
+    # via -r requirements.in
+oslo-i18n==5.1.0 \
+    --hash=sha256:6bf111a6357d5449640852de4640eae4159b5562bbba4c90febb0034abc095d0 \
+    --hash=sha256:75086cfd898819638ca741159f677e2073a78ca86a9c9be8d38b46800cdf2dc9
+    # via oslo-config
+ovs==2.16.0 \
+    --hash=sha256:3316c0b587f0493f9d83fb966778ccd007a3189ef3f9cc8fa81aa96a853e2337
+    # via -r requirements.in
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
@@ -810,6 +900,12 @@ parameterized==0.8.1 \
     --hash=sha256:41bbff37d6186430f77f900d777e5bb6a24928a1c46fb1de692f8b52b8833b5c \
     --hash=sha256:9cbb0b69a03e8695d68b3399a8a5825200976536fe1cb79db60ed6a4c8c9efe9
     # via -r requirements.in
+pbr==5.8.1 \
+    --hash=sha256:27108648368782d07bbf1cb468ad2e2eeef29086affd14087a6d04b7de8af4ec \
+    --hash=sha256:66bc5a34912f408bb3925bf21231cb6f59206267b7f63f3503ef865c1a292e25
+    # via
+    #   oslo-i18n
+    #   stevedore
 pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3
@@ -818,7 +914,7 @@ priority==1.3.0 \
     --hash=sha256:6bc1961a6d7fcacbfc337769f1a382c8e746566aaa365e78047abe9f66b2ffbe \
     --hash=sha256:be4fcb94b5e37cdeb40af5533afe6dd603bd665fe9c8b3052610fc1001d5d1eb
     # via -r requirements.in
-prometheus_client==0.3.1 \
+prometheus-client==0.3.1 \
     --hash=sha256:17bc24c09431644f7c65d7bce9f4237252308070b6395d6d8e87767afe867e24
     # via -r requirements.in
 protobuf==3.19.4 \
@@ -889,6 +985,39 @@ py==1.11.0 \
     --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
     --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
     # via pytest
+pycares==4.1.2 \
+    --hash=sha256:03490be0e7b51a0c8073f877bec347eff31003f64f57d9518d419d9369452837 \
+    --hash=sha256:056330275dea42b7199494047a745e1d9785d39fb8c4cd469dca043532240b80 \
+    --hash=sha256:0aa897543a786daba74ec5e19638bd38b2b432d179a0e248eac1e62de5756207 \
+    --hash=sha256:112e1385c451069112d6b5ea1f9c378544f3c6b89882ff964e9a64be3336d7e4 \
+    --hash=sha256:27a6f09dbfb69bb79609724c0f90dfaa7c215876a7cd9f12d585574d1f922112 \
+    --hash=sha256:2b837315ed08c7df009b67725fe1f50489e99de9089f58ec1b243dc612f172aa \
+    --hash=sha256:2f5f84fe9f83eab9cd68544b165b74ba6e3412d029cc9ab20098d9c332869fc5 \
+    --hash=sha256:40079ed58efa91747c50aac4edf8ecc7e570132ab57dc0a4030eb0d016a6cab8 \
+    --hash=sha256:439799be4b7576e907139a7f9b3c8a01b90d3e38af4af9cd1fc6c1ee9a42b9e6 \
+    --hash=sha256:4d5da840aa0d9b15fa51107f09270c563a348cb77b14ae9653d0bbdbe326fcc2 \
+    --hash=sha256:4e190471a015f8225fa38069617192e06122771cce2b169ac7a60bfdbd3d4ab2 \
+    --hash=sha256:5632f21d92cc0225ba5ff906e4e5dec415ef0b3df322c461d138190681cd5d89 \
+    --hash=sha256:569eef8597b5e02b1bc4644b9f272160304d8c9985357d7ecfcd054da97c0771 \
+    --hash=sha256:58a41a2baabcd95266db776c510d349d417919407f03510fc87ac7488730d913 \
+    --hash=sha256:6831e963a910b0a8cbdd2750ffcdf5f2bb0edb3f53ca69ff18484de2cc3807c4 \
+    --hash=sha256:71b99b9e041ae3356b859822c511f286f84c8889ec9ed1fbf6ac30fb4da13e4c \
+    --hash=sha256:8319afe4838e09df267c421ca93da408f770b945ec6217dda72f1f6a493e37e4 \
+    --hash=sha256:8fd1ff17a26bb004f0f6bb902ba7dddd810059096ae0cc3b45e4f5be46315d19 \
+    --hash=sha256:a810d01c9a426ee8b0f36969c2aef5fb966712be9d7e466920beb328cd9cefa3 \
+    --hash=sha256:ad7b28e1b6bc68edd3d678373fa3af84e39d287090434f25055d21b4716b2fc6 \
+    --hash=sha256:b0e50ddc78252f2e2b6b5f2c73e5b2449dfb6bea7a5a0e21dfd1e2bcc9e17382 \
+    --hash=sha256:b266cec81dcea2c3efbbd3dda00af8d7eb0693ae9e47e8706518334b21f27d4a \
+    --hash=sha256:c000942f5fc64e6e046aa61aa53b629b576ba11607d108909727c3c8f211a157 \
+    --hash=sha256:c6680f7fdc0f1163e8f6c2a11d11b9a0b524a61000d2a71f9ccd410f154fb171 \
+    --hash=sha256:c7eba3c8354b730a54d23237d0b6445a2f68570fa68d0848887da23a3f3b71f3 \
+    --hash=sha256:cbceaa9b2c416aa931627466d3240aecfc905c292c842252e3d77b8630072505 \
+    --hash=sha256:dc942692fca0e27081b7bb414bb971d34609c80df5e953f6d0c62ecc8019acd9 \
+    --hash=sha256:e1489aa25d14dbf7176110ead937c01176ed5a0ebefd3b092bbd6b202241814c \
+    --hash=sha256:e5a060f5fa90ae245aa99a4a8ad13ec39c2340400de037c7e8d27b081e1a3c64 \
+    --hash=sha256:ec00f3594ee775665167b1a1630edceefb1b1283af9ac57480dba2fb6fd6c360 \
+    --hash=sha256:ed71dc4290d9c3353945965604ef1f6a4de631733e9819a7ebc747220b27e641
+    # via aiodns
 pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
@@ -925,10 +1054,16 @@ pycryptodome==3.14.1 \
     --hash=sha256:f403a3e297a59d94121cb3ee4b1cf41f844332940a62d71f9e4a009cc3533493 \
     --hash=sha256:f572a3ff7b6029dd9b904d6be4e0ce9e309dcb847b03e3ac8698d9d23bb36525
     # via -r requirements.in
+pymemoize==1.0.3 \
+    --hash=sha256:07c7b8f592b1f03af74289ef0e554520022dae378ba36d0dbc1f80532130197b
+    # via -r requirements.in
 pyparsing==3.0.7 \
     --hash=sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea \
     --hash=sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484
     # via packaging
+pyroute2==0.5.14 \
+    --hash=sha256:774c5ecf05fe40f0f601a7ab33c19ca0b24f00bf4a094e58deaa5333b7ca49b5
+    # via -r requirements.in
 pyrsistent==0.18.1 \
     --hash=sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c \
     --hash=sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc \
@@ -1015,6 +1150,7 @@ pyyaml==6.0 \
     # via
     #   -r requirements.in
     #   bravado-core
+    #   oslo-config
     #   swagger-spec-validator
 redis==4.1.4 \
     --hash=sha256:04629f8e42be942c4f7d1812f2094568f04c612865ad19ad3ace3005da70631a \
@@ -1028,14 +1164,28 @@ redis-collections==0.11.0 \
     --hash=sha256:0f6cda00666fdd26e3b8ca47da13a653eaf4cc4e45470a3b09f17d65061fea8a \
     --hash=sha256:d23e8c0f6bf50de10c98a14a3b636ff1bb21119386f884f2641c906832bc4ec9
     # via -r requirements.in
+repoze-lru==0.7 \
+    --hash=sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77 \
+    --hash=sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea
+    # via routes
 requests==2.27.1 \
     --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
     --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   oslo-config
+rfc3986==2.0.0 \
+    --hash=sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd \
+    --hash=sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c
+    # via oslo-config
 rfc3987==1.3.8 \
     --hash=sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53 \
     --hash=sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733
     # via jsonschema
+routes==2.5.1 \
+    --hash=sha256:b6346459a15f0cbab01a45a90c3d25caf980d4733d628b4cc1952b865125d053 \
+    --hash=sha256:fab5a042a3a87778eb271d053ca2723cadf43c95b471532a191a48539cb606ea
+    # via -r requirements.in
 scapy==2.4.5 \
     --hash=sha256:bc707e3604784496b6665a9e5b2a69c36cc9fb032af4864b29051531b24c8593
     # via -r requirements.in
@@ -1112,21 +1262,30 @@ six==1.16.0 \
     # via
     #   -r requirements.in
     #   bravado-core
+    #   eventlet
     #   fakeredis
     #   grpcio
     #   jsonschema
     #   python-dateutil
+    #   routes
     #   swagger-spec-validator
+    #   tinyrpc
 snowflake==0.0.3 \
     --hash=sha256:5e0f2310bc9e499c8c47bed8da0695d79ad372057de7e03751e47fef46a6760d
     # via -r requirements.in
 sortedcontainers==2.4.0 \
     --hash=sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88 \
     --hash=sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
-    # via fakeredis
+    # via
+    #   fakeredis
+    #   ovs
 spyne==2.14.0 \
     --hash=sha256:063e950e179a7d5b06b577c9f2c9091a70d40217f1a853076b3709caa2bf3a16
     # via -r requirements.in
+stevedore==3.5.0 \
+    --hash=sha256:a547de73308fd7e90075bb4d301405bebf705292fa90a90fc3bcf9133f58616c \
+    --hash=sha256:f40253887d8712eaa2bb0ea3830374416736dc8ec0e22f5a65092c1174c44335
+    # via oslo-config
 strict-rfc3339==0.7 \
     --hash=sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277
     # via jsonschema
@@ -1136,6 +1295,9 @@ swagger-spec-validator==2.7.4 \
     # via bravado-core
 systemd==0.16.1 \
     --hash=sha256:f44a02434cb1e6ff686bc7d25a7a665cc7af665965e933df3e76fa02d351a75b
+    # via -r requirements.in
+tinyrpc==1.1.4 \
+    --hash=sha256:c99f412e5d9849c2deb468ea37fee2faf12fbc95bdd3616ae5c276ea195ed6bd
     # via -r requirements.in
 toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
@@ -1160,6 +1322,10 @@ webcolors==1.11.1 \
     --hash=sha256:76f360636957d1c976db7466bc71dcb713bb95ac8911944dffc55c01cb516de6 \
     --hash=sha256:b8cd5d865a25c51ff1218f0c90d0c0781fc64312a49b746b320cf50de1648f6e
     # via jsonschema
+webob==1.8.7 \
+    --hash=sha256:73aae30359291c14fa3b956f8b5ca31960e420c28c1bec002547fb04928cf89b \
+    --hash=sha256:b64ef5141be559cfade448f044fa45c2260351edcb6a8ef6b7e00c7dcef0c323
+    # via -r requirements.in
 werkzeug==2.0.3 \
     --hash=sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8 \
     --hash=sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c
@@ -1218,6 +1384,7 @@ wrapt==1.13.3 \
     --hash=sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea
     # via
     #   -r requirements.in
+    #   debtcollector
     #   deprecated
 wsgiserver==1.3 \
     --hash=sha256:1069fd004322f693e4d0b0b336b6785346abb4674a196f851e7d4e601052e383 \

--- a/bazel/external/ryu.BUILD
+++ b/bazel/external/ryu.BUILD
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "ryu_patched",
+    srcs = glob(
+        ["ryu/**/*.py"],
+        exclude = ["**/tests/**"],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("oslo-config"),
+        requirement("routes"),
+        requirement("tinyrpc"),
+        requirement("webob"),
+        requirement("ovs"),
+        requirement("eventlet"),
+    ],
+)

--- a/bazel/python_repositories.bzl
+++ b/bazel/python_repositories.bzl
@@ -13,11 +13,43 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
-def python_repositories():
+def python_repositories(name = ""):
     new_git_repository(
         name = "aioh2_repo",
         build_file = "//bazel/external:aioh2.BUILD",
         commit = "8c1b5ab2399443087795fe52b71e43b652b1031f",
         shallow_since = "1548652954 +0800",
         remote = "https://github.com/URenko/aioh2.git",
+    )
+    new_git_repository(
+        name = "ryu_repo",
+        build_file = "//bazel/external:ryu.BUILD",
+        commit = "c776e4cb68600b2ee0a4f38364f4a355502777f1",  # Corresponds to: tag = "v4.34"
+        shallow_since = "1569926530 +0900",
+        remote = "https://github.com/faucetsdn/ryu.git",
+        patches = [
+            "//lte/gateway/deploy/roles/magma/files/patches:ryu_ipfix_args.patch",
+            "//lte/gateway/deploy/roles/magma/files/patches:0001-Set-unknown-dpid-ofctl-log-to-debug.patch",
+        ],
+        patch_args = ["-p1"],
+    )
+    new_git_repository(
+        name = "aioeventlet_repo",
+        remote = "https://github.com/openstack-archive/deb-python-aioeventlet.git",
+        build_file = "//bazel/external:aioeventlet.BUILD",
+        commit = "0afed1425fd36139d1a7281475a28fde3349047e",  # Corresponds to: tag = "0.5.1"
+        shallow_since = "1456158219 +0100",
+        patches = [
+            "//lte/gateway/deploy/roles/magma/files/patches:aioeventlet_fd_exception.patch",
+            "//lte/gateway/deploy/roles/magma/files/patches:aioeventlet.py38.patch",
+        ],
+        patch_args = ["-p1"],
+    )
+
+    # TODO: This is not a nice solution, because it is not really hermetic.
+    # bcc is installd via apt bcc-tools from a magma repository
+    native.new_local_repository(
+        name = "bcc_repo",
+        build_file = "//bazel/external:bcc.BUILD",
+        path = "/usr/lib/python3/dist-packages/",
     )

--- a/bazel/scripts/run_sudo_tests.sh
+++ b/bazel/scripts/run_sudo_tests.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -euo pipefail
+
+###############################################################################
+# FUNCTION DECLARATIONS
+###############################################################################
+
+help() {
+    echo "Executes all bazel tests that are tagged as sudo_test inside the"
+    echo "specified directory (recursively), or one single test if a test name"
+    echo "is provided."
+    echo "Usage:"
+    echo "   $(basename "$0")  # execute all tests in the magma repository" 
+    echo "   $(basename "$0") path_to_tests_directory/"
+    echo "   $(basename "$0") path_to_tests_directory:test_name"
+    exit 1
+}
+
+create_test_targets() {
+    if [[ "${TARGET_PATH}" == *":"* ]];
+    then
+        echo "Single target specified - running test:"
+        TEST_TARGETS=( "${TARGET_PATH}" )
+    else
+        echo "Multiple targets specified - running tests:"
+        mapfile -t TEST_TARGETS < <(bazel query "attr(tags, sudo_test, kind(py_test, //${TARGET_PATH}...))")
+    fi
+    if [[ "${#TEST_TARGETS[@]}" -eq 0 ]];
+    then
+        echo "ERROR: No test found."
+        help
+        exit 1
+    fi
+    for TARGET in "${TEST_TARGETS[@]}"
+    do
+        echo "${TARGET}"
+    done
+}
+
+run_test() {
+    local TARGET=$1
+    local TARGET_PATH=${TARGET%:*}
+    local SHORT_TARGET=${TARGET#*:}
+    (
+        set -x
+        bazel build "${TARGET}"
+        sudo "bazel-bin/${TARGET_PATH}/${SHORT_TARGET}"
+    )
+}
+
+print_summary() {
+    local NUM_SUCCESS=$1
+    local TOTAL_TESTS=$2
+    echo "SUMMARY: ${NUM_SUCCESS}/${TOTAL_TESTS} tests were successful."
+    for TARGET in "${!TEST_RESULTS[@]}"
+    do
+        echo "  ${TARGET}: ${TEST_RESULTS[${TARGET}]}"
+    done
+}
+
+###############################################################################
+# SCRIPT SECTION
+###############################################################################
+
+TARGET_PATH="${1:-}"
+
+declare -a TEST_TARGETS
+declare -A TEST_RESULTS
+NUM_SUCCESS=0
+NUM_RUN=1
+
+cd "${MAGMA_ROOT}"
+
+create_test_targets
+
+TOTAL_TESTS=${#TEST_TARGETS[@]}
+
+for TARGET in "${TEST_TARGETS[@]}"
+do
+    echo "Starting test ${NUM_RUN}/${TOTAL_TESTS}: ${TARGET}"
+
+    if run_test "${TARGET}";
+    then
+        NUM_SUCCESS=$((NUM_SUCCESS + 1))
+        TEST_RESULTS["${TARGET}"]="PASSED"
+    else
+        TEST_RESULTS["${TARGET}"]="FAILED"
+    fi
+    NUM_RUN=$((NUM_RUN + 1))
+done
+
+print_summary "${NUM_SUCCESS}" "${TOTAL_TESTS}"
+
+[[ "${TOTAL_TESTS}" == "${NUM_SUCCESS}" ]]

--- a/feg/protos/BUILD.bazel
+++ b/feg/protos/BUILD.bazel
@@ -21,6 +21,17 @@ proto_library(
     deps = ["//orc8r/protos:common_proto"],
 )
 
+proto_library(
+    name = "envoy_controller_proto",
+    srcs = ["envoy_controller.proto"],
+    deps = ["//lte/protos:mobilityd_proto"],
+)
+
+python_grpc_library(
+    name = "envoy_controller_python_grpc",
+    protos = [":envoy_controller_proto"],
+)
+
 python_proto_library(
     name = "mconfigs_python_proto",
     protos = [":mconfigs_proto"],

--- a/lte/gateway/deploy/roles/magma/files/patches/BUILD.bazel
+++ b/lte/gateway/deploy/roles/magma/files/patches/BUILD.bazel
@@ -1,0 +1,10 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lte/gateway/python/integ_tests/s1aptests/ovs/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/ovs/BUILD.bazel
@@ -1,0 +1,26 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "constants",
+    testonly = 1,
+    srcs = ["__init__.py"],
+)
+
+py_library(
+    name = "rest_api",
+    testonly = 1,
+    srcs = ["rest_api.py"],
+)

--- a/lte/gateway/python/magma/pipelined/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/BUILD.bazel
@@ -9,11 +9,222 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_python//python:defs.bzl", "py_library")
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 package(default_visibility = ["//visibility:public"])
+
+MAGMA_ROOT = "../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+py_binary(
+    name = "pipelined",
+    srcs = ["main.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    # legacy_create_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
+    legacy_create_init = False,
+    main = "main.py",
+    python_version = "PY3",
+    deps = [
+        ":pipelined_lib",
+        "//lte/gateway/python/magma/pipelined/app:he",
+        "//lte/gateway/python/magma/pipelined/app:of_rest_server",
+        "//lte/protos:mconfigs_python_proto",
+        "//orc8r/gateway/python/magma/common:misc_utils",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
+        "//orc8r/gateway/python/magma/configuration:environment",
+        "@aioeventlet_repo//:aioeventlet",
+    ],
+)
+
+py_library(
+    name = "pipelined_lib",
+    srcs = [
+        "check_quota_server.py",
+        "datapath_setup.py",
+        "gtp_stats_collector.py",
+        "ifaces.py",
+    ],
+    deps = [
+        ":rpc_servicer",
+        ":service_manager",
+        "//lte/gateway/python/magma/pipelined/app:uplink_bridge",
+        "//orc8r/gateway/python/magma/magmad/check:subprocess_workflow",
+        requirement("flask"),
+        requirement("wsgiserver"),
+    ],
+)
+
+py_library(
+    name = "rpc_servicer",
+    srcs = ["rpc_servicer.py"],
+    deps = [
+        "//lte/gateway/python/magma/pipelined/app:check_quota",
+        "//lte/gateway/python/magma/pipelined/app:classifier",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/app:ng_services",
+        "//lte/gateway/python/magma/pipelined/app:tunnel_learn",
+        "//lte/gateway/python/magma/pipelined/app:vlan_learn",
+        "//lte/protos:pipelined_python_grpc",
+    ],
+)
 
 py_library(
     name = "bridge_util",
     srcs = ["bridge_util.py"],
+)
+
+py_library(
+    name = "service_manager",
+    srcs = ["service_manager.py"],
+    deps = [
+        ":internal_ip_allocator",
+        ":rule_mappers",
+        "//lte/gateway/python/magma/pipelined/app:access_control",
+        "//lte/gateway/python/magma/pipelined/app:arp",
+        "//lte/gateway/python/magma/pipelined/app:check_quota",
+        "//lte/gateway/python/magma/pipelined/app:classifier",
+        "//lte/gateway/python/magma/pipelined/app:conntrack",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/app:gy",
+        "//lte/gateway/python/magma/pipelined/app:he",
+        "//lte/gateway/python/magma/pipelined/app:ipv6_solicitation",
+        "//lte/gateway/python/magma/pipelined/app:ng_services",
+        "//lte/gateway/python/magma/pipelined/app:of_rest_server",
+        "//lte/gateway/python/magma/pipelined/app:startup_flows",
+        "//lte/gateway/python/magma/pipelined/app:tunnel_learn",
+        "//lte/gateway/python/magma/pipelined/app:uplink_bridge",
+        "//lte/gateway/python/magma/pipelined/app:vlan_learn",
+        "//lte/gateway/python/magma/pipelined/app:xwf_passthru",
+        "//lte/gateway/python/magma/pipelined/ebpf:ebpf_manager",
+        "//lte/gateway/python/magma/pipelined/qos:common",
+        "//lte/protos:mobilityd_python_grpc",
+        "//lte/protos:session_manager_python_grpc",
+        "//orc8r/gateway/python/magma/common:service",
+        "//orc8r/gateway/python/magma/configuration:environment",
+        "@aioeventlet_repo//:aioeventlet",
+    ],
+)
+
+py_library(
+    name = "rule_mappers",
+    srcs = ["rule_mappers.py"],
+)
+
+py_library(
+    name = "internal_ip_allocator",
+    srcs = ["internal_ip_allocator.py"],
+)
+
+py_library(
+    name = "set_interface_client",
+    srcs = ["set_interface_client.py"],
+    deps = [
+        "//lte/protos:session_manager_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/gateway/python/magma/common:sentry",
+    ],
+)
+
+py_library(
+    name = "directoryd_client",
+    srcs = ["directoryd_client.py"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:service_registry",
+        "//orc8r/protos:directoryd_python_grpc",
+    ],
+)
+
+py_library(
+    name = "mobilityd_client",
+    srcs = ["mobilityd_client.py"],
+    deps = [
+        "//lte/protos:mobilityd_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/gateway/python/magma/common:sentry",
+    ],
+)
+
+py_library(
+    name = "metrics",
+    srcs = ["metrics.py"],
+    deps = [requirement("prometheus_client")],
+)
+
+py_library(
+    name = "imsi",
+    srcs = ["imsi.py"],
+)
+
+py_library(
+    name = "ng_set_session_msg",
+    srcs = ["ng_set_session_msg.py"],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:policy_converters",
+        "//lte/gateway/python/magma/pipelined/ng_manager:session_state_manager_util",
+        "//lte/gateway/python/magma/subscriberdb:sid",
+    ],
+)
+
+py_library(
+    name = "utils",
+    srcs = ["utils.py"],
+    deps = [requirement("netifaces")],
+)
+
+py_library(
+    name = "redirect",
+    srcs = ["redirect.py"],
+    deps = [
+        "//lte/gateway/python/magma/redirectd:redirect_store",
+        requirement("aiodns"),
+        requirement("pymemoize"),
+    ],
+)
+
+py_library(
+    name = "policy_converters",
+    srcs = ["policy_converters.py"],
+    deps = [
+        ":ipv6_prefix_store",
+        "//lte/gateway/python/magma/pipelined/openflow:magma_match",
+        "//lte/protos:mobilityd_python_proto",
+        "//lte/protos:policydb_python_proto",
+        "@ryu_repo//:ryu_patched",
+    ],
+)
+
+py_library(
+    name = "ipv6_prefix_store",
+    srcs = ["ipv6_prefix_store.py"],
+    deps = ["//orc8r/gateway/python/magma/common/redis:client"],
+)
+
+py_library(
+    name = "envoy_client",
+    srcs = ["envoy_client.py"],
+    deps = [
+        "//feg/protos:envoy_controller_python_grpc",
+        "//orc8r/gateway/python/magma/common:service_registry",
+    ],
+)
+
+py_library(
+    name = "encoding",
+    srcs = ["encoding.py"],
+    deps = [requirement("pycryptodome")],
+)
+
+py_library(
+    name = "tunnel_id_store",
+    testonly = True,
+    srcs = ["tunnel_id_store.py"],
+    deps = ["//orc8r/gateway/python/magma/common/redis:client"],
 )

--- a/lte/gateway/python/magma/pipelined/app/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/app/BUILD.bazel
@@ -1,0 +1,232 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "of_rest_server",
+    srcs = ["of_rest_server.py"],
+    deps = ["@ryu_repo//:ryu_patched"],
+)
+
+py_library(
+    name = "uplink_bridge",
+    srcs = ["uplink_bridge.py"],
+)
+
+py_library(
+    name = "classifier",
+    srcs = ["classifier.py"],
+    deps = [
+        ":base",
+        ":inout",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/gateway/python/magma/common:sentry",
+        requirement("grpcio"),
+    ],
+)
+
+py_library(
+    name = "tunnel_learn",
+    srcs = ["tunnel_learn.py"],
+    deps = [
+        ":base",
+        "//lte/gateway/python/magma/pipelined/openflow:flows",
+    ],
+)
+
+py_library(
+    name = "vlan_learn",
+    srcs = ["vlan_learn.py"],
+)
+
+py_library(
+    name = "access_control",
+    srcs = ["access_control.py"],
+    deps = [
+        ":base",
+        "//lte/gateway/python/magma/pipelined/openflow:flows",
+        requirement("netifaces"),
+    ],
+)
+
+py_library(
+    name = "arp",
+    srcs = ["arp.py"],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:directoryd_client",
+        "//lte/gateway/python/magma/pipelined:utils",
+        "//lte/gateway/python/magma/pipelined/app:base",
+        "//lte/gateway/python/magma/pipelined/openflow:flows",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+py_library(
+    name = "conntrack",
+    srcs = ["conntrack.py"],
+    deps = [
+        ":base",
+        "//lte/gateway/python/magma/pipelined/openflow:flows",
+    ],
+)
+
+py_library(
+    name = "gy",
+    srcs = ["gy.py"],
+    deps = [
+        ":base",
+        ":enforcement_stats",
+        ":inout",
+        "//lte/gateway/python/magma/pipelined:redirect",
+        "//lte/gateway/python/magma/pipelined/qos:qos_meter_impl",
+    ],
+)
+
+py_library(
+    name = "ipv6_solicitation",
+    srcs = ["ipv6_solicitation.py"],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:ipv6_prefix_store",
+        "//lte/gateway/python/magma/pipelined/app:base",
+        "//lte/gateway/python/magma/pipelined/openflow:flows",
+        "//orc8r/gateway/python/magma/common:misc_utils",
+    ],
+)
+
+py_library(
+    name = "startup_flows",
+    srcs = ["startup_flows.py"],
+)
+
+py_library(
+    name = "xwf_passthru",
+    srcs = ["xwf_passthru.py"],
+)
+
+py_library(
+    name = "ng_services",
+    srcs = ["ng_services.py"],
+    deps = ["//lte/gateway/python/magma/pipelined/ng_manager:node_state_manager"],
+)
+
+py_library(
+    name = "enforcement",
+    srcs = ["enforcement.py"],
+    deps = [
+        ":base",
+        ":enforcement_stats",
+        "//lte/gateway/python/magma/pipelined:redirect",
+        "//lte/gateway/python/magma/pipelined/qos:qos_meter_impl",
+    ],
+)
+
+py_library(
+    name = "enforcement_stats",
+    srcs = [
+        "enforcement_stats.py",
+        "policy_mixin.py",
+    ],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:utils",
+        "//lte/gateway/python/magma/pipelined/app:dpi",
+        "//lte/gateway/python/magma/pipelined/app:restart_mixin",
+        "//lte/gateway/python/magma/pipelined/ng_manager:session_state_manager",
+        "//lte/gateway/python/magma/pipelined/qos:types",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+    ],
+)
+
+py_library(
+    name = "check_quota",
+    srcs = ["check_quota.py"],
+    deps = [":ue_mac"],
+)
+
+py_library(
+    name = "ue_mac",
+    srcs = ["ue_mac.py"],
+    deps = [
+        ":inout",
+        ":ipfix",
+        "//lte/gateway/python/magma/pipelined:directoryd_client",
+    ],
+)
+
+py_library(
+    name = "ipfix",
+    srcs = ["ipfix.py"],
+    deps = [":dpi"],
+)
+
+py_library(
+    name = "dpi",
+    srcs = ["dpi.py"],
+    deps = [
+        ":base",
+        "//lte/gateway/python/magma/pipelined/openflow:flows",
+    ],
+)
+
+py_library(
+    name = "inout",
+    srcs = [
+        "inout.py",
+        "li_mirror.py",
+    ],
+    deps = [
+        ":base",
+        ":restart_mixin",
+        "//lte/gateway/python/magma/pipelined:imsi",
+        "//lte/gateway/python/magma/pipelined:mobilityd_client",
+        "//lte/gateway/python/magma/pipelined:utils",
+        "//lte/gateway/python/magma/pipelined/openflow:flows",
+        "//orc8r/gateway/python/magma/configuration:mconfig_managers",
+        requirement("scapy"),
+    ],
+)
+
+py_library(
+    name = "restart_mixin",
+    srcs = ["restart_mixin.py"],
+)
+
+py_library(
+    name = "testing",
+    srcs = ["testing.py"],
+)
+
+py_library(
+    name = "he",
+    srcs = ["he.py"],
+    deps = [
+        ":base",
+        "//lte/gateway/python/magma/pipelined:encoding",
+        "//lte/gateway/python/magma/pipelined:envoy_client",
+        "//lte/gateway/python/magma/pipelined/openflow:flows",
+        "//lte/protos:mobilityd_python_proto",
+    ],
+)
+
+py_library(
+    name = "base",
+    srcs = ["base.py"],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined:metrics",
+        "//lte/gateway/python/magma/pipelined/openflow:exceptions",
+        "//lte/protos:pipelined_python_proto",
+        "@ryu_repo//:ryu_patched",
+    ],
+)

--- a/lte/gateway/python/magma/pipelined/ebpf/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/ebpf/BUILD.bazel
@@ -9,24 +9,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:python_test.bzl", "pytest_test")
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
 
-MAGMA_ROOT = "../../../../../../"
+package(default_visibility = ["//visibility:public"])
 
-ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
-
-LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
-
-pytest_test(
-    name = "test_redirect",
-    size = "small",
-    srcs = ["test_redirect.py"],
-    imports = [
-        LTE_ROOT,
-        ORC8R_ROOT,
-    ],
+py_library(
+    name = "ebpf_manager",
+    srcs = ["ebpf_manager.py"],
     deps = [
-        "//lte/gateway/python/magma/redirectd:redirect_server",
-        "//lte/protos:policydb_python_proto",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined:mobilityd_client",
+        "@bcc_repo//:bcc",
+        requirement("netifaces"),
+        requirement("pyroute2"),
+        requirement("scapy"),
     ],
 )

--- a/lte/gateway/python/magma/pipelined/ng_manager/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/ng_manager/BUILD.bazel
@@ -1,0 +1,38 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "session_state_manager",
+    srcs = ["session_state_manager.py"],
+    deps = [
+        ":session_state_manager_util",
+        "//lte/gateway/python/magma/pipelined:set_interface_client",
+    ],
+)
+
+py_library(
+    name = "session_state_manager_util",
+    srcs = ["session_state_manager_util.py"],
+)
+
+py_library(
+    name = "node_state_manager",
+    srcs = ["node_state_manager.py"],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:set_interface_client",
+        requirement("netifaces"),
+    ],
+)

--- a/lte/gateway/python/magma/pipelined/openflow/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/openflow/BUILD.bazel
@@ -1,0 +1,55 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "exceptions",
+    srcs = ["exceptions.py"],
+)
+
+py_library(
+    name = "meters",
+    srcs = ["meters.py"],
+    deps = [
+        ":messages",
+        "//lte/gateway/python/magma/pipelined/qos:utils",
+    ],
+)
+
+py_library(
+    name = "magma_match",
+    srcs = [
+        "magma_match.py",
+        "registers.py",
+    ],
+    deps = ["//lte/gateway/python/magma/pipelined:imsi"],
+)
+
+py_library(
+    name = "flows",
+    srcs = ["flows.py"],
+    deps = [":messages"],
+)
+
+py_library(
+    name = "messages",
+    srcs = ["messages.py"],
+    deps = [
+        ":exceptions",
+        "//lte/gateway/python/magma/pipelined:metrics",
+        "//lte/gateway/python/magma/pipelined:policy_converters",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "@ryu_repo//:ryu_patched",
+    ],
+)

--- a/lte/gateway/python/magma/pipelined/openflow/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/openflow/tests/BUILD.bazel
@@ -1,0 +1,29 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:python_test.bzl", "pytest_test")
+
+MAGMA_ROOT = "../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+pytest_test(
+    name = "test_msg_hub",
+    size = "small",
+    srcs = ["test_msg_hub.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = ["//lte/gateway/python/magma/pipelined/openflow:messages"],
+)

--- a/lte/gateway/python/magma/pipelined/qos/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/qos/BUILD.bazel
@@ -1,0 +1,61 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "types",
+    srcs = ["types.py"],
+)
+
+py_library(
+    name = "utils",
+    srcs = ["utils.py"],
+    deps = ["//orc8r/gateway/python/magma/common/redis:containers"],
+)
+
+py_library(
+    name = "common",
+    srcs = ["common.py"],
+    deps = [
+        ":qos_meter_impl",
+        ":qos_tc_impl",
+        "//orc8r/gateway/python/magma/common/redis:client",
+    ],
+)
+
+py_library(
+    name = "qos_tc_impl",
+    srcs = [
+        "qos_tc_impl.py",
+        "tc_ops.py",
+        "tc_ops_cmd.py",
+        "tc_ops_pyroute2.py",
+    ],
+    deps = [
+        ":types",
+        ":utils",
+        "//lte/protos:policydb_python_proto",
+        requirement("pyroute2"),
+    ],
+)
+
+py_library(
+    name = "qos_meter_impl",
+    srcs = ["qos_meter_impl.py"],
+    deps = [
+        ":types",
+        "//lte/gateway/python/magma/pipelined/openflow:meters",
+    ],
+)

--- a/lte/gateway/python/magma/pipelined/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/tests/BUILD.bazel
@@ -1,0 +1,849 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
+load("//bazel:python_test.bzl", "pytest_test")
+load("//bazel:test_constants.bzl", "TAG_SUDO_TEST")
+
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+py_library(
+    name = "pipelined_test_util",
+    testonly = True,
+    srcs = ["pipelined_test_util.py"],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:service_manager",
+        "//lte/gateway/python/magma/pipelined/tests/app:flow_query",
+        requirement("fakeredis"),
+    ],
+)
+
+pytest_test(
+    name = "test_access_control",
+    size = "small",
+    srcs = ["test_access_control.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:access_control",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:flow_query",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_arp",
+    size = "small",
+    srcs = ["test_arp.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:arp",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_arp_non_nat",
+    size = "small",
+    srcs = ["test_arp_non_nat.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:arp",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:mobilityd_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_check_quota",
+    size = "small",
+    srcs = ["test_check_quota.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_classifier",
+    size = "small",
+    srcs = ["test_classifier.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mobilityd_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_classifier_mme_flow_dl",
+    size = "small",
+    srcs = ["test_classifier_mme_flow_dl.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mobilityd_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_classifier_traffic",
+    size = "small",
+    srcs = ["test_classifier_traffic.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:classifier",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:flow_query",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:mobilityd_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_conntrack",
+    size = "small",
+    srcs = ["test_conntrack.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:conntrack",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_cwf_restart_resilience",
+    size = "small",
+    srcs = ["test_cwf_restart_resilience.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:base",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_dpi",
+    size = "small",
+    srcs = ["test_dpi.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined:policy_converters",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_ebpf_dl_dp",
+    size = "small",
+    srcs = ["test_ebpf_dl_dp.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/ebpf:ebpf_manager",
+        "//lte/protos:mobilityd_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_ebpf_ul_dp",
+    size = "small",
+    srcs = ["test_ebpf_ul_dp.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/ebpf:ebpf_manager",
+        "//lte/protos:mobilityd_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_encoding",
+    size = "small",
+    srcs = ["test_encoding.py"],
+    imports = [LTE_ROOT],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:encoding",
+        "//lte/protos:mconfigs_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_enforcement",
+    size = "small",
+    srcs = ["test_enforcement.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/app:he",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:flow_query",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:mobilityd_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_enforcement_5g",
+    size = "small",
+    srcs = ["test_enforcement_5g.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_enforcement_stats",
+    size = "small",
+    srcs = ["test_enforcement_stats.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_gy",
+    size = "small",
+    srcs = ["test_gy.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:gy",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:flow_query",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_he",
+    size = "small",
+    srcs = ["test_he.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/app:he",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:mobilityd_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_imsi_encoding",
+    size = "small",
+    srcs = ["test_imsi_encoding.py"],
+    imports = [LTE_ROOT],
+    deps = ["//lte/gateway/python/magma/pipelined:imsi"],
+)
+
+pytest_test(
+    name = "test_inout",
+    size = "small",
+    srcs = ["test_inout.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:inout",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+    ],
+)
+
+pytest_test(
+    name = "test_inout_non_nat",
+    size = "small",
+    srcs = ["test_inout_non_nat.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:inout",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mobilityd_python_proto",
+    ],
+)
+
+# This test checks production code that needs a patched ryu library
+# See bazel/python_repositories.bzl ryu_repo
+pytest_test(
+    name = "test_internal_pkt_ipfix_export",
+    size = "small",
+    srcs = ["test_internal_pkt_ipfix_export.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:dpi",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_ipv6_prefix_mapper",
+    size = "small",
+    srcs = ["test_ipv6_prefix_mapper.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = ["//lte/gateway/python/magma/pipelined:ipv6_prefix_store"],
+)
+
+pytest_test(
+    name = "test_ipv6_solicitation",
+    size = "small",
+    srcs = ["test_ipv6_solicitation.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:ipv6_solicitation",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_li_mirror",
+    size = "small",
+    srcs = ["test_li_mirror.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+    ],
+)
+
+pytest_test(
+    name = "test_ng_servicer_node",
+    size = "small",
+    srcs = ["test_ng_servicer_node.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:session_manager_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_ng_servicer_session",
+    size = "small",
+    srcs = ["test_ng_servicer_session.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined:ng_set_session_msg",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_paging",
+    size = "small",
+    srcs = ["test_paging.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:classifier",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:flow_query",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:mobilityd_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_pull_stats",
+    size = "small",
+    srcs = ["test_pull_stats.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_qos",
+    size = "small",
+    srcs = ["test_qos.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/qos:common",
+        "//lte/protos:policydb_python_proto",
+        requirement("fakeredis"),
+    ],
+)
+
+pytest_test(
+    name = "test_qos_pyroute2",
+    size = "small",
+    srcs = ["test_qos_pyroute2.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/qos:qos_tc_impl",
+    ],
+)
+
+pytest_test(
+    name = "test_redirect",
+    size = "small",
+    srcs = ["test_redirect.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:flow_query",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_restart_resilience",
+    size = "small",
+    srcs = ["test_restart_resilience.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:rule_mappers",
+        "//lte/gateway/python/magma/pipelined/app:base",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_rpc_servicer",
+    size = "small",
+    srcs = ["test_rpc_servicer.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:policy_converters",
+        "//lte/gateway/python/magma/pipelined:rpc_servicer",
+        "//lte/gateway/python/magma/pipelined:rule_mappers",
+        "//lte/protos:mobilityd_python_proto",
+        "//lte/protos:pipelined_python_proto",
+        requirement("fakeredis"),
+    ],
+)
+
+pytest_test(
+    name = "test_rule_mappers",
+    size = "small",
+    srcs = ["test_rule_mappers.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:policy_converters",
+        "//lte/gateway/python/magma/pipelined:rule_mappers",
+        requirement("fakeredis"),
+    ],
+)
+
+pytest_test(
+    name = "test_service_manager",
+    size = "small",
+    srcs = ["test_service_manager.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:service_manager",
+        "//lte/gateway/python/magma/pipelined/app:access_control",
+        "//lte/gateway/python/magma/pipelined/app:arp",
+        "//lte/gateway/python/magma/pipelined/app:dpi",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/app:gy",
+        "//lte/gateway/python/magma/pipelined/app:he",
+        "//lte/gateway/python/magma/pipelined/app:ipfix",
+        "//lte/protos:mconfigs_python_proto",
+        requirement("fakeredis"),
+    ],
+)
+
+pytest_test(
+    name = "test_tunnel_id_mapper",
+    size = "small",
+    srcs = ["test_tunnel_id_mapper.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = ["//lte/gateway/python/magma/pipelined:tunnel_id_store"],
+)
+
+pytest_test(
+    name = "test_tunnel_learn",
+    size = "small",
+    srcs = ["test_tunnel_learn.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/app:tunnel_learn",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
+        "//lte/protos:mconfigs_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_ue_mac",
+    size = "small",
+    srcs = ["test_ue_mac.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/app:ue_mac",
+        "//lte/gateway/python/magma/pipelined/tests/app:flow_query",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+    ],
+)
+
+pytest_test(
+    name = "test_ue_passthrough",
+    size = "small",
+    srcs = ["test_ue_passthrough.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined/app:inout",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/app:ue_mac",
+        "//lte/gateway/python/magma/pipelined/tests/app:flow_query",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_builder",
+        "//lte/gateway/python/magma/pipelined/tests/app:packet_injector",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mconfigs_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "test_uplink_bridge",
+    size = "small",
+    srcs = ["test_uplink_bridge.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+    ],
+)
+
+pytest_test(
+    name = "test_vlan_learn",
+    size = "small",
+    srcs = ["test_vlan_learn.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+    ],
+)
+
+pytest_test(
+    name = "ng_node_rpc_servicer",
+    size = "small",
+    srcs = ["ng_node_rpc_servicer.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        "//lte/gateway/python/magma/pipelined/ng_manager:node_state_manager",
+        "//lte/protos:session_manager_python_grpc",
+        "//orc8r/protos:common_python_proto",
+        "@ryu_repo//:ryu_patched",
+        requirement("grpcio"),
+    ],
+)

--- a/lte/gateway/python/magma/pipelined/tests/app/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/tests/app/BUILD.bazel
@@ -1,0 +1,73 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "flow_query",
+    testonly = 1,
+    srcs = ["flow_query.py"],
+    deps = [
+        "//lte/gateway/python/integ_tests/s1aptests/ovs:constants",
+        "//lte/gateway/python/integ_tests/s1aptests/ovs:rest_api",
+    ],
+)
+
+py_library(
+    name = "packet_builder",
+    testonly = 1,
+    srcs = ["packet_builder.py"],
+    deps = [requirement("scapy")],
+)
+
+py_library(
+    name = "packet_injector",
+    testonly = 1,
+    srcs = ["packet_injector.py"],
+    deps = [requirement("scapy")],
+)
+
+py_library(
+    name = "table_isolation",
+    testonly = 1,
+    srcs = ["table_isolation.py"],
+    deps = [
+        "//lte/gateway/python/integ_tests/s1aptests/ovs:constants",
+        "//lte/gateway/python/integ_tests/s1aptests/ovs:rest_api",
+    ],
+)
+
+py_library(
+    name = "subscriber",
+    testonly = 1,
+    srcs = ["subscriber.py"],
+    deps = [
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        requirement("grpcio"),
+    ],
+)
+
+py_library(
+    name = "start_pipelined",
+    testonly = 1,
+    srcs = [
+        "exceptions.py",
+        "start_pipelined.py",
+    ],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:internal_ip_allocator",
+        "//lte/gateway/python/magma/pipelined/app:base",
+        "//lte/gateway/python/magma/pipelined/qos:common",
+    ],
+)

--- a/lte/gateway/python/magma/pipelined/tests/app/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/tests/app/BUILD.bazel
@@ -16,7 +16,7 @@ package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "flow_query",
-    testonly = 1,
+    testonly = True,
     srcs = ["flow_query.py"],
     deps = [
         "//lte/gateway/python/integ_tests/s1aptests/ovs:constants",
@@ -26,21 +26,21 @@ py_library(
 
 py_library(
     name = "packet_builder",
-    testonly = 1,
+    testonly = True,
     srcs = ["packet_builder.py"],
     deps = [requirement("scapy")],
 )
 
 py_library(
     name = "packet_injector",
-    testonly = 1,
+    testonly = True,
     srcs = ["packet_injector.py"],
     deps = [requirement("scapy")],
 )
 
 py_library(
     name = "table_isolation",
-    testonly = 1,
+    testonly = True,
     srcs = ["table_isolation.py"],
     deps = [
         "//lte/gateway/python/integ_tests/s1aptests/ovs:constants",
@@ -50,7 +50,7 @@ py_library(
 
 py_library(
     name = "subscriber",
-    testonly = 1,
+    testonly = True,
     srcs = ["subscriber.py"],
     deps = [
         "//lte/gateway/python/magma/subscriberdb:sid",
@@ -60,7 +60,7 @@ py_library(
 
 py_library(
     name = "start_pipelined",
-    testonly = 1,
+    testonly = True,
     srcs = [
         "exceptions.py",
         "start_pipelined.py",

--- a/lte/gateway/python/magma/pipelined/tests/test_internal_pkt_ipfix_export.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_internal_pkt_ipfix_export.py
@@ -31,7 +31,6 @@ from magma.pipelined.tests.pipelined_test_util import (
     start_ryu_app_thread,
     stop_ryu_app_thread,
 )
-from nose.tools import nottest
 
 
 class InternalPktIpfixExportTest(unittest.TestCase):

--- a/lte/gateway/python/magma/redirectd/BUILD.bazel
+++ b/lte/gateway/python/magma/redirectd/BUILD.bazel
@@ -31,7 +31,7 @@ py_binary(
     python_version = "PY3",
     visibility = ["//visibility:private"],
     deps = [
-        ":redirectd_lib",
+        ":redirect_server",
         "//lte/protos:mconfigs_python_proto",
         "//orc8r/gateway/python/magma/common:sentry",
         "//orc8r/gateway/python/magma/common:service",
@@ -40,20 +40,26 @@ py_binary(
 )
 
 py_library(
-    name = "redirectd_lib",
-    srcs = [
-        "redirect_server.py",
-        "redirect_store.py",
-    ],
+    name = "redirect_server",
+    srcs = ["redirect_server.py"],
     data = [
         "templates/404.html",
         "templates/layout.html",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//lte/protos:policydb_python_proto",
-        "//orc8r/gateway/python/magma/common/redis:client",
+        ":redirect_store",
         requirement("flask"),
         requirement("wsgiserver"),
+    ],
+)
+
+py_library(
+    name = "redirect_store",
+    srcs = ["redirect_store.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lte/protos:policydb_python_proto",
+        "//orc8r/gateway/python/magma/common/redis:client",
     ],
 )

--- a/lte/protos/BUILD.bazel
+++ b/lte/protos/BUILD.bazel
@@ -254,6 +254,19 @@ proto_library(
 python_grpc_library(
     name = "session_manager_python_grpc",
     protos = [":session_manager_proto"],
+    deps = [
+        "//lte/protos:policydb_python_proto",
+        "//orc8r/protos:common_python_proto",
+    ],
+)
+
+python_proto_library(
+    name = "session_manager_python_proto",
+    protos = [":session_manager_proto"],
+    deps = [
+        "//lte/protos:policydb_python_proto",
+        "//orc8r/protos:common_python_proto",
+    ],
 )
 
 cpp_proto_library(
@@ -289,6 +302,20 @@ proto_library(
         ":subscriberdb_proto",
         "//orc8r/protos:common_proto",
     ],
+)
+
+python_proto_library(
+    name = "pipelined_python_proto",
+    protos = [":pipelined_proto"],
+    deps = [
+        ":policydb_python_proto",
+        ":session_manager_python_proto",
+    ],
+)
+
+python_grpc_library(
+    name = "pipelined_python_grpc",
+    protos = [":pipelined_proto"],
 )
 
 cpp_grpc_library(

--- a/orc8r/gateway/python/magma/configuration/BUILD.bazel
+++ b/orc8r/gateway/python/magma/configuration/BUILD.bazel
@@ -43,3 +43,8 @@ py_library(
         requirement("snowflake"),
     ],
 )
+
+py_library(
+    name = "environment",
+    srcs = ["environment.py"],
+)


### PR DESCRIPTION
## Summary

The pipelined service and the corresponding tests are bazelified.
This includes:
- adding new depencies to the devcontainer, the bazel-base container and the requirements.in
- patching the ryu and aioeventlet libraries in bazel (Technical debt)
- adding a custom script to execute sudo tests on the VM

## Test Plan

The service can only run properly on the VM, because it depends on systemctl and openvswitch.
To test the service run:
`bazel build lte/gateway/python/magma/pipelined:pipelined && sudo bazel-bin/lte/gateway/python/magma/pipelined/pipelined`

To execute tests that do not require sudo to run:
`bazel test --test_output=all --cache_test_results=no  lte/gateway/python/magma/pipelined/...`

To execute all sudo test (including the ones in mobilityd) on the VM run:
`cd magma`
`bazel/scripts/run_sudo_tests.sh`
To execute every test in a directory (recursively) you can add a parameter:
`bazel/scripts/run_sudo_tests.sh lte/gateway/python/magma/pipelined/tests/`
You can specify one test target:
`bazel/scripts/run_sudo_tests.sh lte/gateway/python/magma/pipelined/tests:test_arp`


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
