### PR TITLE
refactor(orc8r): Omit nil-checks for multierror.Append calls

### DIFF
--- a/lte/cloud/go/services/subscriberdb/obsidian/models/validate.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/validate.go
@@ -70,9 +70,7 @@ func (m *MutableSubscriber) ValidateModel(context.Context) error {
 func (m MutableSubscribers) ValidateModel(context.Context) error {
 	errs := &multierror.Error{}
 	for _, s := range m {
-		if err := s.ValidateModel(context.Background()); err != nil {
-			errs = multierror.Append(errs, err)
-		}
+		errs = multierror.Append(errs, s.ValidateModel(context.Background()))
 	}
 	return errs.ErrorOrNil()
 }

--- a/lte/cloud/go/services/subscriberdb_cache/worker.go
+++ b/lte/cloud/go/services/subscriberdb_cache/worker.go
@@ -69,9 +69,7 @@ func RenewDigests(config Config, store syncstore.SyncStore) (map[string]string, 
 	leafDigestsByNetwork := map[string][]*protos.LeafDigest{}
 	for _, network := range toUpdate {
 		rootDigest, leaveDigests, err := renewDigestsForNetwork(network, store)
-		if err != nil {
-			errs = multierror.Append(errs, err)
-		}
+		errs = multierror.Append(errs, err)
 		rootDigestsByNetwork[network] = rootDigest
 		leafDigestsByNetwork[network] = leaveDigests
 	}

--- a/orc8r/cloud/go/obsidian/swagger/spec/combine.go
+++ b/orc8r/cloud/go/obsidian/swagger/spec/combine.go
@@ -33,14 +33,10 @@ func Combine(yamlCommon string, yamlSpecs []string) (string, error, error) {
 	warnings := &multierror.Error{}
 
 	common, specs, errs := unmarshalToSwagger(yamlCommon, yamlSpecs)
-	if errs != nil {
-		warnings = multierror.Append(warnings, errs)
-	}
+	warnings = multierror.Append(warnings, errs)
 
 	combined, errs := combine(common, specs)
-	if errs != nil {
-		warnings = multierror.Append(warnings, errs)
-	}
+	warnings = multierror.Append(warnings, errs)
 
 	out, err := marshalToYAML(combined)
 	if err != nil {

--- a/orc8r/cloud/go/parallel/map.go
+++ b/orc8r/cloud/go/parallel/map.go
@@ -82,9 +82,7 @@ func Map(inputs []In, nWorkers int, f Func) ([]Out, error) {
 	for i := 0; i < nJobs; i++ {
 		ret := <-outputs
 		rets[ret.idx] = ret.output
-		if ret.err != nil {
-			errs = multierror.Append(errs, ret.err)
-		}
+		errs = multierror.Append(errs, ret.err)
 	}
 	close(jobs)
 

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_singleton.go
@@ -124,9 +124,7 @@ func (r *reindexerSingleton) reindexJobs(ctx context.Context, jobs []*Job, batch
 	errs := &multierror.Error{}
 	for _, j := range jobs {
 		err := r.reindexJob(j, ctx, batches, sendUpdate)
-		if err != nil {
-			errs = multierror.Append(errs, err)
-		}
+		errs = multierror.Append(errs, err)
 	}
 	return errs.ErrorOrNil()
 }

--- a/orc8r/cloud/go/syncstore/store_writer.go
+++ b/orc8r/cloud/go/syncstore/store_writer.go
@@ -196,9 +196,7 @@ func (l *syncStore) collectGarbageSQL(tracked []string) error {
 			return nil, err
 		}
 		_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
-		if err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "collect garbage for table %+v", tableName))
-		}
+		errs = multierror.Append(errs, errors.Wrapf(err, "collect garbage for table %+v", tableName))
 	}
 	return errs.ErrorOrNil()
 }
@@ -255,14 +253,10 @@ func (l *syncStore) collectGarbageLastResync(tracked []string) error {
 			continue
 		}
 		err = store.Delete(network, storage.MakeTKs(lastResyncBlobstoreType, keys))
-		if err != nil {
-			errs = multierror.Append(errs, err)
-		}
-	}
-	err = store.Commit()
-	if err != nil {
 		errs = multierror.Append(errs, err)
 	}
+	err = store.Commit()
+	errs = multierror.Append(errs, err)
 	return errs.ErrorOrNil()
 }
 
@@ -338,9 +332,7 @@ func (l *syncStore) getInvalidCacheWriter(tracked []string, cacheWriterValidInte
 		invalidByNetwork[network] = invalid
 	}
 	err = store.Commit()
-	if err != nil {
-		errs = multierror.Append(errs, err)
-	}
+	errs = multierror.Append(errs, err)
 	return invalidByNetwork, errs.ErrorOrNil()
 }
 
@@ -386,9 +378,7 @@ func (l *syncStore) deleteCacheWriterBlobstoreRecords(deletedByNetwork map[strin
 		}
 	}
 	err = store.Commit()
-	if err != nil {
-		errs = multierror.Append(errs, err)
-	}
+	errs = multierror.Append(errs, err)
 
 	return errs.ErrorOrNil()
 }


### PR DESCRIPTION
## Summary

`multierror.Append` already handles nil-checks, so checking before calling it is unnecessary, except when the error is formatted with e.g. `fmt.Errorf`. This PR follows this [discussion](https://github.com/magma/magma/pull/12627#discussion_r866240479).

## Test Plan

Run unit tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
