### PR TITLE
docs: correct link to community page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Magma's usage docs, and developer docs, are available at [https://docs.magmacore
 
 ## Join the Magma community
 
-See the [Community](https://www.magmacore.org/community/) page for entry points.
+See the [Community](https://magmacore.org/join-the-open-source-community/) page for entry points.
 
 Start by joining the community on Slack: [magmacore workspace](https://slack.magmacore.org/).
 


### PR DESCRIPTION
The link to the community page in README was pointing to 404
(https://magmacore.org/community/).
Update the link to point to a working page:
https://magmacore.org/join-the-open-source-community/

Signed-off-by: Ivan Sergiienko <darthvanger@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
