### PR TITLE
chore: update golang-linter to version 1.45.0

### DIFF
--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Run Go linter
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42
+          version: v1.45.0
           working-directory: dp/cloud/go/active_mode_controller
           skip-go-installation: true
 

--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -65,7 +65,7 @@ lint_tools:
 	else \
 		echo "-> installing golangci " && \
 			curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-			| sudo sh -s -- -b /usr/sbin/ v1.35.2; \
+			| sudo sh -s -- -b /usr/sbin/ v1.45.0; \
 	fi
 
 build_only:

--- a/lte/cloud/go/services/subscriberdb/digest.go
+++ b/lte/cloud/go/services/subscriberdb/digest.go
@@ -15,6 +15,7 @@ package subscriberdb
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
@@ -127,7 +128,7 @@ func getSubscribersDigest(network string) (string, error) {
 		if err != nil {
 			return "", nil
 		}
-		digestsByPage[string(curPage)] = []byte(pageDigest)
+		digestsByPage[fmt.Sprint(curPage)] = []byte(pageDigest)
 
 		foundEmptyToken = nextToken == ""
 		token = nextToken

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -143,7 +143,7 @@ $(TOOLS_LIST): %_tools:
 
 tools_lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-		| sh -s -- -b $$(go env GOPATH)/bin v1.35.2
+		| sh -s -- -b $$(go env GOPATH)/bin v1.45.0
 
 ######################
 ## Swagger/API docs ##

--- a/orc8r/cloud/go/obsidian/access/tests/rest_middleware_test.go
+++ b/orc8r/cloud/go/obsidian/access/tests/rest_middleware_test.go
@@ -95,7 +95,7 @@ func TestAuthMiddleware(t *testing.T) {
 	})
 
 	tenants.CreateTenant(context.Background(), test_utils.TestTenantId, &tenant_protos.Tenant{
-		Name:     string(test_utils.TestTenantId),
+		Name:     fmt.Sprint(test_utils.TestTenantId),
 		Networks: []string{test_utils.TestTenantNetworkId},
 	})
 	tenantUserToken := test_utils.CreateTestUser(t, store, test_utils.TestTenantUsername, test_utils.TestPassword, []*certprotos.Policy{


### PR DESCRIPTION
## Summary

This is a prerequisite to the [golang update](https://github.com/magma/magma/pull/12151) as [golang-linter version 1.45.0 is the first one to support golang 1.18](https://golangci-lint.run/product/roadmap/#v1450).

- updating golang-linter in three places
- fixing new linter errors after update (see https://github.com/golang/go/issues/32479)

## Test Plan

- `vagrant@magma-dev-focal:~/magma/feg/gateway$ make lint`
  - i.e.: `vagrant@magma-dev-focal:~/magma/feg/gateway$ golangci-lint run --config /home/vagrant/magma/.golangci.yml`
- `vagrant@magma-dev-focal:~/magma/orc8r/cloud$ make lint`
- `act -j active_mode_controller_unit_tests`
  - with dorny-path-filter `base: ${{ github.ref }}` addition 
- `vagrant@magma-dev-focal:~/magma/feg/gateway/docker$ ./build.py -c` with [feg-docker.log](https://github.com/magma/magma/files/8387506/feg-docker.log) successfully.
- `${my_host_machine}:~/magma/orc8r/cloud/docker$ ./build.py -c` with [orc8r-docker.log](https://github.com/magma/magma/files/8387712/orc8r-docker.log) successfully.
