### PR TITLE
refactor(orc8r): Move node_identifier to GatewayEPCConfigs

### DIFF
--- a/lte/cloud/go/services/ha/servicers/southbound/servicer_test.go
+++ b/lte/cloud/go/services/ha/servicers/southbound/servicer_test.go
@@ -225,8 +225,9 @@ func newDefaultGatewayConfig(mmeCode uint32, mmeRelCap uint32) *lte_models.Gatew
 			TransmitEnabled: swag.Bool(true),
 		},
 		Epc: &lte_models.GatewayEpcConfigs{
-			NatEnabled: swag.Bool(true),
-			IPBlock:    "192.168.128.0/24",
+			NatEnabled:     swag.Bool(true),
+			IPBlock:        "192.168.128.0/24",
+			NodeIdentifier: "192.168.200.1",
 		},
 		Ngc: &lte_models.GatewayNgcConfigs{
 			AmfDefaultSd:  "AFAFAF",

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -1340,7 +1340,7 @@ func TestListAndGetGateways(t *testing.T) {
 			{
 				Type: lte.CellularGatewayEntityType, Key: "g1",
 				Config: &lteModels.GatewayCellularConfigs{
-					Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
+					Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24", NodeIdentifier: "192.168.200.1"},
 					Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 					Ngc: &lteModels.GatewayNgcConfigs{
 						AmfDefaultSd:  "AFAFAF",
@@ -1355,7 +1355,7 @@ func TestListAndGetGateways(t *testing.T) {
 			{
 				Type: lte.CellularGatewayEntityType, Key: "g2",
 				Config: &lteModels.GatewayCellularConfigs{
-					Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
+					Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24", NodeIdentifier: "192.168.200.1"},
 					Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 					Ngc: &lteModels.GatewayNgcConfigs{
 						AmfDefaultSd:  "AFAFAF",
@@ -1427,7 +1427,7 @@ func TestListAndGetGateways(t *testing.T) {
 				CheckinTimeout:          5,
 			},
 			Cellular: &lteModels.GatewayCellularConfigs{
-				Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
+				Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24", NodeIdentifier: "192.168.200.1"},
 				Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 				Ngc: &lteModels.GatewayNgcConfigs{
 					AmfDefaultSd:  "AFAFAF",
@@ -1453,7 +1453,7 @@ func TestListAndGetGateways(t *testing.T) {
 				CheckinTimeout:          5,
 			},
 			Cellular: &lteModels.GatewayCellularConfigs{
-				Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
+				Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24", NodeIdentifier: "192.168.200.1"},
 				Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 				Ngc: &lteModels.GatewayNgcConfigs{
 					AmfDefaultSd:  "AFAFAF",
@@ -1496,7 +1496,7 @@ func TestListAndGetGateways(t *testing.T) {
 			CheckinTimeout:          5,
 		},
 		Cellular: &lteModels.GatewayCellularConfigs{
-			Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
+			Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24", NodeIdentifier: "192.168.200.1"},
 			Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 			Ngc: &lteModels.GatewayNgcConfigs{
 				AmfDefaultSd:  "AFAFAF",
@@ -1534,7 +1534,7 @@ func TestListAndGetGateways(t *testing.T) {
 			CheckinTimeout:          5,
 		},
 		Cellular: &lteModels.GatewayCellularConfigs{
-			Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
+			Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24", NodeIdentifier: "192.168.200.1"},
 			Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 			Ngc: &lteModels.GatewayNgcConfigs{
 				AmfDefaultSd:  "AFAFAF",
@@ -1581,7 +1581,7 @@ func TestUpdateGateway(t *testing.T) {
 		{
 			Type: lte.CellularGatewayEntityType, Key: "g1",
 			Config: &lteModels.GatewayCellularConfigs{
-				Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
+				Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24", NodeIdentifier: "192.168.200.1"},
 				Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 				Ngc: &lteModels.GatewayNgcConfigs{
 					AmfDefaultSd:  "AFAFAF",
@@ -1644,7 +1644,7 @@ func TestUpdateGateway(t *testing.T) {
 		},
 		Tier: "t1",
 		Cellular: &lteModels.GatewayCellularConfigs{
-			Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(false), IPBlock: "172.10.10.0/24"},
+			Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(false), IPBlock: "172.10.10.0/24", NodeIdentifier: "192.168.200.1"},
 			Ran: &lteModels.GatewayRanConfigs{Pci: 123, TransmitEnabled: swag.Bool(false)},
 			Ngc: &lteModels.GatewayNgcConfigs{
 				AmfDefaultSd:  "AFAFAF",
@@ -1732,7 +1732,7 @@ func TestDeleteGateway(t *testing.T) {
 		{
 			Type: lte.CellularGatewayEntityType, Key: "g1",
 			Config: &lteModels.GatewayCellularConfigs{
-				Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
+				Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24", NodeIdentifier: "192.168.200.1"},
 				Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 				Ngc: &lteModels.GatewayNgcConfigs{
 					AmfDefaultSd:  "AFAFAF",
@@ -4352,8 +4352,9 @@ func newDefaultGatewayConfig() *lteModels.GatewayCellularConfigs {
 			TransmitEnabled: swag.Bool(true),
 		},
 		Epc: &lteModels.GatewayEpcConfigs{
-			NatEnabled: swag.Bool(true),
-			IPBlock:    "192.168.128.0/24",
+			NatEnabled:     swag.Bool(true),
+			IPBlock:        "192.168.128.0/24",
+			NodeIdentifier: "192.168.200.1",
 		},
 		Ngc: &lteModels.GatewayNgcConfigs{
 			AmfDefaultSd:  "AFAFAF",

--- a/lte/cloud/go/services/lte/obsidian/models/defaults.go
+++ b/lte/cloud/go/services/lte/obsidian/models/defaults.go
@@ -39,7 +39,6 @@ func NewDefaultTDDNetworkConfig() *NetworkCellularConfigs {
 			CloudSubscriberdbEnabled: false,
 			CongestionControlEnabled: swag.Bool(true),
 			Enable5gFeatures:         swag.Bool(false),
-			NodeIdentifier:           "",
 			DefaultRuleID:            "",
 			SubscriberdbSyncInterval: SubscriberdbSyncInterval(300),
 		},

--- a/lte/cloud/go/services/lte/obsidian/models/gateway_epc_configs_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/gateway_epc_configs_swaggergen.go
@@ -66,6 +66,10 @@ type GatewayEpcConfigs struct {
 	// Required: true
 	NatEnabled *bool `json:"nat_enabled"`
 
+	// UPF Node Identifier
+	// Format: ipv4
+	NodeIdentifier strfmt.IPv4 `json:"node_identifier,omitempty"`
+
 	// IP address of gateway for management interface on the AGW
 	// Max Length: 49
 	// Min Length: 5
@@ -129,6 +133,10 @@ func (m *GatewayEpcConfigs) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateNatEnabled(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateNodeIdentifier(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -311,6 +319,19 @@ func (m *GatewayEpcConfigs) validateIPV6PrefixAllocationMode(formats strfmt.Regi
 func (m *GatewayEpcConfigs) validateNatEnabled(formats strfmt.Registry) error {
 
 	if err := validate.Required("nat_enabled", "body", m.NatEnabled); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *GatewayEpcConfigs) validateNodeIdentifier(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.NodeIdentifier) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("node_identifier", "body", "ipv4", m.NodeIdentifier.String(), formats); err != nil {
 		return err
 	}
 

--- a/lte/cloud/go/services/lte/obsidian/models/network_epc_configs_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/network_epc_configs_swaggergen.go
@@ -66,10 +66,6 @@ type NetworkEpcConfigs struct {
 	// Configuration for network services. Services will be instantiated in the listed order.
 	NetworkServices []string `json:"network_services,omitempty"`
 
-	// Node Identifier for 5G Standalone (SA) at a network level
-	// Format: ipv4
-	NodeIdentifier strfmt.IPv4 `json:"node_identifier,omitempty"`
-
 	// List of IMEIs restricted in the network
 	RestrictedImeis []*Imei `json:"restricted_imeis,omitempty"`
 
@@ -125,10 +121,6 @@ func (m *NetworkEpcConfigs) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateNetworkServices(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateNodeIdentifier(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -278,19 +270,6 @@ func (m *NetworkEpcConfigs) validateNetworkServices(formats strfmt.Registry) err
 			return err
 		}
 
-	}
-
-	return nil
-}
-
-func (m *NetworkEpcConfigs) validateNodeIdentifier(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.NodeIdentifier) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("node_identifier", "body", "ipv4", m.NodeIdentifier.String(), formats); err != nil {
-		return err
 	}
 
 	return nil

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -1868,11 +1868,6 @@ definitions:
         type: boolean
         example: true
         default: false
-      node_identifier:
-        type: string
-        description: Node Identifier for 5G Standalone (SA) at a network level
-        format: ipv4
-        example: '192.168.200.1'
       congestion_control_enabled:
         description: Network configuration flag for congestion control on EPC
         type: boolean
@@ -2124,6 +2119,11 @@ definitions:
         type: string
         minLength: 5
         maxLength: 49
+      node_identifier:
+        type: string
+        description: UPF Node Identifier
+        format: ipv4
+        example: '192.168.200.1'
       sgi_management_iface_vlan:
         type: string
         description: VLAN ID for management interface traffic on the AGW

--- a/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
@@ -205,7 +205,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 			HeConfig:                   heConfig,
 			LiUes:                      liUes,
 			Enable5GFeatures:           swag.BoolValue(nwEpc.Enable5gFeatures),
-			UpfNodeIdentifier:          string(nwEpc.NodeIdentifier),
+			UpfNodeIdentifier:          string(gwEpc.NodeIdentifier),
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:         protos.LogLevel_INFO,

--- a/lte/cloud/go/services/lte/servicers/protected/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/protected/builder_servicer_test.go
@@ -166,7 +166,7 @@ func TestBuilder_Build(t *testing.T) {
 			HeConfig:               &lte_mconfig.PipelineD_HEConfig{},
 			LiUes:                  &lte_mconfig.PipelineD_LiUes{},
 			Enable5GFeatures:       false,
-			UpfNodeIdentifier:      "",
+			UpfNodeIdentifier:      "192.168.200.1",
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:         protos.LogLevel_INFO,
@@ -230,7 +230,7 @@ func TestBuilder_Build(t *testing.T) {
 		HeConfig:          &lte_mconfig.PipelineD_HEConfig{},
 		LiUes:             &lte_mconfig.PipelineD_LiUes{},
 		Enable5GFeatures:  false,
-		UpfNodeIdentifier: "",
+		UpfNodeIdentifier: "192.168.200.1",
 	}
 	actual, err = buildNonFederated(&nw, &graph, "gw1")
 	assert.NoError(t, err)
@@ -390,7 +390,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 			HeConfig:               &lte_mconfig.PipelineD_HEConfig{},
 			LiUes:                  &lte_mconfig.PipelineD_LiUes{},
 			Enable5GFeatures:       false,
-			UpfNodeIdentifier:      "",
+			UpfNodeIdentifier:      "192.168.200.1",
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:         protos.LogLevel_INFO,
@@ -508,7 +508,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		HeConfig:               &lte_mconfig.PipelineD_HEConfig{},
 		LiUes:                  &lte_mconfig.PipelineD_LiUes{},
 		Enable5GFeatures:       false,
-		UpfNodeIdentifier:      "",
+		UpfNodeIdentifier:      "192.168.200.1",
 	}
 
 	actual, err = buildNonFederated(&nw, &graph, "gw1")
@@ -541,7 +541,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		HeConfig:                 &lte_mconfig.PipelineD_HEConfig{},
 		LiUes:                    &lte_mconfig.PipelineD_LiUes{},
 		Enable5GFeatures:         false,
-		UpfNodeIdentifier:        "",
+		UpfNodeIdentifier:        "192.168.200.1",
 	}
 
 	actual, err = buildNonFederated(&nw, &graph, "gw1")
@@ -574,7 +574,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		SgiManagementIfaceGw:     "1.2.3.1",
 		HeConfig:                 &lte_mconfig.PipelineD_HEConfig{},
 		LiUes:                    &lte_mconfig.PipelineD_LiUes{},
-		UpfNodeIdentifier:        "",
+		UpfNodeIdentifier:        "192.168.200.1",
 		Enable5GFeatures:         false,
 	}
 
@@ -608,7 +608,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		SgiManagementIfaceIpv6Gw:   "2a12:577:9941:f99c:0002:0001:c731:f114",
 		HeConfig:                   &lte_mconfig.PipelineD_HEConfig{},
 		LiUes:                      &lte_mconfig.PipelineD_LiUes{},
-		UpfNodeIdentifier:          "",
+		UpfNodeIdentifier:          "192.168.200.1",
 		Enable5GFeatures:           false,
 	}
 
@@ -644,7 +644,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 		SgiManagementIfaceIpv6Gw:   "2a12:577:9941:f99c:0002:0001:c731:f114",
 		HeConfig:                   &lte_mconfig.PipelineD_HEConfig{},
 		LiUes:                      &lte_mconfig.PipelineD_LiUes{},
-		UpfNodeIdentifier:          "",
+		UpfNodeIdentifier:          "192.168.200.1",
 		Enable5GFeatures:           false,
 	}
 
@@ -739,7 +739,7 @@ func TestBuilder_Build_NgcConfig(t *testing.T) {
 			HeConfig:          &lte_mconfig.PipelineD_HEConfig{},
 			LiUes:             &lte_mconfig.PipelineD_LiUes{},
 			Enable5GFeatures:  false,
-			UpfNodeIdentifier: "",
+			UpfNodeIdentifier: "192.168.200.1",
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:         protos.LogLevel_INFO,
@@ -877,7 +877,7 @@ func TestBuilder_Build_BaseCase(t *testing.T) {
 			},
 			LiUes:             &lte_mconfig.PipelineD_LiUes{},
 			Enable5GFeatures:  false,
-			UpfNodeIdentifier: "",
+			UpfNodeIdentifier: "192.168.200.1",
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:         protos.LogLevel_INFO,
@@ -1112,7 +1112,7 @@ func TestBuilder_Build_FederatedBaseCase(t *testing.T) {
 			},
 			LiUes:             &lte_mconfig.PipelineD_LiUes{},
 			Enable5GFeatures:  false,
-			UpfNodeIdentifier: "",
+			UpfNodeIdentifier: "192.168.200.1",
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:         protos.LogLevel_INFO,
@@ -1264,7 +1264,7 @@ func TestBuilder_BuildInheritedProperties(t *testing.T) {
 			HeConfig:               &lte_mconfig.PipelineD_HEConfig{},
 			LiUes:                  &lte_mconfig.PipelineD_LiUes{},
 			Enable5GFeatures:       false,
-			UpfNodeIdentifier:      "",
+			UpfNodeIdentifier:      "192.168.200.1",
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:         protos.LogLevel_INFO,
@@ -1401,7 +1401,7 @@ func TestBuilder_BuildUnmanagedEnbConfig(t *testing.T) {
 			HeConfig:               &lte_mconfig.PipelineD_HEConfig{},
 			LiUes:                  &lte_mconfig.PipelineD_LiUes{},
 			Enable5GFeatures:       false,
-			UpfNodeIdentifier:      "",
+			UpfNodeIdentifier:      "192.168.200.1",
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:         protos.LogLevel_INFO,
@@ -1544,7 +1544,7 @@ func TestBuilder_BuildCongestionControlConfig(t *testing.T) {
 			HeConfig:               &lte_mconfig.PipelineD_HEConfig{},
 			LiUes:                  &lte_mconfig.PipelineD_LiUes{},
 			Enable5GFeatures:       false,
-			UpfNodeIdentifier:      "",
+			UpfNodeIdentifier:      "192.168.200.1",
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:         protos.LogLevel_INFO,
@@ -1682,7 +1682,7 @@ func TestBuilder_Build_MMEPool(t *testing.T) {
 			HeConfig:          &lte_mconfig.PipelineD_HEConfig{},
 			LiUes:             &lte_mconfig.PipelineD_LiUes{},
 			Enable5GFeatures:  false,
-			UpfNodeIdentifier: "",
+			UpfNodeIdentifier: "192.168.200.1",
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:         protos.LogLevel_INFO,
@@ -1770,6 +1770,7 @@ func newDefaultGatewayConfig() *lte_models.GatewayCellularConfigs {
 			NatEnabled:               swag.Bool(true),
 			IPBlock:                  "192.168.128.0/24",
 			CongestionControlEnabled: swag.Bool(true),
+			NodeIdentifier:           "192.168.200.1",
 		},
 		NonEpsService: &lte_models.GatewayNonEpsConfigs{
 			CsfbMcc:              "001",
@@ -1799,6 +1800,7 @@ func newGatewayConfigNonNat(vlan string, sgi_ip string, sgi_gw string, sgi_ipv6 
 		Epc: &lte_models.GatewayEpcConfigs{
 			NatEnabled:                 swag.Bool(false),
 			IPBlock:                    "192.168.128.0/24",
+			NodeIdentifier:             "192.168.200.1",
 			SgiManagementIfaceVlan:     vlan,
 			SgiManagementIfaceStaticIP: sgi_ip,
 			SgiManagementIfaceGw:       sgi_gw,
@@ -1832,6 +1834,7 @@ func newGatewayConfigWithNGC() *lte_models.GatewayCellularConfigs {
 			NatEnabled:               swag.Bool(true),
 			IPBlock:                  "192.168.128.0/24",
 			CongestionControlEnabled: swag.Bool(true),
+			NodeIdentifier:           "192.168.200.1",
 		},
 		Ngc: &lte_models.GatewayNgcConfigs{
 			AmfDefaultSd:  "AFAFAF",

--- a/lte/cloud/go/services/policydb/servicers/southbound/assignments_test.go
+++ b/lte/cloud/go/services/policydb/servicers/southbound/assignments_test.go
@@ -155,8 +155,9 @@ func newDefaultGatewayConfig() *lteModels.GatewayCellularConfigs {
 			TransmitEnabled: swag.Bool(true),
 		},
 		Epc: &lteModels.GatewayEpcConfigs{
-			NatEnabled: swag.Bool(true),
-			IPBlock:    "192.168.128.0/24",
+			NatEnabled:     swag.Bool(true),
+			IPBlock:        "192.168.128.0/24",
+			NodeIdentifier: "192.168.200.1",
 		},
 		Ngc: &lteModels.GatewayNgcConfigs{
 			AmfDefaultSd:  "AFAFAF",

--- a/lte/cloud/go/services/subscriberdb/servicers/southbound/subscriberdb_servicer_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/southbound/subscriberdb_servicer_test.go
@@ -72,15 +72,13 @@ func TestListSuciProfiles(t *testing.T) {
 					Mnc: "01",
 					Tac: 1,
 					// 16 bytes of \x11
-					LteAuthOp:  []byte("\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11"),
-					LteAuthAmf: []byte("\x80\x00"),
-
+					LteAuthOp:                []byte("\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11"),
+					LteAuthAmf:               []byte("\x80\x00"),
 					HssRelayEnabled:          swag.Bool(false),
 					GxGyRelayEnabled:         swag.Bool(false),
 					CloudSubscriberdbEnabled: false,
 					CongestionControlEnabled: swag.Bool(true),
 					Enable5gFeatures:         swag.Bool(false),
-					NodeIdentifier:           "",
 					DefaultRuleID:            "",
 					SubscriberdbSyncInterval: lte_models.SubscriberdbSyncInterval(300),
 				},

--- a/nms/generated/MagmaAPIBindings.js
+++ b/nms/generated/MagmaAPIBindings.js
@@ -503,6 +503,7 @@ export type gateway_epc_configs = {
     ipv6_p_cscf_addr ? : string,
     ipv6_prefix_allocation_mode ? : "RANDOM" | "HASH",
     nat_enabled: boolean,
+    node_identifier ? : string,
     sgi_management_iface_gw ? : string,
     sgi_management_iface_ipv6_addr ? : string,
     sgi_management_iface_ipv6_gw ? : string,
@@ -937,7 +938,6 @@ export type network_epc_configs = {
     },
     network_services ? : Array < "dpi" | "policy_enforcement" >
         ,
-    node_identifier ? : string,
     restricted_imeis ? : Array < imei >
         ,
     restricted_plmns ? : Array < plmn_config >

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -8117,6 +8117,11 @@ definitions:
       nat_enabled:
         example: true
         type: boolean
+      node_identifier:
+        description: UPF Node Identifier
+        example: 192.168.200.1
+        format: ipv4
+        type: string
       sgi_management_iface_gw:
         description: IP address of gateway for management interface on the AGW
         format: cidr
@@ -9547,11 +9552,6 @@ definitions:
           type: string
         type: array
         x-omitempty: true
-      node_identifier:
-        description: Node Identifier for 5G Standalone (SA) at a network level
-        example: 192.168.200.1
-        format: ipv4
-        type: string
       restricted_imeis:
         description: List of IMEIs restricted in the network
         items:


### PR DESCRIPTION
Signed-off-by: shivesh-wavelabs <shivesh.ojha@wavelabs.ai>
## Summary
Moved node_identifier from NetworkEpcConfigs to GatewayEpcConfigs since upf_node_identifier is uniquer per gateway, it cannot be common for the entire network

## Test Plan
Written UTs for testing the API.
All UTs passed.