### PR TITLE
fix(ci): the test VM can fetch the appropriate pylint version

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -73,7 +73,7 @@ setup(
         'protobuf==3.19.0',
         'Jinja2>=2.8',
         'netifaces>=0.10.4',
-        'pylint==2.12.2',
+        'pylint>=1.7.1,<2.13.0',
         'PyYAML>=3.12',
         'pytz>=2014.4',
         'prometheus_client==0.3.1',


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Pinning the version of pylint to be at least 1.7.1 and less than 2.13.0. This is needed, because the test VM is using python3.5 where pylint 2.6.2 is the highest version. See also: https://github.com/magma/magma/pull/12290 and https://magmacore.slack.com/archives/C01MDUQDFC3/p1648222335621339

## Test Plan

* on the test VM do `pip3 install 'pylint>=1.7.1,<2.13.0'` and check `pip3 show pylint`
* same on the Magma VM with pip

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
