### PR TITLE
docs: include access to orc8r swagger on s1ap federated integ test

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.7.0/feg/s1ap_federated_test.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/feg/s1ap_federated_test.md
@@ -64,6 +64,15 @@ fab federated_integ_test:build_all=True
 fab federated_integ_test
 ```
 
+You can access Orc8r adding to your keychain the `admin_operator.pfx` cert
+you will find at `/magma/.cache/test_certs`. Then you can check your
+provisioned gateways using
+[swagger interface](https://127.0.0.1:9443/apidocs/v1/?docExpansion=none)
+that will be running on your Orc8r
+
+Please, for more detail, check the following sections which provide more
+insight about this process.
+
 ### Semiautomatic test run
 
 #### Build environment

--- a/docs/readmes/feg/s1ap_federated_test.md
+++ b/docs/readmes/feg/s1ap_federated_test.md
@@ -66,6 +66,15 @@ fab federated_integ_test:build_all=True
 fab federated_integ_test
 ```
 
+You can access Orc8r adding to your keychain the `admin_operator.pfx` cert
+you will find at `/magma/.cache/test_certs`. Then you can check your
+provisioned gateways using
+[swagger interface](https://127.0.0.1:9443/apidocs/v1/?docExpansion=none)
+that will be running on your Orc8r
+
+Please, for more detail, check the following sections which provide more
+insight about this process.
+
 ### Semiautomatic test run
 
 #### Build environment


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add how to access orc8r on s1ap federated integ test

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
