### PR TITLE
fix: run FEG on Vagrant VM on federated integ test

### DIFF
--- a/docs/readmes/feg/s1ap_federated_test.md
+++ b/docs/readmes/feg/s1ap_federated_test.md
@@ -28,14 +28,17 @@ graph LR;
 
 The services will run either on Vagrant VM or on Docker:
 
-| Services          |  Vagrant VM       |  Docker   |
-|-------------------|:-----------------:|:----------:|
-| AGW               | magma             |           |
-| FeG               |                   | &check;   |
-| Orc8r             |                   | &check;   |
-| Traffic server    | magma_trfserver   |           |
-| S1AP tester       | magma_test        |           |
-| HSS               |                   | &check;   |
+| Services          |   Vagrant VM    |  Docker   |
+|-------------------|:---------------:|:---------:|
+| AGW               |      magma      |           |
+| FeG               |     &check;     |  &check;  |
+| Orc8r             |                 |  &check;  |
+| Traffic server    | magma_trfserver |           |
+| S1AP tester       |   magma_test    |           |
+| HSS               |                 |  &check;  |
+
+Note FEG runs on docker inside Magma Vagrant VM. The reason is to guarantee
+docker host mode is supported by the host (not supported by MAC)
 
 ## Running the tests
 
@@ -137,6 +140,11 @@ exit
 - FEG:
 
 ```bash
+cd magma/lte/gateway
+vagrant up magma
+vagrant ssh magma
+
+# inside vagrant vm
 cd magma/lte/gateway/python/integ_tests/federated_tests/docker
 docker-compose build
 docker-compose up -d

--- a/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.override.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.override.yml
@@ -16,10 +16,10 @@ services:
 
   control_proxy:
     extra_hosts:
-      - controller.magma.test:127.0.0.1
-      - bootstrapper-controller.magma.test:127.0.0.1
-      #- controller.magma.test:10.0.2.2
-      #- bootstrapper-controller.magma.test:10.0.0.2
+      # Use 127.0.0.1 when running FEG on the host itself
+      # Use 10.0.2.2 when running FEG on Vagrant VM
+      - controller.magma.test:10.0.2.2
+      - bootstrapper-controller.magma.test:10.0.0.2
     command:
       - /bin/bash
       - -c
@@ -37,10 +37,10 @@ services:
       context: ${BUILD_CONTEXT}
       dockerfile: feg/gateway/docker/python/Dockerfile
     extra_hosts:
-      - controller.magma.test:127.0.0.1
-      - bootstrapper-controller.magma.test:127.0.0.1
-      #- controller.magma.test:10.0.2.2
-      #- bootstrapper-controller.magma.test:10.0.2.2
+      # Use 127.0.0.1 when running FEG on the host itself
+      # Use 10.0.2.2 when running FEG on Vagrant VM
+      - controller.magma.test:10.0.2.2
+      - bootstrapper-controller.magma.test:10.0.2.2
     command: python3.8 -m magma.magmad.main
 
 volumes:

--- a/orc8r/tools/fab/vagrant.py
+++ b/orc8r/tools/fab/vagrant.py
@@ -10,9 +10,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import os
 import os.path
 
-from fabric.api import env, local
+from fabric.api import cd, env, local
 
 
 def __ensure_in_vagrant_dir():
@@ -21,9 +22,11 @@ def __ensure_in_vagrant_dir():
     """
     pwd = local('pwd', capture=True)
     if not os.path.isfile(pwd + '/Vagrantfile'):
-        print("Error: Vagrantfile not found. Try executing from fbcode/magma")
-        exit(1)
-
+        # check if we are on a vagrant subdirectory
+        with cd(pwd):
+            if not local('Vagrant validate', capture=True):
+                print("Error: Vagrantfile not found")
+                exit(1)
     return
 
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR modifies federated integ test fab file to run FEG inside the Magma VM

The reason for that change is that FEG uses host netowrk mode. That mode is not supported properly on MAC so we can't access to FEG services port (so we can send grpc messages from the host). To allow us to send messages and configure grpc services like mock hss, we need to move FEG execution to Vagrant vm, where docker host network mode is supported

Note this will only impact federated integ test.

## Test Plan

`fab test_connectivity`
on federated integ test
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
