### PR TITLE
refactor(dp): Separate field values from metadata

### DIFF
--- a/dp/cloud/go/services/dp/storage/db/fields.go
+++ b/dp/cloud/go/services/dp/storage/db/fields.go
@@ -17,7 +17,6 @@ import "magma/orc8r/cloud/go/sqorc"
 
 type FieldMap map[string]*Field
 type Field struct {
-	Item         BaseType
 	SqlType      sqorc.ColumnType
 	Nullable     bool
 	HasDefault   bool

--- a/dp/cloud/go/services/dp/storage/db/finishing.go
+++ b/dp/cloud/go/services/dp/storage/db/finishing.go
@@ -90,8 +90,8 @@ func (q *Query) List() ([][]Model, error) {
 	return result, rows.Err()
 }
 
-func applyMask(fields FieldMap, mask FieldMask) FieldMap {
-	m := make(FieldMap, len(fields))
+func applyMask(fields map[string]BaseType, mask FieldMask) map[string]BaseType {
+	m := make(map[string]BaseType, len(fields))
 	for k, v := range fields {
 		if mask.ShouldInclude(k) {
 			m[k] = v
@@ -100,10 +100,20 @@ func applyMask(fields FieldMap, mask FieldMask) FieldMap {
 	return m
 }
 
-func toValues(fields FieldMap) map[string]interface{} {
+func applyMaskToMetadata(fields map[string]*Field, mask FieldMask) map[string]*Field {
+	m := make(map[string]*Field, len(fields))
+	for k, v := range fields {
+		if mask.ShouldInclude(k) {
+			m[k] = v
+		}
+	}
+	return m
+}
+
+func toValues(fields map[string]BaseType) map[string]interface{} {
 	m := make(map[string]interface{}, len(fields))
 	for k, v := range fields {
-		m[k] = v.Item.value()
+		m[k] = v.value()
 	}
 	return m
 }

--- a/dp/cloud/go/services/dp/storage/db/join.go
+++ b/dp/cloud/go/services/dp/storage/db/join.go
@@ -66,8 +66,8 @@ func (c *columnNamesCollector) preVisit(q *Query) {
 	table := metadata.Table
 	c.order = append(c.order, table)
 
-	fields := metadata.CreateObject().Fields()
-	cols := getColumns(applyMask(fields, q.arg.mask))
+	fields := metadata.Properties
+	cols := getColumns(applyMaskToMetadata(fields, q.arg.mask))
 	c.columns[table] = cols
 }
 
@@ -93,7 +93,7 @@ func (f *fieldPointersCollector) preVisit(q *Query) {
 	fields := model.Fields()
 	f.models = append(f.models, model)
 	for _, col := range f.columns[metadata.Table] {
-		f.pointers = append(f.pointers, fields[col].Item.ptr())
+		f.pointers = append(f.pointers, fields[col].ptr())
 	}
 }
 

--- a/dp/cloud/go/services/dp/storage/db/models.go
+++ b/dp/cloud/go/services/dp/storage/db/models.go
@@ -15,11 +15,12 @@ package db
 
 type Model interface {
 	GetMetadata() *ModelMetadata
-	Fields() FieldMap
+	Fields() map[string]BaseType // TODO use slice
 }
 
 type ModelMetadata struct {
 	Table        string
 	Relations    map[string]string
+	Properties   map[string]*Field
 	CreateObject func() Model
 }

--- a/dp/cloud/go/services/dp/storage/db/query_test.go
+++ b/dp/cloud/go/services/dp/storage/db/query_test.go
@@ -494,7 +494,24 @@ func (s *someModel) withId(id int64) *someModel {
 
 func (s *someModel) GetMetadata() *db.ModelMetadata {
 	return &db.ModelMetadata{
-		Table:     "some",
+		Table: "some",
+		Properties: map[string]*db.Field{
+			"id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"value": {
+				SqlType: sqorc.ColumnTypeReal,
+			},
+			"name": {
+				SqlType: sqorc.ColumnTypeText,
+			},
+			"flag": {
+				SqlType: sqorc.ColumnTypeBool,
+			},
+			"date": {
+				SqlType: sqorc.ColumnTypeDatetime,
+			},
+		},
 		Relations: nil,
 		CreateObject: func() db.Model {
 			return &someModel{}
@@ -502,28 +519,13 @@ func (s *someModel) GetMetadata() *db.ModelMetadata {
 	}
 }
 
-func (s *someModel) Fields() db.FieldMap {
-	return db.FieldMap{
-		"id": &db.Field{
-			Item:    db.IntType{X: &s.id},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"value": &db.Field{
-			Item:    db.FloatType{X: &s.value},
-			SqlType: sqorc.ColumnTypeReal,
-		},
-		"name": &db.Field{
-			Item:    db.StringType{X: &s.name},
-			SqlType: sqorc.ColumnTypeText,
-		},
-		"flag": &db.Field{
-			Item:    db.BoolType{X: &s.flag},
-			SqlType: sqorc.ColumnTypeBool,
-		},
-		"date": &db.Field{
-			Item:    db.TimeType{X: &s.date},
-			SqlType: sqorc.ColumnTypeDatetime,
-		},
+func (s *someModel) Fields() map[string]db.BaseType {
+	return map[string]db.BaseType{
+		"id":    db.IntType{X: &s.id},
+		"value": db.FloatType{X: &s.value},
+		"name":  db.StringType{X: &s.name},
+		"flag":  db.BoolType{X: &s.flag},
+		"date":  db.TimeType{X: &s.date},
 	}
 }
 
@@ -549,7 +551,32 @@ type otherModel struct {
 
 func (o *otherModel) GetMetadata() *db.ModelMetadata {
 	return &db.ModelMetadata{
-		Table:     "other",
+		Table: "other",
+		Properties: map[string]*db.Field{
+			"id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"some_id": {
+				SqlType:  sqorc.ColumnTypeInt,
+				Nullable: true,
+			},
+			"value": {
+				SqlType:  sqorc.ColumnTypeReal,
+				Nullable: true,
+			},
+			"name": {
+				SqlType:  sqorc.ColumnTypeText,
+				Nullable: true,
+			},
+			"flag": {
+				SqlType:  sqorc.ColumnTypeBool,
+				Nullable: true,
+			},
+			"date": {
+				SqlType:  sqorc.ColumnTypeDatetime,
+				Nullable: true,
+			},
+		},
 		Relations: makeRelationsMap(someTable),
 		CreateObject: func() db.Model {
 			return &otherModel{}
@@ -557,37 +584,14 @@ func (o *otherModel) GetMetadata() *db.ModelMetadata {
 	}
 }
 
-func (o *otherModel) Fields() db.FieldMap {
-	return db.FieldMap{
-		"id": &db.Field{
-			Item:    db.IntType{X: &o.id},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"some_id": &db.Field{
-			Item:     db.IntType{X: &o.someId},
-			SqlType:  sqorc.ColumnTypeInt,
-			Nullable: true,
-		},
-		"value": &db.Field{
-			Item:     db.FloatType{X: &o.value},
-			SqlType:  sqorc.ColumnTypeReal,
-			Nullable: true,
-		},
-		"name": &db.Field{
-			Item:     db.StringType{X: &o.name},
-			SqlType:  sqorc.ColumnTypeText,
-			Nullable: true,
-		},
-		"flag": &db.Field{
-			Item:     db.BoolType{X: &o.flag},
-			SqlType:  sqorc.ColumnTypeBool,
-			Nullable: true,
-		},
-		"date": &db.Field{
-			Item:     db.TimeType{X: &o.date},
-			SqlType:  sqorc.ColumnTypeDatetime,
-			Nullable: true,
-		},
+func (o *otherModel) Fields() map[string]db.BaseType {
+	return map[string]db.BaseType{
+		"id":      db.IntType{X: &o.id},
+		"some_id": db.IntType{X: &o.someId},
+		"value":   db.FloatType{X: &o.value},
+		"name":    db.StringType{X: &o.name},
+		"flag":    db.BoolType{X: &o.flag},
+		"date":    db.TimeType{X: &o.date},
 	}
 }
 
@@ -607,7 +611,21 @@ type anotherModel struct {
 
 func (a *anotherModel) GetMetadata() *db.ModelMetadata {
 	return &db.ModelMetadata{
-		Table:     "another",
+		Table: "another",
+		Properties: map[string]*db.Field{
+			"id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"other_id": {
+				SqlType:  sqorc.ColumnTypeInt,
+				Nullable: true,
+			},
+			"default_value": {
+				SqlType:      sqorc.ColumnTypeInt,
+				HasDefault:   true,
+				DefaultValue: defaultValue,
+			},
+		},
 		Relations: makeRelationsMap(otherTable),
 		CreateObject: func() db.Model {
 			return &anotherModel{}
@@ -615,23 +633,11 @@ func (a *anotherModel) GetMetadata() *db.ModelMetadata {
 	}
 }
 
-func (a *anotherModel) Fields() db.FieldMap {
-	return db.FieldMap{
-		"id": &db.Field{
-			Item:    db.IntType{X: &a.id},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"other_id": &db.Field{
-			Item:     db.IntType{X: &a.otherId},
-			SqlType:  sqorc.ColumnTypeInt,
-			Nullable: true,
-		},
-		"default_value": &db.Field{
-			Item:         db.IntType{X: &a.defaultValue},
-			SqlType:      sqorc.ColumnTypeInt,
-			HasDefault:   true,
-			DefaultValue: defaultValue,
-		},
+func (a *anotherModel) Fields() map[string]db.BaseType {
+	return map[string]db.BaseType{
+		"id":            db.IntType{X: &a.id},
+		"other_id":      db.IntType{X: &a.otherId},
+		"default_value": db.IntType{X: &a.defaultValue},
 	}
 }
 
@@ -652,28 +658,30 @@ type modelWithUniqueFields struct {
 func (m *modelWithUniqueFields) GetMetadata() *db.ModelMetadata {
 	return &db.ModelMetadata{
 		Table: "unique_table",
+		Properties: map[string]*db.Field{
+			"id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"unique_field": {
+				SqlType: sqorc.ColumnTypeInt,
+				Unique:  true,
+			},
+			"another_unique_fied": {
+				SqlType: sqorc.ColumnTypeInt,
+				Unique:  true,
+			},
+		},
 		CreateObject: func() db.Model {
 			return &modelWithUniqueFields{}
 		},
 	}
 }
 
-func (m *modelWithUniqueFields) Fields() db.FieldMap {
-	return db.FieldMap{
-		"id": &db.Field{
-			Item:    db.IntType{X: &m.id},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"unique_field": &db.Field{
-			Item:    db.IntType{X: &m.uniqueField},
-			SqlType: sqorc.ColumnTypeInt,
-			Unique:  true,
-		},
-		"another_unique_fied": &db.Field{
-			Item:    db.IntType{X: &m.anotherUniqueFied},
-			SqlType: sqorc.ColumnTypeInt,
-			Unique:  true,
-		},
+func (m *modelWithUniqueFields) Fields() map[string]db.BaseType {
+	return map[string]db.BaseType{
+		"id":                  db.IntType{X: &m.id},
+		"unique_field":        db.IntType{X: &m.uniqueField},
+		"another_unique_fied": db.IntType{X: &m.anotherUniqueFied},
 	}
 }
 

--- a/dp/cloud/go/services/dp/storage/db/table.go
+++ b/dp/cloud/go/services/dp/storage/db/table.go
@@ -24,7 +24,7 @@ func CreateTable(tx sq.BaseRunner, builder sqorc.StatementBuilder, metadata *Mod
 		IfNotExists().
 		RunWith(tx).
 		PrimaryKey("id")
-	fields := metadata.CreateObject().Fields()
+	fields := metadata.Properties
 	tableBuilder = addColumns(tableBuilder, fields)
 	tableBuilder = addRelations(tableBuilder, metadata)
 	_, err := tableBuilder.Exec()

--- a/dp/cloud/go/services/dp/storage/models.go
+++ b/dp/cloud/go/services/dp/storage/models.go
@@ -38,22 +38,24 @@ type DBGrantState struct {
 	Name sql.NullString
 }
 
-func (gs *DBGrantState) Fields() db.FieldMap {
-	return db.FieldMap{
-		"id": &db.Field{
-			Item:    db.IntType{X: &gs.Id},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"name": &db.Field{
-			Item:    db.StringType{X: &gs.Name},
-			SqlType: sqorc.ColumnTypeText,
-		},
+func (gs *DBGrantState) Fields() map[string]db.BaseType {
+	return map[string]db.BaseType{
+		"id":   db.IntType{X: &gs.Id},
+		"name": db.StringType{X: &gs.Name},
 	}
 }
 
 func (gs *DBGrantState) GetMetadata() *db.ModelMetadata {
 	return &db.ModelMetadata{
-		Table:     GrantStateTable,
+		Table: GrantStateTable,
+		Properties: map[string]*db.Field{
+			"id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"name": {
+				SqlType: sqorc.ColumnTypeText,
+			},
+		},
 		Relations: map[string]string{},
 		CreateObject: func() db.Model {
 			return &DBGrantState{}
@@ -83,63 +85,65 @@ type DBGrant struct {
 	MaxEirp            sql.NullFloat64
 }
 
-func (g *DBGrant) Fields() db.FieldMap {
-	return db.FieldMap{
-		"id": &db.Field{
-			Item:    db.IntType{X: &g.Id},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"state_id": &db.Field{
-			Item:    db.IntType{X: &g.StateId},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"cbsd_id": &db.Field{
-			Item:     db.IntType{X: &g.CbsdId},
-			SqlType:  sqorc.ColumnTypeInt,
-			Nullable: true,
-		},
-		"grant_id": &db.Field{
-			Item:    db.StringType{X: &g.GrantId},
-			SqlType: sqorc.ColumnTypeText,
-		},
-		"grant_expire_time": &db.Field{
-			Item:     db.TimeType{X: &g.GrantExpireTime},
-			SqlType:  sqorc.ColumnTypeDatetime,
-			Nullable: true,
-		},
-		"transmit_expire_time": &db.Field{
-			Item:     db.TimeType{X: &g.TransmitExpireTime},
-			SqlType:  sqorc.ColumnTypeDatetime,
-			Nullable: true,
-		},
-		"heartbeat_interval": &db.Field{
-			Item:     db.IntType{X: &g.HeartbeatInterval},
-			SqlType:  sqorc.ColumnTypeInt,
-			Nullable: true,
-		},
-		"channel_type": &db.Field{
-			Item:     db.StringType{X: &g.ChannelType},
-			SqlType:  sqorc.ColumnTypeText,
-			Nullable: true,
-		},
-		"low_frequency": &db.Field{
-			Item:    db.IntType{X: &g.LowFrequency},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"high_frequency": &db.Field{
-			Item:    db.IntType{X: &g.HighFrequency},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"max_eirp": &db.Field{
-			Item:    db.FloatType{X: &g.MaxEirp},
-			SqlType: sqorc.ColumnTypeReal,
-		},
+func (g *DBGrant) Fields() map[string]db.BaseType {
+	return map[string]db.BaseType{
+		"id":                   db.IntType{X: &g.Id},
+		"state_id":             db.IntType{X: &g.StateId},
+		"cbsd_id":              db.IntType{X: &g.CbsdId},
+		"grant_id":             db.StringType{X: &g.GrantId},
+		"grant_expire_time":    db.TimeType{X: &g.GrantExpireTime},
+		"transmit_expire_time": db.TimeType{X: &g.TransmitExpireTime},
+		"heartbeat_interval":   db.IntType{X: &g.HeartbeatInterval},
+		"channel_type":         db.StringType{X: &g.ChannelType},
+		"low_frequency":        db.IntType{X: &g.LowFrequency},
+		"high_frequency":       db.IntType{X: &g.HighFrequency},
+		"max_eirp":             db.FloatType{X: &g.MaxEirp},
 	}
 }
 
 func (g *DBGrant) GetMetadata() *db.ModelMetadata {
 	return &db.ModelMetadata{
 		Table: GrantTable,
+		Properties: map[string]*db.Field{
+			"id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"state_id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"cbsd_id": {
+				SqlType:  sqorc.ColumnTypeInt,
+				Nullable: true,
+			},
+			"grant_id": {
+				SqlType: sqorc.ColumnTypeText,
+			},
+			"grant_expire_time": {
+				SqlType:  sqorc.ColumnTypeDatetime,
+				Nullable: true,
+			},
+			"transmit_expire_time": {
+				SqlType:  sqorc.ColumnTypeDatetime,
+				Nullable: true,
+			},
+			"heartbeat_interval": {
+				SqlType:  sqorc.ColumnTypeInt,
+				Nullable: true,
+			},
+			"channel_type": {
+				SqlType:  sqorc.ColumnTypeText,
+				Nullable: true,
+			},
+			"low_frequency": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"high_frequency": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"max_eirp": {
+				SqlType: sqorc.ColumnTypeReal,
+			},
+		},
 		Relations: map[string]string{
 			GrantStateTable: "state_id",
 			CbsdTable:       "cbsd_id",
@@ -155,22 +159,24 @@ type DBCbsdState struct {
 	Name sql.NullString
 }
 
-func (cs *DBCbsdState) Fields() db.FieldMap {
-	return db.FieldMap{
-		"id": &db.Field{
-			Item:    db.IntType{X: &cs.Id},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"name": &db.Field{
-			Item:    db.StringType{X: &cs.Name},
-			SqlType: sqorc.ColumnTypeText,
-		},
+func (cs *DBCbsdState) Fields() map[string]db.BaseType {
+	return map[string]db.BaseType{
+		"id":   db.IntType{X: &cs.Id},
+		"name": db.StringType{X: &cs.Name},
 	}
 }
 
 func (cs *DBCbsdState) GetMetadata() *db.ModelMetadata {
 	return &db.ModelMetadata{
-		Table:     "cbsd_states",
+		Table: "cbsd_states",
+		Properties: map[string]*db.Field{
+			"id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"name": {
+				SqlType: sqorc.ColumnTypeText,
+			},
+		},
 		Relations: map[string]string{},
 		CreateObject: func() db.Model {
 			return &DBCbsdState{}
@@ -206,98 +212,100 @@ type DBCbsd struct {
 	ShouldDeregister        sql.NullBool
 }
 
-func (c *DBCbsd) Fields() db.FieldMap {
-	return db.FieldMap{
-		"id": &db.Field{
-			Item:    db.IntType{X: &c.Id},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"network_id": &db.Field{
-			Item:    db.StringType{X: &c.NetworkId},
-			SqlType: sqorc.ColumnTypeText,
-		},
-		"state_id": &db.Field{
-			Item:    db.IntType{X: &c.StateId},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"cbsd_id": &db.Field{
-			Item:     db.StringType{X: &c.CbsdId},
-			SqlType:  sqorc.ColumnTypeText,
-			Nullable: true,
-		},
-		"user_id": &db.Field{
-			Item:     db.StringType{X: &c.UserId},
-			SqlType:  sqorc.ColumnTypeText,
-			Nullable: true,
-		},
-		"fcc_id": &db.Field{
-			Item:     db.StringType{X: &c.FccId},
-			SqlType:  sqorc.ColumnTypeText,
-			Nullable: true,
-		},
-		"cbsd_serial_number": &db.Field{
-			Item:     db.StringType{X: &c.CbsdSerialNumber},
-			SqlType:  sqorc.ColumnTypeText,
-			Nullable: true,
-			Unique:   true,
-		},
-		"last_seen": &db.Field{
-			Item:     db.TimeType{X: &c.LastSeen},
-			SqlType:  sqorc.ColumnTypeDatetime,
-			Nullable: true,
-		},
-		"grant_attempts": &db.Field{
-			Item:         db.IntType{X: &c.GrantAttempts},
-			SqlType:      sqorc.ColumnTypeInt,
-			HasDefault:   true,
-			DefaultValue: 0,
-		},
-		"preferred_bandwidth_mhz": &db.Field{
-			Item:    db.IntType{X: &c.PreferredBandwidthMHz},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"preferred_frequencies_mhz": &db.Field{
-			Item:    db.StringType{X: &c.PreferredFrequenciesMHz},
-			SqlType: sqorc.ColumnTypeText,
-		},
-		"min_power": &db.Field{
-			Item:     db.FloatType{X: &c.MinPower},
-			SqlType:  sqorc.ColumnTypeReal,
-			Nullable: true,
-		},
-		"max_power": &db.Field{
-			Item:     db.FloatType{X: &c.MaxPower},
-			SqlType:  sqorc.ColumnTypeReal,
-			Nullable: true,
-		},
-		"antenna_gain": &db.Field{
-			Item:     db.FloatType{X: &c.AntennaGain},
-			SqlType:  sqorc.ColumnTypeReal,
-			Nullable: true,
-		},
-		"number_of_ports": &db.Field{
-			Item:     db.IntType{X: &c.NumberOfPorts},
-			SqlType:  sqorc.ColumnTypeInt,
-			Nullable: true,
-		},
-		"is_deleted": &db.Field{
-			Item:         db.BoolType{X: &c.IsDeleted},
-			SqlType:      sqorc.ColumnTypeBool,
-			HasDefault:   true,
-			DefaultValue: false,
-		},
-		"should_deregister": &db.Field{
-			Item:         db.BoolType{X: &c.ShouldDeregister},
-			SqlType:      sqorc.ColumnTypeBool,
-			HasDefault:   true,
-			DefaultValue: false,
-		},
+func (c *DBCbsd) Fields() map[string]db.BaseType {
+	return map[string]db.BaseType{
+		"id":                        db.IntType{X: &c.Id},
+		"network_id":                db.StringType{X: &c.NetworkId},
+		"state_id":                  db.IntType{X: &c.StateId},
+		"cbsd_id":                   db.StringType{X: &c.CbsdId},
+		"user_id":                   db.StringType{X: &c.UserId},
+		"fcc_id":                    db.StringType{X: &c.FccId},
+		"cbsd_serial_number":        db.StringType{X: &c.CbsdSerialNumber},
+		"last_seen":                 db.TimeType{X: &c.LastSeen},
+		"grant_attempts":            db.IntType{X: &c.GrantAttempts},
+		"preferred_bandwidth_mhz":   db.IntType{X: &c.PreferredBandwidthMHz},
+		"preferred_frequencies_mhz": db.StringType{X: &c.PreferredFrequenciesMHz},
+		"min_power":                 db.FloatType{X: &c.MinPower},
+		"max_power":                 db.FloatType{X: &c.MaxPower},
+		"antenna_gain":              db.FloatType{X: &c.AntennaGain},
+		"number_of_ports":           db.IntType{X: &c.NumberOfPorts},
+		"is_deleted":                db.BoolType{X: &c.IsDeleted},
+		"should_deregister":         db.BoolType{X: &c.ShouldDeregister},
 	}
 }
 
 func (c *DBCbsd) GetMetadata() *db.ModelMetadata {
 	return &db.ModelMetadata{
 		Table: CbsdTable,
+		Properties: map[string]*db.Field{
+			"id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"network_id": {
+				SqlType: sqorc.ColumnTypeText,
+			},
+			"state_id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"cbsd_id": {
+				SqlType:  sqorc.ColumnTypeText,
+				Nullable: true,
+			},
+			"user_id": {
+				SqlType:  sqorc.ColumnTypeText,
+				Nullable: true,
+			},
+			"fcc_id": {
+				SqlType:  sqorc.ColumnTypeText,
+				Nullable: true,
+			},
+			"cbsd_serial_number": {
+				SqlType:  sqorc.ColumnTypeText,
+				Nullable: true,
+				Unique:   true,
+			},
+			"last_seen": {
+				SqlType:  sqorc.ColumnTypeDatetime,
+				Nullable: true,
+			},
+			"grant_attempts": {
+				SqlType:      sqorc.ColumnTypeInt,
+				HasDefault:   true,
+				DefaultValue: 0,
+			},
+			"preferred_bandwidth_mhz": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"preferred_frequencies_mhz": {
+				SqlType: sqorc.ColumnTypeText,
+			},
+			"min_power": {
+				SqlType:  sqorc.ColumnTypeReal,
+				Nullable: true,
+			},
+			"max_power": {
+				SqlType:  sqorc.ColumnTypeReal,
+				Nullable: true,
+			},
+			"antenna_gain": {
+				SqlType:  sqorc.ColumnTypeReal,
+				Nullable: true,
+			},
+			"number_of_ports": {
+				SqlType:  sqorc.ColumnTypeInt,
+				Nullable: true,
+			},
+			"is_deleted": {
+				SqlType:      sqorc.ColumnTypeBool,
+				HasDefault:   true,
+				DefaultValue: false,
+			},
+			"should_deregister": {
+				SqlType:      sqorc.ColumnTypeBool,
+				HasDefault:   true,
+				DefaultValue: false,
+			},
+		},
 		Relations: map[string]string{
 			CbsdStateTable: "state_id",
 		},
@@ -313,26 +321,28 @@ type DBActiveModeConfig struct {
 	DesiredStateId sql.NullInt64
 }
 
-func (amc *DBActiveModeConfig) Fields() db.FieldMap {
-	return db.FieldMap{
-		"id": &db.Field{
-			Item:    db.IntType{X: &amc.Id},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"cbsd_id": &db.Field{
-			Item:    db.IntType{X: &amc.CbsdId},
-			SqlType: sqorc.ColumnTypeInt,
-		},
-		"desired_state_id": &db.Field{
-			Item:    db.IntType{X: &amc.DesiredStateId},
-			SqlType: sqorc.ColumnTypeInt,
-		},
+func (amc *DBActiveModeConfig) Fields() map[string]db.BaseType {
+	return map[string]db.BaseType{
+		"id":               db.IntType{X: &amc.Id},
+		"cbsd_id":          db.IntType{X: &amc.CbsdId},
+		"desired_state_id": db.IntType{X: &amc.DesiredStateId},
 	}
 }
 
 func (amc *DBActiveModeConfig) GetMetadata() *db.ModelMetadata {
 	return &db.ModelMetadata{
 		Table: ActiveModeConfigTable,
+		Properties: map[string]*db.Field{
+			"id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"cbsd_id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+			"desired_state_id": {
+				SqlType: sqorc.ColumnTypeInt,
+			},
+		},
 		Relations: map[string]string{
 			CbsdTable:      "cbsd_id",
 			CbsdStateTable: "desired_state_id",

--- a/dp/cloud/go/services/dp/storage/models_test.go
+++ b/dp/cloud/go/services/dp/storage/models_test.go
@@ -20,6 +20,7 @@ import (
 
 	"magma/dp/cloud/go/services/dp/storage"
 	"magma/dp/cloud/go/services/dp/storage/db"
+	"magma/orc8r/cloud/go/sqorc"
 )
 
 func TestFields(t *testing.T) {
@@ -88,7 +89,15 @@ func TestGetMetadata(t *testing.T) {
 			name:  "check ModelMetadata structure for DBGrantState",
 			model: &storage.DBGrantState{},
 			expected: db.ModelMetadata{
-				Table:     storage.GrantStateTable,
+				Table: storage.GrantStateTable,
+				Properties: map[string]*db.Field{
+					"id": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"name": {
+						SqlType: sqorc.ColumnTypeText,
+					},
+				},
 				Relations: map[string]string{},
 			},
 		},
@@ -97,6 +106,46 @@ func TestGetMetadata(t *testing.T) {
 			model: &storage.DBGrant{},
 			expected: db.ModelMetadata{
 				Table: storage.GrantTable,
+				Properties: map[string]*db.Field{
+					"id": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"state_id": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"cbsd_id": {
+						SqlType:  sqorc.ColumnTypeInt,
+						Nullable: true,
+					},
+					"grant_id": {
+						SqlType: sqorc.ColumnTypeText,
+					},
+					"grant_expire_time": {
+						SqlType:  sqorc.ColumnTypeDatetime,
+						Nullable: true,
+					},
+					"transmit_expire_time": {
+						SqlType:  sqorc.ColumnTypeDatetime,
+						Nullable: true,
+					},
+					"heartbeat_interval": {
+						SqlType:  sqorc.ColumnTypeInt,
+						Nullable: true,
+					},
+					"channel_type": {
+						SqlType:  sqorc.ColumnTypeText,
+						Nullable: true,
+					},
+					"low_frequency": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"high_frequency": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"max_eirp": {
+						SqlType: sqorc.ColumnTypeReal,
+					},
+				},
 				Relations: map[string]string{
 					storage.CbsdTable:       "cbsd_id",
 					storage.GrantStateTable: "state_id",
@@ -107,7 +156,15 @@ func TestGetMetadata(t *testing.T) {
 			name:  "check ModelMetadata structure for DBCbsdState",
 			model: &storage.DBCbsdState{},
 			expected: db.ModelMetadata{
-				Table:     storage.CbsdStateTable,
+				Table: storage.CbsdStateTable,
+				Properties: map[string]*db.Field{
+					"id": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"name": {
+						SqlType: sqorc.ColumnTypeText,
+					},
+				},
 				Relations: map[string]string{},
 			},
 		},
@@ -116,6 +173,75 @@ func TestGetMetadata(t *testing.T) {
 			model: &storage.DBCbsd{},
 			expected: db.ModelMetadata{
 				Table: storage.CbsdTable,
+				Properties: map[string]*db.Field{
+					"id": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"network_id": {
+						SqlType: sqorc.ColumnTypeText,
+					},
+					"state_id": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"cbsd_id": {
+						SqlType:  sqorc.ColumnTypeText,
+						Nullable: true,
+					},
+					"user_id": {
+						SqlType:  sqorc.ColumnTypeText,
+						Nullable: true,
+					},
+					"fcc_id": {
+						SqlType:  sqorc.ColumnTypeText,
+						Nullable: true,
+					},
+					"cbsd_serial_number": {
+						SqlType:  sqorc.ColumnTypeText,
+						Nullable: true,
+						Unique:   true,
+					},
+					"last_seen": {
+						SqlType:  sqorc.ColumnTypeDatetime,
+						Nullable: true,
+					},
+					"grant_attempts": {
+						SqlType:      sqorc.ColumnTypeInt,
+						HasDefault:   true,
+						DefaultValue: 0,
+					},
+					"preferred_bandwidth_mhz": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"preferred_frequencies_mhz": {
+						SqlType: sqorc.ColumnTypeText,
+					},
+					"min_power": {
+						SqlType:  sqorc.ColumnTypeReal,
+						Nullable: true,
+					},
+					"max_power": {
+						SqlType:  sqorc.ColumnTypeReal,
+						Nullable: true,
+					},
+					"antenna_gain": {
+						SqlType:  sqorc.ColumnTypeReal,
+						Nullable: true,
+					},
+					"number_of_ports": {
+						SqlType:  sqorc.ColumnTypeInt,
+						Nullable: true,
+					},
+					"is_deleted": {
+						SqlType:      sqorc.ColumnTypeBool,
+						HasDefault:   true,
+						DefaultValue: false,
+					},
+					"should_deregister": {
+						SqlType:      sqorc.ColumnTypeBool,
+						HasDefault:   true,
+						DefaultValue: false,
+					},
+				},
 				Relations: map[string]string{
 					storage.CbsdStateTable: "state_id",
 				},
@@ -126,6 +252,17 @@ func TestGetMetadata(t *testing.T) {
 			model: &storage.DBActiveModeConfig{},
 			expected: db.ModelMetadata{
 				Table: storage.ActiveModeConfigTable,
+				Properties: map[string]*db.Field{
+					"id": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"cbsd_id": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+					"desired_state_id": {
+						SqlType: sqorc.ColumnTypeInt,
+					},
+				},
 				Relations: map[string]string{
 					storage.CbsdTable:      "cbsd_id",
 					storage.CbsdStateTable: "desired_state_id",
@@ -139,6 +276,7 @@ func TestGetMetadata(t *testing.T) {
 			obj := actual.CreateObject()
 
 			assert.Equal(t, tc.expected.Relations, actual.Relations)
+			assert.Equal(t, tc.expected.Properties, actual.Properties)
 			assert.Equal(t, tc.expected.Table, actual.Table)
 			assert.Equal(t, tc.model, obj)
 		})


### PR DESCRIPTION
## Summary

Field values are instance level.
Properties (metadata) are model level.
They were combined previously, but should have been separated.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>