### PR TITLE
fix(nms): Cannot add user after editing an organisation

### DIFF
--- a/nms/fbc_js_core/ui/host/OrganizationDialog.js
+++ b/nms/fbc_js_core/ui/host/OrganizationDialog.js
@@ -167,6 +167,7 @@ export default function (props: Props) {
         return;
       }
       const newOrg = {
+        id: organization.id,
         name: organization.name,
         networkIDs: shouldEnableAllNetworks
           ? allNetworks

--- a/nms/fbc_js_core/ui/host/OrganizationInfoDialog.js
+++ b/nms/fbc_js_core/ui/host/OrganizationInfoDialog.js
@@ -59,7 +59,7 @@ export default function (props: DialogProps) {
       )}
       <AltFormField label={'Organization Name'}>
         <OutlinedInput
-          disabled={props.organization.id}
+          disabled={!!props.organization.id}
           data-testid="name"
           placeholder="Organization Name"
           fullWidth={true}


### PR DESCRIPTION
## Steps to reproduce

- Go to the organisation details view
![Screenshot 2022-05-09 at 09 11 25](https://user-images.githubusercontent.com/102796295/167358492-4e7391ca-e6c7-4d6a-a0ff-a6bf1175f71c.png)
- Click "Edit" and save the organisation (no changes are required)
- Click "Add User" 
  - Bug the dialog opens with the "Edit" tab. It is not possible to add users without reloading.  
## Test Plan
Follow the steps to reproduce, make sure that it is not broken anymore.
