### PR TITLE
feat(nms): Redesign popover and account settings

### DIFF
--- a/nms/packages/magmalte/app/components/AccountSettings.js
+++ b/nms/packages/magmalte/app/components/AccountSettings.js
@@ -14,34 +14,35 @@
  * @format
  */
 
-import Button from '../../fbc_js_core/ui/components/design-system/Button';
-import FormGroup from '@material-ui/core/FormGroup';
-import Paper from '@material-ui/core/Paper';
-import React, {useContext} from 'react';
-import Text from '../../fbc_js_core/ui/components/design-system/Text';
-import TextField from '@material-ui/core/TextField';
-import axios from 'axios';
-
 import AppContext from '../../fbc_js_core/ui/context/AppContext';
+import Button from '../../fbc_js_core/ui/components/design-system/Button';
+import Paper from '@material-ui/core/Paper';
+import React, {useContext, useState} from 'react';
+import Text from '../theme/design-system/Text';
 import TopBar from './TopBar';
+import axios from 'axios';
+import {AltFormField, PasswordInput} from './FormField';
+import {List} from '@material-ui/core';
 import {makeStyles} from '@material-ui/styles';
 import {useEnqueueSnackbar} from '../../fbc_js_core/ui/hooks/useSnackbar';
-import {useState} from 'react';
 
 const TITLE = 'Account Settings';
 
 const useStyles = makeStyles(theme => ({
-  input: {},
+  title: {
+    fontSize: '18px',
+  },
+  input: {
+    width: '100%',
+    maxWidth: '400px',
+  },
   formContainer: {
-    margin: theme.spacing(2),
     paddingBottom: theme.spacing(2),
   },
   paper: {
-    margin: theme.spacing(3),
-    padding: theme.spacing(),
-  },
-  formGroup: {
-    marginBottom: theme.spacing(2),
+    margin: theme.spacing(4),
+    padding: theme.spacing(3),
+    paddingBottom: theme.spacing(6),
   },
 }));
 
@@ -53,12 +54,9 @@ export default function AccountSettings() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const {isOrganizations} = useContext(AppContext);
 
-  const onSave = async () => {
-    if (!currentPassword || !newPassword || !confirmPassword) {
-      enqueueSnackbar('Please complete all fields', {variant: 'error'});
-      return;
-    }
+  const isSaveEnabled = currentPassword && newPassword && confirmPassword;
 
+  const onSave = async () => {
     if (newPassword !== confirmPassword) {
       enqueueSnackbar('Passwords do not match', {variant: 'error'});
       return;
@@ -83,46 +81,45 @@ export default function AccountSettings() {
     <>
       {!isOrganizations && <TopBar header={TITLE} tabs={[]} />}
       <Paper className={classes.paper}>
-        <div className={classes.formContainer}>
-          <Text data-testid="change-password-title" variant="h5">
-            Change Password
-          </Text>
-          <FormGroup row className={classes.formGroup}>
-            <TextField
+        <Text data-testid="change-password-title" variant="body1">
+          Change Password
+        </Text>
+        <List className={classes.formContainer}>
+          <AltFormField label="Current Password" disableGutters={true}>
+            <PasswordInput
+              className={classes.input}
               required
-              label="Current Password"
-              type="password"
+              placeholder="Enter Current Password"
               value={currentPassword}
-              onChange={({target}) => setCurrentPassword(target.value)}
-              className={classes.input}
+              onChange={setCurrentPassword}
             />
-          </FormGroup>
-          <FormGroup row className={classes.formGroup}>
-            <TextField
+          </AltFormField>
+
+          <AltFormField label="New Password" disableGutters={true}>
+            <PasswordInput
+              className={classes.input}
               required
               autoComplete="off"
-              label="New Password"
-              type="password"
+              placeholder="Enter New Password"
               value={newPassword}
-              onChange={({target}) => setNewPassword(target.value)}
-              className={classes.input}
+              onChange={setNewPassword}
             />
-          </FormGroup>
-          <FormGroup row className={classes.formGroup}>
-            <TextField
+          </AltFormField>
+
+          <AltFormField label="Confirm New Password" disableGutters={true}>
+            <PasswordInput
+              className={classes.input}
               required
               autoComplete="off"
-              label="Confirm Password"
-              type="password"
+              placeholder="Confirm New Password"
               value={confirmPassword}
-              onChange={({target}) => setConfirmPassword(target.value)}
-              className={classes.input}
+              onChange={setConfirmPassword}
             />
-          </FormGroup>
-          <FormGroup row className={classes.formGroup}>
-            <Button onClick={onSave}>Save</Button>
-          </FormGroup>
-        </div>
+          </AltFormField>
+        </List>
+        <Button onClick={onSave} disabled={!isSaveEnabled}>
+          Save
+        </Button>
       </Paper>
     </>
   );

--- a/nms/packages/magmalte/app/components/FormField.js
+++ b/nms/packages/magmalte/app/components/FormField.js
@@ -163,6 +163,7 @@ export function AltFormFieldSubheading(props: Props) {
 type PasswordProps = {
   value: string,
   onChange: string => void,
+  placeholder?: string,
 };
 
 export function FormDivider() {

--- a/nms/packages/magmalte/app/components/NetworkSelector.js
+++ b/nms/packages/magmalte/app/components/NetworkSelector.js
@@ -26,7 +26,6 @@ import React from 'react';
 import SettingsEthernetIcon from '@material-ui/icons/SettingsEthernet';
 import Text from '../../fbc_js_core/ui/components/design-system/Text';
 import Tooltip from '@material-ui/core/Tooltip';
-import classNames from 'classnames';
 import useMagmaAPI from '../../api/useMagmaAPI';
 
 import {LTE, coalesceNetworkType} from '../../fbc_js_core/types/network';
@@ -37,46 +36,40 @@ import {useCallback, useContext, useEffect, useState} from 'react';
 
 const useStyles = makeStyles(_ => ({
   button: {
-    backgroundColor: colors.primary.white,
-    width: '28px',
-    height: '28px',
-    fontSize: '28px',
-    cursor: 'pointer',
-    borderRadius: '100%',
     display: 'flex',
     justifyContent: 'center',
-    alignItems: 'center',
-    marginBottom: '2px',
-    border: `1px solid ${colors.primary.white}`,
-    '&:hover, &$openButton': {
-      border: `1px solid ${colors.secondary.dodgerBlue}`,
+    width: '100%',
+    padding: '15px 0px',
+    cursor: 'pointer',
+    '&:hover $icon': {
+      color: colors.primary.white,
     },
   },
-  openButton: {},
+  icon: {
+    color: colors.primary.gullGray,
+  },
   itemGutters: {
     '&&': {
-      minWidth: '170px',
-      borderRadius: '4px',
-      padding: '8px 10px',
+      minWidth: '200px',
+      padding: '6px 17px',
       '&:hover': {
-        backgroundColor: 'rgba(145, 145, 145, 0.1)',
+        backgroundColor: colors.primary.concrete,
       },
     },
+  },
+  divider: {
+    margin: '6px 17px',
   },
   networksList: {
     '&&': {
       maxHeight: '400px',
       overflowY: 'auto',
-      padding: '10px 5px',
+      padding: '10px 0',
     },
   },
   networkItemText: {
-    fontSize: '12px',
-    lineHeight: '16px',
-  },
-  selectedNetwork: {
-    color: colors.secondary.dodgerBlue,
-    fontSize: '20px',
+    fontSize: '14px',
+    lineHeight: '20px',
   },
   selectedListItem: {
     '& $networkItemText': {
@@ -87,15 +80,6 @@ const useStyles = makeStyles(_ => ({
     '&$selectedListItem': {
       backgroundColor: colors.primary.concrete,
     },
-    '&:not(:last-child)': {
-      marginBottom: '8px',
-    },
-  },
-  sidebarEntry: {
-    display: 'flex',
-    padding: '9px',
-    justifyContent: 'center',
-    width: '100%',
   },
 }));
 
@@ -143,7 +127,7 @@ const NetworkSelector = () => {
         }}
       />
       <Popout
-        className={classes.sidebarEntry}
+        className={classes.button}
         open={isMenuOpen}
         content={
           <List component="nav" className={classes.networksList}>
@@ -164,7 +148,7 @@ const NetworkSelector = () => {
             ))}
             {appContext.user.isSuperUser && networkType === LTE && (
               <>
-                <Divider />
+                <Divider className={classes.divider} />
                 <ListItem
                   key="create_network"
                   classes={{
@@ -184,14 +168,11 @@ const NetworkSelector = () => {
         }
         onOpen={() => setIsMenuOpen(true)}
         onClose={() => setIsMenuOpen(false)}>
-        <Tooltip title={networkId} placement="right">
-          <div
-            className={classNames({
-              [classes.button]: true,
-              [classes.openButton]: isMenuOpen,
-            })}>
-            <SettingsEthernetIcon className={classes.selectedNetwork} />
-          </div>
+        <Tooltip
+          title={networkId}
+          placement="right"
+          data-testid="networkSelector">
+          <SettingsEthernetIcon className={classes.icon} />
         </Tooltip>
       </Popout>
     </>

--- a/nms/packages/magmalte/app/components/__tests__/AccountSettings-test.js
+++ b/nms/packages/magmalte/app/components/__tests__/AccountSettings-test.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import 'jest-dom/extend-expect';
+import * as React from 'react';
+import AccountSettings from '../AccountSettings';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import defaultTheme from '../../../fbc_js_core/ui/theme/default';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {SnackbarProvider} from 'notistack';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+
+const Wrapper = (props: {children: React.Node}) => (
+  <MemoryRouter initialEntries={['/nms/mynetwork/settings']} initialIndex={0}>
+    <MuiThemeProvider theme={defaultTheme}>
+      <MuiStylesThemeProvider theme={defaultTheme}>
+        <SnackbarProvider>
+          <Route path="/nms/:networkId/settings">{props.children}</Route>
+        </SnackbarProvider>
+      </MuiStylesThemeProvider>
+    </MuiThemeProvider>
+  </MemoryRouter>
+);
+
+afterEach(cleanup);
+
+describe('<AccountSettings />', () => {
+  it('Save button is disabled if form is not filled-out', () => {
+    const {getByRole, getByPlaceholderText} = render(
+      <Wrapper>
+        <AccountSettings />
+      </Wrapper>,
+    );
+
+    const button = getByRole('button', {name: 'Save'});
+    expect(button).toBeDisabled();
+
+    fireEvent.change(getByPlaceholderText('Enter Current Password'), {
+      target: {value: '1234'},
+    });
+    fireEvent.change(getByPlaceholderText('Enter New Password'), {
+      target: {value: 'secret'},
+    });
+    expect(button).toBeDisabled();
+
+    fireEvent.change(getByPlaceholderText('Confirm New Password'), {
+      target: {value: 'secret'},
+    });
+    expect(button).not.toBeDisabled();
+  });
+});

--- a/nms/packages/magmalte/app/e2e/__tests__/FegLte-test.js
+++ b/nms/packages/magmalte/app/e2e/__tests__/FegLte-test.js
@@ -20,7 +20,8 @@ import {addFegLteNetwork, addFegNetwork} from '../NetworkUtils';
 
 const ADMIN_SELECTOR = `//span[text()='Administration']`;
 const ADMIN_NW_SELECTOR = `//a[starts-with(@href, '/nms/test/admin/networks')]`;
-const NAV_SELECTOR = `//div[@data-testid='profileButton']`;
+const PROFILE_BUTTON_SELECTOR = `//*[@data-testid='profileButton']`;
+const NETWORK_SELECTOR_SELECTOR = `//*[@data-testid='networkSelector']`;
 
 let browser;
 beforeEach(async () => {
@@ -47,11 +48,12 @@ describe('Admin component', () => {
       await page.waitForXPath(`//span[text()='Dashboard']`, {
         timeout: 15000,
       });
-      await page.waitForXPath(NAV_SELECTOR);
-      const navSelector = await page.$x(NAV_SELECTOR);
+      await page.waitForXPath(PROFILE_BUTTON_SELECTOR);
+      const navSelector = await page.$x(PROFILE_BUTTON_SELECTOR);
       await navSelector[0].click();
 
       const adminSelector = await page.$x(ADMIN_SELECTOR);
+      await page.waitForTimeout(500);
       await adminSelector[0].click();
 
       await page.waitForXPath(ADMIN_NW_SELECTOR);
@@ -95,9 +97,9 @@ describe('NMS', () => {
         timeout: 15000,
       });
 
-      const networkSelector = 'div[title="test"]';
-      page.waitForSelector(networkSelector);
-      await page.click(networkSelector);
+      page.waitForXPath(NETWORK_SELECTOR_SELECTOR);
+      const networkSelector = await page.$x(NETWORK_SELECTOR_SELECTOR);
+      networkSelector[0].click();
 
       await page.waitForXPath(`//span[text()='Create Network']`);
       const buttonSelector = await page.$x(`//span[text()='Create Network']`);

--- a/nms/packages/magmalte/fbc_js_core/ui/components/NavListItem.js
+++ b/nms/packages/magmalte/fbc_js_core/ui/components/NavListItem.js
@@ -18,14 +18,14 @@ import React, {useCallback, useState} from 'react';
 import Text from './design-system/Text';
 import Tooltip from '@material-ui/core/Tooltip';
 import classNames from 'classnames';
-import symphony from '../theme/symphony';
 import {Link} from 'react-router-dom';
 import {makeStyles} from '@material-ui/styles';
 import {useRouter} from '../../../fbc_js_core/ui/hooks';
+import {colors} from "../../../app/theme/default";
 
 const useStyles = makeStyles(() => ({
   icon: {
-    color: symphony.palette.D300,
+    color: colors.primary.gullGray,
     display: 'flex',
   },
   link: {
@@ -37,17 +37,17 @@ const useStyles = makeStyles(() => ({
     width: '100%',
     padding: '15px 0px',
     '&:hover $icon, &$selected $icon': {
-      color: symphony.palette.white,
+      color: colors.primary.white,
     },
   },
   selected: {
-    backgroundColor: symphony.palette.primary,
+    backgroundColor: colors.secondary.dodgerBlue,
   },
   tooltip: {
     position: 'relative',
     '&&': {
       padding: '8px 12px',
-      backgroundColor: symphony.palette.D900,
+      backgroundColor: colors.primary.brightGray,
     },
   },
   arrow: {
@@ -56,7 +56,7 @@ const useStyles = makeStyles(() => ({
     '&:before': {
       borderBottom: '4px solid transparent',
       borderLeft: '4px solid transparent',
-      borderRight: `4px solid ${symphony.palette.D900}`,
+      borderRight: `4px solid ${colors.primary.brightGray}`,
       borderTop: '4px solid transparent',
       top: '-5px',
       content: '""',
@@ -71,7 +71,7 @@ const useStyles = makeStyles(() => ({
     '&&': {
       fontSize: '12px',
       lineHeight: '16px',
-      color: symphony.palette.white,
+      color: colors.primary.white,
       fontWeight: 'bold',
     },
   },

--- a/nms/packages/magmalte/fbc_js_core/ui/components/Popout.js
+++ b/nms/packages/magmalte/fbc_js_core/ui/components/Popout.js
@@ -30,38 +30,30 @@ type Props = {
 
 const useClasses = makeStyles(theme => ({
   menuPaper: {
+    '&.MuiPopover-paper': {
+      borderRadius: 0,
+    },
     outline: 'none',
     overflowX: 'visible',
     overflowY: 'visible',
-    position: 'absolute',
-    '&:before, &:after': {
+    '&:after': {
       content: '""',
       display: 'block',
       height: 0,
-      left: '11px',
-      position: 'absolute',
       width: 0,
-    },
-    '&:before': {
-      borderLeft: '5px solid transparent',
-      borderRight: '5px solid transparent',
-      borderTop: `6px solid ${theme.palette.grey[100]}`,
-      marginLeft: '-3px',
-      bottom: '-6px',
-      zIndex: 4,
-    },
-    '&:after': {
-      borderLeft: '5px solid transparent',
-      borderRight: '5px solid transparent',
-      borderTop: '7px solid #fff',
-      marginLeft: '-3px',
-      bottom: '-5px',
+      position: 'absolute',
+      left: '-14px',
+      bottom: '30px',
       zIndex: 5,
+
+      borderTop: '11px solid transparent',
+      borderRight: '14px solid #fff',
+      borderBottom: '11px solid transparent',
     },
   },
   popover: {
     '& $menuPaper': {
-      boxShadow: '0px 0px 4px 0px rgba(0, 0, 0, 0.15)',
+      boxShadow: '0px 8px 16px 0px rgba(0, 0, 0, 0.3)',
     },
   },
 }));
@@ -94,14 +86,12 @@ export default function Popout(props: Props) {
         className={classes.popover}
         anchorReference="anchorPosition"
         anchorOrigin={{
-          vertical: 'top',
+          vertical: 'bottom',
           horizontal: 'left',
         }}
         anchorPosition={{
-          top: relativeRefPosition?.y ?? 0,
-          left: relativeRefPosition
-            ? relativeRefPosition.x + relativeRefPosition.width / 2 - 14
-            : 0,
+          top: relativeRefPosition ? relativeRefPosition.bottom + 15 : 0,
+          left: relativeRefPosition?.right ?? 0,
         }}
         transformOrigin={{
           vertical: 'bottom',

--- a/nms/packages/magmalte/fbc_js_core/ui/components/ProfileButton.js
+++ b/nms/packages/magmalte/fbc_js_core/ui/components/ProfileButton.js
@@ -14,75 +14,62 @@
  * @format
  */
 
-import AppContext from '../../../fbc_js_core/ui/context/AppContext';
+import AppContext from '../context/AppContext';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import NetworkContext from '../../../app/components/context/NetworkContext';
-import Popout from '../../../fbc_js_core/ui/components/Popout';
-import ProfileIcon from '../icons/ProfileIcon';
+import Popout from './Popout';
+import PersonIcon from '@material-ui/icons/Person';
 import React, {useContext, useState} from 'react';
 import Text from './design-system/Text';
 import classNames from 'classnames';
-import {Events, GeneralLogger} from '../../../fbc_js_core/ui/utils/Logging';
+import {Events, GeneralLogger} from '../utils/Logging';
 import {makeStyles} from '@material-ui/styles';
 import {useRouter} from '../hooks';
+import {colors} from '../../../app/theme/default';
+import Divider from '@material-ui/core/Divider';
 
 const useStyles = makeStyles(theme => ({
-  accountButton: {
-    backgroundColor: theme.palette.common.white,
-    width: '36px',
-    height: '36px',
-    fontSize: '36px',
-    cursor: 'pointer',
-    borderRadius: '100%',
+  button: {
     display: 'flex',
     justifyContent: 'center',
-    alignItems: 'center',
-    '&:hover, &$openButton': {
-      '& $accountButtonIcon': {
-        fill: theme.palette.primary.main,
-      },
+    width: '100%',
+    padding: '15px 0px',
+    cursor: 'pointer',
+    '&:hover $icon': {
+      color: colors.primary.white,
     },
   },
-  openButton: {},
-  accountButtonIcon: {
-    '&&': {
-      fill: theme.palette.blueGrayDark,
-      fontSize: '19px',
+  selected: {
+    backgroundColor: colors.secondary.dodgerBlue,
+
+    '& $icon': {
+      color: colors.primary.white,
     },
   },
-  accountButtonIconSelected: {
-    '&&': {
-      fill: theme.palette.primary.main,
-    },
+  icon: {
+    color: colors.primary.gullGray,
   },
   itemGutters: {
     '&&': {
-      minWidth: '170px',
-      borderRadius: '4px',
-      padding: '8px 10px',
+      minWidth: '200px',
+      padding: '6px 17px',
       '&:hover': {
-        backgroundColor: 'rgba(145, 145, 145, 0.1)',
+        backgroundColor: colors.primary.concrete,
       },
     },
   },
+  divider: {
+    margin: '6px 17px',
+  },
   profileList: {
     '&&': {
-      padding: '10px 5px',
+      padding: '10px 0',
     },
   },
   profileItemText: {
-    fontSize: '12px',
-    lineHeight: '16px',
-  },
-  selected: {
-    backgroundColor: theme.palette.primary.main,
-  },
-  sidebarEntry: {
-    display: 'flex',
-    padding: '9px',
-    justifyContent: 'center',
-    width: '100%',
+    fontSize: '14px',
+    lineHeight: '20px',
   },
 }));
 
@@ -91,13 +78,18 @@ const ProfileButton = () => {
   const classes = useStyles();
   const [isProfileMenuOpen, toggleProfileMenu] = useState(false);
   const {networkId: selectedNetworkId} = useContext(NetworkContext);
-  const {user, ssoEnabled, isFeatureEnabled, isOrganizations} = useContext(
-    AppContext,
-  );
+  const {
+    user,
+    hasAccountSettings,
+    isFeatureEnabled,
+    isOrganizations,
+  } = useContext(AppContext);
   const {email} = user;
 
   const getUrl = (path: string) =>
-    (selectedNetworkId != undefined || isOrganizations) ? relativeUrl(path) : path;
+    selectedNetworkId != undefined || isOrganizations
+      ? relativeUrl(path)
+      : path;
 
   const adminUrl = getUrl('/admin');
   const settingsUrl = getUrl('/settings');
@@ -106,10 +98,13 @@ const ProfileButton = () => {
     location.pathname.includes(adminUrl) ||
     location.pathname.includes(settingsUrl);
 
+  const hasAdministration = user.isSuperUser && !isOrganizations;
+  const hasDocumentation = isFeatureEnabled('documents_site');
+
   return (
     <Popout
       className={classNames({
-        [classes.sidebarEntry]: true,
+        [classes.button]: true,
         [classes.selected]: isSelected,
       })}
       open={isProfileMenuOpen}
@@ -118,7 +113,8 @@ const ProfileButton = () => {
           <ListItem classes={{gutters: classes.itemGutters}} disabled={true}>
             <Text className={classes.profileItemText}>{email}</Text>
           </ListItem>
-          {!ssoEnabled && (
+          <Divider className={classes.divider} />
+          {hasAccountSettings && (
             <ListItem
               classes={{gutters: classes.itemGutters}}
               button
@@ -131,7 +127,7 @@ const ProfileButton = () => {
               <Text className={classes.profileItemText}>Account Settings</Text>
             </ListItem>
           )}
-          {user.isSuperUser && !isOrganizations && (
+          {hasAdministration && (
             <ListItem
               classes={{gutters: classes.itemGutters}}
               button
@@ -144,7 +140,7 @@ const ProfileButton = () => {
               <Text className={classes.profileItemText}>Administration</Text>
             </ListItem>
           )}
-          {isFeatureEnabled('documents_site') && (
+          {hasDocumentation && (
             <ListItem
               classes={{gutters: classes.itemGutters}}
               button
@@ -155,6 +151,9 @@ const ProfileButton = () => {
               component="a">
               <Text className={classes.profileItemText}>Documentation</Text>
             </ListItem>
+          )}
+          {(hasAccountSettings || hasAdministration || hasDocumentation) && (
+            <Divider className={classes.divider} />
           )}
           <ListItem
             classes={{gutters: classes.itemGutters}}
@@ -167,19 +166,7 @@ const ProfileButton = () => {
       }
       onOpen={() => toggleProfileMenu(true)}
       onClose={() => toggleProfileMenu(false)}>
-      <div
-        data-testid="profileButton"
-        className={classNames({
-          [classes.accountButton]: true,
-          [classes.openButton]: isProfileMenuOpen,
-        })}>
-        <ProfileIcon
-          className={classNames({
-            [classes.accountButtonIcon]: true,
-            [classes.accountButtonIconSelected]: isSelected,
-          })}
-        />
-      </div>
+      <PersonIcon data-testid="profileButton" className={classes.icon} />
     </Popout>
   );
 };

--- a/nms/packages/magmalte/fbc_js_core/ui/components/layout/AppSideBar.js
+++ b/nms/packages/magmalte/fbc_js_core/ui/components/layout/AppSideBar.js
@@ -18,18 +18,19 @@ import ExpandButton from './ExpandButton';
 import ProfileButton from '../ProfileButton';
 import React, {useState} from 'react';
 import {makeStyles} from '@material-ui/styles';
+import {colors} from '../../../../app/theme/default';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles(() => ({
   root: {
     alignItems: 'center',
-    backgroundColor: theme.palette.blueGrayDark,
+    backgroundColor: colors.primary.brightGray,
     boxShadow: '1px 0px 0px 0px rgba(0, 0, 0, 0.1)',
     display: 'flex',
     flexDirection: 'column',
     height: '100vh',
     width: '80px',
     minWidth: '80px',
-    padding: '20px 0px 20px 0px',
+    padding: '20px 0px 36px 0px',
     position: 'relative',
   },
   mainItems: {

--- a/nms/packages/magmalte/fbc_js_core/ui/context/AppContext.js
+++ b/nms/packages/magmalte/fbc_js_core/ui/context/AppContext.js
@@ -42,6 +42,7 @@ export type AppContextType = {
   isTabEnabled: Tab => boolean,
   ssoEnabled: boolean,
   ssoSelectedType: SSOSelectedType,
+  hasAccountSettings: boolean,
 };
 
 export type AppContextAppData = {|
@@ -66,6 +67,7 @@ const appContextDefaults = {
   isTabEnabled: () => false,
   ssoEnabled: false,
   ssoSelectedType: 'none',
+  hasAccountSettings: false,
 };
 
 const AppContext = React.createContext<AppContextType>(appContextDefaults);
@@ -82,6 +84,7 @@ export function AppContextProvider(props: Props) {
   const value = {
     ...appContextDefaults,
     ...appData,
+    hasAccountSettings: !appData.ssoEnabled,
     isOrganizations: !!props.isOrganizations, // is organizations management aka. the host site
     networkIds: props.networkIDs || [],
     isTabEnabled: (tab: Tab): boolean => {


### PR DESCRIPTION
## Summary
Implements design changes from https://www.figma.com/file/Ec5jkliFb4i4OYGdI9AkYk/Combining-Multiple-Portals
Followup of #12402

## New Design
![Screenshot 2022-04-08 at 13 10 50](https://user-images.githubusercontent.com/102796295/162424627-13b806f6-98ae-4bc9-9b15-8210556efc5e.png)
![Screenshot 2022-04-08 at 13 10 37](https://user-images.githubusercontent.com/102796295/162424642-41ce7ee1-e9d1-46d6-83ee-5c95b0cbb999.png)

The account settings are not pixel perfect because I tried to reuse existing elements to keep the UI consistent.
![Screenshot 2022-04-08 at 13 10 13](https://user-images.githubusercontent.com/102796295/162424859-c3fb49d0-473a-4596-be2c-f5be1d7cda82.png)

## Test Plan
Go to the account settings and make sure that changing the password still works.
