### PR TITLE
chore(agw): Clean up unused imports

### DIFF
--- a/lte/gateway/python/integ_tests/common/mobility_service_client.py
+++ b/lte/gateway/python/integ_tests/common/mobility_service_client.py
@@ -14,10 +14,9 @@ limitations under the License.
 import abc
 import ipaddress
 import logging
-import time
 
 import grpc
-from integ_tests.gateway.rpc import get_gateway_hw_id, get_rpc_channel
+from integ_tests.gateway.rpc import get_rpc_channel
 from lte.protos.mobilityd_pb2 import IPAddress, IPBlock, RemoveIPBlockRequest
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from orc8r.protos.common_pb2 import Void

--- a/lte/gateway/python/integ_tests/common/subscriber_db_client.py
+++ b/lte/gateway/python/integ_tests/common/subscriber_db_client.py
@@ -12,18 +12,13 @@ limitations under the License.
 """
 
 import abc
-import base64
 import logging
 import subprocess
 import time
 
 import grpc
 from feg.protos.hss_service_pb2_grpc import HSSConfiguratorStub
-from integ_tests.gateway.rpc import (
-    get_gateway_hw_id,
-    get_hss_rpc_channel,
-    get_rpc_channel,
-)
+from integ_tests.gateway.rpc import get_hss_rpc_channel, get_rpc_channel
 from lte.protos.subscriberdb_pb2 import (
     LTESubscription,
     SubscriberData,

--- a/lte/gateway/python/integ_tests/federated_tests/fabfile.py
+++ b/lte/gateway/python/integ_tests/federated_tests/fabfile.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 from distutils.util import strtobool
 
-from fabric.api import cd, execute, run
+from fabric.api import cd, run
 
 sys.path.append('../../../../../orc8r')
 from tools.fab.hosts import vagrant_setup

--- a/lte/gateway/python/integ_tests/gateway/rpc.py
+++ b/lte/gateway/python/integ_tests/gateway/rpc.py
@@ -13,7 +13,7 @@ limitations under the License.
 import os
 from typing import Any, Dict, List
 
-from magma.common.service_registry import create_grpc_channel, get_ssl_creds
+from magma.common.service_registry import create_grpc_channel
 from magma.configuration.mconfigs import unpack_mconfig_any
 from orc8r.protos.common_pb2 import Void
 from orc8r.protos.magmad_pb2_grpc import MagmadStub

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
@@ -16,7 +16,6 @@ import unittest
 
 import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.ovs.rest_api import get_datapath
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, SpgwUtil
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ipv6.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ipv6.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import time
 import unittest
 
 import s1ap_types

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
@@ -16,7 +16,6 @@ import unittest
 
 import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.ovs.rest_api import get_datapath
 from integ_tests.s1aptests.s1ap_utils import (
     GTPBridgeUtils,
     HeaderEnrichmentUtils,

--- a/lte/gateway/python/load_tests/common.py
+++ b/lte/gateway/python/load_tests/common.py
@@ -13,7 +13,7 @@ limitations under the License.
 import os
 import subprocess  # noqa: S404
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from lte.protos.subscriberdb_pb2 import SubscriberID
 

--- a/lte/gateway/python/magma/mobilityd/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/tests/BUILD.bazel
@@ -31,7 +31,6 @@ pytest_test(
     deps = [
         "//lte/gateway/python/magma/mobilityd:mobilityd_lib",
         "//lte/gateway/python/magma/pipelined:bridge_util",
-        "//orc8r/gateway/python/magma/common/redis:client",
         requirement("fakeredis"),
     ],
 )

--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -20,7 +20,6 @@ import unittest.mock
 from ipaddress import ip_network
 
 import fakeredis
-from magma.common.redis.client import get_default_client
 from magma.mobilityd.ip_address_man import (
     IPAddressManager,
     MappingNotFoundError,

--- a/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
@@ -23,7 +23,6 @@ import time
 import unittest
 
 import fakeredis
-from magma.common.redis.client import get_default_client
 from magma.mobilityd.ip_address_man import (
     IPAddressManager,
     IPNotInUseError,

--- a/lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py
@@ -33,7 +33,6 @@ from lte.protos.mobilityd_pb2 import (
     SubscriberIPTableEntry,
 )
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
-from magma.common.redis.client import get_default_client
 from magma.mobilityd.ip_address_man import IPAddressManager
 from magma.mobilityd.ip_allocator_pool import IpAllocatorPool
 from magma.mobilityd.ipv6_allocator_pool import IPv6AllocatorPool

--- a/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
@@ -16,7 +16,6 @@ import logging
 import socket
 import struct
 import subprocess
-from socket import AF_INET
 
 import netifaces
 from bcc import BPF

--- a/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
@@ -13,21 +13,16 @@ limitations under the License.
 
 import ctypes
 import logging
-import os
 import socket
 import struct
 import subprocess
-from builtins import input
-from socket import AF_INET, htons
-from subprocess import call
-from sys import argv
-from threading import Thread
+from socket import AF_INET
 
 import netifaces
 from bcc import BPF
 from lte.protos.mobilityd_pb2 import IPAddress
 from magma.pipelined.mobilityd_client import get_mobilityd_gw_info
-from pyroute2 import IPDB, IPRoute, NetlinkError, NetNS, NSPopen
+from pyroute2 import IPRoute, NetlinkError
 from scapy.layers.inet6 import getmacbyip6
 from scapy.layers.l2 import getmacbyip
 

--- a/lte/gateway/python/magma/pipelined/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/tests/BUILD.bazel
@@ -675,12 +675,9 @@ pytest_test(
         ORC8R_ROOT,
     ],
     deps = [
-        "//lte/gateway/python/magma/pipelined:policy_converters",
         "//lte/gateway/python/magma/pipelined:rpc_servicer",
-        "//lte/gateway/python/magma/pipelined:rule_mappers",
         "//lte/protos:mobilityd_python_proto",
         "//lte/protos:pipelined_python_proto",
-        requirement("fakeredis"),
     ],
 )
 

--- a/lte/gateway/python/magma/pipelined/tests/app/flow_query.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/flow_query.py
@@ -14,8 +14,6 @@ limitations under the License.
 import abc
 from collections import namedtuple
 
-from integ_tests.s1aptests.ovs import LOCALHOST
-from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
 from ryu.lib import hub
 
 FlowStats = namedtuple(

--- a/lte/gateway/python/magma/pipelined/tests/app/subscriber.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/subscriber.py
@@ -17,12 +17,7 @@ import time
 from collections import namedtuple
 
 import grpc
-from lte.protos.pipelined_pb2 import (
-    ActivateFlowsRequest,
-    DeactivateFlowsRequest,
-)
 from magma.pipelined.policy_converters import convert_ip_str_to_ip_proto
-from magma.subscriberdb.sid import SIDUtils
 from ryu.lib import hub
 
 SubContextConfig = namedtuple(

--- a/lte/gateway/python/magma/pipelined/tests/app/table_isolation.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/table_isolation.py
@@ -14,12 +14,6 @@ limitations under the License.
 import abc
 import copy
 
-from integ_tests.s1aptests.ovs import LOCALHOST
-from integ_tests.s1aptests.ovs.rest_api import (
-    add_flowentry,
-    delete_flowentry,
-    get_datapath,
-)
 from lte.protos.mobilityd_pb2 import IPAddress
 from magma.pipelined.imsi import encode_imsi
 from magma.pipelined.openflow.magma_match import MagmaMatch

--- a/lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py
+++ b/lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py
@@ -6,7 +6,7 @@ import sys
 import time
 
 from scapy.all import *
-from scapy.contrib.gtp import GTP_U_Header, GTPPDUSessionContainer
+from scapy.contrib.gtp import GTP_U_Header
 from scapy.layers.l2 import getmacbyip
 
 ip_src = sys.argv[1]

--- a/lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py
+++ b/lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py
@@ -5,7 +5,7 @@
 import sys
 import time
 
-from scapy.all import *
+from scapy.all import IP, UDP, Ether, sendp
 from scapy.contrib.gtp import GTP_U_Header
 from scapy.layers.l2 import getmacbyip
 

--- a/lte/gateway/python/magma/pipelined/tests/script/ip-packet.py
+++ b/lte/gateway/python/magma/pipelined/tests/script/ip-packet.py
@@ -5,7 +5,7 @@
 import sys
 import time
 
-from scapy.all import *
+from scapy.all import IP, Ether, sendp
 from scapy.layers.l2 import getmacbyip
 
 ip_src = sys.argv[1]

--- a/lte/gateway/python/magma/pipelined/tests/test_arp.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_arp.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import time
 import unittest
 import warnings
 from concurrent.futures import Future
@@ -20,10 +19,7 @@ from lte.protos.mconfig.mconfigs_pb2 import PipelineD
 from magma.pipelined.app.arp import ArpController
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.openflow.registers import DIRECTION_REG, Direction
-from magma.pipelined.tests.app.packet_builder import (
-    ARPPacketBuilder,
-    IPPacketBuilder,
-)
+from magma.pipelined.tests.app.packet_builder import ARPPacketBuilder
 from magma.pipelined.tests.app.packet_injector import ScapyPacketInjector
 from magma.pipelined.tests.app.start_pipelined import (
     PipelinedController,

--- a/lte/gateway/python/magma/pipelined/tests/test_classifier_traffic.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_classifier_traffic.py
@@ -36,8 +36,7 @@ from magma.pipelined.tests.pipelined_test_util import (
     stop_ryu_app_thread,
     wait_after_send,
 )
-from scapy.all import *
-from scapy.all import ARP, IP, UDP, Ether
+from scapy.all import ARP, IP, TCP, UDP, Ether
 from scapy.contrib.gtp import GTP_U_Header
 
 

--- a/lte/gateway/python/magma/pipelined/tests/test_classifier_traffic.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_classifier_traffic.py
@@ -36,7 +36,6 @@ from magma.pipelined.tests.pipelined_test_util import (
     stop_ryu_app_thread,
     wait_after_send,
 )
-from ryu.lib import hub
 from scapy.all import *
 from scapy.all import ARP, IP, UDP, Ether
 from scapy.contrib.gtp import GTP_U_Header

--- a/lte/gateway/python/magma/pipelined/tests/test_ebpf_ul_dp.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ebpf_ul_dp.py
@@ -13,17 +13,13 @@ limitations under the License.
 import logging
 import socket
 import subprocess
-import threading
-import time
 import unittest
-import warnings
-from concurrent.futures import Future
 
 from lte.protos.mobilityd_pb2 import IPAddress
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.ebpf.ebpf_manager import EbpfManager
 from scapy.all import AsyncSniffer
-from scapy.layers.inet import IP, UDP
+from scapy.layers.inet import IP
 
 GTP_SCRIPT = "/home/vagrant/magma/lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py"
 PY_PATH = "/home/vagrant/build/python/bin/python"

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -21,7 +21,7 @@ from concurrent.futures import Future
 from typing import List
 
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress, IPBlock
-from magma.pipelined.app import egress, ingress, middle
+from magma.pipelined.app import egress
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.tests.app.start_pipelined import (
     PipelinedController,

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -18,7 +18,6 @@ import time
 import unittest
 import warnings
 from concurrent.futures import Future
-from os import pipe
 from typing import List
 
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress, IPBlock

--- a/lte/gateway/python/magma/pipelined/tests/test_paging.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_paging.py
@@ -35,7 +35,7 @@ from magma.pipelined.tests.pipelined_test_util import (
     stop_ryu_app_thread,
     wait_after_send,
 )
-from scapy.all import *
+from scapy.all import IP, TCP, UDP, Ether
 from scapy.contrib.gtp import GTP_U_Header
 
 

--- a/lte/gateway/python/magma/pipelined/tests/test_paging.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_paging.py
@@ -35,7 +35,6 @@ from magma.pipelined.tests.pipelined_test_util import (
     stop_ryu_app_thread,
     wait_after_send,
 )
-from ryu.lib import hub
 from scapy.all import *
 from scapy.contrib.gtp import GTP_U_Header
 

--- a/lte/gateway/python/magma/pipelined/tests/test_rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_rpc_servicer.py
@@ -12,10 +12,8 @@ limitations under the License.
 """
 
 import unittest
-from unittest import mock
-from unittest.mock import ANY, MagicMock
+from unittest.mock import MagicMock
 
-import fakeredis
 from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.pipelined_pb2 import (
     ActivateFlowsRequest,
@@ -27,9 +25,7 @@ from lte.protos.pipelined_pb2 import (
 )
 from lte.protos.policydb_pb2 import PolicyRule
 from lte.protos.subscriberdb_pb2 import SubscriberID
-from magma.pipelined.policy_converters import convert_ipv4_str_to_ip_proto
 from magma.pipelined.rpc_servicer import PipelinedRpcServicer
-from magma.pipelined.rule_mappers import SessionRuleToVersionMapper
 
 
 class RPCServicerTest(unittest.TestCase):

--- a/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
@@ -12,7 +12,6 @@ limitations under the License.
 """
 import logging
 import subprocess
-import threading
 import unittest
 import warnings
 from concurrent.futures import Future

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -21,7 +21,6 @@ from generate_service_config import generate_template_config
 from lte.protos.mconfig.mconfigs_pb2 import MME
 from magma.common.misc_utils import (
     IpPreference,
-    get_if_ip_with_netmask,
     get_ip_from_if,
     get_ip_from_if_cidr,
     get_ipv6_from_if,

--- a/lte/gateway/python/scripts/policydb_cli.py
+++ b/lte/gateway/python/scripts/policydb_cli.py
@@ -20,15 +20,11 @@ import grpc
 from google.protobuf import text_format
 from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.policydb_pb2 import (
-    ChargingRuleNameSet,
     DisableStaticRuleRequest,
     EnableStaticRuleRequest,
     FlowDescription,
     FlowMatch,
-    InstalledPolicies,
     PolicyRule,
-    RatingGroup,
-    SubscriberPolicySet,
 )
 from lte.protos.policydb_pb2_grpc import PolicyDBStub
 from magma.common.rpc_utils import grpc_wrapper

--- a/orc8r/gateway/python/scripts/ctraced_cli.py
+++ b/orc8r/gateway/python/scripts/ctraced_cli.py
@@ -18,7 +18,7 @@ import textwrap
 
 from magma.common.rpc_utils import grpc_wrapper
 from orc8r.protos import common_pb2
-from orc8r.protos.ctraced_pb2 import EndTraceRequest, StartTraceRequest
+from orc8r.protos.ctraced_pb2 import StartTraceRequest
 from orc8r.protos.ctraced_pb2_grpc import CallTraceServiceStub
 
 


### PR DESCRIPTION
## Summary

Removes a selection of unused imports found via `cd $MAGMA_ROOT/lte/gateway/python && make check` in the magma-dev VM. Also removes the corresponding dependencies from BUILD.bazel files when they've been used.

## Test Plan

- [x] magma-dev: `cd lte/gateway && make test_python_service UT_PATH=python/magma/mobilityd/tests/`
- [x] magma-dev: `cd lte/gateway && make test_python_service UT_PATH=python/magma/pipelined/tests/`
- [x] magma-dev: `bazel test --cache_test_results=no lte/gateway/python/magma/mobilityd/tests:ip_alloc_dhcp_test`
- [x] magma-dev: `bazel test --cache_test_results=no lte/gateway/python/magma/pipelined/tests:test_rpc_servicer`
- [x] magma-test: Run modified integration tests, i.e. `cd lte/gateway/python/integ_tests && make integ_test TESTS=s1aptests/<test>.py`
- [x] `cd magma/lte/gateway && fab federated_integ_test:build_all=True` 