### PR TITLE
docs(dp): Fix 1.7.0 Domain Proxy Documentation

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -63,14 +63,14 @@
       "docs/docs_overview": {
         "title": "Documentation Overview"
       },
-      "dp/architecture_overview title: Overview hide_title: true": {
-        "title": "dp/architecture_overview title: Overview hide_title: true"
+      "dp/architecture_overview": {
+        "title": "Overview"
       },
-      "dp/debug_logs title: View Logs hide_title: true": {
-        "title": "dp/debug_logs title: View Logs hide_title: true"
+      "dp/debug_logs": {
+        "title": "Debugging and logs"
       },
-      "dp/deploy_build title: Build DP hide_title: true": {
-        "title": "dp/deploy_build title: Build DP hide_title: true"
+      "dp/deploy_build": {
+        "title": "Build and deployment"
       },
       "faq/faq_magma": {
         "title": "Frequently Asked Questions"
@@ -1587,14 +1587,14 @@
       "version-1.7.0/docs/version-1.7.0-docs_overview": {
         "title": "Documentation Overview"
       },
-      "version-1.7.0/dp/version-1.7.0-architecture_overview title: Overview hide_title: true": {
-        "title": "architecture_overview title: Overview hide_title: true"
+      "version-1.7.0/dp/version-1.7.0-architecture_overview": {
+        "title": "Overview"
       },
-      "version-1.7.0/dp/version-1.7.0-debug_logs title: View Logs hide_title: true": {
-        "title": "debug_logs title: View Logs hide_title: true"
+      "version-1.7.0/dp/version-1.7.0-debug_logs": {
+        "title": "Debugging and logs"
       },
-      "version-1.7.0/dp/version-1.7.0-deploy_build title: Build DP hide_title: true": {
-        "title": "deploy_build title: Build DP hide_title: true"
+      "version-1.7.0/dp/version-1.7.0-deploy_build": {
+        "title": "Build and deployment"
       },
       "version-1.7.0/faq/version-1.7.0-faq_magma": {
         "title": "Frequently Asked Questions"

--- a/docs/docusaurus/versioned_docs/version-1.7.0/dp/architecture_overview.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/dp/architecture_overview.md
@@ -1,7 +1,8 @@
 ---
-id: version-1.7.0-architecture_overview title: Overview hide_title: true
-title: architecture_overview title: Overview hide_title: true
-original_id: architecture_overview title: Overview hide_title: true
+id: version-1.7.0-architecture_overview
+title: Overview
+hide_title: true
+original_id: architecture_overview
 ---
 
 # Overview
@@ -110,16 +111,15 @@ The related request is also marked as processed.
 
 #### *Protocol Controller
 
-**NOTE**: This is a historical name for a component that is no longer an independent part of Domain Proxy, but still
-needs to be mentioned.
+**NOTE**: `Protocol Controller` is a historical name for a component that is no longer an independent part of Domain Proxy, but still
+needs to be mentioned. CBSD-SAS `Protocol Controller` was removed by [GitHub PR 12420](https://github.com/magma/magma/pull/12420).
 
 `Protocol Controller` is used to handle incoming requests from an eNB or another domain proxy. It is meant to handle
 messages sent using a specific protocol. Currently, the only eNBs connected to DP speak `TR069` protocol (Sercomm
-Englewood and Baicells 430 Nova) and, although an HTTP Protocol Controller service is available and tested, it is not
-used at the moment and is not a part of Domain Proxy's deployment.
+Englewood and Baicells 430 Nova).
 
 Instead, the component treated by Domain Proxy as the only `Protocol Controller` is currently
-AGW's [Enodebd](lte/README_AGW.md#enodebd)
+AGW's [Enodebd](lte/architecture_overview.md#enodebd)
 being the configuration component for `TR069` based radios.
 
 `Enodebd` communicates with Domain Proxy's `Radio Controller` as if it were just another DP component, over gRPC, using

--- a/docs/docusaurus/versioned_docs/version-1.7.0/dp/debug_logs.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/dp/debug_logs.md
@@ -1,7 +1,8 @@
 ---
-id: version-1.7.0-debug_logs title: View Logs hide_title: true
-title: debug_logs title: View Logs hide_title: true
-original_id: debug_logs title: View Logs hide_title: true
+id: version-1.7.0-debug_logs
+title: Debugging and logs
+hide_title: true
+original_id: debug_logs
 ---
 
 # Debugging
@@ -9,7 +10,123 @@ original_id: debug_logs title: View Logs hide_title: true
 Debugging Domain Proxy usually comes down to checking log content of individual pods. This document describes how to
 access these logs.
 
-## List pods
+## eNB <-> AGW/enodebd
+
+To debug the eNB side of Domain Proxy functionality, it typically comes down to inspecting the TR069 session data or
+looking into eNB specific data model/state machine implementation in `enodebd`.
+
+To view eNB logs from a TR069 session with `AGW`/`enodebd`, login to AGW and look for the `enodebd` log file:
+
+```console
+tail -f /var/log/enodebd.log
+```
+
+### eNB TR069 message flow
+
+[TAR.XZ - example set of logs from AGW/enodebd showing the TR069 message flow with setting of params.](assets/dp/dp_enb_tr069_flow.tar.xz)
+
+[TAR.XZ - example pcap of TR069 session flow between eNB and ACS (enodebd)](assets/dp/dp_enb_tr069.pcap.tar.xz)
+
+Given the following log snippet (trimmed) from Baicells QRTB, the normal flow should consist of:
+
+1. Initial `Inform` which starts the TR069 session between eNB and ACS (enodebd)
+
+    ```console
+    2022-04-25 15:41:17,549 DEBUG Handling TR069 message: Inform {...}
+    2022-04-25 15:41:17,550 DEBUG (Inform msg) Received parameter: Device.DeviceInfo.HardwareVersion = ...
+    [Inform msg output continues]
+    2022-04-25 15:41:17,557 DEBUG State transition from <WaitInformState> to <wait_empty>
+    2022-04-25 15:41:17,558 DEBUG Sending TR069 message: InformResponse {'MaxEnvelopes': '1'}
+    ```
+
+1. Sequence of `GetParameterValues` messages (Transient, Normal, Object)
+
+    ```console
+    2022-04-25 15:41:22,608 DEBUG 10.0.2.243 - "POST / HTTP/1.1" 200 419
+    2022-04-25 15:41:22,612 DEBUG Handling TR069 message: DummyInput {}
+    2022-04-25 15:41:22,612 DEBUG State transition from <WaitEmptyMessageState> to <check_fw_upgrade_download>
+    12022-04-25 15:41:22,613 DEBUG Skipping FW Download for eNB [XXXXXXXXXXXXX], missing firmware upgrade config in enodebd.yml.
+    2022-04-25 15:41:22,613 DEBUG State transition from <CheckFirmwareUpgradeDownloadState> to <get_transient_params>
+    2022-04-25 15:41:22,613 DEBUG State transition from <SendGetTransientParametersState> to <wait_get_transient_params>
+    2022-04-25 15:41:22,613 DEBUG Sending TR069 message: GetParameterValues {...}
+    2022-04-25 15:41:22,617 DEBUG 10.0.2.243 - "POST / HTTP/1.1" 200 912
+    2022-04-25 15:41:22,662 DEBUG Handling TR069 message: GetParameterValuesResponse {...}
+    2022-04-25 15:41:22,662 DEBUG Fetched Transient Params: {...}
+    2022-04-25 15:41:22,663 DEBUG State transition from <WaitGetTransientParametersState> to <get_params>
+    2022-04-25 15:41:22,664 DEBUG State transition from <GetParametersState> to <wait_get_params>
+    2022-04-25 15:41:22,664 DEBUG Sending TR069 message: GetParameterValues {...}
+    2022-04-25 15:41:22,671 DEBUG 10.0.2.243 - "POST / HTTP/1.1" 200 3242
+    2022-04-25 15:41:22,718 DEBUG Handling TR069 message: GetParameterValuesResponse {...}
+    2022-04-25 15:41:22,719 DEBUG Received CPE parameter values: {...}
+    2022-04-25 15:41:22,719 DEBUG State transition from <WaitGetParametersState> to <get_obj_params>
+    2022-04-25 15:41:22,720 DEBUG State transition from <GetObjectParametersState> to <wait_get_obj_params>
+    2022-04-25 15:41:22,720 DEBUG Sending TR069 message: GetParameterValues {...}
+    2022-04-25 15:41:22,723 DEBUG 10.0.2.243 - "POST / HTTP/1.1" 200 877
+    2022-04-25 15:41:22,769 DEBUG Handling TR069 message: GetParameterValuesResponse {...}
+    2022-04-25 15:41:22,770 DEBUG Received object parameters: {...}
+    ```
+
+1. `SetParameterValues` message followed by `GetParameterValues` - conditional, only appears if a configuration change needs to be done on the eNB side. The actual parameters that are set in order to enable transmission based on Domain Proxy grant may differ depending on the eNB model and eNB current configuration state. Please refer to your eNB device model implementation in `lte/gateway/python/magma/enodebd/devices`.
+
+    ```console
+    2022-04-25 15:41:22,771 DEBUG State transition from <WaitGetObjectParametersState> to <set_params>`
+    2022-04-25 15:41:22,772 DEBUG Sending TR069 request to set CPE parameter values: {...}`
+    2022-04-25 15:41:22,773 DEBUG State transition from <SetParameterValuesState> to <wait_set_params>`
+    2022-04-25 15:41:22,773 DEBUG Sending TR069 message: SetParameterValues {...}`
+    2022-04-25 15:41:22,777 DEBUG 10.0.2.243 - "POST / HTTP/1.1" 200 723`
+    2022-04-25 15:41:22,837 DEBUG Handling TR069 message: SetParameterValuesResponse {'Status': '0'}`
+    2022-04-25 15:41:22,838 INFO Successfully configured CPE parameters!`
+    2022-04-25 15:41:22,839 DEBUG State transition from <WaitSetParameterValuesState> to <check_get_params>`
+    2022-04-25 15:41:22,840 DEBUG State transition from <GetParametersState> to <check_wait_get_params>`
+    2022-04-25 15:41:22,840 DEBUG Sending TR069 message: GetParameterValues {...}`
+    2022-04-25 15:41:22,849 DEBUG 10.0.2.243 - "POST / HTTP/1.1" 200 3242`
+    2022-04-25 15:41:22,916 DEBUG Handling TR069 message: GetParameterValuesResponse {...}`
+    ```
+
+1. Update transmission configuration from Domain Proxy and close TR069 session - `notify_dp` is an `enodebd` transition state that calls the Domain Proxy `GetCBSDState` gRPC API. The `GetCBSDState` response contains data, which indicate whether eNB radio should be disabled/turned off or enabled together with transmission parameters. `GetCBSDState` response data is translated to eNB specific parameters that will be applied to eNB. Please refer to your eNB device model implementation in `lte/gateway/python/magma/enodebd/devices`.
+
+    ```console
+    2022-04-25 15:41:22,917 DEBUG State transition from <WaitGetParametersState> to <end_session>
+    2022-04-25 15:41:22,917 DEBUG State transition from <BaicellsQRTBEndSessionState> to <notify_dp>
+    2022-04-25 15:41:23,046 DEBUG Updating desired config based on sas grant
+    2022-04-25 15:41:23,046 DEBUG Sending TR069 message: DummyInput {}
+    ```
+
+## AGW/enodebd <-> Domain Proxy
+
+### AGW
+
+To debug AGW communication with Domain Proxy, look for `control_proxy` logs on the AGW calling gRPC API of Domain Proxy:
+
+```console
+journalctl -xu magma@control_proxy -r
+
+Apr 21 11:58:00 FreedomFi-Gateway control_proxy[1220289]: 2022-04-21T11:58:00.002Z [127.0.0.1 -> dp_service-controller.codistaging.dp.freedomfi.com,8443] "POST /DPService/GetCBSDState
+Apr 21 11:57:55 FreedomFi-Gateway control_proxy[1220289]: 2022-04-21T11:57:54.991Z [127.0.0.1 -> dp_service-controller.codistaging.dp.freedomfi.com,8443] "POST /DPService/GetCBSDState
+Apr 21 11:57:50 FreedomFi-Gateway control_proxy[1220289]: 2022-04-21T11:57:50.044Z [127.0.0.1 -> dp_service-controller.codistaging.dp.freedomfi.com,8443] "POST /DPService/GetCBSDState
+Apr 21 11:57:45 FreedomFi-Gateway control_proxy[1220289]: 2022-04-21T11:57:45.002Z [127.0.0.1 -> dp_service-controller.codistaging.dp.freedomfi.com,8443] "POST /DPService/GetCBSDState
+```
+
+`control_proxy` logs will show if gRPC calls from `enodebd` towards Domain Proxy are made. Since gRPC is binary coded, there isn't much information from tcpdump capture on this end of communication.
+Domain Proxy gRPC call details can be viewed in [NMS](#nms).
+
+### NMS
+
+`enodebd` gRPC calls towards Domain Proxy are visible in NMS: `[Metrics]` menu, `[DP Logs]` tab in a human readable form.
+An `empty` message (blank content in the column) is equivalent to no SAS grant data being sent - which in turn is interpreted by `AGW`/`enodebd` as
+no transmission and the radio transmission must be disabled.
+
+![DP Logs AGW](assets/dp/dp_logs_agw_enodebd.png)
+
+## Domain Proxy <-> SAS
+
+Domain Proxy logs of communication with Spectrum Access System (SAS) are visible in NMS: `[Metrics]` menu, `[DP Logs]` tab
+
+![DP Logs SAS](assets/dp/dp_logs_sas.png)
+
+## Gettings logs from Domain Proxy pods
+
+### Listing Domain Proxy pods in Kubernetes
 
 To list Domain Proxy pods running in production environment type:
 
@@ -27,6 +144,22 @@ domain-proxy-radio-controller-5c868696d9-s7vgg          1/1     Running     0   
 ```
 
 ## Check individual pods' logs
+
+To view logs from individual Domain Proxy pods, execute `kubectl logs` with one of the pod names listed in the [previous chapter](#listing-domain-proxy-pods-in-kubernetes).
+
+- `Radio Controller` (RC) logs:
+    - logs related to AGW/enodebd <-> Domain Proxy communication
+    - logs related to requests generated by Active Mode Controller (Domain Proxy logic, which generates appropriate SAS requests)
+    - logs related with Database modifications, which were the result of incoming API calls (either from AGW or AMC)
+- `Configuration Controller` (CC) logs:
+    - logs related to Domain Proxy <-> SAS communication
+    - logs related with Database modifications, which were the result of processing SAS responses
+- `Active Mode Controller` (AMC) logs:
+    - logs related to internal business logic of Domain Proxy functionality
+    - logs related to Database state management
+    - logs related to generated SAS requests based on Database state
+
+Example commands for gettings the logs:
 
 ```console
 # Last 1000 lines of logs on a specific pod

--- a/docs/docusaurus/versioned_docs/version-1.7.0/dp/deploy_build.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/dp/deploy_build.md
@@ -1,7 +1,8 @@
 ---
-id: version-1.7.0-deploy_build title: Build DP hide_title: true
-title: deploy_build title: Build DP hide_title: true
-original_id: deploy_build title: Build DP hide_title: true
+id: version-1.7.0-deploy_build
+title: Build and deployment
+hide_title: true
+original_id: deploy_build
 ---
 
 # Domain Proxy Installation

--- a/docs/readmes/dp/architecture_overview.md
+++ b/docs/readmes/dp/architecture_overview.md
@@ -1,5 +1,7 @@
 ---
-id: architecture_overview title: Overview hide_title: true
+id: architecture_overview
+title: Overview
+hide_title: true
 ---
 
 # Overview
@@ -37,11 +39,11 @@ NMS UI page for Domain Proxy management is currently under development.
 
 The picture below gives a very general look at the Domain Proxy as a proxy service between radios and SAS
 
-![dp](../assets/dp/dp_high_level_overview.png)
+![dp](assets/dp/dp_high_level_overview.png)
 
 ### Domain Proxy in Magma's Context
 
-![dp](../assets/dp/dp_in_context.png)
+![dp](assets/dp/dp_in_context.png)
 
 If we take a closer look, Domain Proxy as part of Magma is situated next to Orc8r,
 (typically on the same Kubernetes cluster) and uses the same database as the Orc8r.
@@ -73,7 +75,7 @@ radio. This is achieved mainly by
 
 In the picture we see three components that comprise Domain Proxy
 
-![dp](../assets/dp/dp_architecture.png)
+![dp](assets/dp/dp_architecture.png)
 
 #### Radio Controller
 
@@ -108,15 +110,15 @@ The related request is also marked as processed.
 
 #### *Protocol Controller
 
-**NOTE**: This is a historical name for a component that is no longer an independent part of Domain Proxy, but still
-needs to be mentioned. It was removed by that [GitHub PR](https://github.com/magma/magma/pull/12420)
+**NOTE**: `Protocol Controller` is a historical name for a component that is no longer an independent part of Domain Proxy, but still
+needs to be mentioned. CBSD-SAS `Protocol Controller` was removed by [GitHub PR 12420](https://github.com/magma/magma/pull/12420).
 
 `Protocol Controller` is used to handle incoming requests from an eNB or another domain proxy. It is meant to handle
 messages sent using a specific protocol. Currently, the only eNBs connected to DP speak `TR069` protocol (Sercomm
 Englewood and Baicells 430 Nova).
 
 Instead, the component treated by Domain Proxy as the only `Protocol Controller` is currently
-AGW's [Enodebd](lte/README_AGW.md#enodebd)
+AGW's [Enodebd](lte/architecture_overview.md#enodebd)
 being the configuration component for `TR069` based radios.
 
 `Enodebd` communicates with Domain Proxy's `Radio Controller` as if it were just another DP component, over gRPC, using

--- a/docs/readmes/dp/debug_logs.md
+++ b/docs/readmes/dp/debug_logs.md
@@ -1,5 +1,7 @@
 ---
-id: debug_logs title: View Logs hide_title: true
+id: debug_logs
+title: Debugging and logs
+hide_title: true
 ---
 
 # Debugging
@@ -9,10 +11,10 @@ access these logs.
 
 ## eNB <-> AGW/enodebd
 
-To debug eNB side of Domain Proxy functionality, it typically falls down to inspecting the TR069 session data or
+To debug the eNB side of Domain Proxy functionality, it typically comes down to inspecting the TR069 session data or
 looking into eNB specific data model/state machine implementation in `enodebd`.
 
-To view eNB logs from a TR069 session with `AGW`/`enodebd`, login to AGW and look for `enodebd` log file:
+To view eNB logs from a TR069 session with `AGW`/`enodebd`, login to AGW and look for the `enodebd` log file:
 
 ```console
 tail -f /var/log/enodebd.log
@@ -20,9 +22,9 @@ tail -f /var/log/enodebd.log
 
 ### eNB TR069 message flow
 
-[TAR.XZ - example set of logs from AGW/enodebd showing the TR069 message flow with setting of params.](../assets/dp/dp_enb_tr069_flow.tar.xz)
+[TAR.XZ - example set of logs from AGW/enodebd showing the TR069 message flow with setting of params.](assets/dp/dp_enb_tr069_flow.tar.xz)
 
-[TAR.XZ - example pcap of TR069 session flow between eNB and ACS (enodebd)](../assets/dp/dp_enb_tr069.pcap.tar.xz)
+[TAR.XZ - example pcap of TR069 session flow between eNB and ACS (enodebd)](assets/dp/dp_enb_tr069.pcap.tar.xz)
 
 Given the following log snippet (trimmed) from Baicells QRTB, the normal flow should consist of:
 
@@ -63,7 +65,7 @@ Given the following log snippet (trimmed) from Baicells QRTB, the normal flow sh
     2022-04-25 15:41:22,770 DEBUG Received object parameters: {...}
     ```
 
-1. `SetParameterValues` message followed by `GetParameterValues` - conditional, only appears if a configuration change is needed to be done on the eNB side. The actual parameters that are set in order to enable transmission based on Domain Proxy grant may differ depending on the eNB model and eNB current configuration state. Please refer to your eNB device model implementation in `lte/gateway/python/magma/enodebd/devices`.
+1. `SetParameterValues` message followed by `GetParameterValues` - conditional, only appears if a configuration change needs to be done on the eNB side. The actual parameters that are set in order to enable transmission based on Domain Proxy grant may differ depending on the eNB model and eNB current configuration state. Please refer to your eNB device model implementation in `lte/gateway/python/magma/enodebd/devices`.
 
     ```console
     2022-04-25 15:41:22,771 DEBUG State transition from <WaitGetObjectParametersState> to <set_params>`
@@ -80,7 +82,7 @@ Given the following log snippet (trimmed) from Baicells QRTB, the normal flow sh
     2022-04-25 15:41:22,916 DEBUG Handling TR069 message: GetParameterValuesResponse {...}`
     ```
 
-1. Update transmission configuration from Domain Proxy and close TR069 session - `notify_dp` is a `enodebd` transition state that calls Domain Proxy `GetCBSDState` gRPC API. `GetCBSDState` response contains data, which indicate whether eNB radio should be disabled/turned off or enabled together with transmission parameters. `GetCBSDState` response data is translated to eNB specific parameters that will be applied to eNB. Please refer to your eNB device model implementation in `lte/gateway/python/magma/enodebd/devices`.
+1. Update transmission configuration from Domain Proxy and close TR069 session - `notify_dp` is an `enodebd` transition state that calls the Domain Proxy `GetCBSDState` gRPC API. The `GetCBSDState` response contains data, which indicate whether eNB radio should be disabled/turned off or enabled together with transmission parameters. `GetCBSDState` response data is translated to eNB specific parameters that will be applied to eNB. Please refer to your eNB device model implementation in `lte/gateway/python/magma/enodebd/devices`.
 
     ```console
     2022-04-25 15:41:22,917 DEBUG State transition from <WaitGetParametersState> to <end_session>
@@ -111,15 +113,15 @@ Domain Proxy gRPC call details can be viewed in [NMS](#nms).
 
 `enodebd` gRPC calls towards Domain Proxy are visible in NMS: `[Metrics]` menu, `[DP Logs]` tab in a human readable form.
 An `empty` message (blank content in the column) is equivalent to no SAS grant data being sent - which in turn is interpreted by `AGW`/`enodebd` as
-no transmission and the radio transmit must be disabled.
+no transmission and the radio transmission must be disabled.
 
-![DP Logs AGW](../assets/dp/dp_logs_agw_enodebd.png)
+![DP Logs AGW](assets/dp/dp_logs_agw_enodebd.png)
 
 ## Domain Proxy <-> SAS
 
 Domain Proxy logs of communication with Spectrum Access System (SAS) are visible in NMS: `[Metrics]` menu, `[DP Logs]` tab
 
-![DP Logs SAS](../assets/dp/dp_logs_sas.png)
+![DP Logs SAS](assets/dp/dp_logs_sas.png)
 
 ## Gettings logs from Domain Proxy pods
 
@@ -142,12 +144,12 @@ domain-proxy-radio-controller-5c868696d9-s7vgg          1/1     Running     0   
 
 ## Check individual pods' logs
 
-To view logs from individual Domain Proxy pods, execute `kubectl logs` command with one of the pod names listed in [previous chapter].(#listing-domain-proxy-pods-in-kubernetes)
+To view logs from individual Domain Proxy pods, execute `kubectl logs` with one of the pod names listed in the [previous chapter](#listing-domain-proxy-pods-in-kubernetes).
 
 - `Radio Controller` (RC) logs:
     - logs related to AGW/enodebd <-> Domain Proxy communication
     - logs related to requests generated by Active Mode Controller (Domain Proxy logic, which generates appropriate SAS requests)
-    - logs related with Database modifications, which where the result of incoming API calls (either from AGW or AMC)
+    - logs related with Database modifications, which were the result of incoming API calls (either from AGW or AMC)
 - `Configuration Controller` (CC) logs:
     - logs related to Domain Proxy <-> SAS communication
     - logs related with Database modifications, which were the result of processing SAS responses

--- a/docs/readmes/dp/deploy_build.md
+++ b/docs/readmes/dp/deploy_build.md
@@ -1,5 +1,7 @@
 ---
-id: deploy_build title: Build DP hide_title: true
+id: deploy_build
+title: Build and deployment
+hide_title: true
 ---
 
 # Domain Proxy Installation


### PR DESCRIPTION
* Fixed markdown headers of Domain Proxy documentation files
* Fixed asset links to work correctly with DocuSaurus
* Align documentation with 1.7.0 versioned docs

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

We noticed that neither current/next nor 1.7.0 Magma documentation was showing Domain Proxy docs.
This was caused by malformed markdown headers present in the md doc files.

This PR corrects current/next readmes and updates 1.7.0 versioned docs based on the updated readmes.

## Test Plan

* `make dev` in `docs/`
* Checked both `next` and `1.7.0` documentation sections
* Verified local `dev` container links, assets, and doc pages can be selected and viewed properly

## Additional Information

- [ ] This change is backwards-breaking