### PR TITLE
fix(ci): ovs is pinned to be less than 2.17.0

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -128,7 +128,8 @@ setup(
         'pyroute2==0.5.14',
         'aiohttp',
         'jsonpointer>=1.14',
-        'ovs>=2.13',
+        # TODO: (GH #12601) make magma compatible with ovs>=2.17.0
+        'ovs>=2.13,<2.17.0',
         'prometheus-client>=0.3.1',
         'aioeventlet==0.5.1',  # aioeventlet-build.sh
     ],


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>


## Summary

LTE integration tests are failing because ovs was upgraded to 2.17.0.
See: https://github.com/magma/magma/runs/6223542233?check_suite_focus=true
This PR pins ovs to <2.17.0

## Test Plan
Manually execute the sudo tests with various ovs versions.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
