### PR TITLE
docs: fix failing command in CI

### DIFF
--- a/docs/docusaurus/create_docusaurus_website.sh
+++ b/docs/docusaurus/create_docusaurus_website.sh
@@ -50,5 +50,4 @@ echo 'If you want to follow the build logs, run docker-compose logs -f docusauru
 spin
 echo 'Navigate to http://localhost:3000/ to see the docs.'
 
-open 'http://localhost:3000/docs/next/basics/introduction.html' || true
-
+xdg-open 'http://localhost:3000/docs/next/basics/introduction.html' || true


### PR DESCRIPTION
## Summary

- The bash script would fail in CI due to usage of the wrong command. `xdg-open` opens a link in the default browser and should be safe to use. The command `open` does not exist on a standard CI machine.

## Test Plan

- CI
