### PR TITLE
fix(dp): Pin Werkzeug dependency in Protocol Controller

### DIFF
--- a/dp/cloud/python/magma/protocol_controller/plugins/cbsd_sas/tests/requirements.txt
+++ b/dp/cloud/python/magma/protocol_controller/plugins/cbsd_sas/tests/requirements.txt
@@ -4,3 +4,4 @@ grpcio==1.37.1
 grpcio-tools==1.37.1
 parameterized==0.8.1
 pytest==6.2.3
+Werkzeug==2.0.3


### PR DESCRIPTION
## Summary

Werkzeug dependency was not pinned in requirements,
which caused test fails on CI.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>
