### PR TITLE
fix(dp): Fix flake in integration tests

### DIFF
--- a/dp/cloud/python/magma/test_runner/tests/test_active_mode_controller.py
+++ b/dp/cloud/python/magma/test_runner/tests/test_active_mode_controller.py
@@ -62,15 +62,15 @@ class ActiveModeControllerTestCase(DBTestCase):
 
     def given_cbsd_provisioned(self):
         self.given_cbsd_with_transmission_parameters()
-        self.dp_client.GetCBSDState(
-            self._build_cbsd_request(), wait_for_ready=True,
-        )
+        self.dp_client.GetCBSDState(self._build_cbsd_request())
 
         self.then_cbsd_is_eventually_provisioned_in_sas(self.dp_client)
 
     # TODO change this when some API for domain proxy is introduced
     def given_cbsd_with_transmission_parameters(self):
-        state = self.dp_client.CBSDRegister(self._build_cbsd_request())
+        state = self.dp_client.CBSDRegister(
+            self._build_cbsd_request(), wait_for_ready=True,
+        )
         self.session.commit()
         self.assertEqual(self._build_empty_state_result(), state)
 


### PR DESCRIPTION
## Summary

First call to grpc server has to have "wait_for_ready" flag,
since there server may not be running yet,
previously GetCBSDState was the first grpc method called,
and it had that flag set, but later new call was added before,
and this time without that flag, which caused occasional flakes.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>
