### PR TITLE
docs: Update references to Go version from 1.13 to 1.18

### DIFF
--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -31,10 +31,10 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    4. [Vagrant](https://vagrantup.com)
 
    ```bash
-   brew install go@1.13 pyenv
+   brew install go@1.18 pyenv
    # NOTE: this assumes you're using zsh.
    # See the above pyenv install instructions if using alternative shells.
-   echo 'export PATH="/usr/local/opt/go@1.13/bin:$PATH"' >> ~/.zshrc
+   echo 'export PATH="/usr/local/opt/go@1.18/bin:$PATH"' >> ~/.zshrc
    echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
    echo 'eval "$(pyenv init -)"' >> ~/.zshrc
    exec $SHELL
@@ -61,18 +61,18 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    1. [Docker](https://docs.docker.com/engine/install/ubuntu/) and [Docker Compose](https://docs.docker.com/compose/install/)
    2. [VirtualBox](https://www.virtualbox.org/wiki/Linux_Downloads)
    3. [Vagrant](https://www.vagrantup.com/downloads)
-2. Install golang version 13.
+2. Install golang version 18.
 
    1. Download the tar file.
 
       ```bash
-      wget https://golang.org/dl/go1.13.15.linux-amd64.tar.gz
+      wget https://golang.org/dl/go1.18.linux-amd64.tar.gz
       ```
 
    2. Extract the archive you downloaded into `/usr/local`, creating a Go tree in `/usr/local/go`.
 
       ```bash
-      sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.13.15.linux-amd64.tar.gz
+      sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
       ```
 
    3. Add `/usr/local/go/bin` to the PATH environment variable.
@@ -90,7 +90,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
       You should expect something like this
 
       ```bash
-      go version go1.13.15 linux/amd64
+      go version go1.18 linux/amd64
       ```
 
 3. Install `pyenv`.


### PR DESCRIPTION
## Summary

In line with the changes made in https://github.com/magma/magma/pull/12151, this updates the Prerequisites page of the docs to refer to Go 1.18 instead of 1.13. This should be merged alongside https://github.com/magma/magma/pull/12151.
## Test Plan

## Additional Information

- [ ] This change is backwards-breaking