### PR TITLE
feat(enodebd): Add new Baicells models to QRTB

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/device_utils.py
+++ b/lte/gateway/python/magma/enodebd/devices/device_utils.py
@@ -82,6 +82,8 @@ def get_device_name(
         elif sw_version.startswith('BaiBS_QRTB_') and (  # noqa: WPS222
             hw_version == 'E01' and 'mBS31001' in product_class
             or hw_version == 'A01' and 'pBS3101S' in product_class
+            or hw_version == 'A01' and 'pBS31010' in product_class
+            or hw_version == 'D01' and 'mBS31001' in product_class
         ):
             return EnodebDeviceName.BAICELLS_QRTB
         raise UnrecognizedEnodebError(


### PR DESCRIPTION
Extended hardware and product class Baicells BS support for QRTB
firmware.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

* Added new hardware and product class signatures support for QRTB models in enodebd:
* 

## Test Plan

Tested internally within FreedomFi environments using different Baicells BS units including Neutrino430.

## Additional Information

- [ ] This change is backwards-breaking