### PR TITLE
fix(orc8r): Fix automated running of S1AP Federated Integ Test

### DIFF
--- a/orc8r/tools/fab/vagrant.py
+++ b/orc8r/tools/fab/vagrant.py
@@ -24,7 +24,7 @@ def __ensure_in_vagrant_dir():
     if not os.path.isfile(pwd + '/Vagrantfile'):
         # check if we are on a vagrant subdirectory
         with cd(pwd):
-            if not local('Vagrant validate', capture=True):
+            if not local('vagrant validate', capture=True):
                 print("Error: Vagrantfile not found")
                 exit(1)
     return


### PR DESCRIPTION
Signed-off-by: Cameron Voisey <cameron.voisey@tngtech.com>

## Summary

Fixes a command that breaks the automated running of the FeG Integration Test, i.e.

```
cd magma/lte/gateway
fab federated_integ_test:build_all=True
```

## Test Plan


On master, I get the following:
```
...
#### Building FEG on Magma Vagrant VM ####
[localhost] local: pwd
[localhost] local: Vagrant validate

Fatal error: local() encountered an error (return code 127) while executing 'Vagrant validate'

Aborting.

Fatal error: local() encountered an error (return code 1) while executing 'fab build_all:clear_orc8r=False,provision_vm=False'

Aborting.
```

While on this branch, I get:
```
...
*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
PDN_TYPE: 1
IPv4 PDN_ADDRESS:192 168 128 13
************************* Running UE detach for UE id  2
Deleting Ue Context from Traffic Handler
************************* send SCTP SHUTDOWN
Keys left in Redis (list should be empty)[
  
]
Entries in s1ap_imsi_map (should be zero): 0
Entries left in hashtables (should be zero): 0
Entries in mme_ueip_imsi_map (should be zero): 0
.
----------------------------------------------------------------------
Ran 1 test in 5.359s

OK
sleep 1
Connection to 127.0.0.1 closed.

Done.
Disconnecting from vagrant@127.0.0.1:2200... done.
```