### PR TITLE
chore(dp): Move desired state from active mode config to cbsd

### DIFF
--- a/dp/cloud/go/services/dp/storage/cbsd_manager.go
+++ b/dp/cloud/go/services/dp/storage/cbsd_manager.go
@@ -133,28 +133,18 @@ func (c *cbsdManagerInTransaction) createCbsdWithActiveModeConfig(networkId stri
 	if err != nil {
 		return err
 	}
-	data.StateId = db.MakeInt(unregisteredState)
-	data.NetworkId = db.MakeString(networkId)
-	columns := append(getCbsdWriteFields(), "state_id", "network_id")
-	id, err := db.NewQuery().
-		WithBuilder(c.builder).
-		From(data).
-		Select(db.NewIncludeMask(columns...)).
-		Insert()
-	if err != nil {
-		return err
-	}
 	registeredState, err := c.cache.getValue(c.builder, &DBCbsdState{}, "registered")
 	if err != nil {
 		return err
 	}
+	data.StateId = db.MakeInt(unregisteredState)
+	data.DesiredStateId = db.MakeInt(registeredState)
+	data.NetworkId = db.MakeString(networkId)
+	columns := append(getCbsdWriteFields(), "state_id", "desired_state_id", "network_id")
 	_, err = db.NewQuery().
 		WithBuilder(c.builder).
-		From(&DBActiveModeConfig{
-			CbsdId:         db.MakeInt(id),
-			DesiredStateId: db.MakeInt(registeredState),
-		}).
-		Select(db.NewIncludeMask("cbsd_id", "desired_state_id")).
+		From(data).
+		Select(db.NewIncludeMask(columns...)).
 		Insert()
 	return err
 }
@@ -248,7 +238,7 @@ func buildDetailedCbsdQuery(builder sq.StatementBuilderType) *db.Query {
 	return db.NewQuery().
 		WithBuilder(builder).
 		From(&DBCbsd{}).
-		Select(db.NewExcludeMask("network_id", "state_id",
+		Select(db.NewExcludeMask("network_id", "state_id", "desired_state_id",
 			"is_deleted", "should_deregister", "grant_attempts")).
 		Join(db.NewQuery().
 			From(&DBCbsdState{}).

--- a/dp/cloud/go/services/dp/storage/models.go
+++ b/dp/cloud/go/services/dp/storage/models.go
@@ -207,6 +207,7 @@ type DBCbsd struct {
 	Id                      sql.NullInt64
 	NetworkId               sql.NullString
 	StateId                 sql.NullInt64
+	DesiredStateId          sql.NullInt64
 	CbsdId                  sql.NullString
 	UserId                  sql.NullString
 	FccId                   sql.NullString
@@ -228,6 +229,7 @@ func (c *DBCbsd) Fields() []db.BaseType {
 		db.IntType{X: &c.Id},
 		db.StringType{X: &c.NetworkId},
 		db.IntType{X: &c.StateId},
+		db.IntType{X: &c.DesiredStateId},
 		db.StringType{X: &c.CbsdId},
 		db.StringType{X: &c.UserId},
 		db.StringType{X: &c.FccId},
@@ -259,6 +261,11 @@ func (c *DBCbsd) GetMetadata() *db.ModelMetadata {
 			},
 			{
 				Name:     "state_id",
+				SqlType:  sqorc.ColumnTypeInt,
+				Relation: CbsdStateTable,
+			},
+			{
+				Name:     "desired_state_id",
 				SqlType:  sqorc.ColumnTypeInt,
 				Relation: CbsdStateTable,
 			},
@@ -337,45 +344,6 @@ func (c *DBCbsd) GetMetadata() *db.ModelMetadata {
 		},
 		CreateObject: func() db.Model {
 			return &DBCbsd{}
-		},
-	}
-}
-
-type DBActiveModeConfig struct {
-	Id             sql.NullInt64
-	CbsdId         sql.NullInt64
-	DesiredStateId sql.NullInt64
-}
-
-func (amc *DBActiveModeConfig) Fields() []db.BaseType {
-	return []db.BaseType{
-		db.IntType{X: &amc.Id},
-		db.IntType{X: &amc.CbsdId},
-		db.IntType{X: &amc.DesiredStateId},
-	}
-}
-
-func (amc *DBActiveModeConfig) GetMetadata() *db.ModelMetadata {
-	return &db.ModelMetadata{
-		Table: ActiveModeConfigTable,
-		Properties: []*db.Field{
-			{
-				Name:    "id",
-				SqlType: sqorc.ColumnTypeInt,
-			},
-			{
-				Name:     "cbsd_id",
-				SqlType:  sqorc.ColumnTypeInt,
-				Relation: CbsdTable,
-			},
-			{
-				Name:     "desired_state_id",
-				SqlType:  sqorc.ColumnTypeInt,
-				Relation: CbsdStateTable,
-			},
-		},
-		CreateObject: func() db.Model {
-			return &DBActiveModeConfig{}
 		},
 	}
 }

--- a/dp/cloud/go/services/dp/storage/models_test.go
+++ b/dp/cloud/go/services/dp/storage/models_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestFields(t *testing.T) {
 	dbGrant := &storage.DBGrant{}
-	dbActiveModeConfig := &storage.DBActiveModeConfig{}
 	dbCbsd := &storage.DBCbsd{}
 	dbCbsdState := &storage.DBCbsdState{}
 	dbGrantState := &storage.DBGrantState{}
@@ -74,6 +73,7 @@ func TestFields(t *testing.T) {
 				db.IntType{X: &dbCbsd.Id},
 				db.StringType{X: &dbCbsd.NetworkId},
 				db.IntType{X: &dbCbsd.StateId},
+				db.IntType{X: &dbCbsd.DesiredStateId},
 				db.StringType{X: &dbCbsd.CbsdId},
 				db.StringType{X: &dbCbsd.UserId},
 				db.StringType{X: &dbCbsd.FccId},
@@ -88,15 +88,6 @@ func TestFields(t *testing.T) {
 				db.IntType{X: &dbCbsd.NumberOfPorts},
 				db.BoolType{X: &dbCbsd.IsDeleted},
 				db.BoolType{X: &dbCbsd.ShouldDeregister},
-			},
-		},
-		{
-			name:  "check field names for DBActiveModeConfig",
-			model: dbActiveModeConfig,
-			expected: []db.BaseType{
-				db.IntType{X: &dbActiveModeConfig.Id},
-				db.IntType{X: &dbActiveModeConfig.CbsdId},
-				db.IntType{X: &dbActiveModeConfig.DesiredStateId},
 			},
 		},
 	}
@@ -227,6 +218,11 @@ func TestGetMetadata(t *testing.T) {
 						Relation: storage.CbsdStateTable,
 					},
 					{
+						Name:     "desired_state_id",
+						SqlType:  sqorc.ColumnTypeInt,
+						Relation: storage.CbsdStateTable,
+					},
+					{
 						Name:     "cbsd_id",
 						SqlType:  sqorc.ColumnTypeText,
 						Nullable: true,
@@ -297,29 +293,6 @@ func TestGetMetadata(t *testing.T) {
 						SqlType:      sqorc.ColumnTypeBool,
 						HasDefault:   true,
 						DefaultValue: false,
-					},
-				},
-			},
-		},
-		{
-			name:  "check ModelMetadata structure for DBActiveModeConfig",
-			model: &storage.DBActiveModeConfig{},
-			expected: db.ModelMetadata{
-				Table: storage.ActiveModeConfigTable,
-				Properties: []*db.Field{
-					{
-						Name:    "id",
-						SqlType: sqorc.ColumnTypeInt,
-					},
-					{
-						Name:     "cbsd_id",
-						SqlType:  sqorc.ColumnTypeInt,
-						Relation: storage.CbsdTable,
-					},
-					{
-						Name:     "desired_state_id",
-						SqlType:  sqorc.ColumnTypeInt,
-						Relation: storage.CbsdStateTable,
 					},
 				},
 			},

--- a/dp/cloud/python/magma/configuration_controller/tests/unit/test_dp_logs.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/test_dp_logs.py
@@ -44,6 +44,7 @@ class DPLogsTestCase(LocalDBTestCase):
         cbsd_state = DBCbsdState(name='some_cbsd_state')
         cbsd = DBCbsd(
             state=cbsd_state,
+            desired_state=cbsd_state,
             fcc_id=SOME_FCC_ID,
             cbsd_serial_number=SOME_SERIAL_NUMBER,
             network_id=SOME_NETWORK_ID,

--- a/dp/cloud/python/magma/configuration_controller/tests/unit/test_request_consumer.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/test_request_consumer.py
@@ -95,6 +95,7 @@ class RegistrationDBConsumerTestCase(LocalDBTestCase):
                     id=int(i),
                     cbsd_id=f"foo{i}",
                     state=test_state,
+                    desired_state=test_state,
                     user_id="test_user",
                     fcc_id=f"test_fcc_id{i}",
                     cbsd_serial_number=f"test_serial_nr{i}",

--- a/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
@@ -191,6 +191,7 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
             cbsd_serial_number=CBSD_SERIAL_NR,
             grant_attempts=INITIAL_GRANT_ATTEMPTS,
             state=self._get_db_enum(DBCbsdState, CbsdStates.REGISTERED.value),
+            desired_state=self._get_db_enum(DBCbsdState, CbsdStates.REGISTERED.value),
         )
         request = DBRequest(
             type=self._get_db_enum(DBRequestType, message_type),
@@ -467,6 +468,7 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
             cbsd_serial_number=serial_number,
             user_id=user_id,
             state=cbsd_state,
+            desired_state=cbsd_state,
         )
 
         self.session.add(cbsd)

--- a/dp/cloud/python/magma/db_service/migrations/versions/e793671a19a6_.py
+++ b/dp/cloud/python/magma/db_service/migrations/versions/e793671a19a6_.py
@@ -1,0 +1,82 @@
+"""empty message
+
+Revision ID: e793671a19a6
+Revises: 9cd338f28663
+Create Date: 2022-04-22 14:41:00.038838
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'e793671a19a6'
+down_revision = '9cd338f28663'
+branch_labels = None
+depends_on = None
+
+cbsds = sa.table(
+    'cbsds',
+    sa.column('id', sa.Integer),
+    sa.column('desired_state_id', sa.Integer),
+)
+
+active_mode_configs = sa.table(
+    'active_mode_configs',
+    sa.column('cbsd_id', sa.Integer),
+    sa.column('desired_state_id', sa.Integer),
+)
+
+cbsd_states = sa.table(
+    'cbsd_states',
+    sa.column('id', sa.Integer),
+    sa.column('name', sa.String),
+)
+
+
+def upgrade():
+    """
+    Run upgrade
+    """
+    op.add_column('cbsds', sa.Column('desired_state_id', sa.Integer()))
+    op.execute(
+        cbsds.update().
+        values(
+            desired_state_id=sa.select(cbsd_states.c.id).
+            where(cbsd_states.c.name == 'unregistered').
+            scalar_subquery(),
+        ),
+    )
+    op.execute(
+        cbsds.update().
+        values(desired_state_id=active_mode_configs.c.desired_state_id).
+        where(cbsds.c.id == active_mode_configs.c.cbsd_id),
+    )
+    op.alter_column('cbsds', 'desired_state_id', nullable=False)
+    op.create_foreign_key(None, 'cbsds', 'cbsd_states', ['desired_state_id'], ['id'], ondelete='CASCADE')
+    op.drop_table('active_mode_configs')
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    """
+    Run downgrade
+    """
+    op.create_table(
+        'active_mode_configs',
+        sa.Column('id', sa.INTEGER(), autoincrement=True, nullable=False),
+        sa.Column('cbsd_id', sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column('desired_state_id', sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column('created_date', postgresql.TIMESTAMP(timezone=True), server_default=sa.text('statement_timestamp()'), autoincrement=False, nullable=False),
+        sa.Column('updated_date', postgresql.TIMESTAMP(timezone=True), server_default=sa.text('statement_timestamp()'), autoincrement=False, nullable=True),
+        sa.ForeignKeyConstraint(['cbsd_id'], ['cbsds.id'], name='active_mode_configs_cbsd_id_fkey', ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['desired_state_id'], ['cbsd_states.id'], name='active_mode_configs_desired_state_id_fkey', ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id', name='active_mode_configs_pkey'),
+        sa.UniqueConstraint('cbsd_id', name='active_mode_configs_cbsd_id_key'),
+    )
+    op.execute(
+        active_mode_configs.insert().
+        from_select(['cbsd_id', 'desired_state_id'], sa.select(cbsds.c.id, cbsds.c.desired_state_id)),
+    )
+    op.drop_column('cbsds', 'desired_state_id')
+    # ### end Alembic commands ###

--- a/dp/cloud/python/magma/radio_controller/services/radio_controller/service.py
+++ b/dp/cloud/python/magma/radio_controller/services/radio_controller/service.py
@@ -96,7 +96,7 @@ class RadioControllerService(RadioControllerServicer):
     def _get_cbsd_filters(self, request_name: str, request_payload: Dict) -> List:
         return get_cbsd_filter_strategies[request_name](request_payload)
 
-    # TODO extract this so it can be used by other grpc services
+    # TODO remove this (cbsds should not be created implicitly)
     def _create_cbsd(self, session: Session, request_payload: Dict, cbsd_id: Optional[str]):
         cbsd_state = session.query(DBCbsdState).filter(
             DBCbsdState.name == CbsdStates.UNREGISTERED.value,
@@ -107,6 +107,7 @@ class RadioControllerService(RadioControllerServicer):
         cbsd = DBCbsd(
             cbsd_id=cbsd_id,
             state=cbsd_state,
+            desired_state=cbsd_state,
             user_id=user_id,
             fcc_id=fcc_id,
             cbsd_serial_number=cbsd_serial_number,

--- a/dp/cloud/python/magma/radio_controller/tests/test_utils/db_cbsd_builder.py
+++ b/dp/cloud/python/magma/radio_controller/tests/test_utils/db_cbsd_builder.py
@@ -4,13 +4,7 @@ import json
 from datetime import datetime
 from typing import List
 
-from magma.db_service.models import (
-    DBActiveModeConfig,
-    DBCbsd,
-    DBChannel,
-    DBGrant,
-    DBRequest,
-)
+from magma.db_service.models import DBCbsd, DBChannel, DBGrant, DBRequest
 
 
 class DBCbsdBuilder:
@@ -62,11 +56,8 @@ class DBCbsdBuilder:
         self.cbsd.grant_attempts = grant_attempts
         return self
 
-    def with_active_mode_config(self, desired_state_id: int) -> DBCbsdBuilder:
-        config = DBActiveModeConfig(
-            desired_state_id=desired_state_id,
-        )
-        self.cbsd.active_mode_config.append(config)
+    def with_desired_state(self, desired_state_id: int) -> DBCbsdBuilder:
+        self.cbsd.desired_state_id = desired_state_id
         return self
 
     def with_preferences(self, bandwidth_mhz: int, frequencies_mhz: List[int]) -> DBCbsdBuilder:

--- a/dp/cloud/python/magma/radio_controller/tests/unit/test_active_mode_controller_service.py
+++ b/dp/cloud/python/magma/radio_controller/tests/unit/test_active_mode_controller_service.py
@@ -74,7 +74,7 @@ class ActiveModeControllerTestCase(LocalDBTestCase):
             with_state(self.unregistered). \
             with_registration('some'). \
             with_eirp_capabilities(0, 10, 20, 1). \
-            with_active_mode_config(self.registered)
+            with_desired_state(self.registered)
 
     @staticmethod
     def _prepare_base_active_mode_config() -> ActiveModeCbsdBuilder:
@@ -296,14 +296,14 @@ class ActiveModeControllerServerTestCase(ActiveModeControllerTestCase):
             with_state(self.unregistered). \
             with_registration('some'). \
             with_eirp_capabilities(0, 10, 20, 1). \
-            with_active_mode_config(self.registered). \
+            with_desired_state(self.registered). \
             build()
         other_cbsd = DBCbsdBuilder(). \
             with_id(OTHER_ID). \
             with_state(self.registered). \
             with_registration('other'). \
             with_eirp_capabilities(5, 15, 25, 3). \
-            with_active_mode_config(self.registered). \
+            with_desired_state(self.registered). \
             build()
         self.session.add_all([some_cbsd, other_cbsd])
         self.session.commit()
@@ -327,25 +327,11 @@ class ActiveModeControllerServerTestCase(ActiveModeControllerTestCase):
         actual = self.amc_service.GetState(GetStateRequest(), None)
         self.assertEqual(expected, actual)
 
-    def test_not_get_state_without_active_mode_config(self):
-        cbsd = DBCbsdBuilder(). \
-            with_state(self.unregistered). \
-            with_registration('some'). \
-            with_eirp_capabilities(0, 10, 20, 1). \
-            build()
-        self.session.add(cbsd)
-        self.session.commit()
-
-        expected = State()
-
-        actual = self.amc_service.GetState(GetStateRequest(), None)
-        self.assertEqual(expected, actual)
-
     def test_not_get_state_without_registration_params(self):
         cbsd = DBCbsdBuilder(). \
             with_state(self.unregistered). \
             with_eirp_capabilities(0, 10, 20, 1). \
-            with_active_mode_config(self.registered). \
+            with_desired_state(self.registered). \
             build()
         self.session.add(cbsd)
         self.session.commit()
@@ -359,7 +345,7 @@ class ActiveModeControllerServerTestCase(ActiveModeControllerTestCase):
         cbsd = DBCbsdBuilder(). \
             with_state(self.unregistered). \
             with_registration('some'). \
-            with_active_mode_config(self.registered). \
+            with_desired_state(self.registered). \
             build()
         self.session.add(cbsd)
         self.session.commit()

--- a/dp/cloud/python/magma/radio_controller/tests/unit/test_dp_logs.py
+++ b/dp/cloud/python/magma/radio_controller/tests/unit/test_dp_logs.py
@@ -35,6 +35,7 @@ class DPLogsTestCase(LocalDBTestCase):
         cbsd_state = DBCbsdState(name='some_cbsd_state')
         cbsd = DBCbsd(
             state=cbsd_state,
+            desired_state=cbsd_state,
             fcc_id=SOME_FCC_ID,
             cbsd_serial_number=SOME_SERIAL_NUMBER,
             network_id=SOME_NETWORK_ID,

--- a/dp/cloud/python/magma/radio_controller/tests/unit/test_radio_controller_service.py
+++ b/dp/cloud/python/magma/radio_controller/tests/unit/test_radio_controller_service.py
@@ -1,5 +1,3 @@
-import json
-
 import testing.postgresql
 from magma.db_service.db_initialize import DBInitializer
 from magma.db_service.models import DBCbsd, DBCbsdState, DBChannel, DBRequest
@@ -123,7 +121,7 @@ class RadioControllerTestCase(LocalDBTestCase):
     ])
     def test_channels_not_deleted_when_new_spectrum_inquiry_request_arrives(self, number_of_channels):
         # Given
-        cbsd = DBCbsd(id=1, cbsd_id="foo1", state=self.unregistered_state)
+        cbsd = DBCbsd(id=1, cbsd_id="foo1", state=self.unregistered_state, desired_state=self.unregistered_state)
 
         self._create_channels_for_cbsd(cbsd, number_of_channels)
 


### PR DESCRIPTION
## Summary
Move desired state from active mode config to cbsd.
Also remove active mode config table.

## Test Plan
Migrations tested manually, since we don't have automated migration tests yet.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>
