### PR TITLE
chore(pipelined): blocking of local ipv6 addresses is supported

### DIFF
--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_access_control.AccessControlTestLocalIpBlockLTEIpV6.test_blocking_ip_match.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_access_control.AccessControlTestLocalIpBlockLTEIpV6.test_blocking_ip_match.snapshot
@@ -1,6 +1,6 @@
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=100,icmp,reg1=0x1,nw_dst=10.1.0.1 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=100,icmp6,reg1=0x1,ipv6_dst=fe80::linkLocalSuffix actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=access_control(main_table), n_packets=2, n_bytes=68, priority=10,ip,reg1=0x1,nw_dst=127.0.0.0/8 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=127.0.0.0/8 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=10.0.2.15 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=192.168.60.142 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=192.168.129.1 actions=drop
@@ -8,8 +8,8 @@
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=192.168.128.1 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=10.1.0.1 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x1,nw_dst=192.168.1.1 actions=drop
- cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x1,ipv6_dst=::1 actions=drop
- cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x1,ipv6_dst=2020::10 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=54, priority=10,ipv6,reg1=0x1,ipv6_dst=::1 actions=drop
+ cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=54, priority=10,ipv6,reg1=0x1,ipv6_dst=2020::10 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x1,ipv6_dst=fe80::linkLocalSuffix actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x1,ipv6_dst=fe80::linkLocalSuffix actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x1,ipv6_dst=fe80::linkLocalSuffix actions=drop
@@ -34,5 +34,5 @@
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x1,ipv6_dst=fe80::linkLocalSuffix actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ipv6,reg1=0x1,ipv6_dst=fe80::linkLocalSuffix actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=0,reg1=0x1 actions=resubmit(,access_control(scratch_table_0)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=access_control(scratch_table_0), n_packets=1, n_bytes=34, priority=0 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=54, priority=0,reg1=0x1 actions=resubmit(,access_control(scratch_table_0)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=access_control(scratch_table_0), n_packets=1, n_bytes=54, priority=0 actions=resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3


### PR DESCRIPTION
## Summary
See https://github.com/magma/magma/issues/12074.

Couple of notes and questions @pshelar and @koolzz:
* `access_control.py` uses `netifaces` which is outdated
* please have a detailed look at our test: we replaced the suffix of `fe80::` addresses as these are not static in the vm setup - and it is disproportionate to make them static. Is there a test mechanic we did not see that achieves the same?
* in the ipv4 case all `127.*` addresses are blocked - from our research we found that there is not really a fixed ipv6 block for loopback addresses. For now we only blocked in this case `::1`. What is your expectation here?
* should this feature be extended to the blocking list mechanics for ipv6?

## Test Plan

Mainly `test_access_control.py`.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
