### PR TITLE
chore: common module tests are bazelified

### DIFF
--- a/orc8r/gateway/python/magma/common/BUILD.bazel
+++ b/orc8r/gateway/python/magma/common/BUILD.bazel
@@ -52,19 +52,26 @@ py_library(
         "log_count_handler.py",
         "log_counter.py",
         "metrics.py",
-        "metrics_export.py",
         "service.py",
     ],
     deps = [
         ":job",
+        ":metrics_export",
         ":serialization_utils",
         ":service_registry",
         "//orc8r/gateway/python/magma/configuration:mconfig_managers",
         "//orc8r/protos:metrics_python_proto",
-        "//orc8r/protos:metricsd_python_proto",
         "//orc8r/protos:service303_python_grpc",
-        requirement("prometheus_client"),
         requirement("setuptools"),
+    ],
+)
+
+py_library(
+    name = "metrics_export",
+    srcs = ["metrics_export.py"],
+    deps = [
+        "//orc8r/protos:metricsd_python_proto",
+        requirement("prometheus_client"),
     ],
 )
 

--- a/orc8r/gateway/python/magma/common/redis/BUILD.bazel
+++ b/orc8r/gateway/python/magma/common/redis/BUILD.bazel
@@ -16,19 +16,26 @@ package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "client",
+    srcs = ["client.py"],
+    deps = [
+        ":containers",
+        "//feg/protos:mconfigs_python_proto",
+        "//orc8r/gateway/python/magma/configuration:service_configs",
+        requirement("hiredis"),
+        requirement("redis"),
+    ],
+)
+
+py_library(
+    name = "containers",
     srcs = [
-        "client.py",
         "containers.py",
         "serializers.py",
     ],
     deps = [
-        "//feg/protos:mconfigs_python_proto",
-        "//orc8r/gateway/python/magma/configuration:service_configs",
         "//orc8r/protos:redis_python_proto",
-        requirement("redis"),
-        requirement("hiredis"),
-        requirement("redis_collections"),
-        requirement("python-redis-lock"),
         requirement("jsonpickle"),
+        requirement("python-redis-lock"),
+        requirement("redis_collections"),
     ],
 )

--- a/orc8r/gateway/python/magma/common/redis/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/common/redis/tests/BUILD.bazel
@@ -1,0 +1,29 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("//bazel:python_test.bzl", "pytest_test")
+
+MAGMA_ROOT = "../../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+pytest_test(
+    name = "dict_tests",
+    size = "small",
+    srcs = ["dict_tests.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/common/redis:containers",
+        "//orc8r/protos:service303_python_proto",
+        requirement("fakeredis"),
+    ],
+)

--- a/orc8r/gateway/python/magma/common/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/common/tests/BUILD.bazel
@@ -1,0 +1,68 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:python_test.bzl", "pytest_test")
+
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+pytest_test(
+    name = "cert_utils_tests",
+    size = "small",
+    srcs = ["cert_utils_tests.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/common:cert_utils",
+        "//orc8r/gateway/python/magma/common:serialization_utils",
+    ],
+)
+
+pytest_test(
+    name = "cert_validity_tests",
+    size = "small",
+    srcs = ["cert_validity_tests.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/common:cert_validity",
+    ],
+)
+
+pytest_test(
+    name = "metrics_tests",
+    size = "small",
+    srcs = ["metrics_tests.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/common:metrics_export",
+        "//orc8r/protos:metrics_python_proto",
+    ],
+)
+
+pytest_test(
+    name = "sentry_tests",
+    size = "small",
+    srcs = ["sentry_tests.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/common:sentry",
+    ],
+)
+
+pytest_test(
+    name = "service303_tests",
+    size = "small",
+    srcs = ["service303_tests.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/common:service",
+    ],
+)


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

The tests from the python orc8r common module are bazelified 

## Test Plan

`bazel test --test_output=all //orc8r/gateway/python/magma/common/...`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
