### PR TITLE
docs(readme): correct link to community page

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Magma's usage docs, and developer docs, are available at [https://docs.magmacore
 
 ## Join the Magma community
 
-See the [Community](https://www.magmacore.org/community/) page for entry points.
+See the [Community](https://magmacore.org/join-the-open-source-community/) page for entry points.
 
 Start by joining the community on Slack: [magmacore workspace](https://slack.magmacore.org/).
 


### PR DESCRIPTION
The link to the community page in README was pointing to 404
(https://magmacore.org/community/).
Update the link to point to a working page:
https://magmacore.org/join-the-open-source-community/