### PR TITLE
fix: Specify import path on run-tests ghz ansible playbook

### DIFF
--- a/experimental/cloudstrapper/playbooks/roles/ghz-platform/tasks/run-tests.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/ghz-platform/tasks/run-tests.yaml
@@ -13,7 +13,7 @@
 
 - name: run load test script
   command:
-    cmd: "python3 /magma/lte/gateway/python/load_tests/loadtest_{{ item.0.name }}.py {{ item.1.name }}"
+    cmd: "python3 /magma/lte/gateway/python/load_tests/loadtest_{{ item.0.name }}.py {{ item.1.name }} /magma/"
     chdir: "/magma/lte/gateway/python/load_tests"
   environment:
     MAGMA_ROOT: "/magma"


### PR DESCRIPTION
Signed-off-by: Alex Rodriguez <alexrod@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Running latest load tests bring up this error:
```
  File "/home/vagrant/magma/lte/gateway/python/load_tests/common.py", line 91, in benchmark_grpc_request
    if not Path(import_path).exists():
  File "/usr/lib/python3.8/pathlib.py", line 1042, in __new__
    self = cls._from_parts(args, init=False)
  File "/usr/lib/python3.8/pathlib.py", line 683, in _from_parts
    drv, root, parts = self._parse_args(args)
  File "/usr/lib/python3.8/pathlib.py", line 667, in _parse_args
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
- Adding `--import_path` flag to fix it

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
```
(python) vagrant@magma-dev-focal:~$ loadtest_mobilityd.py allocate --import_path /magma/
Preparing allocate load test...
Done
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
