### PR TITLE
docs: fix mini-typo for path

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.7.0/feg/s1ap_federated_test.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/feg/s1ap_federated_test.md
@@ -56,7 +56,7 @@ This script will
 - Run a basic attach/detach test
 
 ```bash
-cd magma/lte/gatewat
+cd magma/lte/gateway
 fab federated_integ_test:build_all=True
 
 # to run it again you can just skip the build_all

--- a/docs/readmes/feg/s1ap_federated_test.md
+++ b/docs/readmes/feg/s1ap_federated_test.md
@@ -58,7 +58,7 @@ This script will
 - Run a basic attach/detach test
 
 ```bash
-cd magma/lte/gatewat
+cd magma/lte/gateway
 fab federated_integ_test:build_all=True
 
 # to run it again you can just skip the build_all


### PR DESCRIPTION
Typo fix suggested in https://github.com/magma/magma/pull/12609/files#r862160457 of https://github.com/magma/magma/pull/12609. Will properly need a rebase and merge conflict fix after merge of #12609 due to a change with less than 3 lines distance.