### PR TITLE
fix(amf): PDU-Reject message is not proper for UnsupportedDNN cause s…

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -506,11 +506,13 @@ int amf_smf_process_pdu_session_packet(amf_ue_ngap_id_t ue_id,
       } else {
         OAILOG_INFO(
             LOG_AMF_APP,
-            "DNN is not Supported or not Subscribed, reject with a cause: 91 "
+            "DNN is not Supported or not Subscribed, reject with a cause: 27 "
             "\n");
-        M5GMmCause cause_dnn_reject =
-            M5GMmCause::DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED;
-        rc = handle_sm_message_routing_failure(ue_id, msg, cause_dnn_reject);
+        rc = amf_pdu_session_establishment_reject(
+            ue_id, msg->payload_container.smf_msg.header.pdu_session_id,
+            msg->payload_container.smf_msg.header.procedure_transaction_id,
+            static_cast<uint8_t>(M5GSmCause::MISSING_OR_UNKNOWN_DNN));
+
         ue_context->amf_context.smf_ctxt_map.erase(
             msg->payload_container.smf_msg.header.pdu_session_id);
         return rc;


### PR DESCRIPTION
PDU-Reject message is not proper for Unsupported DNN cause sent from AMF 

Signed-off-by: Rajeshs23 <rajesh.sure@wavelabs.ai>

## Summary
Issues Handled:
 AMF is sending PDU-Request for PDU-Reject Unsupported DNN .AMF should sent PDU-Reject , 
 instead of PDU-Request.
 Changes are made, unit test case is written for missing_dnn(test_pdu_unknown_dnn_missing_dnn) and test cases are passing .
tested Using UERANSIM and seen amf sending PDU session reject message.  
![missing_dnn_test_case](https://user-images.githubusercontent.com/91061578/163943772-816fcec1-4f2f-472f-9aa5-00fd44b673c8.PNG)
 

## Test Plan
-Tested using UERANSIM
-Unit testing

## Additional Information

![rejectcaue=se](https://user-images.githubusercontent.com/91061578/164253265-55b1103d-f42f-4c27-b79c-20356f0ac4c2.PNG)
These are the cases handling. Above the case is for the Cause 27.
corresponding zenhub taskid  #12478 
 
![pdusessionreject](https://user-images.githubusercontent.com/91061578/163796617-9b8b16c6-3434-4f54-a35f-9fe56732e232.png)
