### PR TITLE
feat(orc8r): created protected port for all orc8r internal services

### DIFF
--- a/cwf/cloud/configs/service_registry.yml
+++ b/cwf/cloud/configs/service_registry.yml
@@ -14,6 +14,7 @@ services:
   cwf:
     host: "localhost"
     port: 9115
+    protected_port: 9215
     echo_port: 10115
     proxy_type: "clientcert"
     labels:

--- a/cwf/cloud/go/services/cwf/cwf/main.go
+++ b/cwf/cloud/go/services/cwf/cwf/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 
-	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, builder_servicers.NewBuilderServicer())
+	builder_protos.RegisterMconfigBuilderServer(srv.ProtectedGrpcServer, builder_servicers.NewBuilderServicer())
 
 	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(cwf_service.ServiceName))
 

--- a/cwf/cloud/go/services/cwf/cwf/main.go
+++ b/cwf/cloud/go/services/cwf/cwf/main.go
@@ -55,7 +55,7 @@ func main() {
 	calcs := cwf_analytics.GetAnalyticsCalculations(&serviceConfig.Analytics)
 	userStateManager := calculations.NewUserStateManager(promQLClient, "active_sessions")
 	collectorServicer := analytics_servicer.NewCollectorServicer(&serviceConfig.Analytics, promQLClient, calcs, userStateManager)
-	protos.RegisterAnalyticsCollectorServer(srv.GrpcServer, collectorServicer)
+	protos.RegisterAnalyticsCollectorServer(srv.ProtectedGrpcServer, collectorServicer)
 
 	err = srv.Run()
 	if err != nil {

--- a/cwf/cloud/go/services/cwf/cwf/main.go
+++ b/cwf/cloud/go/services/cwf/cwf/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, builder_servicers.NewBuilderServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(cwf_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(cwf_service.ServiceName))
 
 	var serviceConfig cwf_service.Config
 	_, _, err = config.GetStructuredServiceConfig(cwf.ModuleName, cwf_service.ServiceName, &serviceConfig)

--- a/cwf/cloud/go/services/cwf/test_init/test_service_init.go
+++ b/cwf/cloud/go/services/cwf/test_init/test_service_init.go
@@ -35,11 +35,11 @@ func StartTestServiceInternal(t *testing.T, builder builder_protos.MconfigBuilde
 		labels[orc8r.MconfigBuilderLabel] = "true"
 	}
 
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, cwf.ServiceName, labels, annotations)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, cwf.ServiceName, labels, annotations)
 
 	if builder != nil {
-		builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, builder)
+		builder_protos.RegisterMconfigBuilderServer(srv.ProtectedGrpcServer, builder)
 	}
 
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 }

--- a/cwf/cloud/helm/cwf-orc8r/templates/cwf.deployment.yaml
+++ b/cwf/cloud/helm/cwf-orc8r/templates/cwf.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/cwf", "-run_echo_server=true
 ports:
   - name: grpc
     containerPort: 9115
+  - name: grpc-internal
+    containerPort: 9215
   - name: http
     containerPort: 10115
 livenessProbe:

--- a/cwf/cloud/helm/cwf-orc8r/templates/cwf.service.yaml
+++ b/cwf/cloud/helm/cwf-orc8r/templates/cwf.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9115
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9215
     - name: http
       port: 8080
       targetPort:  10115

--- a/dp/cloud/configs/service_registry.yml
+++ b/dp/cloud/configs/service_registry.yml
@@ -14,6 +14,7 @@ services:
   dp:
     host: "localhost"
     port: 9124
+    protected_port: 9224
     echo_port: 10124
     proxy_type: "clientcert"
     labels:

--- a/dp/cloud/go/services/dp/dp/main.go
+++ b/dp/cloud/go/services/dp/dp/main.go
@@ -40,7 +40,7 @@ func main() {
 	}
 	obsidian.AttachHandlers(srv.EchoServer, cbsd.GetHandlers())
 	obsidian.AttachHandlers(srv.EchoServer, dp_log.NewHandlersGetter(dp_log.GetElasticClient, "").GetHandlers())
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(dp_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(dp_service.ServiceName))
 
 	var serviceConfig dp_service.Config
 	config.MustGetStructuredServiceConfig(dp.ModuleName, dp_service.ServiceName, &serviceConfig)

--- a/feg/cloud/configs/service_registry.yml
+++ b/feg/cloud/configs/service_registry.yml
@@ -52,6 +52,7 @@ services:
   health:
     host: "localhost"
     port: 9107
+    protected_port: 9207
     proxy_type: "clientcert"
 
   base_acct:

--- a/feg/cloud/configs/service_registry.yml
+++ b/feg/cloud/configs/service_registry.yml
@@ -14,6 +14,7 @@ services:
   feg:
     host: "localhost"
     port: 9114
+    protected_port: 9214
     echo_port: 10114
     proxy_type: "clientcert"
     labels:

--- a/feg/cloud/go/services/feg/feg/main.go
+++ b/feg/cloud/go/services/feg/feg/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, builder_servicers.NewBuilderServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(feg_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(feg_service.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/feg/cloud/go/services/feg/feg/main.go
+++ b/feg/cloud/go/services/feg/feg/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 
-	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, builder_servicers.NewBuilderServicer())
+	builder_protos.RegisterMconfigBuilderServer(srv.ProtectedGrpcServer, builder_servicers.NewBuilderServicer())
 
 	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(feg_service.ServiceName))
 

--- a/feg/cloud/go/services/feg/test_init/test_service_init.go
+++ b/feg/cloud/go/services/feg/test_init/test_service_init.go
@@ -29,8 +29,8 @@ func StartTestService(t *testing.T) {
 		orc8r.MconfigBuilderLabel: "true",
 	}
 
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, feg.ModuleName, feg_service.ServiceName, labels, nil)
-	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, builder_servicers.NewBuilderServicer())
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, feg.ModuleName, feg_service.ServiceName, labels, nil)
+	builder_protos.RegisterMconfigBuilderServer(srv.ProtectedGrpcServer, builder_servicers.NewBuilderServicer())
 
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 }

--- a/feg/cloud/go/services/health/client_api.go
+++ b/feg/cloud/go/services/health/client_api.go
@@ -31,7 +31,7 @@ import (
 // getCloudHealthClient is a utility function to get an RPC connection to the
 // Health service
 func getCloudHealthClient() (protos.CloudHealthClient, error) {
-	conn, err := registry.GetConnection(ServiceName, lib_protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(ServiceName, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)

--- a/feg/cloud/go/services/health/health/main.go
+++ b/feg/cloud/go/services/health/health/main.go
@@ -60,7 +60,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating cloud health servicer: %+v", err)
 	}
-	protos.RegisterCloudHealthServer(srv.GrpcServer, cloudHealthServer)
+	protos.RegisterCloudHealthServer(srv.ProtectedGrpcServer, cloudHealthServer)
 
 	// create a networkHealthStatusReporter to monitor and periodically log metrics
 	// on if all gateways in a network are unhealthy

--- a/feg/cloud/go/services/health/servicers/health_test_service.go
+++ b/feg/cloud/go/services/health/servicers/health_test_service.go
@@ -48,6 +48,14 @@ func (srv *TestHealthServer) UpdateHealth(
 	return srv.HealthServer.UpdateHealth(ctx, req)
 }
 
+func (srv *TestHealthServer) GetHealth(ctx context.Context, req *fegprotos.GatewayStatusRequest) (*fegprotos.HealthStats, error) {
+	return srv.CloudHealthServer.GetHealth(ctx, req)
+}
+
+func (srv *TestHealthServer) GetClusterState(ctx context.Context, req *fegprotos.ClusterStateRequest) (*fegprotos.ClusterState, error) {
+	return srv.CloudHealthServer.GetClusterState(ctx, req)
+}
+
 func NewTestHealthServer(mockFactory blobstore.StoreFactory) (*TestHealthServer, error) {
 	store, err := storage.NewHealthBlobstore(mockFactory)
 	if err != nil {

--- a/feg/cloud/go/services/health/test_init/test_service_init.go
+++ b/feg/cloud/go/services/health/test_init/test_service_init.go
@@ -26,14 +26,14 @@ import (
 )
 
 func StartTestService(t *testing.T) (*servicers.TestHealthServer, error) {
-	srv, lis, _ := test_utils.NewTestService(t, feg.ModuleName, health.ServiceName)
+	srv, lis, plis := test_utils.NewTestService(t, feg.ModuleName, health.ServiceName)
 	factory := test_utils.NewSQLBlobstore(t, health.DBTableName)
 
 	servicer, err := servicers.NewTestHealthServer(factory)
 	assert.NoError(t, err)
 	protos.RegisterHealthServer(srv.GrpcServer, servicer)
-	protos.RegisterCloudHealthServer(srv.GrpcServer, &servicer.CloudHealthServer)
+	protos.RegisterCloudHealthServer(srv.ProtectedGrpcServer, &servicer.CloudHealthServer)
 
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 	return servicer, nil
 }

--- a/feg/cloud/go/services/health/test_init/test_service_init.go
+++ b/feg/cloud/go/services/health/test_init/test_service_init.go
@@ -32,7 +32,7 @@ func StartTestService(t *testing.T) (*servicers.TestHealthServer, error) {
 	servicer, err := servicers.NewTestHealthServer(factory)
 	assert.NoError(t, err)
 	protos.RegisterHealthServer(srv.GrpcServer, servicer)
-	protos.RegisterCloudHealthServer(srv.ProtectedGrpcServer, &servicer.CloudHealthServer)
+	protos.RegisterCloudHealthServer(srv.ProtectedGrpcServer, servicer)
 
 	go srv.RunTest(lis, plis)
 	return servicer, nil

--- a/feg/cloud/helm/feg-orc8r/templates/feg.deployment.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/feg.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/feg", "-run_echo_server=true
 ports:
   - name: grpc
     containerPort: 9114
+  - name: grpc-internal
+    containerPort: 9214
   - name: http
     containerPort: 10114
 livenessProbe:

--- a/feg/cloud/helm/feg-orc8r/templates/feg.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/feg.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9114
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9214
     - name: http
       port: 8080
       targetPort:  10114

--- a/feg/cloud/helm/feg-orc8r/templates/health.deployment.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/health.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/health", "-logtostderr=true"
 ports:
   - name: grpc
     containerPort: 9107
+  - name: grpc-internal
+    containerPort: 9207
 livenessProbe:
   tcpSocket:
     port: 9107

--- a/feg/cloud/helm/feg-orc8r/templates/health.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/health.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9107
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9207
 {{- end -}}

--- a/lte/cloud/configs/service_registry.yml
+++ b/lte/cloud/configs/service_registry.yml
@@ -45,6 +45,7 @@ services:
   subscriberdb:
     host: "localhost"
     port: 9083
+    protected_port: 9183
     echo_port: 10083
     proxy_type: "clientcert"
     labels:

--- a/lte/cloud/configs/service_registry.yml
+++ b/lte/cloud/configs/service_registry.yml
@@ -18,6 +18,7 @@ services:
   lte:
     host: "localhost"
     port: 9113
+    protected_port: 9213
     echo_port: 10113
     proxy_type: "clientcert"
     labels:

--- a/lte/cloud/configs/service_registry.yml
+++ b/lte/cloud/configs/service_registry.yml
@@ -70,6 +70,7 @@ services:
   policydb:
     host: "localhost"
     port: 9085
+    protected_port: 9185
     echo_port: 10085
     proxy_type: "clientcert"
     labels:
@@ -84,6 +85,7 @@ services:
   smsd:
     host: "localhost"
     port: 9120
+    protected_port: 9220
     echo_port: 10086
     proxy_type: "clientcert"
     labels:
@@ -96,6 +98,7 @@ services:
   nprobe:
     host: "localhost"
     port: 9666
+    protected_port: 9766
     echo_port: 10088
     proxy_type: "clientcert"
     labels:

--- a/lte/cloud/go/services/lte/client_api.go
+++ b/lte/cloud/go/services/lte/client_api.go
@@ -74,7 +74,7 @@ func SetEnodebState(ctx context.Context, networkID string, gatewayID string, eno
 }
 
 func getClient() (protos.EnodebStateLookupClient, error) {
-	conn, err := registry.GetConnection(ServiceName, lib_protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(ServiceName, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)

--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -55,7 +55,7 @@ func main() {
 	provider_protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewProviderServicer())
 	state_protos.RegisterIndexerServer(srv.GrpcServer, protected_servicers.NewIndexerServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(lte_service.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(lte_service.ServiceName))
 
 	// Init storage
 	db, err := sqorc.Open(storage.GetSQLDriver(), storage.GetDatabaseSource())

--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -51,9 +51,9 @@ func main() {
 	var serviceConfig lte_service.Config
 	config.MustGetStructuredServiceConfig(lte.ModuleName, lte_service.ServiceName, &serviceConfig)
 
-	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, protected_servicers.NewBuilderServicer(serviceConfig))
-	provider_protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewProviderServicer())
-	state_protos.RegisterIndexerServer(srv.GrpcServer, protected_servicers.NewIndexerServicer())
+	builder_protos.RegisterMconfigBuilderServer(srv.ProtectedGrpcServer, protected_servicers.NewBuilderServicer(serviceConfig))
+	provider_protos.RegisterStreamProviderServer(srv.ProtectedGrpcServer, servicers.NewProviderServicer())
+	state_protos.RegisterIndexerServer(srv.ProtectedGrpcServer, protected_servicers.NewIndexerServicer())
 
 	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(lte_service.ServiceName))
 

--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -66,7 +66,7 @@ func main() {
 	if err := enbStateStore.Initialize(); err != nil {
 		glog.Fatalf("Error initializing enodeb state lookup storage: %v", err)
 	}
-	lte_protos.RegisterEnodebStateLookupServer(srv.GrpcServer, protected_servicers.NewLookupServicer(enbStateStore))
+	lte_protos.RegisterEnodebStateLookupServer(srv.ProtectedGrpcServer, protected_servicers.NewLookupServicer(enbStateStore))
 
 	// Initialize analytics
 	// userStateExpr is a metric which enables us to compute the number of active users using the network

--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -74,7 +74,7 @@ func main() {
 	userStateManager := calculations.NewUserStateManager(promQLClient, "ue_connected")
 	calcs := lte_analytics.GetAnalyticsCalculations(&serviceConfig.Analytics)
 	collectorServicer := analytics_servicer.NewCollectorServicer(&serviceConfig.Analytics, promQLClient, calcs, userStateManager)
-	protos.RegisterAnalyticsCollectorServer(srv.GrpcServer, collectorServicer)
+	protos.RegisterAnalyticsCollectorServer(srv.ProtectedGrpcServer, collectorServicer)
 
 	err = srv.Run()
 	if err != nil {

--- a/lte/cloud/go/services/lte/servicers/provider_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/provider_servicer_test.go
@@ -49,7 +49,7 @@ func TestLTEStreamProviderServicer_GetUpdates(t *testing.T) {
 	configurator_test_init.StartTestService(t)
 	lte_test_init.StartTestService(t)
 
-	conn, err := registry.GetConnection(lte_service.ServiceName, protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(lte_service.ServiceName, protos.ServiceType_PROTECTED)
 	assert.NoError(t, err)
 	c := streamer_protos.NewStreamProviderClient(conn)
 	ctx := context.Background()

--- a/lte/cloud/go/services/lte/test_init/test_service_init.go
+++ b/lte/cloud/go/services/lte/test_init/test_service_init.go
@@ -54,7 +54,7 @@ func StartTestServiceWithConfig(t *testing.T, serviceConfig lte_service.Config) 
 		orc8r.StreamProviderStreamsAnnotation: strings.Join(streams, orc8r.AnnotationFieldSeparator),
 	}
 
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, lte.ModuleName, lte_service.ServiceName, labels, annotations)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, lte.ModuleName, lte_service.ServiceName, labels, annotations)
 	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, protected_servicers.NewBuilderServicer(serviceConfig))
 	provider_protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewProviderServicer())
 
@@ -65,8 +65,8 @@ func StartTestServiceWithConfig(t *testing.T, serviceConfig lte_service.Config) 
 	assert.NoError(t, enbStateStore.Initialize())
 
 	// Add servicers
-	lte_protos.RegisterEnodebStateLookupServer(srv.GrpcServer, protected_servicers.NewLookupServicer(enbStateStore))
+	lte_protos.RegisterEnodebStateLookupServer(srv.ProtectedGrpcServer, protected_servicers.NewLookupServicer(enbStateStore))
 	state_protos.RegisterIndexerServer(srv.GrpcServer, protected_servicers.NewIndexerServicer())
 
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 }

--- a/lte/cloud/go/services/lte/test_init/test_service_init.go
+++ b/lte/cloud/go/services/lte/test_init/test_service_init.go
@@ -55,8 +55,8 @@ func StartTestServiceWithConfig(t *testing.T, serviceConfig lte_service.Config) 
 	}
 
 	srv, lis, plis := test_utils.NewTestOrchestratorService(t, lte.ModuleName, lte_service.ServiceName, labels, annotations)
-	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, protected_servicers.NewBuilderServicer(serviceConfig))
-	provider_protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewProviderServicer())
+	builder_protos.RegisterMconfigBuilderServer(srv.ProtectedGrpcServer, protected_servicers.NewBuilderServicer(serviceConfig))
+	provider_protos.RegisterStreamProviderServer(srv.ProtectedGrpcServer, servicers.NewProviderServicer())
 
 	// Init storage
 	db, err := sqorc.Open("sqlite3", ":memory:")
@@ -66,7 +66,7 @@ func StartTestServiceWithConfig(t *testing.T, serviceConfig lte_service.Config) 
 
 	// Add servicers
 	lte_protos.RegisterEnodebStateLookupServer(srv.ProtectedGrpcServer, protected_servicers.NewLookupServicer(enbStateStore))
-	state_protos.RegisterIndexerServer(srv.GrpcServer, protected_servicers.NewIndexerServicer())
+	state_protos.RegisterIndexerServer(srv.ProtectedGrpcServer, protected_servicers.NewIndexerServicer())
 
 	go srv.RunTest(lis, plis)
 }

--- a/lte/cloud/go/services/nprobe/nprobe/main.go
+++ b/lte/cloud/go/services/nprobe/nprobe/main.go
@@ -58,7 +58,7 @@ func main() {
 
 	// Attach handlers
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers(nprobeBlobstore))
-	protos.RegisterSwaggerSpecServer(srv.GrpcServer, servicers.NewSpecServicerFromFile(nprobe.ServiceName))
+	protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, servicers.NewSpecServicerFromFile(nprobe.ServiceName))
 
 	serviceConfig := nprobe.GetServiceConfig()
 	nProbeManager, err := manager.NewNProbeManager(serviceConfig, nprobeBlobstore)

--- a/lte/cloud/go/services/policydb/policydb/main.go
+++ b/lte/cloud/go/services/policydb/policydb/main.go
@@ -36,7 +36,7 @@ func main() {
 	assignmentServicer := policydb_servicer.NewPolicyAssignmentServer()
 	protos.RegisterPolicyAssignmentControllerServer(srv.GrpcServer, assignmentServicer)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swaggger_servicers.NewSpecServicerFromFile(policydb.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swaggger_servicers.NewSpecServicerFromFile(policydb.ServiceName))
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	err = srv.Run()

--- a/lte/cloud/go/services/smsd/smsd/main.go
+++ b/lte/cloud/go/services/smsd/smsd/main.go
@@ -52,7 +52,7 @@ func main() {
 	obsidian.AttachHandlers(srv.EchoServer, restServicer.GetHandlers())
 	protos.RegisterSmsDServer(srv.GrpcServer, smsd_servicer.NewSMSDServicer(store, &sms_ll.DefaultSMSSerde{}))
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(smsd.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(smsd.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/lte/cloud/go/services/subscriberdb/client_api.go
+++ b/lte/cloud/go/services/subscriberdb/client_api.go
@@ -169,7 +169,7 @@ func SetIMSIsForIPs(ctx context.Context, networkID string, mappings []*protos.IP
 }
 
 func getClient() (protos.SubscriberLookupClient, error) {
-	conn, err := registry.GetConnection(ServiceName, lib_protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(ServiceName, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -79,7 +79,7 @@ func main() {
 	state_protos.RegisterIndexerServer(srv.GrpcServer, lookup_servicers.NewIndexerServicer())
 	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, subscriberdbcloud_servicer.NewSubscriberdbServicer(serviceConfig, subscriberStore))
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(subscriberdb.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(subscriberdb.ServiceName))
 
 	// Run service
 	err = srv.Run()

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -75,7 +75,7 @@ func main() {
 
 	// Attach handlers
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
-	protos.RegisterSubscriberLookupServer(srv.GrpcServer, lookup_servicers.NewLookupServicer(fact, ipStore))
+	protos.RegisterSubscriberLookupServer(srv.ProtectedGrpcServer, lookup_servicers.NewLookupServicer(fact, ipStore))
 	state_protos.RegisterIndexerServer(srv.GrpcServer, lookup_servicers.NewIndexerServicer())
 	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, subscriberdbcloud_servicer.NewSubscriberdbServicer(serviceConfig, subscriberStore))
 

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -76,7 +76,7 @@ func main() {
 	// Attach handlers
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	protos.RegisterSubscriberLookupServer(srv.ProtectedGrpcServer, lookup_servicers.NewLookupServicer(fact, ipStore))
-	state_protos.RegisterIndexerServer(srv.GrpcServer, lookup_servicers.NewIndexerServicer())
+	state_protos.RegisterIndexerServer(srv.ProtectedGrpcServer, lookup_servicers.NewIndexerServicer())
 	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, subscriberdbcloud_servicer.NewSubscriberdbServicer(serviceConfig, subscriberStore))
 
 	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(subscriberdb.ServiceName))

--- a/lte/cloud/go/services/subscriberdb/test_init/test_service_init.go
+++ b/lte/cloud/go/services/subscriberdb/test_init/test_service_init.go
@@ -67,7 +67,7 @@ func StartTestService(t *testing.T) {
 
 	// Add servicers
 	protos.RegisterSubscriberLookupServer(srv.ProtectedGrpcServer, lookup_servicers.NewLookupServicer(fact, ipStore))
-	state_protos.RegisterIndexerServer(srv.GrpcServer, lookup_servicers.NewIndexerServicer())
+	state_protos.RegisterIndexerServer(srv.ProtectedGrpcServer, lookup_servicers.NewIndexerServicer())
 	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, subscriberdbcloud_servicer.NewSubscriberdbServicer(serviceConfig, subscriberStore))
 
 	// Run service

--- a/lte/cloud/go/services/subscriberdb/test_init/test_service_init.go
+++ b/lte/cloud/go/services/subscriberdb/test_init/test_service_init.go
@@ -42,7 +42,7 @@ func StartTestService(t *testing.T) {
 		orc8r.StateIndexerVersionAnnotation: "1",
 		orc8r.StateIndexerTypesAnnotation:   lte.MobilitydStateType,
 	}
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, subscriberdb.ServiceName, labels, annotations)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, subscriberdb.ServiceName, labels, annotations)
 
 	// Init storage
 	db, err := sqorc.Open("sqlite3", ":memory:")
@@ -66,10 +66,10 @@ func StartTestService(t *testing.T) {
 	}
 
 	// Add servicers
-	protos.RegisterSubscriberLookupServer(srv.GrpcServer, lookup_servicers.NewLookupServicer(fact, ipStore))
+	protos.RegisterSubscriberLookupServer(srv.ProtectedGrpcServer, lookup_servicers.NewLookupServicer(fact, ipStore))
 	state_protos.RegisterIndexerServer(srv.GrpcServer, lookup_servicers.NewIndexerServicer())
 	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, subscriberdbcloud_servicer.NewSubscriberdbServicer(serviceConfig, subscriberStore))
 
 	// Run service
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 }

--- a/lte/cloud/helm/lte-orc8r/templates/lte.deployment.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/lte.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/lte", "-run_echo_server=true
 ports:
   - name: grpc
     containerPort: 9113
+  - name: grpc-internal
+    containerPort: 9213
   - name: http
     containerPort: 10113
 livenessProbe:

--- a/lte/cloud/helm/lte-orc8r/templates/lte.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/lte.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9113
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9213
     - name: http
       port: 8080
       targetPort:  10113

--- a/lte/cloud/helm/lte-orc8r/templates/nprobe.deployment.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/nprobe.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/nprobe", "-run_echo_server=t
 ports:
   - name: grpc
     containerPort: 9666
+  - name: grpc-internal
+    containerPort: 9766
   - name: http
     containerPort: 10088
 livenessProbe:

--- a/lte/cloud/helm/lte-orc8r/templates/nprobe.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/nprobe.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9666
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9766
     - name: http
       port: 8080
       targetPort: 10088

--- a/lte/cloud/helm/lte-orc8r/templates/policydb.deployment.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/policydb.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/policydb", "-run_echo_server
 ports:
   - name: grpc
     containerPort: 9085
+  - name: grpc-internal
+    containerPort: 9185
   - name: http
     containerPort: 10085
 livenessProbe:

--- a/lte/cloud/helm/lte-orc8r/templates/policydb.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/policydb.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9085
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9185
     - name: http
       port: 8080
       targetPort:  10085

--- a/lte/cloud/helm/lte-orc8r/templates/smsd.deployment.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/smsd.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/smsd", "-run_echo_server=tru
 ports:
   - name: grpc
     containerPort: 9120
+  - name: grpc-internal
+    containerPort: 9220
   - name: http
     containerPort: 10086
 livenessProbe:

--- a/lte/cloud/helm/lte-orc8r/templates/smsd.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/smsd.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9120
+    - name: grpc-internal
+      port: 9180
+      targetPort: 9220
     - name: http
       port: 8080
       targetPort:  10086

--- a/lte/cloud/helm/lte-orc8r/templates/subscriberdb.deployment.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/subscriberdb.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/subscriberdb", "-run_echo_se
 ports:
   - name: grpc
     containerPort: 9083
+  - name: grpc-internal
+    containerPort: 9183
   - name: http
     containerPort: 10083
 livenessProbe:

--- a/lte/cloud/helm/lte-orc8r/templates/subscriberdb.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/subscriberdb.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9083
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9183
     - name: http
       port: 8080
       targetPort:  10083

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -143,6 +143,7 @@ services:
   device:
     host: "localhost"
     port: 9106
+    protected_port: 9306
     proxy_type: "clientcert"
 
   configurator:

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -149,6 +149,7 @@ services:
   configurator:
     host: "localhost"
     port: 9108
+    protected_port: 9208
     proxy_type: "clientcert"
 
   ctraced:

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -64,6 +64,7 @@ services:
   metricsd:
     host: "localhost"
     port: 9084
+    protected_port: 9184
     echo_port: 10084
     proxy_type: "clientcert"
     labels:

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -99,6 +99,7 @@ services:
   accessd:
     host: "localhost"
     port: 9091
+    protected_port: 9191
     proxy_type: "clientcert"
 
   eventd:

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -128,6 +128,7 @@ services:
   directoryd:
     host: "localhost"
     port: 9100
+    protected_port: 9102
     proxy_type: "clientcert"
 
   state:

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -135,6 +135,7 @@ services:
   state:
     host: "localhost"
     port: 9105
+    protected_port: 9305
     proxy_type: "clientcert"
 
   orc8r_worker:

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -35,6 +35,7 @@ services:
   orchestrator:
     host: "localhost"
     port: 9112
+    protected_port: 9212
     echo_port: 10112
     proxy_type: "clientcert"
     labels:
@@ -106,6 +107,7 @@ services:
   eventd:
     host: "localhost"
     port: 9121
+    protected_port: 9221
     echo_port: 10121
     proxy_type: "clientcert"
     labels:
@@ -158,6 +160,7 @@ services:
   ctraced:
     host: "localhost"
     port: 9118
+    protected_port: 9218
     echo_port: 10118
     proxy_type: "clientcert"
     labels:

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -168,6 +168,7 @@ services:
   tenants:
     host: "localhost"
     port: 9110
+    protected_port: 9210
     echo_port: 10110
     proxy_type: "clientcert"
     labels:

--- a/orc8r/cloud/go/obsidian/reverse_proxy/reverse_proxy_test.go
+++ b/orc8r/cloud/go/obsidian/reverse_proxy/reverse_proxy_test.go
@@ -247,7 +247,7 @@ func addPrefixesToExistingService(serviceName string, newPrefixes string) error 
 
 	pport, err := registry.GetServicePort(serviceName, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
-		glog.Infof("service does not have a protected port")
+		glog.V(1).Infof("service %s does not have a protected port", serviceName)
 	}
 
 	echoPort, err := registry.GetEchoServerPort(serviceName)

--- a/orc8r/cloud/go/obsidian/swagger/handlers/handlers_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/handlers/handlers_test.go
@@ -185,15 +185,15 @@ func registerServicer(
 		orc8r.SwaggerSpecLabel: "true",
 	}
 
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, service, labels, nil)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, service, labels, nil)
 	partialSpec := spec.Spec{Tags: []spec.TagDefinition{partialTag}}
 	standaloneSpec := spec.Spec{Tags: []spec.TagDefinition{standaloneTag}}
 
 	partialYamlSpec := marshalToYAML(t, partialSpec)
 	standaloneYamlSpec := marshalToYAML(t, standaloneSpec)
-	protos.RegisterSwaggerSpecServer(srv.GrpcServer, servicers.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
+	protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, servicers.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
 
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 }
 
 func marshalToYAML(t *testing.T, spec spec.Spec) string {

--- a/orc8r/cloud/go/obsidian/swagger/poll_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/poll_test.go
@@ -115,7 +115,7 @@ func registerServicer(
 		orc8r.SwaggerSpecLabel: "true",
 	}
 
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, service, labels, nil)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, service, labels, nil)
 	partialSpec := spec.Spec{Tags: []spec.TagDefinition{partialTag}}
 	standaloneSpec := spec.Spec{Tags: []spec.TagDefinition{standaloneTag}}
 
@@ -123,7 +123,7 @@ func registerServicer(
 	standaloneYamlSpec := marshalToYAML(t, standaloneSpec)
 	protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, servicers.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
 
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 }
 
 // marshalToYAML marshals the passed Swagger spec to a YAML-formatted string.

--- a/orc8r/cloud/go/obsidian/swagger/poll_test.go
+++ b/orc8r/cloud/go/obsidian/swagger/poll_test.go
@@ -121,7 +121,7 @@ func registerServicer(
 
 	partialYamlSpec := marshalToYAML(t, partialSpec)
 	standaloneYamlSpec := marshalToYAML(t, standaloneSpec)
-	protos.RegisterSwaggerSpecServer(srv.GrpcServer, servicers.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
+	protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, servicers.NewSpecServicer(partialYamlSpec, standaloneYamlSpec))
 
 	go srv.RunTest(lis, nil)
 }

--- a/orc8r/cloud/go/obsidian/swagger/remote_spec.go
+++ b/orc8r/cloud/go/obsidian/swagger/remote_spec.go
@@ -80,7 +80,7 @@ func (s *RemoteSpec) GetService() string {
 const specClientDefaultTimeout = 5 * time.Second
 
 func (s *RemoteSpec) getClient() (protos.SwaggerSpecClient, error) {
-	conn, err := registry.GetConnectionWithTimeout(s.service, specClientDefaultTimeout, lib_protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnectionWithTimeout(s.service, specClientDefaultTimeout, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, s.service)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/accessd/accessd/main.go
+++ b/orc8r/cloud/go/services/accessd/accessd/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// Add servicers to the service
 	accessdServer := servicers.NewAccessdServer(store)
-	protos.RegisterAccessControlManagerServer(srv.GrpcServer, accessdServer)
+	protos.RegisterAccessControlManagerServer(srv.ProtectedGrpcServer, accessdServer)
 
 	// Run the service
 	err = srv.Run()

--- a/orc8r/cloud/go/services/accessd/client_api.go
+++ b/orc8r/cloud/go/services/accessd/client_api.go
@@ -32,7 +32,7 @@ const ServiceName = "accessd"
 // getAccessbClient is a utility function to get a RPC connection to the
 // accessd service
 func getAccessdClient() (accessprotos.AccessControlManagerClient, error) {
-	conn, err := registry.GetConnection(ServiceName, protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(ServiceName, protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/accessd/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/accessd/test_init/test_service_init.go
@@ -25,9 +25,9 @@ import (
 )
 
 func StartTestService(t *testing.T) {
-	srv, lis, _ := test_utils.NewTestService(t, orc8r.ModuleName, accessd.ServiceName)
+	srv, lis, plis := test_utils.NewTestService(t, orc8r.ModuleName, accessd.ServiceName)
 	store := test_utils.NewSQLBlobstore(t, storage.AccessdTableBlobstore)
 	accessdStore := storage.NewAccessdBlobstore(store)
-	protos.RegisterAccessControlManagerServer(srv.GrpcServer, servicers.NewAccessdServer(accessdStore))
-	go srv.RunTest(lis, nil)
+	protos.RegisterAccessControlManagerServer(srv.ProtectedGrpcServer, servicers.NewAccessdServer(accessdStore))
+	go srv.RunTest(lis, plis)
 }

--- a/orc8r/cloud/go/services/analytics/analyzer.go
+++ b/orc8r/cloud/go/services/analytics/analyzer.go
@@ -118,7 +118,7 @@ func getRemoteCollectors() ([]protos.AnalyticsCollectorClient, error) {
 
 	var collectorClientList []protos.AnalyticsCollectorClient
 	for _, s := range services {
-		conn, err := registry.GetConnection(s, lib_protos.ServiceType_SOUTHBOUND)
+		conn, err := registry.GetConnection(s, lib_protos.ServiceType_PROTECTED)
 		if err != nil {
 			glog.Errorf("Unable to get a remote connection %s error %v", s, err)
 			continue

--- a/orc8r/cloud/go/services/certifier/certifier/main.go
+++ b/orc8r/cloud/go/services/certifier/certifier/main.go
@@ -103,7 +103,7 @@ func main() {
 		analytics_service.GetAnalyticsCalculations(&serviceConfig),
 		nil,
 	)
-	analytics_protos.RegisterAnalyticsCollectorServer(srv.GrpcServer, collectorServicer)
+	analytics_protos.RegisterAnalyticsCollectorServer(srv.ProtectedGrpcServer, collectorServicer)
 
 	// Register servicer
 	servicer, err := servicers.NewCertifierServer(store, caMap)

--- a/orc8r/cloud/go/services/certifier/certifier/main.go
+++ b/orc8r/cloud/go/services/certifier/certifier/main.go
@@ -113,7 +113,7 @@ func main() {
 	certprotos.RegisterCertifierServer(srv.ProtectedGrpcServer, servicer)
 
 	// Add handlers that manages users to Swagger
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(certifier.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(certifier.ServiceName))
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 
 	// Start Garbage Collector Ticker

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -710,7 +710,7 @@ func CountEntitiesOfType(ctx context.Context, networkID string, entityType strin
 }
 
 func getNBConfiguratorClient() (protos.NorthboundConfiguratorClient, error) {
-	conn, err := registry.GetConnection(ServiceName, commonProtos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(ServiceName, commonProtos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/configurator/configurator/main.go
+++ b/orc8r/cloud/go/services/configurator/configurator/main.go
@@ -60,7 +60,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Failed to instantiate the user-facing configurator servicer: %v", nbServicer)
 	}
-	protos.RegisterNorthboundConfiguratorServer(srv.GrpcServer, nbServicer)
+	protos.RegisterNorthboundConfiguratorServer(srv.ProtectedGrpcServer, nbServicer)
 
 	sbServicer, err := servicers.NewSouthboundConfiguratorServicer(factory)
 	if err != nil {

--- a/orc8r/cloud/go/services/configurator/mconfig/remote_builder.go
+++ b/orc8r/cloud/go/services/configurator/mconfig/remote_builder.go
@@ -52,7 +52,7 @@ func (r *remoteBuilder) Build(network *storage.Network, graph *storage.EntityGra
 }
 
 func (r *remoteBuilder) getBuilderClient() (protos.MconfigBuilderClient, error) {
-	conn, err := registry.GetConnection(r.service, lib_protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(r.service, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, r.service)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/configurator/test_init/test_builder_servicer.go
+++ b/orc8r/cloud/go/services/configurator/test_init/test_builder_servicer.go
@@ -33,10 +33,10 @@ func StartNewTestBuilder(t *testing.T, builder mconfig.Builder) {
 	labels := map[string]string{
 		orc8r.MconfigBuilderLabel: "true",
 	}
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, "test_mconfig_builder_service", labels, nil)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, "test_mconfig_builder_service", labels, nil)
 	servicer := &builderServicer{builder: builder}
-	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, servicer)
-	go srv.RunTest(lis, nil)
+	builder_protos.RegisterMconfigBuilderServer(srv.ProtectedGrpcServer, servicer)
+	go srv.RunTest(lis, plis)
 }
 
 func (s *builderServicer) Build(ctx context.Context, request *builder_protos.BuildRequest) (*builder_protos.BuildResponse, error) {

--- a/orc8r/cloud/go/services/configurator/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/configurator/test_init/test_service_init.go
@@ -49,12 +49,12 @@ func StartTestService(t *testing.T) {
 	accessd_test_init.StartTestService(t)
 	certifier_test_init.StartTestService(t)
 
-	srv, lis, _ := test_utils.NewTestService(t, orc8r.ModuleName, configurator.ServiceName)
+	srv, lis, plis := test_utils.NewTestService(t, orc8r.ModuleName, configurator.ServiceName)
 	nb, err := protected_servicers.NewNorthboundConfiguratorServicer(storageFactory)
 	if err != nil {
 		t.Fatalf("Failed to create NB configurator servicer: %s", err)
 	}
-	protos.RegisterNorthboundConfiguratorServer(srv.GrpcServer, nb)
+	protos.RegisterNorthboundConfiguratorServer(srv.ProtectedGrpcServer, nb)
 
 	sb, err := servicers.NewSouthboundConfiguratorServicer(storageFactory)
 	if err != nil {
@@ -62,7 +62,7 @@ func StartTestService(t *testing.T) {
 	}
 	protos.RegisterSouthboundConfiguratorServer(srv.GrpcServer, sb)
 
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 }
 
 type sequentialIDGenerator struct {

--- a/orc8r/cloud/go/services/ctraced/ctraced/main.go
+++ b/orc8r/cloud/go/services/ctraced/ctraced/main.go
@@ -52,7 +52,7 @@ func main() {
 
 	// Init gRPC servicer
 	protos.RegisterCallTraceControllerServer(srv.GrpcServer, servicers.NewCallTraceServicer(ctracedBlobstore))
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(ctraced.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(ctraced.ServiceName))
 
 	gwClient := handlers.NewGwCtracedClient()
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers(gwClient, ctracedBlobstore))

--- a/orc8r/cloud/go/services/device/client_api.go
+++ b/orc8r/cloud/go/services/device/client_api.go
@@ -164,7 +164,7 @@ func getDevice(ctx context.Context, networkID, deviceType, deviceKey string) (*p
 }
 
 func getDeviceClient() (protos.DeviceClient, error) {
-	conn, err := registry.GetConnection(ServiceName, lib_protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(ServiceName, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/device/device/main.go
+++ b/orc8r/cloud/go/services/device/device/main.go
@@ -45,7 +45,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Failed to instantiate the device servicer: %v", deviceServicer)
 	}
-	protos.RegisterDeviceServer(srv.GrpcServer, deviceServicer)
+	protos.RegisterDeviceServer(srv.ProtectedGrpcServer, deviceServicer)
 
 	err = srv.Run()
 	if err != nil {

--- a/orc8r/cloud/go/services/device/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/device/test_init/test_service_init.go
@@ -28,9 +28,9 @@ import (
 // StartTestService instantiates a service backed by an in-memory storage
 func StartTestService(t *testing.T) {
 	factory := test_utils.NewSQLBlobstore(t, "device_test_service_blobstore")
-	srv, lis, _ := test_utils.NewTestService(t, orc8r.ModuleName, device.ServiceName)
+	srv, lis, plis := test_utils.NewTestService(t, orc8r.ModuleName, device.ServiceName)
 	server, err := servicers.NewDeviceServicer(factory)
 	assert.NoError(t, err)
-	protos.RegisterDeviceServer(srv.GrpcServer, server)
-	go srv.RunTest(lis, nil)
+	protos.RegisterDeviceServer(srv.ProtectedGrpcServer, server)
+	go srv.RunTest(lis, plis)
 }

--- a/orc8r/cloud/go/services/directoryd/client_api.go
+++ b/orc8r/cloud/go/services/directoryd/client_api.go
@@ -38,7 +38,7 @@ const ServiceName = "directoryd"
 
 // getDirectorydClient returns an RPC connection to the directoryd service.
 func getDirectorydClient() (protos.DirectoryLookupClient, error) {
-	conn, err := registry.GetConnection(ServiceName, lib_protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(ServiceName, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/directoryd/directoryd/main.go
+++ b/orc8r/cloud/go/services/directoryd/directoryd/main.go
@@ -73,7 +73,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating initializing directory servicer: %s", err)
 	}
-	directoryd_protos.RegisterDirectoryLookupServer(srv.GrpcServer, servicer)
+	directoryd_protos.RegisterDirectoryLookupServer(srv.ProtectedGrpcServer, servicer)
 	protos.RegisterGatewayDirectoryServiceServer(srv.GrpcServer, servicers.NewDirectoryUpdateServicer())
 
 	// Run service

--- a/orc8r/cloud/go/services/directoryd/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/directoryd/test_init/test_service_init.go
@@ -31,7 +31,7 @@ import (
 
 func StartTestService(t *testing.T) {
 	// Create service
-	srv, lis, _ := test_utils.NewTestService(t, orc8r.ModuleName, directoryd.ServiceName)
+	srv, lis, plis := test_utils.NewTestService(t, orc8r.ModuleName, directoryd.ServiceName)
 
 	// Init storage
 	db, err := sqorc.Open("sqlite3", ":memory:")
@@ -44,9 +44,9 @@ func StartTestService(t *testing.T) {
 	// Add servicers
 	directoryServicer, err := servicers.NewDirectoryLookupServicer(store)
 	assert.NoError(t, err)
-	directoryd_protos.RegisterDirectoryLookupServer(srv.GrpcServer, directoryServicer)
+	directoryd_protos.RegisterDirectoryLookupServer(srv.ProtectedGrpcServer, directoryServicer)
 	protos.RegisterGatewayDirectoryServiceServer(srv.GrpcServer, servicers.NewDirectoryUpdateServicer())
 
 	// Run service
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 }

--- a/orc8r/cloud/go/services/eventd/eventd/main.go
+++ b/orc8r/cloud/go/services/eventd/eventd/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, servicers.NewSpecServicerFromFile(eventd.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, servicers.NewSpecServicerFromFile(eventd.ServiceName))
 
 	err = srv.Run()
 	if err != nil {

--- a/orc8r/cloud/go/services/metricsd/client_api.go
+++ b/orc8r/cloud/go/services/metricsd/client_api.go
@@ -36,7 +36,7 @@ func PushMetrics(ctx context.Context, metrics *protos.PushedMetricsContainer) er
 // getCloudMetricsdClient is a utility function to get a RPC connection to the
 // metricsd service
 func getCloudMetricsdClient() (protos.CloudMetricsControllerClient, error) {
-	conn, err := service_registry.GetConnection(ServiceName, protos.ServiceType_SOUTHBOUND)
+	conn, err := service_registry.GetConnection(ServiceName, protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/metricsd/exporters/remote_exporter.go
+++ b/orc8r/cloud/go/services/metricsd/exporters/remote_exporter.go
@@ -33,7 +33,7 @@ func (r *remoteExporter) Submit(metrics []MetricAndContext) error {
 }
 
 func (r *remoteExporter) getExporterClient() (protos.MetricsExporterClient, error) {
-	conn, err := registry.GetConnection(r.service, lib_protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(r.service, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, r.service)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/metricsd/metricsd/main.go
+++ b/orc8r/cloud/go/services/metricsd/metricsd/main.go
@@ -54,7 +54,7 @@ func main() {
 	controllerServicer := southbound.NewMetricsControllerServer()
 	protos.RegisterMetricsControllerServer(srv.GrpcServer, controllerServicer)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(metricsd.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(metricsd.ServiceName))
 
 	// Initialize gatherers
 	additionalCollectors := []collection.MetricCollector{

--- a/orc8r/cloud/go/services/metricsd/metricsd/main.go
+++ b/orc8r/cloud/go/services/metricsd/metricsd/main.go
@@ -14,6 +14,7 @@ limitations under the License.
 package main
 
 import (
+	"magma/orc8r/cloud/go/services/metricsd/servicers/southbound"
 	"time"
 
 	"github.com/golang/glog"
@@ -29,7 +30,6 @@ import (
 	"magma/orc8r/cloud/go/services/metricsd/collection"
 	"magma/orc8r/cloud/go/services/metricsd/obsidian/handlers"
 	"magma/orc8r/cloud/go/services/metricsd/servicers/protected"
-	"magma/orc8r/cloud/go/services/metricsd/servicers/southbound"
 	"magma/orc8r/lib/go/protos"
 )
 
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	cloudControllerServicer := protected.NewCloudMetricsControllerServer()
-	protos.RegisterCloudMetricsControllerServer(srv.GrpcServer, cloudControllerServicer)
+	protos.RegisterCloudMetricsControllerServer(srv.ProtectedGrpcServer, cloudControllerServicer)
 
 	controllerServicer := southbound.NewMetricsControllerServer()
 	protos.RegisterMetricsControllerServer(srv.GrpcServer, controllerServicer)

--- a/orc8r/cloud/go/services/metricsd/metricsd/main.go
+++ b/orc8r/cloud/go/services/metricsd/metricsd/main.go
@@ -14,7 +14,6 @@ limitations under the License.
 package main
 
 import (
-	"magma/orc8r/cloud/go/services/metricsd/servicers/southbound"
 	"time"
 
 	"github.com/golang/glog"
@@ -30,6 +29,7 @@ import (
 	"magma/orc8r/cloud/go/services/metricsd/collection"
 	"magma/orc8r/cloud/go/services/metricsd/obsidian/handlers"
 	"magma/orc8r/cloud/go/services/metricsd/servicers/protected"
+	"magma/orc8r/cloud/go/services/metricsd/servicers/southbound"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/orc8r/cloud/go/services/metricsd/test_init/test_exporter_servicer.go
+++ b/orc8r/cloud/go/services/metricsd/test_init/test_exporter_servicer.go
@@ -33,10 +33,10 @@ func StartNewTestExporter(t *testing.T, exporter exporters.Exporter) {
 	labels := map[string]string{
 		orc8r.MetricsExporterLabel: "true",
 	}
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, "MOCK_EXPORTER_SERVICE", labels, nil)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, "MOCK_EXPORTER_SERVICE", labels, nil)
 	servicer := &exporterServicer{exporter: exporter}
-	protos.RegisterMetricsExporterServer(srv.GrpcServer, servicer)
-	go srv.RunTest(lis, nil)
+	protos.RegisterMetricsExporterServer(srv.ProtectedGrpcServer, servicer)
+	go srv.RunTest(lis, plis)
 }
 
 func (e *exporterServicer) Submit(ctx context.Context, req *protos.SubmitMetricsRequest) (*protos.SubmitMetricsResponse, error) {

--- a/orc8r/cloud/go/services/metricsd/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/metricsd/test_init/test_service_init.go
@@ -23,7 +23,7 @@ import (
 )
 
 func StartTestServiceInternal(t *testing.T, exporter protos.MetricsExporterServer) {
-	srv, lis, _ := test_utils.NewTestService(t, orc8r.ModuleName, metricsd.ServiceName)
-	protos.RegisterMetricsExporterServer(srv.GrpcServer, exporter)
-	go srv.RunTest(lis, nil)
+	srv, lis, plis := test_utils.NewTestService(t, orc8r.ModuleName, metricsd.ServiceName)
+	protos.RegisterMetricsExporterServer(srv.ProtectedGrpcServer, exporter)
+	go srv.RunTest(lis, plis)
 }

--- a/orc8r/cloud/go/services/orc8r_worker/orc8r_worker/main.go
+++ b/orc8r/cloud/go/services/orc8r_worker/orc8r_worker/main.go
@@ -64,7 +64,7 @@ func startSingletonReindexer(srv *service.OrchestratorService) {
 	}
 
 	indexerManagerServer := newSingletonIndexerManagerServicer(srv.Config, db, store)
-	indexer_protos.RegisterIndexerManagerServer(srv.GrpcServer, indexerManagerServer)
+	indexer_protos.RegisterIndexerManagerServer(srv.ProtectedGrpcServer, indexerManagerServer)
 }
 
 func newSingletonIndexerManagerServicer(cfg *config.Map, db *sql.DB, store blobstore.StoreFactory) indexer_protos.IndexerManagerServer {

--- a/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
+++ b/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
@@ -69,10 +69,10 @@ func main() {
 	} else {
 		exporterServicer = protected_servicers.NewPushExporterServicer(serviceConfig.PrometheusPushAddresses)
 	}
-	builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, protected_servicers.NewBuilderServicer())
-	exporter_protos.RegisterMetricsExporterServer(srv.GrpcServer, exporterServicer)
-	indexer_protos.RegisterIndexerServer(srv.GrpcServer, protected_servicers.NewIndexerServicer())
-	streamer_protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewProviderServicer())
+	builder_protos.RegisterMconfigBuilderServer(srv.ProtectedGrpcServer, protected_servicers.NewBuilderServicer())
+	exporter_protos.RegisterMetricsExporterServer(srv.ProtectedGrpcServer, exporterServicer)
+	indexer_protos.RegisterIndexerServer(srv.ProtectedGrpcServer, protected_servicers.NewIndexerServicer())
+	streamer_protos.RegisterStreamProviderServer(srv.ProtectedGrpcServer, servicers.NewProviderServicer())
 
 	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger.NewSpecServicerFromFile(orchestrator.ServiceName))
 

--- a/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
+++ b/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
@@ -82,7 +82,7 @@ func main() {
 		analytics_service.GetAnalyticsCalculations(&serviceConfig.Analytics),
 		nil,
 	)
-	analytics_protos.RegisterAnalyticsCollectorServer(srv.GrpcServer, collectorServicer)
+	analytics_protos.RegisterAnalyticsCollectorServer(srv.ProtectedGrpcServer, collectorServicer)
 
 	err = srv.Run()
 	if err != nil {

--- a/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
+++ b/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
@@ -74,7 +74,7 @@ func main() {
 	indexer_protos.RegisterIndexerServer(srv.GrpcServer, protected_servicers.NewIndexerServicer())
 	streamer_protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewProviderServicer())
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger.NewSpecServicerFromFile(orchestrator.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger.NewSpecServicerFromFile(orchestrator.ServiceName))
 
 	collectorServicer := analytics_servicers.NewCollectorServicer(
 		&serviceConfig.Analytics,

--- a/orc8r/cloud/go/services/orchestrator/servicers/protected/grpc_exporter_servicer_test.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/protected/grpc_exporter_servicer_test.go
@@ -1,7 +1,9 @@
 /*
 Copyright 2020 The Magma Authors.
+
 This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -124,9 +126,9 @@ func TestGRPCExporter(t *testing.T) {
 // The returned exporter forwards to the metrics exporter, which in turn
 // forwards to the edge hub.
 func makeExporter(t *testing.T, mockEdge edge_hub.MetricsControllerServer) exporters.Exporter {
-	edgeSrv, lis, _ := test_utils.NewTestService(t, orc8r.ModuleName, edgeControllerServiceName)
+	edgeSrv, lis, plis := test_utils.NewTestService(t, orc8r.ModuleName, edgeControllerServiceName)
 	edge_hub.RegisterMetricsControllerServer(edgeSrv.GrpcServer, mockEdge)
-	go edgeSrv.RunTest(lis, nil)
+	go edgeSrv.RunTest(lis, plis)
 
 	edgeAddr, err := registry.GetServiceAddress(edgeControllerServiceName, lib_protos.ServiceType_SOUTHBOUND)
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/services/orchestrator/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/orchestrator/test_init/test_service_init.go
@@ -58,18 +58,18 @@ func StartTestServiceInternal(
 		annotations[orc8r.StreamProviderStreamsAnnotation] = definitions.MconfigStreamName
 	}
 
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, orchestrator.ServiceName, labels, annotations)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, orchestrator.ServiceName, labels, annotations)
 	protos.RegisterStreamerServer(srv.GrpcServer, &testStreamerServer{})
 
 	if builder != nil {
-		builder_protos.RegisterMconfigBuilderServer(srv.GrpcServer, builder)
+		builder_protos.RegisterMconfigBuilderServer(srv.ProtectedGrpcServer, builder)
 	}
 	if indexer != nil {
-		indexer_protos.RegisterIndexerServer(srv.GrpcServer, indexer)
+		indexer_protos.RegisterIndexerServer(srv.ProtectedGrpcServer, indexer)
 	}
 	if provider != nil {
-		streamer_protos.RegisterStreamProviderServer(srv.GrpcServer, provider)
+		streamer_protos.RegisterStreamProviderServer(srv.ProtectedGrpcServer, provider)
 	}
 
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 }

--- a/orc8r/cloud/go/services/service_registry/service_registry/main.go
+++ b/orc8r/cloud/go/services/service_registry/service_registry/main.go
@@ -54,7 +54,6 @@ func main() {
 		if err != nil {
 			glog.Fatal(err)
 		}
-		protos.RegisterServiceRegistryServer(srv.GrpcServer, servicer)
 		protos.RegisterServiceRegistryServer(srv.ProtectedGrpcServer, servicer)
 	} else {
 		glog.Infof("Registry Mode set to %s. Not creating service registry servicer", registryModeEnvValue)

--- a/orc8r/cloud/go/services/service_registry/servicers/protected/kubernetes_servicer.go
+++ b/orc8r/cloud/go/services/service_registry/servicers/protected/kubernetes_servicer.go
@@ -165,7 +165,6 @@ func (k *KubernetesServiceRegistryServicer) getAddressForPortName(service string
 	if err != nil {
 		return "", err
 	}
-
 	for _, port := range svc.Spec.Ports {
 		if port.Name == portName {
 			return fmt.Sprintf("%s:%d", svc.Name, port.Port), nil

--- a/orc8r/cloud/go/services/state/client_api.go
+++ b/orc8r/cloud/go/services/state/client_api.go
@@ -39,7 +39,7 @@ func GetStateClient() (protos.StateServiceClient, error) {
 
 // GetCloudStateClient returns a client to the state service.
 func GetCloudStateClient() (protos.CloudStateServiceClient, error) {
-	conn, err := registry.GetConnection(ServiceName, protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(ServiceName, protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/state/indexer/remote_indexer.go
+++ b/orc8r/cloud/go/services/state/indexer/remote_indexer.go
@@ -134,7 +134,7 @@ func (r *remoteIndexer) DeIndex(networkID string, states state_types.SerializedS
 }
 
 func (r *remoteIndexer) getIndexerClient() (state_protos.IndexerClient, error) {
-	conn, err := registry.GetConnection(r.service, lib_protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(r.service, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, r.service)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/state/state/main.go
+++ b/orc8r/cloud/go/services/state/state/main.go
@@ -75,7 +75,7 @@ func main() {
 	protos.RegisterStateServiceServer(srv.GrpcServer, stateServicer)
 
 	cloudStateServicer := newCloudStateServicer(store)
-	protos.RegisterCloudStateServiceServer(srv.GrpcServer, cloudStateServicer)
+	protos.RegisterCloudStateServiceServer(srv.ProtectedGrpcServer, cloudStateServicer)
 
 	singletonReindex := srv.Config.MustGetBool(state_config.EnableSingletonReindex)
 	if !singletonReindex {

--- a/orc8r/cloud/go/services/state/state/main.go
+++ b/orc8r/cloud/go/services/state/state/main.go
@@ -81,7 +81,7 @@ func main() {
 	if !singletonReindex {
 		glog.Info("Running reindexer")
 		indexerManagerServer := newIndexerManagerServicer(srv.Config, db, store)
-		indexer_protos.RegisterIndexerManagerServer(srv.GrpcServer, indexerManagerServer)
+		indexer_protos.RegisterIndexerManagerServer(srv.ProtectedGrpcServer, indexerManagerServer)
 	}
 
 	go metrics.PeriodicallyReportGatewayStatus(gatewayStatusReportInterval)

--- a/orc8r/cloud/go/services/state/test_init/test_indexer_servicer.go
+++ b/orc8r/cloud/go/services/state/test_init/test_indexer_servicer.go
@@ -38,10 +38,10 @@ func StartNewTestIndexer(t *testing.T, idx indexer.Indexer) {
 		orc8r.StateIndexerVersionAnnotation: strconv.Itoa(int(idx.GetVersion())),
 		orc8r.StateIndexerTypesAnnotation:   strings.Join(idx.GetTypes(), orc8r.AnnotationFieldSeparator),
 	}
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, idx.GetID(), labels, annotations)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, idx.GetID(), labels, annotations)
 	servicer := &indexerServicer{idx: idx}
-	protos.RegisterIndexerServer(srv.GrpcServer, servicer)
-	go srv.RunTest(lis, nil)
+	protos.RegisterIndexerServer(srv.ProtectedGrpcServer, servicer)
+	go srv.RunTest(lis, plis)
 }
 
 func (i *indexerServicer) Index(ctx context.Context, req *protos.IndexRequest) (*protos.IndexResponse, error) {

--- a/orc8r/cloud/go/services/state/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/state/test_init/test_service_init.go
@@ -69,7 +69,7 @@ func startService(t *testing.T, db *sql.DB) (reindex.Reindexer, reindex.JobQueue
 	require.NoError(t, queue.Initialize())
 	reindexer := reindex.NewReindexerQueue(queue, reindex.NewStore(factory))
 	indexerServicer := protected_servicers.NewIndexerManagerServicer(reindexer, false)
-	indexer_protos.RegisterIndexerManagerServer(srv.GrpcServer, indexerServicer)
+	indexer_protos.RegisterIndexerManagerServer(srv.ProtectedGrpcServer, indexerServicer)
 
 	go srv.RunTest(lis, plis)
 	return reindexer, queue
@@ -85,7 +85,7 @@ func StartTestSingletonServiceInternal(t *testing.T) reindex.Reindexer {
 }
 
 func startSingletonService(t *testing.T, db *sql.DB) reindex.Reindexer {
-	srv, lis, _ := test_utils.NewTestService(t, orc8r.ModuleName, state.ServiceName)
+	srv, lis, plis := test_utils.NewTestService(t, orc8r.ModuleName, state.ServiceName)
 
 	factory := blobstore.NewSQLStoreFactory(state.DBTableName, db, sqorc.GetSqlBuilder())
 	require.NoError(t, factory.InitializeFactory())
@@ -102,8 +102,8 @@ func startSingletonService(t *testing.T, db *sql.DB) reindex.Reindexer {
 	versioner.Initialize()
 	reindexer := reindex.NewReindexerSingleton(reindex.NewStore(factory), versioner)
 	indexerServicer := protected_servicers.NewIndexerManagerServicer(reindexer, false)
-	indexer_protos.RegisterIndexerManagerServer(srv.GrpcServer, indexerServicer)
+	indexer_protos.RegisterIndexerManagerServer(srv.ProtectedGrpcServer, indexerServicer)
 
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 	return reindexer
 }

--- a/orc8r/cloud/go/services/streamer/providers/servicers/protected/remote_provider.go
+++ b/orc8r/cloud/go/services/streamer/providers/servicers/protected/remote_provider.go
@@ -61,7 +61,7 @@ func (r *remoteProvider) GetUpdates(ctx context.Context, gatewayId string, extra
 }
 
 func (r *remoteProvider) getProviderClient() (streamer_protos.StreamProviderClient, error) {
-	conn, err := registry.GetConnection(r.service, protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(r.service, protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, r.service)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/streamer/test_init/test_provider_servicer.go
+++ b/orc8r/cloud/go/services/streamer/test_init/test_provider_servicer.go
@@ -37,10 +37,10 @@ func StartNewTestProvider(t *testing.T, provider stream_provider.StreamProvider,
 	annotations := map[string]string{
 		orc8r.StreamProviderStreamsAnnotation: streamName,
 	}
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, streamName, labels, annotations)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, streamName, labels, annotations)
 	servicer := &providerServicer{provider: provider}
-	streamer_protos.RegisterStreamProviderServer(srv.GrpcServer, servicer)
-	go srv.RunTest(lis, nil)
+	streamer_protos.RegisterStreamProviderServer(srv.ProtectedGrpcServer, servicer)
+	go srv.RunTest(lis, plis)
 }
 
 func (p *providerServicer) GetUpdates(ctx context.Context, req *protos.StreamRequest) (*protos.DataUpdateBatch, error) {

--- a/orc8r/cloud/go/services/tenants/client_api.go
+++ b/orc8r/cloud/go/services/tenants/client_api.go
@@ -30,7 +30,7 @@ import (
 // getTenantsClient is a utility function to get a RPC connection to the
 // tenants service
 func getTenantsClient() (tenant_protos.TenantsServiceClient, error) {
-	conn, err := srvRegistry.GetConnection(ServiceName, protos.ServiceType_SOUTHBOUND)
+	conn, err := srvRegistry.GetConnection(ServiceName, protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, ServiceName)
 		glog.Error(initErr)

--- a/orc8r/cloud/go/services/tenants/servicers/protected/servicer_test.go
+++ b/orc8r/cloud/go/services/tenants/servicers/protected/servicer_test.go
@@ -173,7 +173,7 @@ func newTestService(t *testing.T) (tenant_protos.TenantsServiceServer, error) {
 	store := storage.NewBlobstoreStore(factory)
 	servicer, err := servicers.NewTenantsServicer(store)
 	assert.NoError(t, err)
-	tenant_protos.RegisterTenantsServiceServer(srv.GrpcServer, servicer)
+	tenant_protos.RegisterTenantsServiceServer(srv.ProtectedGrpcServer, servicer)
 	go srv.RunTest(lis, nil)
 	return servicer, nil
 }

--- a/orc8r/cloud/go/services/tenants/tenants/main.go
+++ b/orc8r/cloud/go/services/tenants/tenants/main.go
@@ -51,7 +51,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating tenants server: %s", err)
 	}
-	protos.RegisterTenantsServiceServer(srv.GrpcServer, server)
+	protos.RegisterTenantsServiceServer(srv.ProtectedGrpcServer, server)
 
 	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(tenants.ServiceName))
 

--- a/orc8r/cloud/go/services/tenants/tenants/main.go
+++ b/orc8r/cloud/go/services/tenants/tenants/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 	protos.RegisterTenantsServiceServer(srv.ProtectedGrpcServer, server)
 
-	swagger_protos.RegisterSwaggerSpecServer(srv.GrpcServer, swagger_servicers.NewSpecServicerFromFile(tenants.ServiceName))
+	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(tenants.ServiceName))
 
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers())
 

--- a/orc8r/cloud/go/services/tenants/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/tenants/test_init/test_service_init.go
@@ -29,10 +29,10 @@ import (
 // StartTestService instantiates a service backed by an in-memory storage
 func StartTestService(t *testing.T) {
 	factory := test_utils.NewSQLBlobstore(t, "device_test_service_blobstore")
-	srv, lis, _ := test_utils.NewTestService(t, orc8r.ModuleName, tenants.ServiceName)
+	srv, lis, plis := test_utils.NewTestService(t, orc8r.ModuleName, tenants.ServiceName)
 	store := storage.NewBlobstoreStore(factory)
 	server, err := servicers.NewTenantsServicer(store)
 	assert.NoError(t, err)
-	protos.RegisterTenantsServiceServer(srv.GrpcServer, server)
-	go srv.RunTest(lis, nil)
+	protos.RegisterTenantsServiceServer(srv.ProtectedGrpcServer, server)
+	go srv.RunTest(lis, plis)
 }

--- a/orc8r/cloud/go/test_utils/service.go
+++ b/orc8r/cloud/go/test_utils/service.go
@@ -86,14 +86,9 @@ func NewTestOrchestratorService(t *testing.T, moduleName, serviceName string, la
 		t.Fatal(err)
 	}
 
-	// Only add protected service port to service struct if the service is protected
-	pSrvPort := 0
-	var plis net.Listener
-	if len(serviceType) != 0 && serviceType[0] == lib_protos.ServiceType_PROTECTED {
-		pSrvPort, plis, err = getOpenPort()
-		if err != nil {
-			t.Fatal(err)
-		}
+	pSrvPort, plis, err := getOpenPort()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	echoPort, echoLis, err := getOpenPort()

--- a/orc8r/cloud/go/tools/indexers/cmd/root.go
+++ b/orc8r/cloud/go/tools/indexers/cmd/root.go
@@ -62,7 +62,7 @@ func globalPre(cmd *cobra.Command, args []string) {
 }
 
 func getClient() indexer_protos.IndexerManagerClient {
-	conn, err := registry.GetConnection(state.ServiceName, lib_protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(state.ServiceName, lib_protos.ServiceType_PROTECTED)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/orc8r/cloud/helm/orc8r/templates/accessd.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/accessd.deployment.yaml
@@ -37,7 +37,7 @@ ports:
   - name: grpc
     containerPort: 9091
   - name: grpc-internal
-   targetPort: 9191
+    containerPort: 9191
 livenessProbe:
   tcpSocket:
     port: 9091

--- a/orc8r/cloud/helm/orc8r/templates/accessd.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/accessd.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/accessd", "-logtostderr=true
 ports:
   - name: grpc
     containerPort: 9091
+  - name: grpc-internal
+   targetPort: 9191
 livenessProbe:
   tcpSocket:
     port: 9091

--- a/orc8r/cloud/helm/orc8r/templates/accessd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/accessd.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9091
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9191
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/configurator.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/configurator.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/configurator", "-logtostderr
 ports:
   - name: grpc
     containerPort: 9108
+  - name: grpc-internal
+    containerPort: 9208
 livenessProbe:
   tcpSocket:
     port: 9108

--- a/orc8r/cloud/helm/orc8r/templates/configurator.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/configurator.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9108
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9208
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/ctraced.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ctraced.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/ctraced","-run_echo_server=t
 ports:
   - name: grpc
     containerPort: 9118
+  - name: grpc-internal
+    containerPort: 9218
   - name: http
     containerPort: 10118
 livenessProbe:

--- a/orc8r/cloud/helm/orc8r/templates/ctraced.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ctraced.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9118
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9218
     - name: http
       port: 8080
       targetPort: 10118

--- a/orc8r/cloud/helm/orc8r/templates/device.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/device.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/device", "-logtostderr=true"
 ports:
   - name: grpc
     containerPort: 9106
+  - name: grpc-internal
+    containerPort: 9306
 livenessProbe:
   tcpSocket:
     port: 9106

--- a/orc8r/cloud/helm/orc8r/templates/device.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/device.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9106
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9306
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/directoryd.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/directoryd.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/directoryd", "-logtostderr=t
 ports:
   - name: grpc
     containerPort: 9100
+  - name: grpc-internal
+    containerPort: 9102
 livenessProbe:
   tcpSocket:
     port: 9100

--- a/orc8r/cloud/helm/orc8r/templates/directoryd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/directoryd.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9100
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9102
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/dp.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dp.deployment.yaml
@@ -40,6 +40,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/dp", "-run_echo_server=true"
 ports:
   - name: grpc
     containerPort: 9124
+  - name: grpc-internal
+    containerPort: 9224
   - name: http
     containerPort: 10124
 livenessProbe:

--- a/orc8r/cloud/helm/orc8r/templates/dp.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dp.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9124
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9224
     - name: http
       port: 8080
       targetPort: 10124

--- a/orc8r/cloud/helm/orc8r/templates/eventd.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/eventd.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/eventd", "-run_echo_server=t
 ports:
   - name: grpc
     containerPort: 9121
+  - name: grpc-internal
+    containerPort: 9221
   - name: http
     containerPort: 10121
 livenessProbe:

--- a/orc8r/cloud/helm/orc8r/templates/eventd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/eventd.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9121
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9221
     - name: http
       port: 8080
       targetPort: 10121

--- a/orc8r/cloud/helm/orc8r/templates/metricsd.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/metricsd.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/metricsd", "-run_echo_server
 ports:
   - name: grpc
     containerPort: 9084
+  - name: grpc-internal
+    containerPort: 9184
   - name: http
     containerPort: 10084
 livenessProbe:

--- a/orc8r/cloud/helm/orc8r/templates/metricsd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/metricsd.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9084
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9184
     - name: http
       port: 8080
       targetPort: 10084

--- a/orc8r/cloud/helm/orc8r/templates/orchestrator.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/orchestrator.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/orchestrator","-run_echo_ser
 ports:
   - name: grpc
     containerPort: 9112
+  - name: grpc-internal
+    containerPort: 9212
   - name: http
     containerPort: 10112
 livenessProbe:

--- a/orc8r/cloud/helm/orc8r/templates/orchestrator.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/orchestrator.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9112
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9212
     - name: http
       port: 8080
       targetPort: 10112

--- a/orc8r/cloud/helm/orc8r/templates/state.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/state.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/state", "-logtostderr=true",
 ports:
   - name: grpc
     containerPort: 9105
+  - name: grpc-internal
+    containerPort: 9305
 livenessProbe:
   tcpSocket:
     port: 9105

--- a/orc8r/cloud/helm/orc8r/templates/state.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/state.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9105
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9305
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/tenants.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/tenants.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/tenants", "-run_echo_server=
 ports:
   - name: grpc
     containerPort: 9110
+  - name: grpc-internal
+    containerPort: 9210
   - name: http
     containerPort: 10110
 livenessProbe:

--- a/orc8r/cloud/helm/orc8r/templates/tenants.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/tenants.service.yaml
@@ -30,6 +30,9 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9110
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9210
     - name: http
       port: 8080
       targetPort: 10110

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -463,7 +463,7 @@ func (r *ServiceRegistry) GetConnectionImpl(ctx context.Context, service string,
 }
 
 func (r *ServiceRegistry) getServiceRegistryServiceClient() (protos.ServiceRegistryClient, error) {
-	conn, err := r.GetConnection(ServiceRegistryServiceName, protos.ServiceType_SOUTHBOUND)
+	conn, err := r.GetConnection(ServiceRegistryServiceName, protos.ServiceType_PROTECTED)
 	if err != nil {
 		return nil, err
 	}
@@ -487,13 +487,7 @@ func (r *ServiceRegistry) getGRPCDialOptions() []grpc.DialOption {
 func (r *ServiceRegistry) getServiceRegistryServiceAddress() string {
 	// Use hardcoded address for service_registry service as we can't
 	// dynamically discover the service registry service itself
-	return fmt.Sprintf("orc8r-service-registry:%d", GrpcServicePort)
-}
-
-func (r *ServiceRegistry) getServiceRegistryProtectedServiceAddress() string {
-	// Use hardcoded address for service_registry service as we can't
-	// dynamically discover the service registry service itself
-	return fmt.Sprintf("orc8r-protected-service-registry:%d", ProtectedGrpcServicePort)
+	return fmt.Sprintf("orc8r-service-registry:%d", ProtectedGrpcServicePort)
 }
 
 func (r *ServiceRegistry) addUnsafe(location ServiceLocation) {

--- a/orc8r/lib/go/registry/service_registry.go
+++ b/orc8r/lib/go/registry/service_registry.go
@@ -122,7 +122,7 @@ func convertToServiceLocations(rawMap rawMapType) ([]ServiceLocation, error) {
 		// Get protected port
 		protectedPort, err := configMap.GetInt("protected_port")
 		if err != nil {
-			glog.Infof("service %s does not have a protected port", name)
+			glog.V(1).Infof("service %s does not have a protected port", name)
 		}
 
 		// Get echo port


### PR DESCRIPTION
# summary 
Each orc8r internal service now has its own protected port. These changes should include
1. add protected_port field to {orc8r, feg, lte}/cloud/configs/service_registry.yml
2. in the `main.go` file, changed `Register.*Server(srv.GrpcServer, servicer)` to `Register.*Server(srv.ProtectedGrpcServer, servicer)`
3. in `client_api.go`, should be `registry.GetConnection(ServiceName, lib_protos.ServiceType_PROTECTED)`
4. add relevant fields to `*.deployment.yaml` & `*.service.yaml`
5. changed `RunTest` to accept `plis`

These are the services: 
* Global scope (need to move to service scope)
    * directoryd.proto — DirectoryLookup
    * service303.proto — Service303 (leave this proto at global scope, but still want to make it internal-only at Orc8r)
    * service_registry.proto — ServiceRegistry
    * tenants.proto — TenantsService
* Service scope
    * swagger.proto — SwaggerSpec
    * access.proto — AccessControlManager
    * collector.proto — AnalyticsCollector
    * certifier.proto — Certifier
    * builder.proto — MconfigBuilder
    * northbound.proto — NorthboundConfigurator
    * device.proto — Device
    * exporter.proto — MetricsExporter
    * indexer.proto — Indexer
    * indexer_manager.proto — IndexerManager
    * provider.proto — StreamProvider
1b. lte and feg 
* Service scope
    * lte/enodeb_state.proto — EnodebStateLookup
    * lte/subscriberdb.proto — SubscriberLookup

For protected [supported extensions](https://docs.magmacore.org/docs/orc8r/architecture_modularity#supported-extensions), every service that uses the extension also need to include the protected port. 

# test plan 
ran `./build.py --test`
spun up gateway to make sure that nothing noticeable breaks
deployed via minikube and added logging to make sure getting right port 
<img width="1790" alt="Screen Shot 2022-04-29 at 3 58 34 PM" src="https://user-images.githubusercontent.com/25142344/166064783-d182aeae-7ae7-49ca-9989-066ec8fc8a8d.png">
