### PR TITLE
chore: Apply IWYU to non SessionD/MME services

### DIFF
--- a/dev_tools/iwyu.imp
+++ b/dev_tools/iwyu.imp
@@ -20,9 +20,11 @@
     { include: ["<folly/dynamic-inl.h>", "private", "<folly/dynamic.h>", "public"] },
     { include: ["<folly/lang/Assume-inl.h>", "private", "<folly/lang/Assume.h>", "public"] },
 
-    # Google test / mock 
+    # Google test / mock / flags / log
     { include: ["@<gtest/.*>", "private", "<gtest/gtest.h>", "public"] },
     { include: ["@<gmock/.*>", "private", "<gmock/gmock.h>", "public"] },
+    { include: ["@\"gflags/.*\"", "private", "<gflags/gflags.h>", "public"] },
+    { include: ["@\"glog/.*\"", "private", "<glog/logging.h>", "public"] },
 
     # magma
     { include: ["@\"lte/gateway/c/core/oai/include/.*.messages_types.h\"", "private", "\"lte/gateway/c/core/oai/include/messages_types.h\"", "public"] },

--- a/lte/gateway/c/connection_tracker/src/EventTracker.cpp
+++ b/lte/gateway/c/connection_tracker/src/EventTracker.cpp
@@ -11,28 +11,23 @@
  * limitations under the License.
  */
 
+#include <arpa/inet.h>
+#include <glog/logging.h>
+#include <libmnl/libmnl.h>
+#include <linux/netfilter/nfnetlink_compat.h>
+#include <linux/netlink.h>
+#include <netinet/in.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
 #include <iostream>
-
-#include <libmnl/libmnl.h>
 #include <linux/netfilter/nfnetlink.h>
 #include <linux/netfilter/nfnetlink_conntrack.h>
 
-#include <linux/if_packet.h>
-#include <string.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-#include <net/if.h>
-#include <netinet/ether.h>
-#include <linux/ip.h>
-#include <memory>
-
 #include "lte/gateway/c/connection_tracker/src/EventTracker.hpp"
 
+#include <memory>
+
+#include "lte/gateway/c/connection_tracker/src/PacketGenerator.hpp"
 #include "orc8r/gateway/c/common/logging/magma_logging.h"
 
 static int data_cb(const struct nlmsghdr* nlh, void* data);

--- a/lte/gateway/c/connection_tracker/src/EventTracker.cpp
+++ b/lte/gateway/c/connection_tracker/src/EventTracker.cpp
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 
+#include "lte/gateway/c/connection_tracker/src/EventTracker.hpp"
+
 #include <arpa/inet.h>
 #include <glog/logging.h>
 #include <libmnl/libmnl.h>
@@ -22,9 +24,6 @@
 #include <iostream>
 #include <linux/netfilter/nfnetlink.h>
 #include <linux/netfilter/nfnetlink_conntrack.h>
-
-#include "lte/gateway/c/connection_tracker/src/EventTracker.hpp"
-
 #include <memory>
 
 #include "lte/gateway/c/connection_tracker/src/PacketGenerator.hpp"

--- a/lte/gateway/c/connection_tracker/src/EventTracker.hpp
+++ b/lte/gateway/c/connection_tracker/src/EventTracker.hpp
@@ -12,10 +12,13 @@
  */
 #pragma once
 
+#include <memory>
+
 #include "lte/gateway/c/connection_tracker/src/PacketGenerator.hpp"
 
 namespace magma {
 namespace lte {
+class PacketGenerator;
 
 class EventTracker {
  public:

--- a/lte/gateway/c/connection_tracker/src/PacketGenerator.cpp
+++ b/lte/gateway/c/connection_tracker/src/PacketGenerator.cpp
@@ -11,16 +11,20 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <cassert>
+#include "lte/gateway/c/connection_tracker/src/PacketGenerator.hpp"
+
+#include <glog/logging.h>
+#include <tins/ethernetII.h>
+#include <tins/ip.h>
+#include <tins/ip_address.h>
+#include <tins/packet_sender.h>
+#include <tins/pdu.h>
+#include <tins/tcp.h>
+#include <tins/udp.h>
 #include <iostream>
 #include <string>
 
-#include <tins/tins.h>
-
-#include "lte/gateway/c/connection_tracker/src/PacketGenerator.hpp"
+#include "orc8r/gateway/c/common/logging/magma_logging.h"
 
 namespace magma {
 namespace lte {

--- a/lte/gateway/c/connection_tracker/src/PacketGenerator.hpp
+++ b/lte/gateway/c/connection_tracker/src/PacketGenerator.hpp
@@ -12,7 +12,10 @@
  */
 #pragma once
 
+#include <stdint.h>
+#include <tins/network_interface.h>
 #include <tins/tins.h>
+#include <string>
 
 #include "orc8r/gateway/c/common/logging/magma_logging.h"
 

--- a/lte/gateway/c/connection_tracker/src/main.cpp
+++ b/lte/gateway/c/connection_tracker/src/main.cpp
@@ -11,18 +11,23 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <glog/logging.h>
 #include <lte/protos/mconfig/mconfigs.pb.h>
-
-#include "orc8r/gateway/c/common/service303/includes/MagmaService.hpp"
-#include "orc8r/gateway/c/common/config/includes/MConfigLoader.hpp"
-#include "orc8r/gateway/c/common/service_registry/includes/ServiceRegistrySingleton.hpp"
+#include <orc8r/protos/common.pb.h>
+#include <stdint.h>
+#include <yaml-cpp/yaml.h>
+#include <memory>
+#include <ostream>
+#include <string>
 
 #include "lte/gateway/c/connection_tracker/src/EventTracker.hpp"
 #include "lte/gateway/c/connection_tracker/src/PacketGenerator.hpp"
+#include "orc8r/gateway/c/common/config/includes/MConfigLoader.hpp"
+#include "orc8r/gateway/c/common/config/includes/ServiceConfigLoader.hpp"
+#include "orc8r/gateway/c/common/logging/magma_logging.h"
 #include "orc8r/gateway/c/common/logging/magma_logging_init.h"
 #include "orc8r/gateway/c/common/sentry/includes/SentryWrapper.hpp"
+#include "orc8r/gateway/c/common/service303/includes/MagmaService.hpp"
 
 #define CONNECTION_SERVICE "connectiond"
 #define CONNECTIOND_VERSION "1.0"

--- a/lte/gateway/c/li_agent/src/InterfaceMonitor.cpp
+++ b/lte/gateway/c/li_agent/src/InterfaceMonitor.cpp
@@ -11,11 +11,12 @@
  * limitations under the License.
  */
 
+#include "lte/gateway/c/li_agent/src/InterfaceMonitor.hpp"
+
 #include <stdio.h>
 #include <unistd.h>
 #include <utility>
 
-#include "lte/gateway/c/li_agent/src/InterfaceMonitor.hpp"
 #include "orc8r/gateway/c/common/logging/magma_logging.h"
 
 namespace magma {

--- a/lte/gateway/c/li_agent/src/InterfaceMonitor.hpp
+++ b/lte/gateway/c/li_agent/src/InterfaceMonitor.hpp
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <pcap.h>
-
 #include <string>
 #include <memory>
 

--- a/lte/gateway/c/li_agent/src/MobilitydClient.cpp
+++ b/lte/gateway/c/li_agent/src/MobilitydClient.cpp
@@ -11,10 +11,11 @@
  * limitations under the License.
  */
 
+#include "lte/gateway/c/li_agent/src/MobilitydClient.hpp"
+
 #include <netinet/in.h>
 #include <thread>
 
-#include "lte/gateway/c/li_agent/src/MobilitydClient.hpp"
 #include "orc8r/gateway/c/common/service_registry/includes/ServiceRegistrySingleton.hpp"
 #include "orc8r/gateway/c/common/logging/magma_logging.h"
 

--- a/lte/gateway/c/li_agent/src/PDUGenerator.cpp
+++ b/lte/gateway/c/li_agent/src/PDUGenerator.cpp
@@ -12,16 +12,16 @@
  */
 
 #include "lte/gateway/c/li_agent/src/PDUGenerator.hpp"
-#include "lte/gateway/c/li_agent/src/Utilities.hpp"
 
 #include <uuid/uuid.h>
 #include <netinet/ip.h>
 #include <net/ethernet.h>
-
 #include <future>
 #include <string>
 #include <memory>
 #include <utility>
+
+#include "lte/gateway/c/li_agent/src/Utilities.hpp"
 
 namespace magma {
 namespace lte {

--- a/lte/gateway/c/li_agent/src/PDUGenerator.hpp
+++ b/lte/gateway/c/li_agent/src/PDUGenerator.hpp
@@ -14,12 +14,11 @@
 
 #include <uuid/uuid.h>
 #include <tins/tins.h>
-
+#include <lte/protos/mconfig/mconfigs.pb.h>
 #include <unordered_map>
 #include <string>
 
 #include "orc8r/gateway/c/common/config/includes/MConfigLoader.hpp"
-#include <lte/protos/mconfig/mconfigs.pb.h>
 #include "orc8r/gateway/c/common/logging/magma_logging.h"
 #include "lte/gateway/c/li_agent/src/ProxyConnector.hpp"
 #include "lte/gateway/c/li_agent/src/MobilitydClient.hpp"

--- a/lte/gateway/c/li_agent/src/ProxyConnector.cpp
+++ b/lte/gateway/c/li_agent/src/ProxyConnector.cpp
@@ -11,13 +11,19 @@
  * limitations under the License.
  */
 
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <openssl/ssl.h>
-#include <openssl/err.h>
-#include <unistd.h>
-
 #include "lte/gateway/c/li_agent/src/ProxyConnector.hpp"
+
+#include <arpa/inet.h>
+#include <glog/logging.h>
+#include <netinet/in.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/ssl3.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <ostream>
+
 #include "orc8r/gateway/c/common/logging/magma_logging.h"
 
 namespace magma {

--- a/lte/gateway/c/li_agent/src/ProxyConnector.hpp
+++ b/lte/gateway/c/li_agent/src/ProxyConnector.hpp
@@ -12,8 +12,10 @@
  */
 #pragma once
 
-#include <string>
+#include <openssl/ossl_typ.h>
 #include <openssl/ssl.h>
+#include <stdint.h>
+#include <string>
 
 namespace magma {
 namespace lte {

--- a/lte/gateway/c/li_agent/src/Utilities.cpp
+++ b/lte/gateway/c/li_agent/src/Utilities.cpp
@@ -11,12 +11,15 @@
  * limitations under the License.
  */
 
-#include <chrono>
-
 #include "lte/gateway/c/li_agent/src/Utilities.hpp"
-#include "orc8r/gateway/c/common/service303/includes/MagmaService.hpp"
+
+#include <glog/logging.h>
+#include <orc8r/protos/common.pb.h>
+#include <chrono>
+#include <ostream>
+
 #include "orc8r/gateway/c/common/config/includes/MConfigLoader.hpp"
-#include "orc8r/gateway/c/common/logging/magma_logging_init.h"
+#include "orc8r/gateway/c/common/logging/magma_logging.h"
 
 namespace magma {
 namespace lte {

--- a/lte/gateway/c/li_agent/src/Utilities.hpp
+++ b/lte/gateway/c/li_agent/src/Utilities.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <lte/protos/mconfig/mconfigs.pb.h>
+#include <stdint.h>
 
 namespace magma {
 namespace lte {

--- a/lte/gateway/c/li_agent/src/main.cpp
+++ b/lte/gateway/c/li_agent/src/main.cpp
@@ -18,7 +18,6 @@
 #include "orc8r/gateway/c/common/service303/includes/MagmaService.hpp"
 #include "orc8r/gateway/c/common/config/includes/MConfigLoader.hpp"
 #include "orc8r/gateway/c/common/service_registry/includes/ServiceRegistrySingleton.hpp"
-
 #include "lte/gateway/c/li_agent/src/InterfaceMonitor.hpp"
 #include "lte/gateway/c/li_agent/src/PDUGenerator.hpp"
 #include "lte/gateway/c/li_agent/src/ProxyConnector.hpp"

--- a/lte/gateway/c/li_agent/src/test/test_pdu_generator.cpp
+++ b/lte/gateway/c/li_agent/src/test/test_pdu_generator.cpp
@@ -15,7 +15,6 @@
 #include <net/ethernet.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
-
 #include <limits>
 #include <utility>
 

--- a/lte/gateway/c/sctpd/src/sctp_assoc.cpp
+++ b/lte/gateway/c/sctpd/src/sctp_assoc.cpp
@@ -13,9 +13,11 @@
 
 #include "lte/gateway/c/sctpd/src/sctp_assoc.hpp"
 
+#include <glog/logging.h>
 #include <iostream>
+#include <string>
 
-#include "lte/gateway/c/sctpd/src/util.hpp"
+#include "orc8r/gateway/c/common/logging/magma_logging.h"
 
 namespace magma {
 namespace sctpd {

--- a/lte/gateway/c/sctpd/src/sctp_connection.cpp
+++ b/lte/gateway/c/sctpd/src/sctp_connection.cpp
@@ -13,19 +13,29 @@
 
 #include "lte/gateway/c/sctpd/src/sctp_connection.hpp"
 
-#include <arpa/inet.h>
+// IWYU pragma: no_include <linux/sctp.h>
+
 #include <assert.h>
+#include <bits/exception.h>
 #include <errno.h>
+#include <glog/logging.h>
+#include <lte/protos/sctpd.pb.h>
+#include <netinet/in.h>
 #include <netinet/sctp.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/epoll.h>
-#include <sys/select.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <exception>
+#include <map>
+#include <ostream>
+#include <stdexcept>
+#include <utility>
 
+#include "lte/gateway/c/sctpd/src/sctp_assoc.hpp"
 #include "lte/gateway/c/sctpd/src/sctpd.hpp"
 #include "lte/gateway/c/sctpd/src/util.hpp"
+#include "orc8r/gateway/c/common/logging/magma_logging.h"
 
 namespace magma {
 namespace sctpd {

--- a/lte/gateway/c/sctpd/src/sctp_connection.hpp
+++ b/lte/gateway/c/sctpd/src/sctp_connection.hpp
@@ -13,12 +13,12 @@
 
 #pragma once
 
+#include <lte/protos/sctpd.grpc.pb.h>
+#include <stdint.h>
 #include <atomic>
 #include <memory>
 #include <string>
 #include <thread>
-
-#include <lte/protos/sctpd.grpc.pb.h>
 
 #include "lte/gateway/c/sctpd/src/sctp_desc.hpp"
 
@@ -26,6 +26,7 @@ struct sctp_assoc_change;
 
 namespace magma {
 namespace sctpd {
+class InitReq;
 
 // Describes status of Sctp event (up or down stream)
 enum class SctpStatus {

--- a/lte/gateway/c/sctpd/src/sctp_desc.cpp
+++ b/lte/gateway/c/sctpd/src/sctp_desc.cpp
@@ -13,6 +13,8 @@
 
 #include "lte/gateway/c/sctpd/src/sctp_desc.hpp"
 
+#include <utility>
+
 #include "assert.h"
 
 namespace magma {

--- a/lte/gateway/c/sctpd/src/sctp_desc.hpp
+++ b/lte/gateway/c/sctpd/src/sctp_desc.hpp
@@ -13,9 +13,9 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <map>
 #include <memory>
-#include <stdint.h>
 
 #include "lte/gateway/c/sctpd/src/sctp_assoc.hpp"
 

--- a/lte/gateway/c/sctpd/src/sctpd.cpp
+++ b/lte/gateway/c/sctpd/src/sctpd.cpp
@@ -13,21 +13,29 @@
 
 #include "lte/gateway/c/sctpd/src/sctpd.hpp"
 
-#include <lte/protos/mconfig/mconfigs.pb.h>
-#include <orc8r/protos/mconfig/mconfigs.pb.h>
-
-#include <memory>
+#include <bits/types/siginfo_t.h>
+#include <glog/logging.h>
 #include <grpcpp/grpcpp.h>
+#include <grpcpp/security/credentials.h>
+#include <grpcpp/security/server_credentials.h>
+#include <lte/protos/mconfig/mconfigs.pb.h>
+#include <orc8r/protos/common.pb.h>
 #include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <yaml-cpp/yaml.h>
+#include <memory>
+#include <ostream>
+#include <string>
 
 #include "lte/gateway/c/sctpd/src/sctpd_downlink_impl.hpp"
 #include "lte/gateway/c/sctpd/src/sctpd_event_handler.hpp"
 #include "lte/gateway/c/sctpd/src/sctpd_uplink_client.hpp"
-#include "lte/gateway/c/sctpd/src/util.hpp"
 #include "orc8r/gateway/c/common/config/includes/MConfigLoader.hpp"
+#include "orc8r/gateway/c/common/config/includes/ServiceConfigLoader.hpp"
+#include "orc8r/gateway/c/common/logging/magma_logging.h"
 #include "orc8r/gateway/c/common/logging/magma_logging_init.h"
 #include "orc8r/gateway/c/common/sentry/includes/SentryWrapper.hpp"
-#include "orc8r/gateway/c/common/service_registry/includes/ServiceRegistrySingleton.hpp"
 
 #define SCTPD_SERVICE "sctpd"
 #define SHARED_MCONFIG "shared_mconfig"

--- a/lte/gateway/c/sctpd/src/sctpd_downlink_impl.cpp
+++ b/lte/gateway/c/sctpd/src/sctpd_downlink_impl.cpp
@@ -13,12 +13,17 @@
 
 #include "lte/gateway/c/sctpd/src/sctpd_downlink_impl.hpp"
 
-#include <arpa/inet.h>
-#include <assert.h>
-#include <netinet/sctp.h>
-#include <unistd.h>
-#include "lte/gateway/c/sctpd/src/sctpd.hpp"
-#include "lte/gateway/c/sctpd/src/util.hpp"
+#include <glog/logging.h>
+#include <lte/protos/sctpd.pb.h>
+#include <ostream>
+#include <string>
+#include <utility>
+
+#include "orc8r/gateway/c/common/logging/magma_logging.h"
+
+namespace grpc {
+class ServerContext;
+}  // namespace grpc
 
 namespace magma {
 namespace sctpd {

--- a/lte/gateway/c/sctpd/src/sctpd_downlink_impl.hpp
+++ b/lte/gateway/c/sctpd/src/sctpd_downlink_impl.hpp
@@ -13,15 +13,26 @@
 
 #pragma once
 
+#include <grpc/grpc.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <grpcpp/server_context.h>
+#include <lte/protos/sctpd.grpc.pb.h>
 #include <memory>
 #include <thread>
 
-#include <grpc/grpc.h>
-#include <grpcpp/server_context.h>
-
-#include <lte/protos/sctpd.grpc.pb.h>
-
 #include "lte/gateway/c/sctpd/src/sctp_connection.hpp"
+
+namespace grpc {
+class ServerContext;
+}  // namespace grpc
+namespace magma {
+namespace sctpd {
+class InitReq;
+class InitRes;
+class SendDlReq;
+class SendDlRes;
+}  // namespace sctpd
+}  // namespace magma
 
 #define S1AP 18
 #define NGAP 60

--- a/lte/gateway/c/sctpd/src/sctpd_event_handler.cpp
+++ b/lte/gateway/c/sctpd/src/sctpd_event_handler.cpp
@@ -13,7 +13,9 @@
 
 #include "lte/gateway/c/sctpd/src/sctpd_event_handler.hpp"
 
-#include <lte/protos/sctpd.grpc.pb.h>
+#include <lte/protos/sctpd.pb.h>
+
+#include "lte/gateway/c/sctpd/src/sctpd_uplink_client.hpp"
 
 namespace magma {
 namespace sctpd {

--- a/lte/gateway/c/sctpd/src/sctpd_event_handler.hpp
+++ b/lte/gateway/c/sctpd/src/sctpd_event_handler.hpp
@@ -13,12 +13,15 @@
 
 #pragma once
 
-#include "lte/gateway/c/sctpd/src/sctp_connection.hpp"
+#include <stdint.h>
+#include <string>
 
+#include "lte/gateway/c/sctpd/src/sctp_connection.hpp"
 #include "lte/gateway/c/sctpd/src/sctpd_uplink_client.hpp"
 
 namespace magma {
 namespace sctpd {
+class SctpdUplinkClient;
 
 // Sctp handler that relays events to MME/AMF over GRPC
 class SctpdEventHandler : public SctpEventHandler {

--- a/lte/gateway/c/sctpd/src/sctpd_uplink_client.cpp
+++ b/lte/gateway/c/sctpd/src/sctpd_uplink_client.cpp
@@ -10,13 +10,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <chrono>
-
 #include "lte/gateway/c/sctpd/src/sctpd_uplink_client.hpp"
+
+#include <assert.h>
+#include <glog/logging.h>
+#include <grpcpp/impl/codegen/client_context.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <chrono>
+#include <ostream>
+
 #include "lte/gateway/c/sctpd/src/util.hpp"
+#include "orc8r/gateway/c/common/logging/magma_logging.h"
+
+namespace grpc {
+class Channel;
+}  // namespace grpc
 
 namespace magma {
 namespace sctpd {
+class CloseAssocReq;
+class CloseAssocRes;
+class NewAssocReq;
+class NewAssocRes;
+class SendUlReq;
+class SendUlRes;
 
 using grpc::ClientContext;
 

--- a/lte/gateway/c/sctpd/src/sctpd_uplink_client.hpp
+++ b/lte/gateway/c/sctpd/src/sctpd_uplink_client.hpp
@@ -13,14 +13,23 @@
 
 #pragma once
 
+#include <grpcpp/grpcpp.h>
+#include <lte/protos/sctpd.grpc.pb.h>
+#include <stdint.h>
 #include <memory>
 
-#include <grpcpp/grpcpp.h>
-
-#include <lte/protos/sctpd.grpc.pb.h>
+namespace grpc {
+class Channel;
+}  // namespace grpc
 
 namespace magma {
 namespace sctpd {
+class CloseAssocReq;
+class CloseAssocRes;
+class NewAssocReq;
+class NewAssocRes;
+class SendUlReq;
+class SendUlRes;
 
 using grpc::Channel;
 

--- a/lte/gateway/c/sctpd/src/test/test_event_handler.cpp
+++ b/lte/gateway/c/sctpd/src/test/test_event_handler.cpp
@@ -11,17 +11,20 @@
  * limitations under the License.
  */
 
-#include <memory>
-
-#include <glog/logging.h>
 #include <gmock/gmock.h>
-#include <grpc++/grpc++.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/credentials.h>
 #include <gtest/gtest.h>
-
-#include <lte/protos/sctpd.grpc.pb.h>
+#include <lte/protos/sctpd.pb.h>
+#include <memory>
+#include <string>
 
 #include "lte/gateway/c/sctpd/src/sctpd_event_handler.hpp"
 #include "lte/gateway/c/sctpd/src/sctpd_uplink_client.hpp"
+
+namespace grpc {
+class Channel;
+}  // namespace grpc
 
 using ::testing::_;
 using ::testing::AllOf;

--- a/lte/gateway/c/sctpd/src/test/test_event_handler.cpp
+++ b/lte/gateway/c/sctpd/src/test/test_event_handler.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <gmock/gmock.h>
+#include <google/protobuf/stubs/port.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
 #include <gtest/gtest.h>

--- a/lte/gateway/c/sctpd/src/test/test_sctp_desc.cpp
+++ b/lte/gateway/c/sctpd/src/test/test_sctp_desc.cpp
@@ -11,8 +11,10 @@
  * limitations under the License.
  */
 
-#include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <map>
+#include <stdexcept>
+#include <utility>
 
 #include "lte/gateway/c/sctpd/src/sctp_assoc.hpp"
 #include "lte/gateway/c/sctpd/src/sctp_desc.hpp"

--- a/lte/gateway/c/sctpd/src/util.cpp
+++ b/lte/gateway/c/sctpd/src/util.cpp
@@ -13,7 +13,14 @@
 
 #include "lte/gateway/c/sctpd/src/util.hpp"
 
+#include <arpa/inet.h>
+#include <glog/logging.h>
+#include <linux/sctp.h>
+#include <lte/protos/sctpd.pb.h>
+#include <netinet/in.h>
 #include <netinet/sctp.h>
+#include <stdlib.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include "lte/gateway/c/sctpd/src/sctpd.hpp"

--- a/lte/gateway/c/sctpd/src/util.cpp
+++ b/lte/gateway/c/sctpd/src/util.cpp
@@ -13,9 +13,10 @@
 
 #include "lte/gateway/c/sctpd/src/util.hpp"
 
+// IWYU pragma: no_include <linux/sctp.h>
+
 #include <arpa/inet.h>
 #include <glog/logging.h>
-#include <linux/sctp.h>
 #include <lte/protos/sctpd.pb.h>
 #include <netinet/in.h>
 #include <netinet/sctp.h>

--- a/lte/gateway/c/sctpd/src/util.hpp
+++ b/lte/gateway/c/sctpd/src/util.hpp
@@ -15,16 +15,17 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
-#include <stdint.h>
-
-#include <string>
-
 #include <lte/protos/sctpd.grpc.pb.h>
+#include <stdint.h>
+#include <string.h>
+#include <ostream>
+#include <string>
 
 #include "orc8r/gateway/c/common/logging/magma_logging.h"
 
 namespace magma {
 namespace sctpd {
+class InitReq;
 
 #define MLOG_perror(fname)                                       \
   do {                                                           \

--- a/orc8r/gateway/c/common/async_grpc/GRPCReceiver.cpp
+++ b/orc8r/gateway/c/common/async_grpc/GRPCReceiver.cpp
@@ -12,7 +12,10 @@
  */
 
 #include "orc8r/gateway/c/common/async_grpc/includes/GRPCReceiver.hpp"
+
+#include <glog/logging.h>
 #include <ostream>  // for operator<<, char_traits
+
 #include "orc8r/gateway/c/common/logging/magma_logging.h"  // for MLOG
 
 namespace magma {

--- a/orc8r/gateway/c/common/async_grpc/includes/GRPCReceiver.hpp
+++ b/orc8r/gateway/c/common/async_grpc/includes/GRPCReceiver.hpp
@@ -20,6 +20,7 @@
 #include <chrono>                                  // for operator+, seconds
 #include <functional>                              // for function
 #include <memory>                                  // for unique_ptr
+
 namespace grpc {
 template <class R>
 class ClientAsyncResponseReader;

--- a/orc8r/gateway/c/common/config/MConfigLoader.cpp
+++ b/orc8r/gateway/c/common/config/MConfigLoader.cpp
@@ -14,6 +14,7 @@
 #include "orc8r/gateway/c/common/config/includes/MConfigLoader.hpp"
 
 #include <bits/exception.h>
+#include <glog/logging.h>
 #include <google/protobuf/stubs/status.h>    // for Status
 #include <google/protobuf/util/json_util.h>  // for JsonStringToMessage
 #include <nlohmann/json.hpp>

--- a/orc8r/gateway/c/common/config/ServiceConfigLoader.cpp
+++ b/orc8r/gateway/c/common/config/ServiceConfigLoader.cpp
@@ -13,6 +13,7 @@
 
 #include "orc8r/gateway/c/common/config/includes/ServiceConfigLoader.hpp"
 
+#include <glog/logging.h>
 #include <iostream>  // for operator<<, basic_ostream
 #include <string>    // for allocator, operator+, char_traits
 

--- a/orc8r/gateway/c/common/config/includes/MConfigLoader.hpp
+++ b/orc8r/gateway/c/common/config/includes/MConfigLoader.hpp
@@ -13,8 +13,9 @@
 #pragma once
 
 #include <google/protobuf/message.h>  // for Message
-#include <istream>                    // for istream
-#include <string>                     // for string
+#include <stdint.h>
+#include <istream>  // for istream
+#include <string>   // for string
 
 namespace google {
 namespace protobuf {

--- a/orc8r/gateway/c/common/config/test/test_mconfig_loader.cpp
+++ b/orc8r/gateway/c/common/config/test/test_mconfig_loader.cpp
@@ -11,14 +11,12 @@
  * limitations under the License.
  */
 
-#include <google/protobuf/message.h>
 #include <gtest/gtest.h>
-
 #include <sstream>
 
+#include "lte/protos/mconfig/mconfigs.pb.h"
 #include "orc8r/gateway/c/common/config/includes/MConfigLoader.hpp"
 #include "orc8r/gateway/c/common/logging/magma_logging.h"
-#include "lte/protos/mconfig/mconfigs.pb.h"
 
 namespace {
 

--- a/orc8r/gateway/c/common/config/test/test_yaml_utils.cpp
+++ b/orc8r/gateway/c/common/config/test/test_yaml_utils.cpp
@@ -11,7 +11,8 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include "yaml-cpp/yaml.h"
+#include <yaml-cpp/yaml.h>
+#include <string>
 
 #include "orc8r/gateway/c/common/config/YAMLUtils.hpp"
 

--- a/orc8r/gateway/c/common/ebpf/EbpfMapUtils.h
+++ b/orc8r/gateway/c/common/ebpf/EbpfMapUtils.h
@@ -13,11 +13,13 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <unistd.h>
-#include <string.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include <linux/bpf.h>
 
 #include "orc8r/gateway/c/common/ebpf/EbpfMap.h"

--- a/orc8r/gateway/c/common/eventd/EventdClient.cpp
+++ b/orc8r/gateway/c/common/eventd/EventdClient.cpp
@@ -13,9 +13,9 @@
 #include "orc8r/gateway/c/common/eventd/includes/EventdClient.hpp"
 
 #include <grpcpp/channel.h>
-#include <utility>                        // for move
 #include <orc8r/protos/common.pb.h>       // for Void
 #include <orc8r/protos/eventd.grpc.pb.h>  // for EventService::Stub
+#include <utility>                        // for move
 
 #include "orc8r/gateway/c/common/service_registry/includes/ServiceRegistrySingleton.hpp"  // for ServiceRegistrySin...
 

--- a/orc8r/gateway/c/common/eventd/includes/EventdClient.hpp
+++ b/orc8r/gateway/c/common/eventd/includes/EventdClient.hpp
@@ -16,7 +16,9 @@
 #include <stdint.h>                       // for uint32_t
 #include <functional>                     // for function
 #include <memory>                         // for unique_ptr
+
 #include "orc8r/gateway/c/common/async_grpc/includes/GRPCReceiver.hpp"  // for GRPCReceiver
+
 namespace grpc {
 class Status;
 }

--- a/orc8r/gateway/c/common/logging/magma_logging_init.h
+++ b/orc8r/gateway/c/common/logging/magma_logging_init.h
@@ -12,11 +12,12 @@
  */
 #pragma once
 
+#include <gflags/gflags.h>
+#include <glog/logging.h>
 #include <stdint.h>
+#include <ostream>
 
 #include "orc8r/gateway/c/common/logging/magma_logging.h"
-
-#include <glog/logging.h>
 
 namespace magma {
 

--- a/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsHelpers.cpp
@@ -12,7 +12,9 @@
  */
 
 #include "orc8r/gateway/c/common/service303/includes/MetricsHelpers.hpp"
+
 #include <stdarg.h>  // for va_end, va_list, va_start
+
 #include "orc8r/gateway/c/common/service303/includes/MetricsSingleton.hpp"  // for MetricsSingleton
 
 using magma::service303::MetricsSingleton;

--- a/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
+++ b/orc8r/gateway/c/common/service303/MetricsSingleton.cpp
@@ -23,7 +23,6 @@
 #include "prometheus/gauge.h"
 #include "prometheus/histogram.h"
 #include "prometheus/registry.h"
-
 #include "orc8r/gateway/c/common/service303/includes/MetricsRegistry.h"
 
 using magma::service303::MetricsSingleton;

--- a/orc8r/gateway/c/common/service303/ProcFileUtils.cpp
+++ b/orc8r/gateway/c/common/service303/ProcFileUtils.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "orc8r/gateway/c/common/service303/ProcFileUtils.hpp"
+
 #include <fstream>  // for basic_istream, ifstream
 #include <string>   // for string, operator>>, stod
 

--- a/orc8r/gateway/c/common/service303/test/test_magma_service.cpp
+++ b/orc8r/gateway/c/common/service303/test/test_magma_service.cpp
@@ -10,7 +10,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <google/protobuf/stubs/common.h>
 #include <gtest/gtest.h>
+#include <orc8r/protos/service303.pb.h>
+#include <algorithm>
+#include <string>
 
 #include "orc8r/gateway/c/common/service303/includes/MagmaService.hpp"
 

--- a/orc8r/gateway/c/common/service303/test/test_metrics.cpp
+++ b/orc8r/gateway/c/common/service303/test/test_metrics.cpp
@@ -12,8 +12,23 @@
  */
 
 #include <gtest/gtest.h>
-#include "orc8r/gateway/c/common/service303/includes/MetricsRegistry.h"
 #include <prometheus/registry.h>
+#include <memory>
+#include <string>
+
+#include "orc8r/gateway/c/common/service303/includes/MetricsRegistry.h"
+#include "prometheus/counter_builder.h"
+
+namespace io {
+namespace prometheus {
+namespace client {
+class MetricFamily;
+}  // namespace client
+}  // namespace prometheus
+}  // namespace io
+namespace prometheus {
+class Counter;
+}  // namespace prometheus
 
 using io::prometheus::client::MetricFamily;
 using magma::service303::MetricsRegistry;

--- a/orc8r/gateway/c/common/service303/test/test_service303.cpp
+++ b/orc8r/gateway/c/common/service303/test/test_service303.cpp
@@ -11,20 +11,32 @@
  * limitations under the License.
  */
 
-#include <unistd.h>
-#include <pthread.h>
-#include <prometheus/registry.h>
+#include <assert.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/impl/codegen/client_context.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <grpcpp/security/credentials.h>
 #include <gtest/gtest.h>
-#include <map>
+#include <metrics.pb.h>
+#include <orc8r/protos/common.pb.h>
 #include <orc8r/protos/metricsd.pb.h>
+#include <orc8r/protos/service303.grpc.pb.h>
+#include <orc8r/protos/service303.pb.h>
+#include <unistd.h>
+#include <iostream>
+#include <limits>
+#include <memory>
 #include <string>
 #include <thread>
 
-#include "orc8r/gateway/c/common/service303/includes/MetricsRegistry.h"
-#include "orc8r/gateway/c/common/service303/includes/MetricsSingleton.hpp"
-#include "orc8r/gateway/c/common/service303/includes/MetricsHelpers.hpp"
 #include "orc8r/gateway/c/common/service303/includes/MagmaService.hpp"
+#include "orc8r/gateway/c/common/service303/includes/MetricsHelpers.hpp"
+#include "orc8r/gateway/c/common/service303/includes/MetricsSingleton.hpp"
 #include "orc8r/gateway/c/common/service_registry/includes/ServiceRegistrySingleton.hpp"
+
+namespace grpc {
+class Channel;
+}  // namespace grpc
 
 using grpc::Channel;
 using grpc::ChannelCredentials;


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
* Apply IWYU findings to non SessionD/MME/Sctpd directories
* All changes are automated

```bash
$MAGMA_ROOT/dev_tools/apply-iwyu.sh orc8r/gateway/c/common/
$MAGMA_ROOT/dev_tools/apply-iwyu.sh lte/gateway/c/li_agent/
$MAGMA_ROOT/dev_tools/apply-iwyu.sh lte/gateway/c/connection_tracker/
make -C lte/gateway format_all
```

We are skipping IWYU fixups for MME because IWYU cannot handle our mix C/C++ codebase
We are skipping IWYU fixups for SessionD because we still have not fixed the full path specification tech debt for SessionD (https://github.com/magma/magma/pull/12496)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CI and build/test locally
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
