### PR TITLE
chore(dp): Unify null and non null types behavior on insert

### DIFF
--- a/dp/cloud/go/services/dp/storage/cbsd_manager.go
+++ b/dp/cloud/go/services/dp/storage/cbsd_manager.go
@@ -173,7 +173,7 @@ func (e *enumCache) getValue(builder sq.StatementBuilderType, model db.Model, na
 	if err != nil {
 		return 0, err
 	}
-	e.cache[meta.Table][name] = r[0].Fields()["id"].GetValue().(int64)
+	e.cache[meta.Table][name] = r[0].(EnumModel).GetId()
 	return e.cache[meta.Table][name], nil
 }
 

--- a/dp/cloud/go/services/dp/storage/cbsd_manager_test.go
+++ b/dp/cloud/go/services/dp/storage/cbsd_manager_test.go
@@ -464,10 +464,8 @@ func (s *CbsdManagerTestSuite) getNameIdMapping(model db.Model) map[string]int64
 	s.Require().NoError(err)
 	m := make(map[string]int64, len(resources))
 	for _, r := range resources {
-		fields := r[0].Fields()
-		key := fields["name"].GetValue().(string)
-		value := fields["id"].GetValue().(int64)
-		m[key] = value
+		enum := r[0].(storage.EnumModel)
+		m[enum.GetName()] = enum.GetId()
 	}
 	return m
 }
@@ -486,6 +484,7 @@ func getGrant(stateId int64, cbsdId int64) *storage.DBGrant {
 	base := getBaseGrant()
 	base.CbsdId = db.MakeInt(cbsdId)
 	base.StateId = db.MakeInt(stateId)
+	base.GrantId = db.MakeString("some_grant_id")
 	return base
 }
 
@@ -494,6 +493,9 @@ func getCbsd(networkId string, stateId int64) *storage.DBCbsd {
 	base.NetworkId = db.MakeString(networkId)
 	base.StateId = db.MakeInt(stateId)
 	base.CbsdId = db.MakeString("some_cbsd_id")
+	base.IsUpdated = db.MakeBool(false)
+	base.IsDeleted = db.MakeBool(false)
+	base.GrantAttempts = db.MakeInt(0)
 	return base
 }
 

--- a/dp/cloud/go/services/dp/storage/db/fields.go
+++ b/dp/cloud/go/services/dp/storage/db/fields.go
@@ -24,8 +24,5 @@ type Field struct {
 }
 
 func (f *Field) GetValue() interface{} {
-	if f.Nullable {
-		return f.BaseType.nullableValue()
-	}
 	return f.BaseType.baseValue()
 }

--- a/dp/cloud/go/services/dp/storage/db/types.go
+++ b/dp/cloud/go/services/dp/storage/db/types.go
@@ -21,42 +21,36 @@ import (
 
 type BaseType interface {
 	baseValue() interface{}
-	nullableValue() interface{}
 	ptr() interface{}
 	sqlType() sqorc.ColumnType
 }
 
 type IntType struct{ X *sql.NullInt64 }
 
-func (x IntType) baseValue() interface{}     { return x.X.Int64 }
-func (x IntType) nullableValue() interface{} { return *x.X }
-func (x IntType) ptr() interface{}           { return x.X }
-func (x IntType) sqlType() sqorc.ColumnType  { return sqorc.ColumnTypeInt }
+func (x IntType) baseValue() interface{}    { return *x.X }
+func (x IntType) ptr() interface{}          { return x.X }
+func (x IntType) sqlType() sqorc.ColumnType { return sqorc.ColumnTypeInt }
 
 type FloatType struct{ X *sql.NullFloat64 }
 
-func (x FloatType) baseValue() interface{}     { return x.X.Float64 }
-func (x FloatType) nullableValue() interface{} { return *x.X }
-func (x FloatType) ptr() interface{}           { return x.X }
-func (x FloatType) sqlType() sqorc.ColumnType  { return sqorc.ColumnTypeReal }
+func (x FloatType) baseValue() interface{}    { return *x.X }
+func (x FloatType) ptr() interface{}          { return x.X }
+func (x FloatType) sqlType() sqorc.ColumnType { return sqorc.ColumnTypeReal }
 
 type StringType struct{ X *sql.NullString }
 
-func (x StringType) baseValue() interface{}     { return x.X.String }
-func (x StringType) nullableValue() interface{} { return *x.X }
-func (x StringType) ptr() interface{}           { return x.X }
-func (x StringType) sqlType() sqorc.ColumnType  { return sqorc.ColumnTypeText }
+func (x StringType) baseValue() interface{}    { return *x.X }
+func (x StringType) ptr() interface{}          { return x.X }
+func (x StringType) sqlType() sqorc.ColumnType { return sqorc.ColumnTypeText }
 
 type BoolType struct{ X *sql.NullBool }
 
-func (x BoolType) baseValue() interface{}     { return x.X.Bool }
-func (x BoolType) nullableValue() interface{} { return *x.X }
-func (x BoolType) ptr() interface{}           { return x.X }
-func (x BoolType) sqlType() sqorc.ColumnType  { return sqorc.ColumnTypeBool }
+func (x BoolType) baseValue() interface{}    { return *x.X }
+func (x BoolType) ptr() interface{}          { return x.X }
+func (x BoolType) sqlType() sqorc.ColumnType { return sqorc.ColumnTypeBool }
 
 type TimeType struct{ X *sql.NullTime }
 
-func (x TimeType) baseValue() interface{}     { return x.X.Time }
-func (x TimeType) nullableValue() interface{} { return *x.X }
-func (x TimeType) ptr() interface{}           { return x.X }
-func (x TimeType) sqlType() sqorc.ColumnType  { return sqorc.ColumnTypeDatetime }
+func (x TimeType) baseValue() interface{}    { return *x.X }
+func (x TimeType) ptr() interface{}          { return x.X }
+func (x TimeType) sqlType() sqorc.ColumnType { return sqorc.ColumnTypeDatetime }

--- a/dp/cloud/go/services/dp/storage/models.go
+++ b/dp/cloud/go/services/dp/storage/models.go
@@ -27,6 +27,11 @@ const (
 	ActiveModeConfigTable = "active_mode_configs"
 )
 
+type EnumModel interface {
+	GetId() int64
+	GetName() string
+}
+
 type DBGrantState struct {
 	Id   sql.NullInt64
 	Name sql.NullString
@@ -53,11 +58,19 @@ func (gs *DBGrantState) GetMetadata() *db.ModelMetadata {
 	}
 }
 
+func (gs *DBGrantState) GetId() int64 {
+	return gs.Id.Int64
+}
+
+func (gs *DBGrantState) GetName() string {
+	return gs.Name.String
+}
+
 type DBGrant struct {
 	Id                 sql.NullInt64
 	StateId            sql.NullInt64
 	CbsdId             sql.NullInt64
-	GrantId            sql.NullInt64
+	GrantId            sql.NullString
 	GrantExpireTime    sql.NullTime
 	TransmitExpireTime sql.NullTime
 	HeartbeatInterval  sql.NullInt64
@@ -80,7 +93,7 @@ func (g *DBGrant) Fields() db.FieldMap {
 			Nullable: true,
 		},
 		"grant_id": &db.Field{
-			BaseType: db.IntType{X: &g.GrantId},
+			BaseType: db.StringType{X: &g.GrantId},
 		},
 		"grant_expire_time": &db.Field{
 			BaseType: db.TimeType{X: &g.GrantExpireTime},
@@ -147,6 +160,14 @@ func (cs *DBCbsdState) GetMetadata() *db.ModelMetadata {
 			return &DBCbsdState{}
 		},
 	}
+}
+
+func (cs *DBCbsdState) GetId() int64 {
+	return cs.Id.Int64
+}
+
+func (cs *DBCbsdState) GetName() string {
+	return cs.Name.String
 }
 
 type DBCbsd struct {


### PR DESCRIPTION
## Summary

Previously null and non null types were treated differently on insert.
For example when given field didn't have value and it was required,
then default value was used instead of null.

But there is no point of having separate behavior, since:
- when field is not required then it can be null,
so it should be possible to assign null to it
- when field is required then it is better to explicitly fail,
when no value is provided, rather than using implicit default value

Explicit default values can still be used, with field masks.
In order to use them one has to just omit the given field in the field
mask.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>
