### PR TITLE
ci: Adapt LTE Integ Test VM resources to macOS runners

### DIFF
--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Run the integ test
         run: |
           cd lte/gateway
+          export MAGMA_DEV_CPUS=3
+          export MAGMA_DEV_MEMORY_MB=9216
           fab integ_test
       - name: Get test results
         if: always()

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
      # Enable Dynamic Swap Space to prevent Out of Memory crashes
     config.vm.provision :shell, inline: "swapoff -a && fallocate -l 4G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile && echo '/swapfile none swap sw 0 0' >> /etc/fstab && swapon -a"
     config.vm.provision :shell, inline: "echo vm.swappiness = 10 >> /etc/sysctl.conf && echo vm.vfs_cache_pressure = 50 >> /etc/sysctl.conf && sysctl -p"
-    
+
     magma.vbguest.auto_update = false
 
     # Create a private network, which allows host-only access to the machine
@@ -42,8 +42,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     magma.vm.provider "virtualbox" do |vb|
       vb.name = "magma-dev"
       vb.linked_clone = true
-      vb.customize ["modifyvm", :id, "--memory", "8192"]
-      vb.customize ["modifyvm", :id, "--cpus", "4"]
+      vb.customize ["modifyvm", :id, "--memory", ENV.fetch("MAGMA_DEV_MEMORY_MB", "8192")]
+      vb.customize ["modifyvm", :id, "--cpus", ENV.fetch("MAGMA_DEV_CPUS", "4")]
       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
       vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
     end


### PR DESCRIPTION
## Summary

This is the second attempt at https://github.com/magma/magma/pull/12501 which i had to revert. (I was referring to Github Workflow inputs that only exist in my fork)

## Test Plan

I ran the LTE Integ Test in my fork. I didn't wait for it to complete, but verified that it went past the point that broke in https://github.com/magma/magma/pull/12501.

## Additional Information

- [ ] This change is backwards-breaking