### PR TITLE
chore(ci): Bazel workflows send slack message

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -213,6 +213,16 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "C/C++ unit tests with Bazel"
+          SLACK_USERNAME: "agw-workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
 
   li_agent_test:
     needs: path_filter

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -82,6 +82,16 @@ jobs:
 
           aws s3 cp ${{ env.BAZEL_CACHE_MAGMA_VM_TAR }} ${{ env.S3_BUCKET_PATH }}/${{ env.BAZEL_CACHE_MAGMA_VM_TAR}}
           aws s3 cp ${{ env.BAZEL_CACHE_REPO_MAGMA_VM_TAR }} ${{ env.S3_BUCKET_PATH }}/${{ env.BAZEL_CACHE_REPO_MAGMA_VM_TAR}}
+      - name: Notify failure to slack
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "VM Caches"
+          SLACK_USERNAME: "Push Bazel Cache To S3"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
 
   bazel-build-devcontainer-and-push-cache:
     runs-on: ubuntu-latest
@@ -135,3 +145,14 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Devcontainer Caches"
+          SLACK_USERNAME: "Push Bazel Cache To S3"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -102,6 +102,16 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel Build Job `bazel build //...`"
+          SLACK_USERNAME: "Bazel Build & Test"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+        uses: rtCamp/action-slack-notify@v2.2.0
 
   bazel_test:
     needs: path_filter
@@ -234,6 +244,16 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel Test Job `bazel test //...`"
+          SLACK_USERNAME: "Bazel Build & Test"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+        uses: rtCamp/action-slack-notify@v2.2.0
 
   python_file_check:
     name: Check if there are not bazelified python files
@@ -245,6 +265,16 @@ jobs:
         shell: bash
         run: |
           ./bazel/scripts/check_py_bazel.sh
+      - name: Notify failure to slack
+        if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel Python Check Job `./bazel/scripts/check_py_bazel.sh`"
+          SLACK_USERNAME: "Bazel Build & Test"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+        uses: rtCamp/action-slack-notify@v2.2.0
 
   c_cpp_file_check:
     name: Check if there are non-bazelified c or c++ files
@@ -256,3 +286,13 @@ jobs:
         shell: bash
         run: |
           ./bazel/scripts/check_c_cpp_bazel.sh
+      - name: Notify failure to slack
+        if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel C/C++ Check Job `./bazel/scripts/check_c_cpp_bazel.sh`"
+          SLACK_USERNAME: "Bazel Build & Test"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+        uses: rtCamp/action-slack-notify@v2.2.0

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -134,3 +134,13 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Build all Bazelified C/C++ targets"
+          SLACK_USERNAME: "GCC Warnings & Errors"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -12,6 +12,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//bazel:third_party_repositories.bzl", "grpc")
 
+FAIL
+
 http_archive(
     name = "rules_python",
     sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",


### PR DESCRIPTION

## Summary

Because more code gets bazelified more regression of bazel build files can happen. In order to react proactively, failures of bazel workflows are sent to #bazel-ci. This way the bazel team react fast and support with regression of bazel workflows in PRs and on master.

## Test Plan

* introduced commit with bazel failure - are the failures send to #bazel-ci? TBD

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
