### PR TITLE
chore(mme): redundant EMBEDDED_SGW precompiler statements are cleaned up

### DIFF
--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_config.c
@@ -66,18 +66,6 @@ void pgw_config_init(pgw_config_t* config_pP) {
 
 //------------------------------------------------------------------------------
 status_code_e pgw_config_process(pgw_config_t* config_pP) {
-#if (!EMBEDDED_SGW)
-  async_system_command(TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR,
-                       "iptables -t mangle -F OUTPUT");
-  async_system_command(TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR,
-                       "iptables -t mangle -F POSTROUTING");
-
-  if (config_pP->masquerade_SGI) {
-    async_system_command(TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR,
-                         "iptables -t nat -F PREROUTING");
-  }
-#endif
-
   // Get ipv4 address
   char str[INET_ADDRSTRLEN];
 
@@ -158,37 +146,6 @@ status_code_e pgw_config_process(pgw_config_t* config_pP) {
         break;
       }
     }
-
-#if (!EMBEDDED_SGW)
-    if (config_pP->masquerade_SGI) {
-      async_system_command(
-          TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR,
-          "iptables -t nat -I POSTROUTING -s %s/%d -o %s  ! --protocol sctp -j "
-          "SNAT --to-source %s",
-          inet_ntoa(netaddr), netmask, bdata(config_pP->ipv4.if_name_SGI),
-          str_sgi);
-    }
-
-    uint32_t min_mtu = config_pP->ipv4.mtu_SGI;
-    // 36 = GTPv1-U min header size
-    if ((config_pP->ipv4.mtu_S5_S8 - 36) < min_mtu) {
-      min_mtu = config_pP->ipv4.mtu_S5_S8 - 36;
-    }
-    if (config_pP->ue_tcp_mss_clamp) {
-      async_system_command(
-          TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR,
-          "iptables -t mangle -I FORWARD -s %s/%d   -p tcp --tcp-flags SYN,RST "
-          "SYN -j TCPMSS --set-mss %u",
-          inet_ntoa(netaddr), netmask, min_mtu - 40);
-
-      async_system_command(
-          TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR,
-          "iptables -t mangle -I FORWARD -d %s/%d -p tcp --tcp-flags SYN,RST "
-          "SYN "
-          "-j TCPMSS --set-mss %u",
-          inet_ntoa(netaddr), netmask, min_mtu - 40);
-    }
-#endif
   } else {
     OAILOG_DEBUG(LOG_SPGW_APP, "Nat is OFF");
   }

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.c
@@ -77,11 +77,7 @@ static void add_tunnel_helper(
 
 static teid_t sgw_generate_new_s11_cp_teid(void);
 
-#if EMBEDDED_SGW
 #define TASK_MME TASK_MME_APP
-#else
-#define TASK_MME TASK_S11
-#endif
 
 //------------------------------------------------------------------------------
 uint32_t spgw_get_new_s1u_teid(spgw_state_t* state) {

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_config.c
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_config.c
@@ -53,12 +53,6 @@ void spgw_config_init(spgw_config_t* config_pP) {
 
 //------------------------------------------------------------------------------
 static int spgw_config_process(spgw_config_t* config_pP) {
-#if (!EMBEDDED_SGW)
-  async_system_command(TASK_ASYNC_SYSTEM, SPGW_WARN_ON_ERROR,
-                       "sysctl -w net.ipv4.ip_forward=1");
-  async_system_command(TASK_ASYNC_SYSTEM, SPGW_WARN_ON_ERROR, "sync");
-#endif
-
   if (RETURNok != sgw_config_process(&config_pP->sgw_config)) {
     return RETURNerror;
   }


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

This change removes redundant precompile statements using `EMBEDDED_SGW`. These are redundant because the mme build via make does not use certain source files depending on the value of `EMBEDDED_SGW`.

See https://github.com/magma/magma/blob/81bfb14b911cd5665b72bacf4020ce96fb0db6c9/lte/gateway/c/core/oai/tasks/CMakeLists.txt#L16 the sub-directory `oai/tasks/sgw` is included iff `EMBEDDED_SGW=True`.

Why? Currently, with Bazel, mme is build with all sources. If we want to keep this concept then the change is necessary because at least `pgw_config.c` does not compile with `EMBEDDED_SGW=False`.

## Test Plan

* CI
* optional: build with Bazel with `-DS6A_OVER_GRPC=False -DEMBEDDED_SGW=False` and `-DS6A_OVER_GRPC=True -DEMBEDDED_SGW=True`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
