### PR TITLE
Revert "chore: rules python is upgraded (#12325)"

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -14,30 +14,9 @@ load("//bazel:third_party_repositories.bzl", "grpc")
 
 http_archive(
     name = "rules_python",
-    sha256 = "9fcf91dbcc31fde6d1edb15f117246d912c33c36f44cf681976bd886538deba6",
-    strip_prefix = "rules_python-0.8.0",
-    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.0.tar.gz",
+    sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.5.0/rules_python-0.5.0.tar.gz",
 )
-
-load("//bazel:python_toolchain.bzl", "configure_python_toolchain")
-
-configure_python_toolchain()
-
-load("//bazel:python_dependencies.bzl", "configure_python_dependencies")
-
-configure_python_dependencies()
-
-load("@python_deps//:requirements.bzl", "install_deps")
-
-install_deps()
-
-load("//bazel:python_swagger.bzl", "load_swagger_repositories")
-
-load_swagger_repositories()
-
-load("//bazel:python_repositories.bzl", "python_repositories")
-
-python_repositories()
 
 ### BUILDIFIER DEPENDENCIES
 # See https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md
@@ -148,3 +127,19 @@ new_local_repository(
     build_file = "//bazel/external:system_libraries.BUILD",
     path = "/",
 )
+
+load("//bazel:python_dependencies.bzl", "configure_python_dependencies")
+
+configure_python_dependencies()
+
+load("@python_deps//:requirements.bzl", "install_deps")
+
+install_deps()
+
+load("//bazel:python_swagger.bzl", "load_swagger_repositories")
+
+load_swagger_repositories()
+
+load("//bazel:python_repositories.bzl", "python_repositories")
+
+python_repositories()

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -8,3 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+load(":python_toolchain.bzl", "configure_python_toolchain")
+
+configure_python_toolchain()

--- a/bazel/python_dependencies.bzl
+++ b/bazel/python_dependencies.bzl
@@ -11,14 +11,15 @@
 
 """Python Toolchain and PIP Dependencies"""
 
-load("@python3_8//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 def configure_python_dependencies(name = None):
+    native.register_toolchains("//bazel:py_toolchain")
+
     pip_parse(
         name = "python_deps",
         extra_pip_args = ["--require-hashes"],
-        python_interpreter_target = interpreter,
+        python_interpreter = "python3",
         requirements_lock = "//bazel/external:requirements.txt",
         visibility = ["//visibility:public"],
     )

--- a/bazel/python_toolchain.bzl
+++ b/bazel/python_toolchain.bzl
@@ -11,10 +11,26 @@
 
 """Python toolchain configuration"""
 
-load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+load("@rules_python//python:defs.bzl", "py_runtime", "py_runtime_pair")
 
 def configure_python_toolchain(name = None):
-    python_register_toolchains(
-        name = "python3_8",
-        python_version = "3.8",
+    py_runtime(
+        name = "python3",
+        interpreter_path = "/usr/bin/python3.8",
+        python_version = "PY3",
+        visibility = ["//visibility:public"],
+    )
+
+    py_runtime_pair(
+        name = "py_runtime_pair",
+        py2_runtime = None,
+        py3_runtime = ":python3",
+        visibility = ["//visibility:public"],
+    )
+
+    native.toolchain(
+        name = "py_toolchain",
+        toolchain = ":py_runtime_pair",
+        toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+        visibility = ["//visibility:public"],
     )

--- a/experimental/bazel-base/Dockerfile
+++ b/experimental/bazel-base/Dockerfile
@@ -16,8 +16,6 @@ RUN apt-get update && \
         apt-utils \
         build-essential \
         ca-certificates \
-        # needed to build pip dependencies (e.g. systemd) 
-        clang-11 \
         curl \
         gcc \
         git \
@@ -59,8 +57,7 @@ RUN apt-get update && \
         uuid-dev \
         vim \
         wget \
-        zip && \
-    update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10
+        zip
 
 # Install depencies from facebook repository
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/


### PR DESCRIPTION
This reverts commit ed748a7eddcd7e56976cb6f1b715a840ede91c21.

Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

See #12416. Using pre-compiled Python interpreters is reverted until `linux/aarch64` is supported.

## Test Plan

* Manual test on arm architecture.
* CI for non-arm architecture.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
