### PR TITLE
fix(ci): Allow deps-dev PR scope for dependabot

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -84,6 +84,7 @@ jobs:
             ctraced
             cwg
             deps
+            deps-dev
             directoryd
             dp
             eap


### PR DESCRIPTION
## Summary
For npm development dependancies dependabot uses the scope `deps-dev` see https://github.com/magma/magma/pull/12599/commits/53ba8f5093a6ec4b70782cd82f0a842daecf28f2
