### PR TITLE
feat(pipelined): QFI value Set in RYU

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/patches/0002-QFI-value-set-in-Openflow-controller-using-RYU.patch
+++ b/lte/gateway/deploy/roles/magma/files/patches/0002-QFI-value-set-in-Openflow-controller-using-RYU.patch
@@ -1,0 +1,41 @@
+From 82cb817858258fab69aabf5c3ed007f28d0aa0d3 Mon Sep 17 00:00:00 2001
+From: Prabina Pattnaik <prabinak@wavelabs.ai>
+Date: Wed, 20 Apr 2022 13:53:50 +0530
+Subject: [PATCH] QFI value set in Openflow controller using RYU
+
+Signed-off-by: Prabina Pattnaik <prabinak@wavelabs.ai>
+---
+ ryu/ofproto/nicira_ext.py |  3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/ryu/ofproto/nicira_ext.py b/ryu/ofproto/nicira_ext.py
+index 9c2d2aaf..7c5f9ef4 100644
+--- a/ryu/ofproto/nicira_ext.py
++++ b/ryu/ofproto/nicira_ext.py
+@@ -435,6 +435,7 @@ NXM_NX_PKT_MARK_W = nxm_header_w(0x0001, 33, 4)
+ NXM_NX_TCP_FLAGS = nxm_header(0x0001, 34, 2)
+ NXM_NX_TCP_FLAGS_W = nxm_header_w(0x0001, 34, 2)
+ 
++NXM_NX_QFI = nxm_header(0x0001, 126, 1)
+ 
+ def nxm_nx_reg(idx):
+     return nxm_header(0x0001, idx, 4)
+@@ -632,6 +633,7 @@ reg<idx>         Integer 32bit   Packet register.
+                                  <idx> is register number 0-15.
+ xxreg<idx>       Integer 128bit  Packet extended-extended register.
+                                  <idx> is register number 0-3.
++qfi              Integer 8bit    QFI Value Set.
+ ================ =============== ==============================================
+ 
+ .. Note::
+@@ -709,6 +711,7 @@ oxm_types = [
+     oxm_fields.NiciraExtended1('ct_label', 108, type_desc.Int16),
+     oxm_fields.NiciraExtended1('tun_ipv6_src', 109, type_desc.IPv6Addr),
+     oxm_fields.NiciraExtended1('tun_ipv6_dst', 110, type_desc.IPv6Addr),
++    oxm_fields.NiciraExtended1("qfi", 126, type_desc.Int1),
+ 
+     # Prefix the name with '_' to indicate this is not intended to be used
+     # in wild.
+-- 
+2.11.0
+

--- a/lte/gateway/deploy/roles/magma/files/patches/0003-QFI-value-set-in-Openflow-controller-using-RYU.patch
+++ b/lte/gateway/deploy/roles/magma/files/patches/0003-QFI-value-set-in-Openflow-controller-using-RYU.patch
@@ -1,0 +1,59 @@
+diff --git a/ryu/ofproto/nx_match.py b/ryu/ofproto/nx_match.py
+index 6d886853..81b32c43 100644
+--- a/ryu/ofproto/nx_match.py
++++ b/ryu/ofproto/nx_match.py
+@@ -44,6 +44,7 @@ FWW_ARP_SHA = 1 << 3
+ FWW_ARP_THA = 1 << 6
+ FWW_IPV6_LABEL = 1 << 7
+ FWW_NW_TTL = 1 << 8
++FWW_QFI = 1 << 9
+ FWW_ALL = (1 << 13) - 1
+ 
+ FLOW_NW_FRAG_ANY = 1 << 0
+@@ -94,6 +95,7 @@ class Flow(ofproto_parser.StringifyMixin):
+         self.ipv6_label = 0
+         self.pkt_mark = 0
+         self.tcp_flags = 0
++        self.qfi = 0
+ 
+ 
+ class FlowWildcards(ofproto_parser.StringifyMixin):
+@@ -318,6 +320,10 @@ class ClsRule(ofproto_parser.StringifyMixin):
+         self.flow.tcp_flags = tcp_flags
+         self.wc.tcp_flags_mask = mask
+ 
++    def set_qfi(self, qfi):
++        self.wc.wildcards &= ~FWW_QFI
++        self.flow.qfi = qfi
++
+     def flow_format(self):
+         # Tunnel ID is only supported by NXM
+         if self.wc.tun_id_mask != 0:
+@@ -959,6 +965,16 @@ class MFPktMark(MFField):
+ 
+ 
+ @_register_make
++@_set_nxm_headers([ofproto_v1_0.NXM_NX_QFI])
++class MFPQfi(MFField):
++    @classmethod
++    def make(cls, header):
++        return cls(header, MF_PACK_STRING_8)
++
++    def put(self, buf, offset, rule):
++        return self.put(buf, offset, rule.flow.qfi)
++
++@_register_make
+ @_set_nxm_headers([ofproto_v1_0.NXM_NX_TCP_FLAGS,
+                    ofproto_v1_0.NXM_NX_TCP_FLAGS_W])
+ class MFTcpFlags(MFField):
+@@ -1159,6 +1175,10 @@ def serialize_nxm_match(rule, buf, offset):
+             header = ofproto_v1_0.NXM_NX_TUN_ID_W
+         offset += nxm_put(buf, offset, header, rule)
+ 
++    # QFI Value
++    if not rule.wc.wildcards & FWW_QFI:
++         offset += nxm_put(buf, offset, ofproto_v1_0.NXM_NX_QFI, rule)
++
+     # XXX: Cookie
+ 
+     for i in range(FLOW_N_REGS):

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -428,11 +428,15 @@
   copy:
     src: patches/0002-QFI-value-set-in-Openflow-controller-using-RYU.patch
     dest: /home/vagrant/build/python/lib/python3.8/site-packages/ryu/ofproto/nicira_ext.py
+  when: full_provision
+  ignore_errors: true
 
 - name: Copy ryu qfi patch2 for 3.8
   copy:
     src: patches/0003-QFI-value-set-in-Openflow-controller-using-RYU.patch
     dest: /home/vagrant/build/python/lib/python3.8/site-packages/ryu/ofproto/nx_match.py
+  when: full_provision
+  ignore_errors: true
 
 - name: Change build folder ownership
   ansible.builtin.file:

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -424,6 +424,16 @@
   when: full_provision
   ignore_errors: true
 
+- name: Copy ryu qfi patch1 for 3.8
+  copy:
+    src: patches/0002-QFI-value-set-in-Openflow-controller-using-RYU.patch
+    dest: /home/vagrant/build/python/lib/python3.8/site-packages/ryu/ofproto/nicira_ext.py
+
+- name: Copy ryu qfi patch2 for 3.8
+  copy:
+    src: patches/0003-QFI-value-set-in-Openflow-controller-using-RYU.patch
+    dest: /home/vagrant/build/python/lib/python3.8/site-packages/ryu/ofproto/nx_match.py
+
 - name: Change build folder ownership
   ansible.builtin.file:
     path: /home/vagrant/build

--- a/orc8r/gateway/python/python.mk
+++ b/orc8r/gateway/python/python.mk
@@ -66,6 +66,14 @@ py_patches:
 	&&  (patch -N -s -f $(SITE_PACKAGES_DIR)/ryu/ofproto/nx_actions.py <$(PATCHES_DIR)/0001-Set-unknown-dpid-ofctl-log-to-debug.patch && echo "ryu was patched" ) \
 	|| ( true && echo "skipping ryu patch since it was already applied")
 
+	patch --dry-run -N -s -f $(SITE_PACKAGES_DIR)/ryu/ofproto/nicira_ext.py <$(PATCHES_DIR)/0002-QFI-value-set-in-Openflow-controller-using-RYU.patch 2>/dev/null \
+	&&  (patch -N -s -f $(SITE_PACKAGES_DIR)/ryu/ofproto/nicira_ext.py <$(PATCHES_DIR)/0002-QFI-value-set-in-Openflow-controller-using-RYU.patch && echo "ryu was patched" ) \
+	|| ( true && echo "skipping ryu patch since it was already applied")
+	
+	patch --dry-run -N -s -f $(SITE_PACKAGES_DIR)/ryu/ofproto/nx_match.py <$(PATCHES_DIR)/0003-QFI-value-set-in-Openflow-controller-using-RYU.patch 2>/dev/null \
+ 	&&  (patch -N -s -f $(SITE_PACKAGES_DIR)/ryu/ofproto/nx_match.py <$(PATCHES_DIR)/0003-QFI-value-set-in-Openflow-controller-using-RYU.patch && echo "ryu was patched" ) \
+	|| ( true && echo "skipping ryu patch since it was already applied")
+
 	$(VIRT_ENV_PIP_INSTALL) --force-reinstall git+https://github.com/URenko/aioh2.git
 
 swagger:: swagger_prereqs $(SWAGGER_LIST)


### PR DESCRIPTION
Signed-off-by: prabina pattnaik <prabinak@wavelabs.ai>

## Summary
QFI value set in open-flow controller using RYU.
For QFI functionality support in OVS Datapath for GTP tunnel, following tasks are consider for it:
1) QFI value set in MATCH criteria for Uplink flows
2) QFI value set in ACTION criteria for Downlink flows

## Test Plan


## Additional Information

