### PR TITLE
docs: Fix typos in Test Access Gateway

### DIFF
--- a/docs/readmes/lte/dev_unit_testing.md
+++ b/docs/readmes/lte/dev_unit_testing.md
@@ -42,7 +42,7 @@ The list of services to test are configured in the following files.
 - `orc8r/gateway/python/defs.mk`
 - `lte/gateway/python/defs.mk`
 
-To run unit tests for a single Python service, select a name of the list of services and run
+To run unit tests for a single Python service, select a name from the list of services and run
 
 ```bash
 [VM] cd magma/lte/gateway
@@ -73,7 +73,7 @@ To run tests for those services, run
 [VM] make test_<service_directory_name> # Ex: make test_session_manager
 ```
 
-A subset of the AGW C/C++ directories are in progress of migrating to use Bazel as the default build system. We will list out some of the useful commands here, but please refer to the [Bazel user guide](https://docs.bazel.build/versions/main/guide.html) for a complete overview.
+A subset of the AGW C/C++ directories are in the process of being migrated to use Bazel as the default build system. We will list out some of the useful commands here, but please refer to the [Bazel user guide](https://docs.bazel.build/versions/main/guide.html) for a complete overview.
 
 ```bash
 [VM] cd magma # or any subdirectory inside magma
@@ -105,7 +105,7 @@ cd $MAGMA/lte/gateway/python
 # build the base image
 ./precommit.py --build
 
-# un the flake8 linter by specifying paths
+# run the flake8 linter by specifying paths
 ./precommit.py --lint -p PATH1 PATH2
 # run the flake8 linter on all modified files in HEAD vs master
 # this command can only be run on your host
@@ -120,7 +120,7 @@ cd $MAGMA/lte/gateway/python
 
 ### Format C/C++
 
-To run formatting for each C/C++ services, run
+To run formatting for each C/C++ service, run
 
 ```bash
 [VM] cd magma/lte/gateway


### PR DESCRIPTION
## Summary

Fixes a few typos I spotted when reading through https://docs.magmacore.org/docs/next/lte/dev_unit_testing
