### PR TITLE
chore: Add a utility script to automate IWYU findings

### DIFF
--- a/dev_tools/apply-iwyu.sh
+++ b/dev_tools/apply-iwyu.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# How to use: 
+# 1. Run `Bzl: Bazel/C++: Generate Compilation Database` in the VSCode command palette (CMD+Shift+P) to generate the compilation database
+# 2. $MAGMA_ROOT/dev_tools/apply-iwyu.sh $PATH_TO_APPLY_IWYU
+#    Ex. $MAGMA_ROOT/dev_tools/apply-iwyu.sh lte/gateway/c/core/common
+SOURCE_CODE_PATH=$1
+
+IWYU_OUTPUT_FILE=/tmp/iwyu-output.txt
+
+echo ""
+echo "[IMPORTANT] Make sure you've run 'Bzl: Bazel/C++: Generate Compilation Database' in VSCode's command palette (CMD+Shift+P) to generate an up-to-date compile_commands.json!"
+echo ""
+
+iwyu_tool.py -j "$(nproc --all)" -p "$MAGMA_ROOT"/compile_commands.json "$SOURCE_CODE_PATH" -- -Xiwyu --mapping_file="$MAGMA_ROOT"/dev_tools/iwyu.imp | tee "$IWYU_OUTPUT_FILE"
+
+fix_includes.py < "$IWYU_OUTPUT_FILE" -b --reorder

--- a/dev_tools/iwyu.imp
+++ b/dev_tools/iwyu.imp
@@ -19,4 +19,12 @@
     # folly
     { include: ["<folly/dynamic-inl.h>", "private", "<folly/dynamic.h>", "public"] },
     { include: ["<folly/lang/Assume-inl.h>", "private", "<folly/lang/Assume.h>", "public"] },
+
+    # Google test / mock 
+    { include: ["@<gtest/.*>", "private", "<gtest/gtest.h>", "public"] },
+    { include: ["@<gmock/.*>", "private", "<gmock/gmock.h>", "public"] },
+
+    # magma
+    { include: ["@\"lte/gateway/c/core/oai/include/.*.messages_types.h\"", "private", "\"lte/gateway/c/core/oai/include/messages_types.h\"", "public"] },
+    { include: ["@\"lte/gateway/c/core/oai/include/.*.messages_def.h\"", "private", "\"lte/gateway/c/core/oai/include/messages_def.h\"", "public"] },
 ]


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
A wrapper script to automate running IWYU and applying fixes.

Can be used like this:
```bash
# First run `bsv.cc.compdb.generate` in VSCode to generate the compilation database`
# Runs IWYU and applies it to the session_manager directory
$MAGMA_ROOT/dev_tools/apply-iwyu.sh lte/gateway/c/session_manager
```

I've also added some IWYU mapping config to
* direct IWYU to use <gmock/gmock.h> and <gtest/gtest.h> over private gmock/gtest headers 
* direct IWYU to use `lte/gateway/c/core/oai/include/messages_def.h` and `lte/gateway/c/core/oai/include/messages_types.h` over more specific messages_defs/types headers in that directory. (I think this is the intended way, thought we don't always follow it closely)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
I ran the script for liagentd / connection_tracker etc and it works. Can commit those fixups in a separate PR.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
