### PR TITLE
chore(ci): github runners have more space available

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -143,6 +143,17 @@ jobs:
     name: C/C++ unit tests with Bazel
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        shell: bash
+        run: |
+          echo "Available storage before:"
+          df -h
+          echo "Removing /usr/share/dotnet, /usr/local/lib/android, /opt/ghc"
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          echo "Available storage after:"
+          df -h
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
         uses: actions/checkout@v2
@@ -213,6 +224,11 @@ jobs:
         with:
           name: Unit Test Results
           path: c-cpp-test-results/
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h
 
   li_agent_test:
     needs: path_filter
@@ -326,6 +342,17 @@ jobs:
       BRANCH: "${{ github.base_ref }}"
       REVISION: "${{ github.sha }}"
     steps:
+      - name: Maximize build space
+        shell: bash
+        run: |
+          echo "Available storage before:"
+          df -h
+          echo "Removing /usr/share/dotnet, /usr/local/lib/android, /opt/ghc"
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          echo "Available storage after:"
+          df -h
       - uses: actions/checkout@v2
       - name: Bazel Cache
         uses: actions/cache@v2
@@ -399,6 +426,11 @@ jobs:
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h
 
   lint-clang-format:
     needs: path_filter

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -84,6 +84,17 @@ jobs:
   bazel-build-devcontainer-and-push-cache:
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        shell: bash
+        run: |
+          echo "Available storage before:"
+          df -h
+          echo "Removing /usr/share/dotnet, /usr/local/lib/android, /opt/ghc"
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          echo "Available storage after:"
+          df -h
       - uses: actions/checkout@v2
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -117,3 +128,8 @@ jobs:
 
           aws s3 cp ${{ env.BAZEL_CACHE_DEVCONTAINER_TAR }} ${{ env.S3_BUCKET_PATH }}/${{ env.BAZEL_CACHE_DEVCONTAINER_TAR}}
           aws s3 cp ${{ env.BAZEL_CACHE_REPO_DEVCONTAINER_TAR }} ${{ env.S3_BUCKET_PATH }}/${{ env.BAZEL_CACHE_REPO_DEVCONTAINER_TAR}}
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -59,6 +59,17 @@ jobs:
     name: Bazel Build Job `bazel build //...`
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        shell: bash
+        run: |
+          echo "Available storage before:"
+          df -h
+          echo "Removing /usr/share/dotnet, /usr/local/lib/android, /opt/ghc"
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          echo "Available storage after:"
+          df -h
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
         uses: actions/checkout@v2
@@ -121,6 +132,11 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel build //...
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h
 
   bazel_test:
     needs: path_filter
@@ -132,6 +148,17 @@ jobs:
     name: Bazel Test Job `bazel test //...`
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        shell: bash
+        run: |
+          echo "Available storage before:"
+          df -h
+          echo "Removing /usr/share/dotnet, /usr/local/lib/android, /opt/ghc"
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          echo "Available storage after:"
+          df -h
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
         uses: actions/checkout@v2
@@ -194,3 +221,8 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel run //:check_starlark_format
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -58,6 +58,17 @@ jobs:
     name: Build all Bazelified C/C++ targets
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        shell: bash
+        run: |
+          echo "Available storage before:"
+          df -h
+          echo "Removing /usr/share/dotnet, /usr/local/lib/android, /opt/ghc"
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          echo "Available storage after:"
+          df -h
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
         uses: actions/checkout@v2
@@ -133,3 +144,8 @@ jobs:
         with:
           name: build_logs_c_filtered_log
           path: ${{ github.workspace }}/filtered-compile.log
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Experimenting with the Bazel mme setup we experienced again out-of-space situations in Bazel workflows. There are github actions that clean up the used ubuntu image e.g. [1] (@themarwhal I think you suggested that one the last time we looked into space issues).
[1] does not work directly in our situation as we use `/dev/root` via docker. [1] removes dotnet, android SDKs and Haskell and this can actually be done manually very easy.

`Filesystem      Size  Used Avail Use% Mounted on`
**before cleanup**
`/dev/root        84G   55G   29G  66% /`
**after cleanup**
`/dev/root        84G   38G   47G  45% /`
**after run (Bazel Build & Test)**
`/dev/root        84G   62G   22G  74% /`

-> ~24G are filled for the run
-> without cleanup currently ~79G/84G would be used
-> with cleanup ~22G are still available after run

**Note** I left a `df -h` at the end of the workflows - this might be helpful for future debugging, but I can remove it if requested.

[1] https://github.com/easimon/maximize-build-space

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
