### PR TITLE
fix(dp): change response from 500 to 409 when existing serial number modified

### DIFF
--- a/dp/cloud/go/services/dp/dp/main.go
+++ b/dp/cloud/go/services/dp/dp/main.go
@@ -49,7 +49,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error opening db connection: %s", err)
 	}
-	cbsdStore := dp_storage.NewCbsdManager(db, sqorc.GetSqlBuilder())
+	cbsdStore := dp_storage.NewCbsdManager(db, sqorc.GetSqlBuilder(), sqorc.GetErrorChecker())
 
 	interval := time.Second * time.Duration(serviceConfig.CbsdInactivityIntervalSec)
 	protos.RegisterCbsdManagementServer(srv.GrpcServer, servicers.NewCbsdManager(cbsdStore, interval))

--- a/dp/cloud/go/services/dp/obsidian/cbsd/handlers.go
+++ b/dp/cloud/go/services/dp/obsidian/cbsd/handlers.go
@@ -146,7 +146,7 @@ func createCbsd(c echo.Context) error {
 	ctx := c.Request().Context()
 	_, err = client.CreateCbsd(ctx, &req)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return getHttpError(err)
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -215,6 +215,8 @@ func getHttpError(err error) error {
 	switch s, _ := status.FromError(err); s.Code() {
 	case codes.NotFound:
 		return echo.NewHTTPError(http.StatusNotFound, err)
+	case codes.AlreadyExists:
+		return echo.NewHTTPError(http.StatusConflict, err)
 	default:
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}

--- a/dp/cloud/go/services/dp/servicers/cbsd_manager.go
+++ b/dp/cloud/go/services/dp/servicers/cbsd_manager.go
@@ -166,6 +166,8 @@ func makeErr(err error, wrap string) error {
 	code := codes.Internal
 	if err == merrors.ErrNotFound {
 		code = codes.NotFound
+	} else if err == merrors.ErrAlreadyExists {
+		code = codes.AlreadyExists
 	}
 	return status.Error(code, e.Error())
 }

--- a/dp/cloud/go/services/dp/servicers/cbsd_manager_test.go
+++ b/dp/cloud/go/services/dp/servicers/cbsd_manager_test.go
@@ -72,6 +72,20 @@ func (s *CbsdManagerTestSuite) TestCreateCbsd() {
 	s.Assert().Equal(getDBCbsd(), s.store.data)
 }
 
+func (s *CbsdManagerTestSuite) TestCreateWithDuplicateData() {
+	s.store.err = merrors.ErrAlreadyExists
+
+	request := &protos.CreateCbsdRequest{
+		NetworkId: networkId,
+		Data:      getProtoCbsd(),
+	}
+	_, err := s.manager.CreateCbsd(context.Background(), request)
+	s.Require().Error(err)
+
+	errStatus, _ := status.FromError(err)
+	s.Assert().Equal(codes.AlreadyExists, errStatus.Code())
+}
+
 func (s *CbsdManagerTestSuite) TestUpdateCbsd() {
 	request := &protos.UpdateCbsdRequest{
 		NetworkId: networkId,
@@ -99,6 +113,21 @@ func (s *CbsdManagerTestSuite) TestUpdateNonexistentCbsd() {
 
 	errStatus, _ := status.FromError(err)
 	s.Assert().Equal(codes.NotFound, errStatus.Code())
+}
+
+func (s *CbsdManagerTestSuite) TestUpdateWithDuplicateData() {
+	s.store.err = merrors.ErrAlreadyExists
+
+	request := &protos.UpdateCbsdRequest{
+		NetworkId: networkId,
+		Id:        cbsdId,
+		Data:      getProtoCbsd(),
+	}
+	_, err := s.manager.UpdateCbsd(context.Background(), request)
+	s.Require().Error(err)
+
+	errStatus, _ := status.FromError(err)
+	s.Assert().Equal(codes.AlreadyExists, errStatus.Code())
 }
 
 func (s *CbsdManagerTestSuite) TestDeleteCbsd() {

--- a/dp/cloud/go/services/dp/storage/db/fields.go
+++ b/dp/cloud/go/services/dp/storage/db/fields.go
@@ -20,6 +20,7 @@ type Field struct {
 	Nullable     bool
 	HasDefault   bool
 	DefaultValue interface{}
+	Unique       bool
 }
 
 func (f *Field) GetValue() interface{} {

--- a/dp/cloud/go/services/dp/storage/db/table.go
+++ b/dp/cloud/go/services/dp/storage/db/table.go
@@ -43,6 +43,10 @@ func addColumns(builder sqorc.CreateTableBuilder, fields FieldMap) sqorc.CreateT
 			colBuilder = colBuilder.Default(field.DefaultValue)
 		}
 		builder = colBuilder.EndColumn()
+
+		if field.Unique {
+			builder = builder.Unique(column)
+		}
 	}
 	return builder
 }

--- a/dp/cloud/go/services/dp/storage/models.go
+++ b/dp/cloud/go/services/dp/storage/models.go
@@ -195,6 +195,7 @@ func (c *DBCbsd) Fields() db.FieldMap {
 		"cbsd_serial_number": &db.Field{
 			BaseType: db.StringType{X: &c.CbsdSerialNumber},
 			Nullable: true,
+			Unique:   true,
 		},
 		"last_seen": &db.Field{
 			BaseType: db.TimeType{X: &c.LastSeen},

--- a/dp/cloud/python/magma/test_runner/tests/test_dp_with_orc8r.py
+++ b/dp/cloud/python/magma/test_runner/tests/test_dp_with_orc8r.py
@@ -131,10 +131,8 @@ class DomainProxyOrc8rTestCase(DBTestCase):
     def test_updating_cbsd_returns_409_when_setting_existing_serial_num(self):
         builder = CbsdAPIDataBuilder()
 
-        cbsd1_payload = builder.build_post_data()
-        cbsd2_payload = builder.build_post_data()
-        cbsd1_payload["serial_number"] = "foo"
-        cbsd2_payload["serial_number"] = "bar"
+        cbsd1_payload = builder.build_post_data_with_serial_number("foo")
+        cbsd2_payload = builder.build_post_data_with_serial_number("bar")
         self.when_cbsd_is_created(cbsd1_payload)  # cbsd_id = 1
         self.when_cbsd_is_created(cbsd2_payload)  # cbsd_id = 2
         self.when_cbsd_is_updated(
@@ -421,6 +419,11 @@ class CbsdAPIDataBuilder:
             'serial_number': SERIAL_NUMBER,
             'user_id': USER_ID,
         }
+
+    def build_post_data_with_serial_number(self, serial_number) -> Dict[str, Any]:
+        data = self.build_post_data()
+        data["serial_number"] = serial_number
+        return data
 
     def build_unregistered_data(self) -> Dict[str, Any]:
         data = self.build_post_data()

--- a/dp/cloud/python/magma/test_runner/tests/test_dp_with_orc8r.py
+++ b/dp/cloud/python/magma/test_runner/tests/test_dp_with_orc8r.py
@@ -212,7 +212,7 @@ class DomainProxyOrc8rTestCase(DBTestCase):
 
         return cbsd['id']
 
-    def when_cbsd_is_created(self, data: Dict[str, Any]):
+    def when_cbsd_is_created(self, data: Dict[str, Any], expected_status: int = HTTPStatus.CREATED):
         r = send_request_to_backend('post', 'cbsds', json=data)
         self.assertEqual(r.status_code, expected_status)
 

--- a/orc8r/cloud/go/sqorc/builder.go
+++ b/orc8r/cloud/go/sqorc/builder.go
@@ -52,25 +52,6 @@ func GetSqlBuilder() StatementBuilder {
 	}
 }
 
-// GetErrorChecker returns a squirrel Builder for the configured SQL dialect as
-// found in the SQL_DIALECT env var.
-func GetErrorChecker() ErrorChecker {
-	dialect, envFound := os.LookupEnv(SQLDialectEnv)
-	// Default to postgresql
-	if !envFound {
-		return PostgresErrorChecker{}
-	}
-
-	switch strings.ToLower(dialect) {
-	case PostgresDialect:
-		return PostgresErrorChecker{}
-	case SQLiteDialect:
-		return SQLiteErrorChecker{}
-	default:
-		panic(fmt.Sprintf("unsupported sql dialect %s", dialect))
-	}
-}
-
 // StatementBuilder is an interface which tracks squirrel's
 // StatementBuilderType with the difference that Insert returns this package's
 // InsertBuilder interface type.

--- a/orc8r/cloud/go/sqorc/builder.go
+++ b/orc8r/cloud/go/sqorc/builder.go
@@ -27,14 +27,16 @@ import (
 )
 
 const (
+	SQLDialectEnv   = "SQL_DIALECT"
 	PostgresDialect = "psql"
 	MariaDialect    = "maria"
+	SQLiteDialect   = "sqlite"
 )
 
 // GetSqlBuilder returns a squirrel Builder for the configured SQL dialect as
 // found in the SQL_DIALECT env var.
 func GetSqlBuilder() StatementBuilder {
-	dialect, envFound := os.LookupEnv("SQL_DIALECT")
+	dialect, envFound := os.LookupEnv(SQLDialectEnv)
 	// Default to postgresql
 	if !envFound {
 		return NewPostgresStatementBuilder()
@@ -45,6 +47,25 @@ func GetSqlBuilder() StatementBuilder {
 		return NewPostgresStatementBuilder()
 	case MariaDialect:
 		return NewMariaDBStatementBuilder()
+	default:
+		panic(fmt.Sprintf("unsupported sql dialect %s", dialect))
+	}
+}
+
+// GetErrorChecker returns a squirrel Builder for the configured SQL dialect as
+// found in the SQL_DIALECT env var.
+func GetErrorChecker() ErrorChecker {
+	dialect, envFound := os.LookupEnv(SQLDialectEnv)
+	// Default to postgresql
+	if !envFound {
+		return PostgresErrorChecker{}
+	}
+
+	switch strings.ToLower(dialect) {
+	case PostgresDialect:
+		return PostgresErrorChecker{}
+	case SQLiteDialect:
+		return SQLiteErrorChecker{}
 	default:
 		panic(fmt.Sprintf("unsupported sql dialect %s", dialect))
 	}

--- a/orc8r/cloud/go/sqorc/error_checker.go
+++ b/orc8r/cloud/go/sqorc/error_checker.go
@@ -1,0 +1,40 @@
+package sqorc
+
+import (
+	"magma/orc8r/lib/go/merrors"
+
+	"github.com/lib/pq"
+	"github.com/mattn/go-sqlite3"
+)
+
+const (
+	uniqueViolation = "unique_violation"
+)
+
+type ErrorChecker interface {
+	GetError(error) error
+}
+
+type SQLiteErrorChecker struct{}
+
+type PostgresErrorChecker struct{}
+
+func (c SQLiteErrorChecker) GetError(err error) error {
+	if e, ok := err.(sqlite3.Error); ok {
+		switch e.Code {
+		case sqlite3.ErrConstraint:
+			return merrors.ErrAlreadyExists
+		}
+	}
+	return err
+}
+
+func (c PostgresErrorChecker) GetError(err error) error {
+	if e, ok := err.(*pq.Error); ok {
+		switch e.Code.Name() {
+		case uniqueViolation:
+			return merrors.ErrAlreadyExists
+		}
+	}
+	return err
+}

--- a/orc8r/cloud/go/sqorc/error_checker.go
+++ b/orc8r/cloud/go/sqorc/error_checker.go
@@ -1,10 +1,14 @@
 package sqorc
 
 import (
-	"magma/orc8r/lib/go/merrors"
+	"fmt"
+	"os"
+	"strings"
 
 	"github.com/lib/pq"
 	"github.com/mattn/go-sqlite3"
+
+	"magma/orc8r/lib/go/merrors"
 )
 
 const (
@@ -18,6 +22,25 @@ type ErrorChecker interface {
 type SQLiteErrorChecker struct{}
 
 type PostgresErrorChecker struct{}
+
+// GetErrorChecker returns a squirrel Builder for the configured SQL dialect as
+// found in the SQL_DIALECT env var.
+func GetErrorChecker() ErrorChecker {
+	dialect, envFound := os.LookupEnv(SQLDialectEnv)
+	// Default to postgresql
+	if !envFound {
+		return PostgresErrorChecker{}
+	}
+
+	switch strings.ToLower(dialect) {
+	case PostgresDialect:
+		return PostgresErrorChecker{}
+	case SQLiteDialect:
+		return SQLiteErrorChecker{}
+	default:
+		panic(fmt.Sprintf("unsupported sql dialect %s", dialect))
+	}
+}
 
 func (c SQLiteErrorChecker) GetError(err error) error {
 	if e, ok := err.(sqlite3.Error); ok {

--- a/orc8r/cloud/go/sqorc/error_checker_test.go
+++ b/orc8r/cloud/go/sqorc/error_checker_test.go
@@ -1,0 +1,127 @@
+package sqorc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/lib/go/merrors"
+)
+
+const (
+	uniqueViolationNum = "23505"
+	otherPsqlErrorNum  = "22011"
+)
+
+type customError struct{}
+
+var _ error = customError{}
+
+func (c customError) Error() string {
+	return "custom error message"
+}
+
+type sqliteGetErrorTestCase struct {
+	name          string
+	checker       ErrorChecker
+	err           error
+	expectedError error
+}
+
+type psqlGetErrorTestCase struct {
+	name          string
+	checker       ErrorChecker
+	err           error
+	expectedError error
+}
+
+func TestSQLiteErrorCheckerCreation(t *testing.T) {
+	_ = os.Setenv(SQLDialectEnv, SQLiteDialect)
+	c := GetErrorChecker()
+	assert.IsType(t, SQLiteErrorChecker{}, c)
+}
+
+func TestPostgresErrorCheckerCreation(t *testing.T) {
+	_ = os.Setenv(SQLDialectEnv, PostgresDialect)
+	c := GetErrorChecker()
+	assert.IsType(t, PostgresErrorChecker{}, c)
+}
+
+func TestErrorCheckerNotCreatedWithUnknownDialect(t *testing.T) {
+	_ = os.Setenv(SQLDialectEnv, "someOtherDialect")
+	assert.Panics(t, func() { GetErrorChecker() })
+}
+
+func TestErrorCheckerDefaultsToPostgres(t *testing.T) {
+	c := GetErrorChecker()
+	assert.IsType(t, PostgresErrorChecker{}, c)
+}
+
+func TestSQLiteGetError(t *testing.T) {
+	testCases := []sqliteGetErrorTestCase{
+		{
+			name:    "test sqlite constraint error with SQLiteErrorChecker",
+			checker: SQLiteErrorChecker{},
+			err: sqlite3.Error{
+				Code: sqlite3.ErrConstraint,
+			},
+			expectedError: merrors.ErrAlreadyExists,
+		},
+		{
+			name:    "test other sqlite error with SQLiteErrorChecker",
+			checker: SQLiteErrorChecker{},
+			err: sqlite3.Error{
+				Code: sqlite3.ErrNotFound,
+			},
+			expectedError: sqlite3.Error{},
+		},
+		{
+			name:          "test any other error with SQLiteErrorChecker",
+			checker:       SQLiteErrorChecker{},
+			err:           customError{},
+			expectedError: customError{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.checker.GetError(tc.err)
+			assert.IsType(t, tc.expectedError, err)
+		})
+	}
+}
+
+func TestPostgresGetError(t *testing.T) {
+	testCases := []psqlGetErrorTestCase{
+		{
+			name:    "test postgres constraint error with PostgresErrorChecker",
+			checker: PostgresErrorChecker{},
+			err: &pq.Error{
+				Code: uniqueViolationNum,
+			},
+			expectedError: merrors.ErrAlreadyExists,
+		},
+		{
+			name:    "test other postgres error with PostgresErrorChecker",
+			checker: PostgresErrorChecker{},
+			err: &pq.Error{
+				Code: otherPsqlErrorNum,
+			},
+			expectedError: &pq.Error{},
+		},
+		{
+			name:          "test any other error with PostgresErrorChecker",
+			checker:       PostgresErrorChecker{},
+			err:           customError{},
+			expectedError: customError{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.checker.GetError(tc.err)
+			assert.IsType(t, tc.expectedError, err)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Wojciech Sadowy <wojciech.sadowy@freedomfi.com>

When a CreateCbsd request was issued to backend with a serial_number of an existing cbsd, (Internal server error) 500 error was returned. The same was true for updating a cbsd with a serial number of an already existing serial number. Changed the error to Conflict (409).

## Summary
Modified handlers.go

## Test Plan

Integration tests added
