### PR TITLE
fix(nms): Fix insecure randomness

### DIFF
--- a/nms/fbc_js_core/auth/express.js
+++ b/nms/fbc_js_core/auth/express.js
@@ -36,6 +36,8 @@ import type {ExpressRequest, ExpressResponse} from 'express';
 import type {FBCNMSRequest} from './access';
 import type {UserType} from '../../fbc_js_core/sequelize_models/models/user';
 
+import crypto from 'crypto';
+
 const logger = logging.getLogger(module);
 const PASSWORD_FOR_LOGGING = '<SECRET>';
 
@@ -285,7 +287,7 @@ function userMiddleware(options: Options): express.Router<FBCNMSRequest, *> {
         if (req.organization && userProperties.password === undefined) {
           const organization = await req.organization();
           if (organization.ssoEntrypoint) {
-            userProperties.password = Math.random().toString(36);
+            userProperties.password = crypto.randomBytes(16).toString('hex');
           }
         }
         const user = await User.create(userProperties);

--- a/nms/fbc_js_core/auth/strategies/OrganizationOIDCStrategy.js
+++ b/nms/fbc_js_core/auth/strategies/OrganizationOIDCStrategy.js
@@ -26,6 +26,8 @@ import {injectOrganizationParams} from '../organization';
 
 import type {OpenidUserInfoClaims} from 'openid-client';
 
+import crypto from 'crypto';
+
 const logger = require('../../../fbc_js_core/logging').getLogger(module);
 
 type Config = {
@@ -50,7 +52,7 @@ export default function OrganizationOIDCStrategy(config: Config) {
       if (!user) {
         const createArgs = await injectOrganizationParams(req, {
           email: email.toLowerCase(),
-          password: Math.random().toString(36),
+          password: crypto.randomBytes(16).toString('hex'),
           // Hardcoded role for now, should be configurable
           role: AccessRoles.SUPERUSER,
           ssoDefaultNetworkIDs,

--- a/nms/fbc_js_core/auth/strategies/OrganizationSamlStrategy.js
+++ b/nms/fbc_js_core/auth/strategies/OrganizationSamlStrategy.js
@@ -21,6 +21,8 @@ import {User} from '../../../fbc_js_core/sequelize_models';
 import {getUserFromRequest} from '../util';
 import {injectOrganizationParams} from '../organization';
 
+import crypto from 'crypto';
+
 const logger = require('../../../fbc_js_core/logging').getLogger(module);
 
 type Config = {
@@ -62,7 +64,7 @@ export default function OrganizationSamlStrategy(config: Config) {
         if (!user) {
           const createArgs = await injectOrganizationParams(req, {
             email: email.toLowerCase(),
-            password: Math.random().toString(36),
+            password: crypto.randomBytes(16).toString('hex'),
             // Hardcoded role for now, should be configurable
             role: AccessRoles.SUPERUSER,
             ssoDefaultNetworkIDs,

--- a/nms/fbc_js_core/platform_server/host/routes.js
+++ b/nms/fbc_js_core/platform_server/host/routes.js
@@ -27,6 +27,8 @@ import {FeatureFlag, Organization} from '../../../fbc_js_core/sequelize_models';
 import {User} from '../../../fbc_js_core/sequelize_models';
 import {getPropsToUpdate} from '../../../fbc_js_core/auth/util';
 
+import crypto from 'crypto';
+
 const logger = require('../../../fbc_js_core/logging').getLogger(module);
 
 const router: express.Router<FBCNMSRequest, ExpressResponse> = express.Router();
@@ -214,7 +216,7 @@ router.post(
           },
         });
         if (organization && organization.ssoEntrypoint) {
-          props.password = Math.random().toString(36);
+          props.password = crypto.randomBytes(16).toString('hex');
         }
       }
 


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

fix(nms): Fix insecure randomness

## Summary

Using a cryptographically weak pseudo-random number generator to generate a security-sensitive value, such as a password, makes it easier for an attacker to predict the value. A cryptographically secure pseudo-random number generator should be used instead.

## Additional Information

This is for code scanning alerts:
https://github.com/magma/magma/security/code-scanning/62
https://github.com/magma/magma/security/code-scanning/63
https://github.com/magma/magma/security/code-scanning/64
https://github.com/magma/magma/security/code-scanning/65
