### PR TITLE
chore: update envoy config file to use API v3

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/envoy.yaml
+++ b/lte/gateway/deploy/roles/magma/files/envoy.yaml
@@ -8,33 +8,43 @@ admin:
 dynamic_resources:
   ads_config:
     api_type: GRPC
+    transport_api_version: V3
     grpc_services:
-    - envoy_grpc:
-        cluster_name: xds_cluster
-  cds_config:
-    api_config_source:
-      api_type: GRPC
-      grpc_services:
       - envoy_grpc:
           cluster_name: xds_cluster
+  cds_config:
+    resource_api_version: V3
+    api_config_source:
+      transport_api_version: V3
+      api_type: GRPC
+      grpc_services:
+        - envoy_grpc:
+            cluster_name: xds_cluster
       set_node_on_first_message_only: true
   lds_config:
+    resource_api_version: V3
     api_config_source:
+      transport_api_version: V3
       api_type: GRPC
       grpc_services:
-      - envoy_grpc:
-          cluster_name: xds_cluster
+        - envoy_grpc:
+            cluster_name: xds_cluster
       set_node_on_first_message_only: true
 node:
   cluster: service_greeter
   id: test-id
 static_resources:
   clusters:
-  - connect_timeout: 1s
-    hosts:
-    - socket_address:
-        address: 10.5.0.2
-        port_value: 18000
-    http2_protocol_options: {}
-    name: xds_cluster
-    type: STATIC
+    - connect_timeout: 1s
+      load_assignment:
+        cluster_name: xds_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 10.5.0.2
+                      port_value: 18000
+      http2_protocol_options: {}
+      name: xds_cluster
+      type: STATIC

--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_dp_envoy.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_dp_envoy.service
@@ -19,7 +19,7 @@ Type=simple
 EnvironmentFile=/etc/environment
 # Add delay to let envoy-controller init
 ExecStartPre=/bin/sleep 40
-ExecStart=/sbin/ip netns exec envoy_ns1 /usr/bin/envoy --bootstrap-version 2 -c /var/opt/magma/envoy.yaml --log-path /var/log/envoy.log
+ExecStart=/sbin/ip netns exec envoy_ns1 /usr/bin/envoy -c /var/opt/magma/envoy.yaml --log-path /var/log/envoy.log
 MemoryAccounting=yes
 StandardOutput=syslog
 StandardError=syslog

--- a/lte/gateway/python/magma/pipelined/tests/envoy-tests/envoy-cntr-prod.yaml
+++ b/lte/gateway/python/magma/pipelined/tests/envoy-tests/envoy-cntr-prod.yaml
@@ -8,33 +8,43 @@ admin:
 dynamic_resources:
   ads_config:
     api_type: GRPC
+    transport_api_version: V3
     grpc_services:
-    - envoy_grpc:
-        cluster_name: xds_cluster
-  cds_config:
-    api_config_source:
-      api_type: GRPC
-      grpc_services:
       - envoy_grpc:
           cluster_name: xds_cluster
+  cds_config:
+    resource_api_version: V3
+    api_config_source:
+      transport_api_version: V3
+      api_type: GRPC
+      grpc_services:
+        - envoy_grpc:
+            cluster_name: xds_cluster
       set_node_on_first_message_only: true
   lds_config:
+    resource_api_version: V3
     api_config_source:
+      transport_api_version: V3
       api_type: GRPC
       grpc_services:
-      - envoy_grpc:
-          cluster_name: xds_cluster
+        - envoy_grpc:
+            cluster_name: xds_cluster
       set_node_on_first_message_only: true
 node:
   cluster: service_greeter
   id: test-id
 static_resources:
   clusters:
-  - connect_timeout: 1s
-    hosts:
-    - socket_address:
-        address: 10.5.0.2
-        port_value: 18000
-    http2_protocol_options: {}
-    name: xds_cluster
-    type: STATIC
+    - connect_timeout: 1s
+      load_assignment:
+        cluster_name: xds_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 10.5.0.2
+                      port_value: 18000
+      http2_protocol_options: {}
+      name: xds_cluster
+      type: STATIC


### PR DESCRIPTION
## Summary

After upgrading envoy/go-control-plane to use API v3 in #12227 this PR adapts `envoy.yaml` config file to use API v3. It adds respective config options (see [How to configure envoy to use v3 api](https://www.envoyproxy.io/docs/envoy/latest/faq/api/envoy_v3#how-do-i-configure-envoy-to-use-the-v3-api)) and supersedes the deprecated `hosts` field with its successor `load_assignment` (see [documentation](https://www.envoyproxy.io/docs/envoy/v1.17.4/api-v2/api/v2/cluster.proto#envoy-api-msg-cluster) and [example](https://www.envoyproxy.io/docs/envoy/latest/start/quick-start/configuration-static)).

Identical changes are made to [envoy-cntr-prod.yaml](https://github.com/magma/magma/blob/master/lte/gateway/python/magma/pipelined/tests/envoy-tests/envoy-cntr-prod.yaml).

Also deletes `--bootstrap-version 2` flag from service definition (https://github.com/envoyproxy/envoy/issues/16456).

## Test Plan

- [x] validate config

`envoy --mode validate -c $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/envoy.yaml` returns `OK` without warnings about deprecated fields. 

- [x] pass HE integ tests locally:

s1aptests/test_attach_detach_with_he_policy.py
s1aptests/test_attach_detach_rar_tcp_he.py
Note, that the _rar_tcp_he.py test doesn't pass consistently. Sometimes `GTP_PORT` is `None` and the test fails. To be able to run the test in these cases one can manually set it to `3` or set `ovs_multi_tunnel: false` in `spgw.yml`.

## Additional Information

For changes to take effect in the VM one has to copy config and service files with 
`sudo cp $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/envoy.yaml /var/opt/magma/envoy.yaml` and `sudo cp $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/systemd/magma_dp_envoy.service /etc/systemd/system/magma_dp@envoy.service` (or provision the VM).