### PR TITLE
refactor(agw): NamedTuple usage looks nicer

### DIFF
--- a/lte/gateway/python/magma/enodebd/device_config/configuration_util.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_util.py
@@ -21,12 +21,10 @@ from magma.enodebd.device_config.cbrs_consts import (
 )
 from magma.enodebd.exceptions import ConfigurationError
 
-EnodebConfig = NamedTuple(
-    'EnodebConfig', [
-        ('serial_num', str),
-        ('config', EnodebD.EnodebConfig),
-    ],
-)
+
+class EnodebConfig(NamedTuple):
+    serial_num: str
+    config: EnodebD.EnodebConfig
 
 
 def get_enb_rf_tx_desired(mconfig: EnodebD, enb_serial: str) -> bool:

--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -49,23 +49,21 @@ CACHED_GPS_COORD_FILE_PATH = os.path.join(
 _gps_lat_cached = None
 _gps_lon_cached = None
 
-EnodebStatus = NamedTuple(
-    'EnodebStatus',
-    [
-        ('enodeb_configured', bool),
-        ('gps_latitude', str),
-        ('gps_longitude', str),
-        ('enodeb_connected', bool),
-        ('opstate_enabled', bool),
-        ('rf_tx_on', bool),
-        ('rf_tx_desired', bool),
-        ('gps_connected', bool),
-        ('ptp_connected', bool),
-        ('mme_connected', bool),
-        ('fsm_state', str),
-        ('cell_id', int),
-    ],
-)
+
+class EnodebStatus(NamedTuple):
+    enodeb_configured: bool
+    gps_latitude: str
+    gps_longitude: str
+    enodeb_connected: bool
+    opstate_enabled: bool
+    rf_tx_on: bool
+    rf_tx_desired: bool
+    gps_connected: bool
+    ptp_connected: bool
+    mme_connected: bool
+    fsm_state: str
+    cell_id: int
+
 
 # TODO: Remove after checkins support multiple eNB status
 MagmaOldEnodebdStatus = namedtuple(
@@ -86,20 +84,17 @@ MagmaOldEnodebdStatus = namedtuple(
     ],
 )
 
-MagmaEnodebdStatus = NamedTuple(
-    'MagmaEnodebdStatus',
-    [
-        ('n_enodeb_connected', str),
-        ('all_enodeb_configured', str),
-        ('all_enodeb_opstate_enabled', str),
-        ('all_enodeb_rf_tx_configured', str),
-        ('any_enodeb_gps_connected', str),
-        ('all_enodeb_ptp_connected', str),
-        ('all_enodeb_mme_connected', str),
-        ('gateway_gps_longitude', str),
-        ('gateway_gps_latitude', str),
-    ],
-)
+
+class MagmaEnodebdStatus(NamedTuple):
+    n_enodeb_connected: str
+    all_enodeb_configured: str
+    all_enodeb_opstate_enabled: str
+    all_enodeb_rf_tx_configured: str
+    any_enodeb_gps_connected: str
+    all_enodeb_ptp_connected: str
+    all_enodeb_mme_connected: str
+    gateway_gps_longitude: str
+    gateway_gps_latitude: str
 
 
 def update_status_metrics(status: EnodebStatus) -> None:

--- a/lte/gateway/python/magma/health/state_recovery.py
+++ b/lte/gateway/python/magma/health/state_recovery.py
@@ -25,7 +25,9 @@ from magma.magmad.check import subprocess_workflow
 from orc8r.protos.service_status_pb2 import ServiceExitStatus
 from redis.exceptions import ConnectionError
 
-SystemdServiceParams = NamedTuple('SystemdServiceParams', [('service', str)])
+
+class SystemdServiceParams(NamedTuple):
+    service: str
 
 
 class StateRecoveryJob(Job):

--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -38,13 +38,10 @@ subscriber_icmp_latency_ms = Histogram(
     buckets=[50, 100, 200, 500, 1000, 2000],
 )
 
-PingedTargets = NamedTuple(
-    'PingedTargets',
-    [
-        ('ping_targets', Dict['str', IPAddress]),
-        ('ping_addresses', List[IPAddress]),
-    ],
-)
+
+class PingedTargets(NamedTuple):
+    ping_targets: Dict[str, IPAddress]
+    ping_addresses: List[IPAddress]
 
 
 def _get_addr_from_subscribers(sub_ip) -> str:

--- a/lte/gateway/python/magma/monitord/icmp_state.py
+++ b/lte/gateway/python/magma/monitord/icmp_state.py
@@ -17,13 +17,10 @@ from orc8r.protos.service303_pb2 import State
 
 ICMP_STATE_TYPE = "icmp_monitoring"
 
-ICMPMonitoringResponse = NamedTuple(
-    'ICMPMonitoringResponse',
-    [
-        ('last_reported_time', int),
-        ('latency_ms', float),
-    ],
-)
+
+class ICMPMonitoringResponse(NamedTuple):
+    last_reported_time: int
+    latency_ms: float
 
 
 def serialize_subscriber_states(

--- a/lte/gateway/python/magma/pipelined/app/check_quota.py
+++ b/lte/gateway/python/magma/pipelined/app/check_quota.py
@@ -43,14 +43,13 @@ class CheckQuotaController(MagmaController):
 
     APP_NAME = "check_quota"
     APP_TYPE = ControllerType.LOGICAL
-    CheckQuotaConfig = NamedTuple(
-        'CheckQuotaConfig',
-        [
-            ('bridge_ip', str), ('quota_check_ip', str),
-            ('has_quota_port', int), ('no_quota_port', int),
-            ('cwf_bridge_mac', str),
-        ],
-    )
+
+    class CheckQuotaConfig(NamedTuple):
+        bridge_ip: str
+        quota_check_ip: str
+        has_quota_port: int
+        no_quota_port: int
+        cwf_bridge_mac: str
 
     def __init__(self, *args, **kwargs):
         super(CheckQuotaController, self).__init__(*args, **kwargs)

--- a/lte/gateway/python/magma/pipelined/app/ipfix.py
+++ b/lte/gateway/python/magma/pipelined/app/ipfix.py
@@ -35,15 +35,16 @@ class IPFIXController(MagmaController):
     APP_NAME = "ipfix"
     APP_TYPE = ControllerType.LOGICAL
 
-    IPFIXConfig = NamedTuple(
-        'IPFIXConfig',
-        [
-            ('enabled', bool), ('collector_ip', str), ('collector_port', int),
-            ('probability', int), ('collector_set_id', int),
-            ('obs_domain_id', int), ('obs_point_id', int), ('cache_timeout', int),
-            ('sampling_port', int),
-        ],
-    )
+    class IPFIXConfig(NamedTuple):
+        enabled: bool
+        collector_ip: str
+        collector_port: int
+        probability: int
+        collector_set_id: int
+        obs_domain_id: int
+        obs_point_id: int
+        cache_timeout: int
+        sampling_port: int
 
     def __init__(self, *args, **kwargs):
         super(IPFIXController, self).__init__(*args, **kwargs)

--- a/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
+++ b/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
@@ -23,25 +23,23 @@ from magma.pipelined.metrics import (
     GTP_PORT_USER_PLANE_UL_BYTES,
 )
 
-OVSDBDumpCommandParams = NamedTuple(
-    'OVSDBCommandParams',
-    [('table', str), ('columns', List[str])],
-)
-ParsedInterfaceStats = NamedTuple(
-    'ParsedInterfaceStats', [
-        ('Interface', str),
-        ('rx_bytes', str),
-        ('tx_bytes', str),
-        ('remote_ip', str),
-    ],
-)
-OVSDBCommandResult = NamedTuple(
-    'OVSDBCommandResult',
-    [
-        ('out', List[ParsedInterfaceStats]),
-        ('err', Optional[str]),
-    ],
-)
+
+class OVSDBDumpCommandParams(NamedTuple):
+    table: str
+    columns: List[str]
+
+
+class ParsedInterfaceStats(NamedTuple):
+    Interface: str
+    rx_bytes: str
+    tx_bytes: str
+    remote_ip: str
+
+
+class OVSDBCommandResult(NamedTuple):
+    out: List[ParsedInterfaceStats]
+    err: Optional[str]
+
 
 interface_group = r"(?P<Interface>\w+)"
 remote_ip_group = r"(?P<remote_ip>.*)"

--- a/lte/gateway/python/magma/pipelined/ng_manager/node_state_manager.py
+++ b/lte/gateway/python/magma/pipelined/ng_manager/node_state_manager.py
@@ -40,10 +40,9 @@ class NodeStateManager:
     TEID_RANGE_VALUE = 0
     ASSOC_MAX_RETRIES = 40
 
-    LocalNodeConfig = NamedTuple(
-        'LocalNodeConfig',
-        [('downlink_ip', str), ('node_identifier', str)],
-    )
+    class LocalNodeConfig(NamedTuple):
+        downlink_ip: str
+        node_identifier: str
 
     def __init__(self, loop, sessiond_setinterface, config):
         self.config = self._get_config(config)

--- a/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager.py
+++ b/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager.py
@@ -29,14 +29,11 @@ from magma.pipelined.ng_manager.session_state_manager_util import (
 )
 from magma.pipelined.set_interface_client import send_periodic_session_update
 
+
 # Help to build failure report
-MsgParseOutput = NamedTuple(
-    'MsgParseOutput',
-    [
-        ('offending_ie', OffendingIE),
-        ('cause_info', int),
-    ],
-)
+class MsgParseOutput(NamedTuple):
+    offending_ie: OffendingIE
+    cause_info: int
 
 
 class SessionMessageType(Enum):

--- a/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager_util.py
+++ b/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager_util.py
@@ -17,30 +17,24 @@ from lte.protos.pipelined_pb2 import (
     DeactivateFlowsRequest,
 )
 
-FARRuleEntry = NamedTuple(
-    'FARRuleEntry',
-    [
-        ('apply_action', int),
-        ('o_teid', int),
-        ('gnb_ip_addr', str),
-    ],
-)
 
-PDRRuleEntry = NamedTuple(
-    'PDRRuleEntry',
-    [
-        ('pdr_id', int),
-        ('pdr_version', int),
-        ('pdr_state', int),
-        ('precedence', int),
-        ('local_f_teid', int),
-        ('ue_ip_addr', str),
-        ('del_qos_enforce_rule', DeactivateFlowsRequest),
-        ('add_qos_enforce_rule', ActivateFlowsRequest),
-        ('far_action', FARRuleEntry),
-        ('ue_ipv6_addr', str),
-    ],
-)
+class FARRuleEntry(NamedTuple):
+    apply_action: int
+    o_teid: int
+    gnb_ip_addr: str
+
+
+class PDRRuleEntry(NamedTuple):
+    pdr_id: int
+    pdr_version: int
+    pdr_state: int
+    precedence: int
+    local_f_teid: int
+    ue_ip_addr: str
+    del_qos_enforce_rule: DeactivateFlowsRequest
+    add_qos_enforce_rule: ActivateFlowsRequest
+    far_action: FARRuleEntry
+    ue_ipv6_addr: str
 
 # Create the Named tuple for the FAR entry
 

--- a/lte/gateway/python/magma/subscriberdb/client.py
+++ b/lte/gateway/python/magma/subscriberdb/client.py
@@ -41,33 +41,26 @@ from magma.subscriberdb.metrics import (
 from magma.subscriberdb.store.sqlite import SqliteStore
 from orc8r.protos.digest_pb2 import Changeset, Digest, LeafDigest
 
-CloudSubscribersInfo = NamedTuple(
-    'CloudSubscribersInfo', [
-        ('subscribers', List[SubscriberData]),
-        ('root_digest', Optional[Digest]),
-        ('leaf_digests', Optional[List[LeafDigest]]),
-    ],
-)
-ProcessedChangeset = NamedTuple(
-    'ProcessedChangeset', [
-        ('to_renew', List[SubscriberData]),
-        ('deleted', List[str]),
-    ],
-)
 
-CloudSuciProfilesInfo = NamedTuple(
-    'CloudSuciProfilesInfo', [
-        ('suci_profiles', List[SuciProfile]),
-    ],
-)
+class CloudSubscribersInfo(NamedTuple):
+    subscribers: List[SubscriberData]
+    root_digest: Optional[Digest]
+    leaf_digests: Optional[List[LeafDigest]]
 
-suci_profile_data = NamedTuple(
-    'suci_profile_data', [
-        ('protection_scheme', int),
-        ('home_network_public_key', bytes),
-        ('home_network_private_key', bytes),
-    ],
-)
+
+class ProcessedChangeset(NamedTuple):
+    to_renew: List[SubscriberData]
+    deleted: List[str]
+
+
+class CloudSuciProfilesInfo(NamedTuple):
+    suci_profiles: List[SuciProfile]
+
+
+class suci_profile_data(NamedTuple):
+    protection_scheme: int
+    home_network_public_key: bytes
+    home_network_private_key: bytes
 
 
 class SubscriberDBCloudClient(SDWatchdogTask):

--- a/lte/gateway/python/magma/subscriberdb/crypto/lte.py
+++ b/lte/gateway/python/magma/subscriberdb/crypto/lte.py
@@ -14,14 +14,12 @@ limitations under the License.
 import abc
 from typing import NamedTuple
 
-FiveGRanAuthVector = NamedTuple(
-    'FiveGRanAuthVector', [
-        ('rand', bytes),
-        ('xres_star', bytes),
-        ('autn', bytes),
-        ('kseaf', bytes),
-    ],
-)
+
+class FiveGRanAuthVector(NamedTuple):
+    rand: bytes
+    xres_star: bytes
+    autn: bytes
+    kseaf: bytes
 
 
 class BaseLTEAuthAlgo(metaclass=abc.ABCMeta):

--- a/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
@@ -23,13 +23,11 @@ from magma.subscriberdb.store.base import (
     SubscriberNotFoundError,
 )
 
-suci_profile_data = NamedTuple(
-    'suci_profile_data', [
-        ('protection_scheme', int),
-        ('home_net_public_key', bytes),
-        ('home_net_private_key', bytes),
-    ],
-)
+
+class suci_profile_data(NamedTuple):
+    protection_scheme: int
+    home_net_public_key: bytes
+    home_net_private_key: bytes
 
 
 class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -30,12 +30,10 @@ from magma.subscriberdb.store.base import (
 from magma.subscriberdb.store.onready import OnDataReady, OnDigestsReady
 from orc8r.protos.digest_pb2 import Digest, LeafDigest
 
-DigestDBInfo = NamedTuple(
-    'DigestDBInfo', [
-        ('root_digest_db_location', str),
-        ('leaf_digests_db_location', str),
-    ],
-)
+
+class DigestDBInfo(NamedTuple):
+    root_digest_db_location: str
+    leaf_digests_db_location: str
 
 
 class SqliteStore(BaseStore):

--- a/lte/gateway/python/scripts/test_supi_decrypt_imsi_cli.py
+++ b/lte/gateway/python/scripts/test_supi_decrypt_imsi_cli.py
@@ -26,13 +26,11 @@ from magma.common.rpc_utils import grpc_wrapper
 from magma.subscriberdb.crypto.ECIES import ECIES_UE
 from orc8r.protos.common_pb2 import Void
 
-ue_encrypt_context = NamedTuple(
-    'ue_encrypt_context', [
-        ('pub_key', bytes),
-        ('cipher_text', bytes),
-        ('mac', bytes),
-    ],
-)
+
+class ue_encrypt_context(NamedTuple):
+    pub_key: bytes
+    cipher_text: bytes
+    mac: bytes
 
 
 class UEmsin(object):

--- a/lte/gateway/python/scripts/test_supi_profile_cli.py
+++ b/lte/gateway/python/scripts/test_supi_profile_cli.py
@@ -22,12 +22,10 @@ from magma.common.rpc_utils import grpc_wrapper
 from magma.subscriberdb.crypto.EC import ECDH_SECP256R1, X25519
 from orc8r.protos.common_pb2 import Void
 
-home_network_key_pair = NamedTuple(
-    'home_network_key_pair', [
-        ('home_network_public_key', bytes),
-        ('home_network_private_key', bytes),
-    ],
-)
+
+class home_network_key_pair(NamedTuple):
+    home_network_public_key: bytes
+    home_network_private_key: bytes
 
 
 class HomeNetworkKeyPairGen(object):

--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -35,7 +35,6 @@ pass as a parameter to fpm.
 import argparse
 import contextlib
 import copy
-import functools
 import glob
 import hashlib
 import json
@@ -48,11 +47,10 @@ import shutil
 import subprocess
 import sys
 import tarfile
-import typing
 import zipfile
 from datetime import datetime
 from functools import lru_cache, partial
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union, cast
 
 import apt  # type: ignore
 import pkg_resources
@@ -542,10 +540,10 @@ def lcd(path):
         os.chdir(oldcwd)
 
 
-PkgInfo = typing.NamedTuple('PkgInfo',
-                            [('name', str),
-                             ('version', str),
-                             ('arch', str)])
+class PkgInfo(NamedTuple):
+    name: str
+    version: str
+    arch: str
 
 
 def _cleanup(pkgname: str) -> None:
@@ -854,7 +852,7 @@ def gen_pip_distributions(
                                 'sys.stdout.buffer)')])
 
     result = venv(['python', '-c', freeze_script], capture=True)
-    pip_distributions = {str(p.key): typing.cast(pkg_resources.Distribution, p)
+    pip_distributions = {str(p.key): cast(pkg_resources.Distribution, p)
                          for p in pickle.loads(result.stdout)}
     return pip_distributions
 
@@ -1022,7 +1020,7 @@ def main(args):
     for key in deps:
         if deps[key]['source'] == 'pypi':
             try:
-                ver = typing.cast(str, deps[key]['version'])
+                ver = cast(str, deps[key]['version'])
                 existing_versions[key] = ver
             except KeyError as e:
                 log.error('{} missing key: {}'.format(key, e))

--- a/orc8r/gateway/python/magma/magmad/check/machine_check/cpu_info.py
+++ b/orc8r/gateway/python/magma/magmad/check/machine_check/cpu_info.py
@@ -18,17 +18,17 @@ from typing import NamedTuple, Optional
 
 from magma.magmad.check import subprocess_workflow
 
-LscpuCommandParams = NamedTuple('LscpuCommandParams', [])
-LscpuCommandResult = NamedTuple(
-    'LscpuCommandResult',
-    [
-        ('error', Optional[str]),
-        ('core_count', Optional[int]),
-        ('threads_per_core', Optional[int]),
-        ('architecture', Optional[str]),
-        ('model_name', Optional[str]),
-    ],
-)
+
+class LscpuCommandParams(NamedTuple):
+    pass
+
+
+class LscpuCommandResult(NamedTuple):
+    error: Optional[str]
+    core_count: Optional[int]
+    threads_per_core: Optional[int]
+    architecture: Optional[str]
+    model_name: Optional[str]
 
 
 def get_cpu_info() -> LscpuCommandResult:

--- a/orc8r/gateway/python/magma/magmad/check/network_check/routing_table.py
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/routing_table.py
@@ -17,22 +17,21 @@ from typing import Any, Dict, List, NamedTuple, Optional
 
 from magma.magmad.check import subprocess_workflow
 
-RouteCommandParams = NamedTuple('RouteCommandParams', [])
-Route = NamedTuple(
-    'Route',
-    [
-        ('destination_ip', str), ('gateway_ip', str),
-        ('genmask', str), ('network_interface_id', str),
-    ],
-)
 
-RouteCommandResult = NamedTuple(
-    'RouteCommandResult',
-    [
-        ('error', Optional[str]),
-        ('routing_table', List[Dict[str, Any]]),
-    ],
-)
+class RouteCommandParams(NamedTuple):
+    pass
+
+
+class Route(NamedTuple):
+    destination_ip: str
+    gateway_ip: str
+    genmask: str
+    network_interface_id: str
+
+
+class RouteCommandResult(NamedTuple):
+    error: Optional[str]
+    routing_table: List[Dict[str, Any]]
 
 # TODO: This relies on the SO language being English. Maybe there is a way to
 #  get the info another way.

--- a/orc8r/gateway/python/magma/magmad/config_manager.py
+++ b/orc8r/gateway/python/magma/magmad/config_manager.py
@@ -30,7 +30,11 @@ from orc8r.protos.mconfig_pb2 import GatewayConfigsDigest
 CONFIG_STREAM_NAME = 'configs'
 SHARED_MCONFIG = 'shared_mconfig'
 MAGMAD = 'magmad'
-VersionInfo = NamedTuple('VersionInfo', [('agw_version', Optional[re.Match]), ('orc8r_version', Optional[re.Match])])
+
+
+class VersionInfo(NamedTuple):
+    agw_version: Optional[re.Match]
+    orc8r_version: Optional[re.Match]
 
 
 class ConfigManager(StreamerClient.Callback):

--- a/orc8r/gateway/python/magma/magmad/gateway_status.py
+++ b/orc8r/gateway/python/magma/magmad/gateway_status.py
@@ -37,81 +37,78 @@ from magma.magmad.check.machine_check.cpu_info import get_cpu_info
 from magma.magmad.check.network_check.routing_table import get_routing_table
 from magma.magmad.service_poller import ServicePoller
 
-GatewayStatus = NamedTuple(
-    'GatewayStatus',
-    [
-        ('machine_info', Dict[str, Any]), ('meta', Dict[str, str]),
-        ('platform_info', Dict[str, Any]), ('system_status', Dict[str, Any]),
-    ],
-)
 
-SystemStatus = NamedTuple(
-    'SystemStatus',
-    [
-        ('time', int), ('uptime_secs', int), ('cpu_user', int),
-        ('cpu_system', int), ('cpu_idle', int), ('mem_total', int),
-        ('mem_available', int), ('mem_used', int), ('mem_free', int),
-        ('swap_total', int), ('swap_used', int), ('swap_free', int),
-        ('disk_partitions', List[Dict[str, Any]]),
-    ],
-)
+class GatewayStatus(NamedTuple):
+    machine_info: Dict[str, Any]
+    meta: Dict[str, str]
+    platform_info: Dict[str, Any]
+    system_status: Dict[str, Any]
 
-PlatformInfo = NamedTuple(
-    'PlatformInfo',
-    [
-        ('vpn_ip', str), ('packages', List[Dict[str, Any]]),
-        ('kernel_version', str), ('kernel_versions_installed', List[str]),
-        ('config_info', Dict[str, Any]),
-    ],
-)
 
-MachineInfo = NamedTuple(
-    'MachineInfo',
-    [('cpu_info', Dict[str, Any]), ('network_info', Dict[str, Any])],
-)
+class SystemStatus(NamedTuple):
+    time: int
+    uptime_secs: int
+    cpu_user: int
+    cpu_system: int
+    cpu_idle: int
+    mem_total: int
+    mem_available: int
+    mem_used: int
+    mem_free: int
+    swap_total: int
+    swap_used: int
+    swap_free: int
+    disk_partitions: List[Dict[str, Any]]
 
-NetworkInfo = NamedTuple(
-    'NetworkInfo',
-    [
-        ('network_interfaces', List[Dict[str, Any]]),
-        ('routing_table', List[Dict[str, Any]]),
-    ],
-)
 
-DiskPartition = NamedTuple(
-    'DiskPartition',
-    [
-        ('device', str), ('mount_point', str), ('total', int), ('used', int),
-        ('free', int),
-    ],
-)
+class PlatformInfo(NamedTuple):
+    vpn_ip: str
+    packages: List[Dict[str, Any]]
+    kernel_version: str
+    kernel_versions_installed: List[str]
+    config_info: Dict[str, Any]
 
-ConfigInfo = NamedTuple(
-    'ConfigInfo',
-    [('mconfig_created_at', int)],
-)
 
-Package = NamedTuple(
-    'Package',
-    [('name', str), ('version', str)],
-)
+class MachineInfo(NamedTuple):
+    cpu_info: Dict[str, Any]
+    network_info: Dict[str, Any]
 
-CPUInfo = NamedTuple(
-    'CPUInfo',
-    [
-        ('core_count', int), ('threads_per_core', int), ('architecture', str),
-        ('model_name', str),
-    ],
-)
 
-NetworkInterface = NamedTuple(
-    'NetworkInterface',
-    [
-        ('network_interface_id', str), ('mac_address', str),
-        ('ip_addresses', List[str]), ('status', str),
-        ('ipv6_addresses', List[str]),
-    ],
-)
+class NetworkInfo(NamedTuple):
+    network_interfaces: List[Dict[str, Any]]
+    routing_table: List[Dict[str, Any]]
+
+
+class DiskPartition(NamedTuple):
+    device: str
+    mount_point: str
+    total: int
+    used: int
+    free: int
+
+
+class ConfigInfo(NamedTuple):
+    mconfig_created_at: int
+
+
+class Package(NamedTuple):
+    name: str
+    version: str
+
+
+class CPUInfo(NamedTuple):
+    core_count: int
+    threads_per_core: int
+    architecture: str
+    model_name: str
+
+
+class NetworkInterface(NamedTuple):
+    network_interface_id: str
+    mac_address: str
+    ip_addresses: List[str]
+    status: str
+    ipv6_addresses: List[str]
 
 
 class KernelVersionsPoller(Job):

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -30,14 +30,13 @@ from orc8r.protos.metricsd_pb2_grpc import MetricsControllerStub
 from orc8r.protos.service303_pb2_grpc import Service303Stub
 from prometheus_client.parser import text_string_to_metric_families
 
+
 # ScrapeTarget Holds information required to scrape and process metrics from a
 # prometheus target
-ScrapeTarget = NamedTuple(
-    'ScrapeTarget', [
-        ('url', str), ('name', str),
-        ('interval', int),
-    ],
-)
+class ScrapeTarget(NamedTuple):
+    url: str
+    name: str
+    interval: int
 
 
 class MetricsCollector(object):

--- a/orc8r/tools/fab/types.py
+++ b/orc8r/tools/fab/types.py
@@ -13,10 +13,10 @@ limitations under the License.
 
 from typing import List, NamedTuple
 
-ClientCert = NamedTuple(
-    'ClientCert',
-    [('cert', str), ('key', str)],
-)
+
+class ClientCert(NamedTuple):
+    cert: str
+    key: str
 
 
 class NetworkDNSConfig:


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

Refactoring the declaration of NamedTuples to use the Python 3.8 syntax according to #12435. Not all NamedTuple declarations had type information, and were therefore not refactored. Since the magma_test VM still uses Python 3.5, no NamedTuples in the 
`integ_test` folder were changed. 
#12435 should be left open for now until the magma_test's Python version is updated and the last renaming is done.

## Summary


## Test Plan
According to #12435:
- [x] Python changes formatted
- [x] Python unit tests
- [x] Check running services in the Magma VM
- [x] Some integration tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
