### PR TITLE
fix: add partial update to mock HSS

### DIFF
--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -34,6 +34,8 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07
 	github.com/labstack/echo/v4 v4.2.1
+
+	github.com/mennanov/fieldmask-utils v0.3.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -513,6 +513,8 @@ github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A
 github.com/mattn/go-zglob v0.0.3/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mennanov/fieldmask-utils v0.3.0 h1:wzZ21Zt4EAES5gr38KQL9OYWrFh5ucOTKJtsRLl65+A=
+github.com/mennanov/fieldmask-utils v0.3.0/go.mod h1:JpaanSp6Ql5A8dGktEFxTmA9uBXmz3F+2LAXDZwiimU=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.10/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/feg/gateway/services/testcore/hss/servicers/ai.go
+++ b/feg/gateway/services/testcore/hss/servicers/ai.go
@@ -93,7 +93,7 @@ func (srv *HomeSubscriberServer) setLteAuthNextSeq(subscriber *lteprotos.Subscri
 		return NewAuthDataUnavailableError("subscriber state was nil")
 	}
 	subscriber.State.LteAuthNextSeq = lteAuthNextSeq
-	return srv.store.UpdateSubscriber(subscriber)
+	return srv.store.UpdateSubscriber(&lteprotos.SubscriberUpdate{Data: subscriber})
 }
 
 // NewSuccessfulAIA outputs a successful authentication information answer (AIA) to reply to an

--- a/feg/gateway/services/testcore/hss/servicers/hss.go
+++ b/feg/gateway/services/testcore/hss/servicers/hss.go
@@ -15,7 +15,7 @@ package servicers
 
 import (
 	"context"
-	"fmt"
+	"log"
 	"time"
 
 	"github.com/emakeev/milenage"
@@ -75,6 +75,7 @@ func NewHomeSubscriberServer(store storage.SubscriberStore, config *mconfig.HSSC
 // been added.
 // Input: The subscriber data which will be added.
 func (srv *HomeSubscriberServer) AddSubscriber(ctx context.Context, req *lteprotos.SubscriberData) (*protos.Void, error) {
+	log.Println("Received AddSubscriber")
 	err := srv.store.AddSubscriber(req)
 	err = storage.ConvertStorageErrorToGrpcStatus(err)
 	return &protos.Void{}, err
@@ -85,6 +86,7 @@ func (srv *HomeSubscriberServer) AddSubscriber(ctx context.Context, req *lteprot
 // Input: The id of the subscriber to be looked up.
 // Output: The data of the corresponding subscriber.
 func (srv *HomeSubscriberServer) GetSubscriberData(ctx context.Context, req *lteprotos.SubscriberID) (*lteprotos.SubscriberData, error) {
+	log.Println("Received GetSubscriberData")
 	data, err := srv.store.GetSubscriberData(req.Id)
 	err = storage.ConvertStorageErrorToGrpcStatus(err)
 	return data, err
@@ -94,11 +96,8 @@ func (srv *HomeSubscriberServer) GetSubscriberData(ctx context.Context, req *lte
 // If the subscriber cannot be found, an error is returned instead.
 // Input: The new subscriber data to store
 func (srv *HomeSubscriberServer) UpdateSubscriber(ctx context.Context, req *lteprotos.SubscriberUpdate) (*protos.Void, error) {
-	if req == nil {
-		return &protos.Void{}, fmt.Errorf("UpdateSubscriber got a nil request")
-	}
-	sub := req.Data
-	err := srv.store.UpdateSubscriber(sub)
+	log.Println("Received UpdateSubscriber")
+	err := srv.store.UpdateSubscriber(req)
 	err = storage.ConvertStorageErrorToGrpcStatus(err)
 	return &protos.Void{}, err
 }
@@ -107,6 +106,7 @@ func (srv *HomeSubscriberServer) UpdateSubscriber(ctx context.Context, req *ltep
 // If the subscriber is not found, then this call is ignored.
 // Input: The id of the subscriber to be deleted.
 func (srv *HomeSubscriberServer) DeleteSubscriber(ctx context.Context, req *lteprotos.SubscriberID) (*protos.Void, error) {
+	log.Println("Received DeleteSubscriber")
 	err := srv.store.DeleteSubscriber(req.Id)
 	err = storage.ConvertStorageErrorToGrpcStatus(err)
 	return &protos.Void{}, err
@@ -114,6 +114,7 @@ func (srv *HomeSubscriberServer) DeleteSubscriber(ctx context.Context, req *ltep
 
 // ListSubscribers list all available subscribers by IMSI.
 func (srv *HomeSubscriberServer) ListSubscribers(_ context.Context, _ *protos.Void) (*lteprotos.SubscriberIDSet, error) {
+	log.Println("Received ListSubscribers")
 	data, err := srv.store.GetAllSubscribers()
 	err = storage.ConvertStorageErrorToGrpcStatus(err)
 	return data, err
@@ -123,6 +124,7 @@ func (srv *HomeSubscriberServer) ListSubscribers(_ context.Context, _ *protos.Vo
 // If the subscriber is not found, an error is returned instead.
 // Input: The id of the subscriber to be deregistered.
 func (srv *HomeSubscriberServer) DeregisterSubscriber(ctx context.Context, req *lteprotos.SubscriberID) (*protos.Void, error) {
+	log.Println("Received DeregisterSubscriber")
 	sub, err := srv.store.GetSubscriberData(req.Id)
 	if err != nil {
 		return &protos.Void{}, storage.ConvertStorageErrorToGrpcStatus(err)

--- a/feg/gateway/services/testcore/hss/servicers/hss_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/hss_test.go
@@ -96,7 +96,7 @@ func TestHomeSubscriberServer_UpdateSubscriber(t *testing.T) {
 	server := test_utils.NewTestHomeSubscriberServer(t)
 
 	_, err := server.UpdateSubscriber(context.Background(), nil)
-	assert.EqualError(t, err, "UpdateSubscriber got a nil request")
+	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = Update request cannot be nil")
 
 	sub := &protos.SubscriberData{}
 	_, err = server.UpdateSubscriber(context.Background(), &protos.SubscriberUpdate{Data: sub})

--- a/feg/gateway/services/testcore/hss/servicers/ma.go
+++ b/feg/gateway/services/testcore/hss/servicers/ma.go
@@ -202,5 +202,5 @@ func (srv *HomeSubscriberServer) set3GPPAAAServerName(subscriber *lteprotos.Subs
 	}
 	subscriber.State.TgppAaaServerName = string(serverName)
 	subscriber.State.TgppAaaServerRegistered = false
-	return srv.store.UpdateSubscriber(subscriber)
+	return srv.store.UpdateSubscriber(&lteprotos.SubscriberUpdate{Data: subscriber})
 }

--- a/feg/gateway/services/testcore/hss/servicers/rt.go
+++ b/feg/gateway/services/testcore/hss/servicers/rt.go
@@ -31,7 +31,7 @@ import (
 	"magma/lte/cloud/go/protos"
 )
 
-//Permanently terminate the non-3gpp subscription
+// Permanently terminate the non-3gpp subscription
 const PermanentTermination = 0
 
 func (srv *HomeSubscriberServer) TerminateRegistration(sub *protos.SubscriberData) error {
@@ -124,7 +124,7 @@ func (srv *HomeSubscriberServer) createRTR(sessionID string, username string) *d
 func (srv *HomeSubscriberServer) deregisterSubscriber(subscriber *protos.SubscriberData) error {
 	subscriber.State.TgppAaaServerRegistered = false
 	subscriber.State.TgppAaaServerName = ""
-	return srv.store.UpdateSubscriber(subscriber)
+	return srv.store.UpdateSubscriber(&protos.SubscriberUpdate{Data: subscriber})
 }
 
 func (srv *HomeSubscriberServer) genAAAServerConfig(serverName string) (*diameter.DiameterServerConfig, error) {

--- a/feg/gateway/services/testcore/hss/servicers/sa.go
+++ b/feg/gateway/services/testcore/hss/servicers/sa.go
@@ -62,7 +62,7 @@ func NewSAA(srv *HomeSubscriberServer, msg *diam.Message) (*diam.Message, error)
 
 	if subscriber.GetNon_3Gpp().GetApnConfig() == nil {
 		subscriber.State.TgppAaaServerName = ""
-		err = srv.store.UpdateSubscriber(subscriber)
+		err = srv.store.UpdateSubscriber(&lteprotos.SubscriberUpdate{Data: subscriber})
 		if err != nil {
 			glog.Errorf("Failed to remove the 3GPP AAA Server name: %v", err)
 		}
@@ -77,7 +77,7 @@ func NewSAA(srv *HomeSubscriberServer, msg *diam.Message) (*diam.Message, error)
 	case servicers.ServerAssignnmentType_USER_DEREGISTRATION:
 		subscriber.State.TgppAaaServerName = ""
 		subscriber.State.TgppAaaServerRegistered = false
-		err = srv.store.UpdateSubscriber(subscriber)
+		err = srv.store.UpdateSubscriber(&lteprotos.SubscriberUpdate{Data: subscriber})
 		if err != nil {
 			err = fmt.Errorf("Failed to deregister 3GPP AAA server: %v", err)
 			return ConstructFailureAnswer(msg, sar.SessionID, srv.Config.Server, uint32(diam.UnableToComply)), err
@@ -85,7 +85,7 @@ func NewSAA(srv *HomeSubscriberServer, msg *diam.Message) (*diam.Message, error)
 
 	case servicers.ServerAssignmentType_REGISTRATION:
 		subscriber.State.TgppAaaServerRegistered = true
-		err = srv.store.UpdateSubscriber(subscriber)
+		err = srv.store.UpdateSubscriber(&lteprotos.SubscriberUpdate{Data: subscriber})
 		if err != nil {
 			err = fmt.Errorf("Failed to register 3GPP AAA server: %v", err)
 			return ConstructFailureAnswer(msg, sar.SessionID, srv.Config.Server, uint32(diam.UnableToComply)), err

--- a/feg/gateway/services/testcore/hss/storage/storage.go
+++ b/feg/gateway/services/testcore/hss/storage/storage.go
@@ -38,7 +38,7 @@ type SubscriberStore interface {
 	// UpdateSubscriber changes the data stored for an existing subscriber.
 	// If the subscriber cannot be found, an error is returned instead.
 	// Input: The new subscriber data to store
-	UpdateSubscriber(data *protos.SubscriberData) error
+	UpdateSubscriber(data *protos.SubscriberUpdate) error
 
 	// DeleteSubscriber deletes a subscriber by their Id.
 	// If the subscriber is not found, then this call is ignored.

--- a/feg/gateway/services/testcore/hss/storage/storage_integ_test.go
+++ b/feg/gateway/services/testcore/hss/storage/storage_integ_test.go
@@ -64,7 +64,7 @@ func testTestcoreStorageImpl(t *testing.T, store storage.SubscriberStore) {
 	assert.True(t, proto.Equal(dataRecvd, data0))
 
 	// Update, get data
-	err = store.UpdateSubscriber(data0Updated)
+	err = store.UpdateSubscriber(&protos.SubscriberUpdate{Data: data0Updated})
 	assert.NoError(t, err)
 	dataRecvd, err = store.GetSubscriberData(sub0)
 	assert.NoError(t, err)

--- a/feg/gateway/services/testcore/hss/storage/streamer.go
+++ b/feg/gateway/services/testcore/hss/storage/streamer.go
@@ -63,7 +63,7 @@ func (listener *subscriberListener) Update(batch *orc8rprotos.DataUpdateBatch) b
 			if oldSub.State != nil {
 				subscriber.State = oldSub.State
 			}
-			err = store.UpdateSubscriber(subscriber)
+			err = store.UpdateSubscriber(&lteprotos.SubscriberUpdate{Data: subscriber})
 			glog.Errorf("failed to update subscriber(%s): %s", id, err.Error())
 		} else {
 			err = store.AddSubscriber(subscriber)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Update subscriber on HSS should update only fields stated on proto mask.
This PR includes that functionallity in order to make it compatible with subscriberdb api on federated integ test

This PR is a partial effort to create an automated federated integ test

## Test Plan

make precommit


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
