### PR TITLE
fix(ci): Latest fixes from Eurecom Infrastructure changes

### DIFF
--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -121,7 +121,7 @@ pipeline {
                     branch = 'master'
                     u18_image_tag = 'master'
                     u18_docker_file = 'lte/gateway/docker/mme/Dockerfile.ubuntu18.04'
-                    u18_options = ' --build-arg GIT_PROXY="http://proxy.eurecom.fr:8080"'
+                    u18_options = ''
                   } else {
                     branch = sha1
                     u18_docker_file = 'ci-scripts/docker/Dockerfile.mme.ci.ubuntu18'
@@ -240,7 +240,7 @@ pipeline {
                     branch = 'master'
                     rhel8_image_tag = 'master'
                     rhel8_docker_file = 'lte/gateway/docker/mme/Dockerfile.rhel8'
-                    rhel8_options = ' --build-arg GIT_PROXY="http://proxy.eurecom.fr:8080"'
+                    rhel8_options = ''
                   } else {
                     branch = sha1
                     rhel8_docker_file = 'ci-scripts/docker/Dockerfile.mme.ci.rhel8'

--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -191,6 +191,8 @@ pipeline {
                   // Once again, we are not using the full dockerfile from scratch: too long --> when it is a pull request
                   // On the daily master build, we are doing from scratch
                   sh('docker build --no-cache --target magma-mme --tag magma-mme:' + u18_image_tag + ' --file ' + u18_docker_file + u18_options + ' . > archives/build_magma_mme.log 2>&1')
+                  sh('wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/flatten_image.py -O ci-scripts/ci-flatten_image.py')
+                  sh('python3 ./ci-scripts/ci-flatten_image.py --tag magma-mme:' + u18_image_tag')
                   sh('docker image prune --force > /dev/null 2>&1')
                   sh('docker image ls >> archives/build_magma_mme.log')
                 }
@@ -309,6 +311,8 @@ pipeline {
                     // Once again, we are not using the full dockerfile from scratch: too long --> when it is a pull request
                     // On the daily master build, we are doing from scratch
                     sh('sudo podman build --no-cache --target magma-mme --tag magma-mme:' + rhel8_image_tag + ' --file ' + rhel8_docker_file + rhel8_options + ' . > archives/build_magma_mme_rhel8.log 2>&1')
+                    sh('wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/flatten_image.py -O ci-scripts/ci-flatten_image.py')
+                    sh('python3 ./ci-scripts/ci-flatten_image.py --tag magma-mme:' + u18_image_tag')
                     sh('sudo podman image prune --force > /dev/null 2>&1')
                     sh('sudo podman image ls >> archives/build_magma_mme_rhel8.log')
                   }

--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -121,11 +121,9 @@ pipeline {
                     branch = 'master'
                     u18_image_tag = 'master'
                     u18_docker_file = 'lte/gateway/docker/mme/Dockerfile.ubuntu18.04'
-                    u18_options = ''
                   } else {
                     branch = sha1
                     u18_docker_file = 'ci-scripts/docker/Dockerfile.mme.ci.ubuntu18'
-                    u18_options = ''
                   }
                   checkout(
                     changelog: false,
@@ -189,7 +187,7 @@ pipeline {
                   // Create the image to use
                   // Once again, we are not using the full dockerfile from scratch: too long --> when it is a pull request
                   // On the daily master build, we are doing from scratch
-                  sh('docker build --no-cache --target magma-mme --tag magma-mme:' + u18_image_tag + ' --file ' + u18_docker_file + u18_options + ' . > archives/build_magma_mme.log 2>&1')
+                  sh('docker build --no-cache --target magma-mme --tag magma-mme:' + u18_image_tag + ' --file ' + u18_docker_file + ' . > archives/build_magma_mme.log 2>&1')
                   sh('wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/flatten_image.py -O ci-scripts/ci-flatten_image.py')
                   sh('python3 ./ci-scripts/ci-flatten_image.py --tag magma-mme:' + u18_image_tag)
                   sh('docker image prune --force > /dev/null 2>&1')
@@ -241,11 +239,9 @@ pipeline {
                     branch = 'master'
                     rhel8_image_tag = 'master'
                     rhel8_docker_file = 'lte/gateway/docker/mme/Dockerfile.rhel8'
-                    rhel8_options = ''
                   } else {
                     branch = sha1
                     rhel8_docker_file = 'ci-scripts/docker/Dockerfile.mme.ci.rhel8'
-                    rhel8_options = ''
                   }
                   checkout(
                     changelog: false,
@@ -308,9 +304,9 @@ pipeline {
                     // Create the image to use
                     // Once again, we are not using the full dockerfile from scratch: too long --> when it is a pull request
                     // On the daily master build, we are doing from scratch
-                    sh('sudo podman build --no-cache --target magma-mme --tag magma-mme:' + rhel8_image_tag + ' --file ' + rhel8_docker_file + rhel8_options + ' . > archives/build_magma_mme_rhel8.log 2>&1')
+                    sh('sudo podman build --no-cache --target magma-mme --tag magma-mme:' + rhel8_image_tag + ' --file ' + rhel8_docker_file + ' . > archives/build_magma_mme_rhel8.log 2>&1')
                     sh('wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/flatten_image.py -O ci-scripts/ci-flatten_image.py')
-                    sh('python3 ./ci-scripts/ci-flatten_image.py --tag magma-mme:' + u18_image_tag)
+                    sh('python3 ./ci-scripts/ci-flatten_image.py --tag magma-mme:' + rhel8_image_tag)
                     sh('sudo podman image prune --force > /dev/null 2>&1')
                     sh('sudo podman image ls >> archives/build_magma_mme_rhel8.log')
                   }

--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -191,7 +191,7 @@ pipeline {
                   // On the daily master build, we are doing from scratch
                   sh('docker build --no-cache --target magma-mme --tag magma-mme:' + u18_image_tag + ' --file ' + u18_docker_file + u18_options + ' . > archives/build_magma_mme.log 2>&1')
                   sh('wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/flatten_image.py -O ci-scripts/ci-flatten_image.py')
-                  sh('python3 ./ci-scripts/ci-flatten_image.py --tag magma-mme:' + u18_image_tag')
+                  sh('python3 ./ci-scripts/ci-flatten_image.py --tag magma-mme:' + u18_image_tag)
                   sh('docker image prune --force > /dev/null 2>&1')
                   sh('docker image ls >> archives/build_magma_mme.log')
                 }
@@ -310,7 +310,7 @@ pipeline {
                     // On the daily master build, we are doing from scratch
                     sh('sudo podman build --no-cache --target magma-mme --tag magma-mme:' + rhel8_image_tag + ' --file ' + rhel8_docker_file + rhel8_options + ' . > archives/build_magma_mme_rhel8.log 2>&1')
                     sh('wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/flatten_image.py -O ci-scripts/ci-flatten_image.py')
-                    sh('python3 ./ci-scripts/ci-flatten_image.py --tag magma-mme:' + u18_image_tag')
+                    sh('python3 ./ci-scripts/ci-flatten_image.py --tag magma-mme:' + u18_image_tag)
                     sh('sudo podman image prune --force > /dev/null 2>&1')
                     sh('sudo podman image ls >> archives/build_magma_mme_rhel8.log')
                   }

--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -143,7 +143,6 @@ pipeline {
                       // If so, we will run the OAI pipeline
                       // For security reasons, we retrieve from a trusted forked repository
                       sh 'wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -O ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py || true'
-                      sh 'git fetch --unshallow || true'
                       sh 'python3 ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
                       // If the previous command is OK, no need to run
                       // All the following stages will be bypassed and the CI
@@ -261,7 +260,6 @@ pipeline {
                   if (!params.REGRESSION_TEST) {
                     try {
                       sh 'wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/check_pr_modified_files_for_oai_pipeline.py -O ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py || true'
-                      sh 'git fetch --unshallow || true'
                       sh 'python3 ci-scripts/ci-check_pr_modified_files_for_oai_pipeline.py'
                       runAllRHELPipelineStages = false
                     } catch (Exception e) {

--- a/ci-scripts/flatten_image.py
+++ b/ci-scripts/flatten_image.py
@@ -1,0 +1,104 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import re
+import subprocess  # noqa: S404
+import sys
+
+
+def main() -> None:
+    """Provide command-line options to flatten MAGMA-MME OAI image"""
+    args = _parse_args()
+    status = perform_flattening(args.tag)
+    sys.exit(status)
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse the command line args
+
+    Returns:
+        argparse.Namespace: the created parser
+    """
+    parser = argparse.ArgumentParser(description='Flattening Image')
+
+    parser.add_argument(
+        '--tag', '-t',
+        action='store',
+        required=True,
+        help='Image Tag in image-name:image tag format',
+    )
+    return parser.parse_args()
+
+
+def perform_flattening(tag):
+    """Parse the command line args
+
+    Args:
+        tag: Image Tag in image-name:image tag format
+
+    Returns:
+        int: pass / fail status
+    """
+    # First detect which docker/podman command to use
+    cli = ''
+    image_prefix = ''
+    cmd = 'which podman || true'
+    podman_check = subprocess.check_output(cmd, shell=True, universal_newlines=True)  # noqa: S602
+    if re.search('podman', podman_check.strip()):
+        cli = 'sudo podman'
+        image_prefix = 'localhost/'
+    if cli == '':
+        cmd = 'which docker || true'
+        docker_check = subprocess.check_output(cmd, shell=True, universal_newlines=True)  # noqa: S602
+        if re.search('docker', docker_check.strip()):
+            cli = 'docker'
+            image_prefix = ''
+    if cli == '':
+        print('No docker / podman installed: quitting')
+        return -1
+
+    print(f'Flattening {tag}')
+    # Creating a container
+    cmd = cli + ' run --name test-flatten --entrypoint /bin/true -d ' + tag
+    print(cmd)
+    subprocess.check_output(cmd, shell=True, universal_newlines=True)  # noqa: S602
+
+    # Export / Import trick
+    cmd = cli + ' export test-flatten | ' + cli + ' import '
+    # Bizarro syntax issue with podman
+    if cli == 'docker':
+        cmd += ' --change "ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" '
+    else:
+        cmd += ' --change "ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" '
+    cmd += ' --change "WORKDIR /magma-mme" '
+    cmd += ' --change "EXPOSE 3870/tcp" '
+    cmd += ' --change "EXPOSE 5870/tcp" '
+    cmd += ' --change "EXPOSE 2123/udp" '
+    cmd += ' --change "CMD [\\"sleep\\", \\"infinity\\"]" '  # noqa: WPS342
+    cmd += ' - ' + image_prefix + tag
+    print(cmd)
+    subprocess.check_output(cmd, shell=True, universal_newlines=True)  # noqa: S602
+
+    # Remove container
+    cmd = cli + ' rm -f test-flatten'
+    print(cmd)
+    subprocess.check_output(cmd, shell=True, universal_newlines=True)  # noqa: S602
+
+    # At this point the original image is a dangling image.
+    # CI pipeline will clean up (`image prune --force`)
+    return 0
+
+
+if __name__ == '__main__':
+    main()

--- a/ci-scripts/generateHtmlReport-OAI-pipeline.py
+++ b/ci-scripts/generateHtmlReport-OAI-pipeline.py
@@ -46,6 +46,7 @@ def main() -> None:
 
     if args.mode == 'TestWithDsTest':
         append_build_summary(args, 'test_results_magma_oai_epc.html')
+        append_build_summary(args, 'test_results_magma_epc_u18.html')
 
     if args.mode == 'RHEL8SanityCheck':
         append_build_summary(args, 'test_results_magma_epc_rhel8.html')
@@ -163,6 +164,8 @@ def append_build_summary(args, filename):
         filename: file to append to
     """
     cwd = os.getcwd()
+    if not os.path.isfile(cwd + '/' + filename):
+        return
     report = ''
     org_file = os.path.join(cwd, filename)
     with open(org_file, 'r') as org_f:


### PR DESCRIPTION
## Summary

This month (`April 2022`), our hosting partner (`Eurecom`) did a major network infrastructure upgrade. We had to modify a few things in the pipeline scripts:

* There is no more need for a git proxy in this new network
* the `git fetch --unshallow` was made because of a bad jenkins job configuration on the previous Openshift Jenkins instance
* I've added a flattening script to reduce the size of the MAGMA-MME image.

## Test Plan

Already in production from my `trusted-oai-ci-pipeline` branch.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
