### PR TITLE
chore(dp): Require explicit join

### DIFF
--- a/dp/cloud/go/services/dp/storage/cbsd_manager.go
+++ b/dp/cloud/go/services/dp/storage/cbsd_manager.go
@@ -252,16 +252,21 @@ func buildDetailedCbsdQuery(builder sq.StatementBuilderType) *db.Query {
 			"is_deleted", "should_deregister", "grant_attempts")).
 		Join(db.NewQuery().
 			From(&DBCbsdState{}).
+			On(db.On(CbsdTable, "state_id", CbsdStateTable, "id")).
 			Select(db.NewIncludeMask("name"))).
 		Join(db.NewQuery().
 			From(&DBGrant{}).
+			On(db.On(CbsdTable, "id", GrantTable, "cbsd_id")).
 			Select(db.NewIncludeMask(
 				"grant_expire_time", "transmit_expire_time",
 				"low_frequency", "high_frequency", "max_eirp")).
 			Join(db.NewQuery().
 				From(&DBGrantState{}).
-				Select(db.NewIncludeMask("name")).
-				Where(sq.NotEq{GrantStateTable + ".name": "idle"})).
+				On(sq.And{
+					db.On(GrantTable, "state_id", GrantStateTable, "id"),
+					sq.NotEq{GrantStateTable + ".name": "idle"},
+				}).
+				Select(db.NewIncludeMask("name"))).
 			Nullable())
 }
 

--- a/dp/cloud/go/services/dp/storage/cbsd_manager_test.go
+++ b/dp/cloud/go/services/dp/storage/cbsd_manager_test.go
@@ -99,6 +99,7 @@ func (s *CbsdManagerTestSuite) TestCreateCbsd() {
 			Select(db.NewExcludeMask("id", "state_id")).
 			Join(db.NewQuery().
 				From(&storage.DBCbsdState{}).
+				On(db.On(storage.CbsdTable, "state_id", storage.CbsdStateTable, "id")).
 				Select(db.NewIncludeMask("name"))).
 			Where(sq.Eq{"cbsd_serial_number": "some_serial_number"}).
 			Fetch()
@@ -121,9 +122,11 @@ func (s *CbsdManagerTestSuite) TestCreateCbsd() {
 			Select(db.NewIncludeMask()).
 			Join(db.NewQuery().
 				From(&storage.DBCbsdState{}).
+				On(db.On(storage.CbsdStateTable, "id", storage.ActiveModeConfigTable, "desired_state_id")).
 				Select(db.NewIncludeMask("name"))).
 			Join(db.NewQuery().
 				From(&storage.DBCbsd{}).
+				On(db.On(storage.CbsdTable, "id", storage.ActiveModeConfigTable, "cbsd_id")).
 				Select(db.NewIncludeMask())).
 			Where(sq.Eq{"cbsd_serial_number": "some_serial_number"}).
 			Fetch()

--- a/dp/cloud/go/services/dp/storage/db/query.go
+++ b/dp/cloud/go/services/dp/storage/db/query.go
@@ -29,6 +29,7 @@ type Query struct {
 	arg        *arg
 	join       []*Query
 	pagination *pagination
+	parent     *Query
 }
 
 type arg struct {
@@ -36,6 +37,7 @@ type arg struct {
 	mask     FieldMask
 	nullable bool
 	filter   sq.Sqlizer
+	on       sq.Sqlizer
 }
 
 func (q *Query) WithBuilder(builder sq.StatementBuilderType) *Query {
@@ -58,7 +60,13 @@ func (q *Query) Where(filter sq.Sqlizer) *Query {
 	return q
 }
 
+func (q *Query) On(cond sq.Sqlizer) *Query {
+	q.arg.on = cond
+	return q
+}
+
 func (q *Query) Join(other *Query) *Query {
+	other.parent = q
 	q.join = append(q.join, other)
 	return q
 }

--- a/dp/cloud/go/services/dp/storage/db/query_test.go
+++ b/dp/cloud/go/services/dp/storage/db/query_test.go
@@ -245,6 +245,7 @@ func (s *QueryTestSuite) TestFetch() {
 			Where(sq.Eq{someTable + ".id": id}).
 			Join(db.NewQuery().
 				From(&otherModel{}).
+				On(db.On(someTable, "id", otherTable, "some_id")).
 				Select(db.NewExcludeMask())),
 		expected: []db.Model{
 			getSomeModel(),
@@ -258,6 +259,7 @@ func (s *QueryTestSuite) TestFetch() {
 			Where(sq.Eq{someTable + ".id": 2 * id}).
 			Join(db.NewQuery().
 				From(&otherModel{}).
+				On(db.On(someTable, "id", otherTable, "some_id")).
 				Select(db.NewExcludeMask()).
 				Nullable()),
 		expected: []db.Model{
@@ -265,15 +267,18 @@ func (s *QueryTestSuite) TestFetch() {
 			&otherModel{},
 		},
 	}, {
-		name: "Should use filter as join condition",
+		name: "Should use complex join condition",
 		query: db.NewQuery().
 			From(&someModel{}).
 			Select(db.NewExcludeMask()).
 			Where(sq.Eq{someTable + ".id": id}).
 			Join(db.NewQuery().
 				From(&otherModel{}).
+				On(sq.And{
+					db.On(someTable, "id", otherTable, "some_id"),
+					sq.Eq{otherTable + ".id": id - 1},
+				}).
 				Select(db.NewExcludeMask()).
-				Where(sq.Eq{otherTable + ".id": id - 1}).
 				Nullable()),
 		expected: []db.Model{
 			getSomeModel(),
@@ -287,9 +292,11 @@ func (s *QueryTestSuite) TestFetch() {
 			Where(sq.Eq{someTable + ".id": id}).
 			Join(db.NewQuery().
 				From(&otherModel{}).
+				On(db.On(someTable, "id", otherTable, "some_id")).
 				Select(db.NewExcludeMask()).
 				Join(db.NewQuery().
 					From(&anotherModel{}).
+					On(db.On(otherTable, "id", anotherTable, "other_id")).
 					Select(db.NewExcludeMask()))),
 		expected: []db.Model{
 			getSomeModel(),
@@ -304,11 +311,15 @@ func (s *QueryTestSuite) TestFetch() {
 			Where(sq.Eq{someTable + ".id": id}).
 			Join(db.NewQuery().
 				From(&otherModel{}).
+				On(db.On(someTable, "id", otherTable, "some_id")).
 				Select(db.NewExcludeMask()).
 				Join(db.NewQuery().
 					From(&anotherModel{}).
-					Select(db.NewExcludeMask()).
-					Where(sq.Eq{anotherTable + ".id": id - 1})).
+					On(sq.And{
+						db.On(otherTable, "id", anotherTable, "other_id"),
+						sq.Eq{anotherTable + ".id": id - 1},
+					}).
+					Select(db.NewExcludeMask())).
 				Nullable()),
 		expected: []db.Model{
 			getSomeModel(),
@@ -323,11 +334,15 @@ func (s *QueryTestSuite) TestFetch() {
 			Where(sq.Eq{someTable + ".id": id}).
 			Join(db.NewQuery().
 				From(&otherModel{}).
+				On(db.On(someTable, "id", otherTable, "some_id")).
 				Select(db.NewExcludeMask()).
 				Join(db.NewQuery().
 					From(&anotherModel{}).
+					On(sq.And{
+						db.On(otherTable, "id", anotherTable, "other_id"),
+						sq.Eq{anotherTable + ".id": id - 1},
+					}).
 					Select(db.NewExcludeMask()).
-					Where(sq.Eq{anotherTable + ".id": id - 1}).
 					Nullable()).
 				Nullable()),
 		expected: []db.Model{


### PR DESCRIPTION
## Summary

Previously joins were done implicitly, but it didn't work
when there were multiple relations to the same table.
Now join no longer is deduced and has to be specified manually.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>