### PR TITLE
fix(dp): Unregister CBSD on SAS reponse 103

### DIFF
--- a/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
+++ b/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
@@ -13,7 +13,7 @@ limitations under the License.
 
 import logging
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 from magma.configuration_controller.custom_types.custom_types import DBResponse
 from magma.configuration_controller.response_processor.response_db_processor import (
@@ -35,6 +35,39 @@ CHANNEL_TYPE = "channelType"
 OPERATION_PARAM = "operationParam"
 
 
+def unregister_cbsd_on_response_condition(process_response_func) -> Callable:
+    """
+    Unregister a CBSD on specific SAS response code conditions.
+
+    This decorator is applied to any process response functions
+    which should react to response codes that require Domain Proxy
+    to internally unregister the CBSD.
+
+    Currently a CBSD should be marked as unregistered on Domain Proxy if:
+    * SAS returns a response with responseCode 105 (ResponseCodes.DEREGISTER)
+    * SAS returns a response with responseCode 103 (ResponseCodes.INVALID_VALUE)
+      and responseData has "cbsdId" listed as the INVALID_VALUE parameter
+
+    Parameters:
+        process_response_func: Response processing function
+
+    Returns:
+        response processing function wrapper
+    """
+    def process_response_wrapper(obj: ResponseDBProcessor, response: DBResponse, session: Session) -> None:
+        if any([
+            response.response_code == ResponseCodes.DEREGISTER.value,
+            _is_response_invalid_value_cbsd_id(response),
+        ]):
+            logger.info(f'SAS {response.payload} implies CBSD immedaite unregistration')
+            _unregister_cbsd(response, session)
+            return
+        process_response_func(obj, response, session)
+
+    return process_response_wrapper
+
+
+@unregister_cbsd_on_response_condition
 def process_registration_response(obj: ResponseDBProcessor, response: DBResponse, session: Session) -> None:
     """
     Process registration response
@@ -46,11 +79,11 @@ def process_registration_response(obj: ResponseDBProcessor, response: DBResponse
     """
 
     cbsd_id = response.payload.get("cbsdId", None)
-    if response.response_code == ResponseCodes.DEREGISTER.value:
-        _unregister_cbsd(response, session)
-    elif response.response_code == ResponseCodes.SUCCESS.value and cbsd_id:
+    if response.response_code == ResponseCodes.SUCCESS.value and cbsd_id:
         payload = response.request.payload
         cbsd = _find_cbsd_from_request(session, payload)
+        if not cbsd:
+            return
         cbsd.cbsd_id = cbsd_id
         _change_cbsd_state(cbsd, session, CbsdStates.REGISTERED.value)
 
@@ -58,12 +91,13 @@ def process_registration_response(obj: ResponseDBProcessor, response: DBResponse
 def _find_cbsd_from_request(session: Session, payload: Dict) -> DBCbsd:
     if "cbsdSerialNumber" in payload:
         return session.query(DBCbsd).filter(
-            DBCbsd.cbsd_serial_number == payload["cbsdSerialNumber"],
+            DBCbsd.cbsd_serial_number == payload.get("cbsdSerialNumber"),
         ).scalar()
     if "cbsdId" in payload:
         return session.query(DBCbsd).filter(
-            DBCbsd.cbsd_id == payload["cbsdId"],
+            DBCbsd.cbsd_id == payload.get("cbsdId"),
         ).scalar()
+    logger.warning(f'Could not find CBSD in Database matching {payload=}.')
 
 
 def _change_cbsd_state(cbsd: DBCbsd, session: Session, new_state: str) -> None:
@@ -76,6 +110,7 @@ def _change_cbsd_state(cbsd: DBCbsd, session: Session, new_state: str) -> None:
     cbsd.state = state
 
 
+@unregister_cbsd_on_response_condition
 def process_spectrum_inquiry_response(obj: ResponseDBProcessor, response: DBResponse, session: Session) -> None:
     """
     Process spectrum inquiry response
@@ -86,10 +121,10 @@ def process_spectrum_inquiry_response(obj: ResponseDBProcessor, response: DBResp
         session: Database session
     """
 
-    if response.response_code == ResponseCodes.DEREGISTER.value:
-        _unregister_cbsd(response, session)
-    elif response.response_code == ResponseCodes.SUCCESS.value:
+    if response.response_code == ResponseCodes.SUCCESS.value:
         _create_channels(response, session)
+        return
+    logger.warning(f'process_spectrum_inquiry_response: Received an unsuccessful SAS response, {response.payload}=')
 
 
 def _create_channels(response: DBResponse, session: Session):
@@ -116,6 +151,7 @@ def _create_channels(response: DBResponse, session: Session):
         session.add(channel)
 
 
+@unregister_cbsd_on_response_condition
 def process_grant_response(obj: ResponseDBProcessor, response: DBResponse, session: Session) -> None:
     """
     Process grant response
@@ -128,10 +164,6 @@ def process_grant_response(obj: ResponseDBProcessor, response: DBResponse, sessi
     Returns:
         None
     """
-
-    if response.response_code == ResponseCodes.DEREGISTER.value:
-        _unregister_cbsd(response, session)
-        return
 
     if response.response_code != ResponseCodes.SUCCESS.value:
         cbsd = response.request.cbsd
@@ -157,6 +189,7 @@ def process_grant_response(obj: ResponseDBProcessor, response: DBResponse, sessi
     grant.state = new_state
 
 
+@unregister_cbsd_on_response_condition
 def process_heartbeat_response(obj: ResponseDBProcessor, response: DBResponse, session: Session) -> None:
     """
     Process heartbeat response
@@ -169,10 +202,6 @@ def process_heartbeat_response(obj: ResponseDBProcessor, response: DBResponse, s
     Returns:
         None
     """
-
-    if response.response_code == ResponseCodes.DEREGISTER.value:
-        _unregister_cbsd(response, session)
-        return
 
     grant = _get_or_create_grant_from_response(obj, response, session)
     if not grant:
@@ -199,6 +228,7 @@ def process_heartbeat_response(obj: ResponseDBProcessor, response: DBResponse, s
     grant.last_heartbeat_request_time = datetime.now()
 
 
+@unregister_cbsd_on_response_condition
 def process_relinquishment_response(obj: ResponseDBProcessor, response: DBResponse, session: Session) -> None:
     """
     Process relinquishment response
@@ -212,10 +242,6 @@ def process_relinquishment_response(obj: ResponseDBProcessor, response: DBRespon
         None
     """
 
-    if response.response_code == ResponseCodes.DEREGISTER.value:
-        _unregister_cbsd(response, session)
-        return
-
     grant = _get_or_create_grant_from_response(obj, response, session)
     if not grant:
         return
@@ -223,9 +249,6 @@ def process_relinquishment_response(obj: ResponseDBProcessor, response: DBRespon
 
     if response.response_code == ResponseCodes.SUCCESS.value:
         new_state = obj.grant_states_map[GrantStates.IDLE.value]
-    elif response.response_code == ResponseCodes.DEREGISTER.value:
-        _terminate_all_grants_from_response(response, session)
-        return
     else:
         new_state = grant.state
     logger.info(
@@ -244,7 +267,9 @@ def process_deregistration_response(obj: ResponseDBProcessor, response: DBRespon
         session: Database session
     """
 
-    print(f"Processing response {response.payload}")
+    logger.info(
+        f'process_deregistration_response: Unregistering {response.payload}',
+    )
     _unregister_cbsd(response, session)
 
 
@@ -321,5 +346,17 @@ def _terminate_all_grants_from_response(response: DBResponse, session: Session) 
 def _unregister_cbsd(response: DBResponse, session: Session) -> None:
     payload = response.request.payload
     cbsd = _find_cbsd_from_request(session, payload)
+    if not cbsd:
+        return
     _terminate_all_grants_from_response(response, session)
     _change_cbsd_state(cbsd, session, CbsdStates.UNREGISTERED.value)
+
+
+def _is_response_invalid_value_cbsd_id(response: DBResponse) -> bool:
+    if response.response_code != ResponseCodes.INVALID_VALUE.value:
+        return False
+
+    response_data = response.payload.get(
+        "response", {},
+    ).get("responseData", [])
+    return CBSD_ID in response_data


### PR DESCRIPTION
Fixed an issue where SAS returns responseCode 103 (INVALID_VALUE) for
cbsdId parameter for CBSDs that got deregistered on SAS side, and CBSD
remains stuck on Domain Proxy side in registered state, as SAS never
reported a DEREGISTER response code prior.

reponseCode 103 handing with "cbsdId" as the invalid parameter is now
made identical with responseCode 105 handling - CBSD gets
unregistered on Domain Proxy side.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

* Set CBSD state to "Unregistered" when spectrum inquiry or grant or hearbeat or relinquishment requests get a SAS response with responseCode 103 and responseData object contains "cbsdId" as the invalid paramterer name
* Fixed unit tests 

## Additional Information

- [ ] This change is backwards-breaking