### PR TITLE
fix(state): add missing common:service dependency

### DIFF
--- a/orc8r/gateway/python/magma/state/BUILD.bazel
+++ b/orc8r/gateway/python/magma/state/BUILD.bazel
@@ -31,6 +31,7 @@ py_binary(
         "//lte/protos/oai:all_python_proto",  # Dependency loaded via state.yml
         "//orc8r/gateway/python/magma/common:grpc_client_manager",
         "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
     ],
 )
 
@@ -43,6 +44,7 @@ py_library(
         ":redis_dicts",
         "//orc8r/gateway/python/magma/common:rpc_utils",
         "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
         "//orc8r/gateway/python/magma/common/redis:client",
         "//orc8r/protos:state_python_grpc",
     ],
@@ -65,5 +67,8 @@ py_library(
     name = "state_replicator",
     srcs = ["state_replicator.py"],
     visibility = ["//visibility:public"],
-    deps = ["//orc8r/gateway/python/magma/common:sdwatchdog"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:sdwatchdog",
+        "//orc8r/gateway/python/magma/common:service",
+    ],
 )


### PR DESCRIPTION
## Summary

Add a missing dependency on `common:service` target to the state service

## Test Plan
`bazel run orc8r/gateway/python/magma/state` -> make sure it doesn't fail with `ModuleNotFoundError`

## Additional Information

- [ ] This change is backwards-breaking