### PR TITLE
docs: fix "howtos/pcap" broken link in sidebar

### DIFF
--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -19,7 +19,6 @@
           "howtos/ipv6_agw",
           "howtos/he_api",
           "howtos/inbound_roaming",
-          "howtos/pcap",
           "howtos/l3_transport",
           "howtos/network_probe"
         ]

--- a/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
@@ -16,8 +16,7 @@
           "version-1.6.X-howtos/call_tracing",
           "version-1.6.X-howtos/events_monitoring",
           "version-1.6.X-howtos/he_api",
-          "version-1.6.X-howtos/inbound_roaming",
-          "version-1.6.X-howtos/pcap"
+          "version-1.6.X-howtos/inbound_roaming"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -19,7 +19,6 @@
           "version-1.7.0-howtos/ipv6_agw",
           "version-1.7.0-howtos/he_api",
           "version-1.7.0-howtos/inbound_roaming",
-          "version-1.7.0-howtos/pcap",
           "version-1.7.0-howtos/l3_transport"
         ]
       },


### PR DESCRIPTION
The `Next` button on the [howtos/inbound_roaming](https://docs.magmacore.org/docs/next/howtos/inbound_roaming) page was linking to
a non-existent `howtos/pcap` page, resulting in `404` error.

The reason was the `howtos/pcap` entry in the `sidebars.json`, which was
added in commit [f23a49653abf82c1e1a2ec8b89dd5cda3f0fcd5f](https://github.com/magma/magma/commit/f23a49653abf82c1e1a2ec8b89dd5cda3f0fcd5f). That commit
added the `resources/ref_pcap.md` file, and a proper link to it in the
`Technical Reference` section of the sidebar. However the `howtos/pcap`
link was also added, probably by mistake, as `howtos/pcap.md` doesn't
exist.

Delete the `howtos/pcap` link in the sidebar to fix the `Next` button
for the preceding `howtos/inbound_roaming` docs page.
The bug was present both in the `v1.7` and `v1.6`, so fix both.

Signed-off-by: Ivan Sergiienko <ivan@freedomfi.com>

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/104149278/164490575-f485e5e6-b175-4aca-9b47-a624991f4c6e.png">

<img width="952" alt="image" src="https://user-images.githubusercontent.com/104149278/164490642-8168c394-052f-4919-9236-474530caa180.png">

