### PR TITLE
fix(orc8r): Issue certificate for fluentd service by self-signed CA

### DIFF
--- a/orc8r/cloud/deploy/scripts/create_application_certs.sh
+++ b/orc8r/cloud/deploy/scripts/create_application_certs.sh
@@ -47,18 +47,21 @@ echo "#########################"
 openssl genrsa -out bootstrapper.key 2048
 
 echo ""
-echo "######################"
-echo "Creating fluentd certs"
-echo "######################"
-openssl genrsa -out fluentd.key 2048
-openssl req -x509 -new -nodes -key fluentd.key -sha256 -days 3650 -out fluentd.pem -subj "/C=US/CN=fluentd.$domain"
-
-echo ""
 echo "#####################"
 echo "Creating certifier CA"
 echo "#####################"
 openssl genrsa -out certifier.key 2048
 openssl req -x509 -new -nodes -key certifier.key -sha256 -days 3650 -out certifier.pem -subj "/C=US/CN=certifier.$domain"
+
+echo ""
+echo "######################"
+echo "Creating fluentd certs"
+echo "######################"
+openssl genrsa -out fluentd.key 2048
+openssl req -new -key fluentd.key -out fluentd.csr -subj "/C=US/CN=fluentd.$domain"
+openssl x509 -req -in fluentd.csr \
+  -CA certifier.pem -CAkey certifier.key -CAcreateserial \
+  -out fluentd.pem -days 3650 -sha256
 
 echo ""
 echo "############################"


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz.gromowski@codilime.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Certificate for fluentd service was issued by self-signed CA instead of use self-signed cert without CA
The change was introduced because of this issue:
https://github.com/magma/magma/issues/12251

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Client Authentication works correctly when the client cert was issued with the same CA and logs are flowing to Fluentd forward input

Steps for reproduce and fixing issue with docker-compose

1. generate applications serts
```
 cd orc8r/cloud/docker
../deploy/scripts/create_application_certs.sh localhost
```
2. Generate additional cert/key pair for fluentd input client
```
openssl genrsa -out fclient.key 2048
openssl req -new -key fclient.key -out fclient.csr -subj "/C=US/CN=fclient.localhost"
openssl x509 -req -in fclient.csr -CA certifier.pem -CAkey certifier.key -CAcreateserial -out fclient.pem -days 3650 -sha256
```
3. Prepare temporary config files, and docker-compose manifest
```
cat << EOF > fluent-client.conf
<source>
  @type forward
  port 24224
  host 127.0.0.1
</source>

<match **>
  @log_level debug
  @type forward
  transport tls
  tls_allow_self_signed_cert true
  tls_verify_hostname false
  tls_cert_path /host/certifier.pem
  tls_client_cert_path /host/fclient.pem
  tls_client_private_key_path /host/fclient.key
  <server>
    host fluent-server
    port 24224
  </server>
  <buffer>
    flush_interval 1s
  </buffer>
</match>
EOF

cat  << EOF > fluent-server.conf
<source>
  @type forward
  port 24224
  bind 0.0.0.0
  <transport tls>
    cert_path /host/fluentd.pem
    private_key_path /host/fluentd.key
    client_cert_auth true
    ca_path /host/certifier.pem
  </transport>
</source>

<match **>
  @type stdout
  <buffer>
    flush_interval 1s
  </buffer>
</match>
EOF

cat << EOF > docker-compose-fluentd-certs.yml
version: "3.7"
services:
  fluent-server:
    build: ./fluentd_forward
    container_name: fluentd-server
    user: root
    volumes:
      - ./fluent-server.conf:/fluentd/etc/fluent.conf:ro
      - ./:/host
  fluent-client:
    build: ./fluentd_forward
    container_name: fluentd-client
    user: root
    volumes:
      - ./fluent-client.conf:/fluentd/etc/fluent.conf:ro
      - ./:/host
EOF
```
4.  ```docker-compose -f docker-compose-fluentd-certs.yml up -d```
5. In container logs we will see similar errors as in the issue report.
```
docker logs fluentd-client
```
6. Now when we reissue certificate for the fluentd input service with CA and restart server container, service should work, and we will not see errors anymore
```
openssl req -new -key fluentd.key -out fluentd.csr -subj "/C=US/CN=fluentd.localhost"
openssl x509 -req -in fluentd.csr \
  -CA certifier.pem -CAkey certifier.key -CAcreateserial \
  -out fluentd.pem -days 3650 -sha256
```
7.  We can send something to client and check if it appears in fluentd-server logs
```
docker exec -it fluentd-client sh -c 'echo "test" | fluent-cat -f none test.tag'
docker logs  fluentd-server
```

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
