### PR TITLE
fix(pipelined): pipelined_cli.py not working with debug qos option

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -201,7 +201,7 @@ class QosManager(object):
     def debug(cls, _, __, ___):
         config = load_service_config('pipelined')
         qos_impl_type = QosImplType(config["qos"]["impl"])
-        qos_store = QosStore(cls.__name__)
+        qos_store = QosStore(cls.__name__, client=get_default_client())
         for k, v in qos_store.items():
             _, imsi, ip_addr, rule_num, d = get_key(k)
             _, qid, ambr, leaf = get_data(v)


### PR DESCRIPTION
Signed-off-by: GANESH-WAVELABS <ganesh.irrinki@wavelabs.ai>


## Summary
pipelined_cli.py not working with `debug qos` option, getting Traceback like below:
```
(python) vagrant@magma-dev-focal:~/magma/lte/gateway/python/scripts$ ./pipelined_cli.py debug qos
Traceback (most recent call last):
  File "./pipelined_cli.py", line 936, in <module>
    main()
  File "./pipelined_cli.py", line 932, in main
    args.func(args, PipelinedStub, 'pipelined')
  File "/home/vagrant/magma/lte/gateway/python/magma/pipelined/qos/common.py", line 204, in debug
    qos_store = QosStore(cls.__name__)
TypeError: __init__() missing 1 required positional argument: 'client'
```


## Test Plan
Tested with fix  pipelined_cli.py not giving Traceback with `debug qos` option


## Additional Information
1) Corresponding zenhub task id is : #12337 
2) For more logs refer the following comment section.
