### PR TITLE
chore(cwg): removing vulnerable github.com/moby/moby package version

### DIFF
--- a/cwf/k8s/cwf_operator/go.mod
+++ b/cwf/k8s/cwf_operator/go.mod
@@ -53,8 +53,6 @@ require (
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
 
-	github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309 // Required by Helmgithub.com/openshift/api => github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad // Required until https://github.com/operator-framework/operator-lifecycle-manager/pull/1241 is resolved
-
 	k8s.io/api => k8s.io/api v0.18.2
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.2
 	k8s.io/apimachinery => k8s.io/apimachinery v0.18.2


### PR DESCRIPTION
Signed-off-by: Kristijan <spikey979@gmail.com>

chore(cwg): removing vulnerable github.com/moby/moby package version

## Summary

Currently using package github.com/moby/moby v0.7.3, for which there is an dependabot alert:

Docker Engine before 1.6.1 allows local users to set arbitrary Linux Security Modules (LSM) and docker_t policies via an image that allows volumes to override files in /proc. 
Upgrade package to pathced version 1.6.1.

Since github.com/docker/docker v20.10.1 is used, there is no need for line “github.com/docker/docker => github.com/moby/moby v0.7.3” in the “replace” section. So this part has been removed.


## Test Plan

I ran /magma/feg/gateway/docker/ ./build.py -c and 
/magma/orc8r/cloud/docker/  ./build.py -c

## Additional Information

This is for dependabot alert: 
https://github.com/magma/magma/security/dependabot/163
