### PR TITLE
fix(dp): Configure database connection pool

### DIFF
--- a/dp/cloud/helm/dp/charts/domain-proxy/README.md
+++ b/dp/cloud/helm/dp/charts/domain-proxy/README.md
@@ -49,6 +49,8 @@ The following table lists the configurable parameters of the Domain-proxy chart 
 | `nameOverride` | Replaces the name of the chart in the `Chart.yaml` file. | `""` |
 | `fullnameOverride` | Completely replaces the helm release generated name. | `""` |
 | `configuration_controller.sasEndpointUrl` | Endpoint where sas request should be send. | `""` |
+| `configuration_controller.dbConnectionPoolSize` | How many database connections are made and maintained | `"6"` |
+| `configuration_controller.dbConnectionPoolMaxOverflow` | How many extra database connections can be made when necessary | `"10"` |
 | `configuration_controller.requestProcessingInterval` | How often configuration controller will send requests to SAS. In seconds. | `"10"` |
 | `configuration_controller.database` | Database configuration. | `{}` |
 | `configuration_controller.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
@@ -128,6 +130,8 @@ The following table lists the configurable parameters of the Domain-proxy chart 
 | `radio_controller.database` |  | `{}` |
 | `radio_controller.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
 | `radio_controller.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `radio_controller.dbConnectionPoolSize` | How many database connections are made and maintained | `"40"` |
+| `radio_controller.dbConnectionPoolMaxOverflow` | How many extra database connections can be made when necessary | `"10"` |
 | `radio_controller.enabled` | Enables deployment of the given dp component. | `true` |
 | `radio_controller.name` | Domain proxy component name. | `"radio-controller"` |
 | `radio_controller.image.repository` | Docker image repository. | `"radio-controller"` |
@@ -186,6 +190,8 @@ The following table lists the configurable parameters of the Domain-proxy chart 
 | `db_service.enabled` | Enables deployment of the given service. | `true` |
 | `db_service.nameOverride` | Replaces service part of the dp component deployment name. | `""` |
 | `db_service.fullnameOverride` | Completely replaces dp component deployment name. | `""` |
+| `db_service.dbConnectionPoolSize` | How many database connections are made and maintained | `"6"` |
+| `db_service.dbConnectionPoolMaxOverflow` | How many extra database connections can be made when necessary | `"10"` |
 | `db_service.name` | Domain proxy component name. | `"db-service"` |
 | `db_service.image.repository` | Docker image repository. | `"db-service"` |
 | `db_service.image.pullPolicy` | Default the pull policy of all containers in that pod. | `"IfNotPresent"` |

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/cm.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/cm.yaml
@@ -10,4 +10,10 @@ data:
 {{- if .Values.dp.configuration_controller.sasEndpointUrl }}
   SAS_URL: {{ .Values.dp.configuration_controller.sasEndpointUrl }}
 {{- end }}
+{{- if .Values.dp.configuration_controller.dbConnectionPoolSize }}
+  SQLALCHEMY_ENGINE_POOL_SIZE: {{ quote .Values.dp.configuration_controller.dbConnectionPoolSize }}
+{{- end }}
+{{- if .Values.dp.configuration_controller.dbConnectionPoolMaxOverflow }}
+  SQLALCHEMY_ENGINE_MAX_OVERFLOW: {{ quote .Values.dp.configuration_controller.dbConnectionPoolMaxOverflow }}
+{{- end }}
 {{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/db_service/cm.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/db_service/cm.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.dp.create .Values.dp.db_service.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{-  include "domain-proxy.db_service.labels" . | nindent 4 }}
+  name: {{ include "domain-proxy.db_service.fullname" . }}
+{{ include "domain-proxy.namespace" . | indent 2 }}
+data:
+{{- if .Values.dp.db_service.dbConnectionPoolSize }}
+  SQLALCHEMY_ENGINE_POOL_SIZE: {{ quote .Values.dp.db_service.dbConnectionPoolSize }}
+{{- end }}
+{{- if .Values.dp.db_service.dbConnectionPoolMaxOverflow }}
+  SQLALCHEMY_ENGINE_MAX_OVERFLOW: {{ quote .Values.dp.db_service.dbConnectionPoolMaxOverflow }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/cm.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/cm.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.dp.create .Values.dp.radio_controller.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{-  include "domain-proxy.radio_controller.labels" . | nindent 4 }}
+  name: {{ include "domain-proxy.radio_controller.fullname" . }}
+{{ include "domain-proxy.namespace" . | indent 2 }}
+data:
+{{- if .Values.dp.radio_controller.dbConnectionPoolSize }}
+  SQLALCHEMY_ENGINE_POOL_SIZE: {{ quote .Values.dp.radio_controller.dbConnectionPoolSize }}
+{{- end }}
+{{- if .Values.dp.radio_controller.dbConnectionPoolMaxOverflow }}
+  SQLALCHEMY_ENGINE_MAX_OVERFLOW: {{ quote .Values.dp.radio_controller.dbConnectionPoolMaxOverflow }}
+{{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/deployment.yaml
@@ -65,6 +65,8 @@ spec:
           envFrom:
           - secretRef:
               name: {{ include "domain-proxy.radio_controller.fullname" . }}
+          - configMapRef:
+              name: {{ include "domain-proxy.radio_controller.fullname" . }}
       {{- with .Values.dp.radio_controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/values.yaml
@@ -12,6 +12,8 @@ dp:
 
     sasEndpointUrl: ""  # Endpoint where sas request should be send.
     requestProcessingInterval: "10" # How often configuration controller will send requests to SAS. In seconds.
+    dbConnectionPoolSize: "6"  # How many database connections are made and maintained
+    dbConnectionPoolMaxOverflow: "10"  # How many extra database connections can be made when necessary
 
     database: {} # Database configuration.
       #driver: postgres      # postgres
@@ -253,6 +255,17 @@ dp:
 
   radio_controller:
 
+    dbConnectionPoolSize: "40"  # Size of database connection pool
+    # This value should be adjusted based on the expected number of active eNBs.
+    # Good estimate would be: (number of eNBs) / (average eNB TR069 periodic inform interval)
+    # However this also should not exceed the max number of connections allowed by the underlying Database.
+    # A good default guestimate value here would be 40 - Radio Controller will still only
+    # use just as many as it needs in case of low concurrency.
+    # 40 should suffice for 200 simultaneous eNBs on a Magma deployment (200 eNBs with 5sec TR069 periodic inform intervals)
+
+    dbConnectionPoolMaxOverflow: "10"  # How many temporary extra database connections can be made
+    # Used when default pool size is exceeded and extra connections are required
+
     database: {}
       #driver: postgres      # postgres
       #db: dp          # DB Name
@@ -337,6 +350,7 @@ dp:
     tolerations: []  # Allow the pods to schedule onto nodes with matching taints.
 
     affinity: {}  # Constrain which nodes your pod is eligible to be scheduled on.
+
   active_mode_controller:
 
     nameOverride: ""  # Replaces service part of the dp component deployment name.
@@ -417,6 +431,9 @@ dp:
     affinity: {}  # Constrain which nodes your pod is eligible to be scheduled on.
 
   db_service:
+
+    dbConnectionPoolSize: "6"  # How many database connections are made and maintained
+    dbConnectionPoolMaxOverflow: "10"  # How many extra database connections can be made when necessary
 
     database: {}
       #driver: postgres      # postgres

--- a/dp/cloud/python/magma/configuration_controller/config.py
+++ b/dp/cloud/python/magma/configuration_controller/config.py
@@ -14,6 +14,7 @@ limitations under the License.
 import os
 
 from magma.db_service import config as conf
+from magma.mappings.request_mapping import request_mapping
 
 
 class Config(object):
@@ -25,9 +26,6 @@ class Config(object):
     REQUEST_PROCESSING_INTERVAL_SEC = int(
         os.environ.get('REQUEST_PROCESSING_INTERVAL_SEC', 10),
     )
-    REQUEST_MAPPING_FILE_PATH = os.environ.get(
-        'REQUEST_MAPPING_FILE_PATH', 'mappings/request_mapping.yml',
-    )
     REQUEST_PROCESSING_LIMIT = int(
         os.environ.get('REQUEST_PROCESSING_LIMIT', 100),
     )
@@ -36,11 +34,25 @@ class Config(object):
     SAS_URL = os.environ.get('SAS_URL', 'https://fake-sas-service/v1.2')
     RC_INGEST_URL = os.environ.get('RC_INGEST_URL', '')
 
-    # SQLAlchemy DB URI (scheme + url)
+    # SQLAlchemy
     SQLALCHEMY_DB_URI = conf.Config().SQLALCHEMY_DB_URI
     SQLALCHEMY_DB_ENCODING = conf.Config().SQLALCHEMY_DB_ENCODING
     SQLALCHEMY_ECHO = conf.Config().SQLALCHEMY_ECHO
     SQLALCHEMY_FUTURE = conf.Config().SQLALCHEMY_FUTURE
+    # DB engine connection pool size will default to the amount of request types
+    # as each request type has its own query thread
+    SQLALCHEMY_ENGINE_POOL_SIZE = int(
+        os.environ.get(
+            'SQLALCHEMY_ENGINE_POOL_SIZE',
+            len(request_mapping),
+        ),
+    )
+    SQLALCHEMY_ENGINE_MAX_OVERFLOW = int(
+        os.environ.get(
+            'SQLALCHEMY_ENGINE_MAX_OVERFLOW',
+            conf.Config().SQLALCHEMY_ENGINE_MAX_OVERFLOW,
+        ),
+    )
 
     # Security
     CC_CERT_PATH = os.environ.get(

--- a/dp/cloud/python/magma/configuration_controller/run.py
+++ b/dp/cloud/python/magma/configuration_controller/run.py
@@ -76,6 +76,8 @@ def run():
         encoding=config.SQLALCHEMY_DB_ENCODING,
         echo=config.SQLALCHEMY_ECHO,
         future=config.SQLALCHEMY_FUTURE,
+        pool_size=config.SQLALCHEMY_ENGINE_POOL_SIZE,
+        max_overflow=config.SQLALCHEMY_ENGINE_MAX_OVERFLOW,
     )
     session_manager = SessionManager(db_engine=db_engine)
     router = RequestRouter(

--- a/dp/cloud/python/magma/db_service/config.py
+++ b/dp/cloud/python/magma/db_service/config.py
@@ -28,6 +28,12 @@ class Config(object):
     SQLALCHEMY_DB_ENCODING = os.environ.get('SQLALCHEMY_DB_ENCODING', 'utf8')
     SQLALCHEMY_ECHO = False
     SQLALCHEMY_FUTURE = False
+    SQLALCHEMY_ENGINE_POOL_SIZE = os.environ.get(
+        'SQLALCHEMY_ENGINE_POOL_SIZE', 6,
+    )
+    SQLALCHEMY_ENGINE_MAX_OVERFLOW = os.environ.get(
+        'SQLALCHEMY_ENGINE_MAX_OVERFLOW', 10,
+    )
 
 
 class DevelopmentConfig(Config):

--- a/dp/cloud/python/magma/db_service/db_initialize.py
+++ b/dp/cloud/python/magma/db_service/db_initialize.py
@@ -83,6 +83,8 @@ if __name__ == '__main__':
         encoding=config.SQLALCHEMY_DB_ENCODING,
         echo=config.SQLALCHEMY_ECHO,
         future=config.SQLALCHEMY_FUTURE,
+        pool_size=config.SQLALCHEMY_ENGINE_POOL_SIZE,
+        max_overflow=config.SQLALCHEMY_ENGINE_MAX_OVERFLOW,
     )
     session_manager = SessionManager(db_engine=db_engine)
     initializer = DBInitializer(session_manager)

--- a/dp/cloud/python/magma/radio_controller/config.py
+++ b/dp/cloud/python/magma/radio_controller/config.py
@@ -26,11 +26,23 @@ class Config(object):
     # gRPC
     GRPC_PORT = int(os.environ.get('GRPC_PORT', 50053))
 
-    # SQLAlchemy DB URI (scheme + url)
+    # SQLAlchemy
     SQLALCHEMY_DB_URI = conf.Config().SQLALCHEMY_DB_URI
     SQLALCHEMY_DB_ENCODING = conf.Config().SQLALCHEMY_DB_ENCODING
     SQLALCHEMY_ECHO = conf.Config().SQLALCHEMY_ECHO
     SQLALCHEMY_FUTURE = conf.Config().SQLALCHEMY_FUTURE
+    SQLALCHEMY_ENGINE_POOL_SIZE = int(
+        os.environ.get(
+            'SQLALCHEMY_ENGINE_POOL_SIZE',
+            conf.Config().SQLALCHEMY_ENGINE_POOL_SIZE,
+        ),
+    )
+    SQLALCHEMY_ENGINE_MAX_OVERFLOW = int(
+        os.environ.get(
+            'SQLALCHEMY_ENGINE_MAX_OVERFLOW',
+            conf.Config().SQLALCHEMY_ENGINE_MAX_OVERFLOW,
+        ),
+    )
 
 
 class DevelopmentConfig(Config):

--- a/dp/cloud/python/magma/radio_controller/run.py
+++ b/dp/cloud/python/magma/radio_controller/run.py
@@ -55,6 +55,8 @@ def run():
         encoding=config.SQLALCHEMY_DB_ENCODING,
         echo=config.SQLALCHEMY_ECHO,
         future=config.SQLALCHEMY_FUTURE,
+        pool_size=config.SQLALCHEMY_ENGINE_POOL_SIZE,
+        max_overflow=config.SQLALCHEMY_ENGINE_MAX_OVERFLOW,
     )
     session_manager = SessionManager(db_engine)
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))


### PR DESCRIPTION
Extended service configurations with parameters that allow controlling
database connection pool size and overflow.
Additionally assigned default values for those configuration parameters.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

* Allow setting of connection pool size and overflow in Radio Controller, Configuration Controller and DB Service
* Set default values in helm

## Additional Information

- [ ] This change is backwards-breaking