### PR TITLE
feat(enodebd): Baicells QRTB firmware upgrade

### DIFF
--- a/lte/gateway/configs/enodebd.yml
+++ b/lte/gateway/configs/enodebd.yml
@@ -47,9 +47,12 @@ sas:
 # Main config section for TR069 Download request for FW Upgrade
 # `firmwares` is a dictionary of available firmwares with download details
 #   key is the firmware version signature. Value is an object with:
-#     "url": full url to the firmware file
-#     "username": [optional] auth credentials
-#     "password": [optional] auth credentials
+#     "url": string, full url to the firmware file
+#     "username": [optional] string, auth credentials
+#     "password": [optional] string, auth credentials
+#     "md5": [optional, Baicells mandatory] string, 32 character md5 sum
+#     "rawmode": [optional, Baicells mandatory] bool, Raw mode flag
+#    "md5" and "rawmode" params will be added to Download request if present in the config.
 # `enbs` is a dictionary with serial-level eNB specific firmware upgrade configuration.
 #   key is the eNB serial number.
 #   value is a string matching firmware version listed in the `firmwares` section.
@@ -67,6 +70,8 @@ sas:
 #       url: "http://some_url/some_fw_file.ffw"
 #       username: "user"
 #       password: "password"
+#       md5: "12345678901234567890123456789012"
+#       rawmode: false
 #     "some_other_version":
 #       url: "http://some_other_url/some_other_fw_file.ffw"
 #     "some_yet_unused_version":

--- a/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
@@ -363,6 +363,11 @@ def should_transition_to_firmware_upgrade_download(acs):
         device_serial_number = acs.device_cfg.get_parameter(
             ParameterName.SERIAL_NUMBER,
         )
+    if not device_sw_version or not device_serial_number:
+        logger.debug(
+            f'Skipping FW Download for eNB, missing device config: {device_sw_version=}, {device_serial_number=}.',
+        )
+        return False
     if acs.is_fw_upgrade_in_progress():
         logger.debug(
             'Skipping FW Download for eNB [%s], firmware upgrade in progress.',
@@ -402,14 +407,14 @@ def get_firmware_upgrade_download_config(acs):
         acs, device_serial_number,
     )
     if fw_upgrade_config:
-        logger.info(f'Found {fw_upgrade_config=} for {device_serial_number=}')
+        logger.debug(f'Found {fw_upgrade_config=} for {device_serial_number=}')
         return fw_upgrade_config
     device_model = acs.device_name
     fw_upgrade_config = _get_firmware_upgrade_download_config_for_model(
         acs, device_model,
     )
     if fw_upgrade_config:
-        logger.info(f'Found {fw_upgrade_config=} for {device_model=}')
+        logger.debug(f'Found {fw_upgrade_config=} for {device_model=}')
     return fw_upgrade_config
 
 

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -237,12 +237,16 @@ class FirmwareUpgradeDownloadState(EnodebAcsState):
         target_software_version_url = fw_upgrade_config.get('url', "")
         username = fw_upgrade_config.get('username', "")
         password = fw_upgrade_config.get('password', "")
+        md5 = fw_upgrade_config.get('md5', None)
+        rawmode = fw_upgrade_config.get('rawmode', None)
 
         download_params_dict = {
             "target_software_version": target_software_version,
             "target_software_version_url": target_software_version_url,
             "username": username,
             "password": password,
+            "md5": md5,
+            "rawmode": rawmode,
         }
 
         return download_params_dict
@@ -264,6 +268,12 @@ class FirmwareUpgradeDownloadState(EnodebAcsState):
         request.DelaySeconds = 0
         request.SuccessURL = ""
         request.FailureURL = ""
+
+        # Baicells specific settings
+        if download_params_dict['md5'] is not None:
+            request.Md5 = download_params_dict['md5']
+        if download_params_dict['rawmode'] is not None:
+            request.RawMode = bool(download_params_dict['rawmode'])
         return request
 
 

--- a/lte/gateway/python/magma/enodebd/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/enodebd/tests/BUILD.bazel
@@ -63,9 +63,11 @@ pytest_test(
         "//lte/gateway/python/magma/enodebd/data_models:data_model",
         "//lte/gateway/python/magma/enodebd/device_config:configuration_init",
         "//lte/gateway/python/magma/enodebd/devices:baicells_qrtb",
+        "//lte/gateway/python/magma/enodebd/devices:device_utils",
         "//lte/gateway/python/magma/enodebd/tests/test_utils:enb_acs_builder",
         "//lte/gateway/python/magma/enodebd/tests/test_utils:enodeb_handler",
         "//lte/gateway/python/magma/enodebd/tests/test_utils:tr069_msg_builder",
+        requirement("parameterized"),
     ],
 )
 

--- a/lte/gateway/python/magma/enodebd/tr069/models.py
+++ b/lte/gateway/python/magma/enodebd/tr069/models.py
@@ -294,6 +294,9 @@ class Download(Tr069ComplexModel):
     _type_info["DelaySeconds"] = UnsignedInteger
     _type_info["SuccessURL"] = String(max_length=256)
     _type_info["FailureURL"] = String(max_length=256)
+    # The following are extra aditions introduced for Baicells
+    _type_info["Md5"] = String(max_length=32)
+    _type_info["RawMode"] = Boolean
 
 
 class DownloadResponse(Tr069ComplexModel):
@@ -421,6 +424,9 @@ class AcsToCpeRequests(Tr069ComplexModel):
     _type_info["DelaySeconds"] = UnsignedInteger
     _type_info["SuccessURL"] = String(max_length=256)
     _type_info["FailureURL"] = String(max_length=256)
+    # Optional Baicells specific Download fields
+    _type_info["Md5"] = String(max_length=32)
+    _type_info["RawMode"] = Boolean
 
     # Fields for Reboot
     # _type_info["CommandKey"] = CommandKeyType - Already covered above


### PR DESCRIPTION
Added TR069 firmware upgrade support for Baicells running QRTB firmware.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

* Extended QRTB device model with Firmware Upgrade Download flow states

## Test Plan

Tested on Baicells Neutrino430 BS with QRTB Firmwares 2.7.X and 2.8.X in a staging environment.

## Additional Information

- [ ] This change is backwards-breaking