### PR TITLE
docs(agw): Deprecate approvers-agw-(c,python), approvers-showtech and approvers-openwrt teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,25 +27,23 @@
 
 # approvers-cwf
 /cwf/ @magma/approvers-cwf
+/openwrt/ @magma/approvers-cwf
 
-# approvers-openwrt
-/openwrt/ @magma/approvers-openwrt
-
-# approvers-agw / approvers-agw-python / approvers-agw-c
+# approvers-agw
 /lte/gateway @magma/approvers-agw
 /lte/protos @magma/approvers-agw
-/lte/gateway/python @magma/approvers-agw-python
-/lte/gateway/c @magma/approvers-agw-c
+/lte/gateway/python @magma/approvers-agw
+/lte/gateway/c @magma/approvers-agw
+/show-tech/ @magma/approvers-agw
 
 # agw code related to orc8r
-/orc8r/gateway/c/ @magma/approvers-agw-c
-/orc8r/gateway/python @magma/approvers-agw-python @magma/approvers-orc8r
+/orc8r/gateway/c/ @magma/approvers-agw
+/orc8r/gateway/python @magma/approvers-agw @magma/approvers-orc8r
 
 # approvers-agw-<subsection>
 /lte/gateway/c/session_manager @magma/approvers-agw-sessiond
 /lte/gateway/c/core/oai @magma/approvers-agw-mme
 /lte/gateway/c/sctpd @magma/approvers-agw-mme
-/lte/gateway/c/connection_tracker @koolzz @magma/approvers-agw-c
 /lte/gateway/python/integ_tests @magma/approvers-agw-integtests
 /lte/gateway/docker @magma/approvers-agw-containers @magma/approvers-ci
 
@@ -60,9 +58,6 @@
 /src/go/ @markjen
 
 /dp/ @magma/approvers-domain-proxy
-
-# approvers-showtech
-/show-tech/ @magma/approvers-showtech
 
 /docs/ @magma/approvers-docs
 /docs/readmes/proposals @electronjoe


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

As discussed in #12191 , this PR merges the approving rights of the following teams:
1. Merge `approvers-showtech`, `approvers-agw-c` and `approvers-agw-python` into `approvers-agw`
2. Merge `approvers-openwrt` into `approvers-cwf`

## Test Plan

N/A

## TODO

Once this PR is merged, delete the deprecated teams from [approvers' teams](https://github.com/orgs/magma/teams?query=approvers)