### PR TITLE
feat(nms): Move network switcher into topbar

### DIFF
--- a/nms/app/components/MenuButton.js
+++ b/nms/app/components/MenuButton.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import React from 'react';
+import {colors, shadows} from '../theme/default';
+import {withStyles} from '@material-ui/core/styles';
+
+import type {Node} from 'react';
+
+const StyledMenu = withStyles({
+  paper: {
+    border: `1px solid ${colors.button.lightOutline}`,
+    boxShadow: shadows.DP3,
+  },
+})(props => (
+  <Menu
+    elevation={0}
+    getContentAnchorEl={null}
+    anchorOrigin={{
+      vertical: 'bottom',
+      horizontal: 'center',
+    }}
+    transformOrigin={{
+      vertical: 'top',
+      horizontal: 'center',
+    }}
+    {...props}
+  />
+));
+
+type Props = {|
+  label: string,
+  children: Node,
+  'data-testid'?: string,
+  size?: 'small' | 'medium' | 'large',
+  className?: string,
+|};
+
+export default function MenuButton(props: Props) {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [minWidth, setMinWidth] = React.useState(null);
+
+  const onButtonClick = event => {
+    setMinWidth(event.currentTarget.getBoundingClientRect().width);
+    setAnchorEl(event.currentTarget);
+  };
+  const onClose = () => {
+    setAnchorEl(null);
+    setMinWidth(null);
+  };
+
+  const {children, label, ...passthroughProps} = props;
+  return (
+    <div>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={onButtonClick}
+        endIcon={<ArrowDropDownIcon />}
+        {...passthroughProps}>
+        {label}
+      </Button>
+      <StyledMenu
+        PaperProps={{style: {minWidth}}}
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={onClose}>
+        {children}
+      </StyledMenu>
+    </div>
+  );
+}

--- a/nms/app/components/TopBar.js
+++ b/nms/app/components/TopBar.js
@@ -22,12 +22,11 @@ import React from 'react';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import Text from '../theme/design-system/Text';
-import VersionContext from './context/VersionContext';
 
+import NetworkSelector from './NetworkSelector';
 import {GetCurrentTabPos} from './TabUtils';
 import {colors} from '../theme/default';
 import {makeStyles} from '@material-ui/styles';
-import {useContext} from 'react';
 import {useResolvedPath} from 'react-router-dom';
 
 const useStyles = makeStyles(theme => ({
@@ -80,7 +79,6 @@ export default function TopBar(props: Props) {
     pathname,
     props.tabs.map(tab => tab.to),
   );
-  const {nmsVersion, orc8rVersion} = useContext(VersionContext);
   function tabLabel(label, icon) {
     const Icon = icon;
 
@@ -102,18 +100,7 @@ export default function TopBar(props: Props) {
           <Grid item xs>
             <Text variant="body2">{props.header}</Text>
           </Grid>
-          <Grid item xs>
-            <div className={classes.versionText}>
-              <Text variant="overline" weight="light">
-                {'NMS: ' + nmsVersion}
-              </Text>
-            </div>
-            <div className={classes.versionText}>
-              <Text variant="overline" weight="light">
-                {'Orc8r: ' + orc8rVersion}
-              </Text>
-            </div>
-          </Grid>
+          <NetworkSelector />
         </Grid>
       </div>
       {props.tabs.length > 0 && (

--- a/nms/app/components/__tests__/NetworkSelector-test.js
+++ b/nms/app/components/__tests__/NetworkSelector-test.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strit-local
+ * @format
+ */
+
+import 'jest-dom/extend-expect';
+import MagmaAPIBindings from '../../../generated/MagmaAPIBindings';
+import NetworkContext from '../context/NetworkContext';
+import NetworkSelector from '../NetworkSelector';
+import React from 'react';
+import {AppContextProvider} from '../../../fbc_js_core/ui/context/AppContext';
+import {LTE} from '../../../fbc_js_core/types/network';
+import {MemoryRouter} from 'react-router-dom';
+import {SnackbarProvider} from 'notistack';
+
+// $FlowFixMe Upgrade react-testing-library
+import {fireEvent, render, waitFor} from '@testing-library/react';
+
+import type {Node} from 'react';
+
+jest.mock('../../../generated/MagmaAPIBindings');
+
+const Wrapper = (props: {
+  currentNetworkId?: string,
+  children: Node,
+  isSuperUser: boolean,
+}) => {
+  global.CONFIG = {
+    appData: {
+      user: {
+        isSuperUser: props.isSuperUser,
+      },
+    },
+  };
+
+  return (
+    <MemoryRouter initialEntries={['/nms']} initialIndex={0}>
+      <SnackbarProvider>
+        <AppContextProvider>
+          <NetworkContext.Provider
+            value={{
+              networkId: props.currentNetworkId,
+            }}>
+            {props.children}
+          </NetworkContext.Provider>
+        </AppContextProvider>
+      </SnackbarProvider>
+    </MemoryRouter>
+  );
+};
+
+describe('NetworkSelector', () => {
+  it('renders nothing without network for regular user', () => {
+    MagmaAPIBindings.getNetworks.mockResolvedValue([]);
+    const {container} = render(
+      <Wrapper isSuperUser={false}>
+        <NetworkSelector />
+      </Wrapper>,
+    );
+    expect(container).toBeEmpty();
+  });
+
+  it('renders text with single network for regular user', () => {
+    MagmaAPIBindings.getNetworks.mockResolvedValue(['test']);
+    MagmaAPIBindings.getNetworksByNetworkIdType.mockResolvedValueOnce(LTE);
+
+    const {queryByRole, getByText} = render(
+      <Wrapper isSuperUser={false} currentNetworkId="test">
+        <NetworkSelector />
+      </Wrapper>,
+    );
+    expect(getByText('Network: test')).toBeInTheDocument();
+    expect(queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders menu with network links for regular user', async () => {
+    MagmaAPIBindings.getNetworks.mockResolvedValue(['test', 'other']);
+    MagmaAPIBindings.getNetworksByNetworkIdType.mockResolvedValueOnce(LTE);
+
+    const {getByRole, queryAllByRole} = render(
+      <Wrapper isSuperUser={false} currentNetworkId="test">
+        <NetworkSelector />
+      </Wrapper>,
+    );
+
+    await waitFor(() =>
+      expect(getByRole('button')).toHaveTextContent('Network: test'),
+    );
+    fireEvent.click(getByRole('button'));
+
+    await waitFor(() =>
+      expect(queryAllByRole('menuitem').map(link => link.textContent)).toEqual([
+        'test',
+        'other',
+      ]),
+    );
+  });
+
+  it('renders menu with network links and extra entries for super user', async () => {
+    MagmaAPIBindings.getNetworks.mockResolvedValueOnce(['test', 'other']);
+    MagmaAPIBindings.getNetworksByNetworkIdType.mockResolvedValueOnce(LTE);
+
+    const {getByRole, queryAllByRole} = render(
+      <Wrapper isSuperUser={true} currentNetworkId="test">
+        <NetworkSelector />
+      </Wrapper>,
+    );
+    await waitFor(() =>
+      expect(getByRole('button')).toHaveTextContent('Network: test'),
+    );
+    fireEvent.click(getByRole('button'));
+
+    await waitFor(() =>
+      expect(queryAllByRole('menuitem').map(link => link.textContent)).toEqual([
+        'Create Network',
+        'Manage Networks',
+        'test',
+        'other',
+      ]),
+    );
+  });
+});

--- a/nms/app/e2e/__tests__/FegLte-test.js
+++ b/nms/app/e2e/__tests__/FegLte-test.js
@@ -103,6 +103,7 @@ describe('NMS', () => {
 
       await page.waitForXPath(`//span[text()='Create Network']`);
       const buttonSelector = await page.$x(`//span[text()='Create Network']`);
+      await page.waitForTimeout(500);
       buttonSelector[0].click();
 
       const networkIDSelector = '[data-testid="networkID"]';

--- a/nms/app/views/equipment/GatewayDetailMain.js
+++ b/nms/app/views/equipment/GatewayDetailMain.js
@@ -13,13 +13,8 @@
  * @flow strict-local
  * @format
  */
-import type {WithAlert} from '../../../fbc_js_core/ui/components/Alert/withAlert';
-import type {lte_gateway} from '../../../generated/MagmaAPIBindings';
-
 import AccessAlarmIcon from '@material-ui/icons/AccessAlarm';
-import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import AutorefreshCheckbox from '../../components/AutorefreshCheckbox';
-import Button from '@material-ui/core/Button';
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DashboardAlertTable from '../../components/DashboardAlertTable';
@@ -28,7 +23,7 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '../../theme/design-system/DialogTitle';
 import EventsTable from '../../views/events/EventsTable';
-import GatewayConfig from './GatewayDetailConfig';
+import GatewayConfig, {GatewayJsonConfig} from './GatewayDetailConfig';
 import GatewayConfigYml from './GatewayYMLConfig';
 import GatewayContext from '../../components/context/GatewayContext';
 import GatewayDetailEnodebs from './GatewayDetailEnodebs';
@@ -39,11 +34,11 @@ import GatewaySummary from './GatewaySummary';
 import GraphicEqIcon from '@material-ui/icons/GraphicEq';
 import Grid from '@material-ui/core/Grid';
 import ListAltIcon from '@material-ui/icons/ListAlt';
-import Menu from '@material-ui/core/Menu';
+import MenuButton from '../../components/MenuButton';
 import MenuItem from '@material-ui/core/MenuItem';
 import MyLocationIcon from '@material-ui/icons/MyLocation';
 import PeopleIcon from '@material-ui/icons/People';
-import React from 'react';
+import React, {useContext, useState} from 'react';
 import SettingsIcon from '@material-ui/icons/Settings';
 import SettingsInputAntennaIcon from '@material-ui/icons/SettingsInputAntenna';
 import Tab from '@material-ui/core/Tab';
@@ -52,7 +47,6 @@ import Text from '../../theme/design-system/Text';
 import TopBar from '../../components/TopBar';
 import nullthrows from '../../../fbc_js_core/util/nullthrows';
 import withAlert from '../../../fbc_js_core/ui/components/Alert/withAlert';
-import {GatewayJsonConfig} from './GatewayDetailConfig';
 import {
   GenericCommandControls,
   PingCommandControls,
@@ -60,60 +54,22 @@ import {
 } from '../../components/GatewayCommandFields';
 import {Navigate, Route, Routes, useParams} from 'react-router-dom';
 import {RunGatewayCommands} from '../../state/lte/EquipmentState';
-import {colors, typography} from '../../theme/default';
+import {colors} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
-import {useContext, useState} from 'react';
 import {useEnqueueSnackbar} from '../../../fbc_js_core/ui/hooks/useSnackbar';
-import {withStyles} from '@material-ui/core/styles';
+
+import type {WithAlert} from '../../../fbc_js_core/ui/components/Alert/withAlert';
+import type {lte_gateway} from '../../../generated/MagmaAPIBindings';
 
 const useStyles = makeStyles(theme => ({
   dashboardRoot: {
     margin: theme.spacing(5),
-  },
-  appBarBtn: {
-    color: colors.primary.white,
-    background: colors.primary.comet,
-    fontFamily: typography.button.fontFamily,
-    fontWeight: typography.button.fontWeight,
-    fontSize: typography.button.fontSize,
-    lineHeight: typography.button.lineHeight,
-    letterSpacing: typography.button.letterSpacing,
-
-    '&:hover': {
-      background: colors.primary.mirage,
-    },
-  },
-  paper: {
-    textAlign: 'center',
-    padding: theme.spacing(10),
   },
   tabBar: {
     backgroundColor: colors.primary.brightGray,
     color: colors.primary.white,
   },
 }));
-
-const StyledMenu = withStyles({
-  paper: {
-    border: '1px solid #d3d4d5',
-  },
-})(props => (
-  <Menu
-    data-testid="policy_menu"
-    elevation={0}
-    getContentAnchorEl={null}
-    anchorOrigin={{
-      vertical: 'bottom',
-      horizontal: 'center',
-    }}
-    transformOrigin={{
-      vertical: 'top',
-      horizontal: 'center',
-    }}
-    {...props}
-  />
-));
-
 type CommandProps = {
   gatewayID: string,
   open: boolean,
@@ -161,24 +117,14 @@ function TroubleshootingDialog(props: CommandProps) {
 }
 
 function GatewayMenuInternal(props: WithAlert) {
-  const classes = useStyles();
   const params = useParams();
   const networkId: string = nullthrows(params.networkId);
   const gatewayId: string = nullthrows(params.gatewayId);
-  const [anchorEl, setAnchorEl] = useState(null);
   const [gatewayCommandOpen, setGatewayCommandOpen] = useState(false);
   const [troubleshootingDialogOpen, setTroubleshootingDialogOpen] = useState(
     false,
   );
   const enqueueSnackbar = useEnqueueSnackbar();
-
-  const handleClick = event => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
 
   const handleGatewayMenuClick = (
     command: 'reboot' | 'ping' | 'restartServices' | 'generic',
@@ -217,17 +163,8 @@ function GatewayMenuInternal(props: WithAlert) {
         open={troubleshootingDialogOpen}
         onClose={() => setTroubleshootingDialogOpen(false)}
       />
-      <Button
-        onClick={handleClick}
-        className={classes.appBarBtn}
-        endIcon={<ArrowDropDownIcon />}>
-        Actions
-      </Button>
-      <StyledMenu
-        anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
-        onClose={handleClose}>
+
+      <MenuButton label="Actions" size="small">
         <MenuItem
           data-testid="gatewayReboot"
           onClick={() =>
@@ -236,7 +173,7 @@ function GatewayMenuInternal(props: WithAlert) {
               `Are you sure you want to reboot ${gatewayId}?`,
             )
           }>
-          <Text variant="subtitle2">Reboot</Text>
+          <Text variant="body2">Reboot</Text>
         </MenuItem>
         <MenuItem
           data-testid="gatewayRestartServices"
@@ -246,15 +183,15 @@ function GatewayMenuInternal(props: WithAlert) {
               `Are you sure you want to restart all services on ${gatewayId}?`,
             )
           }>
-          <Text variant="subtitle2">Restart Services</Text>
+          <Text variant="body2">Restart Services</Text>
         </MenuItem>
         <MenuItem onClick={() => setGatewayCommandOpen(true)}>
-          <Text variant="subtitle2">Command</Text>
+          <Text variant="body2">Command</Text>
         </MenuItem>
         <MenuItem onClick={() => setTroubleshootingDialogOpen(true)}>
-          <Text variant="subtitle2">Troubleshoot</Text>
+          <Text variant="body2">Troubleshoot</Text>
         </MenuItem>
-      </StyledMenu>
+      </MenuButton>
     </div>
   );
 }

--- a/nms/app/views/equipment/__tests__/EnodebDetailMainTest.js
+++ b/nms/app/views/equipment/__tests__/EnodebDetailMainTest.js
@@ -61,6 +61,7 @@ describe('<Enodeb />', () => {
     MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mockResolvedValue(
       mockThroughput,
     );
+    MagmaAPIBindings.getNetworks.mockResolvedValue([]);
   });
 
   afterEach(() => {

--- a/nms/app/views/network/__tests__/NetworkTest.js
+++ b/nms/app/views/network/__tests__/NetworkTest.js
@@ -276,6 +276,7 @@ describe('<NetworkDashboard />', () => {
     MagmaAPIBindings.putLteByNetworkIdDns.mockImplementation(() =>
       Promise.resolve({data: {success: true}}),
     );
+    MagmaAPIBindings.getNetworks.mockImplementation(() => Promise.resolve([]));
   });
 
   afterEach(() => {

--- a/nms/app/views/subscriber/SubscriberTable.js
+++ b/nms/app/views/subscriber/SubscriberTable.js
@@ -13,6 +13,24 @@
  * @flow strict-local
  * @format
  */
+import ActionTable from '../../components/ActionTable';
+import Button from '@material-ui/core/Button';
+import CardTitleRow from '../../components/layout/CardTitleRow';
+import Grid from '@material-ui/core/Grid';
+import LaunchIcon from '@material-ui/icons/Launch';
+import MenuItem from '@material-ui/core/MenuItem';
+import NetworkContext from '../../components/context/NetworkContext';
+import React, {useContext, useEffect, useRef, useState} from 'react';
+import SettingsIcon from '@material-ui/icons/Settings';
+import SubscriberContext from '../../components/context/SubscriberContext';
+import Text from '../../theme/design-system/Text';
+import nullthrows from '../../../fbc_js_core/util/nullthrows';
+import withAlert from '../../../fbc_js_core/ui/components/Alert/withAlert';
+import {
+  DEFAULT_PAGE_SIZE,
+  REFRESH_TIMEOUT,
+  SUBSCRIBER_EXPORT_COLUMNS,
+} from './SubscriberUtils';
 import type {ActionQuery} from '../../components/ActionTable';
 import type {EnqueueSnackbarOptions} from 'notistack';
 import type {SubscriberActionType, SubscriberInfo} from './SubscriberUtils';
@@ -25,45 +43,22 @@ import type {
   subscriber,
 } from '../../../generated/MagmaAPIBindings';
 
-import ActionTable from '../../components/ActionTable';
-import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
-import Button from '@material-ui/core/Button';
-import CardTitleRow from '../../components/layout/CardTitleRow';
-import Grid from '@material-ui/core/Grid';
-import LaunchIcon from '@material-ui/icons/Launch';
-import Menu from '@material-ui/core/Menu';
-import MenuItem from '@material-ui/core/MenuItem';
-import NetworkContext from '../../components/context/NetworkContext';
-import React from 'react';
-import SettingsIcon from '@material-ui/icons/Settings';
-import SubscriberContext from '../../components/context/SubscriberContext';
-import Text from '../../theme/design-system/Text';
-import nullthrows from '../../../fbc_js_core/util/nullthrows';
-import withAlert from '../../../fbc_js_core/ui/components/Alert/withAlert';
-
+import MenuButton from '../../components/MenuButton';
 import {AddSubscriberDialog} from './SubscriberAddDialog';
 import {CsvBuilder} from 'filefy';
-import {
-  DEFAULT_PAGE_SIZE,
-  REFRESH_TIMEOUT,
-  SUBSCRIBER_EXPORT_COLUMNS,
-} from './SubscriberUtils';
 import {
   FetchSubscribers,
   handleSubscriberQuery,
 } from '../../state/lte/SubscriberState';
-import {JsonDialog} from './SubscriberOverview';
-import {RenderLink} from './SubscriberOverview';
+import {JsonDialog, RenderLink} from './SubscriberOverview';
 import {
   base64ToHex,
   hexToBase64,
   isValidHex,
 } from '../../../fbc_js_core/util/strings';
 import {makeStyles} from '@material-ui/styles';
-import {useContext, useEffect, useRef, useState} from 'react';
 import {useEnqueueSnackbar} from '../../../fbc_js_core/ui/hooks/useSnackbar';
 import {useNavigate, useParams} from 'react-router-dom';
-import {withStyles} from '@material-ui/core/styles';
 
 // number of subscriber in a chunk
 const SUBSCRIBERS_CHUNK_SIZE = 1000;
@@ -184,28 +179,7 @@ async function exportSubscribers(props: ExportProps) {
   }
 }
 
-const StyledMenu = withStyles({
-  paper: {
-    border: '1px solid #d3d4d5',
-  },
-})(props => (
-  <Menu
-    elevation={0}
-    getContentAnchorEl={null}
-    anchorOrigin={{
-      vertical: 'bottom',
-      horizontal: 'center',
-    }}
-    transformOrigin={{
-      vertical: 'top',
-      horizontal: 'center',
-    }}
-    {...props}
-  />
-));
-
 function SubscriberActionsMenu(props: {onClose: () => void}) {
-  const [anchorEl, setAnchorEl] = React.useState(null);
   const [open, setOpen] = React.useState(false);
   const [error, setError] = React.useState('');
   const enqueueSnackbar = useEnqueueSnackbar();
@@ -215,13 +189,6 @@ function SubscriberActionsMenu(props: {onClose: () => void}) {
     subscriberAction,
     setSubscriberAction,
   ] = useState<SubscriberActionType>('add');
-  const handleClick = event => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
 
   /**
    * Delete array of subscriber IMSIs.
@@ -355,30 +322,18 @@ function SubscriberActionsMenu(props: {onClose: () => void}) {
           props.onClose();
         }}
       />
-
-      <Button
-        variant="contained"
-        color="primary"
-        onClick={handleClick}
-        endIcon={<ArrowDropDownIcon />}>
-        {'Manage Subscribers'}
-      </Button>
-      <StyledMenu
-        anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
-        onClose={handleClose}>
+      <MenuButton label="Manage Subscribers">
         <MenuItem
           data-testid=""
           onClick={() => {
             setSubscriberAction('add');
             setOpen(true);
           }}>
-          <Text variant="subtitle2">Add Subscribers</Text>
+          <Text variant="body2">Add Subscribers</Text>
         </MenuItem>
         <MenuItem>
           <Text
-            variant="subtitle2"
+            variant="body2"
             onClick={() => {
               setSubscriberAction('edit');
               setOpen(true);
@@ -391,9 +346,9 @@ function SubscriberActionsMenu(props: {onClose: () => void}) {
             setSubscriberAction('delete');
             setOpen(true);
           }}>
-          <Text variant="subtitle2">Delete Subscribers</Text>
+          <Text variant="body2">Delete Subscribers</Text>
         </MenuItem>
-      </StyledMenu>
+      </MenuButton>
     </div>
   );
 }

--- a/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.js
@@ -225,6 +225,7 @@ describe('<AddSubscriberButton />', () => {
     MagmaAPIBindings.getLteByNetworkIdSubscriberConfigBaseNames.mockResolvedValue(
       [],
     );
+    MagmaAPIBindings.getNetworks.mockResolvedValue([]);
   });
 
   const AddWrapper = () => {

--- a/nms/app/views/subscriber/__tests__/SubscriberTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberTest.js
@@ -96,6 +96,7 @@ describe('<SubscriberDashboard />', () => {
       subscribers: subscribers,
       next_page_token: '',
     });
+    MagmaAPIBindings.getNetworks.mockResolvedValue([]);
   });
 
   const Wrapper = () => {

--- a/nms/app/views/traffic/TrafficOverview.js
+++ b/nms/app/views/traffic/TrafficOverview.js
@@ -14,17 +14,16 @@
  * @format
  */
 import ApnEditDialog from './ApnEdit';
-import ApnOverview from './ApnOverview';
-import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import ApnOverview, {ApnJsonConfig} from './ApnOverview';
 import BaseNameEditDialog from './BaseNameEdit';
 import Button from '@material-ui/core/Button';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DataPlanEditDialog from './DataPlanEdit';
 import DataPlanOverview from './DataPlanOverview';
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
-import Menu from '@material-ui/core/Menu';
+import MenuButton from '../../components/MenuButton';
 import MenuItem from '@material-ui/core/MenuItem';
-import PolicyOverview from './PolicyOverview';
+import PolicyOverview, {PolicyJsonConfig} from './PolicyOverview';
 import PolicyRuleEditDialog from './PolicyEdit';
 import ProfileEditDialog from './ProfileEdit';
 import RatingGroupEditDialog from './RatingGroupEdit';
@@ -32,69 +31,16 @@ import React from 'react';
 import RssFeedIcon from '@material-ui/icons/RssFeed';
 import Text from '../../theme/design-system/Text';
 import TopBar from '../../components/TopBar';
-
-import {ApnJsonConfig} from './ApnOverview';
 import {Navigate, Route, Routes} from 'react-router-dom';
-import {PolicyJsonConfig} from './PolicyOverview';
-import {colors, typography} from '../../theme/default';
-import {makeStyles} from '@material-ui/styles';
-import {withStyles} from '@material-ui/core/styles';
-
-const useStyles = makeStyles(_ => ({
-  appBarBtn: {
-    color: colors.primary.white,
-    background: colors.primary.comet,
-    fontFamily: typography.button.fontFamily,
-    fontWeight: typography.button.fontWeight,
-    fontSize: typography.button.fontSize,
-    lineHeight: typography.button.lineHeight,
-    letterSpacing: typography.button.letterSpacing,
-
-    '&:hover': {
-      background: colors.primary.mirage,
-    },
-  },
-}));
-
-const StyledMenu = withStyles({
-  paper: {
-    border: '1px solid #d3d4d5',
-  },
-})(props => (
-  <Menu
-    data-testid="policy_menu"
-    elevation={0}
-    getContentAnchorEl={null}
-    anchorOrigin={{
-      vertical: 'bottom',
-      horizontal: 'center',
-    }}
-    transformOrigin={{
-      vertical: 'top',
-      horizontal: 'center',
-    }}
-    {...props}
-  />
-));
 
 /**
  * Button for creation of policies, rating groups, and profiles
  */
 function PolicyMenu() {
-  const classes = useStyles();
-  const [anchorEl, setAnchorEl] = React.useState(null);
   const [open, setOpen] = React.useState(false);
   const [baseNameDialog, setBaseNameDialog] = React.useState(false);
   const [profileDialog, setProfileDialog] = React.useState(false);
   const [ratingGroupDialog, setRatingGroupDialog] = React.useState(false);
-
-  const handleClick = event => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
 
   return (
     <div>
@@ -111,34 +57,24 @@ function PolicyMenu() {
         open={ratingGroupDialog}
         onClose={() => setRatingGroupDialog(false)}
       />
-      <Button
-        onClick={handleClick}
-        className={classes.appBarBtn}
-        endIcon={<ArrowDropDownIcon />}>
-        Create New{' '}
-      </Button>
-      <StyledMenu
-        anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
-        onClose={handleClose}>
+      <MenuButton label="Create New" size="small">
         <MenuItem data-testid="newPolicyMenuItem" onClick={() => setOpen(true)}>
-          <Text variant="subtitle2">Policy</Text>
+          <Text variant="body2">Policy</Text>
         </MenuItem>
         <MenuItem
           data-testid="newBaseNameMenuItem"
           onClick={() => setBaseNameDialog(true)}>
-          <Text variant="subtitle2">Base Name</Text>
+          <Text variant="body2">Base Name</Text>
         </MenuItem>
         <MenuItem onClick={() => setProfileDialog(true)}>
-          <Text variant="subtitle2">Profile</Text>
+          <Text variant="body2">Profile</Text>
         </MenuItem>
         <MenuItem
           data-testid="newRatingGroupMenuItem"
           onClick={() => setRatingGroupDialog(true)}>
-          <Text variant="subtitle2">Rating Group</Text>
+          <Text variant="body2">Rating Group</Text>
         </MenuItem>
-      </StyledMenu>
+      </MenuButton>
     </div>
   );
 }
@@ -147,7 +83,6 @@ function PolicyMenu() {
  * Wrapper for "Create APN" button
  */
 function ApnMenu() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
 
   return (
@@ -155,8 +90,10 @@ function ApnMenu() {
       <ApnEditDialog open={open} onClose={() => setOpen(false)} />
       <Button
         data-testid="newApnButton"
-        onClick={() => setOpen(true)}
-        className={classes.appBarBtn}>
+        variant="contained"
+        color="primary"
+        size="small"
+        onClick={() => setOpen(true)}>
         Create New APN
       </Button>
     </div>
@@ -167,7 +104,6 @@ function ApnMenu() {
  * Wrapper for "Create Data Plan" button
  */
 function DataPlanMenu() {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
 
   return (
@@ -179,8 +115,10 @@ function DataPlanMenu() {
       />
       <Button
         data-testid="newDataPlanButton"
-        onClick={() => setOpen(true)}
-        className={classes.appBarBtn}>
+        variant="contained"
+        color="primary"
+        size="small"
+        onClick={() => setOpen(true)}>
         Create New Data Plan
       </Button>
     </div>

--- a/nms/app/views/traffic/__tests__/ApnAddTest.js
+++ b/nms/app/views/traffic/__tests__/ApnAddTest.js
@@ -81,6 +81,7 @@ describe('<TrafficDashboard />', () => {
   });
   beforeEach(() => {
     MagmaAPIBindings.getLteByNetworkIdApns.mockResolvedValue(apns);
+    MagmaAPIBindings.getNetworks.mockResolvedValue([]);
   });
 
   const {location} = window;

--- a/nms/app/views/traffic/__tests__/PolicyAddEditTest.js
+++ b/nms/app/views/traffic/__tests__/PolicyAddEditTest.js
@@ -190,6 +190,7 @@ describe('<TrafficDashboard />', () => {
         redirect_information: {},
       },
     );
+    MagmaAPIBindings.getNetworks.mockResolvedValue([]);
   });
 
   const PolicyWrapper = ({networkType}) => (

--- a/nms/app/views/traffic/__tests__/TrafficOverviewTest.js
+++ b/nms/app/views/traffic/__tests__/TrafficOverviewTest.js
@@ -181,6 +181,11 @@ describe('<TrafficDashboard />', () => {
       });
     },
   };
+
+  beforeEach(() => {
+    MagmaAPIBindings.getNetworks.mockResolvedValue([]);
+  });
+
   const Wrapper = () => (
     <MemoryRouter
       initialEntries={['/nms/test/traffic/policy']}

--- a/nms/fbc_js_core/ui/components/layout/AppSideBar.js
+++ b/nms/fbc_js_core/ui/components/layout/AppSideBar.js
@@ -14,10 +14,11 @@
  * @format
  */
 
-import NetworkSelector from '../../../../app/components/NetworkSelector';
 import ProfileButton from '../ProfileButton';
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import SidebarItem from '../SidebarItem';
+import Text from '../../../../app/theme/design-system/Text';
+import VersionContext from '../../../../app/components/context/VersionContext';
 import classNames from 'classnames';
 import {colors} from '../../../../app/theme/default';
 import {makeStyles} from '@material-ui/styles';
@@ -34,7 +35,7 @@ const useStyles = makeStyles(() => ({
     backgroundColor: colors.primary.brightGray,
     boxShadow: '1px 0px 0px 0px rgba(0, 0, 0, 0.1)',
     height: '100vh',
-    padding: '60px 0px 36px 0px',
+    padding: '60px 0px 24px 0px',
     position: 'relative',
     zIndex: 100,
     overflowX: 'hidden',
@@ -43,6 +44,14 @@ const useStyles = makeStyles(() => ({
   },
   expanded: {
     width: '208px',
+  },
+  version: {
+    padding: '28px 0 0 28px',
+    color: colors.primary.gullGray,
+    whiteSpace: 'nowrap',
+  },
+  versionHidden: {
+    visibility: 'hidden',
   },
 }));
 
@@ -54,27 +63,20 @@ type ItemConfig = {
 
 type Props = {
   items: Array<ItemConfig>,
-  showNetworkSwitch?: boolean,
 };
 
 const AppSideBar = (props: Props) => {
-  const {items, showNetworkSwitch} = props;
+  const {items} = props;
   const classes = useStyles();
   const [expanded, setIsExpanded] = useState(false);
   const [isProfileMenuOpen, _setProfileMenuOpen] = useState(false);
-  const [isNetworkMenuOpen, _setNetworkMenuOpen] = useState(false);
+  const {nmsVersion} = useContext(VersionContext);
 
   const setProfileMenuOpen = (isOpen: boolean) => {
     if (!isOpen) {
       setIsExpanded(false);
     }
     _setProfileMenuOpen(isOpen);
-  };
-  const setNetworkMenuOpen = (isOpen: boolean) => {
-    if (!isOpen) {
-      setIsExpanded(false);
-    }
-    _setNetworkMenuOpen(isOpen);
   };
 
   return (
@@ -83,7 +85,7 @@ const AppSideBar = (props: Props) => {
       className={classes.root}
       onMouseOver={() => setIsExpanded(true)}
       onMouseLeave={() => {
-        if (!isProfileMenuOpen && !isNetworkMenuOpen) {
+        if (!isProfileMenuOpen) {
           setIsExpanded(false);
         }
       }}>
@@ -104,18 +106,19 @@ const AppSideBar = (props: Props) => {
           ))}
         </div>
         <div className={classes.secondaryItems}>
-          {showNetworkSwitch && (
-            <NetworkSelector
-              expanded={expanded}
-              isMenuOpen={isNetworkMenuOpen}
-              setMenuOpen={setNetworkMenuOpen}
-            />
-          )}
           <ProfileButton
             expanded={expanded}
             isMenuOpen={isProfileMenuOpen}
             setMenuOpen={setProfileMenuOpen}
           />
+          <Text
+            variant="body3"
+            className={classNames({
+              [classes.version]: true,
+              [classes.versionHidden]: !expanded,
+            })}>
+            {'NMS: ' + nmsVersion}
+          </Text>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Second part of #12449. The network switcher has been redesigned and moved into the topbar. The NMS version number has been move into the expanded sidebar. The remaining bits of https://github.com/magma/magma/issues/12449 will be split into several PRs.

## Test Plan

As a non-super user with multiple networks use the network switcher to jump between networks. As a super user try if the "Add Network" and "Manage Networks" button in the  network switcher menu work. Make sure that the buttons are not shown for non-supers. 
![Screenshot 2022-04-22 at 18 36 43](https://user-images.githubusercontent.com/102796295/164757834-c07da339-5e70-44e9-a270-b4cd1d0c1a4e.png)

![Screenshot 2022-04-22 at 18 36 53](https://user-images.githubusercontent.com/102796295/164757838-1df040f4-4719-4aba-9a59-b041d0f39d4b.png)

For non-supers that only have access to single network a text is show instead of the button. 
![Screenshot 2022-04-22 at 18 39 13](https://user-images.githubusercontent.com/102796295/164757930-0fed8ce4-6222-4dbb-9f5e-1bb3eab888e4.png)
 