### PR TITLE
fix(orc8r): make polling for service specs parallel

### DIFF
--- a/orc8r/cloud/go/parallel/map.go
+++ b/orc8r/cloud/go/parallel/map.go
@@ -22,17 +22,23 @@ const (
 	DefaultNumWorkers = 10
 )
 
+// TODO(maxhbr): use generics after go update to 1.18
 type Func func(In) (Out, error)
 type In interface{}
 type Out interface{}
 
-// MapString is same as Map but for strings.
+// MapString is same as Map but for strings to strings.
 func MapString(items []string, nWorkers int, f Func) ([]string, error) {
-	var inps []In
+	var inputs []In
 	for _, s := range items {
-		inps = append(inps, s)
+		inputs = append(inputs, s)
 	}
-	outsI, err := Map(inps, nWorkers, f)
+	return MapInToString(inputs, nWorkers, f)
+}
+
+// MapInToString is same as Map but for []In to strings.
+func MapInToString(inputs []In, nWorkers int, f Func) ([]string, error) {
+	outsI, err := Map(inputs, nWorkers, f)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

This fixes a small todo created by @hcgatewood, where the polling of service specs should be parallelized so that the timeouts of 5secs do not accumulate. They might in the worst case exceed the parent timeout of 60secs. This is related to #7477.

## Test Plan

If polling of a service fails, that result is empty in the array. To test that this is handled, the file `empty.yml` was added to the corresponding testdata.
