### PR TITLE
fix(agw): Fixed CI dashboard reporting and cleanups for flaky retry support

### DIFF
--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -60,10 +60,13 @@ def lte_integ_test(args):
     report = url_to_html_redirect(args.run_id, args.url)
     # Possible args.verdict values are success, failure, or canceled
     verdict = 'inconclusive'
-    if args.verdict.lower() == 'success':
-        verdict = 'pass'
-    elif args.verdict.lower() == 'failure':
-        verdict = 'fail'
+
+    # As per the recent change, CI process runs all integ tests ignoring the
+    # failing test cases, because of which CI report always shows lte integ
+    # test as success. Here we read the CI status from file for more accurate
+    # lte integ test execution status
+    with open('test_status.txt', 'r') as file:
+        verdict = file.read().rstrip()
     publish_report('lte_integ_test', args.build_id, verdict, report)
 
 

--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -26,7 +26,7 @@ $(PYTHON_BUILD)/setupinteg_env:
 RESULTS_DIR := /var/tmp/test_results
 define execute_test
 	echo "Running test: $(1)"
-	timeout --foreground -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(PYTHON_BUILD)/bin/nosetests --with-flaky --force-flaky --no-success-flaky-report --max-runs=1 --min-passes=1 --with-xunit --xunit-file=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x -s $(1) || exit 1
+	timeout --foreground -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(PYTHON_BUILD)/bin/nosetests --with-flaky --force-flaky --no-success-flaky-report --max-runs=1 --min-passes=1 --with-xunit --xunit-file=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x -s $(1) || (echo "fail" > $(MAGMA_ROOT)/test_status.txt && exit 1)
 	sleep 1
 endef
 
@@ -45,6 +45,7 @@ integ_test: $(PYTHON_BUILD)/setupinteg_env $(BIN)/nosetests
 ifdef TESTS
 	$(call execute_test,$(TESTS))
 else
+	echo "pass" > $(MAGMA_ROOT)/test_status.txt
 	$(foreach test,$(EXTENDED_TESTS) $(PRECOMMIT_TESTS),$(call execute_test,$(test));)
 endif
 

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -33,6 +33,8 @@ from util.traffic_messages import (
 
 # Tests shouldn't take longer than a few minutes
 TRAFFIC_TEST_TIMEOUT_SEC = 180
+# For verify function to run properly, setting 5 sec less iperf data timeout
+IPERF_DATA_TIMEOUT_SEC = TRAFFIC_TEST_TIMEOUT_SEC - 5
 
 """
 Using TrafficUtil
@@ -54,17 +56,20 @@ API.
 
 
 class TrafficUtil(object):
-    """ Utility wrapper for tests requiring traffic generation """
+    """Utility wrapper for tests requiring traffic generation"""
 
     # Trfgen library setup
     _trfgen_lib_name = "libtrfgen.so"
     _trfgen_tests = ()
+    # This is set to True if the data traffic fails with some error
+    # and leaving behind running iperf3 server(s) in TRF server VM
+    need_to_close_iperf3_server = False
 
     # Traffic setup
     _remote_ip = ipaddress.IPv4Address("192.168.129.42")
 
     def __init__(self):
-        """ Initialize the trfgen library and its callbacks """
+        """Initialize the trfgen library and its callbacks"""
         # _test_lib is the private variable containing the ctypes reference to
         # the trfgen library.
         self._test_lib = None
@@ -110,8 +115,10 @@ class TrafficUtil(object):
 
         Args:
             command: command (str) to be executed on remote host
-            e.g. 'sed -i \'s/str1/str2/g\' /usr/local/bin/traffic_server.py'
+                e.g. 'sed -i \'s/str1/str2/g\' /usr/local/bin/traffic_server.py'
 
+        Returns:
+            Shell command execution output
         """
         data = self._cmd_data
         data["command"] = '"' + command + '"'
@@ -124,17 +131,22 @@ class TrafficUtil(object):
         )
 
     def update_dl_route(self, ue_ip_block):
-        """ Update downlink route in TRF server """
+        """Update downlink route in TRF server"""
         ret_code = self.exec_command(
             "sudo ip route flush via 192.168.129.1 && sudo ip route "
             "replace " + ue_ip_block + " via 192.168.129.1 dev eth2",
         )
-        if ret_code != 0:
-            return False
-        return True
+        return ret_code == 0
+
+    def close_running_iperf_servers(self):
+        """Close running Iperf3 servers in TRF server VM"""
+        ret_code = self.exec_command(
+            "pidof iperf3 && pidof iperf3 | xargs sudo kill -9",
+        )
+        return ret_code == 0
 
     def _init_lib(self):
-        """ Initialize the trfgen library by loading in binary compiled from C
+        """Initialize the trfgen library by loading in binary compiled from C
         """
         lib_path = os.environ["S1AP_TESTER_ROOT"]
         lib = os.path.join(lib_path, "bin", TrafficUtil._trfgen_lib_name)
@@ -143,7 +155,7 @@ class TrafficUtil(object):
         self._test_lib.trfgen_init()
 
     def _setup_configure_test(self):
-        """ Set up the call to trfgen_configure_test
+        """Set up the call to trfgen_configure_test
 
         The function prototype is:
             void trfgen_configure_test(int test_id, struct_test test_parms)
@@ -156,7 +168,7 @@ class TrafficUtil(object):
         self._config_test.argtypes = (ctypes.c_int32, s1ap_types.struct_test)
 
     def _setup_start_test(self):
-        """ Set up the call to trfgen_start_test
+        """Set up the call to trfgen_start_test
 
         The function prototype is:
             void trfgen_start_test(
@@ -176,14 +188,19 @@ class TrafficUtil(object):
         )
 
     def cleanup(self):
-        """ Cleanup the dll loaded explicitly so the next run doesn't reuse the
-        same globals as ctypes LoadLibrary uses dlopen under the covers """
+        """Cleanup the dll loaded explicitly so the next run doesn't reuse the
+        same globals as ctypes LoadLibrary uses dlopen under the covers"""
         # self._test_lib.dlclose(self._test_lib._handle)
+        if TrafficUtil.need_to_close_iperf3_server:
+            print("Closing all the running Iperf3 servers and forked processes")
+            if not self.close_running_iperf_servers():
+                print("Failed to stop running Iperf3 servers in TRF Server VM")
+            self._test_lib.cleaningAllProcessIds()
         self._test_lib = None
         self._data = None
 
     def configure_test(self, is_uplink, duration, is_udp):
-        """ Returns the test configuration index for the configurations
+        """Return the test configuration index for the configurations
         provided. This is the index that is in the trfgen internal state. If a
         configuration is new, will attempt to create a new one in trfgen
 
@@ -192,10 +209,12 @@ class TrafficUtil(object):
             duration (int): test duration, in seconds
             is_udp (bool): use UDP if True, TCP if False
 
-        Returns: an int, the index of the test configuration in trfgen, a.k.a.
+        Returns:
+            An int, the index of the test configuration in trfgen, a.k.a.
             the test_id
 
-        Raises MemoryError if return test index would exceed
+        Raises:
+            MemoryError: if return test index would exceed
             s1ap_types.MAX_TEST_CFG
         """
         test = s1ap_types.struct_test()
@@ -239,19 +258,24 @@ class TrafficUtil(object):
         )
 
     def generate_traffic_test(
-        self, ips, is_uplink=False, duration=120, is_udp=False,
+        self,
+        ips,
+        is_uplink=False,
+        duration=120,
+        is_udp=False,
     ):
-        """ Creates a TrafficTest object for the given UE IPs and test type
+        """Create a TrafficTest object for the given UE IPs and test type
 
         Args:
-            ips (list(ipaddress.ip_address)): the IP addresses of the UEs to
+            ips: (list(ipaddress.ip_address)): the IP addresses of the UEs to
                 which to connect
-            is_uplink (bool): whether to do an uplink test. Defaults to False
-            duration (int): duration, in seconds, of the test. Defaults to 120
-            is_udp (bool): whether to use UDP. If False, uses TCP. Defaults to
+            is_uplink: (bool): whether to do an uplink test. Defaults to False
+            duration: (int): duration, in seconds, of the test. Defaults to 120
+            is_udp: (bool): whether to use UDP. If False, uses TCP. Defaults to
                 False
 
-        Returns: a TrafficTest object, which is used to interact with the
+        Returns:
+            A TrafficTest object, which is used to interact with the
             trfgen test
         """
         test_id = self.configure_test(is_uplink, duration, is_udp)
@@ -263,26 +287,26 @@ class TrafficUtil(object):
 
 
 class TrafficTest(object):
-    ''' Class for representing a trfgen test with which to interact
+    """Class for representing a trfgen test with which to interact
 
     This is the class that directly interacts with the TrafficTestServer via a
     socketed connection, when the test starts (i.e. the "client" for the
     "server").
-    '''
+    """
 
     _alias_counter = 0
     _alias_lock = threading.Lock()
     _iproute = pyroute2.IPRoute()
-    _net_iface = 'eth2'
+    _net_iface = "eth2"
     _port = 7000
     _port_lock = threading.Lock()
 
     # Remote iperf3 superserver (IP, port) tuple. Port 62462 is chosen because
     # 'MAGMA' translates to 62462 on a 12-key phone pad
-    _remote_server = ('192.168.60.144', 62462)
+    _remote_server = ("192.168.60.144", 62462)
 
     def __init__(self, test_runner, instances, test_ids):
-        ''' Creates a new TrafficTest object for running the test instance(s)
+        """Create a new TrafficTest object for running the test instance(s)
         with the associated test_ids
 
         Ports will be assigned when the test is run by communicating with the
@@ -291,10 +315,10 @@ class TrafficTest(object):
         Args:
             test_runner: the ctypes hook into the traffic gen trfgen_start_test
                 function
-            instances (list(TrafficTestInstance)): the instances to run
-            test_ids (list(int)): the associated trfgen test configuration
+            instances: (list(TrafficTestInstance)): the instances to run
+            test_ids: (list(int)): the associated trfgen test configuration
                 indices; must be the same length as instances
-        '''
+        """
         assert len(instances) is len(test_ids)
         self._done = threading.Event()
         self._instances = tuple(instances)
@@ -304,51 +328,55 @@ class TrafficTest(object):
         self._test_lock = threading.RLock()  # Provide mutex between tests
 
     def __enter__(self):
-        ''' Starts execution of the test '''
+        """Start execution of the test"""
         self.start()
         return self
 
     def __exit__(self, *_):
-        ''' Waits for test to end '''
+        """Wait for test to end"""
         self.wait()
 
     @staticmethod
     def _get_port():
-        ''' Returns the next port for testing '''
+        """Return the next port for testing"""
         with TrafficTest._port_lock:
             TrafficTest._port += 1
             return TrafficTest._port
 
     @staticmethod
     def _iface_up(ip):
-        ''' Brings up an iface for the given IP
+        """Brings up an iface for the given IP
 
         Args:
             ip (ipaddress.ip_address): the IP address to use for bringing up
                 the iface
 
-        Returns the iface name with alias that was brought up
-        '''
+        Returns:
+            The iface name with alias that was brought up
+        """
         # Generate a unique alias
         with TrafficTest._alias_lock:
             TrafficTest._alias_counter += 1
             net_iface = TrafficTest._net_iface
             alias = TrafficTest._alias_counter
-        net_alias = '%s:UE%d' % (net_iface, alias)
+        net_alias = "%s:UE%d" % (net_iface, alias)
 
         # Bring up the iface alias
         net_iface_index = TrafficTest._iproute.link_lookup(
             ifname=TrafficTest._net_iface,
         )[0]
         TrafficTest._iproute.addr(
-            'add', index=net_iface_index, label=net_alias, address=ip.exploded,
+            "add",
+            index=net_iface_index,
+            label=net_alias,
+            address=ip.exploded,
         )
 
         return net_alias
 
     @staticmethod
     def _network_from_ip(ip, mask_len):
-        ''' Returns the ipaddress.ip_network with the given mask that contains
+        """Return the ipaddress.ip_network with the given mask that contains
         the given IP address
 
         Args:
@@ -356,44 +384,46 @@ class TrafficTest(object):
                 the network
             mask_len (int): the number of bits to mask
 
-        Returns an ipaddress.ip_network; works agnostic to IPv4 or IPv6
-        '''
+        Returns:
+            An ipaddress.ip_network; works agnostic to IPv4 or IPv6
+        """
         # Convert to int to make bit shifting easier
-        ip_int = int.from_bytes(ip.packed, 'big')  # Packed is big-endian
+        ip_int = int.from_bytes(ip.packed, "big")  # Packed is big-endian
         ip_masked = ipaddress.ip_address(ip_int >> mask_len << mask_len)
 
         # Compute the appropriate prefix length
         prefix_len = ip.max_prefixlen - mask_len
 
-        return ipaddress.ip_network('%s/%d' % (ip_masked.exploded, prefix_len))
+        return ipaddress.ip_network("%s/%d" % (ip_masked.exploded, prefix_len))
 
     def _run(self):
-        ''' Run the traffic test
+        """Run the traffic test
 
         Sets up traffic test with remote traffic server and local ifaces, then
         runs the runner hook into the trfgen binary and collects the results to
         cache
 
         Will block until the test ends
-        '''
+        """
         # Create a snapshot of the test's states, in case they get changed or
         # wiped in a later operation. Basically, render tests immune to later
         # operations after the test has started.
         with self._test_lock:
-            instances = copy.deepcopy(self._instances)
+            self.instances = copy.deepcopy(self._instances)
             test_ids = copy.deepcopy(self._test_ids)
 
         try:
             # Set up sockets and associated streams
-            sc = socket.create_connection(self._remote_server)
-            sc_in = sc.makefile('rb')
-            sc_out = sc.makefile('wb')
+            self.sc = socket.create_connection(self._remote_server)
+            self.sc_in = self.sc.makefile("rb")
+            self.sc_out = self.sc.makefile("wb")
+            self.sc.settimeout(IPERF_DATA_TIMEOUT_SEC)
 
             # Flush all the addresses left by previous failed tests
             net_iface_index = TrafficTest._iproute.link_lookup(
                 ifname=TrafficTest._net_iface,
             )[0]
-            for instance in instances:
+            for instance in self.instances:
                 TrafficTest._iproute.flush_addr(
                     index=net_iface_index,
                     address=instance.ip.exploded,
@@ -401,7 +431,7 @@ class TrafficTest(object):
 
             # Set up network ifaces and get UL port assignments for DL
             aliases = ()
-            for instance in instances:
+            for instance in self.instances:
                 aliases += (TrafficTest._iface_up(instance.ip),)
                 if not instance.is_uplink:
                     # Assign a local port for the downlink UE server
@@ -409,39 +439,48 @@ class TrafficTest(object):
 
             # Create and send TEST message
             msg = TrafficRequest(
-                TrafficRequestType.TEST, payload=instances,
+                TrafficRequestType.TEST,
+                payload=self.instances,
             )
-            msg.send(sc_out)
+            msg.send(self.sc_out)
 
             # Receive SERVER message and update test instances
-            msg = TrafficMessage.recv(sc_in)
+            msg = TrafficMessage.recv(self.sc_in)
             assert msg.message is TrafficResponseType.SERVER
             r_id = msg.id  # Remote server test identifier
             server_instances = msg.payload  # (TrafficServerInstance, ...)
 
             # Locally keep references to arguments passed into trfgen
-            args = [None] * len(instances)
+            num_instances = len(self.instances)
+            args = [None for _ in range(num_instances)]
 
             # Post-SERVER, pre-START logic
-            for i in range(len(instances)):
-                instance = instances[i]
+            for i in range(num_instances):
+                instance = self.instances[i]
                 server_instance = server_instances[i]
 
                 # Add ip network route
                 net_iface_index = TrafficTest._iproute.link_lookup(
                     ifname=TrafficTest._net_iface,
                 )[0]
-                server_instance_network = \
-                    TrafficTest._network_from_ip(server_instance.ip, 8)
+                server_instance_network = TrafficTest._network_from_ip(
+                    server_instance.ip,
+                    8,
+                )
                 TrafficTest._iproute.route(
-                    'replace', dst=server_instance_network.exploded,
-                    iif=net_iface_index, oif=net_iface_index, scope='link',
+                    "replace",
+                    dst=server_instance_network.exploded,
+                    iif=net_iface_index,
+                    oif=net_iface_index,
+                    scope="link",
                 )
 
                 # Add arp table entry
                 os.system(
-                    '/usr/sbin/arp -s %s %s' % (
-                        server_instance.ip.exploded, server_instance.mac,
+                    "/usr/sbin/arp -s %s %s"
+                    % (
+                        server_instance.ip.exploded,
+                        server_instance.mac,
                     ),
                 )
 
@@ -450,67 +489,62 @@ class TrafficTest(object):
                     instance.port = server_instance.port
                 else:
                     args[i] = self._run_test(
-                        test_ids[i], server_instance.ip, instance.ip,
+                        test_ids[i],
+                        server_instance.ip,
+                        instance.ip,
                         instance.port,
                     )
 
             # Send START for the given r_id
             msg = TrafficRequest(
-                TrafficRequestType.START, identifier=r_id,
+                TrafficRequestType.START,
+                identifier=r_id,
             )
-            msg.send(sc_out)
+            msg.send(self.sc_out)
 
             # Wait for STARTED response
-            msg = TrafficMessage.recv(sc_in)
+            msg = TrafficMessage.recv(self.sc_in)
             assert msg.message is TrafficResponseType.STARTED
             assert msg.id == r_id
 
             # Post-STARTED, pre-RESULTS logic
-            for i in range(len(instances)):
-                instance = instances[i]
+            for i in range(num_instances):
+                instance = self.instances[i]
                 if instance.is_uplink:
                     args[i] = self._run_test(
-                        test_ids[i], server_instances[i].ip, instance.ip,
+                        test_ids[i],
+                        server_instances[i].ip,
+                        instance.ip,
                         server_instances[i].port,
                     )
 
             # Wait for RESULTS message
-            msg = TrafficMessage.recv(sc_in)
+            msg = TrafficMessage.recv(self.sc_in)
             assert msg.message is TrafficResponseType.RESULTS
             assert msg.id == r_id
             results = msg.payload
 
-            # Signal to end connection
-            msg = TrafficRequest(TrafficRequestType.EXIT)
-            msg.send(sc_out)
-
-            # Close out network ifaces
-            net_iface_index = TrafficTest._iproute.link_lookup(
-                ifname=TrafficTest._net_iface,
-            )[0]
-            # For some reason the first call to flush this address flushes all
-            # the addresses brought up during testing. But subsequent flushes
-            # do nothing if the address doesn't exist
-            for instance in instances:
-                TrafficTest._iproute.flush_addr(
-                    index=net_iface_index,
-                    address=instance.ip.exploded,
-                )
-            # Do socket cleanup
-            sc_in.close()
-            sc_out.close()
-            sc.shutdown(socket.SHUT_RDWR)  # Ensures safe socket closure
-            sc.close()
+            # Call cleanup to close network interfaces and open sockets
+            self.cleanup()
 
             # Cache results after cleanup
             with self._test_lock:
                 self._results = results
+
+        except socket.timeout:
+            print("Running iperf data failed with timeout")
+            TrafficUtil.need_to_close_iperf3_server = True
+            self.cleanup()
+        except Exception as e:
+            print("Running iperf data failed. Error: " + str(e))
+            TrafficUtil.need_to_close_iperf3_server = True
+            self.cleanup()
         finally:
             # Signal that we're done
             self._done.set()
 
     def _run_test(self, test_id, host_ip, ue_ip, port):
-        ''' Run the test at the given index by calling the test runner on the
+        """Run the test at the given index by calling the test runner on the
         test parameters for the instance at the given index and port
 
         Args:
@@ -522,11 +556,14 @@ class TrafficTest(object):
             port (int): the UE's port (downlink) or the remote server's port
                 (uplink) [-p]
 
-        Returns the raw arguments passed into the trfgen binary, for the caller
+        Returns:
+            The raw arguments passed into the trfgen binary, for the caller
             to keep track of and avoid garbage collection
-        '''
+        """
         args = (
-            test_id, host_ip.exploded.encode(), ue_ip.exploded.encode(),
+            test_id,
+            host_ip.exploded.encode(),
+            ue_ip.exploded.encode(),
             str(port).encode(),
         )
         self._runner(*args)
@@ -534,19 +571,20 @@ class TrafficTest(object):
 
     @staticmethod
     def combine(test, *tests):
-        ''' Combines TrafficTest objects to produce a single test object that
+        """Combine TrafficTest objects to produce a single test object that
         will run the parameters given in the tests all at the same time
 
         All tests in the argument will become unrunnable, as their instances
         will be stripped!
 
         Args:
-            test (TrafficTest): a test, included to force at least one test to
+            test: (TrafficTest): a test, included to force at least one test to
                 be passed as an argument
-            tests (list(TrafficTest)): any remaining tests to combine
+            tests: (list(TrafficTest)): any remaining tests to combine
 
-        Return a single TrafficTest that will run all the instances together
-        '''
+        Returns:
+            A single TrafficTest that will run all the instances together
+        """
         runner = test._runner
 
         tests = (test,) + tests
@@ -566,37 +604,71 @@ class TrafficTest(object):
 
     @property
     def results(self):
+        """Return the traffic results data"""
         return self._results
 
     def start(self):
-        ''' Start this test by spinning off runner thread '''
+        """Start this test by spinning off runner thread"""
         self._done.clear()
         threading.Thread(target=self._run).start()
 
     def verify(self):
-        ''' Verify the results of this test
+        """Verify the results of this test
 
-        Raises a RuntimeError if any tests returned with an error message
-        '''
+        Raises:
+            RuntimeError: if any tests returned with an error message
+        """
         self.wait()
         with self._test_lock:
             if not isinstance(self.results, tuple):
+                if not self._done.is_set():
+                    TrafficUtil.need_to_close_iperf3_server = True
+                    self._done.set()
+                    self.cleanup()
                 raise RuntimeError(
-                    'Cached results object is not a tuple : {}'.format(
+                    "Cached results object is not a tuple : {0}".format(
                         self.results,
                     ),
                 )
             for result in self.results:
                 if not isinstance(result, iperf3.TestResult):
                     raise RuntimeError(
-                        'Cached results are not iperf3.TestResult objects',
+                        "Cached results are not iperf3.TestResult objects",
                     )
                 if result.error:
+                    TrafficUtil.need_to_close_iperf3_server = True
                     # iPerf dumps out-of-order packet information on stderr,
                     # ignore these while verifying the test results
                     if "OUT OF ORDER" not in result.error:
                         raise RuntimeError(result.error)
 
     def wait(self):
-        ''' Wait for this test to complete '''
+        """Wait for this test to complete"""
         self._done.wait(timeout=TRAFFIC_TEST_TIMEOUT_SEC)
+
+    def cleanup(self):
+        """Cleanup sockets and network interfaces"""
+        # Signal to end connection
+        msg = TrafficRequest(TrafficRequestType.EXIT)
+        msg.send(self.sc_out)
+
+        # Close out network ifaces
+        net_iface = TrafficTest._iproute.link_lookup(
+            ifname=TrafficTest._net_iface,
+        )
+        if net_iface:
+            net_iface_index = net_iface[0]
+            # For some reason the first call to flush this address flushes all
+            # the addresses brought up during testing. But subsequent flushes
+            # do nothing if the address doesn't exist
+            for instance in self.instances:
+                TrafficTest._iproute.flush_addr(
+                    index=net_iface_index,
+                    address=instance.ip.exploded,
+                )
+
+        # Do socket cleanup
+        self.sc_in.close()
+        self.sc_out.close()
+        self.sc.shutdown(socket.SHUT_RDWR)  # Ensures safe socket closure
+        self.sc.close()


### PR DESCRIPTION
## Title
fix(agw): Fixed CI dashboard reporting and cleanups for flaky retry support

## Summary
The 2 recent PRs for adding cleanup for flaky retry support (#11774) and fixing ci dashboard reporting (#11975) were reverted as part of PRs #12107 and #12108 for bringing temporary stability to CI. The changes have been reverified over CI under branch [integ_test_retries_test](https://github.com/magma/magma/tree/integ_test_retries_test) with PR #12357 and now ready to be merged again. Reference CI workflows:
https://github.com/magma/magma/runs/5775912937?check_suite_focus=true

## Test plan
Verified with sanity and CI

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>