### PR TITLE
fix(amf): amf_stateless_test and amf_procedure_test in Bazel test

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.cpp
@@ -168,7 +168,7 @@ void AsyncSmfServiceClient::SetSMFSessionRPC(
 }
 
 bool AsyncSmfServiceClient::set_smf_notification(
-    SetSmNotificationContext& notify) {
+    const SetSmNotificationContext& notify) {
   SetSMFNotificationRPC(
       notify, [](const Status& status, const SmContextVoid& response) {
         handle_session_context_response(status, response);
@@ -178,7 +178,7 @@ bool AsyncSmfServiceClient::set_smf_notification(
 }
 
 void AsyncSmfServiceClient::SetSMFNotificationRPC(
-    SetSmNotificationContext& notify,
+    const SetSmNotificationContext& notify,
     const std::function<void(Status, SmContextVoid)>& callback) {
   auto localResp = new AsyncLocalResponse<SmContextVoid>(std::move(callback),
                                                          RESPONSE_TIMEOUT);

--- a/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.h
+++ b/lte/gateway/c/core/oai/lib/n11/SmfServiceClient.h
@@ -41,7 +41,7 @@ class SmfServiceClient {
  public:
   virtual ~SmfServiceClient() {}
   virtual bool set_smf_session(SetSMSessionContext& request) = 0;
-  virtual bool set_smf_notification(SetSmNotificationContext& notify) = 0;
+  virtual bool set_smf_notification(const SetSmNotificationContext& notify) = 0;
 };
 
 /**
@@ -60,7 +60,7 @@ class AsyncSmfServiceClient : public magma::GRPCReceiver,
       const std::function<void(Status, SmContextVoid)>& callback);
 
   void SetSMFNotificationRPC(
-      SetSmNotificationContext& notify,
+      const SetSmNotificationContext& notify,
       const std::function<void(Status, SmContextVoid)>& callback);
 
  public:
@@ -78,7 +78,7 @@ class AsyncSmfServiceClient : public magma::GRPCReceiver,
 
   bool set_smf_session(SetSMSessionContext& request);
 
-  bool set_smf_notification(SetSmNotificationContext& notify);
+  bool set_smf_notification(const SetSmNotificationContext& notify);
 
   bool n11_update_location_req(const s6a_update_location_req_t* const ulr_p);
 };

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -128,7 +128,7 @@ int AMFClientServicerBase::n11_update_location_req(
 }
 
 bool AMFClientServicerBase::set_smf_notification(
-    SetSmNotificationContext& notify) {
+    const SetSmNotificationContext& notify) {
   return AsyncSmfServiceClient::getInstance().set_smf_notification(notify);
 }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -122,6 +122,16 @@ bool AMFClientServicerBase::get_decrypt_imsi_info(
                                      ciphertext, mac_tag, ue_id));
 }
 
+int AMFClientServicerBase::n11_update_location_req(
+    const s6a_update_location_req_t* const ulr_p) {
+  return AsyncSmfServiceClient::getInstance().n11_update_location_req(ulr_p);
+}
+
+bool AMFClientServicerBase::set_smf_notification(
+    SetSmNotificationContext& notify) {
+  return AsyncSmfServiceClient::getInstance().set_smf_notification(notify);
+}
+
 AMFClientServicer& AMFClientServicer::getInstance() {
   static AMFClientServicer instance;
   return instance;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -257,7 +257,7 @@ int pdu_session_resource_release_complete(
   if ((smf_ctx->pdu_address.pdn_type == IPv6) ||
       (smf_ctx->pdu_address.pdn_type == IPv4_AND_v6)) {
     // Clean up the Mobility IP Address
-    AsyncM5GMobilityServiceClient::getInstance().release_ipv6_address(
+    AMFClientServicer::getInstance().release_ipv6_address(
         imsi, smf_ctx->dnn.c_str(), &(smf_ctx->pdu_address.ipv6_address));
   }
 
@@ -780,7 +780,7 @@ int amf_smf_notification_send(amf_ue_ngap_id_t ue_id,
                "ue_state_idle is set to true \n",
                imsi);
 
-  AsyncSmfServiceClient::getInstance().set_smf_notification(notify_req);
+  AMFClientServicer::getInstance().set_smf_notification(notify_req);
 
   return RETURNok;
 }
@@ -938,7 +938,7 @@ int amf_send_n11_update_location_req(amf_ue_ngap_id_t ue_id) {
   // Set regional_subscription flag
   s6a_ulr_p->supportedfeatures.regional_subscription = true;
 
-  rc = AsyncSmfServiceClient::getInstance().n11_update_location_req(s6a_ulr_p);
+  rc = AMFClientServicer::getInstance().n11_update_location_req(s6a_ulr_p);
 
   delete s6a_ulr_p;
 

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -105,7 +105,7 @@ class AMFClientServicerBase {
   virtual int n11_update_location_req(
       const s6a_update_location_req_t* const ulr_p);
 
-  virtual bool set_smf_notification(SetSmNotificationContext& notify);
+  virtual bool set_smf_notification(const SetSmNotificationContext& notify);
 };
 
 class AMFClientServicer : public AMFClientServicerBase {
@@ -204,7 +204,9 @@ class AMFClientServicer : public AMFClientServicerBase {
     return RETURNok;
   }
 
-  bool set_smf_notification(SetSmNotificationContext& notify) { return true; }
+  bool set_smf_notification(const SetSmNotificationContext& notify) {
+    return true;
+  }
 #endif /* MME_UNIT_TEST */
 
  private:

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.h
@@ -101,6 +101,11 @@ class AMFClientServicerBase {
                                      const std::string& ciphertext,
                                      const std::string& mac_tag,
                                      amf_ue_ngap_id_t ue_id);
+
+  virtual int n11_update_location_req(
+      const s6a_update_location_req_t* const ulr_p);
+
+  virtual bool set_smf_notification(SetSmNotificationContext& notify);
 };
 
 class AMFClientServicer : public AMFClientServicerBase {
@@ -194,6 +199,12 @@ class AMFClientServicer : public AMFClientServicerBase {
                              amf_ue_ngap_id_t ue_id) override {
     return true;
   }
+
+  int n11_update_location_req(const s6a_update_location_req_t* const ulr_p) {
+    return RETURNok;
+  }
+
+  bool set_smf_notification(SetSmNotificationContext& notify) { return true; }
 #endif /* MME_UNIT_TEST */
 
  private:


### PR DESCRIPTION
Signed-off-by: shashidhar-patil <shashidhar.patil@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Fixes the following issues: #11826 #12144 

**Cause:** Actual GRPC APIs were being called during the unit testing. This should not happen during unit testing.

**Fix:** Added the required mock APIs in AMFClientServicer. So, now the actual GRPC calls are not made during the unit test.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

- **Bazel tests (on master)**

   1) `bazel test //lte/gateway/c/core/oai/test/amf:amf_stateless_test --runs_per_test=100 --config=asan` 
![bazel_stateless_100_asan](https://user-images.githubusercontent.com/89975652/159938210-6344b75e-83ba-4076-a5f6-e344424e9e3e.png)

   2) `bazel test //lte/gateway/c/core/oai/test/amf:amf_procedures_test --runs_per_test=100 --config=asan`  
![bazel_procedures_asan_100](https://user-images.githubusercontent.com/89975652/159938483-4563deec-e45b-4f57-8233-eaf0273d54ac.png)

- **Make test_oai**

![bazel_100_oai](https://user-images.githubusercontent.com/89975652/159938867-97221cf7-d116-467c-94f7-f147a7b89139.png)

- **Basic Sanity using Ueransim**

  PCAP snap:
![pcap_snap](https://user-images.githubusercontent.com/89975652/159939088-23072adc-f037-42eb-b98b-4caf5132308a.png)

  Logs:  [mme.log](https://github.com/magma/magma/files/8342320/mme.log)





<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
