### PR TITLE
fix(agw): Format lte/gateway/python with clang-format-11

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -454,10 +454,10 @@ jobs:
           clangFormatVersion: 11.1.0
           # taken from .clang-format
           style: file
-      - name: Check clang-format for lte/gateway/c
+      - name: Check clang-format for lte/gateway
         uses: DoozyX/clang-format-lint-action@v0.13
         with:
-          source: 'lte/gateway/c'
+          source: 'lte/gateway/c lte/gateway/python'
           extensions: 'h,hpp,c,cpp'
           clangFormatVersion: 11.1.0
           # taken from .clang-format

--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -165,6 +165,8 @@ format_all:
 	/usr/bin/clang-format-11 -i {} \;
 	find $(MAGMA_ROOT)/lte/gateway/c/ \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h"  -o -iname "*.hpp" \) -exec \
 	/usr/bin/clang-format-11 -i {} \;
+	find $(MAGMA_ROOT)/lte/gateway/python/ \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h"  -o -iname "*.hpp" \) -exec \
+	/usr/bin/clang-format-11 -i {} \;
 
 build_sctpd:
 	$(call run_cmake, $(C_BUILD)/sctpd, $(GATEWAY_C_DIR)/sctpd, )

--- a/lte/gateway/python/magma/kernsnoopd/ebpf/byte_count.bpf.c
+++ b/lte/gateway/python/magma/kernsnoopd/ebpf/byte_count.bpf.c
@@ -22,7 +22,8 @@
 BPF_HASH(dest_counters, struct key_t);
 
 // Attach kprobe for the `tcp_sendmsg` syscall
-int kprobe__tcp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg, size_t size) {
+int kprobe__tcp_sendmsg(struct pt_regs *ctx, struct sock *sk,
+                        struct msghdr *msg, size_t size) {
   u16 family = sk->sk_family;
 
   // both IPv4 and IPv6
@@ -32,8 +33,7 @@ int kprobe__tcp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg
     // read destination IP address and port
     if (family == AF_INET) {
       key.daddr = sk->sk_daddr;
-    }
-    else if (family == AF_INET6) {
+    } else if (family == AF_INET6) {
       bpf_probe_read(&key.daddr, sizeof(key.daddr), &sk->sk_v6_daddr.s6_addr32);
     }
     u16 dport = sk->sk_dport;
@@ -67,4 +67,3 @@ int kprobe__tcp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg
   }
   return 0;
 }
-

--- a/lte/gateway/python/magma/kernsnoopd/ebpf/common.bpf.h
+++ b/lte/gateway/python/magma/kernsnoopd/ebpf/common.bpf.h
@@ -22,7 +22,6 @@
 #include <uapi/linux/ptrace.h>
 #include <net/sock.h>
 
-
 struct key_t {
   // binary name (task->comm in the kernel)
   char comm[TASK_COMM_LEN];

--- a/lte/gateway/python/magma/pipelined/ebpf/ebpf_dl_handler.c
+++ b/lte/gateway/python/magma/pipelined/ebpf/ebpf_dl_handler.c
@@ -21,16 +21,15 @@
 
 // The map is pinned so that it can be accessed by pipelined or debugging tool
 // to examine datapath state.
-BPF_TABLE_PINNED(
-    "hash", struct dl_map_key, struct dl_map_info, dl_map, 1024 * 512,
-    "/sys/fs/bpf/dl_map");
+BPF_TABLE_PINNED("hash", struct dl_map_key, struct dl_map_info, dl_map,
+                 1024 * 512, "/sys/fs/bpf/dl_map");
 
 struct cfg_array_info {
   u32 if_idx;
 };
 
-BPF_TABLE_PINNED(
-    "array", u32, struct cfg_array_info, cfg_array, 1, "/sys/fs/bpf/cfg_array");
+BPF_TABLE_PINNED("array", u32, struct cfg_array_info, cfg_array, 1,
+                 "/sys/fs/bpf/cfg_array");
 
 // Ingress handler for Uplink traffic.
 int gtpu_egress_handler(struct __sk_buff* skb) {
@@ -42,20 +41,20 @@ int gtpu_egress_handler(struct __sk_buff* skb) {
   int ip_hdr = sizeof(struct ethhdr) + sizeof(struct iphdr);
 
   // 1. a. check pkt length
-  data     = (void*) (long) skb->data;
-  data_end = (void*) (long) skb->data_end;
-  int len  = data_end - data;
+  data = (void*)(long)skb->data;
+  data_end = (void*)(long)skb->data_end;
+  int len = data_end - data;
 
   if ((data + ip_hdr) > data_end) {
-    bpf_trace_printk(
-        "ERR: truncated packet: len: %d, data sz %d\n", skb->len, len);
+    bpf_trace_printk("ERR: truncated packet: len: %d, data sz %d\n", skb->len,
+                     len);
     return TC_ACT_OK;
   }
 
   // 1. b. check UE map
-  iph                          = data + sizeof(struct ethhdr);
+  iph = data + sizeof(struct ethhdr);
   struct dl_map_key lookup_key = {iph->daddr};
-  struct dl_map_info* fwd      = dl_map.lookup(&lookup_key);
+  struct dl_map_info* fwd = dl_map.lookup(&lookup_key);
   if (!fwd) {
     bpf_trace_printk("ERR: UE for IP %x not found\n", iph->daddr);
     return TC_ACT_OK;
@@ -65,17 +64,19 @@ int gtpu_egress_handler(struct __sk_buff* skb) {
   struct bpf_tunnel_key tun_info;
   __builtin_memset(&tun_info, 0x0, sizeof(tun_info));
   tun_info.remote_ipv4 = fwd->remote_ipv4;
-  tun_info.tunnel_id   = fwd->tunnel_id;
-  tun_info.tunnel_ttl  = 64;
+  tun_info.tunnel_id = fwd->tunnel_id;
+  tun_info.tunnel_ttl = 64;
 
-  ret = bpf_skb_set_tunnel_key(skb, &tun_info, sizeof(tun_info), BPF_F_ZERO_CSUM_TX);
+  ret = bpf_skb_set_tunnel_key(skb, &tun_info, sizeof(tun_info),
+                               BPF_F_ZERO_CSUM_TX);
   if (ret < 0) {
-      bpf_trace_printk("ERR: bpf_skb_set_tunnel_key failed with %d", ret);
-      return TC_ACT_SHOT;
+    bpf_trace_printk("ERR: bpf_skb_set_tunnel_key failed with %d", ret);
+    return TC_ACT_SHOT;
   }
-  bpf_trace_printk("INFO: set: key %d remote ip 0x%x ret = %d\n", tun_info.tunnel_id, tun_info.remote_ipv4, ret);
+  bpf_trace_printk("INFO: set: key %d remote ip 0x%x ret = %d\n",
+                   tun_info.tunnel_id, tun_info.remote_ipv4, ret);
 
-  u32  cfg_key   = 0;
+  u32 cfg_key = 0;
   struct cfg_array_info* cfg = cfg_array.lookup(&cfg_key);
   if (!cfg) {
     bpf_trace_printk("ERR: Config array lookup failed\n");


### PR DESCRIPTION
## Summary

Closes https://github.com/magma/magma/issues/12507.

I have:
* added the formatting of `lte/gateway/python` to `lte/gateway/Makefile`
* updated the GitHub workflow, `agw_workflow.yml`, so that the formatting gets run in the CI
* formatted the relevant C files by running `cd lte/gateway && make format_all`

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking
