### PR TITLE
chore: rules python is upgraded

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -14,8 +14,9 @@ load("//bazel:third_party_repositories.bzl", "grpc")
 
 http_archive(
     name = "rules_python",
-    sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.5.0/rules_python-0.5.0.tar.gz",
+    sha256 = "9fcf91dbcc31fde6d1edb15f117246d912c33c36f44cf681976bd886538deba6",
+    strip_prefix = "rules_python-0.8.0",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.0.tar.gz",
 )
 
 ### BUILDIFIER DEPENDENCIES

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -19,6 +19,26 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.0.tar.gz",
 )
 
+load("//bazel:python_toolchain.bzl", "configure_python_toolchain")
+
+configure_python_toolchain()
+
+load("//bazel:python_dependencies.bzl", "configure_python_dependencies")
+
+configure_python_dependencies()
+
+load("@python_deps//:requirements.bzl", "install_deps")
+
+install_deps()
+
+load("//bazel:python_swagger.bzl", "load_swagger_repositories")
+
+load_swagger_repositories()
+
+load("//bazel:python_repositories.bzl", "python_repositories")
+
+python_repositories()
+
 ### BUILDIFIER DEPENDENCIES
 # See https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md
 # buildifier is written in Go and hence needs rules_go to be built.
@@ -128,19 +148,3 @@ new_local_repository(
     build_file = "//bazel/external:system_libraries.BUILD",
     path = "/",
 )
-
-load("//bazel:python_dependencies.bzl", "configure_python_dependencies")
-
-configure_python_dependencies()
-
-load("@python_deps//:requirements.bzl", "install_deps")
-
-install_deps()
-
-load("//bazel:python_swagger.bzl", "load_swagger_repositories")
-
-load_swagger_repositories()
-
-load("//bazel:python_repositories.bzl", "python_repositories")
-
-python_repositories()

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -8,7 +8,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-load(":python_toolchain.bzl", "configure_python_toolchain")
-
-configure_python_toolchain()

--- a/bazel/python_dependencies.bzl
+++ b/bazel/python_dependencies.bzl
@@ -11,15 +11,14 @@
 
 """Python Toolchain and PIP Dependencies"""
 
+load("@python3_8//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 def configure_python_dependencies(name = None):
-    native.register_toolchains("//bazel:py_toolchain")
-
     pip_parse(
         name = "python_deps",
         extra_pip_args = ["--require-hashes"],
-        python_interpreter = "python3",
+        python_interpreter_target = interpreter,
         requirements_lock = "//bazel/external:requirements.txt",
         visibility = ["//visibility:public"],
     )

--- a/bazel/python_toolchain.bzl
+++ b/bazel/python_toolchain.bzl
@@ -11,26 +11,10 @@
 
 """Python toolchain configuration"""
 
-load("@rules_python//python:defs.bzl", "py_runtime", "py_runtime_pair")
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 def configure_python_toolchain(name = None):
-    py_runtime(
-        name = "python3",
-        interpreter_path = "/usr/bin/python3.8",
-        python_version = "PY3",
-        visibility = ["//visibility:public"],
-    )
-
-    py_runtime_pair(
-        name = "py_runtime_pair",
-        py2_runtime = None,
-        py3_runtime = ":python3",
-        visibility = ["//visibility:public"],
-    )
-
-    native.toolchain(
-        name = "py_toolchain",
-        toolchain = ":py_runtime_pair",
-        toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-        visibility = ["//visibility:public"],
+    python_register_toolchains(
+        name = "python3_8",
+        python_version = "3.8",
     )

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && \
         apt-utils \
         build-essential \
         ca-certificates \
+        # needed to build pip dependencies (e.g. systemd) 
+        clang-11 \
         curl \
         gcc \
         git \
@@ -57,7 +59,8 @@ RUN apt-get update && \
         uuid-dev \
         vim \
         wget \
-        zip
+        zip && \
+    update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10
 
 # Install depencies from facebook repository
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/


### PR DESCRIPTION
## Summary

**TODO** if this gets approved and merged, update https://github.com/magma/magma/issues/11346 as obsolete - done

Rules python is upgraded to 0.8.0 and (new feature since 0.7.0) a pre-build python interpreter is used. With this change pre-installed pip dependencies will not influence python builds.  

Note:
* I added clang to the bazel base Dockerfile. Somehow python-systemd is now build the dependency from scratch. I was not able to figure out why this is needed with the hermetic python interpreter.
* I was not able to remove python completely from the bazel base Dockerfile. The bazel grpc seems to need a system interpreter during setup [1]. Maybe this dependency can be solved by upgrading the grpc library (#8457).

[1]
```
ERROR: /tmp/bazel/external/com_github_grpc_grpc/src/python/grpcio/grpc/_cython/BUILD.bazel:12:12: Executing genrule @com_github_grpc_grpc//src/python/grpcio/grpc/_cython:cygrpc.pyx_cython_translation failed: (Exit 127): process-wrapper failed: error executing command 
  (cd /tmp/bazel/sandbox/processwrapper-sandbox/1608/execroot/__main__ && \
  exec env - \
    PATH=/bin:/usr/bin:/usr/local/bin \
    TMPDIR=/tmp \
  /root/.cache/bazel/_bazel_root/install/64841bf12de13c7518c7ada0994bafe2/process-wrapper '--timeout=0' '--kill_delay=15' /bin/bash -c 'source external/bazel_tools/tools/genrule/genrule-setup.sh; PYTHONHASHSEED=0 bazel-out/host/bin/external/cython/cython_binary --cplus external/com_github_grpc_grpc/src/python/grpcio/grpc/_cython/cygrpc.pyx --output-file bazel-out/k8-dbg/bin/external/com_github_grpc_grpc/src/python/grpcio/grpc/_cython/cygrpc.cpp')
/usr/bin/env: 'python': No such file or directory
Target //orc8r/gateway/python/magma/state/tests:state_replicator_test failed to build
Use --verbose_failures to see the command lines of failed build steps.

```

## Test Plan

* on relevant environments (devcontainer, bazel-base, vm, ci) ...
* run all python tests
* run migrated services

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
