### PR TITLE
feat(mme): SCTP Shutdown for NGAP

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/include/ngap_client_servicer.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/include/ngap_client_servicer.h
@@ -24,6 +24,7 @@ extern "C" {
 #endif
 #include <memory.h>
 #include <string.h>
+#include <vector>
 #include "lte/gateway/c/core/oai/include/map.h"
 
 namespace magma5g {
@@ -39,7 +40,8 @@ class NGAPClientServicerBase {
 class NGAPClientServicer : public NGAPClientServicerBase {
  public:
   NGAPClientServicer();
-
+  std::vector<MessagesIds>
+      msgtype_stack;  // stack maintains type of msgs sent to amf
   static NGAPClientServicer& getInstance();
 
   NGAPClientServicer(NGAPClientServicer const&) = delete;

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
@@ -121,6 +121,14 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
 
     } break;
 
+    // SCTP layer notifies NGAP of disconnection of a peer.
+    case SCTP_CLOSE_ASSOCIATION: {
+      is_ue_state_same = true;
+      ngap_handle_sctp_disconnection(
+          state, SCTP_CLOSE_ASSOCIATION(received_message_p).assoc_id,
+          SCTP_CLOSE_ASSOCIATION(received_message_p).reset);
+    } break;
+
     case SCTP_NEW_ASSOCIATION: {
       is_ue_state_same = true;
       increment_counter("amf_new_association", 1, NO_LABELS);

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -1551,8 +1551,8 @@ status_code_e ngap_handle_sctp_disconnection(ngap_state_t* state,
       (void**)&message_p);
 
   /*
-   * Mark the eNB's s1 state as appropriate, the eNB will be deleted or
-   * moved to init state when the last UE's s1 state is cleaned up
+   * Mark the gNB's ng state as appropriate, the gNB will be deleted or
+   * moved to init state when the last UE's ng state is cleaned up
    */
   gnb_association->ng_state = reset ? NGAP_RESETING : NGAP_SHUTDOWN;
   OAILOG_INFO(LOG_NGAP,

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -1497,7 +1497,6 @@ status_code_e ngap_handle_sctp_disconnection(ngap_state_t* state,
                                              const sctp_assoc_id_t assoc_id,
                                              bool reset) {
   arg_ngap_send_gnb_dereg_ind_t arg = {0};
-  int i = 0;
   MessageDef* message_p = NULL;
   gnb_description_t* gnb_association = NULL;
 
@@ -1551,14 +1550,14 @@ status_code_e ngap_handle_sctp_disconnection(ngap_state_t* state,
       &gnb_association->ue_id_coll, ngap_send_gnb_deregistered_ind, (void*)&arg,
       (void**)&message_p);
 
-  for (i = arg.current_ue_index; i < NGAP_ITTI_UE_PER_DEREGISTER_MESSAGE; i++) {
-    NGAP_GNB_DEREGISTERED_IND(message_p).amf_ue_ngap_id[arg.current_ue_index] =
-        0;
-    NGAP_GNB_DEREGISTERED_IND(message_p).gnb_ue_ngap_id[arg.current_ue_index] =
-        0;
-  }
-  NGAP_GNB_DEREGISTERED_IND(message_p).gnb_id = gnb_association->gnb_id;
-  message_p = NULL;
+  /*
+   * Mark the eNB's s1 state as appropriate, the eNB will be deleted or
+   * moved to init state when the last UE's s1 state is cleaned up
+   */
+  gnb_association->ng_state = reset ? NGAP_RESETING : NGAP_SHUTDOWN;
+  OAILOG_INFO(LOG_NGAP,
+              "Marked gnb ng status to %s, attached to assoc_id: %d\n",
+              reset ? "Reset" : "Shutdown", assoc_id);
 
   OAILOG_FUNC_RETURN(LOG_NGAP, RETURNok);
 }

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_client_servicer.cpp
@@ -38,6 +38,7 @@ status_code_e NGAPClientServicer::send_message_to_amf(
   ret = send_msg_to_task(task_zmq_ctx_p, destination_task_id, message);
 #else  /* !MME_UNIT_TEST */
   OAILOG_DEBUG(LOG_NGAP, " Mock is Enabled \n");
+  msgtype_stack.push_back(ITTI_MSG_ID(message));
   itti_free_msg_content(message);
   free(message);
 #endif /* !MME_UNIT_TEST */

--- a/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
@@ -1422,8 +1422,19 @@ TEST_F(NgapFlowTest, NgapHandleSctpDisconnection) {
   // To test SCTP Shutdown for NGAP
   bool reset = false;
 
+  gnb_description_t* gnb_association = NULL;
+  gnb_association = ngap_state_get_gnb(state, peerInfo.assoc_id);
+  ASSERT_TRUE(gnb_association != NULL);
+  EXPECT_EQ(gnb_association->ng_state, NGAP_INIT);
+  gnb_association->nb_ue_associated = 1;
+
   EXPECT_EQ(ngap_handle_sctp_disconnection(state, peerInfo.assoc_id, reset),
             RETURNok);
+
+  gnb_description_t* gnb_association_sd = NULL;
+  gnb_association_sd = ngap_state_get_gnb(state, peerInfo.assoc_id);
+  ASSERT_TRUE(gnb_association_sd != NULL);
+  EXPECT_EQ(gnb_association_sd->ng_state, NGAP_SHUTDOWN);
 }
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
@@ -1413,4 +1413,17 @@ TEST_F(NgapFlowTest, test_ue_notifications_from_amf) {
   bdestroy(ngap_initial_ue_msg);
 }
 
+TEST_F(NgapFlowTest, NgapHandleSctpDisconnection) {
+  // Verify sctp association is successful
+  EXPECT_EQ(ngap_handle_new_association(state, &peerInfo), RETURNok);
+  // Verify number of connected gNB's is 1
+  EXPECT_EQ(state->gnbs.num_elements, 1);
+
+  // To test SCTP Shutdown for NGAP
+  bool reset = false;
+
+  EXPECT_EQ(ngap_handle_sctp_disconnection(state, peerInfo.assoc_id, reset),
+            RETURNok);
+}
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
@@ -1416,6 +1416,7 @@ TEST_F(NgapFlowTest, test_ue_notifications_from_amf) {
 }
 
 TEST_F(NgapFlowTest, NgapHandleSctpDisconnection) {
+  MessageDef* amf_message_p = NULL;
   MessageDef* sctp_message_p = NULL;
   m5g_ue_description_t* ue_ref = NULL;
   Ngap_InitialUEMessage_t* container;
@@ -1429,14 +1430,22 @@ TEST_F(NgapFlowTest, NgapHandleSctpDisconnection) {
       0x00, 0x22, 0x42, 0x65, 0x00, 0x00, 0x01, 0xe4, 0xf7, 0x04, 0x44,
       0x00, 0x5a, 0x40, 0x01, 0x18, 0x00, 0x70, 0x40, 0x01, 0x00};
 
-  std::vector<MessagesIds> expected_Ids{NGAP_INITIAL_UE_MESSAGE,
-                                        NGAP_GNB_DEREGISTERED_IND};
+  std::vector<MessagesIds> expected_Ids{
+      NGAP_INITIAL_UE_MESSAGE, NGAP_GNB_DEREGISTERED_IND, SCTP_DATA_REQ,
+      NGAP_UE_CONTEXT_RELEASE_COMPLETE};
 
   // Verify sctp association is successful
   EXPECT_EQ(ngap_handle_new_association(state, &peerInfo), RETURNok);
   // Verify number of connected gNB's is 1
   EXPECT_EQ(state->gnbs.num_elements, 1);
 
+  gnb_description_t* gnb_association = NULL;
+  gnb_association = ngap_state_get_gnb(state, peerInfo.assoc_id);
+  ASSERT_TRUE(gnb_association != NULL);
+  EXPECT_EQ(gnb_association->ng_state, NGAP_INIT);
+  EXPECT_EQ(gnb_association->nb_ue_associated, 0);
+
+  // Handling initial UE message
   Ngap_NGAP_PDU_t decoded_pdu = {};
   uint16_t length = sizeof(initial_ue_message_hexbuf) / sizeof(unsigned char);
   bstring ngap_initial_ue_msg = blk2bstr(initial_ue_message_hexbuf, length);
@@ -1444,15 +1453,11 @@ TEST_F(NgapFlowTest, NgapHandleSctpDisconnection) {
   // Check if the pdu can be decoded
   ASSERT_EQ(ngap_amf_decode_pdu(&decoded_pdu, ngap_initial_ue_msg), RETURNok);
 
-  // check if initial UE message is handled successfully
+  // Mocking the sending of Initial UE message to AMF
   EXPECT_EQ(ngap_amf_handle_message(state, peerInfo.assoc_id,
                                     peerInfo.instreams, &decoded_pdu),
             RETURNok);
-
-  gnb_description_t* gnb_association = NULL;
-  gnb_association = ngap_state_get_gnb(state, peerInfo.assoc_id);
-  ASSERT_TRUE(gnb_association != NULL);
-  EXPECT_EQ(gnb_association->ng_state, NGAP_INIT);
+  // Checking that UE is connected after Initial UE message
   EXPECT_EQ(gnb_association->nb_ue_associated, 1);
 
   container =
@@ -1468,9 +1473,7 @@ TEST_F(NgapFlowTest, NgapHandleSctpDisconnection) {
   gnb_ue_ngap_id = (gnb_ue_ngap_id_t)(ie->value.choice.RAN_UE_NGAP_ID);
 
   // Mocking the AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION from AMF
-  itti_amf_app_ngap_amf_ue_id_notification_t notification_p;
-  memset(&notification_p, 0,
-         sizeof(itti_amf_app_ngap_amf_ue_id_notification_t));
+  itti_amf_app_ngap_amf_ue_id_notification_t notification_p = {};
   notification_p.gnb_ue_ngap_id = gnb_ue_ngap_id;
   notification_p.amf_ue_ngap_id = 1;
   notification_p.sctp_assoc_id = gnb_association->sctp_assoc_id;
@@ -1493,12 +1496,47 @@ TEST_F(NgapFlowTest, NgapHandleSctpDisconnection) {
   gnb_association_sd = ngap_state_get_gnb(state, peerInfo.assoc_id);
   ASSERT_TRUE(gnb_association_sd != NULL);
   EXPECT_EQ(gnb_association_sd->ng_state, NGAP_SHUTDOWN);
-  EXPECT_EQ(gnb_association->nb_ue_associated, 1);
+  EXPECT_EQ(gnb_association_sd->nb_ue_associated, 1);
+
+  // Mocking the UE_CONTEXT_RELEASE_COMMAND from AMF
+  amf_message_p =
+      itti_alloc_new_message(TASK_AMF_APP, NGAP_UE_CONTEXT_RELEASE_COMMAND);
+  ASSERT_TRUE(amf_message_p != NULL);
+
+  // Check if UE is associated with gnb
+  ue_ref =
+      ngap_state_get_ue_gnbid(gnb_association->sctp_assoc_id, gnb_ue_ngap_id);
+  ASSERT_TRUE(ue_ref != NULL);
+
+  amf_message_p->ittiMsgHeader.imsi = 0x311480000000001;
+  NGAP_UE_CONTEXT_RELEASE_COMMAND(amf_message_p).amf_ue_ngap_id =
+      ue_ref->amf_ue_ngap_id;
+  NGAP_UE_CONTEXT_RELEASE_COMMAND(amf_message_p).gnb_ue_ngap_id =
+      ue_ref->gnb_ue_ngap_id;
+  NGAP_UE_CONTEXT_RELEASE_COMMAND(amf_message_p).cause = NGAP_USER_INACTIVITY;
+
+  EXPECT_EQ(state->num_gnbs, 1);
+
+  // verify ue_context_release_command is encoded correctly
+  EXPECT_EQ(ngap_handle_ue_context_release_command(
+                state, &NGAP_UE_CONTEXT_RELEASE_COMMAND(amf_message_p),
+                amf_message_p->ittiMsgHeader.imsi),
+            RETURNok);
+
+  // Checking the number of gnbs after ue context release in NGAP.
+  EXPECT_EQ(state->num_gnbs, 0);
+
+  // Checking that gnb description should be null after ue context release.
+  gnb_description_t* gnb_association_ue = NULL;
+  gnb_association_ue = ngap_state_get_gnb(state, peerInfo.assoc_id);
+  ASSERT_TRUE(gnb_association_ue == NULL);
 
   EXPECT_TRUE(expected_Ids == NGAPClientServicer::getInstance().msgtype_stack);
 
   itti_free_msg_content(sctp_message_p);
   free(sctp_message_p);
+  itti_free_msg_content(amf_message_p);
+  free(amf_message_p);
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_Ngap_NGAP_PDU, &decoded_pdu);
   bdestroy(ngap_initial_ue_msg);
 }


### PR DESCRIPTION
Signed-off-by: sreedharkumartn <sreedhar.kumar@wavelabs.ai>
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
- Added NGAP Shutdown logic by using ``ngap_handle_sctp_disconnection`` function for ``SCTP_CLOSE_ASSOCIATION`` case.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Validated with UT.
![UT](https://user-images.githubusercontent.com/89978170/160409001-7275d981-3491-4a4f-b524-edf9eaedaf47.jpg)

- Basic sanity with UERANSIM.
Pcap Snap:
![image](https://user-images.githubusercontent.com/89978170/160409217-410b0242-f0ca-4a9f-92ba-3c0107e5ab45.png)

mme log:
[mme.log](https://github.com/magma/magma/files/8363194/mme.log)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
