### PR TITLE
chore(mme): Remove manual tag from mme_procedures_test

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
@@ -122,8 +122,6 @@ cc_test(
         "test_mme_procedures.cpp",
     ],
     flaky = True,
-    # TODO: Remove manual tag when fixed: GH11955
-    tags = ["manual"],
     deps = [
         ":mme_app_test_core",
         ":mme_procedure_test_fixture",


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Remove the last "manual" tag from MME unit tests. The flakiness was addressed in https://github.com/magma/magma/pull/12297

I'll keep the flaky tag as we still seem to see failures occasionally but at a MUCH lower frequency. (see test plan)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run `bazel test //lte/gateway/c/core/oai/test/mme_app_task:mme_procedures_test --runs_per_test=1000` and got failure only 1/1000 times
![Screen Shot 2022-03-28 at 1 49 59 PM](https://user-images.githubusercontent.com/37634144/160457228-9306130e-07fc-4db6-9362-1310545c2215.png)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
