### PR TITLE
fix(agw): s1aptest TestAttachDetachRarTcpDataWithHE is flaky / or broken

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -128,7 +128,8 @@ s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
 s1aptests/test_service_req_ul_udp_data_with_mme_restart.py \
-s1aptests/test_attach_detach_setsessionrules_tcp_data.py
+s1aptests/test_attach_detach_setsessionrules_tcp_data.py \
+s1aptests/test_attach_detach_rar_tcp_he.py
 
 EXTENDED_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \
 s1aptests/test_attach_detach_multi_ue_looped.py \


### PR DESCRIPTION
Signed-off-by: Vikram G <vikram.gurrappagaru@radisys.com>

## Summary
Fixes #6254
Default flows in table 0 to 4

## Test Plan
make integ_test

## Additional Information

