### PR TITLE
chore(smsd): smsd is bazelified

### DIFF
--- a/lte/gateway/python/magma/smsd/BUILD.bazel
+++ b/lte/gateway/python/magma/smsd/BUILD.bazel
@@ -1,0 +1,48 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+MAGMA_ROOT = "../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+py_binary(
+    name = "smsd",
+    srcs = ["main.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    # legacy_create_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
+    legacy_create_init = False,
+    main = "main.py",
+    python_version = "PY3",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":smsd_lib",
+        "//lte/protos:sms_orc8r_python_grpc",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
+    ],
+)
+
+py_library(
+    name = "smsd_lib",
+    srcs = ["relay.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/protos:directoryd_python_grpc",
+    ],
+)

--- a/lte/protos/BUILD.bazel
+++ b/lte/protos/BUILD.bazel
@@ -354,6 +354,12 @@ cpp_grpc_library(
     deps = [":sms_orc8r_cpp_proto"],
 )
 
+python_grpc_library(
+    name = "sms_orc8r_python_grpc",
+    protos = [":sms_orc8r_proto"],
+    deps = ["//orc8r/protos:common_python_proto"],
+)
+
 proto_library(
     name = "diam_errors_proto",
     srcs = ["diam_errors.proto"],


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

Run the following comand on the devcontainer, magma VM and bazel-base container:
`bazel run lte/gateway/python/magma/smsd:smsd`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
