### PR TITLE
fix(amf): Malformed session accept message issue

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -299,9 +299,9 @@ imsi64_t amf_app_handle_initial_ue_message(
   bool is_mm_ctx_new = false;
   gnb_ngap_id_key_t gnb_ngap_id_key = INVALID_GNB_UE_NGAP_ID_KEY;
   imsi64_t imsi64 = INVALID_IMSI64;
-  guti_m5_t guti = {0};
-  plmn_t plmn = {0};
-  s_tmsi_m5_t s_tmsi = {0};
+  guti_m5_t guti = {};
+  plmn_t plmn = {};
+  s_tmsi_m5_t s_tmsi = {};
   amf_ue_ngap_id_t amf_ue_ngap_id = INVALID_AMF_UE_NGAP_ID;
 
   if (initial_pP->amf_ue_ngap_id != INVALID_AMF_UE_NGAP_ID) {
@@ -959,7 +959,7 @@ int amf_app_handle_pdu_session_accept(
     smf_msg->msg.pdu_session_estab_accept.nssai.len = SST_LENGTH;
     smf_msg->msg.pdu_session_estab_accept.nssai.sst = slice_information.sst;
   }
-  buf_len = smf_msg->msg.pdu_session_estab_accept.nssai.len + 2;
+  buf_len += smf_msg->msg.pdu_session_estab_accept.nssai.len + 2;
 
   /* DNN
   -------------------------------------


### PR DESCRIPTION
Signed-off-by: Sathyaj27 <sathya.jayadev@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Fixing #12509 
Issue :

- Buffer allocation was wrong as the value was over written causing a minimum length failure in dnn even though DNN length was more than required value.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Tested on abott.
- Testd Via UT.( TestPDUv6SessionSetup is the corresponding UT)
<img width="924" alt="neelima" src="https://user-images.githubusercontent.com/94469973/166926880-c6d11407-de57-44b8-b146-109e8eec806c.PNG">


## Additional Information

- [ ] This change is not backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
