### PR TITLE
fix(orc8r): Fix grpc_internal port for smsd service

### DIFF
--- a/lte/cloud/helm/lte-orc8r/templates/smsd.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/smsd.service.yaml
@@ -31,7 +31,7 @@ spec:
       port: 9180
       targetPort: 9120
     - name: grpc-internal
-      port: 9180
+      port: 9190
       targetPort: 9220
     - name: http
       port: 8080


### PR DESCRIPTION
Fixed port number for grpc_internal introduced in #12564.
Port number for grpc_internal had same value as grpc port.
Changed grpc_internal port to grpc port +10 as was done
with other services in PR #12564.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

Magma PR https://github.com/magma/magma/pull/12564 got merged despite the fact that Domain Proxy CI jobs indicated a mistake in the helm charts for smsd (https://github.com/magma/magma/runs/6261712285?check_suite_focus=true):
```
Error: INSTALLATION FAILED: Service "orc8r-smsd" is invalid: spec.ports[1]: Duplicate value: core.ServicePort{Name:"", Protocol:"TCP", AppProtocol:(*string)(nil), Port:9180, TargetPort:intstr.IntOrString{Type:0, IntVal:0, StrVal:""}, NodePort:0}
```
This PR fixes the port duplication for smsd service in helm charts.

## Additional Information

- [ ] This change is backwards-breaking
