### PR TITLE
fix(agw): Update pylint to 2.12.2

### DIFF
--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -68,20 +68,16 @@ $(BIN)/coverage: install_virtualenv
 	$(VIRT_ENV_PIP_INSTALL) "coverage>=6.1.2"
 
 $(BIN)/pylint: install_virtualenv
-    # https://github.com/PyCQA/pylint/issues/380
-    # compile issue with py3.4 so install with no-compile
-	$(VIRT_ENV_PIP_INSTALL) pylint==1.6.4 --no-compile
+	$(VIRT_ENV_PIP_INSTALL) pylint==2.12.2
 
 $(BIN)/pep8: install_virtualenv
 	# pylint doesn't cover all the pep8 style guidelines. Specifically,
 	# E203, E301, E303, W203, W291, W292
 	$(VIRT_ENV_PIP_INSTALL) pep8==1.7.0
 
-# Disable C0330: bad-continuation errors with pylint1.6.4 as it conflicts with pep8
-# 	https://github.com/pylint-bot/pylint-unofficial/issues/289
 # Disable W0511: todo warnings
 # Disable R0903: Too few public methods
-CHECK_CMD_PYLINT := find . -name '*.py' -exec $(BIN)/pylint --disable=C0330,R0903,W0511 {} +;
+CHECK_CMD_PYLINT := find . -name '*.py' -exec $(BIN)/pylint --disable=R0903,W0511 {} +;
 CHECK_CMD_PEP8 := find . -name '*.py' -exec $(BIN)/pep8 {} +;
 check: buildenv $(BIN)/pylint $(BIN)/pep8
 	$(CHECK_CMD_PEP8)


### PR DESCRIPTION
## Summary

Closes https://github.com/magma/magma/issues/12332.

I have updated pylint as described in the issue, which resolves the reported error. I have also removed the `--no-compile` flag and the disabling of a certain type of error (C0330) when running pylint, since when I run pylint without them I don't encounter the problems which led to them being introduced, presumably due to more up-to-date versions of pylint/python.

## Test Plan

I ran `make check` in `lte/gateway/python` and verified that the reported error was no longer there.

## Additional Information

- [ ] This change is backwards-breaking
