### PR TITLE
chore(agw): Clean up unused variables

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
@@ -37,7 +37,6 @@ class TestAttachASR(unittest.TestCase):
         """ single UE """
         num_ues = 1
         self._s1ap_wrapper.configUEDevice(num_ues)
-        datapath = get_datapath()
 
         req = self._s1ap_wrapper.ue_req
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py
@@ -41,7 +41,7 @@ class TestAttachDetachDedicatedDeactTmrExp(unittest.TestCase):
         num_ues = 1
         self._s1ap_wrapper.configUEDevice(num_ues)
 
-        for i in range(num_ues):
+        for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
             print(
                 "********************** Running End to End attach for ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_looped.py
@@ -38,7 +38,7 @@ class TestAttachDetachDedicatedLooped(unittest.TestCase):
         loop = 3
         self._s1ap_wrapper.configUEDevice(num_ues)
 
-        for i in range(num_ues):
+        for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
             print(
                 "********************* Running End to End attach for ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
@@ -57,7 +57,7 @@ class TestMaximumBearersTwoPdnsPerUe(unittest.TestCase):
         # APN list to be configured
         apn_list = [ims]
 
-        for i in range(num_ues):
+        for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
 
             self._s1ap_wrapper.configAPN(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_last_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_last_pdn.py
@@ -39,7 +39,7 @@ class TestAttachDetachNwTriggeredDeleteLastPdn(unittest.TestCase):
         num_ues = 1
         self._s1ap_wrapper.configUEDevice(num_ues)
 
-        for i in range(num_ues):
+        for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
             print(
                 "********************** Running End to End attach for ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_dedicated_bearer.py
@@ -42,7 +42,7 @@ class TestSecondaryPdnDisConnDedBearerReq(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         req = self._s1ap_wrapper.ue_req
 
-        for i in range(num_ues):
+        for _ in range(num_ues):
             ue_id = req.ue_id
             # APN of the secondary PDN
             ims = {

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer.py
@@ -40,7 +40,7 @@ class TestSecondaryPdnConnWithDedBearerReq(unittest.TestCase):
 
         self._s1ap_wrapper.configUEDevice(num_ues)
 
-        for i in range(num_ues):
+        for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
             ue_id = req.ue_id
             # APN of the secondary PDN

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py
@@ -41,7 +41,7 @@ class TestSecondaryPdnConnWithDedBearerDeactivateReq(unittest.TestCase):
 
         self._s1ap_wrapper.configUEDevice(num_ues)
 
-        for i in range(num_ues):
+        for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
             ue_id = req.ue_id
             # APN of the secondary PDN

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_looped.py
@@ -42,7 +42,7 @@ class TestSecondaryPdnConnWithDedBearerLooped(unittest.TestCase):
 
         self._s1ap_wrapper.configUEDevice(num_ues)
 
-        for i in range(num_ues):
+        for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
             ue_id = req.ue_id
             # APN of the secondary PDN

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
@@ -53,7 +53,6 @@ class TestAttachDetachWithHE(unittest.TestCase):
         ]
         wait_for_s1 = [True, False]
         self._s1ap_wrapper.configUEDevice(num_ues)
-        datapath = get_datapath()
         MAX_NUM_RETRIES = 5
         gtp_br_util = GTPBridgeUtils()
         PROXY_PORT = gtp_br_util.get_proxy_port_no()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_timerexpiration.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_timerexpiration.py
@@ -81,7 +81,7 @@ class TestEsmInformation(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete,
         )
 
-        for i in range(num_of_expires):
+        for _ in range(num_of_expires):
             # Esm Information Request indication
             print(
                 "Received Esm Information Request ue-id", sec_mode_complete.ue_Id,

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_mme_restart_detach_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_mme_restart_detach_multi_ue.py
@@ -47,7 +47,7 @@ class TestAttachMmeRestartDetachMultiUe(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
 
         ue_ids = []
-        for i in range(num_ues):
+        for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
             print(
                 "************************* Running End to End attach for ",

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -90,7 +90,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         """ test get_ip_for_sid without any assignment """
         sid = 'IMSI11'
         with self.assertRaises(SubscriberDBStaticIPValueError):
-            ip0, _ = self._allocator.alloc_ip_address(sid)
+            self._allocator.alloc_ip_address(sid)
 
     def test_get_ip_for_subscriber_with_apn(self):
         """ test get_ip_for_sid with static IP """
@@ -470,7 +470,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         )
 
         with self.assertRaises(InvalidVlanId):
-            ip0, _ = self._allocator.alloc_ip_address(sid)
+            self._allocator.alloc_ip_address(sid)
 
     def test_get_ip_for_subscriber_with_apn_dup_assignment(self):
         """ test duplicate static IPs """
@@ -534,4 +534,4 @@ class StaticIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
 
         with self.assertRaises(DuplicateIPAssignmentError):
-            ip0, _ = self._allocator.alloc_ip_address(sid)
+            self._allocator.alloc_ip_address(sid)

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ipv6_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ipv6_alloc.py
@@ -92,7 +92,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         """ test get_ip_for_sid without any assignment """
         sid = 'IMSI11'
         with self.assertRaises(SubscriberDBStaticIPValueError):
-            ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+            self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
 
     def test_get_ipv6_for_subscriber_with_apn(self):
         """ test get_ip_for_sid with static IP """
@@ -472,7 +472,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         )
 
         with self.assertRaises(InvalidVlanId):
-            ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+            self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
 
     def test_get_ipv6_for_subscriber_with_apn_dup_assignment(self):
         """ test duplicate static IPs """
@@ -537,4 +537,4 @@ class StaticIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
 
         with self.assertRaises(DuplicateIPAssignmentError):
-            ip0, _ = self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)
+            self._allocator.alloc_ip_address(sid, version=IPAddress.IPV6)

--- a/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
@@ -110,7 +110,7 @@ class EbpfManager:
         ipr = IPRoute()
         try:
             ipr.tc("add", "clsact", s1_if_index)
-        except NetlinkError as ex:
+        except NetlinkError:
             LOG.error("error adding ingress ")
 
         try:
@@ -118,7 +118,7 @@ class EbpfManager:
                 "add-filter", "bpf", s1_if_index, ":1", fd=self.s1_fn.fd, name=self.s1_fn.name,
                 parent="ffff:fff2", classid=1, direct_action=True,
             )
-        except NetlinkError as ex:
+        except NetlinkError:
             LOG.error("error adding ingress ")
 
         LOG.debug("Attach done")
@@ -164,7 +164,7 @@ class EbpfManager:
             pass
         try:
             ipr.tc("del", "ingress", s1_if_index, "ffff:")
-        except NetlinkError as ex:
+        except NetlinkError:
             pass
         sys_file = BASE_MAP_FS + UL_MAP_NAME
         out1 = subprocess.run(["unlink", sys_file], capture_output=True)
@@ -194,7 +194,6 @@ class EbpfManager:
     def add_ul_entry(self, mark: int, ue_ip: str):
         if not self.enabled:
             return
-        sz = len(self.ul_map)
         ip_addr = self._pack_ip(ue_ip)
         LOG.debug(
             "Add entry: ip: %x mac src %s mac dst: %s" %

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -602,7 +602,7 @@ def wait_for_snapshots(
             include_stats=include_stats,
         )
         if try_snapshot:
-            snapshot_file, expected_ = expected_snapshot(
+            _, expected_ = expected_snapshot(
                 test_case,
                 bridge_name,
                 snapshot_name,

--- a/lte/gateway/python/magma/pipelined/tests/test_he.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_he.py
@@ -542,8 +542,6 @@ class EnforcementTableHeTest(unittest.TestCase):
         Add policy to subscriber with HE config
 
         """
-        cls = self.__class__
-
         fake_controller_setup(self.enforcement_controller)
 
         imsi = 'IMSI010000000088888'

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -117,7 +117,6 @@ class TestQosManager(unittest.TestCase):
         self, mock_get_action_inst, mock_traffic_cls, d, qid, qos_info,
         parent_qid=0, skip_filter=False,
     ):
-        intf = self.ul_intf if d == FlowMatch.UPLINK else self.dl_intf
         mock_get_action_inst.assert_any_call(qid)
         mock_traffic_cls.init_qdisc.assert_any_call(self.ul_intf, enable_pyroute2=False, default_gbr='80Kbit')
         mock_traffic_cls.init_qdisc.assert_any_call(self.dl_intf, enable_pyroute2=False, default_gbr='80Kbit')

--- a/lte/gateway/python/magma/pipelined/tests/test_restart_resilience.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_restart_resilience.py
@@ -205,7 +205,6 @@ class RestartResilienceTest(unittest.TestCase):
                 version=1,
             ),
         ]
-        enf_stat_name = [imsi + '|ipv6_rule' + '|' + str(sub_ip) + "|" + "1"]
         setup_flows_request = SetupFlowsRequest(
             requests=[
                 ActivateFlowsRequest(
@@ -313,10 +312,6 @@ class RestartResilienceTest(unittest.TestCase):
                 version=1,
             ),
         ]
-        enf_stat_name = [
-            imsi1 + '|sub1_rule_temp' + '|' + sub2_ip,
-            imsi2 + '|sub2_rule_keep' + '|' + sub2_ip,
-        ]
 
         self.service_manager.session_rule_version_mapper.save_version(
             imsi1, convert_ipv4_str_to_ip_proto(sub2_ip), 'sub1_rule_temp', 1,
@@ -391,10 +386,6 @@ class RestartResilienceTest(unittest.TestCase):
                 rule=PolicyRule(id='sub2_rule_keep', priority=3, flow_list=flow_list2),
                 version=1,
             ),
-        ]
-        enf_stat_name = [
-            imsi2 + '|sub2_new_rule' + '|' + sub2_ip + "|" + "1",
-            imsi2 + '|sub2_rule_keep' + '|' + sub2_ip + "|" + "1",
         ]
         setup_flows_request = SetupFlowsRequest(
             requests=[

--- a/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
@@ -184,9 +184,6 @@ class UplinkBridgeWithNonNATTest(unittest.TestCase):
             cls.VLAN_DEV_OUT, "71",
         )
 
-        # dummy uplink interface
-        vlan = "10"
-
         BridgeTools.create_internal_iface(
             cls.UPLINK_BRIDGE,
             cls.UPLINK_DHCP, None,
@@ -212,7 +209,6 @@ class UplinkBridgeWithNonNATTest(unittest.TestCase):
         BridgeTools.destroy_bridge(cls.UPLINK_BRIDGE)
 
     def testFlowSnapshotMatch(self):
-        cls = self.__class__
         assert_bridge_snapshot_match(
             self, self.UPLINK_BRIDGE, self.service_manager,
             include_stats=False,
@@ -301,8 +297,6 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
             cls.VLAN_DEV_OUT, "71",
         )
 
-        # validate vlan id set
-        vlan = "10"
         BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
 
         BridgeTools.create_internal_iface(
@@ -330,7 +324,6 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
         BridgeTools.destroy_bridge(cls.UPLINK_BRIDGE)
 
     def testFlowSnapshotMatch(self):
-        cls = self.__class__
         assert_bridge_snapshot_match(
             self, self.UPLINK_BRIDGE, self.service_manager,
             include_stats=False,


### PR DESCRIPTION
## Summary

Removes a selection of unused variables found via `cd lte/gateway/python && make check`.

## Test Plan

- [x] magma-dev: `cd lte/gateway && make test_python_service UT_PATH=python/magma/mobilityd/tests/`
- [x] magma-dev: `cd lte/gateway && make test_python_service UT_PATH=python/magma/pipelined/tests/`
- [x] magma-test: Run modified integration tests, i.e. `cd lte/gateway/python/integ_tests && make integ_test TESTS=s1aptests/<test>.py`