### PR TITLE
chore(orc8r): upgrade orc8r ansible files to use Go 1.18

### DIFF
--- a/orc8r/cloud/deploy/roles/golang/defaults/main.yml
+++ b/orc8r/cloud/deploy/roles/golang/defaults/main.yml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  golang_tar: go1.11.linux-amd64.tar.gz
+  golang_tar: go1.18.linux-amd64.tar.gz
   golang_tar_checksum: 'sha256:b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499'
   go_install_path: /usr/local
   gopath: '/home/{{ user }}/go'

--- a/orc8r/tools/ansible/roles/golang/defaults/main.yml
+++ b/orc8r/tools/ansible/roles/golang/defaults/main.yml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  golang_tar: go1.12.4.linux-amd64.tar.gz
+  golang_tar: go1.18.linux-amd64.tar.gz
   golang_tar_checksum: 'sha256:d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5'
   go_install_path: /usr/local
   gopath: '/home/{{ user }}/go'


### PR DESCRIPTION
## Summary

Upgrades ansible roles in orc8r to use Go 1.18. Merge after Go upgrade #12151.

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking
