### PR TITLE
fix(mme): check entire supported TA list

### DIFF
--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_ta.c
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_ta.c
@@ -122,6 +122,7 @@ static int s1ap_mme_compare_tac(const S1ap_TAC_t* const tac) {
 int s1ap_mme_compare_ta_lists(S1ap_SupportedTAs_t* ta_list) {
   int i;
   int tac_ret, bplmn_ret;
+  int tac_matches = 0, bplmn_matches = 0;
 
   DevAssert(ta_list != NULL);
 
@@ -137,17 +138,25 @@ int s1ap_mme_compare_ta_lists(S1ap_SupportedTAs_t* ta_list) {
     bplmn_ret = s1ap_mme_compare_plmns(&ta->broadcastPLMNs);
 
     if (tac_ret == TA_LIST_NO_MATCH && bplmn_ret == TA_LIST_NO_MATCH) {
-      return TA_LIST_UNKNOWN_PLMN + TA_LIST_UNKNOWN_TAC;
-    } else {
-      if (tac_ret > TA_LIST_NO_MATCH && bplmn_ret == TA_LIST_NO_MATCH) {
-        return TA_LIST_UNKNOWN_PLMN;
-      } else if (tac_ret == TA_LIST_NO_MATCH && bplmn_ret > TA_LIST_NO_MATCH) {
-        return TA_LIST_UNKNOWN_TAC;
-      }
+      continue;
+    }
+
+    if (tac_ret > TA_LIST_NO_MATCH && bplmn_ret == TA_LIST_NO_MATCH) {
+      tac_matches++;
+    } else if (tac_ret == TA_LIST_NO_MATCH && bplmn_ret > TA_LIST_NO_MATCH) {
+      bplmn_matches++;
+    } else if (tac_ret > TA_LIST_NO_MATCH && bplmn_ret > TA_LIST_NO_MATCH) {
+      return TA_LIST_RET_OK;
     }
   }
 
-  return TA_LIST_RET_OK;
+  if (tac_matches > 0) {
+    return TA_LIST_UNKNOWN_PLMN;
+  } else if (bplmn_matches > 0) {
+    return TA_LIST_UNKNOWN_TAC;
+  }
+
+  return TA_LIST_UNKNOWN_TAC + TA_LIST_UNKNOWN_PLMN;
 }
 
 /* @brief compare PLMNs

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -62,14 +62,9 @@ s1aptests/test_enb_partial_reset_con_dereg.py \
 s1aptests/test_enb_partial_reset.py \
 s1aptests/test_nas_non_delivery_for_auth.py \
 s1aptests/test_outoforder_attach_complete_ICSR.py \
-<<<<<<< HEAD
 s1aptests/test_s1setup_failure_incorrect_plmn.py \
 s1aptests/test_s1setup_failure_incorrect_tac.py \
-=======
-s1aptests/test_s1setup_incorrect_plmn.py \
-s1aptests/test_s1setup_incorrect_tac.py \
-s1aptests/test_s1setup_secondary_plmn.py \
->>>>>>> 794d7850c (fix(mme): check entire supported TA list)
+s1aptests/test_s1setup_success_secondary_plmn.py \
 s1aptests/test_sctp_abort_after_auth_req.py \
 s1aptests/test_sctp_abort_after_identity_req.py \
 s1aptests/test_sctp_abort_after_smc.py \

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -62,8 +62,14 @@ s1aptests/test_enb_partial_reset_con_dereg.py \
 s1aptests/test_enb_partial_reset.py \
 s1aptests/test_nas_non_delivery_for_auth.py \
 s1aptests/test_outoforder_attach_complete_ICSR.py \
+<<<<<<< HEAD
 s1aptests/test_s1setup_failure_incorrect_plmn.py \
 s1aptests/test_s1setup_failure_incorrect_tac.py \
+=======
+s1aptests/test_s1setup_incorrect_plmn.py \
+s1aptests/test_s1setup_incorrect_tac.py \
+s1aptests/test_s1setup_secondary_plmn.py \
+>>>>>>> 794d7850c (fix(mme): check entire supported TA list)
 s1aptests/test_sctp_abort_after_auth_req.py \
 s1aptests/test_sctp_abort_after_identity_req.py \
 s1aptests/test_sctp_abort_after_smc.py \

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1setup_success_secondary_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1setup_success_secondary_plmn.py
@@ -13,8 +13,6 @@ limitations under the License.
 
 import ctypes
 import unittest
-import time
-import os
 
 import s1ap_types
 from integ_tests.s1aptests.s1ap_utils import S1ApUtil

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1setup_success_secondary_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1setup_success_secondary_plmn.py
@@ -1,0 +1,89 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import ctypes
+import unittest
+import time
+import os
+
+import s1ap_types
+from integ_tests.s1aptests.s1ap_utils import S1ApUtil
+
+
+class TestS1SetupSuccessSecondBPLMN(unittest.TestCase):
+    def setUp(self):
+        self._s1_util = S1ApUtil()
+
+    def tearDown(self):
+        print("************************* Sending SCTP SHUTDOWN")
+        self._s1_util.issue_cmd(s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None)
+        self._s1_util.cleanup()
+
+    def test_s1setup_secondary_plmn(self):
+        """ S1 Setup with multiple bPLMN IDs, the second being valid. """
+
+        print("************************* Enb tester configuration")
+        req = s1ap_types.FwNbConfigReq_t()
+
+        req.cellId_pr.pres = True
+        req.cellId_pr.cell_id = 1
+
+        req.plmnId_pr.pres = True
+        req.plmnId_pr.plmn_id = (ctypes.c_ubyte * 6).from_buffer_copy(
+            bytearray(b"333333"),
+        )
+
+        req.suppTAs.pres = True
+        req.suppTAs.numTAs = 1
+        req.suppTAs.suppTA[0].tac = 1
+        req.suppTAs.suppTA[0].bPlmnList.numBPlmns = 2
+
+        # 333333 - invalid MCC/MNC
+        req.suppTAs.suppTA[0].bPlmnList.bPlmn[0].numMncDigits = 3
+        req.suppTAs.suppTA[0].bPlmnList.bPlmn[0].mcc = (ctypes.c_ubyte * 3).from_buffer_copy(
+            bytearray(b"\x03\x03\x03"),
+        )
+        req.suppTAs.suppTA[0].bPlmnList.bPlmn[0].mnc = (ctypes.c_ubyte * 3).from_buffer_copy(
+            bytearray(b"\x03\x03\x03"),
+        )
+
+        # 00101 - Valid MCC/MNC
+        req.suppTAs.suppTA[0].bPlmnList.bPlmn[1].numMncDigits = 2
+        req.suppTAs.suppTA[0].bPlmnList.bPlmn[1].mcc = (ctypes.c_ubyte * 3).from_buffer_copy(
+            bytearray(b"\x00\x00\x01"),
+        )
+        req.suppTAs.suppTA[0].bPlmnList.bPlmn[1].mnc = (ctypes.c_ubyte * 3).from_buffer_copy(
+            bytearray(b"\x00\x01\x00"),
+        )
+
+        print("************************* Sending ENB configuration Request")
+        assert self._s1_util.issue_cmd(s1ap_types.tfwCmd.ENB_CONFIG, req) == 0
+        response = self._s1_util.get_response()
+        assert response.msg_type == s1ap_types.tfwCmd.ENB_CONFIG_CONFIRM.value
+        res = response.cast(s1ap_types.FwNbConfigCfm_t)
+        assert res.status == s1ap_types.CfgStatus.CFG_DONE.value
+
+        print("************************* Sending S1-setup Request")
+        req = None
+        assert (
+            self._s1_util.issue_cmd(s1ap_types.tfwCmd.ENB_S1_SETUP_REQ, req)
+            == 0
+        )
+        response = self._s1_util.get_response()
+        assert response.msg_type == s1ap_types.tfwCmd.ENB_S1_SETUP_RESP.value
+        res = response.cast(s1ap_types.FwNbS1setupRsp_t)
+        assert res.res == s1ap_types.S1_setp_Result.S1_SETUP_SUCCESS.value
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: Josiah White <me@josiahwhite.io>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

Fixed a bug in the MME where an S1 setup request with multiple broadcast PLMNs would be rejected if the first PLMN did not match the configured PLMN.

This PR changes the checking so that the MME will accept the S1 setup request as long as a single item matches the configured PLMNs and TAC in the MME configuration.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

Verified with existing integration tests, added an additional test for this situation.
Confirmed with pcap before and after that this problem is solved.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

The supplied test case will not succeed until the S1APTester code has been patched to properly handle the `suppTA` parameter. The S1APTester PR has been opened here: https://github.com/magma/S1APTester/pull/74
