### PR TITLE
chore: kernsnoopd is bazelified

### DIFF
--- a/lte/gateway/python/magma/kernsnoopd/BUILD.bazel
+++ b/lte/gateway/python/magma/kernsnoopd/BUILD.bazel
@@ -1,0 +1,57 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+MAGMA_ROOT = "../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+py_binary(
+    name = "kernsnoopd",
+    srcs = ["main.py"],
+    data = [
+        "ebpf/byte_count.bpf.c",
+        "ebpf/common.bpf.h",
+    ],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    # legacy_create_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
+    legacy_create_init = False,
+    main = "main.py",
+    python_version = "PY3",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":kernsnoopd_lib",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
+    ],
+)
+
+py_library(
+    name = "kernsnoopd_lib",
+    srcs = [
+        "handlers.py",
+        "metrics.py",
+        "snooper.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("jinja2"),
+        requirement("psutil"),
+        requirement("prometheus_client"),
+    ],
+)

--- a/lte/gateway/python/magma/kernsnoopd/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/kernsnoopd/tests/BUILD.bazel
@@ -1,0 +1,24 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:python_test.bzl", "pytest_test")
+
+MAGMA_ROOT = "../../../../../../"
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+pytest_test(
+    name = "byte_counter_tests",
+    size = "small",
+    srcs = ["byte_counter_tests.py"],
+    imports = [LTE_ROOT],
+    deps = ["//lte/gateway/python/magma/kernsnoopd:kernsnoopd_lib"],
+)


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

kernsnoopd python service is migrated to bazel (including tests).
Note: kernsnoopd needs to be enabled manually by modifying `lte/gateway/configs/kernsnoopd.yml` (line 22).
With this modification this service only runs on the virtual machine with `sudo`.

## Test Plan

* CI
* `bazel test lte/gateway/python/magma/kernsnoopd/...`
* `bazel run lte/gateway/python/magma/kernsnoopd`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
