### PR TITLE
fix(orc8r): Allow updating QoS profiles

### DIFF
--- a/lte/cloud/go/services/policydb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/conversion.go
@@ -147,12 +147,13 @@ func (m *PolicyRule) FromEntity(ent configurator.NetworkEntity) *PolicyRule {
 	return m
 }
 
-func (m *PolicyRule) ToEntityUpdateCriteria() configurator.EntityUpdateCriteria {
+func (m *PolicyRule) ToEntityUpdateCriteria(associationsToAdd storage.TKs, associationsToDelete storage.TKs) configurator.EntityUpdateCriteria {
 	update := configurator.EntityUpdateCriteria{
-		Type:              lte.PolicyRuleEntityType,
-		Key:               string(m.ID),
-		NewConfig:         m.getConfig(),
-		AssociationsToAdd: m.GetAssocs(),
+		Type:                 lte.PolicyRuleEntityType,
+		Key:                  string(m.ID),
+		NewConfig:            m.getConfig(),
+		AssociationsToAdd:    associationsToAdd,
+		AssociationsToDelete: associationsToDelete,
 	}
 	return update
 }


### PR DESCRIPTION
## Summary

Updating of QoS profiles was broken because the update handler did not remove old associations from the DB.
Fixes #12307.

## Test Plan

- Adapted integration test to include an update that changes between profiles.
- Started NMS and confirmed that changing profiles is now possible.

## Additional Information

- [ ] This change is backwards-breaking