### PR TITLE
ci(dp): Run integration tests once and improve logging from them

### DIFF
--- a/dp/Makefile
+++ b/dp/Makefile
@@ -66,13 +66,13 @@ dev_orc8r:
 
 
 .PHONY: dev_orc8r_integration_test
-dev_orc8r_integration_test: cleanup_test_db
+dev_orc8r_integration_test: cleanup_test_db _ci_init
 	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
 	kubectl delete pods test-runner-orc8r --ignore-not-found=true
 	skaffold dev -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only --trigger=manual
 
 .PHONY: dev_integration_test
-dev_integration_test: cleanup_test_db
+dev_integration_test: cleanup_test_db _ci_init
 	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
 	kubectl delete pods test-runner --ignore-not-found=true
 	skaffold dev -p integration-tests-no-orc8 --trigger=manual
@@ -117,6 +117,7 @@ _ci_init: _generate_certificates _generate_harness_config
 		deployment.apps/orc8r-fluentd-forward \
 		configmap/orc8r-fluentd-forward-configs \
 		--ignore-not-found
+	helm uninstall domain-proxy orc8r orc8r-lte || true
 	#kubectl apply -f ./tools/deployment/vendor/postgresql.yml
 	#kubectl rollout status --watch --timeout=600s statefulset/postgres-database
 
@@ -143,24 +144,26 @@ _generate_harness_config:
 	--from-file=tools/deployment/vendor/sas.cfg;
 
 .PHONY: _ci_integration_tests_no_orc8r
-_ci_integration_tests_no_orc8r: _install_skaffold_ci cleanup_test_db
+_ci_integration_tests_no_orc8r: _install_skaffold_ci cleanup_test_db _ci_init
 	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
 	kubectl delete pods test-runner --ignore-not-found=true
 	skaffold run -p integration-tests-no-orc8
 	kubectl logs test-runner -f | tee /tmp/$@.txt
 	@set -e;\
+	sleep 2;\
 	SUCCESS=$$(kubectl get pods test-runner -o jsonpath='{.status.phase}');\
-	if [[ $$SUCCESS != 'Succeeded' ]]; then exit 1; fi
+	if [[ $$SUCCESS != 'Succeeded' ]]; then kubectl get pods test-runner -o yaml && exit 1; fi
 
 .PHONY: _ci_integration_tests_orc8r
-_ci_integration_tests_orc8r: _install_skaffold_ci cleanup_test_db
+_ci_integration_tests_orc8r: _install_skaffold_ci cleanup_test_db _ci_init
 	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
 	kubectl delete pods test-runner-orc8r --ignore-not-found=true
 	skaffold run -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only
 	kubectl logs test-runner-orc8r -f | tee /tmp/$@.txt
 	@set -e;\
+	sleep 2;\
 	SUCCESS=$$(kubectl get pods test-runner-orc8r -o jsonpath='{.status.phase}');\
-	if [[ $$SUCCESS != 'Succeeded' ]]; then exit 1; fi
+	if [[ $$SUCCESS != 'Succeeded' ]]; then kubectl get pods test-runner-orc8r -o yaml && exit 1; fi
 
 .PHONY: _setup_db
 _setup_db: _postgres_db_setup

--- a/dp/Makefile
+++ b/dp/Makefile
@@ -64,12 +64,17 @@ clean:
 dev_orc8r:
 	skaffold dev -p orc8r-deployment --trigger=manual
 
+
 .PHONY: dev_orc8r_integration_test
-dev_orc8r_integration_test:
+dev_orc8r_integration_test: cleanup_test_db
+	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
+	kubectl delete pods test-runner-orc8r --ignore-not-found=true
 	skaffold dev -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only --trigger=manual
 
 .PHONY: dev_integration_test
-dev_integration_test:
+dev_integration_test: cleanup_test_db
+	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
+	kubectl delete pods test-runner --ignore-not-found=true
 	skaffold dev -p integration-tests-no-orc8 --trigger=manual
 
 .PHONY: dev
@@ -138,30 +143,24 @@ _generate_harness_config:
 	--from-file=tools/deployment/vendor/sas.cfg;
 
 .PHONY: _ci_integration_tests_no_orc8r
-_ci_integration_tests_no_orc8r: _install_skaffold_ci
-	kubectl delete --ignore-not-found=true job test-runner-job
+_ci_integration_tests_no_orc8r: _install_skaffold_ci cleanup_test_db
+	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
+	kubectl delete pods test-runner --ignore-not-found=true
 	skaffold run -p integration-tests-no-orc8
-	kubectl wait --for=condition=complete --timeout=10m job/test-runner-job & \
-	kubectl wait --for=condition=failed --timeout=10m job/test-runner-job & \
-	wait -n 1 2
-	kubectl logs -l type=integration-tests | tee /tmp/$@.txt
+	kubectl logs test-runner -f | tee /tmp/$@.txt
 	@set -e;\
-	SUCCESS=$$(kubectl get jobs test-runner-job -o jsonpath='{.status.succeeded}');\
-	if [[ -z $$SUCCESS ]]; then SUCCESS=0; fi; \
-	if [[ $$SUCCESS != '1' ]]; then exit 1; fi
+	SUCCESS=$$(kubectl get pods test-runner -o jsonpath='{.status.phase}');\
+	if [[ $$SUCCESS != 'Succeeded' ]]; then exit 1; fi
 
 .PHONY: _ci_integration_tests_orc8r
-_ci_integration_tests_orc8r: _install_skaffold_ci
-	kubectl delete --ignore-not-found=true job test-runner-job-orc8r
+_ci_integration_tests_orc8r: _install_skaffold_ci cleanup_test_db
+	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
+	kubectl delete pods test-runner-orc8r --ignore-not-found=true
 	skaffold run -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only
-	kubectl wait --for=condition=complete --timeout=10m job/test-runner-job-orc8r & \
-	kubectl wait --for=condition=failed --timeout=10m job/test-runner-job-orc8r & \
-	wait -n 1 2
-	kubectl logs -l type=integration-tests | tee /tmp/$@.txt
+	kubectl logs test-runner-orc8r -f | tee /tmp/$@.txt
 	@set -e;\
-	SUCCESS=$$(kubectl get jobs test-runner-job-orc8r -o jsonpath='{.status.succeeded}');\
-	if [[ -z $$SUCCESS ]]; then SUCCESS=0; fi; \
-	if [[ $$SUCCESS != '1' ]]; then exit 1; fi
+	SUCCESS=$$(kubectl get pods test-runner-orc8r -o jsonpath='{.status.phase}');\
+	if [[ $$SUCCESS != 'Succeeded' ]]; then exit 1; fi
 
 .PHONY: _setup_db
 _setup_db: _postgres_db_setup
@@ -208,6 +207,17 @@ build_db:
 	alembic -c ./alembic.ini upgrade head; \
 	cd ..; \
 	python3 db_initialize.py; \
+
+.PHONY: cleanup_test_db
+cleanup_test_db:
+	kubectl exec -it postgres-database-0 \
+		--container postgres-test -- \
+		psql -p 5433 -U postgres -c \
+		"drop database dp_test with (force);" || true ;\
+	kubectl exec -it postgres-database-0 \
+		--container postgres-test -- \
+		psql -p 5433 -U postgres -c \
+		"create database dp_test;" || true;
 
 LOGS_COUNT ?= 1000
 CBSDS_COUNT ?= 1000

--- a/dp/Makefile
+++ b/dp/Makefile
@@ -144,7 +144,7 @@ _generate_harness_config:
 	--from-file=tools/deployment/vendor/sas.cfg;
 
 .PHONY: _ci_integration_tests_no_orc8r
-_ci_integration_tests_no_orc8r: _install_skaffold_ci cleanup_test_db _ci_init
+_ci_integration_tests_no_orc8r: _install_skaffold_ci
 	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
 	kubectl delete pods test-runner --ignore-not-found=true
 	skaffold run -p integration-tests-no-orc8
@@ -155,7 +155,7 @@ _ci_integration_tests_no_orc8r: _install_skaffold_ci cleanup_test_db _ci_init
 	if [[ $$SUCCESS != 'Succeeded' ]]; then kubectl get pods test-runner -o yaml && exit 1; fi
 
 .PHONY: _ci_integration_tests_orc8r
-_ci_integration_tests_orc8r: _install_skaffold_ci cleanup_test_db _ci_init
+_ci_integration_tests_orc8r: _install_skaffold_ci
 	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
 	kubectl delete pods test-runner-orc8r --ignore-not-found=true
 	skaffold run -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/db_service/job.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/db_service/job.yaml
@@ -3,6 +3,8 @@ apiVersion: {{ template "domain-proxy.job.apiVersion" . }}
 kind: Job
 metadata:
   name: {{ include "domain-proxy.db_service.fullname" . }}-{{ .Release.Revision }}
+  labels:
+    jobName: domain-proxy-db-setup
 spec:
   ttlSecondsAfterFinished: 100
   template:

--- a/dp/cloud/python/magma/test_runner/tests/integration_testcase.py
+++ b/dp/cloud/python/magma/test_runner/tests/integration_testcase.py
@@ -1,0 +1,40 @@
+from time import sleep
+from unittest import TestCase
+
+import grpc
+import requests
+from dp.protos.enodebd_dp_pb2_grpc import DPServiceStub
+from magma.test_runner.config import TestConfig
+from retrying import retry
+
+config = TestConfig()
+
+
+class DomainProxyIntegrationTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        grpc_channel = grpc.insecure_channel(
+            f"{config.GRPC_SERVICE}:{config.GRPC_PORT}",
+        )
+        cls.dp_client = DPServiceStub(grpc_channel)
+        wait_for_elastic_to_start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        _delete_dp_elasticsearch_indices()
+
+
+@retry(stop_max_attempt_number=30, wait_fixed=1000)
+def wait_for_elastic_to_start() -> None:
+    requests.get(f'{config.ELASTICSEARCH_URL}/_status')
+
+
+def when_elastic_indexes_data():
+    # TODO use retrying instead
+    sleep(15)
+
+
+def _delete_dp_elasticsearch_indices() -> None:
+    requests.delete(f"{config.ELASTICSEARCH_URL}/{config.ELASTICSEARCH_INDEX}*")

--- a/dp/cloud/python/magma/test_runner/tests/test_active_mode_controller.py
+++ b/dp/cloud/python/magma/test_runner/tests/test_active_mode_controller.py
@@ -23,10 +23,11 @@ from magma.db_service.session_manager import SessionManager
 from magma.db_service.tests.db_testcase import BaseDBTestCase
 from magma.test_runner.config import TestConfig
 from retrying import retry
+from uuid import uuid4
+import json
 
 config = TestConfig()
 
-SERIAL_NUMBER = "some_serial_number"
 FCC_ID = "some_fcc_id"
 USER_ID = "some_user_id"
 
@@ -36,7 +37,12 @@ class ActiveModeControllerTestCase(BaseDBTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        wait_for_elastic_to_start()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        _delete_dp_elasticsearch_indices()
+
 
     def setUp(self):
         super().setUp()
@@ -45,9 +51,7 @@ class ActiveModeControllerTestCase(BaseDBTestCase):
         )
         self.dp_client = DPServiceStub(grpc_channel)
         DBInitializer(SessionManager(self.engine)).initialize()
-        # Indexing from previous test may not have been finished yet
-        sleep(5)
-        self._delete_dp_elasticsearch_indices()
+        self.serial_number = self._testMethodName + '_' + str(uuid4())
 
     # retrying is needed because of a possible deadlock
     # with cc locking request table
@@ -57,15 +61,12 @@ class ActiveModeControllerTestCase(BaseDBTestCase):
 
     def tearDown(self):
         super().tearDown()
-        self._delete_dp_elasticsearch_indices()
 
     def test_provision_cbsd_in_sas_requested_by_dp_client(self):
         self.given_cbsd_provisioned()
 
     def test_logs_are_written_to_elasticsearch(self):
         self.given_cbsd_provisioned()
-        # Giving ElasticSearch time to index logs
-        sleep(5)
         self.then_elasticsearch_contains_logs()
 
     def test_grant_relinquished_after_inactivity(self):
@@ -85,8 +86,26 @@ class ActiveModeControllerTestCase(BaseDBTestCase):
 
         self.then_cbsd_is_eventually_provisioned_in_sas(self.dp_client)
 
+    @retry(stop_max_attempt_number=60, wait_fixed=1000)
     def then_elasticsearch_contains_logs(self):
-        actual = requests.get(f"{config.ELASTICSEARCH_URL}/dp*/_search?size=100").json()
+        query = {
+            "query": {
+                "term": {
+                    "cbsd_serial_number.keyword": {
+                        "value": self.serial_number
+                    }
+                }
+            }
+        }
+
+        actual = requests.post(
+            f"{config.ELASTICSEARCH_URL}/dp*/_search?size=100",
+            data = json.dumps(query),
+            headers= {
+                "Content-type": "application/json"
+            }
+        ).json()
+
         log_field_names = [
             "log_from",
             "log_to",
@@ -109,11 +128,10 @@ class ActiveModeControllerTestCase(BaseDBTestCase):
         self.assertEqual(1, actual_log_types["registrationResponse"])
         self.assertEqual(1, actual_log_types["spectrumInquiryRequest"])
         self.assertEqual(1, actual_log_types["spectrumInquiryResponse"])
-        self.assertEqual(1, actual_log_types["spectrumInquiryResponse"])
         self.assertEqual(1, actual_log_types["grantRequest"])
         self.assertEqual(1, actual_log_types["grantResponse"])
-        self.assertEqual(1, actual_log_types["heartbeatRequest"])
         # The number of GetCBSDStateRequest and heartbeatResponse may differ between tests, so only asserting they have been logged
+        self.assertGreater(actual_log_types["heartbeatRequest"], 0)
         self.assertGreater(actual_log_types["heartbeatResponse"], 0)
         self.assertGreater(actual_log_types["GetCBSDStateRequest"], 0)
         self.assertGreater(actual_log_types["GetCBSDStateResponse"], 0)
@@ -143,12 +161,11 @@ class ActiveModeControllerTestCase(BaseDBTestCase):
         state = dp_client.GetCBSDState(self._build_cbsd_request())
         self.assertEqual(self._build_empty_state_result(), state)
 
-    @staticmethod
-    def _build_cbsd_request() -> CBSDRequest:
+    def _build_cbsd_request(self) -> CBSDRequest:
         return CBSDRequest(
             user_id=USER_ID,
             fcc_id=FCC_ID,
-            serial_number=SERIAL_NUMBER,
+            serial_number=self.serial_number,
             min_power=0,
             max_power=20,
             antenna_gain=15,
@@ -170,10 +187,5 @@ class ActiveModeControllerTestCase(BaseDBTestCase):
     def _build_empty_state_result() -> CBSDStateResult:
         return CBSDStateResult(radio_enabled=False)
 
-    def _delete_dp_elasticsearch_indices(self):
-        requests.delete(f"{config.ELASTICSEARCH_URL}/{config.ELASTICSEARCH_INDEX}*")
-
-
-@retry(stop_max_attempt_number=30, wait_fixed=1000)
-def wait_for_elastic_to_start() -> None:
-    requests.get(f'{config.ELASTICSEARCH_URL}/_status')
+def _delete_dp_elasticsearch_indices():
+    requests.delete(f"{config.ELASTICSEARCH_URL}/{config.ELASTICSEARCH_INDEX}*")

--- a/dp/cloud/python/magma/test_runner/tests/test_dp_with_orc8r.py
+++ b/dp/cloud/python/magma/test_runner/tests/test_dp_with_orc8r.py
@@ -21,15 +21,13 @@ from time import sleep
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
-import grpc
 import pytest
 import requests
 from dp.protos.enodebd_dp_pb2 import CBSDRequest, CBSDStateResult, LteChannel
-from dp.protos.enodebd_dp_pb2_grpc import DPServiceStub
-from magma.db_service.db_initialize import DBInitializer
-from magma.db_service.session_manager import SessionManager
-from magma.db_service.tests.db_testcase import BaseDBTestCase
 from magma.test_runner.config import TestConfig
+from magma.test_runner.tests.integration_testcase import (
+    DomainProxyIntegrationTestCase,
+)
 from retrying import retry
 
 config = TestConfig()
@@ -45,35 +43,9 @@ DATETIME_WAY_BACK = '2010-03-28T09:13:25.407877399+00:00'
 
 
 @pytest.mark.orc8r
-class DomainProxyOrc8rTestCase(BaseDBTestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        cls.set_up_db_test_case()
-        cls.create_all()
-        DBInitializer(SessionManager(cls.engine)).initialize()
-        grpc_channel = grpc.insecure_channel(
-            f"{config.GRPC_SERVICE}:{config.GRPC_PORT}",
-        )
-        cls.dp_client = DPServiceStub(grpc_channel)
-        wait_for_elastic_to_start()
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        # retrying is needed because of a possible deadlock
-        # with cc locking request table
-        @retry(stop_max_attempt_number=5, wait_fixed=100)
-        def drop_database_with_retries():
-            cls.drop_all()
-
-        drop_database_with_retries()
-        _delete_dp_elasticsearch_indices()
-
+class DomainProxyOrc8rTestCase(DomainProxyIntegrationTestCase):
     def setUp(self) -> None:
         self.serial_number = self._testMethodName + '_' + str(uuid4())
-
-    def tearDown(self) -> None:
-        pass
 
     def test_cbsd_sas_flow(self):
         builder = CbsdAPIDataBuilder().with_serial_number(self.serial_number)

--- a/dp/cloud/python/magma/test_runner/tests/test_dp_with_orc8r.py
+++ b/dp/cloud/python/magma/test_runner/tests/test_dp_with_orc8r.py
@@ -117,8 +117,6 @@ class DomainProxyOrc8rTestCase(DomainProxyIntegrationTestCase):
         cbsd = self.when_cbsd_is_fetched(builder.serial_number)
         self.then_cbsd_is(cbsd, builder.build_registered_inactive_data())
 
-        self.delete_cbsd(cbsd_id)
-
     def test_frequency_preferences(self):
         builder = CbsdAPIDataBuilder(). \
             with_serial_number(self.serial_number). \

--- a/dp/skaffold.yaml
+++ b/dp/skaffold.yaml
@@ -50,6 +50,10 @@ deploy:
         - host:
             command: ["kubectl", "rollout", "status", "--watch", "--timeout=600s", "statefulset/postgres-database"]
         - host:
+            command: ["kubectl", "apply", "-f", "./tools/deployment/vendor/elasticsearch.yml"]
+        - host:
+            command: ["kubectl", "rollout", "status", "--watch", "--timeout=600s", "deployment/elasticsearch-deployment"]
+        - host:
             command: ["dp/tools/skaffold_hooks/hooks.sh", "create_secrets"]
             dir: ..
         - host:
@@ -80,7 +84,6 @@ deploy:
     defaultNamespace: default
     manifests:
       - "./tools/deployment/vendor/fake_sas.yml"
-      - "./tools/deployment/vendor/elasticsearch.yml"
 profiles:
   - name: integration-tests-no-orc8
     patches:
@@ -253,7 +256,7 @@ profiles:
                 - "-c"
                 - "/var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator || exit 0"
       - op: remove
-        path: /deploy/helm/hooks/before/3
+        path: /deploy/helm/hooks/before/5
   - name: remote-push
     patches:
       - op: remove

--- a/dp/skaffold.yaml
+++ b/dp/skaffold.yaml
@@ -108,7 +108,9 @@ profiles:
               extraEnv:
                 APP_CONFIG: "TestConfig"
             db_service:
-              enabled: false
+              enabled: true
+              extraEnv:
+                APP_CONFIG: "TestConfig"
       - op: add
         path: /deploy/kubectl/flags
         value:

--- a/dp/tools/deployment/tests/test_runner_deployment.yml
+++ b/dp/tools/deployment/tests/test_runner_deployment.yml
@@ -9,7 +9,7 @@ metadata:
 spec:
   restartPolicy: Never
   initContainers:
-    - name:  wait-for-elasticsearch
+    - name: wait-for-elasticsearch
       image: curlimages/curl
       command: ['sh', '-c', "until curl -sf http://elasticsearch:9200/_cluster/health; do echo \"waiting for elasticsearch...\"; sleep 0.2; done"]
   containers:

--- a/dp/tools/deployment/tests/test_runner_deployment.yml
+++ b/dp/tools/deployment/tests/test_runner_deployment.yml
@@ -1,37 +1,36 @@
 ---
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Pod
 metadata:
-  name: test-runner-job
+  name: test-runner
+  labels:
+    name: test-runner
+    type: integration-tests
 spec:
-  template:
-    metadata:
-      labels:
-        app: test-runner
-        type: integration-tests
-      name: test-runner-pod
-    spec:
-      restartPolicy: Never
-      containers:
-        - image: test_runner_image
-          name: test-runner
-          imagePullPolicy: IfNotPresent
-          command: ["python"]
-          args: ["-m", "pytest", "-vvv", "-s", "-m", "local", "--junit-xml=/backend/test_runner/test-results/test_report.xml", "tests"]
-          volumeMounts:
-            - name: test-results
-              mountPath: /backend/test_runner/test-results
-            - name: certificates
-              mountPath: /backend/test_runner/certs
-              readOnly: true
-      volumes:
+  restartPolicy: Never
+  initContainers:
+    - name:  wait-for-elasticsearch
+      image: curlimages/curl
+      command: ['sh', '-c', "until curl -sf http://elasticsearch:9200/_cluster/health; do echo \"waiting for elasticsearch...\"; sleep 0.2; done"]
+  containers:
+    - image: test_runner_image
+      name: test-runner
+      imagePullPolicy: IfNotPresent
+      command: ["python"]
+      args: ["-m", "pytest", "-vvv", "-s", "-m", "local", "--junit-xml=/backend/test_runner/test-results/test_report.xml", "tests"]
+      volumeMounts:
         - name: test-results
-          hostPath:
-            path: /tmp/integration-tests-results
-            type: DirectoryOrCreate
+          mountPath: /backend/test_runner/test-results
         - name: certificates
-          projected:
-            sources:
-              - secret:
-                  name: orc8r-secrets-certs
-  backoffLimit: 10
+          mountPath: /backend/test_runner/certs
+          readOnly: true
+  volumes:
+    - name: test-results
+      hostPath:
+        path: /tmp/integration-tests-results
+        type: DirectoryOrCreate
+    - name: certificates
+      projected:
+        sources:
+          - secret:
+              name: orc8r-secrets-certs

--- a/dp/tools/deployment/tests/test_runner_deployment_orc8r.yml
+++ b/dp/tools/deployment/tests/test_runner_deployment_orc8r.yml
@@ -9,7 +9,7 @@ metadata:
 spec:
   restartPolicy: Never
   initContainers:
-    - name:  wait-for-elasticsearch
+    - name: wait-for-elasticsearch
       image: curlimages/curl
       command: ['sh', '-c', "until curl -sf http://elasticsearch:9200/_cluster/health; do echo \"waiting for elasticsearch...\"; sleep 0.2; done"]
   containers:

--- a/dp/tools/deployment/tests/test_runner_deployment_orc8r.yml
+++ b/dp/tools/deployment/tests/test_runner_deployment_orc8r.yml
@@ -1,37 +1,36 @@
 ---
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Pod
 metadata:
-  name: test-runner-job-orc8r
+  name: test-runner-orc8r
+  labels:
+    name: test-runner-orc8r
+    type: integration-tests
 spec:
-  template:
-    metadata:
-      labels:
-        app: test-runner
-        type: integration-tests
-      name: test-runner-pod
-    spec:
-      restartPolicy: Never
-      containers:
-        - image: test_runner_image
-          name: test-runner-orc8
-          imagePullPolicy: IfNotPresent
-          command: ["python"]
-          args: ["-m", "pytest", "-vvv", "-s", "-m", "orc8r", "--junit-xml=/backend/test_runner/test-results/test_report.xml", "tests"]
-          volumeMounts:
-            - name: test-results
-              mountPath: /backend/test_runner/test-results
-            - name: certificates
-              mountPath: /backend/test_runner/certs
-              readOnly: true
-      volumes:
+  restartPolicy: Never
+  initContainers:
+    - name:  wait-for-elasticsearch
+      image: curlimages/curl
+      command: ['sh', '-c', "until curl -sf http://elasticsearch:9200/_cluster/health; do echo \"waiting for elasticsearch...\"; sleep 0.2; done"]
+  containers:
+    - image: test_runner_image
+      name: test-runner-orc8
+      imagePullPolicy: IfNotPresent
+      command: ["python"]
+      args: ["-m", "pytest", "-vvv", "-s", "-m", "orc8r", "--junit-xml=/backend/test_runner/test-results/test_report.xml", "tests"]
+      volumeMounts:
         - name: test-results
-          hostPath:
-            path: /tmp/integration-tests-results
-            type: DirectoryOrCreate
+          mountPath: /backend/test_runner/test-results
         - name: certificates
-          projected:
-            sources:
-              - secret:
-                  name: orc8r-secrets-certs
-  backoffLimit: 10
+          mountPath: /backend/test_runner/certs
+          readOnly: true
+  volumes:
+    - name: test-results
+      hostPath:
+        path: /tmp/integration-tests-results
+        type: DirectoryOrCreate
+    - name: certificates
+      projected:
+        sources:
+          - secret:
+              name: orc8r-secrets-certs


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
- Run integration tests only once
- Print  test logs on stdout
- Initcontainer to wait for elasticsearch 


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
