### PR TITLE
chore: kernsnoopd tests are refactored and executed

### DIFF
--- a/lte/gateway/python/defs.mk
+++ b/lte/gateway/python/defs.mk
@@ -15,15 +15,16 @@ SWAGGER_LIST:=lte_swagger_specs orc8r_swagger_specs
 
 # Path to the test files
 TESTS=magma/tests \
-	  magma/policydb/tests \
-	  magma/enodebd/tests \
+      magma/policydb/tests \
+      magma/enodebd/tests \
       magma/mobilityd/tests \
       magma/pipelined/openflow/tests \
       magma/pkt_tester/tests \
       magma/redirectd/tests \
       magma/subscriberdb/tests \
-      magma/monitord/tests
+      magma/monitord/tests \
+      magma/kernsnoopd/tests
 
-SUDO_TESTS= magma/mobilityd/tests/ip_alloc_dhcp_test.py \
-	    magma/mobilityd/tests/test_dhcp_client.py \
-	    magma/pipelined/tests \
+SUDO_TESTS=magma/mobilityd/tests/ip_alloc_dhcp_test.py \
+      magma/mobilityd/tests/test_dhcp_client.py \
+      magma/pipelined/tests

--- a/lte/gateway/python/magma/kernsnoopd/handlers.py
+++ b/lte/gateway/python/magma/kernsnoopd/handlers.py
@@ -167,8 +167,9 @@ class ByteCounter(EBPFHandler):
             # get python service name from command line args
             # e.g. "python3 -m magma.state.main"
             cmdline = self._get_cmdline(key.pid)
-            if cmdline[2].startswith('magma.'):
-                return cmdline[2].split('.')[1]
+            python_service = self._get_service_from_cmdline(cmdline)
+            if python_service:
+                return python_service
         # key.pid process has exited or was not a Python service
         except (psutil.NoSuchProcess, IndexError):
             binary_name = key.comm.decode()
@@ -176,6 +177,11 @@ class ByteCounter(EBPFHandler):
                 # was a non-Python service
                 return binary_name
         raise ValueError('Could not infer service name from key %s' % key.comm)
+
+    def _get_service_from_cmdline(self, cmdline):
+        if cmdline[2].startswith('magma.'):
+            return cmdline[2].split('.')[1]
+        return None
 
 
 def _inc_service_counter(source_service, dest_service, count) -> None:

--- a/lte/gateway/python/magma/kernsnoopd/tests/byte_counter_tests.py
+++ b/lte/gateway/python/magma/kernsnoopd/tests/byte_counter_tests.py
@@ -39,56 +39,95 @@ class ByteCounterTests(unittest.TestCase):
         registry = MockServiceRegistry()
         self.byte_counter = ByteCounter(registry)
 
-    @unittest.mock.patch('psutil.Process.cmdline')
-    def test_get_source_service_python(self, cmdline_mock):
+    @unittest.mock.patch('psutil.Process')
+    def test_get_source_service_python(self, process_mock):
         """
         Test _get_source_service Python service happy path
         """
-        cmdline_mock.return_value = 'python3 -m magma.subscriberdb.main'.split(
-            ' ',
-        )
+        cmdline_value = 'python3 -m magma.subscriberdb.main'.split(' ')
+        process_mock.return_value.cmdline.return_value = cmdline_value
         key = MagicMock()
-        key.pid = 0
         self.assertEqual(
             'subscriberdb',
             self.byte_counter._get_source_service(key),
         )
 
-    @unittest.mock.patch('psutil.Process.cmdline')
-    def test_get_source_service_native(self, cmdline_mock):
+    @unittest.mock.patch('psutil.Process')
+    def test_get_source_service_index_error_with_fallback(self, process_mock):
         """
-        Test _get_source_service native service happy path
+        Test _get_source_service sessiond in service list
         """
-        cmdline_mock.return_value = 'sessiond'.split(' ')
+        cmdline_value = 'sessiond'.split(' ')
+        process_mock.return_value.cmdline.return_value = cmdline_value
         key = MagicMock()
-        key.pid, key.comm = 0, b'sessiond'
+        key.comm = b'sessiond'
         self.assertEqual(
             'sessiond',
             self.byte_counter._get_source_service(key),
         )
 
-    @unittest.mock.patch('psutil.Process.cmdline')
-    def test_get_source_service_fail(self, cmdline_mock):
+    @unittest.mock.patch('psutil.Process')
+    def test_get_source_service_index_error_fail(self, process_mock):
         """
-        Test _get_source_service failure
+        Test _get_source_service sshd not in service list
         """
-        cmdline_mock.return_value = 'sshd'.split(' ')
+        cmdline_value = 'sshd'.split(' ')
+        process_mock.return_value.cmdline.return_value = cmdline_value
         key = MagicMock()
-        key.pid, key.comm = 0, b'sshd'
+        key.comm = b'sshd'
         self.assertRaises(
             ValueError, self.byte_counter._get_source_service,
             key,
         )
 
+    def test_check_cmdline_for_magma_service_python_service_found(self):
+        """
+        Test _check_cmdline_for_magma_service python service name found in cmdline
+        """
+        cmdline_value = 'python3 -m magma.subscriberdb.main'.split(' ')
+        self.assertEqual(
+            'subscriberdb',
+            self.byte_counter._get_service_from_cmdline(cmdline_value),
+        )
+
+    def test_check_cmdline_for_magma_service_native_service_found(self):
+        """
+        Test _check_cmdline_for_magma_service native service name found in cmdline
+        """
+        cmdline_value = 'foo bar magma.sessiond'.split(' ')
+        self.assertEqual(
+            'sessiond',
+            self.byte_counter._get_service_from_cmdline(cmdline_value),
+        )
+
+    def test_check_cmdline_for_magma_service_index_error(self):
+        """
+        Test _check_cmdline_for_magma_service index error
+        """
+        cmdline_value = 'sshd'.split(' ')
+        self.assertRaises(
+            IndexError, self.byte_counter._get_service_from_cmdline,
+            cmdline_value,
+        )
+
+    def test_check_cmdline_for_magma_service_magma_not_found(self):
+        """
+        Test _check_cmdline_for_magma_service no magma. in cmdline
+        """
+        cmdline_value = 'python3 -m subscriberdb.main'.split(' ')
+        self.assertIsNone(self.byte_counter._get_service_from_cmdline(cmdline_value))
+
     @unittest.mock.patch('magma.kernsnoopd.metrics.MAGMA_BYTES_SENT_TOTAL')
-    def test_handle_magma_counters(self, bytes_count_mock):
+    @unittest.mock.patch('psutil.Process')
+    def test_handle_magma_counters(self, process_mock, bytes_count_mock):
         """
         Test handle with Magma service to Magma service traffic
         """
         bytes_count_mock.labels = MagicMock(return_value=MagicMock())
+        cmdline_value = 'python3 -m magma.subscriberdb.main'.split(' ')
+        process_mock.return_value.cmdline.return_value = cmdline_value
 
         key = MagicMock()
-        key.pid, key.comm = 0, b'subscriberdb'
         key.family = AF_INET
         # 16777343 is "127.0.0.1" packed as a 4 byte int
         key.daddr = self.byte_counter.Addr(16777343, 0)
@@ -106,19 +145,21 @@ class ByteCounterTests(unittest.TestCase):
         bytes_count_mock.labels.return_value.inc.assert_called_once_with(100)
 
     @unittest.mock.patch('magma.kernsnoopd.metrics.LINUX_BYTES_SENT_TOTAL')
-    def test_handle_linux_counters(self, bytes_count_mock):
+    @unittest.mock.patch('psutil.Process')
+    def test_handle_linux_counters(self, process_mock, bytes_count_mock):
         """
         Test handle with Linux binary traffic
         """
         bytes_count_mock.labels = MagicMock(return_value=MagicMock())
+        cmdline_value = 'sshd'.split(' ')
+        process_mock.return_value.cmdline.return_value = cmdline_value
 
         key = MagicMock()
-        key.pid, key.comm = 0, b'sshd'
+        key.comm = b'sshd'
         key.family = AF_INET6
         # localhost in IPv6 with embedded IPv4
         # ::ffff:127.0.0.1 = 0x0100007FFFFF0000
         key.daddr = self.byte_counter.Addr(0, 0x0100007FFFFF0000)
-        key.dport = htons(443)
 
         count = MagicMock()
         count.value = 100


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

This is a preparation for #11725. 
The kernsnoopd tests are currently not executed with make and have some structural problems.
These issues are addressed here.

## Test Plan

CI, `lte/gateway/python$ make test_all` check that kernsnoopd tests are executed.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
