### PR TITLE
fix(orc8r): Freeze fluentd docker image gem versions #12198

### DIFF
--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -1,5 +1,8 @@
 FROM fluent/fluentd:v1.7-1
 USER root
-RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "3.5.5"]
-RUN ["fluent-gem", "install", "fluent-plugin-multi-format-parser"]
+RUN gem install \
+    elasticsearch:7.13.0 \
+    fluent-plugin-elasticsearch:5.2.1 \
+    fluent-plugin-multi-format-parser:1.0.0 \
+    --no-document
 USER fluent

--- a/orc8r/cloud/docker/fluentd_forward/Dockerfile
+++ b/orc8r/cloud/docker/fluentd_forward/Dockerfile
@@ -1,5 +1,8 @@
 FROM fluent/fluentd:v1.7-1
 USER root
-RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "3.5.5"]
-RUN ["fluent-gem", "install", "fluent-plugin-multi-format-parser"]
+RUN gem install \
+    elasticsearch:7.13.0 \
+    fluent-plugin-elasticsearch:5.2.1 \
+    fluent-plugin-multi-format-parser:1.0.0 \
+    --no-document
 USER fluent


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz.gromowski@codilime.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Fluentd elasticsearch plugin doesn't define the version of Elasticsearch gem. So always recent is installed, which doesn't work correctly with fluentd-plugin-elasticsearch version 3.5.5.
https://github.com/uken/fluent-plugin-elasticsearch/blob/96ff1706282a3bdb77533b72d3792d692530b547/fluent-plugin-elasticsearch.gemspec#L27

This change will freeze Elasticsearch  gem version to 7.13, which is compatible with both Elasticsearch and Opensearch
https://opensearch.org/docs/latest/clients/index/
It will also bump fluentd elasticsearch plugin version to latest 5.2.1

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
After the change introduces, data are saved to Elasticsearch indexes, I don't see errors anymore.
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
