### PR TITLE
fix(mme): Race nearby mme_app_timer_management.

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.hpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.hpp
@@ -21,6 +21,7 @@ extern "C" {
 // C++ includes ------------------------------------------------------------
 #include <czmq.h>
 #include <map>
+#include <mutex>
 #include <utility>
 #include <stddef.h>
 #include <stdint.h>
@@ -34,6 +35,7 @@ typedef timer_arg_t TimerArgType;
 class MmeUeContext {
  private:
   std::map<int, TimerArgType> mme_app_timers;
+  std::mutex mme_app_timers_lock;
   MmeUeContext() : mme_app_timers(){};
 
  public:


### PR DESCRIPTION
mme_app_start_timer() introduced in 4b98ca08996 relaced timer_setup().
Alike timer_setup(), mme_app_start_timer() uses internal structure
`mme_app_timers' to hold all timers registered by the application.
Unlike timer_setup(), new code doesn't take a lock on the modified
structure `mme_app_timers' using it in multithreading environment.

As starting and stopping timers is a quite infrequent event, previously
it didn't fire with noticable frequency.

 == How it looks in gdb ==
(gdb) p mme_app_timers
$12 = std::map with 220 elements = {
 [15] = 15556,
 [16] = 15557,
...
 [1752] = 10710,
 [1757] = 19622,
 [1759] = 19795,
 [1760] = 19408<error reading variable: Cannot access memory at address 0x18>
 ...
}
(gdb)

 == 4b98ca08996 / master ==
-  if (timer_setup(
-          ue_context_p->initial_context_setup_rsp_timer.sec, 0, TASK_MME_APP,
-          INSTANCE_DEFAULT, TIMER_ONE_SHOT, &timer_callback_fun,
-          sizeof(timer_callback_fun),
-          &(ue_context_p->initial_context_setup_rsp_timer.id)) < 0) {
+  if ((ue_context_p->initial_context_setup_rsp_timer.id = mme_app_start_timer(
+           ue_context_p->initial_context_setup_rsp_timer.sec * 1000,
+           TIMER_REPEAT_ONCE,
+           mme_app_handle_initial_context_setup_rsp_timer_expiry,
+           ue_context_p->mme_ue_s1ap_id)) == -1) {

== old timer-start function implementation details ==
int timer_setup(
    uint32_t interval_sec, uint32_t interval_us, task_id_t task_id,
    int32_t instance, timer_type_t type, void* timer_arg, size_t arg_size,
    long* timer_id) {
  ...
  /*
   * Lock the queue and insert the timer at the tail
   */
  pthread_mutex_lock(&timer_desc.timer_list_mutex);
  STAILQ_INSERT_TAIL(&timer_desc.timer_queue, timer_p, entries);
  pthread_mutex_unlock(&timer_desc.timer_list_mutex);
  return 0;
}

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
