### PR TITLE
chore(ci): bazel workflows use the bazel base image

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -18,6 +18,7 @@ concurrency:
 
 env:
   DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 
@@ -181,10 +182,10 @@ jobs:
           BAZEL_CACHE_CUTOFF_MB: 6000
         run: |
           ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
-      - name: Setup Devcontainer Image
+      - name: Setup Bazel Base Image
         uses: addnab/docker-run-action@v2
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the devontainer image!"
@@ -192,22 +193,22 @@ jobs:
         uses: addnab/docker-run-action@v2
         with:
           shell: bash
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          options: -v ${{ github.workspace }}:/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
-            cd /workspaces/magma
+            cd /magma
             mkdir -p c-cpp-test-results/
             echo "created c-cpp-test-results/ directory"
       - name: Run `bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* --config=asan`
         uses: addnab/docker-run-action@v2
         with:
           shell: bash
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          options: -v ${{ github.workspace }}:/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
-            cd /workspaces/magma
+            cd /magma
             bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* --config=asan --test_output=errors --cache_test_results=no
             TEST_RESULT=$?
             # copy out test results
@@ -375,6 +376,13 @@ jobs:
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the devontainer image!"
+      - name: Setup Bazel Base Image
+        uses: addnab/docker-run-action@v2
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the bazel base image!"
             bazel # pull down bazel, if bazel download fails we can fail before we do all the lengthy work below
       - name: Run codecov with CMake (MME)
         if: always()
@@ -391,9 +399,9 @@ jobs:
         if: always()
         uses: addnab/docker-run-action@v2
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          options: -v ${{ github.workspace }}:/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
             cd $MAGMA_ROOT
             # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
     # Run four times a day to build bazel cache
     - cron: '0 0,6,12,18 * * *'
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
   CACHE_SUB_KEY_BUILD_ALL: build-all
@@ -115,22 +115,22 @@ jobs:
           BAZEL_CACHE_REPO_CUTOFF_MB: 600
         run: |
           ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_REPO_DIR" "$BAZEL_CACHE_REPO_CUTOFF_MB"
-      - name: Setup Devcontainer Image
+      - name: Setup Bazel Base Image
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           options: --pull always
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
-            echo "Pulled the devontainer image!"
+            echo "Pulled the bazel base image!"
       - name: Run `bazel build //...`
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/
+          options: -v ${{ github.workspace }}:/magma/
           run: |
-            cd /workspaces/magma
+            cd /magma
             bazel build //...
       - name: Build space left after run
         shell: bash
@@ -195,40 +195,40 @@ jobs:
         run: |
           ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
       # Letting the Build job above handle cache clean up for bazel-cache-repo
-      - name: Setup Devcontainer Image
+      - name: Setup Bazel Base Image
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           options: --pull always
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
-            echo "Pulled the devontainer image!"
+            echo "Pulled the bazel base image!"
       - name: Run `bazel test //...`
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          options: -v ${{ github.workspace }}:/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
-            cd /workspaces/magma
+            cd /magma
             bazel test //... --test_output=errors --cache_test_results=no
       - name: Run `bazel run //:check_starlark_format`
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/
+          options: -v ${{ github.workspace }}:/magma/
           run: |
-            cd /workspaces/magma
+            cd /magma
             bazel run //:check_starlark_format
       - name: Test python services for missing modules
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/
+          options: -v ${{ github.workspace }}:/magma/
           run: |
-            cd /workspaces/magma
+            cd /magma
             bazel/scripts/test_python_service_imports.sh
       - name: Build space left after run
         shell: bash

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -22,7 +22,7 @@ on:
       - reopened
       - synchronize
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
   CACHE_SUB_KEY: build-warnings
@@ -93,13 +93,13 @@ jobs:
           BAZEL_CACHE_CUTOFF_MB: 5000
         run: |
           ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
-      - name: Setup Devcontainer Image
+      - name: Setup Bazel Base Image
         uses: addnab/docker-run-action@v2
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
-            echo "Pulled the devontainer image!"
+            echo "Pulled the bazel base image!"
       - name: Fetch list of changed files
         # I am using mmagician fork of get-changed-files (forked from jitterbit/get-changed-files)
         #   Rationale: our workflow (merge branch into upstream master) is incompatible
@@ -111,11 +111,11 @@ jobs:
       - name: Build and Apply GCC Problem Matcher
         uses: addnab/docker-run-action@v2
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma
+          options: -v ${{ github.workspace }}:/magma
           run: |
-            cd /workspaces/magma
+            cd /magma
             ./.github/workflows/generate-gcc-warnings.sh "${{ steps.changed_files.outputs.all }}"
       - name: Load problem matcher
         # If needed https://github.com/microsoft/vscode-cpptools/issues/2266 for path fixups
@@ -130,10 +130,10 @@ jobs:
       - name: Cat compilation log (filtered by file names)
         uses: addnab/docker-run-action@v2
         with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
+          image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma
-          run: cat /workspaces/magma/filtered-compile.log
+          options: -v ${{ github.workspace }}:/magma
+          run: cat /magma/filtered-compile.log
       - name: Store build_logs_c_full_log Artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Currently the devcontainer image is used for Bazel CI workflows. This has the disadvantage that pre-installed libraries can be conflicting the hermetic(-ish) build process of Bazel. We should use the leaner Bazel base image for the workflows.

Another advantage of the Bazel Base image is that less pre-installed libraries makes it more easy to switch to an ARM based image. See https://github.com/magma/magma/issues/12532.

Note that `bazel-cache-push.yml` was not adapted because s3 caches for the github code-space feature are created here, i.e., it makes complete sense to do this in the devcontainer image. 

## Test Plan

* CI
* `bazel.yml`, `agw-workflow.yml`, `gcc-problems.yml` have been run successfully on the forked repo -> https://github.com/nstng/magma/actions

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
