### PR TITLE
chore(mobilityd): remove unused dependency in bazel

### DIFF
--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -34,7 +34,6 @@ pycryptodome>=3.9.9
 spyne
 aiohttp
 lxml==4.7.1
-typing_extensions
 eventlet==0.30.2
 aiodns>=1.1.1
 pymemoize>=1.0.2

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -882,7 +882,7 @@ oslo-config==8.8.0 \
     --hash=sha256:96933d3011dae15608a11616bfb00d947e22da3cb09b6ff37ddd7576abd4764c \
     --hash=sha256:b1e2a398450ea35a8e5630d8b23057b8939838c4433cd25a20cc3a36d5df9e3b
     # via -r requirements.in
-oslo-i18n==5.1.0 \
+oslo.i18n==5.1.0 \
     --hash=sha256:6bf111a6357d5449640852de4640eae4159b5562bbba4c90febb0034abc095d0 \
     --hash=sha256:75086cfd898819638ca741159f677e2073a78ca86a9c9be8d38b46800cdf2dc9
     # via oslo-config
@@ -904,7 +904,7 @@ pbr==5.8.1 \
     --hash=sha256:27108648368782d07bbf1cb468ad2e2eeef29086affd14087a6d04b7de8af4ec \
     --hash=sha256:66bc5a34912f408bb3925bf21231cb6f59206267b7f63f3503ef865c1a292e25
     # via
-    #   oslo-i18n
+    #   oslo.i18n
     #   stevedore
 pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
@@ -914,7 +914,7 @@ priority==1.3.0 \
     --hash=sha256:6bc1961a6d7fcacbfc337769f1a382c8e746566aaa365e78047abe9f66b2ffbe \
     --hash=sha256:be4fcb94b5e37cdeb40af5533afe6dd603bd665fe9c8b3052610fc1001d5d1eb
     # via -r requirements.in
-prometheus-client==0.3.1 \
+prometheus_client==0.3.1 \
     --hash=sha256:17bc24c09431644f7c65d7bce9f4237252308070b6395d6d8e87767afe867e24
     # via -r requirements.in
 protobuf==3.19.4 \
@@ -1164,7 +1164,7 @@ redis-collections==0.11.0 \
     --hash=sha256:0f6cda00666fdd26e3b8ca47da13a653eaf4cc4e45470a3b09f17d65061fea8a \
     --hash=sha256:d23e8c0f6bf50de10c98a14a3b636ff1bb21119386f884f2641c906832bc4ec9
     # via -r requirements.in
-repoze-lru==0.7 \
+repoze.lru==0.7 \
     --hash=sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77 \
     --hash=sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea
     # via routes
@@ -1307,10 +1307,6 @@ tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via pytest
-typing-extensions==4.1.1 \
-    --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42 \
-    --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
-    # via -r requirements.in
 urllib3==1.26.8 \
     --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed \
     --hash=sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c

--- a/lte/gateway/python/magma/mobilityd/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/BUILD.bazel
@@ -74,7 +74,6 @@ py_library(
         "//orc8r/gateway/python/magma/common/redis:client",
         requirement("netifaces"),
         requirement("scapy"),
-        requirement("typing_extensions"),
         requirement("prometheus_client"),
     ],
 )


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Unused dependency `typing_extensions` is removed in bazel.
- `requirements.txt` is recompiled to reflect this change.

## Test Plan

- In the `bazel-base` container run:
 `bazel test lte/gateway/python/... orc8r/gateway/python/...`

- In the `magma-vm` run:
`bazel run lte/gateway/python/magma/mobilityd`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
