### PR TITLE
ci: always pull docker image from remote to prevent out of sync tags

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,7 @@
 		"ryuta46.multi-command",
 		"coolchyni.beyond-debug",
 	],
+	"initializeCommand": "docker pull ghcr.io/magma/magma/devcontainer:latest",
 	"image": "ghcr.io/magma/magma/devcontainer:latest",
 	"settings": {
 		"search.followSymlinks": false,

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -108,6 +108,7 @@ jobs:
         uses: addnab/docker-run-action@v2
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          options: --pull always
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the devontainer image!"
@@ -171,6 +172,7 @@ jobs:
         uses: addnab/docker-run-action@v2
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
+          options: --pull always
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the devontainer image!"

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_REPO_DIR" "$BAZEL_CACHE_REPO_CUTOFF_MB"
       - name: Setup Devcontainer Image
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           options: --pull always
@@ -113,7 +113,7 @@ jobs:
           run: |
             echo "Pulled the devontainer image!"
       - name: Run `bazel build //...`
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -169,7 +169,7 @@ jobs:
           ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
       # Letting the Build job above handle cache clean up for bazel-cache-repo
       - name: Setup Devcontainer Image
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           options: --pull always
@@ -177,7 +177,7 @@ jobs:
           run: |
             echo "Pulled the devontainer image!"
       - name: Run `bazel test //...`
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -186,7 +186,7 @@ jobs:
             cd /workspaces/magma
             bazel test //... --test_output=errors --cache_test_results=no
       - name: Run `bazel run //:check_starlark_format`
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)


### PR DESCRIPTION
## Summary

Github action runners are not managed by Magma and might be reused several times. The [docker documentation](https://docs.docker.com/engine/reference/commandline/run/) seems to suggest, that if a image is already present in the local docker registry, it will not be re-fetched from the remote unless explicitly told so. See the option `--pull` with default `missing` [in the docker documentation](https://docs.docker.com/engine/reference/commandline/run/). This can lead to stale images being used. 

To mitigate the issue we need to force pull the first time we use an image within the workflow.
Keep in mind that we do _not_ want to force pull in every following action as this would bring the risk to use different images in one workflow run, when a image tag is updated during that workflow run.

The `addnab/docker-run-action` required an update to version `v3` for this to work.

## Test Plan

- CI
- future observation for unexpected behaviour in CI

## Additional Information

- Thanks to @nstng for finding this and vivid discussion!
