### PR TITLE
fix(ci): postpone lldb install until after unattended-upgrades

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -195,15 +195,6 @@
       - python3-aioeventlet
   retries: 5
 
-- name: Install LLDB debugger
-  # TODO: Make this preburn
-  apt:
-    pkg: lldb
-    state: present
-    update_cache: no
-  retries: 5
-  when: full_provision
-
 # /etc/environment doesn't expand variables, so if we want to modify the path,
 # we need to do it in profile.d
 - name: Create the env script
@@ -468,3 +459,12 @@
     purge: yes
     pkg:
       - unattended-upgrades
+
+- name: Install LLDB debugger
+  # TODO: Make this preburn
+  apt:
+    pkg: lldb
+    state: present
+    update_cache: no
+  retries: 5
+  when: full_provision


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Problem: See issue #12326
- Cause: APT package (in this case `lldb`) installation conflicted with `unattended-upgrades`
  - This is a race condition and does not fail reproducibly
- Solution: Postpone lldb install until after `unattended-upgrades`

## Test Plan

- Run `LTE integ test` workflow via GH actions (on fork)

## Additional Information

- [ ] This change is backwards-breaking

