### PR TITLE
fix: Change feg REDIS port to 6381

### DIFF
--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -55,7 +55,7 @@ const (
 	PCRFPort2        = 9206
 	HSSPort          = 9204
 	PipelinedPort    = 8443
-	RedisPort        = 6380
+	RedisPort        = 6381
 	DirectorydPort   = 8443
 
 	// If updating these, also update the ipfix exported hex values
@@ -80,7 +80,7 @@ const (
 	GyValidityTime  = 60   // in second
 )
 
-//TestRunner helps setting up all associated services
+// TestRunner helps setting up all associated services
 type TestRunner struct {
 	t           *testing.T
 	imsis       map[string]bool
@@ -281,14 +281,14 @@ func (tr *TestRunner) GenULTrafficBasedOnPolicyUsage(req *cwfprotos.GenTrafficRe
 	for start := time.Now(); time.Since(start) < waitFor; {
 		startGenTrafficTime := time.Now()
 		res, err = uesim.GenTrafficWithReatempts(req)
-		if err != nil{
+		if err != nil {
 			return res, fmt.Errorf("GenULTrafficBasedOnPolicyUsage failed during GenTraffic: %s", err)
 		}
-		completeCycle := time.Now().Sub(startGenTrafficTime)%time.Second
-		if  waitNeeded {
+		completeCycle := time.Now().Sub(startGenTrafficTime) % time.Second
+		if waitNeeded {
 			// this wait makes sure the time passes is exact in seconds. This way
 			// we make sure policies had time to sync
-			time.Sleep(completeCycle + 200 * time.Millisecond)
+			time.Sleep(completeCycle + 200*time.Millisecond)
 			waitNeeded = false
 		}
 		time.Sleep(2200 * time.Millisecond)
@@ -306,19 +306,21 @@ func (tr *TestRunner) GenULTrafficBasedOnPolicyUsage(req *cwfprotos.GenTrafficRe
 		req.Bitrate = &wrappers.StringValue{Value: "10M"}
 		if remaining > 100*KiloBytes {
 			newVolume = uint64(float64(remaining) * 0.95)
-			if newVolume > 5 * MegaBytes {
+			if newVolume > 5*MegaBytes {
 				newVolume = 5 * MegaBytes
 			}
 			// only add wait for the bigger chunks
 			waitNeeded = true
 		}
-		if newVolume < 1000 {newVolume = 1000}
+		if newVolume < 1000 {
+			newVolume = 1000
+		}
 		newVolumeStr := fmt.Sprintf("%dK", newVolume/1000)
 
 		req.Volume = &wrappers.StringValue{Value: newVolumeStr}
 		fmt.Printf("- not enough traffic genereted, sending %dKB more. Will be around %d%% of volume requested\n",
 			newVolume/1000,
-			100 * (record.BytesTx+newVolume)/totalVolume,
+			100*(record.BytesTx+newVolume)/totalVolume,
 		)
 	}
 	return res, fmt.Errorf("error: not enough traffic generated to fullfil GenULTrafficBasedOnPolicyUsage requieriment: %s", err)
@@ -477,34 +479,34 @@ func (tr *TestRunner) WaitForEnforcementStatsForRuleGreaterThanOrDoesNotExist(im
 	}
 }
 
- func (tr *TestRunner) WaitForEnforcementStatsForRuleGreaterThanOrDoesNotExistFunc (imsi, ruleID string, min uint64)(*lteprotos.RuleRecord, bool) {
-		fmt.Printf("\tWaiting until %s, %s has more than %d bytes in enforcement stats or rule does not exist ...\n", imsi, ruleID, min)
-		records, err := tr.GetPolicyUsage()
-		if err != nil {
-			return nil, false
-		}
-		imsi = prependIMSIPrefix(imsi)
-		if records[imsi] == nil {
-			// Session is gone
-			fmt.Printf("\tSession for %s, does not exist...\n", imsi)
-			return nil, true
-		}
-		record := records[imsi][ruleID]
-		if record == nil {
-			// Session is gone
-			fmt.Printf("\tRule %s for %s, does not exist...\n", ruleID, imsi)
-			return nil, true
-		}
-		txBytes := record.BytesTx
-		if record.BytesTx < min {
-			return record, false
-		}
-		fmt.Printf("\t\u2713 %s, %s now passed %d > %d in enforcement stats!(%d%%)\n",
-			imsi, ruleID, txBytes, min, 100* txBytes/min)
-		return record, true
+func (tr *TestRunner) WaitForEnforcementStatsForRuleGreaterThanOrDoesNotExistFunc(imsi, ruleID string, min uint64) (*lteprotos.RuleRecord, bool) {
+	fmt.Printf("\tWaiting until %s, %s has more than %d bytes in enforcement stats or rule does not exist ...\n", imsi, ruleID, min)
+	records, err := tr.GetPolicyUsage()
+	if err != nil {
+		return nil, false
 	}
+	imsi = prependIMSIPrefix(imsi)
+	if records[imsi] == nil {
+		// Session is gone
+		fmt.Printf("\tSession for %s, does not exist...\n", imsi)
+		return nil, true
+	}
+	record := records[imsi][ruleID]
+	if record == nil {
+		// Session is gone
+		fmt.Printf("\tRule %s for %s, does not exist...\n", ruleID, imsi)
+		return nil, true
+	}
+	txBytes := record.BytesTx
+	if record.BytesTx < min {
+		return record, false
+	}
+	fmt.Printf("\t\u2713 %s, %s now passed %d > %d in enforcement stats!(%d%%)\n",
+		imsi, ruleID, txBytes, min, 100*txBytes/min)
+	return record, true
+}
 
-//WaitForPolicyReAuthToProcess returns a method which checks for reauth answer and
+// WaitForPolicyReAuthToProcess returns a method which checks for reauth answer and
 // if it has sessionID which contains the IMSI
 func (tr *TestRunner) WaitForPolicyReAuthToProcess(raa *fegprotos.PolicyReAuthAnswer, imsi string) func() bool {
 	// Todo figure out the best way to figure out when RAR is processed
@@ -516,7 +518,7 @@ func (tr *TestRunner) WaitForPolicyReAuthToProcess(raa *fegprotos.PolicyReAuthAn
 	}
 }
 
-//WaitForChargingReAuthToProcess returns a method which checks for reauth answer and
+// WaitForChargingReAuthToProcess returns a method which checks for reauth answer and
 // if it has sessionID which contains the IMSI
 func (tr *TestRunner) WaitForChargingReAuthToProcess(raa *fegprotos.ChargingReAuthAnswer, imsi string) func() bool {
 	// Todo figure out the best way to figure out when RAR is processed

--- a/feg/gateway/configs/redis.yml
+++ b/feg/gateway/configs/redis.yml
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-port: 6380
+port: 6381
 bind: 127.0.0.1
 redis_loglevel: notice
 dir: /var/opt/magma

--- a/feg/gateway/registry/local_registry.go
+++ b/feg/gateway/registry/local_registry.go
@@ -80,7 +80,7 @@ var fegRegistry = Get()
 func init() {
 
 	// Add default Local Service Locations
-	addLocalService(REDIS, 6380)
+	addLocalService(REDIS, 6381)
 
 	addLocalService(FEG_HELLO, 9093)
 	addLocalService(SESSION_PROXY, 9097)

--- a/lte/gateway/python/integ_tests/federated_tests/configs/redis.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/redis.yml
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-port: 6380
+port: 6381
 bind: 127.0.0.1
 redis_loglevel: notice
 dir: /var/opt/magma


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

To be able to run agw and feg on the same VM we need to use different REDIS ports. This PR changes FEG redis port from 6380 to 6381. 

This will allow us to run federated integ test on the same Vagrant VM too.

## Test Plan

teravm test
cwag integ test (on CI)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
