### PR TITLE
refactor: all bazel testonly variables are set to True

### DIFF
--- a/lte/gateway/c/core/oai/test/spgw_task/data/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/spgw_task/data/BUILD.bazel
@@ -13,6 +13,6 @@ package(default_visibility = ["//lte/gateway/c/core/oai/test/spgw_task:__pkg__"]
 
 filegroup(
     name = "data",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["*"]),
 )


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

Not all `testonly` variables have the same bool style in the `BAZEL.build` files. This commit changes all the remaining ones to be set to `True`.

## Test Plan

`magma$ bazel test lte/gateway/c/core/oai/...`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
