### PR TITLE
feat(ci): add federated integ test to ci

### DIFF
--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -12,22 +12,67 @@ on:  # yamllint disable-line rule:truthy
       - 'v1.*'
     types:
       - completed
-  push:
-    branches:
-      - master
-      - 'v1.*'
-  pull_request:
-    branches:
-      - master
-      - 'v1.*'
-    types: [opened, reopened, synchronize]
 
 jobs:
+  # Build images on ubuntu which is faster than MacOs.
+  docker-build-orc8r:
+    runs-on: ubuntu-latest
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Orc8r docker images
+        run: |
+          cd orc8r/cloud/docker
+          ./build.py --deployment all
+          docker images
+      - name: Export docker images to deploy them
+        run: |
+          mkdir images
+          cd images
+          docker images
+          docker save orc8r_nginx:latest | gzip > fed_orc8r_nginx.tar.gz
+          docker save orc8r_controller:latest  | gzip > fed_orc8r_controller.tar.gz
+          docker save orc8r_fluentd:latest  | gzip > fed_orc8r_fluentd.tar.gz
+          docker save orc8r_test:latest  | gzip > fed_orc8r_test.tar.gz
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docker-build-orc8r-images
+          path: images
+
+  docker-build-feg:
+    runs-on: ubuntu-latest
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
+    steps:
+      - uses: actions/checkout@v2
+      - name: pre requisites to build feg
+        run: |
+          cd ${{ env.MAGMA_ROOT }} && mkdir -p .cache/test_certs/ && mkdir -p .cache/feg/
+          cd ${{ env.MAGMA_ROOT }}/.cache/feg/ && touch snowflake
+      - name: Build FEG docker images
+        run: |
+          cd feg/gateway/docker
+          docker-compose build --force-rm --parallel
+          docker images
+      - name: Export docker images to deploy them
+        run: |
+          mkdir images
+          cd images
+          docker save feg_gateway_go:latest  | gzip > fed_feg_gateway_go.tar.gz
+          docker save feg_gateway_python:latest  | gzip > fed_feg_gateway_python.tar.gz
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docker-build-feg-images
+          path: images
+
   federated-integ-test:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: macos-10.15
     env:
       SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
+      MAGMA_ROOT: "${{ github.workspace }}"
+      AGW_ROOT: "${{ github.workspace }}/lte/gateway"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -43,33 +88,59 @@ jobs:
         run: |
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
-          vagrant plugin install vagrant-vbguest vagrant-disksize
-
-      # Docker install
-      - uses: docker-practice/actions-setup-docker@master
-      - name: Check Docker install
+          vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-scp
+      - name: Vagrant Host prerequisites for federated integ test
         run: |
-          set -x
-          docker version
-      - name: Install Docker Compose
-        shell: bash
-        run: |
-          sudo curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` -o /usr/l→
-          sudo chmod +x /usr/local/bin/docker-compose
-          docker-compose version
-
-
+          cd ${{ env.AGW_ROOT }} && fab open_orc8r_port_in_vagrant
+          cd ${{ env.MAGMA_ROOT }} && mkdir -p .cache/test_certs/ && mkdir -p .cache/feg/ && touch snowflake
+          cd ${{ env.MAGMA_ROOT }}/.cache/feg/ && touch snowflake
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/
           sudo touch /etc/vbox/networks.conf
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
-      - name: Run the integ test
+      - name: Build test vms
+        run: |
+          cd ${{ env.AGW_ROOT }} && fab build_test_vms
+          cd ${{ env.AGW_ROOT }} && vagrant halt magma_test && vagrant halt magma_trfserver
+      - name: build_agw
+        run: |
+          cd lte/gateway/python/integ_tests/federated_tests
+          export MAGMA_DEV_CPUS=3
+          export MAGMA_DEV_MEMORY_MB=9216
+          fab build_agw
+      # Download to local and delete artifacts from remote
+      - uses: actions/download-artifact@v2
+        with:
+          name: docker-build-orc8r-images
+          path: ${{ env.AGW_ROOT }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: docker-build-feg-images
+          path: ${{ env.AGW_ROOT }}
+      - uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            docker-build-orc8r-images |
+            docker-build-feg-images
+      - name: Load Docker images from tar files
+        run: |
+          set -x
+          cd ${{ env.AGW_ROOT }}
+          for IMAGE in `ls -a1 *.gz`
+          do
+            echo Image being loaded $IMAGE
+            gzip -cd $IMAGE > image.tar
+            vagrant ssh magma -c 'cat magma/lte/gateway/image.tar | docker load'
+            rm image.tar
+          done
+          mkdir -p /tmp/fed_integ_test-images
+      - name: Run the federated integ test
         run: |
           cd lte/gateway
           export MAGMA_DEV_CPUS=3
           export MAGMA_DEV_MEMORY_MB=9216
-          fab federated_integ_test:build_all=True
+          fab federated_integ_test:build_all=False,orc8r_on_vagrant=True
       - name: Get test results
         if: always()
         run: |

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -1,0 +1,121 @@
+---
+
+name: Federated integ test
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - build-all
+    branches:
+      - master
+      - 'v1.*'
+    types:
+      - completed
+  push:
+    branches:
+      - master
+      - 'v1.*'
+  pull_request:
+    branches:
+      - master
+      - 'v1.*'
+    types: [opened, reopened, synchronize]
+
+jobs:
+  federated-integ-test:
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-10.15
+    env:
+      SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.SHA }}
+      - name: setup pyenv
+        uses: "gabrielfalcao/pyenv-action@v8"
+        with:
+          default: 3.8.5
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.5'
+      - name: Install pre requisites
+        run: |
+          pip3 install --upgrade pip
+          pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
+          vagrant plugin install vagrant-vbguest vagrant-disksize
+
+      # Docker install
+      - uses: docker-practice/actions-setup-docker@master
+      - name: Check Docker install
+        run: |
+          set -x
+          docker version
+      - name: Install Docker Compose
+        shell: bash
+        run: |
+          sudo curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` -o /usr/l→
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose version
+
+
+      - name: Open up network interfaces for VM
+        run: |
+          sudo mkdir -p /etc/vbox/
+          sudo touch /etc/vbox/networks.conf
+          sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
+      - name: Run the integ test
+        run: |
+          cd lte/gateway
+          export MAGMA_DEV_CPUS=3
+          export MAGMA_DEV_MEMORY_MB=9216
+          fab federated_integ_test:build_all=True
+      - name: Get test results
+        if: always()
+        run: |
+          cd lte/gateway
+          fab get_test_summaries:dst_path="test-results"
+          ls -R
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-results
+          path: lte/gateway/test-results/**/*.xml
+      - name: Get test logs
+        if: failure()
+        run: |
+          cd lte/gateway
+          fab get_test_logs:dst_path=./logs.tar.gz
+      - name: Upload test logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-logs
+          path: lte/gateway/logs.tar.gz
+      - name: Publish Unit Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        with:
+          files: lte/gateway/test-results/**/*.xml
+          check_run_annotations: all tests
+      - name: Publish results to Firebase
+        if: always() && github.event.workflow_run.event == 'push'
+        env:
+          FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
+          REPORT_FILENAME: "federated_integ_test_${{ env.SHA }}.html"
+        run: |
+          npm install -g xunit-viewer
+          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
+          [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
+          [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
+          python ci-scripts/firebase_publish_report.py -id ${{ env.SHA }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} lte --url $URL
+      - name: Notify failure to slack
+        if: failure() && github.event.workflow_run.event == 'push'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: "LTE integ test"
+          SLACK_AVATAR: ":boom:"
+        uses: Ilshidur/action-slack@2.1.0
+        with:
+          args: "Federated integration test test failed on [${{ env.SHA }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ env.SHA }}): ${{ steps.commit.outputs.title}}"

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -39,6 +39,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # iperf3 trfserver routable IP.
     magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
 
+
     magma.vm.provider "virtualbox" do |vb|
       vb.name = "magma-dev"
       vb.linked_clone = true

--- a/lte/gateway/dev_tools.py
+++ b/lte/gateway/dev_tools.py
@@ -175,7 +175,7 @@ def check_agw_cloud_connectivity(timeout=10):
     """
     vagrant_setup("magma", destroy_vm=False, force_provision=False)
     with cd("/home/vagrant/build/python/bin/"):
-        dev_utils.run_fab_command_with_repetition("./checkin_cli.py", timeout)
+        dev_utils.run_remote_command_with_repetition("./checkin_cli.py", timeout)
 
 
 def check_agw_feg_connectivity(timeout=10):
@@ -186,14 +186,13 @@ def check_agw_feg_connectivity(timeout=10):
     """
     vagrant_setup("magma", destroy_vm=False, force_provision=False)
     with cd("/home/vagrant/build/python/bin/"):
-        dev_utils.run_fab_command_with_repetition("./feg_hello_cli.py m 0", timeout)
+        dev_utils.run_remote_command_with_repetition("./feg_hello_cli.py m 0", timeout)
 
 
 def _register_network(network_type: str, payload: Any):
     network_id = NIDS_BY_TYPE[network_type]
     if not dev_utils.does_network_exist(network_id):
         dev_utils.cloud_post(network_type, payload)
-
     dev_utils.create_tier_if_not_exists(network_id, 'default')
 
 

--- a/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.override.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.override.yml
@@ -1,6 +1,9 @@
 version: "3.7"
 
 services:
+  s6a_proxy:
+    depends_on:
+      - hss
   hss:
     container_name: hss
     image: feg_gateway_go
@@ -20,7 +23,7 @@ services:
       # Use 127.0.0.1 when running FEG on the host itself
       # Use 10.0.2.2 when running FEG on Vagrant VM
       - controller.magma.test:10.0.2.2
-      - bootstrapper-controller.magma.test:10.0.0.2
+      - bootstrapper-controller.magma.test:10.0.2.2
     command:
       - /bin/bash
       - -c

--- a/orc8r/tools/fab/dev_utils.py
+++ b/orc8r/tools/fab/dev_utils.py
@@ -431,7 +431,7 @@ def local_command_with_repetition(command, timeout=5):
     _command_with_repetition(local, command, timeout)
 
 
-def run_fab_command_with_repetition(command, timeout=5):
+def run_remote_command_with_repetition(command, timeout=5):
     """
     Run command on remote machine using fabric.api.run. Repeats on error
     Args:


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR adds Federated Integ Test to CI. This task is a modification of l[te-integ-test.](http://github.com/magma/magma/blob/master/.github/workflows/lte-integ-test.yml#L3-L3)


Even this works there are possible enhancements to make it faster or more reliable:
1. Modify this job to run in a ubuntu box. That will allow us to install docker on the ubuntu box. This may requiere changes on the fab script and on Vagrant vms to make sure they work in both, linux and MacOS (remember the test needs to run on MacOs so developers can use it locally)

2. Modify s1ap federated integ test to run Orc8r inside the magma Vagrant machine. That may work but that would make a mess on the local scenario. Also this doesn't assure that the runner takes hours to run due to low ram memory (docker over vagrant over the runner) 

3. Run S1ap Federated integ test on a AWS node that can support Virtualization


Enhancements
- Feg and Orc8r are build previously by other jobs. Those images are uploaded to magma core jfrog docker registry. Instead of building them again in this task, we could point the vm docker to the JFROG repo and grab the already built image from there.

## Test Plan

For this test we triggered the job to run Federated Integ test on PRs. This is triggered here https://github.com/magma/magma/pull/12633/files#diff-6a95f663e4dfd08ee0988d079f574d7c7782a84b3b3ba2459a8b4891e48ca944R15-R24 . But once this work, we can remove those lines and just execute this on merge. This code is just here so we are able to execute the test and troubleshoot it

![image](https://user-images.githubusercontent.com/16157139/176024054-4495f4b5-052d-49db-aac1-9c29986a7a03.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
