### PR TITLE
fix(mme): Reduce flakiness in MME procedure unit tests

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_procedure_test_fixture.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_procedure_test_fixture.h
@@ -137,8 +137,8 @@ class MmeAppProcedureTest : public ::testing::Test {
     task_sgw_s8.detach();
     task_sms_orc8r.detach();
 
-    // Sleep for 10 milliseconds to make sure all mock tasks are up before the
-    // test
+    // Sleep for 10 milliseconds to make sure all mock tasks
+    // are running before the test starts
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     mme_app_init(&mme_config);

--- a/lte/gateway/c/core/oai/test/mme_app_task/mme_procedure_test_fixture.h
+++ b/lte/gateway/c/core/oai/test/mme_app_task/mme_procedure_test_fixture.h
@@ -107,7 +107,6 @@ class MmeAppProcedureTest : public ::testing::Test {
 
     // initialize mme config
     mme_config_init(&mme_config);
-    nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
     create_partial_lists(&mme_config);
     mme_config.use_stateless = true;
     mme_config.nas_config.prefered_integrity_algorithm[0] = EIA2_128_ALG_ID;
@@ -118,24 +117,29 @@ class MmeAppProcedureTest : public ::testing::Test {
     init_task_context(TASK_MAIN, task_id_list, 10, handle_message,
                       &task_zmq_ctx_main);
 
-    std::thread task_ha(start_mock_ha_task);
-    std::thread task_s1ap(start_mock_s1ap_task, s1ap_handler);
     std::thread task_s6a(start_mock_s6a_task, s6a_handler);
+    std::thread task_s1ap(start_mock_s1ap_task, s1ap_handler);
+    std::thread task_spgw(start_mock_spgw_task, spgw_handler);
+    std::thread task_ha(start_mock_ha_task);
     std::thread task_s11(start_mock_s11_task);
     std::thread task_service303(start_mock_service303_task, service303_handler);
     std::thread task_sgs(start_mock_sgs_task);
     std::thread task_sgw_s8(start_mock_sgw_s8_task, s8_handler);
     std::thread task_sms_orc8r(start_mock_sms_orc8r_task);
-    std::thread task_spgw(start_mock_spgw_task, spgw_handler);
-    task_ha.detach();
-    task_s1ap.detach();
+
     task_s6a.detach();
+    task_s1ap.detach();
+    task_spgw.detach();
+    task_ha.detach();
     task_s11.detach();
     task_service303.detach();
     task_sgs.detach();
     task_sgw_s8.detach();
     task_sms_orc8r.detach();
-    task_spgw.detach();
+
+    // Sleep for 10 milliseconds to make sure all mock tasks are up before the
+    // test
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     mme_app_init(&mme_config);
     // Fake initialize sctp server.

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -1842,9 +1842,6 @@ TEST_F(MmeAppProcedureTest, TestCLRNwInitiatedDetach) {
   std::unique_lock<std::mutex> lock(mx);
 
   MME_APP_EXPECT_CALLS(4, 1, 1, 1, 1, 0, 1, 1, 0, 1, 2);
-  // Setting the 3422 and 3460 timers to standard duration
-  mme_config.nas_config.t3422_msec = 8000;
-  mme_config.nas_config.t3460_msec = 8000;
 
   // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
   send_mme_app_initial_ue_msg(nas_msg_imsi_attach_req,

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures.cpp
@@ -28,6 +28,7 @@
 
 extern "C" {
 #include "lte/gateway/c/core/oai/include/mme_app_state.h"
+#include "lte/gateway/c/core/oai/include/mme_config.h"
 }
 namespace magma {
 namespace lte {
@@ -198,6 +199,9 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachEpsOnlyAirTimeout) {
   std::condition_variable cv;
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
+
+  // Reduce the S6a timer duration for testing
+  mme_config.nas_config.ts6a_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1);
 
@@ -400,6 +404,9 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectAuthRetxFailure) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
+  // Reduce timer 3460 duration for testing
+  mme_config.nas_config.t3460_msec = MME_APP_TIMER_TO_MSEC;
+
   MME_APP_EXPECT_CALLS(6, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1);
 
   // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
@@ -437,6 +444,9 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectSmcRetxFailure) {
   std::condition_variable cv;
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
+
+  // Reduce timer 3460 duration for testing
+  mme_config.nas_config.t3460_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(6, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1);
 
@@ -479,6 +489,9 @@ TEST_F(MmeAppProcedureTest, TestGutiAttachExpiredIdentity) {
   std::condition_variable cv;
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
+
+  // Reduce timer 3470 duration for testing
+  mme_config.nas_config.t3470_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(8, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
@@ -557,6 +570,9 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectIdentRetxFailure) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
+  // Reduce timer duration for testing
+  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
+
   MME_APP_EXPECT_CALLS(6, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1);
 
   // Constructing and sending Initial Attach Request to mme_app mimicing S1AP
@@ -591,9 +607,13 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachRejectIdentRetxFailure) {
 TEST_F(MmeAppProcedureTest, TestIcsRequestTimeout) {
   mme_app_desc_t* mme_state_p =
       magma::lte::MmeNasStateManager::getInstance().get_state(false);
+
   std::condition_variable cv;
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
+
+  // Reduce the ICS timeout for testing
+  mme_config.nas_config.tics_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(2, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1);
 
@@ -880,6 +900,9 @@ TEST_F(MmeAppProcedureTest, TestPagingMaxRetx) {
   std::condition_variable cv;
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
+
+  // Reduce paging retransmission timer duration for testing
+  mme_config.nas_config.tpaging_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(3, 2, 2, 1, 1, 1, 1, 2, 1, 1, 4);
 
@@ -1286,6 +1309,9 @@ TEST_F(MmeAppProcedureTest, TestFailedPagingForPendingBearers) {
   std::condition_variable cv;
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
+
+  // Reduce the paging retransmission timer duration for testing
+  mme_config.nas_config.tpaging_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(3, 1, 2, 1, 1, 1, 1, 1, 1, 1, 4);
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_mobile_reachability_timer.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_mobile_reachability_timer.cpp
@@ -32,6 +32,12 @@ TEST_F(MmeAppProcedureTest, TestMobileReachabilityTimer) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
+  // Reduce timer 3412 duration for testing since mobile reachability
+  // and implicit detach timers are calculated from that
+  mme_config.nas_config.t3412_min = 1;
+  mme_config.nas_config.t3412_msec =
+      50 * MME_APP_TIMER_TO_MSEC;  // implicit detach after 2x of this value
+
   MME_APP_EXPECT_CALLS(3, 1, 2, 1, 1, 1, 1, 1, 1, 1, 3);
 
   // Attach the UE

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_nas_timer.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_nas_timer.cpp
@@ -33,6 +33,8 @@ TEST_F(MmeAppProcedureTest, TestImsiAttachExpiredNasTimers) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
+  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
+
   MME_APP_EXPECT_CALLS(15, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
   // Constructing and sending Initial Attach Request to mme_app mimicing S1AP

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_network_initiated.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_network_initiated.cpp
@@ -83,6 +83,9 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedExpiredDetach) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
+  // Reduce timer duration for testing
+  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
+
   MME_APP_EXPECT_CALLS(8, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
   // Attach the UE
@@ -130,6 +133,9 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedDetachRetxFailure) {
   std::condition_variable cv;
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
+
+  // Reduce timer duration for testing
+  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
 
   MME_APP_EXPECT_CALLS(8, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_network_initiated.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_network_initiated.cpp
@@ -23,6 +23,10 @@
 #include "lte/gateway/c/core/oai/test/mme_app_task/mme_app_test_util.h"
 #include "lte/gateway/c/core/oai/test/mme_app_task/mme_procedure_test_fixture.h"
 
+extern "C" {
+#include "lte/gateway/c/core/oai/include/mme_config.h"
+}
+
 namespace magma {
 namespace lte {
 
@@ -214,6 +218,9 @@ TEST_F(MmeAppProcedureTest,
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
+  // Reduce timer durations for testing
+  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
+
   MME_APP_EXPECT_CALLS(7, 1, 1, 1, 1, 1, 1, 1, 0, 1, 3);
 
   // Attach the UE
@@ -253,6 +260,9 @@ TEST_F(MmeAppProcedureTest,
   std::condition_variable cv;
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
+
+  // Reduce timer duration for testing
+  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
 
   MME_APP_EXPECT_CALLS(3, 1, 1, 1, 1, 1, 1, 1, 0, 1, 4);
 
@@ -385,6 +395,9 @@ TEST_F(
   std::condition_variable cv;
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
+
+  // Reduce timer durations for testing
+  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
 
   MME_APP_EXPECT_CALLS(7, 1, 1, 1, 1, 1, 1, 1, 0, 1, 4);
 

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_network_initiated.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_procedures_network_initiated.cpp
@@ -83,8 +83,8 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedExpiredDetach) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  // Reduce timer duration for testing
-  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
+  // Reduce timer 3422 duration for testing
+  mme_config.nas_config.t3422_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(8, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
@@ -134,8 +134,8 @@ TEST_F(MmeAppProcedureTest, TestNwInitiatedDetachRetxFailure) {
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  // Reduce timer duration for testing
-  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
+  // Reduce timer 3422 duration for testing
+  mme_config.nas_config.t3422_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(8, 1, 1, 1, 1, 1, 1, 1, 0, 1, 2);
 
@@ -224,8 +224,8 @@ TEST_F(MmeAppProcedureTest,
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  // Reduce timer durations for testing
-  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
+  // Reduce timer 3485 durations for testing
+  mme_config.nas_config.t3485_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(7, 1, 1, 1, 1, 1, 1, 1, 0, 1, 3);
 
@@ -267,8 +267,8 @@ TEST_F(MmeAppProcedureTest,
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  // Reduce timer duration for testing
-  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
+  // Reduce timer 3495 duration for testing
+  mme_config.nas_config.t3495_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(3, 1, 1, 1, 1, 1, 1, 1, 0, 1, 4);
 
@@ -328,6 +328,7 @@ TEST_F(MmeAppProcedureTest,
 
   detach_ue(cv, lock, mme_state_p, guti, false);
 }
+
 TEST_F(MmeAppProcedureTest,
        TestNwInitiatedActivateDeactivateDedicatedBearerRequest) {
   mme_app_desc_t* mme_state_p =
@@ -402,8 +403,9 @@ TEST_F(
   std::mutex mx;
   std::unique_lock<std::mutex> lock(mx);
 
-  // Reduce timer durations for testing
-  nas_config_timer_reinit(&mme_config.nas_config, MME_APP_TIMER_TO_MSEC);
+  // Reduce timer 3485 and 3495 durations for testing
+  mme_config.nas_config.t3485_msec = MME_APP_TIMER_TO_MSEC;
+  mme_config.nas_config.t3495_msec = MME_APP_TIMER_TO_MSEC;
 
   MME_APP_EXPECT_CALLS(7, 1, 1, 1, 1, 1, 1, 1, 0, 1, 4);
 


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

MME procedures test have been flaky because:
1. The timer values were reduced for all tests, leading to unexpected timer expiration and too many message retransmissions, leading to more than expected calls to s1ap_generate_dl_nas_transport()
2. The S6a handler was not starting before the test ran, leading to zero calls to s6a_* functions

This PR fixes these issues by:
1. Removing the timer override from default Setup() call and only modifying individual timer durations as part of individual tests.
2. Reordering the thread creation and adding a 10 msec wait in the setup of each test to make sure all mock tasks are running before the test begins

## Test Plan

No failure seen with the following:

`bazel test //lte/gateway/c/core/oai/test/mme_app_task/... --runs_per_test=50`
`bazel test //lte/gateway/c/core/oai/test/mme_app_task/... --runs_per_test=100`

**TODO**
Test `TestImsiAttachRejectIdentRetxFailure` is testing Identity retx with an IMSI attach, which seems incorrect. This needs to be cleaned up in a separate PR before the call to `nas_config_timer_reinit` can be replaced with a specific timer.
