### PR TITLE
fix(amf): Removes manual tag in Bazel test

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/amf/BUILD.bazel
@@ -43,8 +43,6 @@ cc_test(
     srcs = [
         "test_amf_procedures.cpp",
     ],
-    # TODO: Remove manual tag when fixed: GH12144
-    tags = ["manual"],
     deps = [
         ":amf_app_test_util",
         "//lte/gateway/c/core",
@@ -59,8 +57,6 @@ cc_test(
     srcs = [
         "test_amf_stateless.cpp",
     ],
-    # TODO: Remove manual tag when fixed: GH11826
-    tags = ["manual"],
     deps = [
         ":amf_app_test_util",
         "//lte/gateway/c/core",


### PR DESCRIPTION
Signed-off-by: shashidhar-patil <shashidhar.patil@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Enables all amf unit tests in OAI. Removed manual tags in BUILD.Bazel

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Removing this tag will make it so that these tests are run by default when using ... or *. (Ex: `bazel test //lte/gateway/c/core/... `or `bazel test lte/gateway/c/core/oai/test/amf:*`)

![bazel_tag](https://user-images.githubusercontent.com/89975652/160428993-1620b25e-6a43-4882-87ce-f3f39f005a40.png)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
