### PR TITLE
chore(agw): Adapt magma-dev VM resources to macOS runners

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -42,8 +42,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     magma.vm.provider "virtualbox" do |vb|
       vb.name = "magma-dev"
       vb.linked_clone = true
-      vb.customize ["modifyvm", :id, "--memory", "8192"]
-      vb.customize ["modifyvm", :id, "--cpus", "4"]
+      vb.customize ["modifyvm", :id, "--memory", "9126"]
+      vb.customize ["modifyvm", :id, "--cpus", "3"]
       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
       vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
     end


### PR DESCRIPTION
## Summary

This reduces the amount of virtual CPUs used by the magma-dev VM from 4 to 3 and increases the virtual memory from 8 GiB to 9 GiB.

The macOS runners have 14 GiB of memory (not all of which is usable as some is already used by other processes, and some by the magma-test VM that we are also launching as part of the Integ test) and 3 CPUs. (see [here](https://github.com/jheidbrink/magma/runs/5955546161))

I found that when executing `bazel build` as part of the _LTE Integ Test_ workflow, these settings decrease the time the workflow takes by roughly 20 minutes (the exact time is difficult to determine because there is some variation in the build time, and the build times are > 5 hours so it takes a while to gather data).
Given that our [experimental LTE Integ Test with Bazel](https://github.com/jheidbrink/magma/blob/a214c33c7d97987320d7870f3cf9bfbfe815551c/.github/workflows/lte-integ-test-bazel.yml) already takes nearly 6 hours which is the maximum allowed workflow duration, this reduction is helpful.

I also tested the non-Bazel LTE Integ Test with this change and found a negligible improvement of 8 minutes (which is well below the variation we already see in the build times)

## Test Plan

I tested various combinations of CPU (3, 4, 6) and memory (8 GiB, 9 GiB and 10 GiB), and the workflow durations so far suggest that 3 CPUs with 9 GiB is the fastest.

## Additional Information

- [ ] This change is backwards-breaking
