### PR TITLE
fix(ci): Fix codecov_src_go by specifying go version

### DIFF
--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -182,10 +182,13 @@ jobs:
   codecov_src_go:
     needs: pre_job_src_go_determinator
     if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
+    strategy:
+      matrix:
+        go-version: [1.18.x]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code


### PR DESCRIPTION
Prerequisite for https://github.com/magma/magma/pull/12151.

## Summary

codecov_src_go is failing [here](https://github.com/magma/magma/runs/5696311341?check_suite_focus=true), for example, because os.ReadFile and os.WriteFile are undefined. I believe this is because an inconsistent version of Go is being used for the test (1.15.15), since a version >= 1.16 is required to use these functions. Before 1.16, these functions were instead defined by the io/ioutil package (see e.g. [here](https://pkg.go.dev/io/ioutil#ReadFile)). Here, I specify version 1.18, which is the latest available release, which requires updating actions/setup-go from v2 to v3.

## Test Plan

Checked that codecov_src_go downloads Go 1.18 as desired and passes: https://github.com/magma/magma/runs/5717337059?check_suite_focus=true.

## Additional Information

- [ ] This change is backwards-breaking
