### PR TITLE
feat: Add support for grpc configuration for mock HSS at federated integ test

### DIFF
--- a/feg/cloud/configs/service_registry.yml
+++ b/feg/cloud/configs/service_registry.yml
@@ -48,6 +48,8 @@ services:
         port: 9079
       pcrf:
         port: 9079
+      hss:
+        port: 9079
 
   health:
     host: "localhost"

--- a/feg/gateway/configs/hss.yml
+++ b/feg/gateway/configs/hss.yml
@@ -14,7 +14,7 @@
 # HSS Config
 #
 # ---
-#subscribers:
+# subscribers:
 #  <imsi>:
 #    <auth_key>: - required (hex string)
 #    <non_3gpp_enabled>: - optional (bool)

--- a/lte/gateway/python/integ_tests/federated_tests/configs/hss.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/configs/hss.yml
@@ -18,10 +18,14 @@
 #  <imsi>:
 #    <auth_key>: - required (hex string)
 #    <non_3gpp_enabled>: - optional (bool)
-subscribers:
-  "001010000000001":
-    auth_key: "000102030405060708090A0B0C0D0E0F"
-    lte_auth_next_seq: 1
-  "001010000000002":
-    auth_key: "000102030405060708090A0B0C0D0E0F"
-    lte_auth_next_seq: 1
+#
+#
+#
+# Sample configuration
+#subscribers:
+#  "001010000000001":
+#    auth_key: "000102030405060708090A0B0C0D0E0F"
+#    lte_auth_next_seq: 1
+#  "001010000000002":
+#    auth_key: "000102030405060708090A0B0C0D0E0F"
+#    lte_auth_next_seq: 1

--- a/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.override.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.override.yml
@@ -11,8 +11,9 @@ services:
       - gwconfigs:/var/opt/magma/configs
     restart: always
     environment:
+      MAGMA_PRINT_GRPC_PAYLOAD: 2
       USE_REMOTE_SWX_PROXY: 0
-    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/hss -logtostderr=true -v=0
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/hss -logtostderr=true -v=9
 
   control_proxy:
     extra_hosts:

--- a/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.yml
@@ -116,7 +116,7 @@ services:
     <<: *goservice
     container_name: s6a_proxy
     environment:
-      MAGMA_PRINT_GRPC_PAYLOAD: 1
+      MAGMA_PRINT_GRPC_PAYLOAD: 2
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s6a_proxy -logtostderr=true -v=9
 
 

--- a/lte/gateway/python/integ_tests/federated_tests/s1aptests/test_attach_detach.py
+++ b/lte/gateway/python/integ_tests/federated_tests/s1aptests/test_attach_detach.py
@@ -23,7 +23,7 @@ from integ_tests.s1aptests import s1ap_wrapper
 class TestAttachDetach(unittest.TestCase):
 
     def setUp(self):
-        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper(federated_mode=True)
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -41,8 +41,8 @@ class TestAttachDetach(unittest.TestCase):
         for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
             print(
-                "************************* Running End to End attach for ",
-                "UE id ", req.ue_id,
+                "************************* Running Federated End to End attach "
+                "for UE id ", req.ue_id,
             )
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(

--- a/lte/gateway/python/integ_tests/gateway/rpc.py
+++ b/lte/gateway/python/integ_tests/gateway/rpc.py
@@ -13,7 +13,7 @@ limitations under the License.
 import os
 from typing import Any, Dict, List
 
-from magma.common.service_registry import create_grpc_channel
+from magma.common.service_registry import create_grpc_channel, get_ssl_creds
 from magma.configuration.mconfigs import unpack_mconfig_any
 from orc8r.protos.common_pb2 import Void
 from orc8r.protos.magmad_pb2_grpc import MagmadStub
@@ -24,9 +24,30 @@ def get_rpc_channel(service):
     """
     Returns a RPC channel to the service in the gateway.
     """
-    return create_grpc_channel(
+
+    res = create_grpc_channel(
         os.environ.get('GATEWAY_IP', '192.168.60.142'),
         os.environ.get('GATEWAY_PORT', '8443'),
+        '%s.local' % service,
+    )
+
+    return res
+
+
+def get_hss_rpc_channel():
+    """
+    Returns RPC channel to hss
+    """
+    return get_feg_rpc_channel('9204', 'hss')
+
+
+def get_feg_rpc_channel(port, service):
+    """
+    Returns RPC channel to the service in the gateway.
+    """
+    return create_grpc_channel(
+        '192.168.60.142',
+        port,
         '%s.local' % service,
     )
 

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -757,6 +757,7 @@ class SubscriberUtil(object):
             self._subscriber_client.add_subscriber(sid)
             imei = self._generate_imei()
             subscribers.append(self._get_s1ap_sub(sid, imei))
+
         self._subscriber_client.wait_for_changes()
         return subscribers
 

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -22,6 +22,7 @@ from integ_tests.common.magmad_client import MagmadServiceGrpc
 from integ_tests.common.mobility_service_client import MobilityServiceGrpc
 from integ_tests.common.service303_utils import GatewayServicesUtil
 from integ_tests.common.subscriber_db_client import (
+    HSSGrpc,
     SubscriberDbCassandra,
     SubscriberDbGrpc,
 )
@@ -60,6 +61,7 @@ class TestWrapper(object):
         stateless_mode=MagmadUtil.stateless_cmds.ENABLE,
         apn_correction=MagmadUtil.apn_correction_cmds.DISABLE,
         health_service=MagmadUtil.health_service_cmds.DISABLE,
+        federated_mode=False,
     ):
         """
         Initialize the various classes required by the tests and setup.
@@ -77,6 +79,9 @@ class TestWrapper(object):
         if self._test_oai_upstream:
             subscriber_client = SubscriberDbCassandra()
             self.wait_gateway_healthy = False
+        elif federated_mode:
+            subscriber_client = HSSGrpc()
+            self.wait_gateway_healthy = True
         else:
             subscriber_client = SubscriberDbGrpc()
             self.wait_gateway_healthy = True


### PR DESCRIPTION
…teg test

Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR adds support to configure mock HSS running on FEG through s1aptestr.

We had to subclass SubscriberDBGrpc object to be able to use it with either a subscriberDB grpc stub or with a mock HSS grpc stub.

Note this PR depends on https://github.com/magma/magma/pull/12391, https://github.com/magma/magma/pull/12387, https://github.com/magma/magma/pull/12345 (and part of this issue https://github.com/magma/magma/issues/11338)

Note this framework can be used to add support to configure mock PCRF and mock OCS  we have on magma [testcore](https://github.com/magma/magma/tree/master/feg/gateway/services/testcore)


## Test Plan

This log below shows the federated test running using mock hss. In that case the HSS is configured with two subscribers, updated with specific APN.  Subscriber db remains unconfigured for this case 

The second log shows how HSS is configured with those subscribers.

Third log shows `s6a_proxy` running on that setup showing authentication messages comming from HSS

```
vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make integ_test TESTS=federated_tests/s1aptests/test_attach_detach.py
make: Warning: File 'defs.mk' has modification time 443954 s in the future
. /home/vagrant/build/python/bin/activate
echo "Running test: federated_tests/s1aptests/test_attach_detach.py"
Running test: federated_tests/s1aptests/test_attach_detach.py
timeout --foreground -k 930s 900s sudo -E PATH=/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin PYTHONPATH=:/home/vagrant/s1ap-tester/bin /home/vagrant/build/python/bin/nosetests --with-flaky --force-flaky --no-success-flaky-report --max-runs=1 --min-passes=1 --with-xunit --xunit-file=/var/tmp/test_results/test_attach_detach.xml -x -s federated_tests/s1aptests/test_attach_detach.py || (echo "fail" > /home/vagrant/magma/test_status.txt && exit 1)
Start time 19:45:52
tag: AUTH_TYPE tagVal: MILENAGE
************************* Enb tester config

**********************TPT open server******** 0

 Server Socket FD =[13]
************* Testing *Time elapsed(in usec): for timer expiry               :4043 usec
AGW is stateless
APN Correction configured
Health service is disabled
Using subscriber IMSI IMSI001010000000001
Using IMEI 3805468432113171
Using subscriber IMSI IMSI001010000000002
Using IMEI 3805468432113172
************************* UE device config for ue_id  1
************************* UE device config for ue_id  2
************************* Configuring IP block
************************* Waiting for IP changes to propagate
************************* S1 setup
************************* UE App config
************************* Running Federated End to End attach for UE id  1
ue id 1 found
PDN_TYPE: 1
IPv4 PDN_ADDRESS:192 168 128 12

*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
************************* Running UE detach for UE id  1
Deleting Ue Context from Traffic Handler
************************* Running Federated End to End attach for UE id  2
ue id 2 found

*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
PDN_TYPE: 1
IPv4 PDN_ADDRESS:192 168 128 13
************************* Running UE detach for UE id  2
Deleting Ue Context from Traffic Handler
************************* send SCTP SHUTDOWN
Keys left in Redis (list should be empty)[

]
Entries in s1ap_imsi_map (should be zero): 0
Entries left in hashtables (should be zero): 0
Entries in mme_ueip_imsi_map (should be zero): 0
.
----------------------------------------------------------------------
Ran 1 test in 8.597s

OK
sleep 1
make: warning:  Clock skew detected.  Your build may be incomplete.
```




mock hss grpc log

```

hss              | I0405 23:50:59.539818       1 impl.go:51] Mconfig refresh succeeded from: /var/opt/magma/configs/gateway.mconfig
hss              | 2022/04/05 23:52:30 Received ListSubscribers
hss              | I0405 23:52:30.078017       1 logcodec.go:96] Sending: *protos.SubscriberIDSet: {
hss              | 	"sids": [
hss              | 	]
hss              | }
hss              | 2022/04/05 23:52:30 Received ListSubscribers
hss              | I0405 23:52:30.078934       1 logcodec.go:96] Sending: *protos.SubscriberIDSet: {
hss              | 	"sids": [
hss              | 	]
hss              | }
hss              | I0405 23:52:32.434674       1 logcodec.go:96] Received: *protos.SubscriberData: {
hss              | 	"sid": {
hss              | 		"id": "001010000000001",
hss              | 		"type": "IMSI"
hss              | 	},
hss              | 	"gsm": null,
hss              | 	"lte": {
hss              | 		"state": "ACTIVE",
hss              | 		"auth_algo": "MILENAGE",
hss              | 		"auth_key": "AAECAwQFBgcICQoLDA0ODw==",
hss              | 		"auth_opc": null,
hss              | 		"assigned_base_names": [
hss              | 		],
hss              | 		"assigned_policies": [
hss              | 		]
hss              | 	},
hss              | 	"network_id": null,
hss              | 	"state": {
hss              | 		"lte_auth_next_seq": "1",
hss              | 		"tgpp_aaa_server_name": "",
hss              | 		"tgpp_aaa_server_registered": false
hss              | 	},
hss              | 	"sub_profile": "",
hss              | 	"non_3gpp": null,
hss              | 	"sub_network": null
hss              | }
hss              | 2022/04/05 23:52:32 Received AddSubscriber
hss              | I0405 23:52:32.436879       1 logcodec.go:96] Received: *protos.SubscriberData: {
hss              | 	"sid": {
hss              | 		"id": "001010000000002",
hss              | 		"type": "IMSI"
hss              | 	},
hss              | 	"gsm": null,
hss              | 	"lte": {
hss              | 		"state": "ACTIVE",
hss              | 		"auth_algo": "MILENAGE",
hss              | 		"auth_key": "AAECAwQFBgcICQoLDA0ODw==",
hss              | 		"auth_opc": null,
hss              | 		"assigned_base_names": [
hss              | 		],
hss              | 		"assigned_policies": [
hss              | 		]
hss              | 	},
hss              | 	"network_id": null,
hss              | 	"state": {
hss              | 		"lte_auth_next_seq": "1",
hss              | 		"tgpp_aaa_server_name": "",
hss              | 		"tgpp_aaa_server_registered": false
hss              | 	},
hss              | 	"sub_profile": "",
hss              | 	"non_3gpp": null,
hss              | 	"sub_network": null
hss              | }
hss              | 2022/04/05 23:52:32 Received AddSubscriber
hss              | I0405 23:52:32.439213       1 logcodec.go:96] Received: *protos.SubscriberUpdate: {
hss              | 	"data": {
hss              | 		"sid": {
hss              | 			"id": "001010000000001",
hss              | 			"type": "IMSI"
hss              | 		},
hss              | 		"gsm": null,
hss              | 		"lte": null,
hss              | 		"network_id": null,
hss              | 		"state": null,
hss              | 		"sub_profile": "",
hss              | 		"non_3gpp": {
hss              | 			"msisdn": "",
hss              | 			"non_3gpp_ip_access": "NON_3GPP_SUBSCRIPTION_ALLOWED",
hss              | 			"non_3gpp_ip_access_apn": "NON_3GPP_APNS_ENABLE",
hss              | 			"ambr": null,
hss              | 			"apn_config": [
hss              | 				{
hss              | 					"context_id": 0,
hss              | 					"service_selection": "magma.ipv4",
hss              | 					"qos_profile": {
hss              | 						"class_id": 9,
hss              | 						"priority_level": 15,
hss              | 						"preemption_capability": true,
hss              | 						"preemption_vulnerability": false
hss              | 					},
hss              | 					"ambr": {
hss              | 						"max_bandwidth_ul": 200000000,
hss              | 						"max_bandwidth_dl": 100000000,
hss              | 						"br_unit": "BPS"
hss              | 					},
hss              | 					"pdn": "IPV4",
hss              | 					"assigned_static_ip": "",
hss              | 					"resource": null
hss              | 				}
hss              | 			],
hss              | 			"access_net_id": "HRPD",
hss              | 			"subscriber_apn_config": [
hss              | 			]
hss              | 		},
hss              | 		"sub_network": null
hss              | 	},
hss              | 	"mask": {
hss              | 		"paths": [
hss              | 			"non_3gpp"
hss              | 		]
hss              | 	}
hss              | }
hss              | 2022/04/05 23:52:32 Received UpdateSubscriber
hss              | 2022/04/05 23:52:32 Received ListSubscribers
hss              | I0405 23:52:32.439918       1 logcodec.go:96] Sending: *protos.SubscriberIDSet: {
hss              | 	"sids": [
hss              | 		{
hss              | 			"id": "001010000000001",
hss              | 			"type": "IMSI"
hss              | 		},
hss              | 		{
hss              | 			"id": "001010000000002",
hss              | 			"type": "IMSI"
hss              | 		}
hss              | 	]
hss              | }
hss              | I0405 23:52:32.441666       1 logcodec.go:96] Received: *protos.SubscriberUpdate: {
hss              | 	"data": {
hss              | 		"sid": {
hss              | 			"id": "001010000000002",
hss              | 			"type": "IMSI"
hss              | 		},
hss              | 		"gsm": null,
hss              | 		"lte": null,
hss              | 		"network_id": null,
hss              | 		"state": null,
hss              | 		"sub_profile": "",
hss              | 		"non_3gpp": {
hss              | 			"msisdn": "",
hss              | 			"non_3gpp_ip_access": "NON_3GPP_SUBSCRIPTION_ALLOWED",
hss              | 			"non_3gpp_ip_access_apn": "NON_3GPP_APNS_ENABLE",
hss              | 			"ambr": null,
hss              | 			"apn_config": [
hss              | 				{
hss              | 					"context_id": 0,
hss              | 					"service_selection": "magma.ipv4",
hss              | 					"qos_profile": {
hss              | 						"class_id": 9,
hss              | 						"priority_level": 15,
hss              | 						"preemption_capability": true,
hss              | 						"preemption_vulnerability": false
hss              | 					},
hss              | 					"ambr": {
hss              | 						"max_bandwidth_ul": 200000000,
hss              | 						"max_bandwidth_dl": 100000000,
hss              | 						"br_unit": "BPS"
hss              | 					},
hss              | 					"pdn": "IPV4",
hss              | 					"assigned_static_ip": "",
hss              | 					"resource": null
hss              | 				}
hss              | 			],
hss              | 			"access_net_id": "HRPD",
hss              | 			"subscriber_apn_config": [
hss              | 			]
hss              | 		},
hss              | 		"sub_network": null
hss              | 	},
hss              | 	"mask": {
hss              | 		"paths": [
hss              | 			"non_3gpp"
hss              | 		]
hss              | 	}
hss              | }

```

s6a_proxy log showing authentication AVP and grpc protos

```
s6a_proxy        | Update-Location-Answer (ULA)
s6a_proxy        | {Code:316,Flags:0x40,Version:0x1,Length:576,ApplicationId:16777251,HopByHopId:0x4522165a,EndToEndId:0xb299f797}
s6a_proxy        | 	Session-Id {Code:263,Flags:0x40,Length:60,VendorId:0,Value:UTF8String{string-s6a;14109053113800215333;2073675763;a4e7d9d0},Padding:1}
s6a_proxy        | 	Result-Code {Code:268,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{2001}}
s6a_proxy        | 	Origin-Host {Code:264,Flags:0x40,Length:32,VendorId:0,Value:DiameterIdentity{magma-fedgw.magma.com},Padding:3}
s6a_proxy        | 	Origin-Realm {Code:296,Flags:0x40,Length:20,VendorId:0,Value:DiameterIdentity{magma.com},Padding:3}
s6a_proxy        | 	Origin-State-Id {Code:278,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{1649203845}}
s6a_proxy        | 	Vendor-Specific-Application-Id {Code:260,Flags:0x40,Length:32,VendorId:0,Value:Grouped{
s6a_proxy        | 		Vendor-Id {Code:266,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{10415}},
s6a_proxy        | 		Auth-Application-Id {Code:258,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{16777251}},
s6a_proxy        | 	}}
s6a_proxy        | 	Auth-Session-State {Code:277,Flags:0x40,Length:12,VendorId:0,Value:Enumerated{1}}
s6a_proxy        | 	ULA-Flags {Code:1406,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{0}}
s6a_proxy        | 	Subscription-Data {Code:1400,Flags:0xc0,Length:360,VendorId:10415,Value:Grouped{
s6a_proxy        | 		MSISDN {Code:701,Flags:0xc0,Length:20,VendorId:10415,Value:OctetString{0x3132333435},Padding:3},
s6a_proxy        | 		Access-Restriction-Data {Code:1426,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{47}},
s6a_proxy        | 		Subscriber-Status {Code:1424,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{0}},
s6a_proxy        | 		Network-Access-Mode {Code:1417,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{2}},
s6a_proxy        | 		APN-Configuration-Profile {Code:1429,Flags:0xc0,Length:236,VendorId:10415,Value:Grouped{
s6a_proxy        | 			Context-Identifier {Code:1423,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{0}},
s6a_proxy        | 			All-APN-Configurations-Included-Indicator {Code:1428,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{0}},
s6a_proxy        | 			APN-Configuration {Code:1430,Flags:0xc0,Length:192,VendorId:10415,Value:Grouped{
s6a_proxy        | 				Context-Identifier {Code:1423,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{0}},
s6a_proxy        | 				PDN-Type {Code:1456,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{0}},
s6a_proxy        | 				Unknown-493-0 {Code:493,Flags:0x40,Length:16,VendorId:0,Value:Unknown{0x6f61692e69707634},Padding:0} (Could not find AVP uint32(493) for Vendor: 0),
s6a_proxy        | 				EPS-Subscribed-QoS-Profile {Code:1431,Flags:0xc0,Length:88,VendorId:10415,Value:Grouped{
s6a_proxy        | 					QoS-Class-Identifier {Code:1028,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{9}},
s6a_proxy        | 					Allocation-Retention-Priority {Code:1034,Flags:0xc0,Length:60,VendorId:10415,Value:Grouped{
s6a_proxy        | 						Priority-Level {Code:1046,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{15}},
s6a_proxy        | 						Pre-emption-Capability {Code:1047,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{1}},
s6a_proxy        | 						Pre-emption-Vulnerability {Code:1048,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{0}},
s6a_proxy        | 					}}
s6a_proxy        | 				}}
s6a_proxy        | 					AMBR {Code:1435,Flags:0xc0,Length:44,VendorId:10415,Value:Grouped{
s6a_proxy        | 						Max-Requested-Bandwidth-DL {Code:515,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{20000000}},
s6a_proxy        | 						Max-Requested-Bandwidth-UL {Code:516,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{10000000}},
s6a_proxy        | 					}}
s6a_proxy        | 			}}
s6a_proxy        | 		}}
s6a_proxy        | 			AMBR {Code:1435,Flags:0xc0,Length:44,VendorId:10415,Value:Grouped{
s6a_proxy        | 				Max-Requested-Bandwidth-DL {Code:515,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{20000000}},
s6a_proxy        | 				Max-Requested-Bandwidth-UL {Code:516,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{10000000}},
s6a_proxy        | 			}}
s6a_proxy        | 	}}
s6a_proxy        |
s6a_proxy        | I0406 00:10:45.365679       1 logcodec.go:96] Sending: *protos.UpdateLocationAnswer: {
s6a_proxy        | 	"error_code": "UNDEFINED",
s6a_proxy        | 	"default_context_id": 0,
s6a_proxy        | 	"total_ambr": {
s6a_proxy        | 		"max_bandwidth_ul": 10000000,
s6a_proxy        | 		"max_bandwidth_dl": 20000000,
s6a_proxy        | 		"unit": "BPS"
s6a_proxy        | 	},
s6a_proxy        | 	"all_apns_included": true,
s6a_proxy        | 	"apn": [
s6a_proxy        | 		{
s6a_proxy        | 			"context_id": 0,
s6a_proxy        | 			"service_selection": "oai.ipv4",
s6a_proxy        | 			"qos_profile": {
s6a_proxy        | 				"class_id": 9,
s6a_proxy        | 				"priority_level": 15,
s6a_proxy        | 				"preemption_capability": false,
s6a_proxy        | 				"preemption_vulnerability": true
s6a_proxy        | 			},
s6a_proxy        | 			"ambr": {
s6a_proxy        | 				"max_bandwidth_ul": 10000000,
s6a_proxy        | 				"max_bandwidth_dl": 20000000,
s6a_proxy        | 				"unit": "BPS"
s6a_proxy        | 			},
s6a_proxy        | 			"pdn": "IPV4",
s6a_proxy        | 			"charging_characteristics": ""
s6a_proxy        | 		}
s6a_proxy        | 	],
s6a_proxy        | 	"default_charging_characteristics": "",
s6a_proxy        | 	"msisdn": "MTIzNDU=",
s6a_proxy        | 	"network_access_mode": "ONLY_PACKET",
s6a_proxy        | 	"regional_subscription_zone_code": [
s6a_proxy        | 	],
s6a_proxy        | 	"feature_list_id_2": null,
s6a_proxy        | 	"feature_list_id_1": null
s6a_proxy        | }
s6a_proxy        | I0406 00:10:45.452530       1 logcodec.go:96] Received: *protos.PurgeUERequest: {
s6a_proxy        | 	"user_name": "001010000000002"
s6a_proxy        | }
```

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
