### PR TITLE
fix(ci): iwyu build in devcontainer is fixed

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -293,7 +293,7 @@ RUN git clone https://github.com/include-what-you-use/include-what-you-use && \
     git checkout 0.15 && \
     cd .. && \
     mkdir build_iwyu && cd build_iwyu && \
-    cmake -G "Unix Makefiles" -DIWHYU_LLVM_ROOT_PATH=/usr/lib/llvm-11 ../include-what-you-use/ && \
+    cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-11 ../include-what-you-use/ && \
     make && \
     make install && \
     cd / && \


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

### Problem
The [Build Docker image for DevContainer](https://github.com/magma/magma/actions/workflows/docker-builder-devcontainer.yml) workflow is failing for a couple of weeks :(
Reason is the iwyu build, see ,e.g., https://github.com/magma/magma/runs/6162803464?check_suite_focus=true.

### Analysis
I do not found a change that could have caused the failure - maybe it was an unpined and upgraded dependency. Chaning the build script to the recommended way on https://github.com/include-what-you-use/include-what-you-use worked locally for me.

### Next Step
It's on my list to make failing jobs related to bazel more visible ... failing for a couple of weeks is not a good sign for visibility.

## Test Plan

CI: https://github.com/magma/magma/actions/runs/2222783519

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
