### PR TITLE
test(dp): Retain DB state in orc8r integration tests

### DIFF
--- a/dp/cloud/python/magma/db_service/tests/alembic_testcase.py
+++ b/dp/cloud/python/magma/db_service/tests/alembic_testcase.py
@@ -27,6 +27,7 @@ class AlembicTestCase(DBTestCaseBlueprint):
 
     @classmethod
     def setUpClass(cls) -> None:
+        super().setUpClass()
         cls.postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)()
 
     @classmethod
@@ -34,7 +35,7 @@ class AlembicTestCase(DBTestCaseBlueprint):
         cls.postgresql.stop()
 
     def setUp(self) -> None:
-        self.metadata = sqlalchemy.MetaData()
+        self.setMetadata(sqlalchemy.MetaData())
         self.set_up_db_test_case(SQLALCHEMY_DB_URI=self.postgresql.url())
         self.up_revision = self.up_revision or "head"
         self.down_revision = self.down_revision or "base"

--- a/dp/cloud/python/magma/db_service/tests/db_testcase.py
+++ b/dp/cloud/python/magma/db_service/tests/db_testcase.py
@@ -13,42 +13,54 @@ class DBTestCaseBlueprint(unittest.TestCase):
     engine: sqlalchemy.engine.Engine
     session: Session
 
-    def drop_all(self):
-        self.metadata.drop_all()
+    @classmethod
+    def drop_all(cls):
+        cls.metadata.drop_all()
 
-    def set_up_db_test_case(self, **kwargs: Optional[Dict]):
-        self.engine = self.get_test_db_engine(**kwargs)
-        self.session = Session(bind=self.engine)
-        self.bind_engine()
+    @classmethod
+    def create_all(cls):
+        cls.metadata.create_all()
+
+    @classmethod
+    def setMetadata(cls, metadata: MetaData = Base.metadata):
+        cls.metadata = metadata
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.setMetadata(metadata=Base.metadata)
+
+    @classmethod
+    def set_up_db_test_case(cls, **kwargs: Optional[Dict]):
+        cls.engine = cls.get_test_db_engine(**kwargs)
+        cls.session = Session(bind=cls.engine)
+        cls.bind_engine()
 
     @staticmethod
     def get_test_db_engine(**kwargs) -> sqlalchemy.engine.Engine:
         config = TestConfig()
         return create_engine(
-            url=kwargs.get("SQLALCHEMY_DB_URI") or config.SQLALCHEMY_DB_URI,
-            encoding=kwargs.get("SQLALCHEMY_DB_ENCODING") or config.SQLALCHEMY_DB_ENCODING,
+            url=kwargs.get("SQLALCHEMY_DB_URI", config.SQLALCHEMY_DB_URI),
+            encoding=kwargs.get("SQLALCHEMY_DB_ENCODING", config.SQLALCHEMY_DB_ENCODING),
             echo=False,
-            future=kwargs.get("SQLALCHEMY_FUTURE") or config.SQLALCHEMY_FUTURE,
+            future=kwargs.get("SQLALCHEMY_FUTURE", config.SQLALCHEMY_FUTURE),
         )
 
-    def bind_engine(self):
-        self.metadata.bind = self.engine
+    @classmethod
+    def bind_engine(cls):
+        cls.metadata.bind = cls.engine
 
-    def close_session(self):
-        self.session.rollback()
-        self.session.close()
+    @classmethod
+    def close_session(cls):
+        cls.session.rollback()
+        cls.session.close()
 
 
 class BaseDBTestCase(DBTestCaseBlueprint):
 
     def setUp(self):
-        self.metadata = Base.metadata
         self.set_up_db_test_case()
         self.create_all()
 
     def tearDown(self):
         self.close_session()
         self.drop_all()
-
-    def create_all(self):
-        self.metadata.create_all()

--- a/dp/cloud/python/magma/db_service/tests/local_db_test_case.py
+++ b/dp/cloud/python/magma/db_service/tests/local_db_test_case.py
@@ -8,6 +8,7 @@ class LocalDBTestCase(BaseDBTestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
+        super().setUpClass()
         cls.postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)()
 
     @classmethod
@@ -15,6 +16,5 @@ class LocalDBTestCase(BaseDBTestCase):
         cls.postgresql.stop()
 
     def setUp(self):
-        self.metadata = Base.metadata
         self.set_up_db_test_case(SQLALCHEMY_DB_URI=self.postgresql.url())
         self.create_all()

--- a/dp/cloud/python/magma/test_runner/tests/test_active_mode_controller.py
+++ b/dp/cloud/python/magma/test_runner/tests/test_active_mode_controller.py
@@ -35,6 +35,7 @@ USER_ID = "some_user_id"
 class ActiveModeControllerTestCase(BaseDBTestCase):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         wait_for_elastic_to_start()
 
     def setUp(self):


### PR DESCRIPTION
## Summary

* Do not clear/initialize DB in orc8r integration tests setup/teardown
* Clear/initialize DB in orc8r integration testcase classes
* Use randmized CBSD serial numbers per orc8r integration test to meet unique constraint on that field in the (now retained between tests) DB

## Additional Information

- [ ] This change is backwards-breaking
