### PR TITLE
chore(pipelined): devcontainer and bazel-base use needed depencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -71,6 +71,7 @@ RUN echo "Install general purpose packages" && \
         lld \
         lldb \
         make \
+        netbase \
         ninja-build \
         openjdk-8-jdk \
         perl \
@@ -334,12 +335,12 @@ ENV PYTHON_VENV_EXECUTABLE=${PYTHON_VENV}/bin/python${PYTHON_VERSION}
 RUN virtualenv --system-site-packages --python=/usr/bin/python${PYTHON_VERSION} ${PYTHON_VENV}
 RUN ${PYTHON_VENV_EXECUTABLE} -m pip install --quiet --upgrade --no-cache-dir "setuptools==49.6.0"
 
-### install python3-aioeventlet from the magma apt repo
+### install python3-aioeventlet and bcc-tools from the magma apt repo
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/
 RUN apt-key add /tmp/jfrog.pub && \
     echo "deb https://facebookconnectivity.jfrog.io/artifactory/list/dev-focal/ focal main" > /etc/apt/sources.list.d/fbc.list && \
     apt-get update -y && \
-    apt-get install -y python3-aioeventlet && \
+    apt-get install -y python3-aioeventlet bcc-tools && \
     rm -f /tmp/* && \
     rm -rf /var/lib/apt/lists/*  # delete lists that are downloaded by apt-get update
 

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -46,6 +46,8 @@ RUN apt-get update && \
         lld \
         # dependency of python services (e.g. magmad)
         net-tools \
+        # dependency of python services (e.g. pipelined)
+        netbase \
         python3 \
         python-is-python3 \
         # dependency of python services (e.g. magmad)
@@ -56,6 +58,13 @@ RUN apt-get update && \
         vim \
         wget \
         zip
+
+# Install depencies from facebook repository
+COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/
+RUN apt-key add /tmp/jfrog.pub && \
+    echo "deb https://facebookconnectivity.jfrog.io/artifactory/list/dev-focal/ focal main" > /etc/apt/sources.list.d/fbc.list && \
+    apt-get update -y && \
+    apt-get install -y bcc-tools
 
 # Install bazel
 WORKDIR /usr/sbin


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add needed dependencies for devcontainer and bazel-base which are required by https://github.com/magma/magma/pull/12271

## Test Plan

No docker build failures in CI. Tested locally with #12271.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
