### PR TITLE
chore: Shared code ownership for orc8r Python files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,7 +36,10 @@
 /lte/protos @magma/approvers-agw
 /lte/gateway/python @magma/approvers-agw-python
 /lte/gateway/c @magma/approvers-agw-c
+
+# agw code related to orc8r
 /orc8r/gateway/c/ @magma/approvers-agw-c
+/orc8r/gateway/python @magma/approvers-agw-python @magma/approvers-orc8r
 
 # approvers-agw-<subsection>
 /lte/gateway/c/session_manager @magma/approvers-agw-sessiond


### PR DESCRIPTION
## Summary

The Python services and libraries in orc8r are actually AGW code and contain both orc8r-related services and shared utility libs (for example, the generic AGW service.py or the Sentry config). For this reason, the code ownership should be shared by the orc8r and python-agw approvers.

## Test Plan

🤷

## Additional Information

- [ ] This change is backwards-breaking