### PR TITLE
fix(enodebd): Set device cfg serial from Inform

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
@@ -49,6 +49,14 @@ def process_inform_message(
     for name, val in name_to_val.items():
         device_cfg.set_parameter(name, val)
 
+    # In case the SerialNumber does not come in the inform ParameterList
+    # it can still be present in the Inform structure, fill it in.
+    if (
+        hasattr(inform, 'DeviceId')
+        and hasattr(inform.DeviceId, 'SerialNumber')
+    ):
+        device_cfg.set_parameter(ParameterName.SERIAL_NUMBER, inform.DeviceId.SerialNumber)
+
 
 def get_device_name_from_inform(
     inform: models.Inform,


### PR DESCRIPTION
Currently, data models typically contain a `SERIAL_NUMBER` parameter with
a designated TR path (`Device.DeviceInfo.SerialNumber`).
When Inform is processed, parameters from the model are being set
in device config according to ParameterList from the Inform.
Serial Number paramter may not necessarily come as part of Inform's
ParameterList parmas.
As a result, when first Inform is processed, and Serial Number is not
part of the ParameterList, device config will not get updated with the
Serial Number passed in the Inform message - it will be updated during
GetParameters, which is typically a later step in the state machines.
    
Inform message may however still contain device Serial Number as part of
the Inform's DeviceId structure.
    
This commit tries to set device config `SERIAL_NUMBER` parameter when Inform
contains serial number in the DeviceId structure.
    
Future functionalities, like fw upgrade or Domain Proxy integration will
equire Serial Number to be present within the device config as soon as
possible even before any Get requests are made towards the eNBs.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

* Set eNB device config SERIAL_NUMBER during Inform processing if Inform's `DeviceId` structure contains it.

## Additional Information

- [ ] This change is backwards-breaking