### PR TITLE
chore: bazelified python services are tested for missing modules

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -221,6 +221,15 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel run //:check_starlark_format
+      - name: Test python services for missing modules
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ env.DEVCONTAINER_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/
+          run: |
+            cd /workspaces/magma
+            bazel/scripts/test_python_service_imports.sh
       - name: Build space left after run
         shell: bash
         run: |

--- a/bazel/scripts/test_python_service_imports.sh
+++ b/bazel/scripts/test_python_service_imports.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -euo pipefail
+
+###############################################################################
+# FUNCTION DECLARATIONS
+###############################################################################
+
+help() {
+    echo "Tests all python services for missing imports or the ones found in"
+    echo "the specified directory (recursively), or one single service if a"
+    echo "service name is provided."
+    echo "Usage:"
+    echo "   $(basename "$0")  # test all python services in the magma repository"
+    echo "   $(basename "$0") path_to_services_directory/"
+    echo "   $(basename "$0") path_to_services_directory:service_name"
+    exit 1
+}
+
+collect_services() {
+    if [[ "${SERVICE_PATH}" == *":"* ]];
+    then
+        echo "Single service specified:"
+        SERVICES=( "${SERVICE_PATH}" )
+    else
+        echo "Multiple services specified:"
+        mapfile -t SERVICES < <(bazel query "attr(main, main.py, kind(py_binary, //${SERVICE_PATH}...))")
+    fi
+    if [[ "${#SERVICES[@]}" -eq 0 ]];
+    then
+        echo "ERROR: No services found."
+        help
+        exit 1
+    fi
+    for SERVICE in "${SERVICES[@]}"
+    do
+        echo "${SERVICE}"
+    done
+}
+
+print_summary() {
+    local NUM_SUCCESS=$1
+    local TOTAL_TESTS=$2
+    echo "SUMMARY: ${NUM_SUCCESS}/${TOTAL_TESTS} succeeded."
+    for SERVICE in "${!TEST_RESULTS[@]}"
+    do
+        RESULT=${TEST_RESULTS[${SERVICE}]}
+        RESULT="${RESULT#ModuleNotFoundError: }"
+        echo "  ${SERVICE}: ${RESULT}"
+    done
+}
+
+###############################################################################
+# SCRIPT SECTION
+###############################################################################
+
+SERVICE_PATH="${1:-}"
+
+echo "Collecting services"
+declare -a SERVICES
+declare -A TEST_RESULTS
+LOGGING_FILE="/tmp/test_import_logging.log"
+NUM_SUCCESS=0
+
+collect_services
+
+for SERVICE in "${SERVICES[@]}"
+do
+    echo "Building service: ${SERVICE}"
+    bazel build "${SERVICE}"
+    echo "Testing service: ${SERVICE}"
+    if timeout --preserve-status 5 bazel run "${SERVICE}" 2>&1  | tee "${LOGGING_FILE}";
+    then
+        echo "Service successfully started."
+        NUM_SUCCESS=$((NUM_SUCCESS + 1))
+        TEST_RESULTS["${SERVICE}"]="PASSED"
+    else
+        echo "Checking if ModuleNotFoundError is present in logs."
+        RESULT=$(grep -m 1 "ModuleNotFoundError" "${LOGGING_FILE}" || [[ $? == 1 ]])
+        if [[ "${RESULT}" != "" ]];
+        then
+            echo "ModuleNotFoundError found in logs from ${SERVICE}:"
+            echo "${RESULT}"
+            TEST_RESULTS["${SERVICE}"]="${RESULT}"
+        else
+            echo "ModuleNotFoundError not found in logs from ${SERVICE}:"
+            NUM_SUCCESS=$((NUM_SUCCESS + 1))
+            TEST_RESULTS["${SERVICE}"]="PASSED"
+        fi
+    fi
+    echo -e "\n################################################################################\n"
+done
+
+print_summary "${NUM_SUCCESS}" "${#SERVICES[@]}"
+
+[[ "${NUM_SUCCESS}" == "${#SERVICES[@]}" ]]


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

## Summary

The bazelified python services can be built successfully with bazel, but this does not mean that every necessary module is imported. The script provided here starts up these services and looks for `ModuleNotFoundError` in the logs. The script is added to the CI pipeline inside the "Bazel Build & Test" job.

## Test Plan

To test all python services:
`bazel/scripts/test_python_service_imports.sh`
To test all python services inside a provided directory (recursively):
`bazel/scripts/test_python_service_imports.sh  lte/gateway/python/magma/`
To test a single specified service:
`bazel/scripts/test_python_service_imports.sh  lte/gateway/python/magma/monitord:monitord`
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
