### PR TITLE
feat(pipelined): Support for Extended bitrates for 5g #7278

### DIFF
--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -913,6 +913,24 @@ void SessionStateEnforcer::set_pdr_attributes(
   const auto& config = session_state->get_config();
   auto ue_ipv4 = config.common_context.ue_ipv4();
   auto ue_ipv6 = config.common_context.ue_ipv6();
+  if (config.rat_specific_context.m5gsm_session_context()
+          .has_subscribed_qos()) {
+    auto bit_rate = config.rat_specific_context.m5gsm_session_context()
+                        .subscribed_qos()
+                        .br_unit();
+    switch (bit_rate) {
+      case M5GQosInformationRequest_BitrateUnitsAMBR_KBPS: {
+        rule->mutable_activate_flow_req()->mutable_apn_ambr()->set_br_unit(
+            AggregatedMaximumBitrate_BitrateUnitsAMBR_KBPS);
+        break;
+      }
+      default: {
+        rule->mutable_activate_flow_req()->mutable_apn_ambr()->set_br_unit(
+            AggregatedMaximumBitrate_BitrateUnitsAMBR_BPS);
+        break;
+      }
+    }
+  }
 
   rule->mutable_pdi()->set_ue_ipv4(ue_ipv4);
   rule->mutable_pdi()->set_ue_ipv6(ue_ipv6);

--- a/lte/gateway/python/magma/pipelined/app/policy_mixin.py
+++ b/lte/gateway/python/magma/pipelined/app/policy_mixin.py
@@ -313,12 +313,18 @@ class PolicyMixin(metaclass=ABCMeta):
                 qos_info = QosInfo(gbr=qos.gbr_dl, mbr=mbr_dl)
 
         if qos_info or ambr:
+            if ambr and apn_ambr.br_unit == 0:
+                units = "bit"
+            if ambr and apn_ambr.br_unit == 1:
+                units = "kbit"
+
+            self.logger.debug("ambr: %s, apn_ambr.br_unit :%s, units : %s", ambr, apn_ambr.br_unit, units)
             cleanup_rule_func = lambda: self._invalidate_rule_version(
                 imsi,
                 ip_addr, rule_id,
             )
             action, inst, qos_handle = qos_mgr.add_subscriber_qos(
-                imsi, ip_addr.address.decode('utf8'), ambr, rule_num, d,
+                imsi, ip_addr.address.decode('utf8'), ambr, units, rule_num, d,
                 qos_info, cleanup_rule_func,
             )
 

--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -386,6 +386,7 @@ class QosManager(object):
             imsi: str,
             ip_addr: str,
             apn_ambr: int,
+            units: str,
             rule_num: int,
             direction: FlowMatch.Direction,
             qos_info: QosInfo,
@@ -430,7 +431,7 @@ class QosManager(object):
                 if not ambr_qos_handle_root:
                     ambr_qos_handle_root = self.impl.add_qos(
                         direction, QosInfo(gbr=None, mbr=apn_ambr),
-                        cleanup_rule,
+                        cleanup_rule, units=units,
                         skip_filter=True,
                     )
                     if not ambr_qos_handle_root:
@@ -452,7 +453,7 @@ class QosManager(object):
                     ambr_qos_handle_leaf = self.impl.add_qos(
                         direction,
                         QosInfo(gbr=None, mbr=apn_ambr),
-                        cleanup_rule,
+                        cleanup_rule, units=units,
                         parent=ambr_qos_handle_root,
                     )
                     if ambr_qos_handle_leaf:
@@ -472,7 +473,7 @@ class QosManager(object):
 
             if qos_info:
                 qos_handle = self.impl.add_qos(
-                    direction, qos_info, cleanup_rule,
+                    direction, qos_info, cleanup_rule, units=units,
                     parent=ambr_qos_handle_root,
                 )
                 LOG.debug("Added ded brr handle: %d", qos_handle)

--- a/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
@@ -48,7 +48,7 @@ class TrafficClass:
 
     @staticmethod
     def create_class(
-        intf: str, qid: int, max_bw: int, rate=None,
+        intf: str, qid: int, max_bw: int, units: str, rate=None,
         parent_qid=None, skip_filter=False,
     ) -> int:
         if not rate:
@@ -65,7 +65,7 @@ class TrafficClass:
 
         qid_hex = hex(qid)
         parent_qid_hex = '1:' + hex(parent_qid)
-        err = TrafficClass.tc_ops.create_htb(intf, qid_hex, max_bw, rate, parent_qid_hex)
+        err = TrafficClass.tc_ops.create_htb(intf, qid_hex, max_bw, rate, units, parent_qid_hex)
         if err < 0 or skip_filter:
             return err
 
@@ -295,7 +295,7 @@ class TCManager(object):
 
     def create_class_async(
         self, d: FlowMatch.Direction, qos_info: QosInfo,
-        qid,
+        units: str, qid,
         parent, skip_filter, cleanup_rule,
     ):
         intf = self._uplink if d == FlowMatch.UPLINK else self._downlink
@@ -304,7 +304,7 @@ class TCManager(object):
             gbr = self._gbr_rate
         err = TrafficClass.create_class(
             intf, qid, qos_info.mbr,
-            rate=gbr,
+            units=units, rate=gbr,
             parent_qid=parent,
             skip_filter=skip_filter,
         )
@@ -319,13 +319,13 @@ class TCManager(object):
         LOG.debug("create done: if: %s qid %d err %s", intf, qid, err_no)
 
     def add_qos(
-        self, d: FlowMatch.Direction, qos_info: QosInfo,
-        cleanup_rule=None, parent=None, skip_filter=False,
+            self, d: FlowMatch.Direction, qos_info: QosInfo,
+        cleanup_rule=None, units='', parent=None, skip_filter=False,
     ) -> int:
         LOG.debug("add QoS: %s", qos_info)
         qid = self._id_manager.allocate_idx()
         self.create_class_async(
-            d, qos_info,
+            d, qos_info, units,
             qid, parent, skip_filter, cleanup_rule,
         )
         LOG.debug("assigned qid: %d", qid)

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops.py
@@ -31,7 +31,7 @@ class TcOpsBase(ABC):
     @abstractmethod
     def create_htb(
         self, iface: str, qid: str, max_bw: str, rate: str,
-        parent_qid: str = None,
+        units: str, parent_qid: str = None,
     ) -> int:
         """
         Create HTB scheduler

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops_cmd.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops_cmd.py
@@ -53,13 +53,13 @@ class TcOpsCmd(TcOpsBase):
 
     def create_htb(
         self, iface: str, qid: str, max_bw: str, rate: str,
-        parent_qid: str = None,
+        units: str, parent_qid: str = None,
     ) -> int:
         tc_cmd = "tc class add dev {intf} parent {parent_qid} "
-        tc_cmd += "classid 1:{qid} htb rate {rate} ceil {maxbw} prio 2"
+        tc_cmd += "classid 1:{qid} htb rate {rate} ceil {maxbw}{units} prio 2"
         tc_cmd = tc_cmd.format(
             intf=iface, parent_qid=parent_qid,
-            qid=qid, rate=rate, maxbw=max_bw,
+            qid=qid, rate=rate, maxbw=max_bw, units=units,
         )
 
         return run_cmd([tc_cmd], True)

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
@@ -38,7 +38,7 @@ class TcOpsPyRoute2(TcOpsBase):
 
     def create_htb(
         self, iface: str, qid: str, max_bw: int, rate: str,
-        parent_qid: str = None,
+        units: str, parent_qid: str = None,
     ) -> int:
         """
         Create HTB class for a UE session.
@@ -54,16 +54,15 @@ class TcOpsPyRoute2(TcOpsBase):
             zero on success.
         """
 
-        LOG.debug("Create HTB iface %s qid %s max_bw %s rate %s", iface, qid, max_bw, rate)
+        LOG.debug("Create HTB iface %s qid %s max_bw %s%s rate %s", iface, qid, max_bw, units, rate)
         try:
             # API needs ceiling in bytes per sec.
-            max_bw = max_bw / 8
             if_index = self._get_if_index(iface)
             htb_queue = QUEUE_PREFIX + qid
             ret = self._ipr.tc(
                 "add-class", "htb", if_index,
                 htb_queue, parent=parent_qid,
-                rate=str(rate).lower(), ceil=max_bw, prio=1,
+                rate=str(rate).lower(), ceil=str(max_bw) + units, prio=1,
             )
             LOG.debug("Return: %s", ret)
         except (ValueError, NetlinkError) as ex:


### PR DESCRIPTION
Signed-off-by: GANESH-WAVELABS <ganesh.irrinki@wavelabs.ai>

## Summary
In order to support extended bit rates for 5g (feature defined here https://github.com/magma/magma/issues/5676), we are introducing a flag on Qos to set units of the bitrates (either bps or kbps)

Pipelined needs to check the value of units to apply the right value for Qos

Pipelined will receive a new field called br_units on apn_ambr (as you can see below). That field is the multiplier for the values.

## Test Plan
1) Tested with sessiond stub CLI `magma/lte/gateway/python/scripts/smf_upf_integration_cli.py`

## Additional Information
1) Corresponding zenhub task Id is : #7278 
2) For complete logs please refer the following comments section.
