### PR TITLE
fix(agw): Added flaky testcase iteration count

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -53,7 +53,7 @@ class TestWrapper(object):
     # IP address pool
     TEST_IP_BLOCK = "192.168.128.0/24"
     MSX_S1_RETRY = 2
-    IS_TEST_RUNNING_FIRST_TIME = True
+    TEST_CASE_EXECUTION_COUNT = 0
 
     def __init__(
         self,
@@ -64,10 +64,14 @@ class TestWrapper(object):
         """
         Initialize the various classes required by the tests and setup.
         """
-        if not TestWrapper.IS_TEST_RUNNING_FIRST_TIME:
+        if TestWrapper.TEST_CASE_EXECUTION_COUNT != 0:
             print("\n**Running the test case again to identify flaky behavior")
+        TestWrapper.TEST_CASE_EXECUTION_COUNT += 1
+        print(
+            "Test Case Execution Count:",
+            TestWrapper.TEST_CASE_EXECUTION_COUNT,
+        )
 
-        TestWrapper.IS_TEST_RUNNING_FIRST_TIME = False
         t = time.localtime()
         current_time = time.strftime("%H:%M:%S", t)
         print("Start time", current_time)

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1setup_failure_incorrect_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1setup_failure_incorrect_plmn.py
@@ -25,9 +25,13 @@ class TestS1SetupFailureIncorrectPlmn(unittest.TestCase):
 
     def setUp(self):
         """Initialize before test case execution"""
-        if not s1ap_wrapper.TestWrapper.IS_TEST_RUNNING_FIRST_TIME:
+        if s1ap_wrapper.TestWrapper.TEST_CASE_EXECUTION_COUNT != 0:
             print("\n**Running the test case again to identify flaky behavior")
-        s1ap_wrapper.TestWrapper.IS_TEST_RUNNING_FIRST_TIME = False
+        s1ap_wrapper.TestWrapper.TEST_CASE_EXECUTION_COUNT += 1
+        print(
+            "Test Case Execution Count:",
+            s1ap_wrapper.TestWrapper.TEST_CASE_EXECUTION_COUNT,
+        )
         self._s1_util = S1ApUtil()
 
     def tearDown(self):

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1setup_failure_incorrect_tac.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1setup_failure_incorrect_tac.py
@@ -24,9 +24,13 @@ class TestS1SetupFailureIncorrectTac(unittest.TestCase):
 
     def setUp(self):
         """Initialize before test case execution"""
-        if not s1ap_wrapper.TestWrapper.IS_TEST_RUNNING_FIRST_TIME:
+        if s1ap_wrapper.TestWrapper.TEST_CASE_EXECUTION_COUNT != 0:
             print("\n**Running the test case again to identify flaky behavior")
-        s1ap_wrapper.TestWrapper.IS_TEST_RUNNING_FIRST_TIME = False
+        s1ap_wrapper.TestWrapper.TEST_CASE_EXECUTION_COUNT += 1
+        print(
+            "Test Case Execution Count:",
+            s1ap_wrapper.TestWrapper.TEST_CASE_EXECUTION_COUNT,
+        )
         self._s1_util = S1ApUtil()
 
     def tearDown(self):


### PR DESCRIPTION
## Title
fix(agw): Added flaky testcase iteration count

## Summary
From the CI logs it was difficult to identify which iteration of test case is executing for flaky test cases retrying on failure. This PR adds print to display the test case execution iteration count.

## Test plan
Verified with sanity

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>