### PR TITLE
fix(amf): Handling return type of AMF functions

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -45,13 +45,13 @@ amf_as_data_t amf_data_sec;
 nas_amf_smc_proc_t smc_proc;
 static int amf_registration_failure_authentication_cb(
     amf_context_t* amf_context);
-static int amf_start_registration_proc_security(
+static status_code_e amf_start_registration_proc_security(
     amf_context_t* amf_context, nas_amf_registration_proc_t* registration_proc);
 static int amf_registration(amf_context_t* amf_context);
 static int amf_registration_failure_security_cb(amf_context_t* amf_context);
 
-static int amf_registration_reject(amf_context_t* amf_context,
-                                   nas_amf_registration_proc_t* nas_base_proc);
+static status_code_e amf_registration_reject(
+    amf_context_t* amf_context, nas_amf_registration_proc_t* nas_base_proc);
 static int registration_accept_t3550_handler(zloop_t* loop, int timer_id,
                                              void* arg);
 
@@ -84,11 +84,11 @@ int amf_registration_success_authentication_cb(amf_context_t* amf_context) {
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_start_registration_proc_authentication(
+status_code_e amf_start_registration_proc_authentication(
     amf_context_t* amf_context,
     nas_amf_registration_proc_t* registration_proc) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   if ((amf_context) && (registration_proc)) {
     rc = amf_proc_authentication(amf_context, &registration_proc->amf_spec_proc,
                                  amf_registration_success_authentication_cb,
@@ -164,11 +164,11 @@ void amf_proc_create_procedure_registration_request(
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_proc_registration_request(amf_ue_ngap_id_t ue_id,
-                                  const bool is_mm_ctx_new,
-                                  amf_registration_request_ies_t* ies) {
+status_code_e amf_proc_registration_request(
+    amf_ue_ngap_id_t ue_id, const bool is_mm_ctx_new,
+    amf_registration_request_ies_t* ies) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   ue_m5gmm_context_s ue_ctx;
   amf_ue_ngap_id_t old_ue_id = 0;
   imsi64_t imsi64 = INVALID_IMSI64;
@@ -243,7 +243,7 @@ int amf_proc_registration_request(amf_ue_ngap_id_t ue_id,
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
   }
 
-  rc = ue_state_handle_message_initial(
+  rc = (status_code_e)ue_state_handle_message_initial(
       ue_m5gmm_context->mm_state, STATE_EVENT_REG_REQUEST, SESSION_NULL,
       ue_m5gmm_context, &ue_m5gmm_context->amf_context);
 
@@ -258,10 +258,10 @@ int amf_proc_registration_request(amf_ue_ngap_id_t ue_id,
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_proc_registration_reject(amf_ue_ngap_id_t ue_id,
-                                 amf_cause_t amf_cause) {
+status_code_e amf_proc_registration_reject(amf_ue_ngap_id_t ue_id,
+                                           amf_cause_t amf_cause) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   amf_context_t* amf_ctx = amf_context_get(ue_id);
 
   if (amf_ctx) {
@@ -298,10 +298,10 @@ int amf_proc_registration_reject(amf_ue_ngap_id_t ue_id,
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-static int amf_registration_reject(amf_context_t* amf_context,
-                                   nas_amf_registration_proc_t* nas_base_proc) {
+static status_code_e amf_registration_reject(
+    amf_context_t* amf_context, nas_amf_registration_proc_t* nas_base_proc) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   amf_sap_t amf_sap = {};
   nas_amf_registration_proc_t* registration_proc =
       (nas_amf_registration_proc_t*)nas_base_proc;
@@ -522,11 +522,11 @@ int amf_registration_success_security_cb(amf_context_t* amf_context) {
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-static int amf_start_registration_proc_security(
+static status_code_e amf_start_registration_proc_security(
     amf_context_t* amf_context,
     nas_amf_registration_proc_t* registration_proc) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
 
   if ((amf_context) && (registration_proc)) {
     /*
@@ -834,11 +834,11 @@ int amf_proc_registration_complete(amf_context_t* amf_ctx) {
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int amf_handle_registration_complete_response(
+status_code_e amf_handle_registration_complete_response(
     amf_ue_ngap_id_t ue_id, RegistrationCompleteMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t status) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   ue_m5gmm_context_s* ue_m5gmm_context = NULL;
 
   OAILOG_DEBUG(LOG_NAS_AMF,
@@ -917,9 +917,9 @@ int amf_proc_amf_information(ue_m5gmm_context_s* ue_amf_ctx) {
  **      Others:    None                                              **
  **                                                                   **
  ***********************************************************************/
-int amf_reg_send(amf_sap_t* const msg) {
+status_code_e amf_reg_send(amf_sap_t* const msg) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   // TODO in future it will be implemented based on request of
   // PDU session establishment with initial registration
   amf_primitive_t primitive = msg->primitive;

--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -248,7 +248,7 @@ status_code_e amf_proc_registration_request(
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
   }
 
-  rc = (status_code_e)ue_state_handle_message_initial(
+  rc = ue_state_handle_message_initial(
       ue_m5gmm_context->mm_state, STATE_EVENT_REG_REQUEST, SESSION_NULL,
       ue_m5gmm_context, &ue_m5gmm_context->amf_context);
 

--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -349,9 +349,9 @@ static status_code_e amf_registration_reject(
 **                                                                        **
 ***************************************************************************/
 
-int amf_registration_run_procedure(amf_context_t* amf_context) {
+status_code_e amf_registration_run_procedure(amf_context_t* amf_context) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   nas_amf_registration_proc_t* registration_proc =
       get_nas_specific_procedure_registration(amf_context);
   if (registration_proc == NULL) {
@@ -759,10 +759,10 @@ static int registration_accept_t3550_handler(zloop_t* loop, int timer_id,
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int amf_proc_registration_complete(amf_context_t* amf_ctx) {
+status_code_e amf_proc_registration_complete(amf_context_t* amf_ctx) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   nas_amf_registration_proc_t* registration_proc = NULL;
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   amf_sap_t amf_sap = {};
   amf_ue_ngap_id_t ue_id =
       PARENT_STRUCT(amf_ctx, struct ue_m5gmm_context_s, amf_context)
@@ -875,8 +875,8 @@ status_code_e amf_handle_registration_complete_response(
  **                                                                        **
  ***************************************************************************/
 
-int amf_proc_amf_information(ue_m5gmm_context_s* ue_amf_ctx) {
-  int rc = RETURNerror;
+status_code_e amf_proc_amf_information(ue_m5gmm_context_s* ue_amf_ctx) {
+  status_code_e rc = RETURNerror;
   amf_sap_t amf_sap = {};
   amf_as_data_t* amf_as = &amf_sap.u.amf_as.u.data;
   amf_context_t* amf_ctx = &(ue_amf_ctx->amf_context);
@@ -1046,10 +1046,10 @@ void amf_delete_registration_ies(amf_registration_request_ies_t** ies) {
 **      Others:    None                                                   **
 **                                                                        **
 ***************************************************************************/
-int amf_proc_registration_abort(amf_context_t* amf_ctx,
-                                struct ue_m5gmm_context_s* ue_context_p) {
-  OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+status_code_e amf_proc_registration_abort(
+    amf_context_t* amf_ctx, struct ue_m5gmm_context_s* ue_context_p) {
+  OAILOG_FUNC_IN(LOG_AMF_APP);
+  status_code_e rc = RETURNerror;
   if (ue_context_p) {
     amf_app_itti_ue_context_release(ue_context_p, NGAP_NAS_DEREGISTER);
     amf_delete_registration_proc(&ue_context_p->amf_context);
@@ -1067,11 +1067,11 @@ int amf_proc_registration_abort(amf_context_t* amf_ctx,
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int get_decrypt_imsi_suci_extension(amf_context_t* amf_context,
-                                    uint8_t ue_pubkey_identifier,
-                                    const std::string& ue_pubkey,
-                                    const std::string& ciphertext,
-                                    const std::string& mac_tag) {
+status_code_e get_decrypt_imsi_suci_extension(amf_context_t* amf_context,
+                                              uint8_t ue_pubkey_identifier,
+                                              const std::string& ue_pubkey,
+                                              const std::string& ciphertext,
+                                              const std::string& mac_tag) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
 
   amf_ue_ngap_id_t ue_id =

--- a/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_Security_Mode.cpp
@@ -40,12 +40,12 @@ namespace magma5g {
  **                                                                        **
  **                                                                        **
  ***************************************************************************/
-int amf_handle_security_complete_response(
+status_code_e amf_handle_security_complete_response(
     amf_ue_ngap_id_t ue_id, amf_nas_message_decode_status_t decode_status) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   ue_m5gmm_context_s* ue_mm_context = NULL;
   amf_context_t* amf_ctx = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   OAILOG_DEBUG(LOG_NAS_AMF,
                "Security mode procedures complete for "
                "(ue_id=" AMF_UE_NGAP_ID_FMT ")\n",

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.hpp
@@ -37,7 +37,7 @@ status_code_e amf_app_handle_uplink_nas_message(amf_app_desc_t* amf_app_desc_p,
                                                 bstring msg,
                                                 amf_ue_ngap_id_t ue_id,
                                                 const tai_t originating_tai);
-int amf_app_handle_pdu_session_response(
+status_code_e amf_app_handle_pdu_session_response(
     itti_n11_create_pdu_session_response_t* pdu_session_resp);
 int amf_app_handle_pdu_session_failure(
     itti_n11_create_pdu_session_failure_t* pdu_session_failure);
@@ -48,7 +48,7 @@ int amf_app_handle_pdu_session_accept(
 void convert_ambr(const uint32_t* pdu_ambr_response_unit,
                   const uint32_t* pdu_ambr_response_value,
                   M5GSessionAmbrUnit* ambr_unit, uint16_t* ambr_value);
-int amf_smf_handle_ip_address_response(
+status_code_e amf_smf_handle_ip_address_response(
     itti_amf_ip_allocation_response_t* response_p);
 void amf_app_handle_initial_context_setup_rsp(
     amf_app_desc_t* amf_app_desc_p,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.hpp
@@ -39,9 +39,9 @@ status_code_e amf_app_handle_uplink_nas_message(amf_app_desc_t* amf_app_desc_p,
                                                 const tai_t originating_tai);
 status_code_e amf_app_handle_pdu_session_response(
     itti_n11_create_pdu_session_response_t* pdu_session_resp);
-int amf_app_handle_pdu_session_failure(
+status_code_e amf_app_handle_pdu_session_failure(
     itti_n11_create_pdu_session_failure_t* pdu_session_failure);
-int amf_app_handle_notification_received(
+status_code_e amf_app_handle_notification_received(
     itti_n11_received_notification_t* notification);
 int amf_app_handle_pdu_session_accept(
     itti_n11_create_pdu_session_response_t* pdu_session_resp, uint64_t ue_id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.hpp
@@ -31,11 +31,12 @@ typedef struct amf_app_desc_s {
 imsi64_t amf_app_handle_initial_ue_message(
     amf_app_desc_t* amf_app_desc_p,
     itti_ngap_initial_ue_message_t* conn_est_ind_pP);
-int amf_app_handle_nas_dl_req(amf_ue_ngap_id_t ue_id, bstring nas_msg,
-                              nas5g_error_code_t transaction_status);
-int amf_app_handle_uplink_nas_message(amf_app_desc_t* amf_app_desc_p,
-                                      bstring msg, amf_ue_ngap_id_t ue_id,
-                                      const tai_t originating_tai);
+status_code_e amf_app_handle_nas_dl_req(amf_ue_ngap_id_t ue_id, bstring nas_msg,
+                                        nas5g_error_code_t transaction_status);
+status_code_e amf_app_handle_uplink_nas_message(amf_app_desc_t* amf_app_desc_p,
+                                                bstring msg,
+                                                amf_ue_ngap_id_t ue_id,
+                                                const tai_t originating_tai);
 int amf_app_handle_pdu_session_response(
     itti_n11_create_pdu_session_response_t* pdu_session_resp);
 int amf_app_handle_pdu_session_failure(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.hpp
@@ -53,7 +53,7 @@ status_code_e amf_smf_handle_ip_address_response(
 void amf_app_handle_initial_context_setup_rsp(
     amf_app_desc_t* amf_app_desc_p,
     itti_amf_app_initial_context_setup_rsp_t* initial_context_rsp);
-int amf_send_n11_update_location_req(amf_ue_ngap_id_t ue_id);
+status_code_e amf_send_n11_update_location_req(amf_ue_ngap_id_t ue_id);
 int amf_app_pdu_session_modification_request(
     itti_n11_create_pdu_session_response_t* pdu_sess_mod_req,
     amf_ue_ngap_id_t ue_id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_defs.hpp
@@ -43,7 +43,7 @@ status_code_e amf_app_handle_pdu_session_failure(
     itti_n11_create_pdu_session_failure_t* pdu_session_failure);
 status_code_e amf_app_handle_notification_received(
     itti_n11_received_notification_t* notification);
-int amf_app_handle_pdu_session_accept(
+status_code_e amf_app_handle_pdu_session_accept(
     itti_n11_create_pdu_session_response_t* pdu_session_resp, uint64_t ue_id);
 void convert_ambr(const uint32_t* pdu_ambr_response_unit,
                   const uint32_t* pdu_ambr_response_value,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -1558,14 +1558,14 @@ static int paging_t3513_handler(zloop_t* loop, int timer_id, void* arg) {
 
 // Doing Paging Request handling received from SMF in AMF CORE
 // int amf_app_defs::amf_app_handle_notification_received(
-int amf_app_handle_notification_received(
+status_code_e amf_app_handle_notification_received(
     itti_n11_received_notification_t* notification) {
   ue_m5gmm_context_s* ue_context = nullptr;
   amf_context_t* amf_ctx = nullptr;
   paging_context_t* paging_ctx = nullptr;
   MessageDef* message_p = nullptr;
   itti_ngap_paging_request_t* ngap_paging_notify = nullptr;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   imsi64_t imsi64;
   IMSI_STRING_TO_IMSI64(notification->imsi, &imsi64);
@@ -1576,7 +1576,7 @@ int amf_app_handle_notification_received(
 
   if (!ue_context) {
     OAILOG_ERROR(LOG_AMF_APP, "UE context is null\n");
-    return -1;
+    return RETURNerror;
   }
 
   switch (notification->notify_ue_evnt) {
@@ -1722,7 +1722,7 @@ void amf_app_handle_initial_context_setup_rsp(
   }
 }
 using grpc::Status;
-int amf_app_handle_pdu_session_failure(
+status_code_e amf_app_handle_pdu_session_failure(
     itti_n11_create_pdu_session_failure_t* pdu_session_failure) {
   if (!pdu_session_failure) {
     return RETURNok;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -795,10 +795,8 @@ int paa_to_address_info(const paa_t* paa, uint8_t* pdu_address_info,
 **      Return:    RETURNok, RETURNerror                                  **
 **                                                                        **
 ***************************************************************************/
-int amf_app_handle_pdu_session_accept(
+status_code_e amf_app_handle_pdu_session_accept(
     itti_n11_create_pdu_session_response_t* pdu_session_resp, uint64_t ue_id) {
-  nas5g_error_code_t rc = M5G_AS_SUCCESS;
-
   DLNASTransportMsg* encode_msg;
   amf_nas_message_t msg = {};
   uint32_t bytes = 0;
@@ -817,7 +815,7 @@ int amf_app_handle_pdu_session_accept(
     OAILOG_ERROR(LOG_AMF_APP,
                  "ue context not found for the ue_id:" AMF_UE_NGAP_ID_FMT,
                  ue_id);
-    OAILOG_FUNC_RETURN(LOG_AMF_APP, M5G_AS_FAILURE);
+    OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
   }
 
   smf_ctx = amf_get_smf_context_by_pdu_session_id(
@@ -825,7 +823,7 @@ int amf_app_handle_pdu_session_accept(
   if (!smf_ctx) {
     OAILOG_ERROR(LOG_AMF_APP,
                  "Smf context is not exist UE ID:" AMF_UE_NGAP_ID_FMT, ue_id);
-    OAILOG_FUNC_RETURN(LOG_AMF_APP, M5G_AS_FAILURE);
+    OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
   }
   // updating session state
   smf_ctx->pdu_session_state = ACTIVE;
@@ -976,7 +974,7 @@ int amf_app_handle_pdu_session_accept(
                  "Slice Configuration does not exist:" AMF_UE_NGAP_ID_FMT,
                  ue_id);
 
-    OAILOG_FUNC_RETURN(LOG_AMF_APP, M5G_AS_FAILURE);
+    OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
   }
 
   if (slice_information.sd[0]) {
@@ -1052,7 +1050,7 @@ int amf_app_handle_pdu_session_accept(
   bdestroy(smf_msg->msg.pdu_session_estab_accept.authorized_qosrules);
   bdestroy(smf_msg->msg.pdu_session_estab_accept.authorized_qosflowdescriptors);
 
-  return rc;
+  return RETURNok;
 }  // namespace magma5g
 
 /* Handling PDU Session Resource Setup Response sent from gNB*/

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -497,12 +497,13 @@ imsi64_t amf_app_handle_initial_ue_message(
 **      Return:    RETURNok, RETURNerror                                  **
 **                                                                        **
 ***************************************************************************/
-int amf_app_handle_uplink_nas_message(amf_app_desc_t* amf_app_desc_p,
-                                      bstring msg, amf_ue_ngap_id_t ue_id,
-                                      const tai_t originating_tai) {
+status_code_e amf_app_handle_uplink_nas_message(amf_app_desc_t* amf_app_desc_p,
+                                                bstring msg,
+                                                amf_ue_ngap_id_t ue_id,
+                                                const tai_t originating_tai) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   if (msg) {
     amf_sap_t amf_sap = {};
     /*

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -548,7 +548,7 @@ static int amf_smf_session_update_pti_proc(
 /* Received the session created response message from SMF. Populate and Send
  * PDU Session Resource Setup Request message to gNB and  PDU Session
  * Establishment Accept Message to UE*/
-int amf_app_handle_pdu_session_response(
+status_code_e amf_app_handle_pdu_session_response(
     itti_n11_create_pdu_session_response_t* pdu_session_resp) {
   DLNASTransportMsg encode_msg;
   memset(&encode_msg, 0, sizeof(encode_msg));
@@ -558,7 +558,7 @@ int amf_app_handle_pdu_session_response(
   memset(&amf_smf_msg, 0, sizeof(amf_smf_msg));
   // TODO: hardcoded for now, addressed in the upcoming multi-UE PR
   uint64_t ue_id = 0;
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   uint32_t event;
 
   imsi64_t imsi64 = 0;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
@@ -71,7 +71,7 @@ void ambr_calculation_pdu_session(uint16_t* dl_session_ambr,
  * information in smf_context or default. No NAS message is involved and direct
  * itti_message is sent to NGAP.
  */
-int pdu_session_resource_setup_request(
+status_code_e pdu_session_resource_setup_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
     std::shared_ptr<smf_context_t> smf_context, bstring nas_msg) {
   OAILOG_FUNC_IN(LOG_AMF_APP);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.cpp
@@ -105,9 +105,10 @@ AmfNasStateManager::~AmfNasStateManager() { free_state(); }
 
 // Singleton class initializer which calls to create new object of
 // AmfNasStateManager
-int AmfNasStateManager::initialize_state(const amf_config_t* amf_config_p) {
+status_code_e AmfNasStateManager::initialize_state(
+    const amf_config_t* amf_config_p) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
-  uint32_t rc = RETURNok;
+  status_code_e rc = RETURNok;
   persist_state_enabled = amf_config_p->use_stateless;
   max_ue_htbl_lists_ = amf_config_p->max_ues;
   amf_statistic_timer_ = amf_config_p->amf_statistic_timer;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.hpp
@@ -93,7 +93,7 @@ class AmfNasStateManager
   static AmfNasStateManager& getInstance();
 
   // Initialize the local in-memory state when Amf app inits
-  int initialize_state(const amf_config_t* amf_config_p);
+  status_code_e initialize_state(const amf_config_t* amf_config_p);
 
   /**
    * Retrieve the state pointer from state manager. The read_from_db flag is a

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_transport.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_transport.cpp
@@ -31,11 +31,12 @@ namespace magma5g {
 extern task_zmq_ctx_t amf_app_task_zmq_ctx;
 
 /* Handles NAS encoded message and sends it to NGAP task */
-int amf_app_handle_nas_dl_req(const amf_ue_ngap_id_t ue_id, bstring nas_msg,
-                              nas5g_error_code_t transaction_status) {
+status_code_e amf_app_handle_nas_dl_req(const amf_ue_ngap_id_t ue_id,
+                                        bstring nas_msg,
+                                        nas5g_error_code_t transaction_status) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   MessageDef* message_p = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   gnb_ue_ngap_id_t gnb_ue_ngap_id = 0;
   message_p = itti_alloc_new_message(TASK_AMF_APP, NGAP_NAS_DL_DATA_REQ);
   amf_app_desc_t* amf_app_desc_p = get_amf_nas_state(false);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -514,7 +514,7 @@ tmsi_t amf_lookup_guti_by_ueid(amf_ue_ngap_id_t ue_id) {
  **                                                                        **
  **                                                                        **
  ***************************************************************************/
-int amf_idle_mode_procedure(amf_context_t* amf_ctx) {
+status_code_e amf_idle_mode_procedure(amf_context_t* amf_ctx) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   ue_m5gmm_context_s* ue_context_p =
       PARENT_STRUCT(amf_ctx, ue_m5gmm_context_s, amf_context);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
@@ -994,7 +994,7 @@ void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p);
 status_code_e m5g_security_select_algorithms(const int ue_iaP, const int ue_eaP,
                                              int* const amf_iaP,
                                              int* const amf_eaP);
-int create_session_grpc_req_on_gnb_setup_rsp(
+status_code_e create_session_grpc_req_on_gnb_setup_rsp(
     amf_smf_establish_t* message, char* imsi, uint32_t version,
     std::shared_ptr<smf_context_t> smf_ctx);
 int pdu_session_resource_modify_request(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
@@ -861,7 +861,7 @@ void amf_remove_ue_context(amf_ue_context_t* const amf_ue_context_p,
 void amf_smf_context_cleanup_pdu_session(ue_m5gmm_context_s* ue_context);
 
 // PDU session related communication to gNB
-int pdu_session_resource_setup_request(
+status_code_e pdu_session_resource_setup_request(
     ue_m5gmm_context_s* ue_context, amf_ue_ngap_id_t amf_ue_ngap_id,
     std::shared_ptr<smf_context_t> smf_context, bstring nas_msg);
 void amf_app_handle_resource_setup_response(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
@@ -680,14 +680,16 @@ typedef struct nas_amf_specific_proc_s {
 } nas_amf_specific_proc_t;
 
 // UL identification routines.
-int amf_proc_identification(amf_context_t* const amf_context,
-                            nas_amf_proc_t* const amf_proc,
-                            const identity_type2_t type, success_cb_t success,
-                            failure_cb_t failure);
-int amf_proc_identification_complete(const amf_ue_ngap_id_t ue_id,
-                                     imsi_t* const imsi, imei_t* const imei,
-                                     imeisv_t* const imeisv,
-                                     uint32_t* const tmsi);
+status_code_e amf_proc_identification(amf_context_t* const amf_context,
+                                      nas_amf_proc_t* const amf_proc,
+                                      const identity_type2_t type,
+                                      success_cb_t success,
+                                      failure_cb_t failure);
+status_code_e amf_proc_identification_complete(const amf_ue_ngap_id_t ue_id,
+                                               imsi_t* const imsi,
+                                               imei_t* const imei,
+                                               imeisv_t* const imeisv,
+                                               uint32_t* const tmsi);
 
 typedef struct nas_amf_auth_proc_s {
   nas_amf_common_proc_t amf_com_proc;
@@ -720,11 +722,11 @@ typedef struct nas5g_cn_procedure_s {
 } nas5g_cn_procedure_t;
 
 // Clasify all UL NAS messages based on message type
-int nas_proc_establish_ind(const amf_ue_ngap_id_t ue_id,
-                           const bool is_mm_ctx_new,
-                           const tai_t originating_tai, const ecgi_t ecgi,
-                           const m5g_rrc_establishment_cause_t as_cause,
-                           const s_tmsi_m5_t s_tmsi, bstring msg);
+status_code_e nas_proc_establish_ind(
+    const amf_ue_ngap_id_t ue_id, const bool is_mm_ctx_new,
+    const tai_t originating_tai, const ecgi_t ecgi,
+    const m5g_rrc_establishment_cause_t as_cause, const s_tmsi_m5_t s_tmsi,
+    bstring msg);
 // Registration procedure routine
 nas_amf_registration_proc_t* get_nas_specific_procedure_registration(
     const amf_context_t* ctxt);
@@ -834,11 +836,10 @@ class nas_amf_smc_proc_t {
 
 nas_amf_smc_proc_t* get_nas5g_common_procedure_smc(const amf_context_t* ctxt);
 
-int amf_proc_security_mode_control(amf_context_t* amf_ctx,
-                                   nas_amf_specific_proc_t* amf_specific_proc,
-                                   ksi_t ksi, success_cb_t success,
-                                   failure_cb_t failure);
-int amf_proc_security_mode_reject(amf_ue_ngap_id_t ue_id);
+status_code_e amf_proc_security_mode_control(
+    amf_context_t* amf_ctx, nas_amf_specific_proc_t* amf_specific_proc,
+    ksi_t ksi, success_cb_t success, failure_cb_t failure);
+status_code_e amf_proc_security_mode_reject(amf_ue_ngap_id_t ue_id);
 void amf_proc_create_procedure_registration_request(
     ue_m5gmm_context_s* ue_ctx, amf_registration_request_ies_t* ies);
 
@@ -849,8 +850,8 @@ int amf_proc_amf_information(ue_m5gmm_context_s* ue_amf_ctx);
 int amf_send_registration_accept(amf_context_t* amf_context);
 
 // UE originated deregistration procedures
-int amf_proc_deregistration_request(amf_ue_ngap_id_t ue_id,
-                                    amf_deregistration_request_ies_t* params);
+status_code_e amf_proc_deregistration_request(
+    amf_ue_ngap_id_t ue_id, amf_deregistration_request_ies_t* params);
 int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id);
 
 // Remove ue context
@@ -987,8 +988,9 @@ void nas_delete_all_amf_procedures(amf_context_t* const amf_context);
 
 int amf_idle_mode_procedure(amf_context_t* amf_ctx);
 void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p);
-int m5g_security_select_algorithms(const int ue_iaP, const int ue_eaP,
-                                   int* const amf_iaP, int* const amf_eaP);
+status_code_e m5g_security_select_algorithms(const int ue_iaP, const int ue_eaP,
+                                             int* const amf_iaP,
+                                             int* const amf_eaP);
 int create_session_grpc_req_on_gnb_setup_rsp(
     amf_smf_establish_t* message, char* imsi, uint32_t version,
     std::shared_ptr<smf_context_t> smf_ctx);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
@@ -847,7 +847,7 @@ amf_procedures_t* nas_new_amf_procedures(amf_context_t* amf_context);
 void amf_nas_proc_clean_up(ue_m5gmm_context_s* ue_context_p);
 
 status_code_e amf_proc_amf_information(ue_m5gmm_context_s* ue_amf_ctx);
-int amf_send_registration_accept(amf_context_t* amf_context);
+status_code_e amf_send_registration_accept(amf_context_t* amf_context);
 
 // UE originated deregistration procedures
 status_code_e amf_proc_deregistration_request(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
@@ -893,20 +893,23 @@ status_code_e amf_registration_run_procedure(amf_context_t* amf_context);
 status_code_e amf_proc_registration_complete(amf_context_t* amf_context);
 
 // Finite state machine handlers
-int ue_state_handle_message_initial(m5gmm_state_t cur_state, int event,
-                                    SMSessionFSMState session_state,
-                                    ue_m5gmm_context_s* ue_m5gmm_context,
-                                    amf_context_t* amf_context);
-int ue_state_handle_message_reg_conn(m5gmm_state_t, int, SMSessionFSMState,
-                                     ue_m5gmm_context_s*, amf_ue_ngap_id_t,
-                                     bstring, int,
-                                     amf_nas_message_decode_status_t);
-int ue_state_handle_message_dereg(m5gmm_state_t, int event, SMSessionFSMState,
-                                  ue_m5gmm_context_s*, amf_ue_ngap_id_t);
-int pdu_state_handle_message(m5gmm_state_t, int event,
-                             SMSessionFSMState session_state,
-                             ue_m5gmm_context_s*, amf_smf_t, char*,
-                             itti_n11_create_pdu_session_response_t*, uint32_t);
+status_code_e ue_state_handle_message_initial(
+    m5gmm_state_t cur_state, int event, SMSessionFSMState session_state,
+    ue_m5gmm_context_s* ue_m5gmm_context, amf_context_t* amf_context);
+status_code_e ue_state_handle_message_reg_conn(m5gmm_state_t, int,
+                                               SMSessionFSMState,
+                                               ue_m5gmm_context_s*,
+                                               amf_ue_ngap_id_t, bstring, int,
+                                               amf_nas_message_decode_status_t);
+status_code_e ue_state_handle_message_dereg(m5gmm_state_t, int event,
+                                            SMSessionFSMState,
+                                            ue_m5gmm_context_s*,
+                                            amf_ue_ngap_id_t);
+status_code_e pdu_state_handle_message(m5gmm_state_t, int event,
+                                       SMSessionFSMState session_state,
+                                       ue_m5gmm_context_s*, amf_smf_t, char*,
+                                       itti_n11_create_pdu_session_response_t*,
+                                       uint32_t);
 nas_amf_ident_proc_t* get_5g_nas_common_procedure_identification(
     const amf_context_t* ctxt);
 void amf_delete_registration_proc(amf_context_t* amf_txt);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
@@ -846,13 +846,13 @@ void amf_proc_create_procedure_registration_request(
 amf_procedures_t* nas_new_amf_procedures(amf_context_t* amf_context);
 void amf_nas_proc_clean_up(ue_m5gmm_context_s* ue_context_p);
 
-int amf_proc_amf_information(ue_m5gmm_context_s* ue_amf_ctx);
+status_code_e amf_proc_amf_information(ue_m5gmm_context_s* ue_amf_ctx);
 int amf_send_registration_accept(amf_context_t* amf_context);
 
 // UE originated deregistration procedures
 status_code_e amf_proc_deregistration_request(
     amf_ue_ngap_id_t ue_id, amf_deregistration_request_ies_t* params);
-int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id);
+status_code_e amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id);
 
 // Remove ue context
 void amf_remove_ue_context(amf_ue_context_t* const amf_ue_context_p,
@@ -889,8 +889,8 @@ int nas5g_message_encode(unsigned char* buffer,
                          const amf_nas_message_t* const msg, uint32_t length,
                          void* security);
 
-int amf_registration_run_procedure(amf_context_t* amf_context);
-int amf_proc_registration_complete(amf_context_t* amf_context);
+status_code_e amf_registration_run_procedure(amf_context_t* amf_context);
+status_code_e amf_proc_registration_complete(amf_context_t* amf_context);
 
 // Finite state machine handlers
 int ue_state_handle_message_initial(m5gmm_state_t cur_state, int event,
@@ -926,8 +926,8 @@ void ambr_calculation_pdu_session(uint16_t* dl_session_ambr,
                                   uint16_t* ul_session_ambr,
                                   M5GSessionAmbrUnit ul_ambr_unit,
                                   uint64_t* dl_pdu_ambr, uint64_t* ul_pdu_ambr);
-int amf_proc_registration_abort(amf_context_t* amf_ctx,
-                                struct ue_m5gmm_context_s* ue_amf_context);
+status_code_e amf_proc_registration_abort(
+    amf_context_t* amf_ctx, struct ue_m5gmm_context_s* ue_amf_context);
 
 // Fetch the ue context from imsi
 struct ue_m5gmm_context_s* amf_ue_context_exists_imsi(
@@ -941,7 +941,7 @@ ue_m5gmm_context_s* amf_ue_context_exists_gnb_ue_ngap_id(
     amf_ue_context_t* const amf_ue_context_p, const gnb_ngap_id_key_t gnb_key);
 
 // Implicitly detach the ue
-int amf_nas_proc_implicit_deregister_ue_ind(amf_ue_ngap_id_t ue_id);
+status_code_e amf_nas_proc_implicit_deregister_ue_ind(amf_ue_ngap_id_t ue_id);
 
 // Handling the CM connection for UE
 void amf_ue_context_update_ue_sig_connection_state(
@@ -986,7 +986,7 @@ void amf_ctx_clear_auth_vectors(amf_context_t* const);
 /* Delete all amf procedures */
 void nas_delete_all_amf_procedures(amf_context_t* const amf_context);
 
-int amf_idle_mode_procedure(amf_context_t* amf_ctx);
+status_code_e amf_idle_mode_procedure(amf_context_t* amf_ctx);
 void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p);
 status_code_e m5g_security_select_algorithms(const int ue_iaP, const int ue_eaP,
                                              int* const amf_iaP,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -51,7 +51,8 @@ using namespace magma;
 namespace magma5g {
 /*forward declaration*/
 extern task_zmq_ctx_t amf_app_task_zmq_ctx;
-static int amf_as_establish_req(amf_as_establish_t* msg, int* amf_cause);
+static status_code_e amf_as_establish_req(amf_as_establish_t* msg,
+                                          int* amf_cause);
 static int amf_as_security_req(const amf_as_security_t* msg,
                                m5g_dl_info_transfer_req_t* as_msg);
 static int amf_as_security_rej(const amf_as_security_t* msg,
@@ -79,8 +80,8 @@ static int amf_service_reject(const amf_as_data_t* msg,
 **      Others : None                                                    **
 **                                                                       **
 **************************************************************************/
-int amf_as_send(amf_as_t* msg) {
-  int rc = RETURNok;
+status_code_e amf_as_send(amf_as_t* msg) {
+  status_code_e rc = RETURNok;
   int amf_cause = AMF_CAUSE_SUCCESS;
   amf_as_primitive_t primitive = msg->primitive;
   OAILOG_FUNC_IN(LOG_AMF_APP);
@@ -120,13 +121,14 @@ int amf_as_send(amf_as_t* msg) {
 **      Others:    None                                                   **
 **                                                                        **
 ***************************************************************************/
-static int amf_as_establish_req(amf_as_establish_t* msg, int* amf_cause) {
+static status_code_e amf_as_establish_req(amf_as_establish_t* msg,
+                                          int* amf_cause) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   amf_security_context_t* amf_security_context = NULL;
   amf_nas_message_decode_status_t decode_status;
   memset(&decode_status, 0, sizeof(decode_status));
   int decoder_rc = 1;
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   tai_t originating_tai = {0};
   amf_nas_message_t nas_msg = {0};
   ue_m5gmm_context_s* ue_m5gmm_context = NULL;
@@ -250,7 +252,7 @@ static int amf_as_establish_req(amf_as_establish_t* msg, int* amf_cause) {
  **      Others: None                                                    **
  **                                                                      **
  *************************************************************************/
-int amf_as_send_ng(const amf_as_t* msg) {
+status_code_e amf_as_send_ng(const amf_as_t* msg) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   amf_as_message_t as_msg = {0};
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -1184,8 +1184,9 @@ static int amf_as_security_rej(const amf_as_security_t* msg,
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, 0);
 }
 
-int initial_context_setup_request(amf_ue_ngap_id_t ue_id,
-                                  amf_context_t* amf_ctx, bstring nas_msg) {
+status_code_e initial_context_setup_request(amf_ue_ngap_id_t ue_id,
+                                            amf_context_t* amf_ctx,
+                                            bstring nas_msg) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   /*This message is sent by the AMF to NG-RAN node to request the setup of a UE
    * context before Registration Accept is sent to UE*/

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.hpp
@@ -30,11 +30,11 @@ namespace magma5g {
 #define M5GSMobileIdentityMsg_GUTI_LENGTH 11
 
 // AMF_AS Service Access point primitive
-int amf_as_send(amf_as_t* msg);
+status_code_e amf_as_send(amf_as_t* msg);
 
 // Builds NAS message according to the given AMFAS Service Access Point
 // primitive
-int amf_as_send_ng(const amf_as_t* msg);
+status_code_e amf_as_send_ng(const amf_as_t* msg);
 
 int initial_context_setup_request(amf_ue_ngap_id_t ue_id,
                                   amf_context_t* amf_ctx, bstring nas_msg);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.hpp
@@ -36,8 +36,9 @@ status_code_e amf_as_send(amf_as_t* msg);
 // primitive
 status_code_e amf_as_send_ng(const amf_as_t* msg);
 
-int initial_context_setup_request(amf_ue_ngap_id_t ue_id,
-                                  amf_context_t* amf_ctx, bstring nas_msg);
+status_code_e initial_context_setup_request(amf_ue_ngap_id_t ue_id,
+                                            amf_context_t* amf_ctx,
+                                            bstring nas_msg);
 
 // For _AMFAS_DATA_REQ primitive
 uint16_t amf_as_data_req(const amf_as_data_t* msg,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -70,8 +70,8 @@ nas5g_cn_proc_t* get_nas5g_cn_procedure(const amf_context_t* ctxt,
   OAILOG_FUNC_RETURN(LOG_AMF_APP, NULL);
 }
 
-static int calculate_amf_serving_network_name(amf_context_t* amf_ctx,
-                                              uint8_t* snni);
+static status_code_e calculate_amf_serving_network_name(amf_context_t* amf_ctx,
+                                                        uint8_t* snni);
 /***************************************************************************
 **                                                                        **
 ** Name:    get_nas5g_cn_procedure_auth_info()                            **
@@ -96,12 +96,12 @@ nas5g_auth_info_proc_t* get_nas5g_cn_procedure_auth_info(
 **                                                                       **
 **                                                                        **
 ***************************************************************************/
-static int start_authentication_information_procedure(
+static status_code_e start_authentication_information_procedure(
     amf_context_t* amf_context, nas5g_amf_auth_proc_t* const auth_proc,
     const_bstring auts) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
 
   amf_ue_ngap_id_t ue_id =
       PARENT_STRUCT(amf_context, ue_m5gmm_context_s, amf_context)
@@ -326,11 +326,12 @@ nas5g_amf_auth_proc_t* nas5g_new_authentication_procedure(
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_proc_authentication(amf_context_t* amf_context,
-                            nas_amf_specific_proc_t* const amf_specific_proc,
-                            success_cb_t success, failure_cb_t failure) {
+status_code_e amf_proc_authentication(
+    amf_context_t* amf_context,
+    nas_amf_specific_proc_t* const amf_specific_proc, success_cb_t success,
+    failure_cb_t failure) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   bool run_auth_info_proc = false;
   ksi_t eksi = 0;
   OAILOG_DEBUG(LOG_NGAP, "starting Authentication procedure");
@@ -438,13 +439,13 @@ int amf_proc_authentication(amf_context_t* amf_context,
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int amf_proc_authentication_ksi(
+status_code_e amf_proc_authentication_ksi(
     amf_context_t* amf_context,
     nas_amf_specific_proc_t* const amf_specific_proc, ksi_t ksi,
     const uint8_t* const rand, const uint8_t* const autn, success_cb_t success,
     failure_cb_t failure) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   nas5g_amf_auth_proc_t* auth_proc;
   amf_ue_ngap_id_t ue_id;
   auth_proc = get_nas5g_common_procedure_authentication(amf_context);
@@ -526,11 +527,13 @@ int amf_proc_authentication_ksi(
  **      Others:    amf_data, T3560                                        **
  **                                                                        **
  ***************************************************************************/
-int amf_proc_authentication_complete(amf_ue_ngap_id_t ue_id,
-                                     AuthenticationResponseMsg* msg,
-                                     int amf_cause, const unsigned char* res) {
+status_code_e amf_proc_authentication_complete(amf_ue_ngap_id_t ue_id,
+                                               AuthenticationResponseMsg* msg,
+                                               int amf_cause,
+                                               const unsigned char* res) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
+  int mcmp_res = 0;
   bool is_xres_validation_failed = false;
   nas_amf_smc_proc_t nas_amf_smc_proc_autn;
   nas_amf_registration_proc_t* registration_proc = NULL;
@@ -593,12 +596,14 @@ int amf_proc_authentication_complete(amf_ue_ngap_id_t ue_id,
     nas_amf_smc_proc_autn.amf_ctx_set_security_eksi(amf_ctx, auth_proc->ksi);
     registration_proc->ksi = auth_proc->ksi;
 
-    rc = memcmp(
+    mcmp_res = memcmp(
         amf_ctx->_vector[auth_proc->ksi % MAX_EPS_AUTH_VECTORS].xres_star,
         msg->autn_response_parameter.response_parameter, AUTH_XRES_SIZE);
 
-    if (rc != RETURNok) {
+    if (mcmp_res != RETURNok) {
       is_xres_validation_failed = true;
+    } else {
+      rc = RETURNok;
     }
 
     /* As per Spec 24.501 Sec 5.4.1.3.5 If the authentication response (RES*)
@@ -677,7 +682,7 @@ int amf_proc_authentication_complete(amf_ue_ngap_id_t ue_id,
   /* Completing Authentication response and invoking Security Request
    * Invoking success directly to handle security mode command
    * */
-  rc = amf_registration_success_authentication_cb(amf_ctx);
+  rc = (status_code_e)amf_registration_success_authentication_cb(amf_ctx);
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 
@@ -702,9 +707,9 @@ void amf_ctx_clear_auth_vectors(amf_context_t* const ctxt) {
   OAILOG_FUNC_OUT(LOG_AMF_APP);
 }
 
-int amf_auth_auth_rej(amf_ue_ngap_id_t ue_id) {
+status_code_e amf_auth_auth_rej(amf_ue_ngap_id_t ue_id) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   ue_m5gmm_context_s* ue_mm_context = nullptr;
   amf_sap_t amf_sap = {};
   amf_sap.primitive = AMFAS_SECURITY_REJ;
@@ -741,9 +746,9 @@ int amf_auth_auth_rej(amf_ue_ngap_id_t ue_id) {
  **      Others:    amf_data, T3560                                        **
  **                                                                        **
  ***************************************************************************/
-int amf_proc_authentication_failure(amf_ue_ngap_id_t ue_id,
-                                    AuthenticationFailureMsg* msg,
-                                    int amf_cause) {
+status_code_e amf_proc_authentication_failure(amf_ue_ngap_id_t ue_id,
+                                              AuthenticationFailureMsg* msg,
+                                              int amf_cause) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
 
   OAILOG_DEBUG(LOG_NAS_AMF,
@@ -751,7 +756,7 @@ int amf_proc_authentication_failure(amf_ue_ngap_id_t ue_id,
                "(ue_id=" AMF_UE_NGAP_ID_FMT ")\n",
                ue_id);
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   ue_m5gmm_context_s* ue_mm_context = NULL;
   amf_context_t* amf_ctx = NULL;
 
@@ -894,10 +899,10 @@ int amf_proc_authentication_failure(amf_ue_ngap_id_t ue_id,
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-int amf_send_authentication_request(amf_context_t* amf_ctx,
-                                    nas5g_amf_auth_proc_t* auth_proc) {
+status_code_e amf_send_authentication_request(
+    amf_context_t* amf_ctx, nas5g_amf_auth_proc_t* auth_proc) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   auth_proc->T3560.id = NAS5G_TIMER_INACTIVE_ID;
   if (auth_proc) {
     /*
@@ -938,8 +943,8 @@ int amf_send_authentication_request(amf_context_t* amf_ctx,
 }
 
 // Fetch the serving network name
-static int calculate_amf_serving_network_name(amf_context_t* amf_ctx,
-                                              unsigned char* snni) {
+static status_code_e calculate_amf_serving_network_name(amf_context_t* amf_ctx,
+                                                        unsigned char* snni) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   uint32_t mcc = 0;
   uint32_t mnc = 0;
@@ -980,13 +985,13 @@ static int calculate_amf_serving_network_name(amf_context_t* amf_ctx,
  **      Return:    RETURNok, RETURNerror                                  **
  **                                                                        **
  ***************************************************************************/
-int amf_authentication_proc_success(amf_context_t* amf_ctx) {
+status_code_e amf_authentication_proc_success(amf_context_t* amf_ctx) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
 
   nas5g_amf_auth_proc_t* auth_proc = NULL;
   nas5g_auth_info_proc_t* auth_info_proc = NULL;
   uint8_t snni[40] = {0};
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
 
   /* Get Auth Proc */
   auth_proc = get_nas5g_common_procedure_authentication(amf_ctx);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -644,8 +644,10 @@ status_code_e amf_proc_authentication_complete(amf_ue_ngap_id_t ue_id,
           (amf_ctx->reg_id_type == M5GSMobileIdentityMsg_GUTI)) {
         rc = amf_proc_identification(
             amf_ctx, (nas_amf_proc_t*)registration_proc, IDENTITY_TYPE_2_IMSI,
-            amf_registration_success_identification_cb,
-            amf_registration_failure_identification_cb);
+            reinterpret_cast<int (*)(amf_context_t*)>(
+                amf_registration_success_identification_cb),
+            reinterpret_cast<int (*)(amf_context_t*)>(
+                amf_registration_failure_identification_cb));
       } else {
         rc = RETURNerror;
       }
@@ -814,8 +816,10 @@ status_code_e amf_proc_authentication_failure(amf_ue_ngap_id_t ue_id,
           (amf_ctx->reg_id_type == M5GSMobileIdentityMsg_GUTI)) {
         rc = amf_proc_identification(
             amf_ctx, (nas_amf_proc_t*)registration_proc, IDENTITY_TYPE_2_IMSI,
-            amf_registration_success_identification_cb,
-            amf_registration_failure_identification_cb);
+            reinterpret_cast<int (*)(amf_context_t*)>(
+                amf_registration_success_identification_cb),
+            reinterpret_cast<int (*)(amf_context_t*)>(
+                amf_registration_failure_identification_cb));
       } else {
         /*
          * in case of SUCI BASED REGISTRATION Send AUTH_REJECT */

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -684,7 +684,7 @@ status_code_e amf_proc_authentication_complete(amf_ue_ngap_id_t ue_id,
   /* Completing Authentication response and invoking Security Request
    * Invoking success directly to handle security mode command
    * */
-  rc = (status_code_e)amf_registration_success_authentication_cb(amf_ctx);
+  rc = amf_registration_success_authentication_cb(amf_ctx);
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.hpp
@@ -58,34 +58,37 @@ nas5g_auth_info_proc_t* get_nas5g_cn_procedure_auth_info(
 void nas5g_delete_cn_procedure(struct amf_context_s* amf_context,
                                nas5g_cn_proc_t* cn_proc);
 
-int amf_proc_authentication_ksi(
+status_code_e amf_proc_authentication_ksi(
     amf_context_t* amf_context,
     nas_amf_specific_proc_t* const amf_specific_proc, ksi_t ksi,
     const uint8_t* const rand, const uint8_t* const autn, success_cb_t success,
     failure_cb_t failure);
-int amf_proc_authentication(amf_context_t* amf_context,
-                            nas_amf_specific_proc_t* const amf_specific_proc,
-                            success_cb_t success, failure_cb_t failure);
-int amf_proc_authentication_complete(amf_ue_ngap_id_t ue_id,
-                                     AuthenticationResponseMsg* msg,
-                                     int amf_cause, const unsigned char* res);
-int amf_proc_authentication_failure(amf_ue_ngap_id_t ue_id,
-                                    AuthenticationFailureMsg* msg,
-                                    int amf_cause);
+status_code_e amf_proc_authentication(
+    amf_context_t* amf_context,
+    nas_amf_specific_proc_t* const amf_specific_proc, success_cb_t success,
+    failure_cb_t failure);
+status_code_e amf_proc_authentication_complete(amf_ue_ngap_id_t ue_id,
+                                               AuthenticationResponseMsg* msg,
+                                               int amf_cause,
+                                               const unsigned char* res);
+status_code_e amf_proc_authentication_failure(amf_ue_ngap_id_t ue_id,
+                                              AuthenticationFailureMsg* msg,
+                                              int amf_cause);
 int amf_registration_security(amf_context_t* amf_context);
-int amf_send_authentication_request(amf_context_t* amf_context,
-                                    nas5g_amf_auth_proc_t* auth_proc);
+status_code_e amf_send_authentication_request(amf_context_t* amf_context,
+                                              nas5g_amf_auth_proc_t* auth_proc);
 
 // To be called when authentication is successful from subscriberdb
-int amf_authentication_proc_success(amf_context_t* amf_context);
+status_code_e amf_authentication_proc_success(amf_context_t* amf_context);
 status_code_e amf_authentication_request_sent(amf_ue_ngap_id_t ue_id);
-int amf_nas_proc_authentication_info_answer(itti_amf_subs_auth_info_ans_t* aia);
+status_code_e amf_nas_proc_authentication_info_answer(
+    itti_amf_subs_auth_info_ans_t* aia);
 nas5g_amf_auth_proc_t* get_nas5g_common_procedure_authentication(
     const amf_context_t* const ctxt);
 
 void amf_proc_stop_t3560_timer(nas5g_amf_auth_proc_t* auth_proc);
 
-int amf_start_registration_proc_authentication(
+status_code_e amf_start_registration_proc_authentication(
     amf_context_t* amf_context, nas_amf_registration_proc_t* registration_proc);
 
 int amf_handle_s6a_update_location_ans(const s6a_update_location_ans_t* ula_pP);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.hpp
@@ -91,7 +91,8 @@ void amf_proc_stop_t3560_timer(nas5g_amf_auth_proc_t* auth_proc);
 status_code_e amf_start_registration_proc_authentication(
     amf_context_t* amf_context, nas_amf_registration_proc_t* registration_proc);
 
-int amf_handle_s6a_update_location_ans(const s6a_update_location_ans_t* ula_pP);
+status_code_e amf_handle_s6a_update_location_ans(
+    const s6a_update_location_ans_t* ula_pP);
 
 nas_amf_registration_proc_t* nas_new_registration_procedure(
     ue_m5gmm_context_s* ue_ctxt);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -126,9 +126,12 @@ bool AMFClientServicerBase::get_decrypt_imsi_info(
                                      ciphertext, mac_tag, ue_id));
 }
 
-int AMFClientServicerBase::n11_update_location_req(
+status_code_e AMFClientServicerBase::n11_update_location_req(
     const s6a_update_location_req_t* const ulr_p) {
-  return AsyncSmfServiceClient::getInstance().n11_update_location_req(ulr_p);
+  if (AsyncSmfServiceClient::getInstance().n11_update_location_req(ulr_p))
+    return RETURNok;
+  else
+    return RETURNerror;
 }
 
 bool AMFClientServicerBase::set_smf_notification(

--- a/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_client_servicer.cpp
@@ -100,16 +100,17 @@ int AMFClientServicerBase::release_ipv4v6_address(
       subscriber_id, apn, ipv4_addr, ipv6_addr);
 }
 
-int AMFClientServicerBase::amf_smf_create_pdu_session(
+status_code_e AMFClientServicerBase::amf_smf_create_pdu_session(
     char* imsi, uint8_t* apn, uint32_t pdu_session_id,
     uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
     uint8_t* gnb_gtp_teid_ip_addr, char* ue_ipv4_addr, char* ue_ipv6_addr,
     const ambr_t& state_ambr, uint32_t version,
     const eps_subscribed_qos_profile_t& qos_profile) {
-  return AsyncSmfServiceClient::getInstance().amf_smf_create_pdu_session(
-      imsi, apn, pdu_session_id, pdu_session_type, gnb_gtp_teid, pti,
-      gnb_gtp_teid_ip_addr, ue_ipv4_addr, ue_ipv6_addr, state_ambr, version,
-      qos_profile);
+  return (status_code_e)AsyncSmfServiceClient::getInstance()
+      .amf_smf_create_pdu_session(imsi, apn, pdu_session_id, pdu_session_type,
+                                  gnb_gtp_teid, pti, gnb_gtp_teid_ip_addr,
+                                  ue_ipv4_addr, ue_ipv6_addr, state_ambr,
+                                  version, qos_profile);
 }
 
 bool AMFClientServicerBase::set_smf_session(SetSMSessionContext& request) {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_cn.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_cn.cpp
@@ -37,10 +37,10 @@ extern "C" {
 namespace magma5g {
 
 //------------------------------------------------------------------------------
-static int amf_cn_authentication_res(amf_cn_auth_res_t* const msg) {
+static status_code_e amf_cn_authentication_res(amf_cn_auth_res_t* const msg) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   amf_context_t* amf_ctx = NULL;
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
 
   /*
    * We received security vector from HSS. Try to setup security with UE
@@ -102,8 +102,8 @@ static int amf_cn_implicit_deregister_ue(const amf_ue_ngap_id_t ue_id) {
 }
 
 //------------------------------------------------------------------------------
-int amf_cn_send(const amf_cn_t* msg) {
-  int rc = RETURNerror;
+status_code_e amf_cn_send(const amf_cn_t* msg) {
+  status_code_e rc = RETURNerror;
   amf_cn_primitive_t primitive = msg->primitive;
 
   OAILOG_FUNC_IN(LOG_NAS_AMF);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_cn.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_cn.cpp
@@ -73,8 +73,9 @@ static status_code_e amf_cn_authentication_res(amf_cn_auth_res_t* const msg) {
 }
 
 //------------------------------------------------------------------------------
-static int amf_cn_implicit_deregister_ue(const amf_ue_ngap_id_t ue_id) {
-  int rc = RETURNok;
+static status_code_e amf_cn_implicit_deregister_ue(
+    const amf_ue_ngap_id_t ue_id) {
+  status_code_e rc = RETURNok;
   struct amf_context_s* amf_ctx_p = NULL;
 
   OAILOG_FUNC_IN(LOG_NAS_AMF);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
@@ -197,10 +197,9 @@ void create_state_matrix() {
  * state,ue_context,amf_context
  * @return int for success or failure
  */
-int ue_state_handle_message_initial(m5gmm_state_t cur_state, int event,
-                                    SMSessionFSMState session_state,
-                                    ue_m5gmm_context_s* ue_m5gmm_context,
-                                    amf_context_t* amf_context) {
+status_code_e ue_state_handle_message_initial(
+    m5gmm_state_t cur_state, int event, SMSessionFSMState session_state,
+    ue_m5gmm_context_s* ue_m5gmm_context, amf_context_t* amf_context) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   if (ue_state_matrix[cur_state][event][session_state].handler.func) {
     OAILOG_INFO(
@@ -219,9 +218,9 @@ int ue_state_handle_message_initial(m5gmm_state_t cur_state, int event,
 
     OAILOG_FUNC_RETURN(
         LOG_AMF_APP,
-        reinterpret_cast<int (*)(amf_context_t*)>(
-            ue_state_matrix[cur_state][event][session_state].handler.func)(
-            amf_context));
+        reinterpret_cast<status_code_e (*)(amf_context_t*)>(
+        ue_state_matrix[cur_state][event][session_state].handler.func)(
+        amf_context));
   } else {
     OAILOG_ERROR(LOG_NAS_AMF, "FSM %s: No Proper Handler Found\n", __func__);
     OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
@@ -235,7 +234,7 @@ int ue_state_handle_message_initial(m5gmm_state_t cur_state, int event,
  * state,ue_context,ue_id,smf_msg,amf_cause,decode_status
  * @return int for success or failure
  */
-int ue_state_handle_message_reg_conn(
+status_code_e ue_state_handle_message_reg_conn(
     m5gmm_state_t cur_state, int event, SMSessionFSMState session_state,
     ue_m5gmm_context_s* ue_m5gmm_context, amf_ue_ngap_id_t ue_id,
     bstring smf_msg_pP, int amf_cause,
@@ -246,10 +245,10 @@ int ue_state_handle_message_reg_conn(
         ue_state_matrix[cur_state][event][session_state].next_state;
     OAILOG_FUNC_RETURN(
         LOG_AMF_APP,
-        reinterpret_cast<int (*)(amf_ue_ngap_id_t, bstring, int,
-                                 const amf_nas_message_decode_status_t)>(
-            ue_state_matrix[cur_state][event][session_state].handler.func)(
-            ue_id, smf_msg_pP, amf_cause, decode_status));
+reinterpret_cast<status_code_e (*)(
+        amf_ue_ngap_id_t, bstring, int, const amf_nas_message_decode_status_t)>(
+        ue_state_matrix[cur_state][event][session_state].handler.func)(
+        ue_id, smf_msg_pP, amf_cause, decode_status));
   } else {
     OAILOG_ERROR(LOG_NAS_AMF, "FSM %s: No Proper Handler Found\n", __func__);
     OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
@@ -264,10 +263,9 @@ int ue_state_handle_message_reg_conn(
  * state,ue_context,ue_id
  * @return int for success or failure
  */
-int ue_state_handle_message_dereg(m5gmm_state_t cur_state, int event,
-                                  SMSessionFSMState session_state,
-                                  ue_m5gmm_context_s* ue_m5gmm_context,
-                                  amf_ue_ngap_id_t ue_id) {
+status_code_e ue_state_handle_message_dereg(
+    m5gmm_state_t cur_state, int event, SMSessionFSMState session_state,
+    ue_m5gmm_context_s* ue_m5gmm_context, amf_ue_ngap_id_t ue_id) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   if (ue_state_matrix[cur_state][event][session_state].handler.func) {
     ue_m5gmm_context->mm_state =
@@ -275,9 +273,8 @@ int ue_state_handle_message_dereg(m5gmm_state_t cur_state, int event,
 
     OAILOG_FUNC_RETURN(
         LOG_AMF_APP,
-        reinterpret_cast<int (*)(amf_ue_ngap_id_t)>(
-            ue_state_matrix[cur_state][event][session_state].handler.func)(
-            ue_id));
+        reinterpret_cast<status_code_e (*)(amf_ue_ngap_id_t)>(
+        ue_state_matrix[cur_state][event][session_state].handler.func)(ue_id));
   } else {
     OAILOG_ERROR(LOG_NAS_AMF, "FSM %s: No Proper Handler Found\n", __func__);
     OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
@@ -292,7 +289,7 @@ int ue_state_handle_message_dereg(m5gmm_state_t cur_state, int event,
  * state,ue_context,amf_smf_msg,imsi,pdu_session_resp,ue_id
  * @return int for success or failure
  */
-int pdu_state_handle_message(
+status_code_e pdu_state_handle_message(
     m5gmm_state_t cur_state, int event, SMSessionFSMState session_state,
     ue_m5gmm_context_s* ue_m5gmm_context, amf_smf_t amf_smf_msg, char* imsi,
     itti_n11_create_pdu_session_response_t* pdu_session_resp, uint32_t ue_id) {
@@ -318,14 +315,14 @@ int pdu_state_handle_message(
       case STATE_PDU_SESSION_ESTABLISHMENT_REQUEST:
         smf_ctx->pdu_session_state =
             ue_state_matrix[cur_state][event][session_state].next_sess_state;
-        return reinterpret_cast<int (*)(amf_smf_establish_t*, char*)>(
+        return reinterpret_cast<status_code_e (*)(amf_smf_establish_t*, char*)>(
             ue_state_matrix[cur_state][event][session_state].handler.func)(
             &amf_smf_msg.u.establish, imsi);
         break;
       case STATE_PDU_SESSION_RELEASE_COMPLETE:
         smf_ctx->pdu_session_state =
             ue_state_matrix[cur_state][event][session_state].next_sess_state;
-        return reinterpret_cast<int (*)(amf_smf_release_t*, char*)>(
+        return reinterpret_cast<status_code_e (*)(amf_smf_release_t*, char*)>(
             ue_state_matrix[cur_state][event][session_state].handler.func)(
             &amf_smf_msg.u.release, imsi);
         break;
@@ -333,8 +330,8 @@ int pdu_state_handle_message(
         smf_ctx->pdu_session_state =
             ue_state_matrix[cur_state][event][session_state].next_sess_state;
 
-        return reinterpret_cast<int (*)(itti_n11_create_pdu_session_response_t*,
-                                        uint32_t)>(
+        return reinterpret_cast<status_code_e (*)(
+            itti_n11_create_pdu_session_response_t*, uint32_t)>(
             ue_state_matrix[cur_state][event][session_state].handler.func)(
             pdu_session_resp, ue_id);
         break;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
@@ -219,8 +219,8 @@ status_code_e ue_state_handle_message_initial(
     OAILOG_FUNC_RETURN(
         LOG_AMF_APP,
         reinterpret_cast<status_code_e (*)(amf_context_t*)>(
-        ue_state_matrix[cur_state][event][session_state].handler.func)(
-        amf_context));
+            ue_state_matrix[cur_state][event][session_state].handler.func)(
+            amf_context));
   } else {
     OAILOG_ERROR(LOG_NAS_AMF, "FSM %s: No Proper Handler Found\n", __func__);
     OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
@@ -245,10 +245,11 @@ status_code_e ue_state_handle_message_reg_conn(
         ue_state_matrix[cur_state][event][session_state].next_state;
     OAILOG_FUNC_RETURN(
         LOG_AMF_APP,
-reinterpret_cast<status_code_e (*)(
-        amf_ue_ngap_id_t, bstring, int, const amf_nas_message_decode_status_t)>(
-        ue_state_matrix[cur_state][event][session_state].handler.func)(
-        ue_id, smf_msg_pP, amf_cause, decode_status));
+        reinterpret_cast<status_code_e (*)(
+            amf_ue_ngap_id_t, bstring, int,
+            const amf_nas_message_decode_status_t)>(
+            ue_state_matrix[cur_state][event][session_state].handler.func)(
+            ue_id, smf_msg_pP, amf_cause, decode_status));
   } else {
     OAILOG_ERROR(LOG_NAS_AMF, "FSM %s: No Proper Handler Found\n", __func__);
     OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
@@ -274,7 +275,8 @@ status_code_e ue_state_handle_message_dereg(
     OAILOG_FUNC_RETURN(
         LOG_AMF_APP,
         reinterpret_cast<status_code_e (*)(amf_ue_ngap_id_t)>(
-        ue_state_matrix[cur_state][event][session_state].handler.func)(ue_id));
+            ue_state_matrix[cur_state][event][session_state].handler.func)(
+            ue_id));
   } else {
     OAILOG_ERROR(LOG_NAS_AMF, "FSM %s: No Proper Handler Found\n", __func__);
     OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNerror);
@@ -338,22 +340,22 @@ status_code_e pdu_state_handle_message(
       case STATE_PDU_SESSION_MODIFICATION_REQUEST:
         smf_ctx->pdu_session_state =
             ue_state_matrix[cur_state][event][session_state].next_sess_state;
-        return reinterpret_cast<int (*)(itti_n11_create_pdu_session_response_t*,
-                                        uint32_t)>(
+        return reinterpret_cast<status_code_e (*)(
+            itti_n11_create_pdu_session_response_t*, uint32_t)>(
             ue_state_matrix[cur_state][event][session_state].handler.func)(
             pdu_session_resp, ue_id);
         break;
       case STATE_PDU_SESSION_MODIFICATION_COMPLETE:
         smf_ctx->pdu_session_state =
             ue_state_matrix[cur_state][event][session_state].next_sess_state;
-        return reinterpret_cast<int (*)(amf_smf_establish_t*, char*)>(
+        return reinterpret_cast<status_code_e (*)(amf_smf_establish_t*, char*)>(
             ue_state_matrix[cur_state][event][session_state].handler.func)(
             &amf_smf_msg.u.establish, imsi);
         break;
       case STATE_PDU_SESSION_MODIFICATION_COMMAND_REJECT:
         smf_ctx->pdu_session_state =
             ue_state_matrix[cur_state][event][session_state].next_sess_state;
-        return reinterpret_cast<int (*)(amf_smf_establish_t*, char*)>(
+        return reinterpret_cast<status_code_e (*)(amf_smf_establish_t*, char*)>(
             ue_state_matrix[cur_state][event][session_state].handler.func)(
             &amf_smf_msg.u.establish, imsi);
         break;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_identity.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_identity.cpp
@@ -110,13 +110,11 @@ void amf_ctx_set_valid_imei(amf_context_t* const ctxt, imei_t* imei) {
  **      Others:    amf_data, T3570                                        **
  **                                                                        **
  ***************************************************************************/
-int amf_proc_identification_complete(const amf_ue_ngap_id_t ue_id,
-                                     imsi_t* const imsi, imei_t* const imei,
-                                     imeisv_t* const imeisv,
-                                     uint32_t* const tmsi,
-                                     guti_m5_t* amf_ctx_guti) {
+status_code_e amf_proc_identification_complete(
+    const amf_ue_ngap_id_t ue_id, imsi_t* const imsi, imei_t* const imei,
+    imeisv_t* const imeisv, uint32_t* const tmsi, guti_m5_t* amf_ctx_guti) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   amf_context_t* amf_ctx = NULL;
 
   OAILOG_DEBUG(LOG_NAS_AMF,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_identity.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_identity.hpp
@@ -36,11 +36,9 @@ int amf_cn_identity_res(amf_ue_ngap_id_t ue_id, M5GSMobileIdentityMsg* msg,
                         const amf_nas_message_decode_status_t* status);
 
 // Performs the identification completion procedure
-int amf_proc_identification_complete(const amf_ue_ngap_id_t ue_id,
-                                     imsi_t* const imsi, imei_t* const imei,
-                                     imeisv_t* const imeisv,
-                                     uint32_t* const tmsii,
-                                     guti_m5_t* amf_ctx_guti);
+status_code_e amf_proc_identification_complete(
+    const amf_ue_ngap_id_t ue_id, imsi_t* const imsi, imei_t* const imei,
+    imeisv_t* const imeisv, uint32_t* const tmsii, guti_m5_t* amf_ctx_guti);
 
 typedef struct amf_guamfi_s {
   amf_plmn_t plmn; /*MCC + MNC*/

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -35,11 +35,11 @@ extern "C" {
 #define AMF_CAUSE_UE_SEC_CAP_MISSMATCH (23)
 namespace magma5g {
 
-int amf_handle_service_request(
+status_code_e amf_handle_service_request(
     amf_ue_ngap_id_t ue_id, ServiceRequestMsg* msg,
     const amf_nas_message_decode_status_t decode_status) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   ue_m5gmm_context_s* ue_context = nullptr;
   notify_ue_event notify_ue_event_type;
   amf_sap_t amf_sap;
@@ -276,13 +276,13 @@ void amf_get_registration_type_request(
 }
 
 /* Identifies 5GS Registration type and processes the Message accordingly */
-int amf_handle_registration_request(
+status_code_e amf_handle_registration_request(
     amf_ue_ngap_id_t ue_id, tai_t* originating_tai, ecgi_t* originating_ecgi,
     RegistrationRequestMsg* msg, const bool is_initial,
     const bool is_amf_ctx_new, int amf_cause,
     const amf_nas_message_decode_status_t decode_status) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   // Local imsi to be put in imsi defined in 3gpp_23.003.h
   supi_as_imsi_t supi_imsi;
   amf_guti_m5g_t amf_guti;
@@ -573,11 +573,11 @@ int amf_handle_registration_request(
  **                                                                        **
  ***************************************************************************/
 
-int amf_handle_identity_response(
+status_code_e amf_handle_identity_response(
     amf_ue_ngap_id_t ue_id, M5GSMobileIdentityMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   /*
    * Message processing
    */
@@ -682,12 +682,11 @@ int amf_handle_identity_response(
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int amf_handle_authentication_response(amf_ue_ngap_id_t ue_id,
-                                       AuthenticationResponseMsg* msg,
-                                       int amf_cause,
-                                       amf_nas_message_decode_status_t status) {
+status_code_e amf_handle_authentication_response(
+    amf_ue_ngap_id_t ue_id, AuthenticationResponseMsg* msg, int amf_cause,
+    amf_nas_message_decode_status_t status) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   /*
    * Message checking
    */
@@ -729,12 +728,11 @@ int amf_handle_authentication_response(amf_ue_ngap_id_t ue_id,
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int amf_handle_authentication_failure(amf_ue_ngap_id_t ue_id,
-                                      AuthenticationFailureMsg* msg,
-                                      int amf_cause,
-                                      amf_nas_message_decode_status_t status) {
+status_code_e amf_handle_authentication_failure(
+    amf_ue_ngap_id_t ue_id, AuthenticationFailureMsg* msg, int amf_cause,
+    amf_nas_message_decode_status_t status) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   /*
    * Handle message checking error
@@ -766,11 +764,11 @@ int amf_handle_authentication_failure(amf_ue_ngap_id_t ue_id,
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int amf_handle_security_mode_reject(
+status_code_e amf_handle_security_mode_reject(
     amf_ue_ngap_id_t ue_id, SecurityModeRejectMsg* msg, int amf_cause,
     const amf_nas_message_decode_status_t status) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   OAILOG_WARNING(LOG_NAS_AMF,
                  "AMFAS-SAP - Received Security Mode Reject message "

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -233,8 +233,8 @@ void amf_copy_plmn_to_supi(const ImsiM5GSMobileIdentity& imsi,
   OAILOG_FUNC_OUT(LOG_AMF_APP);
 }
 
-int amf_copy_plmn_to_context(const ImsiM5GSMobileIdentity& imsi,
-                             ue_m5gmm_context_s* ue_context) {
+status_code_e amf_copy_plmn_to_context(const ImsiM5GSMobileIdentity& imsi,
+                                       ue_m5gmm_context_s* ue_context) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   if (ue_context == NULL) {
     OAILOG_ERROR(LOG_AMF_APP, "UE context is null");

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.hpp
@@ -64,10 +64,13 @@ status_code_e amf_smf_notification_send(amf_ue_ngap_id_t ueid,
 status_code_e amf_proc_registration_request(
     amf_ue_ngap_id_t ue_id, const bool is_mm_ctx_new,
     amf_registration_request_ies_t* ies);
-int amf_registration_success_identification_cb(amf_context_t* amf_context);
-int amf_registration_failure_identification_cb(amf_context_t* amf_context);
-int amf_registration_success_authentication_cb(amf_context_t* amf_context);
-int amf_registration_success_security_cb(amf_context_t* amf_context);
+status_code_e amf_registration_success_identification_cb(
+    amf_context_t* amf_context);
+status_code_e amf_registration_failure_identification_cb(
+    amf_context_t* amf_context);
+status_code_e amf_registration_success_authentication_cb(
+    amf_context_t* amf_context);
+status_code_e amf_registration_success_security_cb(amf_context_t* amf_context);
 status_code_e amf_proc_registration_reject(const amf_ue_ngap_id_t ue_id,
                                            amf_cause_t amf_cause);
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.hpp
@@ -74,11 +74,11 @@ status_code_e amf_registration_success_security_cb(amf_context_t* amf_context);
 status_code_e amf_proc_registration_reject(const amf_ue_ngap_id_t ue_id,
                                            amf_cause_t amf_cause);
 
-int get_decrypt_imsi_suci_extension(amf_context_t* amf_context,
-                                    uint8_t ue_pubkey_identifier,
-                                    const std::string& ue_pubkey,
-                                    const std::string& ciphertext,
-                                    const std::string& mac_tag);
+status_code_e get_decrypt_imsi_suci_extension(amf_context_t* amf_context,
+                                              uint8_t ue_pubkey_identifier,
+                                              const std::string& ue_pubkey,
+                                              const std::string& ciphertext,
+                                              const std::string& mac_tag);
 int amf_decrypt_msin_info_answer(itti_amf_decrypted_msin_info_ans_t* aia);
 void amf_copy_plmn_to_supi(const ImsiM5GSMobileIdentity& imsi,
                            supi_as_imsi_t& supi_imsi);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.hpp
@@ -20,56 +20,55 @@
 
 namespace magma5g {
 // AMF registration procedures
-int amf_handle_registration_request(
+status_code_e amf_handle_registration_request(
     amf_ue_ngap_id_t ue_id, tai_t* originating_tai, ecgi_t* ecgi,
     RegistrationRequestMsg* msg, const bool is_initial,
     const bool is_amf_ctx_new, int amf_cause,
     amf_nas_message_decode_status_t decode_status);
-int amf_handle_service_request(
+status_code_e amf_handle_service_request(
     amf_ue_ngap_id_t ue_id, ServiceRequestMsg* msg,
     const amf_nas_message_decode_status_t decode_status);
 int amf_registration_run_procedure(amf_context_t* amf_context);
-int amf_handle_identity_response(amf_ue_ngap_id_t ue_id,
-                                 M5GSMobileIdentityMsg* msg, int amf_cause,
-                                 amf_nas_message_decode_status_t decode_status);
-int amf_handle_authentication_response(amf_ue_ngap_id_t ue_id,
-                                       AuthenticationResponseMsg* msg,
-                                       int amf_cause,
-                                       amf_nas_message_decode_status_t status);
-int amf_handle_authentication_failure(amf_ue_ngap_id_t ue_id,
-                                      AuthenticationFailureMsg* msg,
-                                      int amf_cause,
-                                      amf_nas_message_decode_status_t status);
-int amf_handle_security_complete_response(
+status_code_e amf_handle_identity_response(
+    amf_ue_ngap_id_t ue_id, M5GSMobileIdentityMsg* msg, int amf_cause,
+    amf_nas_message_decode_status_t decode_status);
+status_code_e amf_handle_authentication_response(
+    amf_ue_ngap_id_t ue_id, AuthenticationResponseMsg* msg, int amf_cause,
+    amf_nas_message_decode_status_t status);
+status_code_e amf_handle_authentication_failure(
+    amf_ue_ngap_id_t ue_id, AuthenticationFailureMsg* msg, int amf_cause,
+    amf_nas_message_decode_status_t status);
+status_code_e amf_handle_security_complete_response(
     amf_ue_ngap_id_t ue_id, amf_nas_message_decode_status_t decode_status);
-int amf_handle_security_mode_reject(
+status_code_e amf_handle_security_mode_reject(
     const amf_ue_ngap_id_t ueid, SecurityModeRejectMsg* msg,
     int const amf_cause, const amf_nas_message_decode_status_t decode_status);
-int amf_handle_registration_complete_response(
+status_code_e amf_handle_registration_complete_response(
     amf_ue_ngap_id_t ue_id, RegistrationCompleteMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status);
-int amf_handle_deregistration_ue_origin_req(
+status_code_e amf_handle_deregistration_ue_origin_req(
     amf_ue_ngap_id_t ue_id, DeRegistrationRequestUEInitMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status);
 int amf_validate_dnn(const amf_context_s* amf_ctxt_p, std::string dnn_string,
                      int* index, bool ue_sent_dnn);
 void smf_dnn_ambr_select(const std::shared_ptr<smf_context_t>& smf_ctx,
                          ue_m5gmm_context_s* ue_context, int index_dnn);
-int amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ueid,
-                                       ULNASTransportMsg* msg, int amf_cause);
+status_code_e amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ueid,
+                                                 ULNASTransportMsg* msg,
+                                                 int amf_cause);
 int amf_smf_notification_send(amf_ue_ngap_id_t ueid,
                               ue_m5gmm_context_s* ue_context,
                               notify_ue_event notify_event_type,
                               uint16_t session_id);
-int amf_proc_registration_request(amf_ue_ngap_id_t ue_id,
-                                  const bool is_mm_ctx_new,
-                                  amf_registration_request_ies_t* ies);
+status_code_e amf_proc_registration_request(
+    amf_ue_ngap_id_t ue_id, const bool is_mm_ctx_new,
+    amf_registration_request_ies_t* ies);
 int amf_registration_success_identification_cb(amf_context_t* amf_context);
 int amf_registration_failure_identification_cb(amf_context_t* amf_context);
 int amf_registration_success_authentication_cb(amf_context_t* amf_context);
 int amf_registration_success_security_cb(amf_context_t* amf_context);
-int amf_proc_registration_reject(const amf_ue_ngap_id_t ue_id,
-                                 amf_cause_t amf_cause);
+status_code_e amf_proc_registration_reject(const amf_ue_ngap_id_t ue_id,
+                                           amf_cause_t amf_cause);
 
 int get_decrypt_imsi_suci_extension(amf_context_t* amf_context,
                                     uint8_t ue_pubkey_identifier,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.hpp
@@ -28,7 +28,7 @@ status_code_e amf_handle_registration_request(
 status_code_e amf_handle_service_request(
     amf_ue_ngap_id_t ue_id, ServiceRequestMsg* msg,
     const amf_nas_message_decode_status_t decode_status);
-int amf_registration_run_procedure(amf_context_t* amf_context);
+status_code_e amf_registration_run_procedure(amf_context_t* amf_context);
 status_code_e amf_handle_identity_response(
     amf_ue_ngap_id_t ue_id, M5GSMobileIdentityMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status);
@@ -49,17 +49,18 @@ status_code_e amf_handle_registration_complete_response(
 status_code_e amf_handle_deregistration_ue_origin_req(
     amf_ue_ngap_id_t ue_id, DeRegistrationRequestUEInitMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status);
-int amf_validate_dnn(const amf_context_s* amf_ctxt_p, std::string dnn_string,
-                     int* index, bool ue_sent_dnn);
+status_code_e amf_validate_dnn(const amf_context_s* amf_ctxt_p,
+                               std::string dnn_string, int* index,
+                               bool ue_sent_dnn);
 void smf_dnn_ambr_select(const std::shared_ptr<smf_context_t>& smf_ctx,
                          ue_m5gmm_context_s* ue_context, int index_dnn);
 status_code_e amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ueid,
                                                  ULNASTransportMsg* msg,
                                                  int amf_cause);
-int amf_smf_notification_send(amf_ue_ngap_id_t ueid,
-                              ue_m5gmm_context_s* ue_context,
-                              notify_ue_event notify_event_type,
-                              uint16_t session_id);
+status_code_e amf_smf_notification_send(amf_ue_ngap_id_t ueid,
+                                        ue_m5gmm_context_s* ue_context,
+                                        notify_ue_event notify_event_type,
+                                        uint16_t session_id);
 status_code_e amf_proc_registration_request(
     amf_ue_ngap_id_t ue_id, const bool is_mm_ctx_new,
     amf_registration_request_ies_t* ies);
@@ -78,6 +79,6 @@ int get_decrypt_imsi_suci_extension(amf_context_t* amf_context,
 int amf_decrypt_msin_info_answer(itti_amf_decrypted_msin_info_ans_t* aia);
 void amf_copy_plmn_to_supi(const ImsiM5GSMobileIdentity& imsi,
                            supi_as_imsi_t& supi_imsi);
-int amf_copy_plmn_to_context(const ImsiM5GSMobileIdentity& imsi,
-                             ue_m5gmm_context_s* ue_context);
+status_code_e amf_copy_plmn_to_context(const ImsiM5GSMobileIdentity& imsi,
+                                       ue_m5gmm_context_s* ue_context);
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_sap.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_sap.cpp
@@ -33,8 +33,8 @@ namespace magma5g {
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_sap_send(amf_sap_t* msg) {
-  int rc = RETURNerror;
+status_code_e amf_sap_send(amf_sap_t* msg) {
+  status_code_e rc = RETURNerror;
   amf_primitive_t primitive = msg->primitive;
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   /*

--- a/lte/gateway/c/core/oai/tasks/amf/amf_sap.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_sap.hpp
@@ -164,10 +164,10 @@ typedef struct amf_sap_s {
 } amf_sap_t;
 
 // Message passing from Access to Service Access Point.
-int amf_sap_send(amf_sap_t* msg);
+status_code_e amf_sap_send(amf_sap_t* msg);
 
 // Functions to handle all UL message final actions*/
-int amf_cn_send(const amf_cn_t* msg);
-int amf_reg_send(amf_sap_t* const msg);
+status_code_e amf_cn_send(const amf_cn_t* msg);
+status_code_e amf_reg_send(amf_sap_t* const msg);
 
 }  // namespace  magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_security_mode_control.cpp
@@ -123,12 +123,12 @@ nas_amf_smc_proc_t* nas5g_new_smc_procedure(amf_context_t* const amf_context) {
  **                                                                        **
  **                                                                        **
  ***************************************************************************/
-static int amf_security_request(nas_amf_smc_proc_t* const smc_proc) {
+static status_code_e amf_security_request(nas_amf_smc_proc_t* const smc_proc) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   ue_m5gmm_context_s* ue_mm_context = NULL;
   amf_context_t* amf_ctx = NULL;
   amf_sap_t amf_sap = {};
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   smc_proc->T3560.id = NAS5G_TIMER_INACTIVE_ID;
 
   if (smc_proc) {
@@ -292,12 +292,11 @@ static int security_mode_t3560_handler(zloop_t* loop, int timer_id, void* arg) {
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int amf_proc_security_mode_control(amf_context_t* amf_ctx,
-                                   nas_amf_specific_proc_t* amf_specific_proc,
-                                   ksi_t ksi, success_cb_t success,
-                                   failure_cb_t failure) {
+status_code_e amf_proc_security_mode_control(
+    amf_context_t* amf_ctx, nas_amf_specific_proc_t* amf_specific_proc,
+    ksi_t ksi, success_cb_t success, failure_cb_t failure) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   bool security_context_is_new = false;
   int amf_ea = M5G_NAS_SECURITY_ALGORITHMS_5G_EA0;
   int amf_ia = M5G_NAS_SECURITY_ALGORITHMS_5G_IA0;
@@ -449,11 +448,11 @@ int amf_proc_security_mode_control(amf_context_t* amf_ctx,
  **      Others:    None                                                   **
  **                                                                        **
  ***************************************************************************/
-int amf_proc_security_mode_reject(amf_ue_ngap_id_t ue_id) {
+status_code_e amf_proc_security_mode_reject(amf_ue_ngap_id_t ue_id) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   ue_m5gmm_context_s* ue_mm_context = NULL;
   amf_context_t* amf_ctx = NULL;
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
 
   OAILOG_WARNING(LOG_NAS_AMF,
                  "AMF-PROC  - Security mode command not accepted by the UE"
@@ -521,8 +520,9 @@ int amf_proc_security_mode_reject(amf_ue_ngap_id_t ue_id) {
  **                                                                        **
  ***************************************************************************/
 
-int m5g_security_select_algorithms(const int ue_iaP, const int ue_eaP,
-                                   int* const amf_iaP, int* const amf_eaP) {
+status_code_e m5g_security_select_algorithms(const int ue_iaP, const int ue_eaP,
+                                             int* const amf_iaP,
+                                             int* const amf_eaP) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   int preference_index;
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.hpp
@@ -83,8 +83,8 @@ typedef struct amf_smf_s {
 int amf_smf_handle_pdu_establishment_request(SmfMsg* msg,
                                              amf_smf_t* amf_smf_msg);
 int amf_smf_handle_pdu_release_request(SmfMsg* msg, amf_smf_t* amf_smf_msg);
-int amf_smf_initiate_pdu_session_creation(amf_smf_establish_t* message,
-                                          char* imsi, uint32_t version);
+status_code_e amf_smf_initiate_pdu_session_creation(
+    amf_smf_establish_t* message, char* imsi, uint32_t version);
 
 status_code_e amf_smf_create_session_req(
     char* imsi, uint8_t* apn, uint32_t pdu_session_id,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smfDefs.hpp
@@ -86,16 +86,14 @@ int amf_smf_handle_pdu_release_request(SmfMsg* msg, amf_smf_t* amf_smf_msg);
 int amf_smf_initiate_pdu_session_creation(amf_smf_establish_t* message,
                                           char* imsi, uint32_t version);
 
-int amf_smf_create_session_req(char* imsi, uint8_t* apn,
-                               uint32_t pdu_session_id,
-                               uint32_t pdu_session_type, uint32_t gnb_gtp_teid,
-                               uint8_t pti, uint8_t* gnb_gtp_teid_ip_addr,
-                               char* ue_ipv4_addr, char* ue_ipv6_addr,
-                               const ambr_t& state_ambr,
-                               const eps_subscribed_qos_profile_t& qos_profile);
-int create_session_grpc_req_on_gnb_setup_rsp(amf_smf_establish_t* message,
-                                             char* imsi, uint32_t version);
-int create_session_grpc_req(amf_smf_establish_t* message, char* imsi);
-int release_session_gprc_req(amf_smf_release_t* message, char* imsi);
+status_code_e amf_smf_create_session_req(
+    char* imsi, uint8_t* apn, uint32_t pdu_session_id,
+    uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
+    uint8_t* gnb_gtp_teid_ip_addr, char* ue_ipv4_addr, char* ue_ipv6_addr,
+    const ambr_t& state_ambr, const eps_subscribed_qos_profile_t& qos_profile);
 
+status_code_e create_session_grpc_req_on_gnb_setup_rsp(
+    amf_smf_establish_t* message, char* imsi, uint32_t version);
+int create_session_grpc_req(amf_smf_establish_t* message, char* imsi);
+status_code_e release_session_gprc_req(amf_smf_release_t* message, char* imsi);
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -793,8 +793,9 @@ M5GMmCause amf_smf_validate_context(amf_ue_ngap_id_t ue_id,
 ** This function validates the DNN string received from UE or from        **
 ** mme.yml againt apn stored in amf_context for a particular imsi.        **
 ***************************************************************************/
-int amf_validate_dnn(const amf_context_s* amf_ctxt_p, std::string dnn_string,
-                     int* index, bool ue_sent_dnn) {
+status_code_e amf_validate_dnn(const amf_context_s* amf_ctxt_p,
+                               std::string dnn_string, int* index,
+                               bool ue_sent_dnn) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   // Validating apn_configuration_s
   if (dnn_string.empty()) {
@@ -825,10 +826,10 @@ int amf_validate_dnn(const amf_context_s* amf_ctxt_p, std::string dnn_string,
 ** UE_PERIODIC_REG_ACTIVE_MODE_NOTIFY                                     **
 **                                                                        **
 ***************************************************************************/
-int amf_smf_notification_send(amf_ue_ngap_id_t ue_id,
-                              ue_m5gmm_context_s* ue_context,
-                              notify_ue_event notify_event_type,
-                              uint16_t session_id) {
+status_code_e amf_smf_notification_send(amf_ue_ngap_id_t ue_id,
+                                        ue_m5gmm_context_s* ue_context,
+                                        notify_ue_event notify_event_type,
+                                        uint16_t session_id) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   /* Get gRPC structure of notification to be filled common and
    * rat type elements.

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -275,11 +275,11 @@ int pdu_session_resource_release_complete(
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
 
-int pdu_session_resource_modification_complete(
+status_code_e pdu_session_resource_modification_complete(
     ue_m5gmm_context_s* ue_context, amf_smf_t amf_smf_msg,
     std::shared_ptr<smf_context_t> smf_ctx) {
   char imsi[IMSI_BCD_DIGITS_MAX + 1];
-  int rc = 1;
+  status_code_e rc = RETURNok;
 
   IMSI64_TO_STRING(ue_context->amf_context.imsi64, imsi, 15);
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -885,8 +885,8 @@ int amf_smf_notification_send(amf_ue_ngap_id_t ue_id,
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_update_smf_context_pdu_ip(const std::shared_ptr<smf_context_t>& smf_ctx,
-                                  paa_t* address_info) {
+status_code_e amf_update_smf_context_pdu_ip(
+    const std::shared_ptr<smf_context_t>& smf_ctx, paa_t* address_info) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   OAILOG_INFO(LOG_AMF_APP, "SMF context PDU address updated\n");
   memcpy(&(smf_ctx->pdu_address), address_info, sizeof(paa_t));
@@ -902,13 +902,13 @@ int amf_update_smf_context_pdu_ip(const std::shared_ptr<smf_context_t>& smf_ctx,
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_smf_handle_ip_address_response(
+status_code_e amf_smf_handle_ip_address_response(
     itti_amf_ip_allocation_response_t* response_p) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   ue_m5gmm_context_s* ue_context;
   std::shared_ptr<smf_context_t> smf_ctx;
   imsi64_t imsi64;
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
 
   IMSI_STRING_TO_IMSI64(response_p->imsi, &imsi64);
   ue_context = lookup_ue_ctxt_by_imsi(imsi64);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -411,10 +411,11 @@ static int pdu_session_resource_release_t3592_handler(zloop_t* loop,
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ue_id,
-                                       ULNASTransportMsg* msg, int amf_cause) {
+status_code_e amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ue_id,
+                                                 ULNASTransportMsg* msg,
+                                                 int amf_cause) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   amf_smf_t amf_smf_msg = {};
   std::shared_ptr<smf_context_t> smf_ctx;
   char imsi[IMSI_BCD_DIGITS_MAX + 1] = {0};
@@ -574,7 +575,7 @@ int amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ue_id,
       /*
        * Execute the Grpc Send call of PDU establishment Request from AMF to SMF
        */
-      rc = pdu_state_handle_message(
+      rc = (status_code_e)pdu_state_handle_message(
           // ue_context->mm_state, STATE_PDU_SESSION_ESTABLISHMENT_REQUEST,
           REGISTERED_CONNECTED, STATE_PDU_SESSION_ESTABLISHMENT_REQUEST,
           // smf_ctx->pdu_session_state, ue_context, amf_smf_msg, imsi, NULL,
@@ -1050,11 +1051,11 @@ int amf_send_n11_update_location_req(amf_ue_ngap_id_t ue_id) {
  **  Return     :  RETURNok, RETURNerror                                   **
  **                                                                        **
  ***************************************************************************/
-int handle_sm_message_routing_failure(amf_ue_ngap_id_t ue_id,
-                                      ULNASTransportMsg* ulmsg,
-                                      M5GMmCause m5gmmcause) {
+status_code_e handle_sm_message_routing_failure(amf_ue_ngap_id_t ue_id,
+                                                ULNASTransportMsg* ulmsg,
+                                                M5GMmCause m5gmmcause) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   DLNASTransportMsg* dlmsg = nullptr;
   uint32_t bytes = 0;
   uint32_t len = 0;
@@ -1295,11 +1296,11 @@ int construct_pdu_session_reject_dl_req(uint8_t sequence_number,
  **  Return     :  RETURNok, RETURNerror                                   **
  **                                                                        **
  ***************************************************************************/
-int amf_pdu_session_establishment_reject(amf_ue_ngap_id_t ue_id,
-                                         uint8_t session_id, uint8_t pti,
-                                         uint8_t cause) {
+status_code_e amf_pdu_session_establishment_reject(amf_ue_ngap_id_t ue_id,
+                                                   uint8_t session_id,
+                                                   uint8_t pti, uint8_t cause) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   uint32_t bytes = 0;
   uint32_t len = 0;
   bstring buffer;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -575,7 +575,7 @@ status_code_e amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ue_id,
       /*
        * Execute the Grpc Send call of PDU establishment Request from AMF to SMF
        */
-      rc = (status_code_e)pdu_state_handle_message(
+      rc = pdu_state_handle_message(
           // ue_context->mm_state, STATE_PDU_SESSION_ESTABLISHMENT_REQUEST,
           REGISTERED_CONNECTED, STATE_PDU_SESSION_ESTABLISHMENT_REQUEST,
           // smf_ctx->pdu_session_state, ue_context, amf_smf_msg, imsi, NULL,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -996,10 +996,10 @@ status_code_e amf_smf_handle_ip_address_response(
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
 }
 
-int amf_send_n11_update_location_req(amf_ue_ngap_id_t ue_id) {
+status_code_e amf_send_n11_update_location_req(amf_ue_ngap_id_t ue_id) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   ue_m5gmm_context_s* ue_context_p = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   OAILOG_INFO(
       LOG_AMF_APP,

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -50,13 +50,13 @@ amf_as_data_t amf_data_de_reg_sec;
  *        switch-off or normal de-registration.
  *        re-registration required is out of mvc scope now.
  */
-int amf_handle_deregistration_ue_origin_req(
+status_code_e amf_handle_deregistration_ue_origin_req(
     amf_ue_ngap_id_t ue_id, DeRegistrationRequestUEInitMsg* msg, int amf_cause,
     amf_nas_message_decode_status_t decode_status) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   OAILOG_DEBUG(LOG_NAS_AMF,
                "UE originated deregistration procedures started\n");
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   amf_deregistration_request_ies_t params;
   if (msg->m5gs_de_reg_type.switchoff) {
     params.de_reg_type = AMF_SWITCHOFF_DEREGISTRATION;
@@ -104,19 +104,19 @@ int amf_handle_deregistration_ue_origin_req(
  *
  * Description : Process the UE originated De-Registration request
  */
-int amf_proc_deregistration_request(amf_ue_ngap_id_t ue_id,
-                                    amf_deregistration_request_ies_t* params) {
+status_code_e amf_proc_deregistration_request(
+    amf_ue_ngap_id_t ue_id, amf_deregistration_request_ies_t* params) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   OAILOG_DEBUG(LOG_NAS_AMF,
                "Processing deregistration UE-id = " AMF_UE_NGAP_ID_FMT
                " type = %d",
                ue_id, params->de_reg_type);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
 
   ue_m5gmm_context_s* ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
 
   if (ue_context == NULL) {
-    return -1;
+    return RETURNerror;
   }
 
   amf_context_t* amf_ctx = amf_context_get(ue_id);
@@ -171,7 +171,7 @@ int amf_proc_deregistration_request(amf_ue_ngap_id_t ue_id,
      */
 
     ue_context->ue_context_rel_cause = NGAP_NAS_DEREGISTER;
-    rc = ue_state_handle_message_dereg(ue_context->mm_state,
+    rc = (status_code_e)ue_state_handle_message_dereg(ue_context->mm_state,
                                        STATE_EVENT_DEREGISTER, SESSION_NULL,
                                        ue_context, ue_id);
   }

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -171,9 +171,9 @@ status_code_e amf_proc_deregistration_request(
      */
 
     ue_context->ue_context_rel_cause = NGAP_NAS_DEREGISTER;
-    rc = (status_code_e)ue_state_handle_message_dereg(ue_context->mm_state,
-                                       STATE_EVENT_DEREGISTER, SESSION_NULL,
-                                       ue_context, ue_id);
+    rc = (status_code_e)ue_state_handle_message_dereg(
+        ue_context->mm_state, STATE_EVENT_DEREGISTER, SESSION_NULL, ue_context,
+        ue_id);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }
@@ -186,9 +186,9 @@ status_code_e amf_proc_deregistration_request(
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id) {
+status_code_e amf_app_handle_deregistration_req(amf_ue_ngap_id_t ue_id) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   amf_app_desc_t* amf_app_desc_p = get_amf_nas_state(false);
   ue_m5gmm_context_s* ue_context_p =
       amf_ue_context_exists_amf_ue_ngap_id(ue_id);

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -171,9 +171,9 @@ status_code_e amf_proc_deregistration_request(
      */
 
     ue_context->ue_context_rel_cause = NGAP_NAS_DEREGISTER;
-    rc = (status_code_e)ue_state_handle_message_dereg(
-        ue_context->mm_state, STATE_EVENT_DEREGISTER, SESSION_NULL, ue_context,
-        ue_id);
+    rc = ue_state_handle_message_dereg(ue_context->mm_state,
+                                       STATE_EVENT_DEREGISTER, SESSION_NULL,
+                                       ue_context, ue_id);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
 }

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.hpp
@@ -102,7 +102,7 @@ class AMFClientServicerBase {
                                      const std::string& mac_tag,
                                      amf_ue_ngap_id_t ue_id);
 
-  virtual int n11_update_location_req(
+  virtual status_code_e n11_update_location_req(
       const s6a_update_location_req_t* const ulr_p);
 
   virtual bool set_smf_notification(const SetSmNotificationContext& notify);
@@ -200,7 +200,8 @@ class AMFClientServicer : public AMFClientServicerBase {
     return true;
   }
 
-  int n11_update_location_req(const s6a_update_location_req_t* const ulr_p) {
+  status_code_e n11_update_location_req(
+      const s6a_update_location_req_t* const ulr_p) {
     return RETURNok;
   }
 

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_client_servicer.hpp
@@ -88,7 +88,7 @@ class AMFClientServicerBase {
                                      const struct in_addr* ipv4_addr,
                                      const struct in6_addr* ipv6_addr);
 
-  virtual int amf_smf_create_pdu_session(
+  virtual status_code_e amf_smf_create_pdu_session(
       char* imsi, uint8_t* apn, uint32_t pdu_session_id,
       uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
       uint8_t* gnb_gtp_teid_ip_addr, char* ue_ipv4_addr, char* ue_ipv6_addr,
@@ -182,7 +182,7 @@ class AMFClientServicer : public AMFClientServicerBase {
     return RETURNok;
   }
 
-  int amf_smf_create_pdu_session(
+  status_code_e amf_smf_create_pdu_session(
       char* imsi, uint8_t* apn, uint32_t pdu_session_id,
       uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
       uint8_t* gnb_gtp_teid_ip_addr, char* ue_ipv4_addr, char* ue_ipv6_addr,

--- a/lte/gateway/c/core/oai/tasks/amf/include/amf_smf_packet_handler.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/include/amf_smf_packet_handler.hpp
@@ -22,13 +22,13 @@ namespace magma5g {
 #define MAX_UE_PDU_SESSION_LIMIT 15
 #define MAX_UE_INITIAL_PDU_SESSION_ESTABLISHMENT_REQ_ALLOWED 5
 
-int handle_sm_message_routing_failure(amf_ue_ngap_id_t ue_id,
-                                      ULNASTransportMsg* msg,
-                                      M5GMmCause m5gmmcause);
+status_code_e handle_sm_message_routing_failure(amf_ue_ngap_id_t ue_id,
+                                                ULNASTransportMsg* msg,
+                                                M5GMmCause m5gmmcause);
 int amf_max_pdu_session_reject(amf_ue_ngap_id_t ue_id, ULNASTransportMsg* msg);
-int amf_pdu_session_establishment_reject(amf_ue_ngap_id_t ue_id,
-                                         uint8_t session_id, uint8_t pti,
-                                         uint8_t cause);
+status_code_e amf_pdu_session_establishment_reject(amf_ue_ngap_id_t ue_id,
+                                                   uint8_t session_id,
+                                                   uint8_t pti, uint8_t cause);
 int construct_pdu_session_reject_dl_req(uint8_t sequence_number,
                                         uint8_t session_id, uint8_t pti,
                                         uint8_t cause, bool is_security_enabled,

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -41,14 +41,14 @@ extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 AmfMsg amf_msg_obj;
 static int identification_t3570_handler(zloop_t* loop, int timer_id, void* arg);
 static int subs_auth_retry(zloop_t* loop, int timer_id, void* arg);
-int nas_proc_establish_ind(const amf_ue_ngap_id_t ue_id,
-                           const bool is_mm_ctx_new,
-                           const tai_t originating_tai, const ecgi_t ecgi,
-                           const m5g_rrc_establishment_cause_t as_cause,
-                           const s_tmsi_m5_t s_tmsi, bstring msg) {
+status_code_e nas_proc_establish_ind(
+    const amf_ue_ngap_id_t ue_id, const bool is_mm_ctx_new,
+    const tai_t originating_tai, const ecgi_t ecgi,
+    const m5g_rrc_establishment_cause_t as_cause, const s_tmsi_m5_t s_tmsi,
+    bstring msg) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   amf_sap_t amf_sap = {};
-  uint32_t rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   if (msg) {
     /*
      * Notify the AMF procedure call manager that NAS signaling
@@ -466,10 +466,11 @@ nas_amf_ident_proc_t* nas5g_new_identification_procedure(
 ** Outputs:        None                                                   **
 **      Return:    None                                                   **
 ***************************************************************************/
-static int amf_identification_request(nas_amf_ident_proc_t* const proc) {
+static status_code_e amf_identification_request(
+    nas_amf_ident_proc_t* const proc) {
   OAILOG_FUNC_IN(LOG_NAS_EMM);
   amf_sap_t amf_sap = {};
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   proc->T3570.id = NAS5G_TIMER_INACTIVE_ID;
   OAILOG_DEBUG(LOG_AMF_APP, "Sending AS IDENTITY_REQUEST\n");
   /*
@@ -572,12 +573,13 @@ static int identification_t3570_handler(zloop_t* loop, int timer_id,
 }
 
 //-------------------------------------------------------------------------------------
-int amf_proc_identification(amf_context_t* const amf_context,
-                            nas_amf_proc_t* const amf_proc,
-                            const identity_type2_t type, success_cb_t success,
-                            failure_cb_t failure) {
+status_code_e amf_proc_identification(amf_context_t* const amf_context,
+                                      nas_amf_proc_t* const amf_proc,
+                                      const identity_type2_t type,
+                                      success_cb_t success,
+                                      failure_cb_t failure) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   amf_context->amf_fsm_state = AMF_REGISTERED;
   if ((amf_context) && ((AMF_DEREGISTERED == amf_context->amf_fsm_state) ||
                         (AMF_REGISTERED == amf_context->amf_fsm_state))) {
@@ -648,11 +650,11 @@ int amf_nas_proc_implicit_deregister_ue_ind(amf_ue_ngap_id_t ue_id) {
  **                                                                        **
  **                                                                        **
  ***************************************************************************/
-int amf_nas_proc_auth_param_res(amf_ue_ngap_id_t amf_ue_ngap_id,
+status_code_e amf_nas_proc_auth_param_res(amf_ue_ngap_id_t amf_ue_ngap_id,
                                 uint8_t nb_vectors, m5gauth_vector_t* vectors) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   amf_sap_t amf_sap = {};
   amf_cn_auth_res_t amf_cn_auth_res = {};
 
@@ -738,10 +740,10 @@ static int subs_auth_retry(zloop_t* loop, int timer_id, void* arg) {
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
 }
 
-int amf_nas_proc_authentication_info_answer(
+status_code_e amf_nas_proc_authentication_info_answer(
     itti_amf_subs_auth_info_ans_t* aia) {
   imsi64_t imsi64 = INVALID_IMSI64;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   amf_context_t* amf_ctxt_p = NULL;
   ue_m5gmm_context_s* ue_5gmm_context_p = NULL;
   int amf_cause = -1;

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -630,8 +630,8 @@ status_code_e amf_proc_identification(amf_context_t* const amf_context,
  **                                                                        **
  **                                                                        **
  ***************************************************************************/
-int amf_nas_proc_implicit_deregister_ue_ind(amf_ue_ngap_id_t ue_id) {
-  int rc = RETURNerror;
+status_code_e amf_nas_proc_implicit_deregister_ue_ind(amf_ue_ngap_id_t ue_id) {
+  status_code_e rc = RETURNerror;
   amf_sap_t amf_sap = {};
 
   OAILOG_FUNC_IN(LOG_AMF_APP);
@@ -651,7 +651,8 @@ int amf_nas_proc_implicit_deregister_ue_ind(amf_ue_ngap_id_t ue_id) {
  **                                                                        **
  ***************************************************************************/
 status_code_e amf_nas_proc_auth_param_res(amf_ue_ngap_id_t amf_ue_ngap_id,
-                                uint8_t nb_vectors, m5gauth_vector_t* vectors) {
+                                          uint8_t nb_vectors,
+                                          m5gauth_vector_t* vectors) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
 
   status_code_e rc = RETURNerror;
@@ -836,7 +837,7 @@ status_code_e amf_nas_proc_authentication_info_answer(
 
 int amf_decrypt_msin_info_answer(itti_amf_decrypted_msin_info_ans_t* aia) {
   imsi64_t imsi64 = INVALID_IMSI64;
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   amf_context_t* amf_ctxt_p = NULL;
   ue_m5gmm_context_s* ue_context = NULL;
 
@@ -934,7 +935,7 @@ int amf_decrypt_msin_info_answer(itti_amf_decrypted_msin_info_ans_t* aia) {
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
 }
 
-int amf_handle_s6a_update_location_ans(
+status_code_e amf_handle_s6a_update_location_ans(
     const s6a_update_location_ans_t* ula_pP) {
   imsi64_t imsi64 = INVALID_IMSI64;
   amf_context_t* amf_ctxt_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
@@ -231,8 +231,8 @@ status_code_e amf_smf_create_session_req(
  * **                                                                        **
  * **                                                                        **
  * ***************************************************************************/
-int amf_smf_initiate_pdu_session_creation(amf_smf_establish_t* message,
-                                          char* imsi, uint32_t version) {
+status_code_e amf_smf_initiate_pdu_session_creation(
+    amf_smf_establish_t* message, char* imsi, uint32_t version) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   imsi64_t imsi64 = INVALID_IMSI64;
   amf_context_t* amf_ctxt_p = NULL;

--- a/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/prepare_request_for_smf.cpp
@@ -63,10 +63,10 @@ namespace magma5g {
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int create_session_grpc_req_on_gnb_setup_rsp(
+status_code_e create_session_grpc_req_on_gnb_setup_rsp(
     amf_smf_establish_t* message, char* imsi, uint32_t version,
     std::shared_ptr<smf_context_t> smf_ctx) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   magma::lte::SetSMSessionContext req;
 
   auto imsi_str = std::string(imsi);
@@ -190,7 +190,7 @@ int amf_send_grpc_req_on_gnb_pdu_sess_mod_rsp(
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int amf_smf_create_session_req(
+status_code_e amf_smf_create_session_req(
     char* imsi, uint8_t* apn, uint32_t pdu_session_id,
     uint32_t pdu_session_type, uint32_t gnb_gtp_teid, uint8_t pti,
     uint8_t* gnb_gtp_teid_ip_addr, char* ue_ipv4_addr, char* ue_ipv6_addr,
@@ -287,7 +287,7 @@ int amf_smf_initiate_pdu_session_creation(amf_smf_establish_t* message,
 **                                                                        **
 **                                                                        **
 ***************************************************************************/
-int release_session_gprc_req(amf_smf_release_t* message, char* imsi) {
+status_code_e release_session_gprc_req(amf_smf_release_t* message, char* imsi) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
   magma::lte::SetSMSessionContext req;
   auto imsi_str = std::string(imsi);

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -214,11 +214,9 @@ status_code_e send_uplink_nas_message_ue_auth_response(
 }
 
 /* Create security mode complete response from ue */
-int send_uplink_nas_message_ue_smc_response(amf_app_desc_t* amf_app_desc_p,
-                                            amf_ue_ngap_id_t ue_id,
-                                            const plmn_t& plmn,
-                                            const uint8_t* nas_msg,
-                                            uint8_t nas_msg_length) {
+status_code_e send_uplink_nas_message_ue_smc_response(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length) {
   bstring uplink_nas_smc_response;
   tai_t originating_tai = {};
 
@@ -227,7 +225,7 @@ int send_uplink_nas_message_ue_smc_response(amf_app_desc_t* amf_app_desc_p,
   originating_tai.plmn = plmn;
   originating_tai.tac = 1;
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   rc = amf_app_handle_uplink_nas_message(
       amf_app_desc_p, uplink_nas_smc_response, ue_id, originating_tai);
 
@@ -276,7 +274,7 @@ int send_uplink_nas_registration_complete(amf_app_desc_t* amf_app_desc_p,
 }
 
 /* Create pdu session establishment request from ue */
-int send_uplink_nas_pdu_session_establishment_request(
+status_code_e send_uplink_nas_pdu_session_establishment_request(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
     const uint8_t* nas_msg, uint8_t nas_msg_length) {
   bstring pdu_session_est_req;
@@ -291,7 +289,7 @@ int send_uplink_nas_pdu_session_establishment_request(
   originating_tai.plmn = plmn;
   originating_tai.tac = 1;
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   rc = amf_app_handle_uplink_nas_message(amf_app_desc_p, pdu_session_est_req,
                                          ue_id, originating_tai);
 
@@ -373,8 +371,8 @@ void create_ip_address_response_itti(
   response->result = SGI_STATUS_OK;
 }
 
-int send_ip_address_response_itti(pdn_type_value_t type) {
-  int rc = RETURNerror;
+status_code_e send_ip_address_response_itti(pdn_type_value_t type) {
+  status_code_e rc = RETURNerror;
 
   itti_amf_ip_allocation_response_t response = {};
   create_ip_address_response_itti(type, &response);
@@ -451,8 +449,8 @@ void create_pdu_session_response_itti(
   }
 }
 
-int send_pdu_session_response_itti(pdn_type_value_t type) {
-  int rc = RETURNerror;
+status_code_e send_pdu_session_response_itti(pdn_type_value_t type) {
+  status_code_e rc = RETURNerror;
   itti_n11_create_pdu_session_response_t response = {};
   create_pdu_session_response_itti(type, &response);
 
@@ -526,8 +524,8 @@ void create_pdu_resource_modify_response_itti(
       .qos_flow_add_or_modify_response_list.item[0]
       .qos_flow_identifier = 3;
 }
-int send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id) {
-  int rc = RETURNok;
+status_code_e send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id) {
+  status_code_e rc = RETURNok;
   itti_ngap_pdusessionresource_setup_rsp_t response = {};
   create_pdu_resource_setup_response_itti(&response, ue_id);
 
@@ -721,11 +719,9 @@ void create_pdu_session_modify_request_itti(
 }
 
 /* Create pdu session release message from ue */
-int send_uplink_nas_pdu_session_release_message(amf_app_desc_t* amf_app_desc_p,
-                                                amf_ue_ngap_id_t ue_id,
-                                                const plmn_t& plmn,
-                                                const uint8_t* nas_msg,
-                                                uint8_t nas_msg_length) {
+status_code_e send_uplink_nas_pdu_session_release_message(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length) {
   bstring pdu_session_req;
   tai_t originating_tai = {};
 
@@ -738,7 +734,7 @@ int send_uplink_nas_pdu_session_release_message(amf_app_desc_t* amf_app_desc_p,
   originating_tai.plmn = plmn;
   originating_tai.tac = 1;
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   rc = amf_app_handle_uplink_nas_message(amf_app_desc_p, pdu_session_req, ue_id,
                                          originating_tai);
 
@@ -746,14 +742,14 @@ int send_uplink_nas_pdu_session_release_message(amf_app_desc_t* amf_app_desc_p,
 }
 
 /* Create ue deregistration request */
-int send_uplink_nas_ue_deregistration_request(amf_app_desc_t* amf_app_desc_p,
+status_code_e send_uplink_nas_ue_deregistration_request(amf_app_desc_t* amf_app_desc_p,
                                               amf_ue_ngap_id_t ue_id,
                                               const plmn_t& plmn,
                                               uint8_t* nas_msg,
                                               uint8_t nas_msg_length) {
   bstring uplink_nas_ue_dereg_req;
   tai_t originating_tai = {};
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
 
   tmsi_t ue_tmsi = htonl(amf_lookup_guti_by_ueid(ue_id));
   if (ue_tmsi == 0) {

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -148,8 +148,9 @@ int send_uplink_nas_identity_response_message(amf_app_desc_t* amf_app_desc_p,
 }
 
 /* Create authentication answer from subscriberdb */
-int send_proc_authentication_info_answer(const std::string& imsi,
-                                         amf_ue_ngap_id_t ue_id, bool success) {
+status_code_e send_proc_authentication_info_answer(const std::string& imsi,
+                                                   amf_ue_ngap_id_t ue_id,
+                                                   bool success) {
   itti_amf_subs_auth_info_ans_t aia_itti_msg = {};
 
   strncpy(aia_itti_msg.imsi, imsi.c_str(), imsi.size());
@@ -187,18 +188,16 @@ int send_proc_authentication_info_answer(const std::string& imsi,
     aia_itti_msg.result = DIAMETER_UNABLE_TO_COMPLY;
   }
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   rc = amf_nas_proc_authentication_info_answer(&aia_itti_msg);
 
   return (rc);
 }
 
 /* Create authentication response from ue */
-int send_uplink_nas_message_ue_auth_response(amf_app_desc_t* amf_app_desc_p,
-                                             amf_ue_ngap_id_t ue_id,
-                                             const plmn_t& plmn,
-                                             const uint8_t* nas_msg,
-                                             uint8_t nas_msg_length) {
+status_code_e send_uplink_nas_message_ue_auth_response(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length) {
   bstring uplink_nas_auth_response;
   tai_t originating_tai = {};
 
@@ -207,7 +206,7 @@ int send_uplink_nas_message_ue_auth_response(amf_app_desc_t* amf_app_desc_p,
   originating_tai.plmn = plmn;
   originating_tai.tac = 1;
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   rc = amf_app_handle_uplink_nas_message(
       amf_app_desc_p, uplink_nas_auth_response, ue_id, originating_tai);
 

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -123,11 +123,9 @@ uint64_t send_initial_ue_message_with_tmsi(
 }
 
 /* Create the identiy response message */
-int send_uplink_nas_identity_response_message(amf_app_desc_t* amf_app_desc_p,
-                                              amf_ue_ngap_id_t ue_id,
-                                              const plmn_t& plmn,
-                                              const uint8_t* nas_msg,
-                                              uint8_t nas_msg_length) {
+status_code_e send_uplink_nas_identity_response_message(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length) {
   bstring pdu_session_req;
   tai_t originating_tai = {};
 
@@ -140,11 +138,11 @@ int send_uplink_nas_identity_response_message(amf_app_desc_t* amf_app_desc_p,
   originating_tai.plmn = plmn;
   originating_tai.tac = 1;
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   rc = amf_app_handle_uplink_nas_message(amf_app_desc_p, pdu_session_req, ue_id,
                                          originating_tai);
 
-  return (rc);
+  return rc;
 }
 
 /* Create authentication answer from subscriberdb */
@@ -253,11 +251,9 @@ void send_initial_context_response(amf_app_desc_t* amf_app_desc_p,
 }
 
 /* Create registration mode complete response from ue */
-int send_uplink_nas_registration_complete(amf_app_desc_t* amf_app_desc_p,
-                                          amf_ue_ngap_id_t ue_id,
-                                          const plmn_t& plmn,
-                                          const uint8_t* nas_msg,
-                                          uint8_t nas_msg_length) {
+status_code_e send_uplink_nas_registration_complete(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length) {
   bstring ue_registration_complete;
   tai_t originating_tai = {};
 
@@ -266,11 +262,11 @@ int send_uplink_nas_registration_complete(amf_app_desc_t* amf_app_desc_p,
   originating_tai.plmn = plmn;
   originating_tai.tac = 1;
 
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   rc = amf_app_handle_uplink_nas_message(
       amf_app_desc_p, ue_registration_complete, ue_id, originating_tai);
 
-  return (rc);
+  return rc;
 }
 
 /* Create pdu session establishment request from ue */
@@ -620,8 +616,8 @@ void create_pdu_notification_response_itti(
   response->notify_ue_evnt = PDU_SESSION_STATE_NOTIFY;
 }
 
-int send_pdu_notification_response() {
-  int rc = RETURNerror;
+status_code_e send_pdu_notification_response() {
+  status_code_e rc = RETURNerror;
   itti_n11_received_notification_t response = {};
   create_pdu_notification_response_itti(&response);
 
@@ -738,15 +734,13 @@ status_code_e send_uplink_nas_pdu_session_release_message(
   rc = amf_app_handle_uplink_nas_message(amf_app_desc_p, pdu_session_req, ue_id,
                                          originating_tai);
 
-  return (rc);
+  return rc;
 }
 
 /* Create ue deregistration request */
-status_code_e send_uplink_nas_ue_deregistration_request(amf_app_desc_t* amf_app_desc_p,
-                                              amf_ue_ngap_id_t ue_id,
-                                              const plmn_t& plmn,
-                                              uint8_t* nas_msg,
-                                              uint8_t nas_msg_length) {
+status_code_e send_uplink_nas_ue_deregistration_request(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    uint8_t* nas_msg, uint8_t nas_msg_length) {
   bstring uplink_nas_ue_dereg_req;
   tai_t originating_tai = {};
   status_code_e rc = RETURNerror;
@@ -856,15 +850,15 @@ imsi64_t send_initial_ue_message_service_request(
   return imsi64;
 }
 
-int send_uplink_nas_message_service_request_with_pdu(
+status_code_e send_uplink_nas_message_service_request_with_pdu(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t amf_ue_ngap_id,
     const plmn_t& plmn, const uint8_t* nas_msg, uint8_t nas_msg_length) {
   bstring uplink_nas_service_request;
   tai_t originating_tai = {.plmn = plmn, .tac = 1};
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   tmsi_t ue_tmsi = amf_lookup_guti_by_ueid(amf_ue_ngap_id);
   if (ue_tmsi == 0) {
-    return (rc);
+    return rc;
   }
 
   uplink_nas_service_request = blk2bstr(nas_msg, nas_msg_length);
@@ -879,7 +873,7 @@ int send_uplink_nas_message_service_request_with_pdu(
   rc = amf_app_handle_uplink_nas_message(amf_app_desc_p,
                                          uplink_nas_service_request,
                                          amf_ue_ngap_id, originating_tai);
-  return (rc);
+  return rc;
 }
 
 // Check the ue context state

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -70,15 +70,14 @@ int send_uplink_nas_message_service_request_with_pdu(
     const plmn_t& plmn, const uint8_t* nas_msg, uint8_t nas_msg_length);
 
 /* API for creating subscriberdb auth answer */
-int send_proc_authentication_info_answer(const std::string& imsi,
-                                         amf_ue_ngap_id_t ue_id, bool success);
+status_code_e send_proc_authentication_info_answer(const std::string& imsi,
+                                                   amf_ue_ngap_id_t ue_id,
+                                                   bool success);
 
 /* API for creating uplink nas message for Auth Response */
-int send_uplink_nas_message_ue_auth_response(amf_app_desc_t* amf_app_desc_p,
-                                             amf_ue_ngap_id_t amf_ue_ngap_id,
-                                             const plmn_t& plmn,
-                                             const uint8_t* nas_msg,
-                                             uint8_t nas_msg_length);
+status_code_e send_uplink_nas_message_ue_auth_response(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t amf_ue_ngap_id,
+    const plmn_t& plmn, const uint8_t* nas_msg, uint8_t nas_msg_length);
 
 /* API for creating uplink nas message for security mode complete response */
 int send_uplink_nas_message_ue_smc_response(amf_app_desc_t* amf_app_desc_p,

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -53,11 +53,9 @@ uint64_t send_initial_ue_message_with_tmsi(
     const uint8_t* nas_msg, uint8_t nas_msg_length);
 
 /* For generating the identity response message */
-int send_uplink_nas_identity_response_message(amf_app_desc_t* amf_app_desc_p,
-                                              amf_ue_ngap_id_t ue_id,
-                                              const plmn_t& plmn,
-                                              const uint8_t* nas_msg,
-                                              uint8_t nas_msg_length);
+status_code_e send_uplink_nas_identity_response_message(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length);
 
 imsi64_t send_initial_ue_message_service_request(
     amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,
@@ -65,7 +63,7 @@ imsi64_t send_initial_ue_message_service_request(
     amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, const uint8_t* nas_msg,
     uint8_t nas_msg_length, uint8_t tmsi_offset);
 
-int send_uplink_nas_message_service_request_with_pdu(
+status_code_e send_uplink_nas_message_service_request_with_pdu(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t amf_ue_ngap_id,
     const plmn_t& plmn, const uint8_t* nas_msg, uint8_t nas_msg_length);
 
@@ -89,11 +87,9 @@ void send_initial_context_response(amf_app_desc_t* amf_app_desc_p,
                                    amf_ue_ngap_id_t ue_id);
 
 /* API for creating uplink nas message for registration complete response */
-int send_uplink_nas_registration_complete(amf_app_desc_t* amf_app_desc_p,
-                                          amf_ue_ngap_id_t ue_id,
-                                          const plmn_t& plmn,
-                                          const uint8_t* nas_msg,
-                                          uint8_t nas_msg_length);
+status_code_e send_uplink_nas_registration_complete(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length);
 
 /* Create pdu session establishment  request from ue */
 status_code_e send_uplink_nas_pdu_session_establishment_request(
@@ -124,7 +120,7 @@ status_code_e send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id);
 void create_pdu_notification_response_itti(
     itti_n11_received_notification_t* response);
 
-int send_pdu_notification_response();
+status_code_e send_pdu_notification_response();
 
 /* Create pdu session  release from ue */
 status_code_e send_uplink_nas_pdu_session_release_message(

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -80,11 +80,9 @@ status_code_e send_uplink_nas_message_ue_auth_response(
     const plmn_t& plmn, const uint8_t* nas_msg, uint8_t nas_msg_length);
 
 /* API for creating uplink nas message for security mode complete response */
-int send_uplink_nas_message_ue_smc_response(amf_app_desc_t* amf_app_desc_p,
-                                            amf_ue_ngap_id_t ue_id,
-                                            const plmn_t& plmn,
-                                            const uint8_t* nas_msg,
-                                            uint8_t nas_msg_length);
+status_code_e send_uplink_nas_message_ue_smc_response(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length);
 
 /* API for sending initial context setup response */
 void send_initial_context_response(amf_app_desc_t* amf_app_desc_p,
@@ -98,19 +96,19 @@ int send_uplink_nas_registration_complete(amf_app_desc_t* amf_app_desc_p,
                                           uint8_t nas_msg_length);
 
 /* Create pdu session establishment  request from ue */
-int send_uplink_nas_pdu_session_establishment_request(
+status_code_e send_uplink_nas_pdu_session_establishment_request(
     amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
     const uint8_t* nas_msg, uint8_t nas_msg_length);
 
 void create_ip_address_response_itti(
     itti_amf_ip_allocation_response_t* response);
 
-int send_ip_address_response_itti(pdn_type_value_t type);
+status_code_e send_ip_address_response_itti(pdn_type_value_t type);
 
 void create_pdu_session_response_ipv4_itti(
     itti_n11_create_pdu_session_response_t* response);
 
-int send_pdu_session_response_itti(pdn_type_value_t type);
+status_code_e send_pdu_session_response_itti(pdn_type_value_t type);
 
 void create_pdu_resource_setup_response_itti(
     itti_ngap_pdusessionresource_setup_rsp_t* response, amf_ue_ngap_id_t ue_id);
@@ -121,7 +119,7 @@ void create_pdu_session_modify_request_itti(
 void create_pdu_session_modify_deletion_request_itti(
     itti_n11_create_pdu_session_response_t* response);
 
-int send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id);
+status_code_e send_pdu_resource_setup_response(amf_ue_ngap_id_t ue_id);
 
 void create_pdu_notification_response_itti(
     itti_n11_received_notification_t* response);
@@ -129,17 +127,13 @@ void create_pdu_notification_response_itti(
 int send_pdu_notification_response();
 
 /* Create pdu session  release from ue */
-int send_uplink_nas_pdu_session_release_message(amf_app_desc_t* amf_app_desc_p,
-                                                amf_ue_ngap_id_t ue_id,
-                                                const plmn_t& plmn,
-                                                const uint8_t* nas_msg,
-                                                uint8_t nas_msg_length);
+status_code_e send_uplink_nas_pdu_session_release_message(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    const uint8_t* nas_msg, uint8_t nas_msg_length);
 
-int send_uplink_nas_ue_deregistration_request(amf_app_desc_t* amf_app_desc_p,
-                                              amf_ue_ngap_id_t ue_id,
-                                              const plmn_t& plmn,
-                                              uint8_t* nas_msg,
-                                              uint8_t nas_msg_length);
+status_code_e send_uplink_nas_ue_deregistration_request(
+    amf_app_desc_t* amf_app_desc_p, amf_ue_ngap_id_t ue_id, const plmn_t& plmn,
+    uint8_t* nas_msg, uint8_t nas_msg_length);
 
 /* Send ue context release message */
 void send_ue_context_release_request_message(amf_app_desc_t* amf_app_desc_p,


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Issue: Functions have "int" as return type, and they return RETURNok, RETURNerror.

Code changes:  Changed return types of relevant functions to status_code_e.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
-  Unit test snap
![test_fsm](https://user-images.githubusercontent.com/89975652/163793788-cb92c2d9-cc61-40ae-a7c7-7df8428b8115.png)

- Tested with ueransim 
![pcap-fsm](https://user-images.githubusercontent.com/89975652/163793933-ac7d8d29-6783-4569-8660-b5d58a26d121.png)

mme logs: 
[mme_fsm.log](https://github.com/magma/magma/files/8505020/mme_fsm.log)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
