### PR TITLE
fix(ci): py linter only runs on added or modified files (not on deleted)

### DIFF
--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           filters: |
             filesChanged:
-              - ["**/*.py"]
+              - added|modified: ["**/*.py"]
           list-files: 'shell'
       # Need to save PR number as Github action does not propagate it with workflow_run event
       - name: Save PR number


### PR DESCRIPTION
## Summary

https://github.com/magma/magma/pull/12291 refactored the changed files mechanics to using `dorny/paths-filter` `filesChanged` logic. The original `--diff-filter=ACMRT` was not taken over correctly. This causes `python-workflow.yml` to fail if a py file is deleted. See, e.g., https://github.com/magma/magma/runs/6195817220?check_suite_focus=true.

### Solution Here
Use `dorny/paths-filter` with addition `added|modified` filter.

## Test Plan

CI, see https://github.com/magma/magma/actions/runs/2238242192 for a run where a py file was deleted (dropped this test commit afterwards).

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
