### PR TITLE
fix(agw): Added python version requirement infromation

### DIFF
--- a/lte/gateway/docker/python-precommit/README.md
+++ b/lte/gateway/docker/python-precommit/README.md
@@ -26,12 +26,12 @@ cd $MAGMA/lte/gateway/python
 # to run the flake8 linter by specifying paths
 ./precommit.py --lint -p PATH1 PATH2
 # to run the flake8 linter on all modified files in the current commit
-./precommit.py --lint--diff
+./precommit.py --lint --diff
 
 # to run all available formatters by specifying paths
 ./precommit.py --format -p PATH1 PATH2
 # to run all available formatters on all modified files in the current commit
-./precommit.py --format--diff
+./precommit.py --format --diff
 ```
 
 Note: Python version >= 3.7 is needed to run the above precommit.py script

--- a/lte/gateway/docker/python-precommit/README.md
+++ b/lte/gateway/docker/python-precommit/README.md
@@ -34,6 +34,8 @@ cd $MAGMA/lte/gateway/python
 ./precommit.py --format--diff
 ```
 
+Note: Python version >= 3.7 is needed to run the above precommit.py script
+
 ## How to add/update Python dependencies via `requirements.in`
 `requirements.in` is the file that manages most `Python` package dependencies for this Dockerfile.
 If you need to add or update dependencies in `requirements.in`, always run the following commands.

--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Note: Python version >= 3.7 is needed to run this script
 """
 Copyright 2020 The Magma Authors.
 


### PR DESCRIPTION
## Title
fix(agw): Added python version requirement information

## Summary
The precommit script uses arguments that needs Python version 3.7 or above. This PR adds informative comment regarding python version requirement

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>