### PR TITLE
fix(nms): Fix SubscriberStateTable details are always empty

### DIFF
--- a/nms/app/views/subscriber/SubscriberStateTable.js
+++ b/nms/app/views/subscriber/SubscriberStateTable.js
@@ -290,9 +290,7 @@ export default function SubscriberStateTable() {
                 return <ExpandMore data-testid="details" />;
               },
               openIcon: ExpandLess,
-              render: rowData => (
-                <SubscriberStateDetailPanel rowData={rowData} />
-              ),
+              render: rowData => <SubscriberStateDetailPanel {...rowData} />,
             },
           ]}
         />


### PR DESCRIPTION
## Summary
The details for the subscriber state table were always empty. This bug was introduced when switching to `@material-table/core` because of a breaking difference https://material-table-core.com/docs/breaking-changes#detail-panel 

![Screenshot 2022-04-26 at 17 14 29](https://user-images.githubusercontent.com/102796295/165334203-c15c7fe1-029d-4672-bc5f-57740dd39f71.png)


## Test Plan
Open the subscriber state details and make sure they not empty. The mock sever can be used to test this.
