### PR TITLE
fix(agw): support v1.7 in containerized agw

### DIFF
--- a/lte/gateway/deploy/agw_install_docker.sh
+++ b/lte/gateway/deploy/agw_install_docker.sh
@@ -29,13 +29,6 @@ if ! grep -q 'Ubuntu' /etc/issue; then
   exit 1
 fi
 
-echo "Making sure $MAGMA_USER user is sudoers"
-if ! grep -q "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" /etc/sudoers; then
-  apt install -y sudo
-  adduser --disabled-password --gecos "" $MAGMA_USER
-  adduser $MAGMA_USER sudo
-  echo "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-fi
 
 ROOTCA="/var/opt/magma/certs/rootCA.pem"
 if [ ! -f "$ROOTCA" ]; then
@@ -48,9 +41,41 @@ ln -sf /var/run/systemd/resolve/resolv.conf /etc/resolv.conf
 sed -i 's/#DNS=/DNS=8.8.8.8 208.67.222.222/' /etc/systemd/resolved.conf
 service systemd-resolved restart
 
+echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+cat > /etc/apt/apt.conf.d/20auto-upgrades << EOF
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::AutocleanInterval "0";
+APT::Periodic::Unattended-Upgrade "0";
+EOF
+
+apt purge --auto-remove unattended-upgrades -y
+apt-mark hold `uname -r` linux-aws linux-headers-aws linux-image-aws
+
+
+# interface config
+INTERFACE_DIR="/etc/network/interfaces.d"
+mkdir -p "$INTERFACE_DIR"
+echo "source-directory $INTERFACE_DIR" > /etc/network/interfaces
+
+# get rid of netplan
+systemctl unmask networking
+systemctl enable networking
+
 echo "Install Magma"
 apt-get update -y
-apt-get install curl zip python3-pip docker.io -y
+apt-get upgrade -y
+apt-get install curl zip python3-pip docker.io net-tools -y
+
+echo "Making sure $MAGMA_USER user is sudoers"
+if ! grep -q "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" /etc/sudoers; then
+  apt install -y sudo
+  adduser --disabled-password --gecos "" $MAGMA_USER
+  adduser $MAGMA_USER sudo
+  echo "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+fi
+
 adduser $MAGMA_USER docker
 
 alias python=python3
@@ -61,6 +86,22 @@ git clone "${GIT_URL}" /opt/magma
 cd /opt/magma || exit
 git checkout "$MAGMA_VERSION"
 
+# changing intefaces name
+sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
+sed -i 's/ens5/eth0/g' /etc/netplan/50-cloud-init.yaml
+# changing interface name
+grub-mkconfig -o /boot/grub/grub.cfg
+
+cat >  /etc/netplan/70-secondary-itf.yaml << EOF
+network:
+    ethernets:
+        eth1:
+            dhcp4: true
+            dhcp6: false
+    version: 2
+EOF
+
+netplan apply
 
 echo "Generating localhost hostfile for Ansible"
 echo "[agw_docker]
@@ -72,4 +113,5 @@ else
   # install magma and its dependencies including OVS.
   su - $MAGMA_USER -c "sudo ansible-playbook -e \"MAGMA_ROOT='/opt/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts --tags agwc $DEPLOY_PATH/magma_docker.yml"
 fi
-cd /root || exit
+
+reboot

--- a/lte/gateway/deploy/agw_install_docker.sh
+++ b/lte/gateway/deploy/agw_install_docker.sh
@@ -66,11 +66,10 @@ systemctl enable networking
 echo "Install Magma"
 apt-get update -y
 apt-get upgrade -y
-apt-get install curl zip python3-pip docker.io net-tools -y
+apt-get install curl zip python3-pip docker.io net-tools sudo -y
 
 echo "Making sure $MAGMA_USER user is sudoers"
 if ! grep -q "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" /etc/sudoers; then
-  apt install -y sudo
   adduser --disabled-password --gecos "" $MAGMA_USER
   adduser $MAGMA_USER sudo
   echo "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
@@ -90,9 +89,9 @@ git checkout "$MAGMA_VERSION"
 sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
 sed -i 's/ens5/eth0/g' /etc/netplan/50-cloud-init.yaml
 # changing interface name
-grub-mkconfig -o /boot/grub/grub.cfg
+update-grub2
 
-cat >  /etc/netplan/70-secondary-itf.yaml << EOF
+cat > /etc/netplan/70-secondary-itf.yaml << EOF
 network:
     ethernets:
         eth1:

--- a/lte/gateway/deploy/agw_install_docker.sh
+++ b/lte/gateway/deploy/agw_install_docker.sh
@@ -51,7 +51,7 @@ APT::Periodic::Unattended-Upgrade "0";
 EOF
 
 apt purge --auto-remove unattended-upgrades -y
-apt-mark hold `uname -r` linux-aws linux-headers-aws linux-image-aws
+apt-mark hold "$(uname -r)" linux-aws linux-headers-aws linux-image-aws
 
 
 # interface config

--- a/lte/gateway/deploy/roles/agw_docker/tasks/main.yml
+++ b/lte/gateway/deploy/roles/agw_docker/tasks/main.yml
@@ -134,7 +134,7 @@
   tags:
     - agwc
     - base
- 
+
 - name: replace magmad init system
   ansible.builtin.replace:
     path: /etc/magma/magma.yml

--- a/lte/gateway/deploy/roles/agw_docker/tasks/main.yml
+++ b/lte/gateway/deploy/roles/agw_docker/tasks/main.yml
@@ -125,12 +125,27 @@
     - base
 
 - name: copy docker compose config file
-  shell: cp -r  /opt/magma/lte/gateway/docker/docker-compose.yaml /var/opt/magma/docker/
+  shell: cp -r /opt/magma/lte/gateway/docker/docker-compose.yaml /var/opt/magma/docker/
   tags:
     - agwc
 
 - name: update nat interface
   shell: cp -f /etc/magma/pipelined.yml_prod /etc/magma/pipelined.yml
+  tags:
+    - agwc
+    - base
+ 
+- name: replace magmad init system
+  ansible.builtin.replace:
+    path: /etc/magma/magma.yml
+    regexp: 'init_system: systemd'
+    replace: 'init_system: docker'
+  tags:
+    - agwc
+    - base
+
+- name: copy the python scripts
+  shell: cp -r /opt/magma/lte/gateway/python/scripts/* /usr/local/bin/
   tags:
     - agwc
     - base

--- a/lte/gateway/deploy/roles/agw_docker/vars/all.yaml
+++ b/lte/gateway/deploy/roles/agw_docker/vars/all.yaml
@@ -13,7 +13,7 @@
 magma_pkgrepo_proto: https
 magma_pkgrepo_host: artifactory.magmacore.org/artifactory/debian
 magma_pkgrepo_path: ""
-magma_pkgrepo_dist: focal-1.6.0
+magma_pkgrepo_dist: focal-1.7.0
 magma_pkgrepo_component: main
 magma_pkgrepo_name: "magma"
 
@@ -23,7 +23,7 @@ magma_use_pkgrepo: yes
 
 docker_compose_version: 1.29.2
 
-docker_registry: ""
+docker_registry: "public.ecr.aws/z2g3r6f7/"
 docker_user: ""
 docker_pass: ""
 image_version: "latest"

--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -38,7 +38,6 @@
     - agwc
     - base
 
-
 - name: Trigger update of CA certs
   ignore_errors: true
   become: true
@@ -174,6 +173,7 @@
   copy:
     src={{ item.src }}
     dest={{ item.dest }}
+    mode=0755
   with_items:
     - { src: 'magma_ifaces_gtp', dest: '/etc/network/interfaces.d/gtp' }
     - { src: 'magma_modules_load', dest: '/etc/modules-load.d/magma.conf' }

--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -214,6 +214,7 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libkeyutils* /usr/lib/x86_64-linux
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcurl.so.* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/librtmp.so.* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libssh.so.* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libtspi.so.* /usr/lib/x86_64-linux-gnu/
 
 
 COPY --from=builder /usr/local/lib/liblfds710.so /usr/local/lib/

--- a/lte/gateway/docker/services/python/Dockerfile
+++ b/lte/gateway/docker/services/python/Dockerfile
@@ -12,7 +12,7 @@
 ################################################################################
 
 # -----------------------------------------------------------------------------
-# Builder image for C binaries and Magma proto files
+# Builder image for Python binaries and Magma proto files
 # -----------------------------------------------------------------------------
 ARG OS_DIST=ubuntu
 ARG OS_RELEASE=focal
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y \
   ruby \
   sudo \
   ruby-dev \
+  docker.io \
   python3-pip \
   python3-dev \
   python3-eventlet \
@@ -126,7 +127,9 @@ RUN apt-get update && apt-get install -y \
   libopenvswitch \
   openvswitch-datapath-dkms \
   openvswitch-common \
-  openvswitch-switch
+  openvswitch-switch \
+  bcc-tools \
+  wireguard
 
 COPY --from=builder /build /build
 COPY --from=builder /magma /magma


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

+ This PR introduce fixes for c and python image build to support v1.7 (bcc-tools, libtspi.so)
+ Prevent kernel upgrade from 5.4 to higher version
+ Rework the installation script to handle the secondary interface
+ Update ansible agw_docker role to copy the required scripts at the host level

## Test Plan

<img width="1601" alt="Screen Shot 2022-03-25 at 12 25 20 AM" src="https://user-images.githubusercontent.com/8215369/160074111-ef758583-1027-44f8-b4dd-328d0d5a0920.png">

```
root@ip-10-10-30-204:/var/opt/magma/docker# docker-compose  ps
    Name                   Command                  State       Ports
---------------------------------------------------------------------
connectiond     /usr/local/bin/connectiond       Up (healthy)        
control_proxy   sh -c /usr/local/bin/gener ...   Up (healthy)        
ctraced         /usr/bin/env python3 -m ma ...   Up (healthy)        
directoryd      /usr/bin/env python3 -m ma ...   Up (healthy)        
enodebd         /usr/bin/env python3 -m ma ...   Up (healthy)        
eventd          /usr/bin/env python3 -m ma ...   Up (healthy)        
health          /usr/bin/env python3 -m ma ...   Up (healthy)        
liagentd        /usr/local/bin/liagentd          Exit 0              
magmad          /usr/bin/env python3 -m ma ...   Up                  
mobilityd       /usr/bin/env python3 -m ma ...   Up (healthy)        
monitord        /usr/bin/env python3 -m ma ...   Up (healthy)        
oai_config      /usr/bin/env python3 /usr/ ...   Exit 0              
pipelined       bash -c /usr/bin/ovs-vsctl ...   Up (healthy)        
policydb        /usr/bin/env python3 -m ma ...   Up (healthy)        
redirectd       /usr/bin/env python3 -m ma ...   Up (healthy)        
redis           /bin/bash -c /usr/local/bi ...   Up (healthy)        
sctpd           /usr/local/bin/sctpd             Up                  
sessiond        sh -c mkdir -p /var/opt/ma ...   Up (healthy)        
smsd            /usr/bin/env python3 -m ma ...   Up (healthy)        
state           /usr/bin/env python3 -m ma ...   Up (healthy)        
subscriberdb    /usr/bin/env python3 -m ma ...   Up (healthy)        
td-agent-bit    /bin/bash -c /usr/local/bi ...   Up (healthy)     
```
