### PR TITLE
chore(agw): upgrade Go installation in VM

### DIFF
--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -39,8 +39,8 @@
     - role: ovs
     - role: golang
       vars:
-        golang_tar: go1.13.4.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c'
+        golang_tar: go1.18.1.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334'
     - role: cwag
 
   tasks:

--- a/cwf/gateway/deploy/cwag_dev_centos7.yml
+++ b/cwf/gateway/deploy/cwag_dev_centos7.yml
@@ -31,6 +31,9 @@
     - role: test_certs
     - role: ovs
     - role: golang
+      vars:
+        golang_tar: go1.18.1.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334'
 #    - role: cwag
 
   tasks:
@@ -67,7 +70,7 @@
       copy:
         dest: /etc/sudoers.d/secure_path
         content: "Defaults secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/go/bin\n"
-        
+
     - name: Install basic build tools
       yum:
         name:

--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -30,8 +30,8 @@
         override_nameserver: 8.8.8.8
     - role: golang
       vars:
-        golang_tar: go1.13.4.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c'
+        golang_tar: go1.18.1.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334'
     - role: cwag_test
   tasks:
     - name: Set build environment variables

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -329,19 +329,28 @@
     - gmock
   when: preburn
 
+- name: Remove existing golang installation
+  # TODO: make golang installation preburn and delete this step
+  # it is necessary because the old golang installation has to be removed
+  # before installing the new one (https://go.dev/doc/install)
+  shell: rm -rf /usr/local/go
+  when: full_provision
+
 - name: Download golang tar
+  # TODO: make this preburn again
   get_url:
     url: "https://storage.googleapis.com/golang/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
     dest: "{{ all_vars.WORK_DIR }}"
     mode: 0440
-  when: preburn
+  when: full_provision
 
 - name: Extract Go tarball
+  # TODO: make this preburn again
   unarchive:
     src: "{{all_vars.WORK_DIR}}/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
     dest: /usr/local
     copy: no
-  when: preburn
+  when: full_provision
 
 - name: Set Go environment vars in profile
   lineinfile:
@@ -350,6 +359,7 @@
     line: "{{ item }}"
   with_items:
     - export PATH=$PATH:/usr/local/bin/go/
+    - export PATH=$PATH:$(go env GOPATH)/bin/
   when: full_provision
 
 - name: Install dnsmasq

--- a/lte/gateway/deploy/roles/magma/vars/all.yaml
+++ b/lte/gateway/deploy/roles/magma/vars/all.yaml
@@ -1,2 +1,2 @@
 WORK_DIR: "~/"
-GO_VERSION: "1.15.3"
+GO_VERSION: "1.18.1"

--- a/orc8r/cloud/deploy/roles/golang/defaults/main.yml
+++ b/orc8r/cloud/deploy/roles/golang/defaults/main.yml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  golang_tar: go1.11.linux-amd64.tar.gz
+  golang_tar: go1.18.1.linux-amd64.tar.gz
   golang_tar_checksum: 'sha256:b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499'
   go_install_path: /usr/local
   gopath: '/home/{{ user }}/go'

--- a/orc8r/tools/ansible/roles/golang/defaults/main.yml
+++ b/orc8r/tools/ansible/roles/golang/defaults/main.yml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  golang_tar: go1.12.4.linux-amd64.tar.gz
+  golang_tar: go1.18.1.linux-amd64.tar.gz
   golang_tar_checksum: 'sha256:d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5'
   go_install_path: /usr/local
   gopath: '/home/{{ user }}/go'

--- a/orc8r/tools/ansible/roles/golang/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/golang/tasks/main.yml
@@ -50,7 +50,7 @@
     GOPATH: "{{ gopath }}"
     GOBIN: "{{ gobin }}"
     PATH: "{{ ansible_env.PATH }}:{{ go_bin_path }}"
-  command: go get -u github.com/golang/protobuf/protoc-gen-go
+  command: go install github.com/golang/protobuf/protoc-gen-go@v1.5.2
   when: full_provision
 
 - name: Install golint
@@ -60,7 +60,7 @@
     GOPATH: "{{ gopath }}"
     GOBIN: "{{ gobin }}"
     PATH: "{{ ansible_env.PATH }}:{{ go_bin_path }}"
-  command: go get -u golang.org/x/lint/golint
+  command: go install golang.org/x/lint/golint@6edffad5e616
   when: full_provision
 
 - name: Install gotestsum
@@ -70,7 +70,7 @@
     GOPATH: "{{ gopath }}"
     GOBIN: "{{ gobin }}"
     PATH: "{{ ansible_env.PATH }}:{{ go_bin_path }}"
-  command: go get -u gotest.tools/gotestsum
+  command: go install gotest.tools/gotestsum@v1.8.0
   when: full_provision
 
 - name: Install buildifier
@@ -80,5 +80,5 @@
     GOPATH: "{{ gopath }}"
     GOBIN: "{{ gobin }}"
     PATH: "{{ ansible_env.PATH }}:{{ go_bin_path }}"
-  command: go get -u github.com/bazelbuild/buildtools/buildifier
+  command: go install github.com/bazelbuild/buildtools/buildifier@c802c3b06ba6
   when: full_provision


### PR DESCRIPTION
## Summary

[_Merge with #12151._]

Upgrade Go to 1.18 in lte magma VM and cwag VMs. This is necessary because of #12151.

In order to install Go correctly in the magma VM, the existing installation has to be removed first [1]. Thus an extra step was added for removal to make it possible to upgrade by executing `vagrant up magma --provision`.
Would be ideal to make this preburn eventually and delete the step that removes the existing go installation again. 

Addition: This PR also updates the `orc8r/cloud/deploy/roles/golang/`role to Go 1.18.

[1] https://go.dev/doc/install The relevant part: "Do not untar the archive into an existing /usr/local/go tree. This is known to produce broken Go installations."

## Test Plan

Tested locally.
