### PR TITLE
chore(orc8r): Protobuf upgrade clean up

### DIFF
--- a/lte/cloud/go/services/subscriberdb/servicers/protected/lookup_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/protected/lookup_test.go
@@ -231,9 +231,7 @@ func TestLookupServicer_IPs(t *testing.T) {
 			Ips:       []string{"ipA", "ipB", "ipC"},
 		})
 		assert.NoError(t, err)
-		for i := range want {
-			test_utils.AssertMessagesEqual(t, want[i], got.IpMappings[i])
-		}
+		test_utils.AssertListsEqual(t, want, got.IpMappings)
 	})
 
 	t.Run("validate requests", func(t *testing.T) {
@@ -283,8 +281,7 @@ func TestLookupServicer_IPs(t *testing.T) {
 			{Ip: "ipB", Imsi: "IMSI0", Apn: "apn1"},
 			{Ip: "ipC", Imsi: "IMSI1", Apn: "apn0"},
 		}
-		for i := range want {
-			test_utils.AssertMessagesEqual(t, want[i], got.IpMappings[i])
-		}
+
+		test_utils.AssertListsEqual(t, want, got.IpMappings)
 	})
 }

--- a/lte/cloud/go/services/subscriberdb/storage/ip_lookup_test.go
+++ b/lte/cloud/go/services/subscriberdb/storage/ip_lookup_test.go
@@ -55,7 +55,7 @@ func TestIPLookup(t *testing.T) {
 			{Ip: "ipA", Imsi: "IMSI0", Apn: "apn0"},
 			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn0"},
 		}
-		assertEqualArrays(t, want, got)
+		test_utils.AssertListsEqual(t, want, got)
 
 		got, err = s.GetIPs("n0", []string{"ipA", "ipB"})
 		assert.NoError(t, err)
@@ -65,7 +65,7 @@ func TestIPLookup(t *testing.T) {
 			{Ip: "ipB", Imsi: "IMSI1", Apn: "apn1"},
 			{Ip: "ipB", Imsi: "IMSI2", Apn: "apn2"},
 		}
-		assertEqualArrays(t, want, got)
+		test_utils.AssertListsEqual(t, want, got)
 	})
 
 	t.Run("upsert", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestIPLookup(t *testing.T) {
 			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn0"},
 			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn1"},
 		}
-		assertEqualArrays(t, want, got)
+		test_utils.AssertListsEqual(t, want, got)
 
 		got, err = s.GetIPs("n0", []string{"ipA", "ipB", "ipC"})
 		assert.NoError(t, err)
@@ -95,7 +95,7 @@ func TestIPLookup(t *testing.T) {
 			{Ip: "ipB", Imsi: "IMSI2", Apn: "apn1"},
 			{Ip: "ipC", Imsi: "IMSI2", Apn: "apn2"},
 		}
-		assertEqualArrays(t, want, got)
+		test_utils.AssertListsEqual(t, want, got)
 	})
 
 	t.Run("additional network", func(t *testing.T) {
@@ -114,22 +114,13 @@ func TestIPLookup(t *testing.T) {
 			{Ip: "ipB", Imsi: "IMSI2", Apn: "apn1"},
 			{Ip: "ipC", Imsi: "IMSI2", Apn: "apn2"},
 		}
-		assertEqualArrays(t, want, got)
+		test_utils.AssertListsEqual(t, want, got)
 
 		got, err = s.GetIPs("n1", []string{"ipA", "ipB", "ipC", "ipZ"})
 		assert.NoError(t, err)
 		want = []*protos.IPMapping{
 			{Ip: "ipZ", Imsi: "IMSI0", Apn: "apn0"},
 		}
-		assertEqualArrays(t, want, got)
+		test_utils.AssertListsEqual(t, want, got)
 	})
-}
-
-// assertEqualArrays uses proto.Equal to determine equality of proto messages. This ignores
-// proto internals which would make the comparison fail with assert.Equal.
-func assertEqualArrays(t *testing.T, expected, actual []*protos.IPMapping) {
-	assert.Equal(t, len(expected), len(actual))
-	for i := range actual {
-		test_utils.AssertMessagesEqual(t, expected[i], actual[i])
-	}
 }

--- a/orc8r/cloud/go/test_utils/unit_test_proto_utils_test.go
+++ b/orc8r/cloud/go/test_utils/unit_test_proto_utils_test.go
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_utils
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+
+	"magma/orc8r/lib/go/protos"
+	mconfig_protos "magma/orc8r/lib/go/protos/mconfig"
+)
+
+type testCase struct {
+	expected    interface{}
+	actual      interface{}
+	test_result bool
+}
+
+func TestAssertMapsEqual(t *testing.T) {
+	testCases := []testCase{
+		{
+			actual:      1,
+			expected:    1,
+			test_result: false,
+		}, {
+			actual:      map[string]int{"k1": 7, "k2": 13},
+			expected:    1,
+			test_result: false,
+		}, {
+			actual:      1,
+			expected:    map[string]int{"k1": 7, "k2": 13},
+			test_result: false,
+		}, {
+			actual:      map[string]int{"k1": 7, "k2": 13},
+			expected:    1,
+			test_result: false,
+		}, {
+			actual:      map[string]int{"k1": 7, "k2": 13},
+			expected:    map[string]int{},
+			test_result: false,
+		}, {
+			actual:      map[string]int{"k1": 7, "k2": 13},
+			expected:    map[string]int{"k1": 7, "k3": 13},
+			test_result: false,
+		}, {
+			actual:      map[string]int{"k1": 7, "k2": 13, "k3": 13},
+			expected:    map[string]int{"k1": 8, "k2": 13, "k3": 13},
+			test_result: false,
+		}, {
+			actual:      map[string]int{"k1": 7, "k2": 13, "k3": 13},
+			expected:    map[string]int{"k1": 7, "k2": 13, "k3": 13},
+			test_result: true,
+		}, {
+			actual: map[string]int{"k1": 7, "k2": 13, "k3": 13},
+			expected: map[string]proto.Message{
+				"eventd":         &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+				"state":          &mconfig_protos.State{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+				"shared_mconfig": &mconfig_protos.SharedMconfig{SentryConfig: nil},
+			},
+			test_result: false,
+		}, {
+			actual: map[string]proto.Message{
+				"eventd":         &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+				"state":          &mconfig_protos.State{SyncInterval: 2, LogLevel: protos.LogLevel_INFO},
+				"shared_mconfig": &mconfig_protos.SharedMconfig{SentryConfig: nil},
+			},
+			expected: map[string]proto.Message{
+				"eventd":         &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+				"state":          &mconfig_protos.State{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+				"shared_mconfig": &mconfig_protos.SharedMconfig{SentryConfig: nil},
+			},
+			test_result: false,
+		}, {
+			actual: map[string]proto.Message{
+				"eventd":         &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+				"state":          &mconfig_protos.State{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+				"shared_mconfig": &mconfig_protos.SharedMconfig{SentryConfig: nil},
+			},
+			expected: map[string]proto.Message{
+				"eventd":         &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+				"state":          &mconfig_protos.State{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+				"shared_mconfig": &mconfig_protos.SharedMconfig{SentryConfig: nil},
+			},
+			test_result: true,
+		},
+	}
+	runTestCases(t, testCases, AssertMapsEqual)
+}
+
+func TestAssertListsEqual(t *testing.T) {
+	testCases := []testCase{
+		{
+			actual:      1,
+			expected:    1,
+			test_result: false,
+		}, {
+			actual: []*mconfig_protos.State{
+				{SyncInterval: 2, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 4, LogLevel: protos.LogLevel_INFO},
+			},
+			expected:    1,
+			test_result: false,
+		}, {
+			actual: 1,
+			expected: []*mconfig_protos.State{
+				{SyncInterval: 2, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 4, LogLevel: protos.LogLevel_INFO},
+			},
+			test_result: false,
+		}, {
+			actual: []*mconfig_protos.State{
+				{SyncInterval: 2, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 5, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 4, LogLevel: protos.LogLevel_INFO},
+			},
+			expected: []*mconfig_protos.State{
+				{SyncInterval: 2, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 4, LogLevel: protos.LogLevel_INFO},
+			},
+			test_result: false,
+		}, {
+			actual: []*mconfig_protos.State{
+				{SyncInterval: 2, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 4, LogLevel: protos.LogLevel_INFO},
+			},
+			expected: []*mconfig_protos.State{
+				{SyncInterval: 2, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+				{SyncInterval: 4, LogLevel: protos.LogLevel_INFO},
+			},
+			test_result: true,
+		},
+	}
+	runTestCases(t, testCases, AssertListsEqual)
+}
+
+func TestAssertMessageEqual(t *testing.T) {
+	testCases := []testCase{
+		{
+			actual:      1,
+			expected:    1,
+			test_result: true,
+		}, {
+			actual:      1,
+			expected:    &mconfig_protos.State{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+			test_result: false,
+		}, {
+			actual:      &mconfig_protos.State{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+			expected:    1,
+			test_result: false,
+		}, {
+			actual:      &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+			expected:    &mconfig_protos.State{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+			test_result: false,
+		}, {
+			actual:      &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+			expected:    &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+			test_result: true,
+		},
+	}
+	runTestCases(t, testCases, AssertMessagesEqual)
+
+}
+
+func TestAssertMessageNotEqual(t *testing.T) {
+	testCases := []testCase{
+		{
+			actual:      1,
+			expected:    1,
+			test_result: false,
+		}, {
+			actual:      1,
+			expected:    &mconfig_protos.State{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+			test_result: true,
+		}, {
+			actual:      &mconfig_protos.State{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+			expected:    1,
+			test_result: true,
+		}, {
+			actual:      &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+			expected:    &mconfig_protos.State{SyncInterval: 3, LogLevel: protos.LogLevel_INFO},
+			test_result: true,
+		}, {
+			actual:      &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+			expected:    &mconfig_protos.EventD{LogLevel: protos.LogLevel_INFO, EventVerbosity: 0},
+			test_result: false,
+		},
+	}
+	runTestCases(t, testCases, AssertMessagesNotEqual)
+
+}
+
+func runTestCases(t *testing.T, testCases []testCase, assertFunction func(t *testing.T, expected, actual interface{})) {
+	_t := new(testing.T)
+	for _, testCase := range testCases {
+		if testCase.test_result {
+			assertFunction(t, testCase.expected, testCase.actual)
+		} else {
+			assertFunction(_t, testCase.expected, testCase.actual)
+			if !_t.Failed() {
+				t.Error("Error: Arguments are asserted to be equal but are not equal")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary
The PR contains the remaining clean up task (see #12571) from the protobuf upgrade #12546. Assert functions are refactored and extended to deal with different proto message versions. Affected tests are adapted.

## Test Plan
run `~/magma/orc8r/cloud/docker$ ./build.py --tests`

## Additional Information

- [ ] This change is backwards-breaking
