### PR TITLE
chore(health): Bazelify health service

### DIFF
--- a/lte/gateway/python/magma/health/BUILD.bazel
+++ b/lte/gateway/python/magma/health/BUILD.bazel
@@ -1,0 +1,49 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+MAGMA_ROOT = "../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+py_binary(
+    name = "health",
+    srcs = ["main.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    # legacy_create_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
+    legacy_create_init = False,
+    main = "main.py",
+    python_version = "PY3",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":health_lib",
+        "//orc8r/gateway/python/magma/common:sentry",
+        "//orc8r/gateway/python/magma/common:service",
+        "//orc8r/gateway/python/magma/common/health:service_state_wrapper",
+    ],
+)
+
+py_library(
+    name = "health_lib",
+    srcs = ["state_recovery.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:job",
+        "//orc8r/gateway/python/magma/common/health:service_state_wrapper",
+        "//orc8r/gateway/python/magma/magmad/check:subprocess_workflow",
+    ],
+)

--- a/lte/gateway/python/magma/health/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/health/tests/BUILD.bazel
@@ -1,0 +1,24 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:python_test.bzl", "pytest_test")
+
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+pytest_test(
+    name = "test_state_recovery",
+    size = "small",
+    srcs = ["test_state_recovery.py"],
+    imports = [ORC8R_ROOT],
+    deps = ["//lte/gateway/python/magma/health:health_lib"],
+)

--- a/lte/gateway/python/magma/health/tests/test_state_recovery.py
+++ b/lte/gateway/python/magma/health/tests/test_state_recovery.py
@@ -1,0 +1,63 @@
+"""
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from lte.gateway.python.magma.health.state_recovery import StateRecoveryJob
+
+
+class MockServiceResult():
+    def __init__(self, num_fail_exits):
+        self.num_fail_exits = num_fail_exits
+
+
+class TestStateRecovery(unittest.TestCase):
+    """
+    Tests for the StateRecoveryJob python class
+    """
+
+    def test_get_last_service_restarts_without_services(self):
+        services = []
+        job = StateRecoveryJob(
+            MagicMock(), MagicMock(),
+            services,
+            MagicMock(), MagicMock(),
+            MagicMock(), MagicMock(),
+        )
+        last_services_restarts = job._get_last_service_restarts()
+        self.assertDictEqual({}, last_services_restarts)
+
+    def test_get_last_service_restarts_with_restarts(self):
+        services = ["service1", "service2"]
+        job = StateRecoveryJob(
+            MagicMock(), MagicMock(),
+            services,
+            MagicMock(), MagicMock(),
+            MagicMock(), MagicMock(),
+        )
+        job._get_service_status = MagicMock(return_value=MockServiceResult(5))
+        last_services_restarts = job._get_last_service_restarts()
+        self.assertDictEqual({services[0]: 5, services[1]: 5}, last_services_restarts)
+
+    def test_get_last_service_restarts_without_restarts(self):
+        services = ["service1"]
+        job = StateRecoveryJob(
+            MagicMock(), MagicMock(),
+            services,
+            MagicMock(), MagicMock(),
+            MagicMock(), MagicMock(),
+        )
+        job._get_service_status = MagicMock(return_value=None)
+        last_services_restarts = job._get_last_service_restarts()
+        self.assertDictEqual({services[0]: 0}, last_services_restarts)


### PR DESCRIPTION
## Summary

This PR adds a new unit test for the health service, and bazelifies both the service and the new test. 

## Test Plan

Execute the service with Bazel on Devcontainer, Bazel-base and the VM:
`bazel run lte/gateway/python/magma/health:health`
Test the service with Bazel on Devcontainer, Bazel-base and the VM:
`bazel test lte/gateway/python/magma/health/tests/...`

## Additional Information

- [ ] This change is backwards-breaking
