### PR TITLE
fix(ci): bazel-cache-push.yml has enough memory for build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 startup --output_base=/tmp/bazel
+startup --host_jvm_args="-Xmx8g"
 
 # STYLE CONFIGS
 build --announce_rc
@@ -70,6 +71,11 @@ build:asan --per_file_copt=^.*/gateway/c/.*$@-fsanitize=address,-fsanitize=undef
 # LSAN
 build:lsan --linkopt=-fsanitize=leak
 build:lsan --per_file_copt=^.*/gateway/c/.*$@-fsanitize=leak,-fno-omit-frame-pointer
+
+# Config for running Bazel with limited memory
+# see https://bazel.build/docs/memory-saving-mode
+# This is helpful for builds on the VM on github runners where only 14g are available.
+build:limit_mem --discard_analysis_cache --nokeep_state_after_build --notrack_incremental_state
 
 # Config for turning up more GCC warnings
 build:max_gcc_warnings --per_file_copt=^.*/gateway/c/.*$@-Wextra,-Wshadow,-Wimplicit-fallthrough,-Wduplicated-cond,-Wduplicated-branches,-Wlogical-op,-Wnull-dereference,-Wformat=2,-Wstrict-overflow=4,-Wuninitialized,-Wshift-overflow=2

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -56,23 +56,25 @@ jobs:
       - name: Bring up the Magma VM
         run: |
           cd lte/gateway
+          export MAGMA_DEV_CPUS=3
+          export MAGMA_DEV_MEMORY_MB=9216
           vagrant up magma
       - name: Build all with production config `bazel build //... --config=production`
         run: |
           cd lte/gateway
-          vagrant ssh -c 'cd ~/magma; bazel build //... --config=production' magma
+          vagrant ssh -c 'cd ~/magma; bazel build --config=limit_mem //... --config=production' magma
       - name: Build all `bazel build //...`
         run: |
           cd lte/gateway
-          vagrant ssh -c 'cd ~/magma; bazel build //...' magma
+          vagrant ssh -c 'cd ~/magma; bazel build --config=limit_mem //...' magma
       - name: Test all `bazel test //...`
         run: |
           cd lte/gateway
-          vagrant ssh -c 'cd ~/magma; bazel test //...' magma
+          vagrant ssh -c 'cd ~/magma; bazel test --config=limit_mem //...' magma
       - name: Test C/C++ with ASAN `bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan`
         run: |
           cd lte/gateway
-          vagrant ssh -c 'cd ~/magma; bazel test //orc8r/gateway/c/... //lte/gateway/c/... --config=asan' magma
+          vagrant ssh -c 'cd ~/magma; bazel test --config=limit_mem //orc8r/gateway/c/... //lte/gateway/c/... --config=asan' magma
       - name: Upload .bazel-cache and .bazel-cache-repo to S3
         run: |
           tar -zcvf ${{ env.BAZEL_CACHE_MAGMA_VM_TAR }} ${{ env.BAZEL_CACHE }}/


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

The VM-part of the "Push Bazel Cache To S3" workflow is currently failing - see https://github.com/magma/magma/actions/workflows/bazel-cache-push.yml.

### Analysis
* The reason are out of memory errors https://github.com/magma/magma/runs/6143309276?check_suite_focus=true
```
FATAL: bazel ran out of memory and crashed. Printing stack trace:
java.lang.OutOfMemoryError: Java heap space
```
* Memory reserved for a VM is hardcoded - compared to docker, where the available memory from the host is used. This is, by hardcoding the VM memory correctly, the job might run through without failure. But compared to a docker setup, the VM also needs some overhead memory.
  * **Not done here:** check if the VM memory can be increased so that the job runs successfully with the current configuration.

### Solution Here
* Increase VM memory (slightly) by using mechanics from https://github.com/magma/magma/pull/12524 (thx @jheidbrink)
* Running Bazel with memory saving settings - this has negative effects on incremental builds (this should not matter much here as these are non-incremental CI builds, see https://bazel.build/docs/memory-saving-mode)

## Test Plan

The workflow only runs on master pushes. Run on local fork: https://github.com/nstng/magma/actions/runs/2216611016

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
