### PR TITLE
chore(dp): Move sql types out of value types

### DIFF
--- a/dp/cloud/go/services/dp/storage/db/fields.go
+++ b/dp/cloud/go/services/dp/storage/db/fields.go
@@ -13,16 +13,14 @@ limitations under the License.
 
 package db
 
-type FieldMap map[string]*Field
+import "magma/orc8r/cloud/go/sqorc"
 
+type FieldMap map[string]*Field
 type Field struct {
-	BaseType     BaseType
+	Item         BaseType
+	SqlType      sqorc.ColumnType
 	Nullable     bool
 	HasDefault   bool
 	DefaultValue interface{}
 	Unique       bool
-}
-
-func (f *Field) GetValue() interface{} {
-	return f.BaseType.baseValue()
 }

--- a/dp/cloud/go/services/dp/storage/db/finishing.go
+++ b/dp/cloud/go/services/dp/storage/db/finishing.go
@@ -103,7 +103,7 @@ func applyMask(fields FieldMap, mask FieldMask) FieldMap {
 func toValues(fields FieldMap) map[string]interface{} {
 	m := make(map[string]interface{}, len(fields))
 	for k, v := range fields {
-		m[k] = v.GetValue()
+		m[k] = v.Item.value()
 	}
 	return m
 }

--- a/dp/cloud/go/services/dp/storage/db/join.go
+++ b/dp/cloud/go/services/dp/storage/db/join.go
@@ -93,7 +93,7 @@ func (f *fieldPointersCollector) preVisit(q *Query) {
 	fields := model.Fields()
 	f.models = append(f.models, model)
 	for _, col := range f.columns[metadata.Table] {
-		f.pointers = append(f.pointers, fields[col].BaseType.ptr())
+		f.pointers = append(f.pointers, fields[col].Item.ptr())
 	}
 }
 

--- a/dp/cloud/go/services/dp/storage/db/query_test.go
+++ b/dp/cloud/go/services/dp/storage/db/query_test.go
@@ -505,19 +505,24 @@ func (s *someModel) GetMetadata() *db.ModelMetadata {
 func (s *someModel) Fields() db.FieldMap {
 	return db.FieldMap{
 		"id": &db.Field{
-			BaseType: db.IntType{X: &s.id},
+			Item:    db.IntType{X: &s.id},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"value": &db.Field{
-			BaseType: db.FloatType{X: &s.value},
+			Item:    db.FloatType{X: &s.value},
+			SqlType: sqorc.ColumnTypeReal,
 		},
 		"name": &db.Field{
-			BaseType: db.StringType{X: &s.name},
+			Item:    db.StringType{X: &s.name},
+			SqlType: sqorc.ColumnTypeText,
 		},
 		"flag": &db.Field{
-			BaseType: db.BoolType{X: &s.flag},
+			Item:    db.BoolType{X: &s.flag},
+			SqlType: sqorc.ColumnTypeBool,
 		},
 		"date": &db.Field{
-			BaseType: db.TimeType{X: &s.date},
+			Item:    db.TimeType{X: &s.date},
+			SqlType: sqorc.ColumnTypeDatetime,
 		},
 	}
 }
@@ -555,26 +560,32 @@ func (o *otherModel) GetMetadata() *db.ModelMetadata {
 func (o *otherModel) Fields() db.FieldMap {
 	return db.FieldMap{
 		"id": &db.Field{
-			BaseType: db.IntType{X: &o.id},
+			Item:    db.IntType{X: &o.id},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"some_id": &db.Field{
-			BaseType: db.IntType{X: &o.someId},
+			Item:     db.IntType{X: &o.someId},
+			SqlType:  sqorc.ColumnTypeInt,
 			Nullable: true,
 		},
 		"value": &db.Field{
-			BaseType: db.FloatType{X: &o.value},
+			Item:     db.FloatType{X: &o.value},
+			SqlType:  sqorc.ColumnTypeReal,
 			Nullable: true,
 		},
 		"name": &db.Field{
-			BaseType: db.StringType{X: &o.name},
+			Item:     db.StringType{X: &o.name},
+			SqlType:  sqorc.ColumnTypeText,
 			Nullable: true,
 		},
 		"flag": &db.Field{
-			BaseType: db.BoolType{X: &o.flag},
+			Item:     db.BoolType{X: &o.flag},
+			SqlType:  sqorc.ColumnTypeBool,
 			Nullable: true,
 		},
 		"date": &db.Field{
-			BaseType: db.TimeType{X: &o.date},
+			Item:     db.TimeType{X: &o.date},
+			SqlType:  sqorc.ColumnTypeDatetime,
 			Nullable: true,
 		},
 	}
@@ -607,14 +618,17 @@ func (a *anotherModel) GetMetadata() *db.ModelMetadata {
 func (a *anotherModel) Fields() db.FieldMap {
 	return db.FieldMap{
 		"id": &db.Field{
-			BaseType: db.IntType{X: &a.id},
+			Item:    db.IntType{X: &a.id},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"other_id": &db.Field{
-			BaseType: db.IntType{X: &a.otherId},
+			Item:     db.IntType{X: &a.otherId},
+			SqlType:  sqorc.ColumnTypeInt,
 			Nullable: true,
 		},
 		"default_value": &db.Field{
-			BaseType:     db.IntType{X: &a.defaultValue},
+			Item:         db.IntType{X: &a.defaultValue},
+			SqlType:      sqorc.ColumnTypeInt,
 			HasDefault:   true,
 			DefaultValue: defaultValue,
 		},
@@ -647,15 +661,18 @@ func (m *modelWithUniqueFields) GetMetadata() *db.ModelMetadata {
 func (m *modelWithUniqueFields) Fields() db.FieldMap {
 	return db.FieldMap{
 		"id": &db.Field{
-			BaseType: db.IntType{X: &m.id},
+			Item:    db.IntType{X: &m.id},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"unique_field": &db.Field{
-			BaseType: db.IntType{X: &m.uniqueField},
-			Unique:   true,
+			Item:    db.IntType{X: &m.uniqueField},
+			SqlType: sqorc.ColumnTypeInt,
+			Unique:  true,
 		},
 		"another_unique_fied": &db.Field{
-			BaseType: db.IntType{X: &m.anotherUniqueFied},
-			Unique:   true,
+			Item:    db.IntType{X: &m.anotherUniqueFied},
+			SqlType: sqorc.ColumnTypeInt,
+			Unique:  true,
 		},
 	}
 }

--- a/dp/cloud/go/services/dp/storage/db/table.go
+++ b/dp/cloud/go/services/dp/storage/db/table.go
@@ -35,7 +35,7 @@ func addColumns(builder sqorc.CreateTableBuilder, fields FieldMap) sqorc.CreateT
 	for column, field := range fields {
 		colBuilder := builder.
 			Column(column).
-			Type(field.BaseType.sqlType())
+			Type(field.SqlType)
 		if !field.Nullable {
 			colBuilder = colBuilder.NotNull()
 		}

--- a/dp/cloud/go/services/dp/storage/db/types.go
+++ b/dp/cloud/go/services/dp/storage/db/types.go
@@ -15,42 +15,34 @@ package db
 
 import (
 	"database/sql"
-
-	"magma/orc8r/cloud/go/sqorc"
 )
 
 type BaseType interface {
-	baseValue() interface{}
+	value() interface{}
 	ptr() interface{}
-	sqlType() sqorc.ColumnType
 }
 
 type IntType struct{ X *sql.NullInt64 }
 
-func (x IntType) baseValue() interface{}    { return *x.X }
-func (x IntType) ptr() interface{}          { return x.X }
-func (x IntType) sqlType() sqorc.ColumnType { return sqorc.ColumnTypeInt }
+func (x IntType) value() interface{} { return *x.X }
+func (x IntType) ptr() interface{}   { return x.X }
 
 type FloatType struct{ X *sql.NullFloat64 }
 
-func (x FloatType) baseValue() interface{}    { return *x.X }
-func (x FloatType) ptr() interface{}          { return x.X }
-func (x FloatType) sqlType() sqorc.ColumnType { return sqorc.ColumnTypeReal }
+func (x FloatType) value() interface{} { return *x.X }
+func (x FloatType) ptr() interface{}   { return x.X }
 
 type StringType struct{ X *sql.NullString }
 
-func (x StringType) baseValue() interface{}    { return *x.X }
-func (x StringType) ptr() interface{}          { return x.X }
-func (x StringType) sqlType() sqorc.ColumnType { return sqorc.ColumnTypeText }
+func (x StringType) value() interface{} { return *x.X }
+func (x StringType) ptr() interface{}   { return x.X }
 
 type BoolType struct{ X *sql.NullBool }
 
-func (x BoolType) baseValue() interface{}    { return *x.X }
-func (x BoolType) ptr() interface{}          { return x.X }
-func (x BoolType) sqlType() sqorc.ColumnType { return sqorc.ColumnTypeBool }
+func (x BoolType) value() interface{} { return *x.X }
+func (x BoolType) ptr() interface{}   { return x.X }
 
 type TimeType struct{ X *sql.NullTime }
 
-func (x TimeType) baseValue() interface{}    { return *x.X }
-func (x TimeType) ptr() interface{}          { return x.X }
-func (x TimeType) sqlType() sqorc.ColumnType { return sqorc.ColumnTypeDatetime }
+func (x TimeType) value() interface{} { return *x.X }
+func (x TimeType) ptr() interface{}   { return x.X }

--- a/dp/cloud/go/services/dp/storage/models.go
+++ b/dp/cloud/go/services/dp/storage/models.go
@@ -17,6 +17,7 @@ import (
 	"database/sql"
 
 	"magma/dp/cloud/go/services/dp/storage/db"
+	"magma/orc8r/cloud/go/sqorc"
 )
 
 const (
@@ -40,10 +41,12 @@ type DBGrantState struct {
 func (gs *DBGrantState) Fields() db.FieldMap {
 	return db.FieldMap{
 		"id": &db.Field{
-			BaseType: db.IntType{X: &gs.Id},
+			Item:    db.IntType{X: &gs.Id},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"name": &db.Field{
-			BaseType: db.StringType{X: &gs.Name},
+			Item:    db.StringType{X: &gs.Name},
+			SqlType: sqorc.ColumnTypeText,
 		},
 	}
 }
@@ -83,42 +86,53 @@ type DBGrant struct {
 func (g *DBGrant) Fields() db.FieldMap {
 	return db.FieldMap{
 		"id": &db.Field{
-			BaseType: db.IntType{X: &g.Id},
+			Item:    db.IntType{X: &g.Id},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"state_id": &db.Field{
-			BaseType: db.IntType{X: &g.StateId},
+			Item:    db.IntType{X: &g.StateId},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"cbsd_id": &db.Field{
-			BaseType: db.IntType{X: &g.CbsdId},
+			Item:     db.IntType{X: &g.CbsdId},
+			SqlType:  sqorc.ColumnTypeInt,
 			Nullable: true,
 		},
 		"grant_id": &db.Field{
-			BaseType: db.StringType{X: &g.GrantId},
+			Item:    db.StringType{X: &g.GrantId},
+			SqlType: sqorc.ColumnTypeText,
 		},
 		"grant_expire_time": &db.Field{
-			BaseType: db.TimeType{X: &g.GrantExpireTime},
+			Item:     db.TimeType{X: &g.GrantExpireTime},
+			SqlType:  sqorc.ColumnTypeDatetime,
 			Nullable: true,
 		},
 		"transmit_expire_time": &db.Field{
-			BaseType: db.TimeType{X: &g.TransmitExpireTime},
+			Item:     db.TimeType{X: &g.TransmitExpireTime},
+			SqlType:  sqorc.ColumnTypeDatetime,
 			Nullable: true,
 		},
 		"heartbeat_interval": &db.Field{
-			BaseType: db.IntType{X: &g.HeartbeatInterval},
+			Item:     db.IntType{X: &g.HeartbeatInterval},
+			SqlType:  sqorc.ColumnTypeInt,
 			Nullable: true,
 		},
 		"channel_type": &db.Field{
-			BaseType: db.StringType{X: &g.ChannelType},
+			Item:     db.StringType{X: &g.ChannelType},
+			SqlType:  sqorc.ColumnTypeText,
 			Nullable: true,
 		},
 		"low_frequency": &db.Field{
-			BaseType: db.IntType{X: &g.LowFrequency},
+			Item:    db.IntType{X: &g.LowFrequency},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"high_frequency": &db.Field{
-			BaseType: db.IntType{X: &g.HighFrequency},
+			Item:    db.IntType{X: &g.HighFrequency},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"max_eirp": &db.Field{
-			BaseType: db.FloatType{X: &g.MaxEirp},
+			Item:    db.FloatType{X: &g.MaxEirp},
+			SqlType: sqorc.ColumnTypeReal,
 		},
 	}
 }
@@ -144,10 +158,12 @@ type DBCbsdState struct {
 func (cs *DBCbsdState) Fields() db.FieldMap {
 	return db.FieldMap{
 		"id": &db.Field{
-			BaseType: db.IntType{X: &cs.Id},
+			Item:    db.IntType{X: &cs.Id},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"name": &db.Field{
-			BaseType: db.StringType{X: &cs.Name},
+			Item:    db.StringType{X: &cs.Name},
+			SqlType: sqorc.ColumnTypeText,
 		},
 	}
 }
@@ -193,69 +209,86 @@ type DBCbsd struct {
 func (c *DBCbsd) Fields() db.FieldMap {
 	return db.FieldMap{
 		"id": &db.Field{
-			BaseType: db.IntType{X: &c.Id},
+			Item:    db.IntType{X: &c.Id},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"network_id": &db.Field{
-			BaseType: db.StringType{X: &c.NetworkId},
+			Item:    db.StringType{X: &c.NetworkId},
+			SqlType: sqorc.ColumnTypeText,
 		},
 		"state_id": &db.Field{
-			BaseType: db.IntType{X: &c.StateId},
+			Item:    db.IntType{X: &c.StateId},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"cbsd_id": &db.Field{
-			BaseType: db.StringType{X: &c.CbsdId},
+			Item:     db.StringType{X: &c.CbsdId},
+			SqlType:  sqorc.ColumnTypeText,
 			Nullable: true,
 		},
 		"user_id": &db.Field{
-			BaseType: db.StringType{X: &c.UserId},
+			Item:     db.StringType{X: &c.UserId},
+			SqlType:  sqorc.ColumnTypeText,
 			Nullable: true,
 		},
 		"fcc_id": &db.Field{
-			BaseType: db.StringType{X: &c.FccId},
+			Item:     db.StringType{X: &c.FccId},
+			SqlType:  sqorc.ColumnTypeText,
 			Nullable: true,
 		},
 		"cbsd_serial_number": &db.Field{
-			BaseType: db.StringType{X: &c.CbsdSerialNumber},
+			Item:     db.StringType{X: &c.CbsdSerialNumber},
+			SqlType:  sqorc.ColumnTypeText,
 			Nullable: true,
 			Unique:   true,
 		},
 		"last_seen": &db.Field{
-			BaseType: db.TimeType{X: &c.LastSeen},
+			Item:     db.TimeType{X: &c.LastSeen},
+			SqlType:  sqorc.ColumnTypeDatetime,
 			Nullable: true,
 		},
 		"grant_attempts": &db.Field{
-			BaseType:     db.IntType{X: &c.GrantAttempts},
+			Item:         db.IntType{X: &c.GrantAttempts},
+			SqlType:      sqorc.ColumnTypeInt,
 			HasDefault:   true,
 			DefaultValue: 0,
 		},
 		"preferred_bandwidth_mhz": &db.Field{
-			BaseType: db.IntType{X: &c.PreferredBandwidthMHz},
+			Item:    db.IntType{X: &c.PreferredBandwidthMHz},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"preferred_frequencies_mhz": &db.Field{
-			BaseType: db.StringType{X: &c.PreferredFrequenciesMHz},
+			Item:    db.StringType{X: &c.PreferredFrequenciesMHz},
+			SqlType: sqorc.ColumnTypeText,
 		},
 		"min_power": &db.Field{
-			BaseType: db.FloatType{X: &c.MinPower},
+			Item:     db.FloatType{X: &c.MinPower},
+			SqlType:  sqorc.ColumnTypeReal,
 			Nullable: true,
 		},
 		"max_power": &db.Field{
-			BaseType: db.FloatType{X: &c.MaxPower},
+			Item:     db.FloatType{X: &c.MaxPower},
+			SqlType:  sqorc.ColumnTypeReal,
 			Nullable: true,
 		},
 		"antenna_gain": &db.Field{
-			BaseType: db.FloatType{X: &c.AntennaGain},
+			Item:     db.FloatType{X: &c.AntennaGain},
+			SqlType:  sqorc.ColumnTypeReal,
 			Nullable: true,
 		},
 		"number_of_ports": &db.Field{
-			BaseType: db.IntType{X: &c.NumberOfPorts},
+			Item:     db.IntType{X: &c.NumberOfPorts},
+			SqlType:  sqorc.ColumnTypeInt,
 			Nullable: true,
 		},
 		"is_deleted": &db.Field{
-			BaseType:     db.BoolType{X: &c.IsDeleted},
+			Item:         db.BoolType{X: &c.IsDeleted},
+			SqlType:      sqorc.ColumnTypeBool,
 			HasDefault:   true,
 			DefaultValue: false,
 		},
 		"is_updated": &db.Field{
-			BaseType:     db.BoolType{X: &c.IsUpdated},
+			Item:         db.BoolType{X: &c.IsUpdated},
+			SqlType:      sqorc.ColumnTypeBool,
 			HasDefault:   true,
 			DefaultValue: false,
 		},
@@ -283,13 +316,16 @@ type DBActiveModeConfig struct {
 func (amc *DBActiveModeConfig) Fields() db.FieldMap {
 	return db.FieldMap{
 		"id": &db.Field{
-			BaseType: db.IntType{X: &amc.Id},
+			Item:    db.IntType{X: &amc.Id},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"cbsd_id": &db.Field{
-			BaseType: db.IntType{X: &amc.CbsdId},
+			Item:    db.IntType{X: &amc.CbsdId},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 		"desired_state_id": &db.Field{
-			BaseType: db.IntType{X: &amc.DesiredStateId},
+			Item:    db.IntType{X: &amc.DesiredStateId},
+			SqlType: sqorc.ColumnTypeInt,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Previously value types stored information about sql types,
but the point is that value types are supposed to be instance level,
whereas sql types are model level.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>