### PR TITLE
chore: add a utility script to generate compilation db with Bazel

### DIFF
--- a/dev_tools/apply-iwyu.sh
+++ b/dev_tools/apply-iwyu.sh
@@ -13,17 +13,26 @@
 ################################################################################
 
 # How to use: 
-# 1. Run `Bzl: Bazel/C++: Generate Compilation Database` in the VSCode command palette (CMD+Shift+P) to generate the compilation database
-# 2. $MAGMA_ROOT/dev_tools/apply-iwyu.sh $PATH_TO_APPLY_IWYU
+# 1. $MAGMA_ROOT/dev_tools/apply-iwyu.sh $PATH_TO_APPLY_IWYU
 #    Ex. $MAGMA_ROOT/dev_tools/apply-iwyu.sh lte/gateway/c/core/common
 SOURCE_CODE_PATH=$1
 
 IWYU_OUTPUT_FILE=/tmp/iwyu-output.txt
 
 echo ""
-echo "[IMPORTANT] Make sure you've run 'Bzl: Bazel/C++: Generate Compilation Database' in VSCode's command palette (CMD+Shift+P) to generate an up-to-date compile_commands.json!"
+echo "Generating /tmp/compile_commands.json ..."
 echo ""
 
-iwyu_tool.py -j "$(nproc --all)" -p "$MAGMA_ROOT"/compile_commands.json "$SOURCE_CODE_PATH" -- -Xiwyu --mapping_file="$MAGMA_ROOT"/dev_tools/iwyu.imp | tee "$IWYU_OUTPUT_FILE"
+dev_tools/gen_compilation_database.py --output_dir=/tmp
+
+echo ""
+echo "Piping IWYU output into /tmp/iwyu-output.txt ..."
+echo ""
+
+iwyu_tool.py -j "$(nproc --all)" -p /tmp/compile_commands.json "$SOURCE_CODE_PATH" -- -Xiwyu --mapping_file="$MAGMA_ROOT"/dev_tools/iwyu.imp | tee "$IWYU_OUTPUT_FILE"
+
+echo ""
+echo "Applying /tmp/iwyu-output.txt ..."
+echo ""
 
 fix_includes.py < "$IWYU_OUTPUT_FILE" -b --reorder

--- a/dev_tools/gen_compilation_database.py
+++ b/dev_tools/gen_compilation_database.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script was modified from github.com/envoyproxy/envoy
+# See https://github.com/envoyproxy/envoy/blob/dca672af515029d36ddfc378480e3041f4d3a9f3/tools/gen_compilation_database.py
+
+# The original script does not work for our repository, so I've made some changes to the compile_commands combination logic.
+# Other than that, I also removed logic that was specific to envoyproxy.
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+
+# This method is equivalent to https://github.com/grailbio/bazel-compilation-database/blob/master/generate.py
+def generate_compilation_database(args):
+    subprocess.check_call(
+        ["bazel", "build"] + [
+            "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
+            "--output_groups=compdb_files,header_files",
+        ] + args.bazel_targets,
+    )
+
+    execroot = subprocess.check_output(
+        ["bazel", "info", "execution_root"],
+    ).decode().strip()
+
+    db_entries = []
+    for db in Path(execroot).glob('**/*.compile_commands.json'):
+        raw_commands = db.read_text().splitlines()
+        for raw_command in raw_commands:
+            db_entries.append(json.loads(raw_command.rstrip(',')))
+
+    def replace_execroot_marker(db_entry):
+        if 'directory' in db_entry and db_entry['directory'] == '__EXEC_ROOT__':
+            db_entry['directory'] = execroot
+        if 'command' in db_entry:
+            db_entry['command'] = (
+                db_entry['command'].replace('-isysroot __BAZEL_XCODE_SDKROOT__', '')
+            )
+        return db_entry
+
+    return list(map(replace_execroot_marker, db_entries))
+
+
+def is_header(filename):
+    for ext in (".h", ".hh", ".hpp", ".hxx"):
+        if filename.endswith(ext):
+            return True
+    return False
+
+
+def modify_compile_command(target, args):
+    cc, options = target["command"].split(" ", 1)
+
+    # # Workaround for bazel added C++11 options, those doesn't affect build itself but
+    # # clang-tidy will misinterpret them.
+    options = options.replace("-std=c++0x ", "")
+    options = options.replace("-std=c++14 ", "")
+    # clang-tidy does not recognize this flag
+    options = options.replace("-fno-canonical-system-headers ", "")
+
+    # Visual Studio Code doesn't seem to like "-iquote". Replace it with
+    # old-style "-I".
+    options = options.replace("-iquote ", "-I ")
+
+    if is_header(target["file"]):
+        options += " -Wno-pragma-once-outside-header -Wno-unused-const-variable"
+        options += " -Wno-unused-function"
+
+    target["command"] = " ".join([cc, options])
+    return target
+
+
+def fix_compilation_database(args, db):
+    db = [modify_compile_command(target, args) for target in db]
+    out = args.output_dir + "/compile_commands.json"
+    print("Generated compile db: " + out)
+    with open(out, "w") as db_file:
+        json.dump(db, db_file, indent=2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Generate JSON compilation database')
+    parser.add_argument(
+        'bazel_targets',
+        nargs='*',
+        default=[
+            "//lte/gateway/c/...",
+            "//orc8r/gateway/c/...",
+        ],
+    )
+    parser.add_argument(
+        '--output_dir',
+        default=os.getenv('MAGMA_ROOT'),
+        help="Directory where compile_commands.json should be generated. Default value is $MAGMA_ROOT",
+        action='store',
+    )
+    args = parser.parse_args()
+    fix_compilation_database(args, generate_compilation_database(args))


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
We currently rely on a VSCode plug in to generate the compilation_commands.json file with Bazel. While this useful, if we want to enable IWYU / clang-tidy based checks in CI, we will need a separate script to handle this. This PR provides a script that can generate a compilation db without relying on the plugin :)

I based this script off of a script that the envoy proxy team created. (https://github.com/envoyproxy/envoy/blob/dca672af515029d36ddfc378480e3041f4d3a9f3/tools/gen_compilation_database.py) They use an apache 2 license, so I copied that into the file and mentioned which commit I copied off of.

I am thinking it might be good have the script run everytime a devcontainer is opened so that we skip a manual step in IDE configuration, but I will think about that a bit more.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
I ran `dev_tools/gen_compilation_database.py` and made sure a compile_commands.json file is enabled. I ran the clangd plugin against it to double check it is a valid output.
I ran `dev_tools/gen_compilation_database.py --output_dir=/tmp` and ran the apply-iwyu script against it to also double check it is a valid DB.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
