### PR TITLE
chore: Generate compile_commands.json on devcontainer creation

### DIFF
--- a/.devcontainer/post-create-commands.sh
+++ b/.devcontainer/post-create-commands.sh
@@ -18,3 +18,6 @@ else
     # Fetch build cache
     wget -qO- https://magma-cache.s3.amazonaws.com/bazel-cache-devcontainer.tar.gz | tar xvfz -
 fi
+
+echo "Generating compile_commands.json for C/C++ code navigation"
+"$1"/dev_tools/gen_compilation_database.py


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
I've recently added a script to generate compile_commands.json quickly without relying on a VSCode extension (which can be clunky sometimes). Since the generation only takes a few seconds, I'm adding the generation to devcontainer startup logic so that clangd can pick it up on startup.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Testing by spinning up a codespace from this PR
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
