### PR TITLE
fix(agw): fix secondary interface config for agwc

### DIFF
--- a/lte/gateway/deploy/agw_install_docker.sh
+++ b/lte/gateway/deploy/agw_install_docker.sh
@@ -88,7 +88,7 @@ EOF
 
   # changing intefaces name
   sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
-  sed -i 's/ens5/eth0/g; s/ens6/eth0/g' /etc/netplan/50-cloud-init.yaml
+  sed -i 's/ens5/eth0/g; s/ens6/eth1/g' /etc/netplan/50-cloud-init.yaml
   # changing interface name
   update-grub2
 
@@ -99,6 +99,8 @@ EOF
             eth1:
                 dhcp4: true
                 dhcp6: false
+                dhcp4-overrides:
+                  route-metric: 200
         version: 2
 EOF
   fi

--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -19,6 +19,7 @@ x-standard-volumes: &volumes_anchor
   - /var/run:/var/run
   - /tmp:/tmp
   - /var/log:/var/log
+  - /etc/openvswitch:/etc/openvswitch
 
 x-generic-service: &service
   volumes: *volumes_anchor
@@ -216,9 +217,11 @@ services:
     privileged: true
     environment:
       MAGMA_PRINT_GRPC_PAYLOAD: 0
+    pid: "host"
     cap_add:
       - NET_ADMIN
       - NET_RAW
+      - SYS_NICE
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50063"]
       timeout: "4s"
@@ -227,11 +230,9 @@ services:
       bash -c "/usr/bin/ovs-vsctl --all destroy Flow_Sample_Collector_Set &&
         /usr/bin/ovs-vsctl set bridge gtp_br0 protocols=OpenFlow10,OpenFlow13,OpenFlow14 other-config:disable-in-band=true &&
         /usr/bin/ovs-vsctl set-controller gtp_br0 tcp:127.0.0.1:6633 tcp:127.0.0.1:6654 &&
-        /usr/bin/ovsdb-client dump Controller _uuid|tail -n +4 | while read id ; do \
-          /usr/bin/ovs-vsctl set Controller $${id} inactivity_probe=300 ; done &&
         /usr/bin/ovs-vsctl set-fail-mode gtp_br0 secure &&
         /usr/bin/ovs-vsctl set-manager ptcp:6640 &&
-        /usr/bin/env python3 -m magma.pipelined.main "
+        /usr/bin/env python3 -m magma.pipelined.main"
 
   sessiond:
     <<: *ltecservice


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

Fixing the agwc setup to correct the secondary interface configuration.
Removing controller inactivity time change as It is stopping packets processing in ovs (To be tshoot further)

## Test Plan

Tested with SRSRan over arm64
```
srsenb  | 
srsenb  | ==== eNodeB started ===
srsenb  | Current sample rate is 11.52 MHz with a base rate of 23.04 MHz (x2 decimation)
srsenb  | Current sample rate is 11.52 MHz with a base rate of 23.04 MHz (x2 decimation)
srsenb  | Setting frequency: DL=2680.0 Mhz, UL=2560.0 MHz for cc_idx=0 nof_prb=50
srsenb  | Type <t> to view trace
srsenb  | Closing stdin thread.
srsue   | Waiting PHY to initialize ... done!
srsue   | Attaching UE...
srsue   | Closing stdin thread.
srsue   | Current sample rate is 1.92 MHz with a base rate of 23.04 MHz (x12 decimation)
srsue   | Current sample rate is 1.92 MHz with a base rate of 23.04 MHz (x12 decimation)
srsue   | .
srsue   | Found Cell:  Mode=FDD, PCI=1, PRB=50, Ports=1, CP=Normal, CFO=-0.2 KHz
srsue   | Current sample rate is 11.52 MHz with a base rate of 23.04 MHz (x2 decimation)
srsue   | Current sample rate is 11.52 MHz with a base rate of 23.04 MHz (x2 decimation)
srsue   | Found PLMN:  Id=00101, TAC=7
srsue   | Random Access Transmission: seq=36, tti=4501, ra-rnti=0x2
srsenb  | RACH:  tti=4501, cc=0, preamble=36, offset=0, temp_crnti=0x46
srsue   | RRC Connected
srsue   | Random Access Complete.     c-rnti=0x46, ta=0
srsue   | Network attach successful. IP: 192.168.128.12
srsenb  | User 0x46 connected
srsue   | E
```
```
ubuntu@ip-172-31-19-118:~/srsRAN-demo$ docker exec -it srsue ping 192.168.128.1
PING 192.168.128.1 (192.168.128.1) 56(84) bytes of data.
64 bytes from 192.168.128.1: icmp_seq=1 ttl=64 time=47.1 ms
64 bytes from 192.168.128.1: icmp_seq=2 ttl=64 time=32.6 ms
^C
```