### PR TITLE
ci: stale bot is far to agressive

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,21 +1,45 @@
 ---
-# Number of days of inactivity before an issue becomes stale
-daysUntilStale: 45
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
-# Issues with these labels will never be considered stale
+#  ISC License
+#
+#  Copyright (c) 2017, Brandon Keepers
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
-  - status: willfix
-# Label to use when marking an issue as stale
+  - willfix
+  - bazel-cleanup
+  - "good first issue"
+  - ready2merge
+  - sentry
+  - sentry-clenup-python
+  - "type: proposal"
+# Label to use when marking as stale
 staleLabel: wontfix
-# Comment to post when marking an issue as stale. Set to `false` to disable
+# Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This pull request has been automatically marked as stale because it has not
-  had any recent activity by the author or maintainer in the past 45 days.
-  It will be closed if no further activity occurs in the next 7 days.
-  Thank you for your contributions.
+  This issue or pull request has been automatically marked as stale because it has not
+  had any recent activity. It will be closed if no further activity occurs in the next 14 days.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
-  This pull request has exceeded its lifecylce and will be closed.
-  Should you wish to continue working on this, please reopen it or start a new pull request.
-  Thank you again for your contributions.
+  This issue or pull request has exceeded its lifecylce and was automatically closed.
+  Should you wish to continue working on this, please reopen it.


### PR DESCRIPTION
## Summary

[Stale bot](https://github.com/probot/stale) was introduced without TSC vote or any community announcement with https://github.com/magma/magma/pull/11933. Amongst the [over 1250 closed issues](https://github.com/magma/magma/issues?page=49&q=is%3Aissue+label%3Awontfix+is%3Aclosed) were a lot of very valid and elaborate issues and proposals.

There are several issues with the current implementation which are addressed with this PR:
- Configuration from the Bot was copied but no license header was given.
- The wait time for the bot 
  - was reduced below the default without reasoning.
  - is far too short and would even close issue from active developers just going for a vacation.
- The exempt label list is incorrect and needs to be extended to work well with other automation.
  - The label should be called `willfix` and not `status: willfix` due to following reasons:
    - Inconsistency between `wontfix` and `status: willfix` vs. `willfix` label.
    - The label `status: willfix` was not created for the repository and is nowhere used.
    - The label `willfix` was created and is currently used 44 times.
  -  Additional labels should be added, amongst others proposals, ready-to-merge PRs and issues created by the Sentry automation should likely never be closed automatically.
- The comment text is misleading as
  - it only refers to PRs and not issues, while both are affected.
  - suggests that only authors and maintainers can take action [while anybody can](https://github.com/marketplace/stale).
