### PR TITLE
fix(dp): Unregister CBSD on SAS response 105

### DIFF
--- a/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
+++ b/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
@@ -52,24 +52,32 @@ def process_registration_response(obj: ResponseDBProcessor, response: DBResponse
 
     cbsd_id = response.payload.get("cbsdId", None)
     if response.response_code == ResponseCodes.DEREGISTER.value:
-        _terminate_all_grants_from_response(response, session)
+        _unregister_cbsd(response, session)
     elif response.response_code == ResponseCodes.SUCCESS.value and cbsd_id:
         payload = response.request.payload
-        cbsd = _find_cbsd_from_registration_request(session, payload)
+        cbsd = _find_cbsd_from_request(session, payload)
         cbsd.cbsd_id = cbsd_id
         _change_cbsd_state(cbsd, session, CbsdStates.REGISTERED.value)
 
 
-def _find_cbsd_from_registration_request(session: Session, payload: Dict) -> DBCbsd:
-    return session.query(DBCbsd).filter(
-        DBCbsd.cbsd_serial_number == payload["cbsdSerialNumber"],
-    ).scalar()
+def _find_cbsd_from_request(session: Session, payload: Dict) -> DBCbsd:
+    if "cbsdSerialNumber" in payload:
+        return session.query(DBCbsd).filter(
+            DBCbsd.cbsd_serial_number == payload["cbsdSerialNumber"],
+        ).scalar()
+    if "cbsdId" in payload:
+        return session.query(DBCbsd).filter(
+            DBCbsd.cbsd_id == payload["cbsdId"],
+        ).scalar()
 
 
 def _change_cbsd_state(cbsd: DBCbsd, session: Session, new_state: str) -> None:
+    if not cbsd:
+        return
     state = session.query(DBCbsdState).filter(
         DBCbsdState.name == new_state,
     ).scalar()
+    print(f"Changing {cbsd=} {cbsd.state=} to {new_state=}")
     cbsd.state = state
 
 
@@ -84,7 +92,7 @@ def process_spectrum_inquiry_response(obj: ResponseDBProcessor, response: DBResp
     """
 
     if response.response_code == ResponseCodes.DEREGISTER.value:
-        _terminate_all_grants_from_response(response, session)
+        _unregister_cbsd(response, session)
     elif response.response_code == ResponseCodes.SUCCESS.value:
         _create_channels(response, session)
 
@@ -125,6 +133,11 @@ def process_grant_response(obj: ResponseDBProcessor, response: DBResponse, sessi
     Returns:
         None
     """
+
+    if response.response_code == ResponseCodes.DEREGISTER.value:
+        _unregister_cbsd(response, session)
+        return
+
     if response.response_code != ResponseCodes.SUCCESS.value:
         cbsd = response.request.cbsd
         if cbsd:
@@ -161,6 +174,10 @@ def process_heartbeat_response(obj: ResponseDBProcessor, response: DBResponse, s
     Returns:
         None
     """
+
+    if response.response_code == ResponseCodes.DEREGISTER.value:
+        _unregister_cbsd(response, session)
+        return
 
     grant = _get_or_create_grant_from_response(obj, response, session)
     if not grant:
@@ -200,6 +217,10 @@ def process_relinquishment_response(obj: ResponseDBProcessor, response: DBRespon
         None
     """
 
+    if response.response_code == ResponseCodes.DEREGISTER.value:
+        _unregister_cbsd(response, session)
+        return
+
     grant = _get_or_create_grant_from_response(obj, response, session)
     if not grant:
         return
@@ -228,11 +249,8 @@ def process_deregistration_response(obj: ResponseDBProcessor, response: DBRespon
         session: Database session
     """
 
-    _terminate_all_grants_from_response(response, session)
-    cbsd_id = response.payload.get("cbsdId", None)
-    if cbsd_id:
-        cbsd = session.query(DBCbsd).filter(DBCbsd.cbsd_id == cbsd_id).scalar()
-        _change_cbsd_state(cbsd, session, CbsdStates.UNREGISTERED.value)
+    print(f"Processing response {response.payload}")
+    _unregister_cbsd(response, session)
 
 
 def _get_or_create_grant_from_response(
@@ -316,3 +334,10 @@ def _terminate_all_grants_from_response(response: DBResponse, session: Session) 
     session.query(DBGrant).filter(DBGrant.cbsd == cbsd).delete()
     logger.info(f"Deleting all channels for {cbsd_id=}")
     session.query(DBChannel).filter(DBChannel.cbsd == cbsd).delete()
+
+
+def _unregister_cbsd(response: DBResponse, session: Session) -> None:
+    payload = response.request.payload
+    cbsd = _find_cbsd_from_request(session, payload)
+    _terminate_all_grants_from_response(response, session)
+    _change_cbsd_state(cbsd, session, CbsdStates.UNREGISTERED.value)

--- a/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
@@ -346,6 +346,36 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
         self.assertEqual(high_frequency, grant.high_frequency)
         self.assertEqual(max_eirp, grant.max_eirp)
 
+    @parameterized.expand([
+        (REGISTRATION_REQ, registration_requests),
+        (SPECTRUM_INQ_REQ, spectrum_inquiry_requests),
+        (GRANT_REQ, grant_requests),
+        (HEARTBEAT_REQ, heartbeat_requests),
+        (RELINQUISHMENT_REQ, relinquishment_requests),
+        (DEREGISTRATION_REQ, deregistration_requests),
+    ])
+    @responses.activate
+    def test_cbsd_unregistered_after_105_response_code(self, request_type, request_fixture):
+        # Given
+        db_requests = self._create_db_requests(
+            request_type, request_fixture,
+        )
+        response = self._prepare_response_from_db_requests(
+            db_requests, ResponseCodes.DEREGISTER.value,
+        )
+
+        # When
+        self._process_response(
+            request_type_name=request_type, response=response, db_requests=db_requests,
+        )
+        states = [req.cbsd.state for req in db_requests]
+
+        # Then
+        [
+            self.assertTrue(state.name == CbsdStates.UNREGISTERED.value)
+            for state in states
+        ]
+
     def _process_response(self, request_type_name, response, db_requests):
         processor = self._get_response_processor(request_type_name)
 


### PR DESCRIPTION
Fixed an issue where a CBSD state remained "registered" when SAS
returned a response with reponseCode 105.
Response code 105 means the CBSD got unregistered in SAS and should
consider itself "Unregistered".
This PR changes the CBSD state to "unregistered" when any SAS response
is a 105 code.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

* Set CBSD state to "Unregistered" on each SAS response that has the responseCode 105.

## Additional Information

- [ ] This change is backwards-breaking