### PR TITLE
refactor: Remove more calls to pkg errors

### DIFF
--- a/cwf/cloud/go/go.mod
+++ b/cwf/cloud/go/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.2
 	github.com/labstack/echo v3.3.10+incompatible
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.7.0
@@ -82,6 +81,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olivere/elastic/v7 v7.0.6 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect

--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/cwf/cloud/go/cwf"
 	"magma/cwf/cloud/go/serdes"
@@ -151,7 +150,7 @@ func getGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load cwf gateway"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load cwf gateway: %w", err))
 	}
 
 	ret := &cwfModels.CwfGateway{
@@ -417,7 +416,7 @@ func updateHAPairHandler(c echo.Context) error {
 	// 404 if pair doesn't exist
 	exists, err := configurator.DoesEntityExist(reqCtx, networkID, cwf.CwfHAPairType, haPairID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to check if ha pair exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to check if ha pair exists: %w", err))
 	}
 	if !exists {
 		return echo.ErrNotFound

--- a/cwf/cloud/go/services/cwf/obsidian/models/validate.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/validate.go
@@ -15,12 +15,12 @@ package models
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/pkg/errors"
 )
 
 func (m *CwfNetwork) ValidateModel(context.Context) error {

--- a/cwf/cloud/go/services/cwf/servicers/protected/builder_servicer.go
+++ b/cwf/cloud/go/services/cwf/servicers/protected/builder_servicer.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/cwf/cloud/go/cwf"
 	cwf_mconfig "magma/cwf/cloud/go/protos/mconfig"
@@ -90,7 +89,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 	}
 	vals, err := buildFromConfigs(nwConfig, gwConfig.Config.(*models.GatewayCwfConfigs), haPairConfigs)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	ret.ConfigsByKey, err = mconfig.MarshalConfigs(vals)
 	if err != nil {

--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/go-redis/redis v6.15.5+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.2
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/shirou/gopsutil/v3 v3.21.5
 	github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c
@@ -108,6 +107,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olivere/elastic/v7 v7.0.6 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect

--- a/cwf/gateway/integ_tests/service_wrappers.go
+++ b/cwf/gateway/integ_tests/service_wrappers.go
@@ -15,6 +15,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"magma/cwf/gateway/registry"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/go-redis/redis"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -80,7 +80,7 @@ const (
 	GyValidityTime  = 60   // in second
 )
 
-//TestRunner helps setting up all associated services
+// TestRunner helps setting up all associated services
 type TestRunner struct {
 	t           *testing.T
 	imsis       map[string]bool
@@ -281,14 +281,14 @@ func (tr *TestRunner) GenULTrafficBasedOnPolicyUsage(req *cwfprotos.GenTrafficRe
 	for start := time.Now(); time.Since(start) < waitFor; {
 		startGenTrafficTime := time.Now()
 		res, err = uesim.GenTrafficWithReatempts(req)
-		if err != nil{
+		if err != nil {
 			return res, fmt.Errorf("GenULTrafficBasedOnPolicyUsage failed during GenTraffic: %s", err)
 		}
-		completeCycle := time.Now().Sub(startGenTrafficTime)%time.Second
-		if  waitNeeded {
+		completeCycle := time.Now().Sub(startGenTrafficTime) % time.Second
+		if waitNeeded {
 			// this wait makes sure the time passes is exact in seconds. This way
 			// we make sure policies had time to sync
-			time.Sleep(completeCycle + 200 * time.Millisecond)
+			time.Sleep(completeCycle + 200*time.Millisecond)
 			waitNeeded = false
 		}
 		time.Sleep(2200 * time.Millisecond)
@@ -306,19 +306,21 @@ func (tr *TestRunner) GenULTrafficBasedOnPolicyUsage(req *cwfprotos.GenTrafficRe
 		req.Bitrate = &wrappers.StringValue{Value: "10M"}
 		if remaining > 100*KiloBytes {
 			newVolume = uint64(float64(remaining) * 0.95)
-			if newVolume > 5 * MegaBytes {
+			if newVolume > 5*MegaBytes {
 				newVolume = 5 * MegaBytes
 			}
 			// only add wait for the bigger chunks
 			waitNeeded = true
 		}
-		if newVolume < 1000 {newVolume = 1000}
+		if newVolume < 1000 {
+			newVolume = 1000
+		}
 		newVolumeStr := fmt.Sprintf("%dK", newVolume/1000)
 
 		req.Volume = &wrappers.StringValue{Value: newVolumeStr}
 		fmt.Printf("- not enough traffic genereted, sending %dKB more. Will be around %d%% of volume requested\n",
 			newVolume/1000,
-			100 * (record.BytesTx+newVolume)/totalVolume,
+			100*(record.BytesTx+newVolume)/totalVolume,
 		)
 	}
 	return res, fmt.Errorf("error: not enough traffic generated to fullfil GenULTrafficBasedOnPolicyUsage requieriment: %s", err)
@@ -477,34 +479,34 @@ func (tr *TestRunner) WaitForEnforcementStatsForRuleGreaterThanOrDoesNotExist(im
 	}
 }
 
- func (tr *TestRunner) WaitForEnforcementStatsForRuleGreaterThanOrDoesNotExistFunc (imsi, ruleID string, min uint64)(*lteprotos.RuleRecord, bool) {
-		fmt.Printf("\tWaiting until %s, %s has more than %d bytes in enforcement stats or rule does not exist ...\n", imsi, ruleID, min)
-		records, err := tr.GetPolicyUsage()
-		if err != nil {
-			return nil, false
-		}
-		imsi = prependIMSIPrefix(imsi)
-		if records[imsi] == nil {
-			// Session is gone
-			fmt.Printf("\tSession for %s, does not exist...\n", imsi)
-			return nil, true
-		}
-		record := records[imsi][ruleID]
-		if record == nil {
-			// Session is gone
-			fmt.Printf("\tRule %s for %s, does not exist...\n", ruleID, imsi)
-			return nil, true
-		}
-		txBytes := record.BytesTx
-		if record.BytesTx < min {
-			return record, false
-		}
-		fmt.Printf("\t\u2713 %s, %s now passed %d > %d in enforcement stats!(%d%%)\n",
-			imsi, ruleID, txBytes, min, 100* txBytes/min)
-		return record, true
+func (tr *TestRunner) WaitForEnforcementStatsForRuleGreaterThanOrDoesNotExistFunc(imsi, ruleID string, min uint64) (*lteprotos.RuleRecord, bool) {
+	fmt.Printf("\tWaiting until %s, %s has more than %d bytes in enforcement stats or rule does not exist ...\n", imsi, ruleID, min)
+	records, err := tr.GetPolicyUsage()
+	if err != nil {
+		return nil, false
 	}
+	imsi = prependIMSIPrefix(imsi)
+	if records[imsi] == nil {
+		// Session is gone
+		fmt.Printf("\tSession for %s, does not exist...\n", imsi)
+		return nil, true
+	}
+	record := records[imsi][ruleID]
+	if record == nil {
+		// Session is gone
+		fmt.Printf("\tRule %s for %s, does not exist...\n", ruleID, imsi)
+		return nil, true
+	}
+	txBytes := record.BytesTx
+	if record.BytesTx < min {
+		return record, false
+	}
+	fmt.Printf("\t\u2713 %s, %s now passed %d > %d in enforcement stats!(%d%%)\n",
+		imsi, ruleID, txBytes, min, 100*txBytes/min)
+	return record, true
+}
 
-//WaitForPolicyReAuthToProcess returns a method which checks for reauth answer and
+// WaitForPolicyReAuthToProcess returns a method which checks for reauth answer and
 // if it has sessionID which contains the IMSI
 func (tr *TestRunner) WaitForPolicyReAuthToProcess(raa *fegprotos.PolicyReAuthAnswer, imsi string) func() bool {
 	// Todo figure out the best way to figure out when RAR is processed
@@ -516,7 +518,7 @@ func (tr *TestRunner) WaitForPolicyReAuthToProcess(raa *fegprotos.PolicyReAuthAn
 	}
 }
 
-//WaitForChargingReAuthToProcess returns a method which checks for reauth answer and
+// WaitForChargingReAuthToProcess returns a method which checks for reauth answer and
 // if it has sessionID which contains the IMSI
 func (tr *TestRunner) WaitForChargingReAuthToProcess(raa *fegprotos.ChargingReAuthAnswer, imsi string) func() bool {
 	// Todo figure out the best way to figure out when RAR is processed

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -175,19 +175,19 @@ func (tr *TestRunner) ConfigUEsPerInstance(IMSIs []string, pcrfInstance, ocsInst
 
 		err = uesim.AddUE(ue)
 		if err != nil {
-			return nil, errors.Wrap(err, "Error adding UE to UESimServer")
+			return nil, fmt.Errorf("Error adding UE to UESimServer: %w", err)
 		}
 		err = addSubscriberToHSS(sub)
 		if err != nil {
-			return nil, errors.Wrap(err, "Error adding Subscriber to HSS")
+			return nil, fmt.Errorf("Error adding Subscriber to HSS: %w", err)
 		}
 		err = addSubscriberToPCRFPerInstance(pcrfInstance, sub.GetSid())
 		if err != nil {
-			return nil, errors.Wrap(err, "Error adding Subscriber to PCRF")
+			return nil, fmt.Errorf("Error adding Subscriber to PCRF: %w", err)
 		}
 		err = addSubscriberToOCSPerInstance(ocsInstance, sub.GetSid())
 		if err != nil {
-			return nil, errors.Wrap(err, "Error adding Subscriber to OCS")
+			return nil, fmt.Errorf("Error adding Subscriber to OCS: %w", err)
 		}
 
 		ues = append(ues, ue)
@@ -211,7 +211,7 @@ func (tr *TestRunner) Authenticate(imsi, calledStationID string) (*radius.Packet
 	encoded := res.GetRadiusPacket()
 	radiusP, err := radius.Parse(encoded, []byte(Secret))
 	if err != nil {
-		err = errors.Wrap(err, "Error while parsing encoded Radius packet")
+		err = fmt.Errorf("Error while parsing encoded Radius packet: %w", err)
 		fmt.Println(err)
 		return &radius.Packet{}, err
 	}
@@ -230,7 +230,7 @@ func (tr *TestRunner) Disconnect(imsi, calledStationID string) (*radius.Packet, 
 	encoded := res.GetRadiusPacket()
 	radiusP, err := radius.Parse(encoded, []byte(Secret))
 	if err != nil {
-		err = errors.Wrap(err, "Error while parsing encoded Radius packet")
+		err = fmt.Errorf("Error while parsing encoded Radius packet: %w", err)
 		fmt.Println(err)
 		return &radius.Packet{}, err
 	}

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -30,7 +30,6 @@ import (
 	lteprotos "magma/lte/cloud/go/protos"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -162,7 +161,7 @@ func (tr *TestRunner) ConfigUEsPerInstance(IMSIs []string, pcrfInstance, ocsInst
 	for _, imsi := range IMSIs {
 		// If IMSIs were generated properly they should never give an error here
 		if _, present := tr.imsis[imsi]; present {
-			return nil, errors.Errorf("IMSI %s already exist in database, use generateRandomIMSIS(num, tr.imsis) to create unique list", imsi)
+			return nil, fmt.Errorf("IMSI %s already exist in database, use generateRandomIMSIS(num, tr.imsis) to create unique list", imsi)
 		}
 		key, opc, err := getRandKeyOpcFromOp([]byte(Op))
 		if err != nil {

--- a/cwf/gateway/services/uesim/servicers/config.go
+++ b/cwf/gateway/services/uesim/servicers/config.go
@@ -15,13 +15,13 @@ package servicers
 
 import (
 	"encoding/hex"
+	"fmt"
 	"net"
 
 	"magma/cwf/gateway/registry"
 	"magma/orc8r/lib/go/service/config"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -41,7 +41,7 @@ var (
 func GetUESimConfig() (*UESimConfig, error) {
 	uecfg, err := config.GetServiceConfig("", registry.UeSim)
 	if err != nil {
-		glog.Error(errors.Wrap(err, "No service config found, using default config"))
+		glog.Error(fmt.Errorf("No service config found, using default config: %w", err))
 		return getDefaultUESimConfig(), nil
 	}
 	authAddr, err := uecfg.GetString("radius_auth_address")

--- a/cwf/gateway/services/uesim/servicers/eap.go
+++ b/cwf/gateway/services/uesim/servicers/eap.go
@@ -14,6 +14,8 @@
 package servicers
 
 import (
+	"fmt"
+
 	cwfprotos "magma/cwf/cloud/go/protos"
 	fegprotos "magma/feg/gateway/services/aaa/protos"
 	"magma/feg/gateway/services/eap"
@@ -30,7 +32,7 @@ const (
 func (srv *UESimServer) HandleEap(ue *cwfprotos.UEConfig, req eap.Packet) (eap.Packet, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "Error validating EAP packet")
+		return nil, fmt.Errorf("Error validating EAP packet: %w", err)
 	}
 
 	switch fegprotos.EapType(req.Type()) {

--- a/cwf/gateway/services/uesim/servicers/eap.go
+++ b/cwf/gateway/services/uesim/servicers/eap.go
@@ -19,8 +19,6 @@ import (
 	cwfprotos "magma/cwf/cloud/go/protos"
 	fegprotos "magma/feg/gateway/services/aaa/protos"
 	"magma/feg/gateway/services/eap"
-
-	"github.com/pkg/errors"
 )
 
 // todo Replace constants with configurable fields
@@ -41,7 +39,7 @@ func (srv *UESimServer) HandleEap(ue *cwfprotos.UEConfig, req eap.Packet) (eap.P
 	case fegprotos.EapType_AKA:
 		return srv.handleEapAka(ue, req)
 	}
-	return nil, errors.Errorf("Unsupported Eap Type: %d", req[eap.EapMsgMethodType])
+	return nil, fmt.Errorf("Unsupported Eap Type: %d", req[eap.EapMsgMethodType])
 }
 
 func (srv *UESimServer) eapIdentityRequest(ue *cwfprotos.UEConfig, req eap.Packet) (res eap.Packet, err error) {

--- a/cwf/gateway/services/uesim/servicers/eap_aka.go
+++ b/cwf/gateway/services/uesim/servicers/eap_aka.go
@@ -18,8 +18,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"magma/feg/gateway/services/testcore/hss/servicers"
 	"reflect"
+
+	"magma/feg/gateway/services/testcore/hss/servicers"
 
 	"magma/cwf/cloud/go/protos"
 	"magma/feg/gateway/services/eap"
@@ -27,7 +28,6 @@ import (
 	"magma/lte/cloud/go/crypto"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // todo Replace constants with configurable fields
@@ -54,7 +54,7 @@ func (srv *UESimServer) handleEapAka(ue *protos.UEConfig, req eap.Packet) (eap.P
 	case aka.SubtypeChallenge:
 		return srv.eapAkaChallengeRequest(ue, req)
 	default:
-		return nil, errors.Errorf("Unsupported Subtype: %d", req[eap.EapSubtype])
+		return nil, fmt.Errorf("Unsupported Subtype: %d", req[eap.EapSubtype])
 	}
 }
 
@@ -113,7 +113,7 @@ func (srv *UESimServer) eapAkaChallengeRequest(ue *protos.UEConfig, req eap.Pack
 		return nil, fmt.Errorf("Error while parsing attributes of request packet: %w", err)
 	}
 	if attrs.rand == nil || attrs.autn == nil || attrs.mac == nil {
-		return nil, errors.Errorf("Missing one or more expected attributes\nRAND: %s\nAUTN: %s\nMAC: %s\n", attrs.rand, attrs.autn, attrs.mac)
+		return nil, fmt.Errorf("Missing one or more expected attributes\nRAND: %s\nAUTN: %s\nMAC: %s\n", attrs.rand, attrs.autn, attrs.mac)
 	}
 
 	// Parse out RAND, expected AUTN, and expected MAC values.

--- a/cwf/gateway/services/uesim/servicers/eap_aka.go
+++ b/cwf/gateway/services/uesim/servicers/eap_aka.go
@@ -62,7 +62,7 @@ func (srv *UESimServer) handleEapAka(ue *protos.UEConfig, req eap.Packet) (eap.P
 func (srv *UESimServer) eapAkaIdentityRequest(ue *protos.UEConfig, req eap.Packet) (eap.Packet, error) {
 	scanner, err := eap.NewAttributeScanner(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error creating new attribute scanner")
+		return nil, fmt.Errorf("Error creating new attribute scanner: %w", err)
 	}
 
 	var a eap.Attribute
@@ -90,14 +90,14 @@ func (srv *UESimServer) eapAkaIdentityRequest(ue *protos.UEConfig, req eap.Packe
 				),
 			)
 			if err != nil {
-				return nil, errors.Wrap(err, "Error appending attribute to packet")
+				return nil, fmt.Errorf("Error appending attribute to packet: %w", err)
 			}
 			return p, nil
 		default:
 			glog.Info(fmt.Sprintf("Unexpected EAP-AKA Identity Request Attribute type %d", a.Type()))
 		}
 	}
-	return nil, errors.Wrap(err, "Error while processing EAP-AKA Identity Request")
+	return nil, fmt.Errorf("Error while processing EAP-AKA Identity Request: %w", err)
 }
 
 type challengeAttributes struct {
@@ -110,7 +110,7 @@ type challengeAttributes struct {
 func (srv *UESimServer) eapAkaChallengeRequest(ue *protos.UEConfig, req eap.Packet) (eap.Packet, error) {
 	attrs, err := parseChallengeAttributes(req)
 	if err != io.EOF {
-		return nil, errors.Wrap(err, "Error while parsing attributes of request packet")
+		return nil, fmt.Errorf("Error while parsing attributes of request packet: %w", err)
 	}
 	if attrs.rand == nil || attrs.autn == nil || attrs.mac == nil {
 		return nil, errors.Errorf("Missing one or more expected attributes\nRAND: %s\nAUTN: %s\nMAC: %s\n", attrs.rand, attrs.autn, attrs.mac)
@@ -139,18 +139,18 @@ func (srv *UESimServer) eapAkaChallengeRequest(ue *protos.UEConfig, req eap.Pack
 	// Calculate RES and other keys.
 	milenage, err := crypto.NewMilenageCipher(srv.cfg.amf)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error creating milenage cipher")
+		return nil, fmt.Errorf("Error creating milenage cipher: %w", err)
 	}
 	intermediateVec, err := milenage.GenerateSIPAuthVectorWithRand(rand, key, opc[:], sqn)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error calculating authentication vector")
+		return nil, fmt.Errorf("Error calculating authentication vector: %w", err)
 	}
 	// Make copy of packet and zero out MAC value.
 	copyReq := make([]byte, len(req))
 	copy(copyReq, req)
 	copyAttrs, err := parseChallengeAttributes(eap.Packet(copyReq))
 	if err != io.EOF {
-		return nil, errors.Wrap(err, "Error while parsing attributes of copied request packet")
+		return nil, fmt.Errorf("Error while parsing attributes of copied request packet: %w", err)
 	}
 	copyMacBytes := copyAttrs.mac.Marshaled()
 	for i := aka.ATT_HDR_LEN; i < len(copyMacBytes); i++ {
@@ -168,7 +168,7 @@ func (srv *UESimServer) eapAkaChallengeRequest(ue *protos.UEConfig, req eap.Pack
 	receivedSqn := extractSqnFromAutn(expectedAutn, intermediateVec.AnonymityKey[:])
 	resultVec, err := milenage.GenerateSIPAuthVectorWithRand(rand, key, opc[:], receivedSqn)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error calculating authentication vector")
+		return nil, fmt.Errorf("Error calculating authentication vector: %w", err)
 	}
 	if !reflect.DeepEqual(expectedAutn[MacAStart:], resultVec.Autn[MacAStart:]) {
 		return nil, fmt.Errorf("Invalid MacA in AUTN: Received MacA %x; Calculated MacA: %x",
@@ -205,7 +205,7 @@ func (srv *UESimServer) eapAkaChallengeRequest(ue *protos.UEConfig, req eap.Pack
 		),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error appending attribute to packet")
+		return nil, fmt.Errorf("Error appending attribute to packet: %w", err)
 	}
 
 	// Add the CHECKCODE attribute.
@@ -226,7 +226,7 @@ func (srv *UESimServer) eapAkaChallengeRequest(ue *protos.UEConfig, req eap.Pack
 		),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error appending attribute to packet")
+		return nil, fmt.Errorf("Error appending attribute to packet: %w", err)
 	}
 
 	// Calculate and Copy MAC into packet.
@@ -242,7 +242,7 @@ func parseChallengeAttributes(req eap.Packet) (challengeAttributes, error) {
 
 	scanner, err := eap.NewAttributeScanner(req)
 	if err != nil {
-		return attrs, errors.Wrap(err, "Error creating new attribute scanner")
+		return attrs, fmt.Errorf("Error creating new attribute scanner: %w", err)
 	}
 	var a eap.Attribute
 	for a, err = scanner.Next(); err == nil; a, err = scanner.Next() {

--- a/cwf/gateway/services/uesim/servicers/radius.go
+++ b/cwf/gateway/services/uesim/servicers/radius.go
@@ -25,8 +25,6 @@ import (
 	"fbc/lib/go/radius/rfc2866"
 	"fbc/lib/go/radius/rfc2869"
 	"magma/feg/gateway/services/eap"
-
-	"github.com/pkg/errors"
 )
 
 // todo Replace constants with configurable fields
@@ -41,12 +39,12 @@ func (srv *UESimServer) HandleRadius(imsi string, calledStationID string, p *rad
 	// Extract EAP packet.
 	eapMessage, err := packet.NewPacketFromRadius(p)
 	if err != nil {
-		err = errors.Wrap(err, "Error extracting EAP message from Radius packet")
+		err = fmt.Errorf("Error extracting EAP message from Radius packet: %w", err)
 		return nil, err
 	}
 	eapBytes, err := eapMessage.Bytes()
 	if err != nil {
-		err = errors.Wrap(err, "Error converting EAP packet to bytes")
+		err = fmt.Errorf("Error converting EAP packet to bytes: %w", err)
 		return nil, err
 	}
 
@@ -97,7 +95,7 @@ func (srv *UESimServer) EapToRadius(eapP eap.Packet, imsi string, calledStationI
 
 	encoded, err := radiusP.Encode()
 	if err != nil {
-		return nil, errors.Wrap(err, "Error encoding Radius packet")
+		return nil, fmt.Errorf("Error encoding Radius packet: %w", err)
 	}
 
 	// Add Message-Authenticator Attribute.

--- a/cwf/gateway/services/uesim/servicers/ue_store_utils.go
+++ b/cwf/gateway/services/uesim/servicers/ue_store_utils.go
@@ -14,18 +14,18 @@
 package servicers
 
 import (
+	"fmt"
+
 	cwfprotos "magma/cwf/cloud/go/protos"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/lib/go/protos"
-
-	"github.com/pkg/errors"
 )
 
 func addUeToStore(srvstore blobstore.StoreFactory, ue *cwfprotos.UEConfig) {
 	blob, err := ueToBlob(ue)
 	store, err := srvstore.StartTransaction(nil)
 	if err != nil {
-		err = errors.Wrap(err, "Error while starting transaction")
+		err = fmt.Errorf("Error while starting transaction: %w", err)
 		err = ConvertStorageErrorToGrpcStatus(err)
 		return
 	}
@@ -33,12 +33,12 @@ func addUeToStore(srvstore blobstore.StoreFactory, ue *cwfprotos.UEConfig) {
 		switch err {
 		case nil:
 			if commitErr := store.Commit(); commitErr != nil {
-				err = errors.Wrap(err, "Error while committing transaction")
+				err = fmt.Errorf("Error while committing transaction: %w", err)
 				err = ConvertStorageErrorToGrpcStatus(err)
 			}
 		default:
 			if rollbackErr := store.Rollback(); rollbackErr != nil {
-				err = errors.Wrap(err, "Error while rolling back transaction")
+				err = fmt.Errorf("Error while rolling back transaction: %w", err)
 				err = ConvertStorageErrorToGrpcStatus(err)
 			}
 		}

--- a/cwf/gateway/services/uesim/servicers/uesim.go
+++ b/cwf/gateway/services/uesim/servicers/uesim.go
@@ -31,7 +31,6 @@ import (
 	"magma/orc8r/lib/go/protos"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -188,7 +187,7 @@ func (srv *UESimServer) Authenticate(ctx context.Context, id *cwfprotos.Authenti
 
 	resultBytes, err := result.Encode()
 	if err != nil {
-		return &cwfprotos.AuthenticateResponse{}, errors.Wrap(err, "Error encoding Radius packet")
+		return &cwfprotos.AuthenticateResponse{}, fmt.Errorf("Error encoding Radius packet: %w", err)
 	}
 	radiusPacket := &cwfprotos.AuthenticateResponse{RadiusPacket: resultBytes}
 
@@ -198,15 +197,15 @@ func (srv *UESimServer) Authenticate(ctx context.Context, id *cwfprotos.Authenti
 func (srv *UESimServer) Disconnect(ctx context.Context, id *cwfprotos.DisconnectRequest) (*cwfprotos.DisconnectResponse, error) {
 	radiusP, err := srv.MakeAccountingStopRequest(id.GetCalledStationID())
 	if err != nil {
-		return nil, errors.Wrap(err, "Error making Accounting Stop Radius message")
+		return nil, fmt.Errorf("Error making Accounting Stop Radius message: %w", err)
 	}
 	response, err := radius.Exchange(context.Background(), radiusP, srv.cfg.radiusAcctAddress)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error exchanging Radius message")
+		return nil, fmt.Errorf("Error exchanging Radius message: %w", err)
 	}
 	encoded, err := response.Encode()
 	if err != nil {
-		return nil, errors.Wrap(err, "Error encoding Radius packet")
+		return nil, fmt.Errorf("Error encoding Radius packet: %w", err)
 	}
 	return &cwfprotos.DisconnectResponse{RadiusPacket: encoded}, nil
 }
@@ -263,14 +262,14 @@ func blobToUE(blob blobstore.Blob) (*cwfprotos.UEConfig, error) {
 func getUE(blobStoreFactory blobstore.StoreFactory, imsi string) (ue *cwfprotos.UEConfig, err error) {
 	store, err := blobStoreFactory.StartTransaction(nil)
 	if err != nil {
-		err = errors.Wrap(err, "Error while starting transaction")
+		err = fmt.Errorf("Error while starting transaction: %w", err)
 		return
 	}
 	defer func() {
 		switch err {
 		case nil:
 			if commitErr := store.Commit(); commitErr != nil {
-				err = errors.Wrap(err, "Error while committing transaction")
+				err = fmt.Errorf("Error while committing transaction: %w", err)
 			}
 		default:
 			if rollbackErr := store.Rollback(); rollbackErr != nil {
@@ -281,7 +280,7 @@ func getUE(blobStoreFactory blobstore.StoreFactory, imsi string) (ue *cwfprotos.
 
 	blob, err := store.Get(networkIDPlaceholder, storage.TK{Type: blobTypePlaceholder, Key: imsi})
 	if err != nil {
-		err = errors.Wrap(err, "Error getting UE with specified IMSI")
+		err = fmt.Errorf("Error getting UE with specified IMSI: %w", err)
 		return
 	}
 	ue, err = blobToUE(blob)
@@ -381,7 +380,7 @@ func executeCommandWithRetries(command string, argList []string) (*IperfResponse
 		if !isIperfErrorDueToControlMessage(err) {
 			break
 		}
-		glog.Warning( "Retried IPERF command due to an specific error")
+		glog.Warning("Retried IPERF command due to an specific error")
 		time.Sleep(300 * time.Millisecond)
 	}
 	if err != nil {
@@ -397,9 +396,9 @@ func executeCommand(command string, argList []string) (*IperfResponse, error) {
 	rawOutput, err := cmd.Output()
 	output, _ := (&IperfResponse{}).FromBytes(rawOutput)
 	if err != nil {
-		newError := errors.Wrap(err, fmt.Sprintf(
+		newError := fmt.Errorf(fmt.Sprintf(
 			"error while executing \"%s %s\"\n output:\n%v",
-			command, strings.Join(argList, " "), string(rawOutput)))
+			command, strings.Join(argList, " "), string(rawOutput))+": %w", err)
 		glog.Error(newError)
 		return output, newError
 	}
@@ -412,7 +411,7 @@ func isIperfErrorDueToControlMessage(iperf_err error) bool {
 		return false
 	}
 	return strings.Contains(iperf_err.Error(), "unable to receive control message")
-	//|
+	// |
 	//	strings.Contains(iperf_err.Error(), "the server is busy")
 }
 

--- a/dp/cloud/go/go.mod
+++ b/dp/cloud/go/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/olivere/elastic/v7 v7.0.6
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.43.0
 	google.golang.org/protobuf v1.28.0
@@ -76,6 +75,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.5.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/dp/cloud/go/services/dp/servicers/cbsd_manager.go
+++ b/dp/cloud/go/services/dp/servicers/cbsd_manager.go
@@ -16,9 +16,9 @@ package servicers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -195,7 +195,7 @@ func cbsdFromDatabase(data *storage.DetailedCbsd, inactivityInterval time.Durati
 }
 
 func makeErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	code := codes.Internal
 	if err == merrors.ErrNotFound {
 		code = codes.NotFound

--- a/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
+++ b/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
@@ -56,7 +56,7 @@ func ExecuteNextTestCase(testMachines map[string]statemachines.TestMachine, stor
 
 	machine, ok := testMachines[tc.TestCaseType]
 	if !ok {
-		return errors.Errorf("no test state machine found matching %s", tc.TestCaseType)
+		return fmt.Errorf("no test state machine found matching %s", tc.TestCaseType)
 	}
 	unmarshalledConfig, err := serde.Deserialize(tc.TestConfig, tc.TestCaseType, serdes)
 	if err != nil {

--- a/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
+++ b/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
@@ -15,6 +15,7 @@ package testcontroller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -59,7 +60,7 @@ func ExecuteNextTestCase(testMachines map[string]statemachines.TestMachine, stor
 	}
 	unmarshalledConfig, err := serde.Deserialize(tc.TestConfig, tc.TestCaseType, serdes)
 	if err != nil {
-		return errors.Wrapf(err, "could not deserialize test %s config", tc.TestCaseType)
+		return fmt.Errorf("could not deserialize test %s config: %w", tc.TestCaseType, err)
 	}
 	var prevErr error
 	if tc.Error != "" {
@@ -96,7 +97,7 @@ func GetTestCases(ctx context.Context, pks []int64, serdes serde.Registry) (map[
 	for pk, tc := range res.Tests {
 		unmarshalledConfig, err := serde.Deserialize(tc.TestConfig, tc.TestCaseType, serdes)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to deserialize test case of type %s", tc.TestCaseType)
+			return nil, fmt.Errorf("failed to deserialize test case of type %s: %w", tc.TestCaseType, err)
 		}
 		ret[pk] = &UnmarshalledTestCase{
 			TestCase:          tc,
@@ -109,7 +110,7 @@ func GetTestCases(ctx context.Context, pks []int64, serdes serde.Registry) (map[
 func CreateOrUpdateTestCase(ctx context.Context, pk int64, testCaseType string, testCaseConfig interface{}, serdes serde.Registry) error {
 	marshaledConfig, err := serde.Serialize(testCaseConfig, testCaseType, serdes)
 	if err != nil {
-		return errors.Wrap(err, "failed to serialize config")
+		return fmt.Errorf("failed to serialize config: %w", err)
 	}
 
 	client, err := getE2EClient()

--- a/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
+++ b/fbinternal/cloud/go/services/testcontroller/e2e_client_api.go
@@ -15,10 +15,10 @@ package testcontroller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/fbinternal/cloud/go/services/testcontroller/protos"
 	"magma/fbinternal/cloud/go/services/testcontroller/statemachines"

--- a/feg/cloud/go/go.mod
+++ b/feg/cloud/go/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/magma/augmented-networks/accounting/protos v0.1.1
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.43.0
@@ -81,6 +80,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olivere/elastic/v7 v7.0.6 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.9.1 // indirect

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/feg/cloud/go/feg"
 	"magma/feg/cloud/go/serdes"
@@ -128,7 +127,7 @@ func getGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load federation gateway"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load federation gateway: %w", err))
 	}
 
 	ret := &fegModels.FederationGateway{

--- a/feg/cloud/go/services/feg/obsidian/models/validate.go
+++ b/feg/cloud/go/services/feg/obsidian/models/validate.go
@@ -32,7 +32,7 @@ func (m FegNetworkID) ValidateModel(ctx context.Context) error {
 	if !swag.IsZero(m) {
 		exists, err := configurator.DoesNetworkExist(ctx, string(m))
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Failed to search for network %s", string(m)))
+			return fmt.Errorf(fmt.Sprintf("Failed to search for network %s: %w", string(m)), err)
 		}
 		if !exists {
 			return errors.New(fmt.Sprintf("Network: %s does not exist", string(m)))
@@ -49,7 +49,7 @@ func (m *FederatedNetworkConfigs) ValidateModel(ctx context.Context) error {
 	if !swag.IsZero(nid) {
 		exists, err := configurator.DoesNetworkExist(ctx, nid)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Failed to search for network %s", nid))
+			return fmt.Errorf(fmt.Sprintf("Failed to search for network %s: %w", nid), err)
 		}
 		if !exists {
 			return fmt.Errorf("Network: %s does not exist", nid)

--- a/feg/cloud/go/services/feg/obsidian/models/validate.go
+++ b/feg/cloud/go/services/feg/obsidian/models/validate.go
@@ -15,12 +15,12 @@ package models
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/configurator"
 )

--- a/feg/cloud/go/services/feg/servicers/protected/builder_servicer.go
+++ b/feg/cloud/go/services/feg/servicers/protected/builder_servicer.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/feg/cloud/go/feg"
 	feg_mconfig "magma/feg/cloud/go/protos/mconfig"
@@ -175,7 +174,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 func getFegConfig(gatewayID string, network configurator.Network, graph configurator.EntityGraph) (*models.GatewayFederationConfigs, error) {
 	fegGW, err := graph.GetEntity(feg.FegGatewayType, gatewayID)
 	if err != nil && err != merrors.ErrNotFound {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	// err can only be merrors.ErrNotFound at this point - if it's nil, we'll
 	// just return the feg gateway config if it exists

--- a/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
+++ b/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 
 	"magma/feg/cloud/go/feg"
@@ -93,7 +92,7 @@ func getFegCfg(ctx context.Context, networkID, gatewayID string) (*models.Gatewa
 		serdes.Entity,
 	)
 	if err != nil && err != merrors.ErrNotFound {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	if err == nil && fegGateway.Config != nil {
 		return fegGateway.Config.(*models.GatewayFederationConfigs), nil

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/labstack/echo/v4 v4.2.1
 	github.com/mennanov/fieldmask-utils v0.5.0
 	github.com/ory/go-acc v0.2.8
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0
@@ -121,6 +120,7 @@ require (
 	github.com/ory/viper v1.7.5 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/spf13/afero v1.8.0 // indirect

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
@@ -14,10 +14,10 @@ limitations under the License.
 package mock_pgw
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	"github.com/wmnsk/go-gtp/gtpv2"
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 	"github.com/wmnsk/go-gtp/gtpv2/message"

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
@@ -52,7 +52,7 @@ func (mPgw *MockPgw) CreateBearerRequest(req CreateBearerRequest) (chan CBReq, e
 
 	sgwTeidC, err := session.GetTEID(gtpv2.IFTypeS5S8SGWGTPC)
 	if err != nil {
-		err = errors.Wrap(err, "Error, couldnt find teid con Create Bearer Request")
+		err = fmt.Errorf("Error, couldnt find teid con Create Bearer Request: %w", err)
 		return nil, err
 	}
 

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/wmnsk/go-gtp/gtpv2"
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 	"github.com/wmnsk/go-gtp/gtpv2/message"
@@ -50,7 +49,7 @@ func (mPgw *MockPgw) getHandleCreateSessionRequest() gtpv2.HandlerFunc {
 				case *gtpv2.UnknownIMSIError:
 					// whole new session. just ignore.
 				default:
-					return errors.Wrap(err2, "got something unexpected")
+					return fmt.Errorf("got something unexpected: %w", err2)
 				}
 			} else {
 				fmt.Printf("Existing IMSI during Create Session Request on PGW (%s). Deleting previous session\n", imsi)
@@ -409,7 +408,7 @@ func (mPgw *MockPgw) getHandleCreateSessionResponseWithMissingIE() gtpv2.Handler
 		csRspFromPGW := message.NewCreateSessionResponse(
 			sgwTEID.MustTEID(), msg.Sequence(),
 			ie.NewCause(gtpv2.CauseRequestAccepted, 0, 0, 0, nil),
-			//pgwFTEIDc,
+			// pgwFTEIDc,
 			ie.NewPDNAddressAllocation("10.1.2.3"),
 			ie.NewAPNRestriction(gtpv2.APNRestrictionPublic2),
 			ie.NewBearerContext(

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/db.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/db.go
@@ -14,10 +14,10 @@ limitations under the License.
 package mock_pgw
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	"github.com/wmnsk/go-gtp/gtpv2"
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 	"github.com/wmnsk/go-gtp/gtpv2/message"

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/db.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/db.go
@@ -41,7 +41,7 @@ func (mPgw *MockPgw) DeleteBearerRequest(req DeleteBearerRequest) (chan DBReq, e
 
 	sgwTeidC, err := session.GetTEID(gtpv2.IFTypeS5S8SGWGTPC)
 	if err != nil {
-		err = errors.Wrap(err, "Error, couldnt find teid on Dedicated Bearer Request")
+		err = fmt.Errorf("Error, couldnt find teid on Dedicated Bearer Request: %w", err)
 		return nil, err
 	}
 

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/ds.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/ds.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	"github.com/wmnsk/go-gtp/gtpv2"
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 	"github.com/wmnsk/go-gtp/gtpv2/message"
@@ -42,7 +41,7 @@ func (mPgw *MockPgw) getHandleDeleteSessionRequest() gtpv2.HandlerFunc {
 		// get TEUD
 		sgwTeidC, err := session.GetTEID(gtpv2.IFTypeS5S8SGWGTPC)
 		if err != nil {
-			err = errors.Wrap(err, "Error")
+			err = fmt.Errorf("Error: %w", err)
 			return err
 		}
 

--- a/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
@@ -335,7 +335,7 @@ func (srv *OCSDiamServer) AbortSession(
 	srv.mux.Handle(diam.ASA, asaHandler)
 	err := sendASR(account.CurrentState, srv.mux.Settings())
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to send Gy ASR")
+		return nil, fmt.Errorf("Failed to send Gy ASR: %w", err)
 	}
 	select {
 	case asa := <-resp:

--- a/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
@@ -15,6 +15,7 @@ package mock_ocs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -25,7 +26,6 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/sm"
 	"github.com/fiorix/go-diameter/v4/diam/sm/smpeer"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
@@ -292,7 +292,7 @@ func (srv *PCRFServer) AbortSession(
 	srv.mux.Handle(diam.ASA, asaHandler)
 	err := sendASR(account.CurrentState, srv.mux.Settings())
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to send Gx ASR")
+		return nil, fmt.Errorf("Failed to send Gx ASR: %w", err)
 	}
 	select {
 	case asa := <-resp:

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
@@ -15,6 +15,7 @@ package mock_pcrf
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -25,7 +26,6 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/sm"
 	"github.com/fiorix/go-diameter/v4/diam/sm/smpeer"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"

--- a/feg/radius/lib/go/http/auth/mac.go
+++ b/feg/radius/lib/go/http/auth/mac.go
@@ -145,7 +145,7 @@ func (m *MACMiddleware) verify(r *http.Request) error {
 		return fmt.Errorf("parse timestamp: %v: %w", ts, err)
 	}
 	if ts := time.Unix(n, 0); abs(time.Since(ts)) > m.TimeSkew {
-		return errors.Errorf("stable timestamp: %v", ts)
+		return fmt.Errorf("stable timestamp: %v", ts)
 	}
 	h := m.Hash.New()
 	if err := hashRequest(h, r, ts); err != nil {

--- a/feg/radius/lib/go/http/auth/mac.go
+++ b/feg/radius/lib/go/http/auth/mac.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -29,8 +30,6 @@ import (
 	"time"
 
 	"fbc/lib/go/http/httputil"
-
-	"github.com/pkg/errors"
 )
 
 const (

--- a/feg/radius/lib/go/http/go.mod
+++ b/feg/radius/lib/go/http/go.mod
@@ -11,7 +11,6 @@ require (
 	fbc/lib/go/log v0.0.0
 	github.com/google/uuid v1.1.1
 	github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	go.opencensus.io v0.21.0
 	go.uber.org/multierr v1.1.0

--- a/feg/radius/lib/go/http/go.sum
+++ b/feg/radius/lib/go/http/go.sum
@@ -17,7 +17,6 @@ github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4 h1:xKkUL6QBojw
 github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da h1:5y58+OCjoHCYB8182mpf/dEsq0vwTKPOo4zGfH0xW9A=
 github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da/go.mod h1:oLH0CmIaxCGXD67VKGR5AacGXZSMznlmeqM8RzPrcY8=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/feg/radius/lib/go/http/server/config.go
+++ b/feg/radius/lib/go/http/server/config.go
@@ -14,9 +14,9 @@ limitations under the License.
 package server
 
 import (
+	"fmt"
 	"io"
 	"net/http"
-
 	// register pprof with default http mux
 	_ "net/http/pprof"
 
@@ -82,7 +82,7 @@ func (config *Config) createLogger() (*zap.Logger, error) {
 	}
 
 	if err != nil {
-		return nil, errors.Wrap(err, "creating logger")
+		return nil, fmt.Errorf("creating logger: %w", err)
 	}
 
 	return logger.WithOptions(zap.AddStacktrace(zap.DPanicLevel)), nil

--- a/feg/radius/lib/go/http/server/config.go
+++ b/feg/radius/lib/go/http/server/config.go
@@ -24,7 +24,6 @@ import (
 	"fbc/lib/go/log"
 
 	"github.com/justinas/alice"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -78,7 +77,7 @@ func (config *Config) createLogger() (*zap.Logger, error) {
 		}
 		logger, err = config.Build()
 	default:
-		err = errors.Errorf("unknown logger type: %q", lc.Type)
+		err = fmt.Errorf("unknown logger type: %q", lc.Type)
 	}
 
 	if err != nil {

--- a/feg/radius/lib/go/http/server/server.go
+++ b/feg/radius/lib/go/http/server/server.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"net"
@@ -30,7 +31,6 @@ import (
 	"fbc/lib/go/log"
 
 	"github.com/justinas/alice"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
@@ -105,7 +105,7 @@ func New(config Config, options ...Option) (*Server, error) {
 	srv := &Server{Server: http.Server{Addr: config.Addr}}
 	err := srv.Apply(options[:idx]...)
 	if err != nil {
-		return nil, errors.Wrap(err, "applying early options")
+		return nil, fmt.Errorf("applying early options: %w", err)
 	}
 
 	if srv.Logger == nil {
@@ -119,7 +119,7 @@ func New(config Config, options ...Option) (*Server, error) {
 	srv.Mux, srv.Handler = config.createServeMux(srv.Logger)
 	err = srv.Apply(options[idx:]...)
 	if err != nil {
-		return nil, errors.Wrap(err, "applying late options")
+		return nil, fmt.Errorf("applying late options: %w", err)
 	}
 
 	return srv, nil

--- a/feg/radius/lib/go/libgraphql/client.go
+++ b/feg/radius/lib/go/libgraphql/client.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -85,7 +84,7 @@ func (c *Client) Do(op Op) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return errors.Errorf("libgraphql: invalid status code: %s", res.Status)
+		return fmt.Errorf("libgraphql: invalid status code: %s", res.Status)
 	}
 	if err := json.NewDecoder(res.Body).Decode(op); err != nil {
 		return err

--- a/feg/radius/lib/go/libgraphql/go.mod
+++ b/feg/radius/lib/go/libgraphql/go.mod
@@ -1,8 +1,5 @@
 module libgraphql
 
-require (
-	github.com/google/uuid v1.1.1
-	github.com/pkg/errors v0.8.1
-)
+require github.com/google/uuid v1.1.1
 
 go 1.18

--- a/feg/radius/lib/go/libgraphql/go.sum
+++ b/feg/radius/lib/go/libgraphql/go.sum
@@ -1,4 +1,2 @@
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/feg/radius/lib/go/log/config.go
+++ b/feg/radius/lib/go/log/config.go
@@ -16,7 +16,6 @@ package log
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -42,7 +41,7 @@ func (cfg Config) Build() (Factory, error) {
 	case "json":
 		c = zap.NewProductionConfig()
 	default:
-		return nil, errors.Errorf("unsupported logging format: %q", cfg.Format)
+		return nil, fmt.Errorf("unsupported logging format: %q", cfg.Format)
 	}
 
 	var level zapcore.Level

--- a/feg/radius/lib/go/log/config.go
+++ b/feg/radius/lib/go/log/config.go
@@ -14,6 +14,8 @@ limitations under the License.
 package log
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -45,13 +47,13 @@ func (cfg Config) Build() (Factory, error) {
 
 	var level zapcore.Level
 	if err := level.Set(cfg.Level); err != nil {
-		return nil, errors.Wrap(err, "setting log level")
+		return nil, fmt.Errorf("setting log level: %w", err)
 	}
 	c.Level = zap.NewAtomicLevelAt(level)
 
 	logger, err := c.Build(zap.AddStacktrace(zap.DPanicLevel))
 	if err != nil {
-		return nil, errors.Wrap(err, "creating logger")
+		return nil, fmt.Errorf("creating logger: %w", err)
 	}
 	return NewFactory(logger), nil
 }

--- a/feg/radius/lib/go/log/go.mod
+++ b/feg/radius/lib/go/log/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	go.opencensus.io v0.21.0
 	go.uber.org/zap v1.10.0
@@ -14,6 +13,7 @@ require (
 
 require (
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/feg/radius/lib/go/oc/config.go
+++ b/feg/radius/lib/go/oc/config.go
@@ -25,7 +25,6 @@ import (
 
 	"contrib.go.opencensus.io/exporter/jaeger"
 	"github.com/jessevdk/go-flags"
-	"github.com/pkg/errors"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
@@ -178,7 +177,7 @@ func (cfg *Config) buildStats(opt options) (handler http.Handler, closers []func
 		}
 		views := viewer.Views()
 		if err = view.Register(views...); err != nil {
-			err = errors.WithMessagef(err, "registering %s views", name)
+			err = fmt.Errorf("registering %s views: %w", name, err)
 			return
 		}
 		closers = append(closers, func() {
@@ -188,7 +187,7 @@ func (cfg *Config) buildStats(opt options) (handler http.Handler, closers []func
 
 	var closer func()
 	if handler, closer, err = ocstats.NewHandler(opts...); err != nil {
-		err = errors.WithMessage(err, "creating stats handler")
+		err = fmt.Errorf("creating stats handler: %w", err)
 		return
 	}
 	closers = append(closers, closer)

--- a/feg/radius/lib/go/oc/config.go
+++ b/feg/radius/lib/go/oc/config.go
@@ -16,6 +16,7 @@ package oc
 import (
 	"encoding/json"
 	"fbc/lib/go/oc/ocstats"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -238,7 +239,7 @@ func (cfg *Config) buildJaeger(opt options) (func(), error) {
 	}
 	exporter, err := jaeger.NewExporter(cfg.Jaeger.Options)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating jaeger exporter")
+		return nil, fmt.Errorf("creating jaeger exporter: %w", err)
 	}
 	trace.RegisterExporter(exporter)
 	return func() {

--- a/feg/radius/lib/go/oc/config.go
+++ b/feg/radius/lib/go/oc/config.go
@@ -15,12 +15,13 @@ package oc
 
 import (
 	"encoding/json"
-	"fbc/lib/go/oc/ocstats"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"fbc/lib/go/oc/ocstats"
 
 	"contrib.go.opencensus.io/exporter/jaeger"
 	"github.com/jessevdk/go-flags"
@@ -172,7 +173,7 @@ func (cfg *Config) buildStats(opt options) (handler http.Handler, closers []func
 		}
 		viewer := GetViewer(name)
 		if viewer == nil {
-			err = errors.Errorf("unknown view name %q", name)
+			err = fmt.Errorf("unknown view name %q", name)
 			return
 		}
 		views := viewer.Views()

--- a/feg/radius/lib/go/oc/exporters/ods.go
+++ b/feg/radius/lib/go/oc/exporters/ods.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -29,6 +28,7 @@ import (
 	"time"
 
 	"fbc/lib/go/oc"
+
 	"github.com/kelseyhightower/envconfig"
 	"go.opencensus.io/stats/view"
 )
@@ -114,13 +114,13 @@ func PostToODS(metricsData map[string]string, cfg Config) error {
 	}
 	req, err := http.NewRequest(http.MethodPost, cfg.GraphURL, strings.NewReader(urlValues.Encode()))
 	if err != nil {
-		return errors.WithMessage(err, "failed to create http post request")
+		return fmt.Errorf("failed to create http post request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := oc.DefaultClient.Do(req)
 
 	if err != nil {
-		return errors.WithMessage(err, "failed to post form")
+		return fmt.Errorf("failed to post form: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -139,7 +139,7 @@ func getURLValues(datapoints []Datapoint, cfg Config) (url.Values, error) {
 	urlValues := url.Values{}
 	datapointsJSON, err := json.Marshal(datapoints)
 	if err != nil {
-		return urlValues, errors.WithMessage(err, "error marshaling datapoints")
+		return urlValues, fmt.Errorf("error marshaling datapoints: %w", err)
 	}
 
 	urlValues.Add("access_token", cfg.Token)

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -17,7 +17,6 @@ require (
 	fbc/lib/go/oc/helpers v0.0.0
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
 	github.com/kelseyhightower/envconfig v1.3.0
-	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/stretchr/testify v1.3.0
 	go.opencensus.io v0.21.0

--- a/feg/radius/lib/go/oc/go.sum
+++ b/feg/radius/lib/go/oc/go.sum
@@ -72,7 +72,6 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/feg/radius/lib/go/oc/ocstats/handler.go
+++ b/feg/radius/lib/go/oc/ocstats/handler.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	ocprom "contrib.go.opencensus.io/exporter/prometheus"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
@@ -72,7 +71,7 @@ func NewHandler(opt ...Option) (http.Handler, func(), error) {
 	opts := ocprom.Options{Registry: prometheus.NewRegistry()}
 	for i := range opt {
 		if err := opt[i](&opts); err != nil {
-			return nil, nil, errors.WithMessage(err, "applying option")
+			return nil, nil, fmt.Errorf("applying option: %w", err)
 		}
 	}
 	exporter, err := ocprom.NewExporter(opts)

--- a/feg/radius/lib/go/oc/ocstats/handler.go
+++ b/feg/radius/lib/go/oc/ocstats/handler.go
@@ -14,6 +14,7 @@ limitations under the License.
 package ocstats
 
 import (
+	"fmt"
 	"net/http"
 
 	ocprom "contrib.go.opencensus.io/exporter/prometheus"
@@ -50,7 +51,7 @@ func WithProcessCollector() Option {
 		if err := opts.Registry.Register(prometheus.NewProcessCollector(
 			prometheus.ProcessCollectorOpts{Namespace: opts.Namespace},
 		)); err != nil {
-			return errors.Wrap(err, "registering process collector")
+			return fmt.Errorf("registering process collector: %w", err)
 		}
 		return nil
 	}
@@ -60,7 +61,7 @@ func WithProcessCollector() Option {
 func WithGoCollector() Option {
 	return func(opts *ocprom.Options) error {
 		if err := opts.Registry.Register(prometheus.NewGoCollector()); err != nil {
-			return errors.Wrap(err, "registering go collector")
+			return fmt.Errorf("registering go collector: %w", err)
 		}
 		return nil
 	}
@@ -76,7 +77,7 @@ func NewHandler(opt ...Option) (http.Handler, func(), error) {
 	}
 	exporter, err := ocprom.NewExporter(opts)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "creating prometheus exporter")
+		return nil, nil, fmt.Errorf("creating prometheus exporter: %w", err)
 	}
 	view.RegisterExporter(exporter)
 	closer := func() { view.UnregisterExporter(exporter) }

--- a/feg/radius/lib/go/oc/server_options.go
+++ b/feg/radius/lib/go/oc/server_options.go
@@ -22,7 +22,6 @@ import (
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"fbc/lib/go/http/server"
 	"fbc/lib/go/oc/helpers"
-	"github.com/pkg/errors"
 	prom_client "github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats/view"

--- a/feg/radius/lib/go/oc/server_options.go
+++ b/feg/radius/lib/go/oc/server_options.go
@@ -15,6 +15,7 @@ package oc
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"contrib.go.opencensus.io/exporter/aws"
 	"contrib.go.opencensus.io/exporter/jaeger"
@@ -56,7 +57,7 @@ var ServerResponseCountByStatusAndPath = &view.View{
 func NewConfig(config string) (*CensusConfig, error) {
 	var cc CensusConfig
 	if err := json.Unmarshal([]byte(config), &cc); err != nil {
-		return nil, errors.Wrapf(err, "parsing census config: %q", config)
+		return nil, fmt.Errorf("parsing census config: %q: %w", config, err)
 	}
 	return &cc, nil
 }
@@ -115,7 +116,7 @@ func xrayOption(options xrayOptions) server.Option {
 		})))
 		exporter, err := aws.NewExporter(opts...)
 		if err != nil {
-			return errors.Wrap(err, "creating xray exporter")
+			return fmt.Errorf("creating xray exporter: %w", err)
 		}
 		trace.RegisterExporter(exporter)
 		err = srv.Apply(server.Closer(closerFunc(func() error { exporter.Flush(); return nil })))
@@ -133,7 +134,7 @@ func jaegerOption(options jaeger.Options) server.Option {
 		}
 		exporter, err := jaeger.NewExporter(options)
 		if err != nil {
-			return errors.Wrap(err, "creating jaeger exporter")
+			return fmt.Errorf("creating jaeger exporter: %w", err)
 		}
 		trace.RegisterExporter(exporter)
 		err = srv.Apply(server.Closer(closerFunc(func() error { exporter.Flush(); return nil })))
@@ -152,19 +153,19 @@ func prometheusOption(options prometheus.Options) server.Option {
 		options.Registry = prom_client.NewRegistry()
 		exporter, err := prometheus.NewExporter(options)
 		if err != nil {
-			return errors.Wrap(err, "creating prometheus exporter")
+			return fmt.Errorf("creating prometheus exporter: %w", err)
 		}
 
 		// Adding process collector
 		if err := options.Registry.Register(prom_client.NewProcessCollector(
 			prom_client.ProcessCollectorOpts{Namespace: options.Namespace},
 		)); err != nil {
-			return errors.Wrap(err, "registering process collector")
+			return fmt.Errorf("registering process collector: %w", err)
 		}
 
 		// Adding GO collector
 		if err := options.Registry.Register(prom_client.NewGoCollector()); err != nil {
-			return errors.Wrap(err, "registering go collector")
+			return fmt.Errorf("registering go collector: %w", err)
 		}
 		if err := view.Register(
 			ochttp.ServerRequestCountView,
@@ -175,7 +176,7 @@ func prometheusOption(options prometheus.Options) server.Option {
 			ochttp.ServerResponseCountByStatusCode,
 			ServerResponseCountByStatusAndPath,
 		); err != nil {
-			return errors.Wrap(err, "registering http server views")
+			return fmt.Errorf("registering http server views: %w", err)
 		}
 		if err := view.Register(
 			ochttp.ClientCompletedCount,
@@ -184,7 +185,7 @@ func prometheusOption(options prometheus.Options) server.Option {
 			ochttp.ClientRoundtripLatencyDistribution,
 			ochttp.ClientCompletedCount,
 		); err != nil {
-			return errors.Wrap(err, "registering http client views")
+			return fmt.Errorf("registering http client views: %w", err)
 		}
 		if err := view.Register(
 			helpers.LatencyView,
@@ -192,7 +193,7 @@ func prometheusOption(options prometheus.Options) server.Option {
 			helpers.SuccessCountView,
 			helpers.CountView,
 		); err != nil {
-			return errors.Wrap(err, "registering customized KPI views")
+			return fmt.Errorf("registering customized KPI views: %w", err)
 		}
 
 		view.RegisterExporter(exporter)

--- a/feg/radius/lib/go/oc/server_options.go
+++ b/feg/radius/lib/go/oc/server_options.go
@@ -121,7 +121,7 @@ func xrayOption(options xrayOptions) server.Option {
 		trace.RegisterExporter(exporter)
 		err = srv.Apply(server.Closer(closerFunc(func() error { exporter.Flush(); return nil })))
 		if err != nil {
-			return errors.WithMessage(err, "registering xray flusher")
+			return fmt.Errorf("registering xray flusher: %w", err)
 		}
 		return nil
 	})
@@ -139,7 +139,7 @@ func jaegerOption(options jaeger.Options) server.Option {
 		trace.RegisterExporter(exporter)
 		err = srv.Apply(server.Closer(closerFunc(func() error { exporter.Flush(); return nil })))
 		if err != nil {
-			return errors.WithMessage(err, "registering jaeger flusher")
+			return fmt.Errorf("registering jaeger flusher: %w", err)
 		}
 		return nil
 	})

--- a/feg/radius/src/go.mod
+++ b/feg/radius/src/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/stretchr/testify v1.7.0
 	go.opencensus.io v0.21.0

--- a/feg/radius/src/modules/analytics/graphql/client.go
+++ b/feg/radius/src/modules/analytics/graphql/client.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -85,7 +84,7 @@ func (c *Client) Do(op Op) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return errors.Errorf("libgraphql: invalid status code: %s", res.Status)
+		return fmt.Errorf("libgraphql: invalid status code: %s", res.Status)
 	}
 	if err := json.NewDecoder(res.Body).Decode(op); err != nil {
 		return err

--- a/feg/radius/src/modules/coafixedip/coa_fixed_ip.go
+++ b/feg/radius/src/modules/coafixedip/coa_fixed_ip.go
@@ -15,11 +15,11 @@ package coafixedip
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 
 	"fbc/cwf/radius/modules"
 	"fbc/lib/go/radius"

--- a/feg/radius/src/modules/coafixedip/coa_fixed_ip.go
+++ b/feg/radius/src/modules/coafixedip/coa_fixed_ip.go
@@ -15,6 +15,7 @@ package coafixedip
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/mitchellh/mapstructure"
@@ -56,7 +57,7 @@ func Init(logger *zap.Logger, config modules.ModuleConfig) (modules.Context, err
 	}
 
 	if nil == net.ParseIP(host) {
-		return nil, errors.Wrap(err, "Invalid ip address specified")
+		return nil, fmt.Errorf("Invalid ip address specified: %w", err)
 	}
 
 	return ModuleCtx{target: coaConfig.Target}, nil

--- a/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
+++ b/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
@@ -115,7 +115,7 @@ func Handle(m modules.Context, rc *modules.RequestContext, r *radius.Request, _ 
 	}
 	encodedMsg, err := json.Marshal(jsonPacket)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to marshal radius packet")
+		return nil, fmt.Errorf("unable to marshal radius packet: %w", err)
 	}
 	req, err := http.NewRequest(http.MethodPost, ctx.URI, bytes.NewReader(encodedMsg))
 	if err != nil {
@@ -126,7 +126,7 @@ func Handle(m modules.Context, rc *modules.RequestContext, r *radius.Request, _ 
 
 	resp, err := ctx.HTTPClient.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "error sending response to endpoint")
+		return nil, fmt.Errorf("error sending response to endpoint: %w", err)
 	}
 	defer resp.Body.Close()
 	rc.Logger.Debug("got response", zap.String("status", resp.Status),
@@ -145,7 +145,7 @@ func Handle(m modules.Context, rc *modules.RequestContext, r *radius.Request, _ 
 	}
 	var endPointResponse EndpointResponse
 	if err := json.NewDecoder(resp.Body).Decode(&endPointResponse); err != nil {
-		return nil, errors.Wrap(err, "unable to decode endpoint response")
+		return nil, fmt.Errorf("unable to decode endpoint response: %w", err)
 	}
 
 	if len(endPointResponse.Auth) == 0 {

--- a/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
+++ b/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -27,7 +28,6 @@ import (
 	"fbc/lib/go/radius/rfc2865"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 

--- a/feg/radius/src/monitoring/census/with.go
+++ b/feg/radius/src/monitoring/census/with.go
@@ -1,8 +1,9 @@
 package census
 
 import (
+	"fmt"
+
 	ocprom "contrib.go.opencensus.io/exporter/prometheus"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
@@ -31,7 +32,7 @@ func WithProcessCollector() Option {
 		if err := opts.Registry.Register(prometheus.NewProcessCollector(
 			prometheus.ProcessCollectorOpts{Namespace: opts.Namespace},
 		)); err != nil {
-			return errors.Wrap(err, "registering process collector")
+			return fmt.Errorf("registering process collector: %w", err)
 		}
 		return nil
 	}
@@ -41,7 +42,7 @@ func WithProcessCollector() Option {
 func WithGoCollector() Option {
 	return func(opts *ocprom.Options) error {
 		if err := opts.Registry.Register(prometheus.NewGoCollector()); err != nil {
-			return errors.Wrap(err, "registering go collector")
+			return fmt.Errorf("registering go collector: %w", err)
 		}
 		return nil
 	}

--- a/feg/radius/src/monitoring/init.go
+++ b/feg/radius/src/monitoring/init.go
@@ -1,11 +1,13 @@
 package monitoring
 
 import (
+	"errors"
+
 	"fbc/cwf/radius/config"
 	"fbc/cwf/radius/monitoring/census"
 	"fbc/cwf/radius/monitoring/ods"
 	"fbc/cwf/radius/monitoring/scuba"
-	"github.com/pkg/errors"
+
 	"go.uber.org/zap"
 )
 

--- a/feg/radius/src/monitoring/ods/ods.go
+++ b/feg/radius/src/monitoring/ods/ods.go
@@ -16,7 +16,6 @@ package ods
 import (
 	"crypto/tls"
 	"encoding/json"
-	"fbc/cwf/radius/config"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -27,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
+	"fbc/cwf/radius/config"
 
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats/view"
@@ -88,12 +87,12 @@ func PostToODS(metricsData map[string]string, cfg config.Ods) error {
 		strings.NewReader(urlValues.Encode()),
 	)
 	if err != nil {
-		return errors.WithMessage(err, "failed to create http post request")
+		return fmt.Errorf("failed to create http post request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := DefaultClient.Do(req)
 	if err != nil {
-		return errors.WithMessage(err, "failed to post form")
+		return fmt.Errorf("failed to post form: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -116,7 +115,7 @@ func getURLValues(datapoints []Datapoint, cfg config.Ods) (url.Values, error) {
 	urlValues := url.Values{}
 	datapointsJSON, err := json.Marshal(datapoints)
 	if err != nil {
-		return urlValues, errors.WithMessage(err, "error marshaling datapoints")
+		return urlValues, fmt.Errorf("error marshaling datapoints: %w", err)
 	}
 
 	urlValues.Add("access_token", cfg.Token)

--- a/lte/cloud/go/go.mod
+++ b/lte/cloud/go/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/lib/pq v1.2.0
 	github.com/olivere/elastic/v7 v7.0.6
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.7.0
@@ -92,6 +91,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect

--- a/lte/cloud/go/services/ha/servicers/southbound/servicer.go
+++ b/lte/cloud/go/services/ha/servicers/southbound/servicer.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -59,7 +58,7 @@ func (s *HAServicer) GetEnodebOffloadState(ctx context.Context, req *lte_protos.
 	}
 	cfg, err := configurator.LoadEntityConfig(ctx, secondaryGw.GetNetworkId(), lte.CellularGatewayEntityType, secondaryGw.LogicalId, lte_models.EntitySerdes)
 	if err != nil {
-		errors.Wrap(err, "unable to load cellular gateway configs to find primary gateway's in its pool")
+		fmt.Errorf("unable to load cellular gateway configs to find primary gateway's in its pool: %w", err)
 		return ret, err
 	}
 	cellularCfg, ok := cfg.(*lte_models.GatewayCellularConfigs)

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/lte/cloud/go/lte"
@@ -193,7 +192,7 @@ func getGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load cellular gateway"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load cellular gateway: %w", err))
 	}
 
 	ret := &lte_models.LteGateway{
@@ -219,7 +218,7 @@ func getGateway(c echo.Context) error {
 		case lte.APNResourceEntityType:
 			e, err := configurator.LoadEntity(reqCtx, nid, tk.Type, tk.Key, configurator.EntityLoadCriteria{LoadConfig: true}, serdes.Entity)
 			if err != nil {
-				return errors.Wrap(err, "error loading apn resource entity")
+				return fmt.Errorf("error loading apn resource entity: %w", err)
 			}
 			apnResource := (&lte_models.ApnResource{}).FromEntity(e)
 			ret.ApnResources[string(apnResource.ApnName)] = *apnResource
@@ -257,7 +256,7 @@ func deleteGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "error loading existing cellular gateway"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("error loading existing cellular gateway: %w", err))
 	}
 	deletes = append(deletes, gw.Associations.Filter(lte.APNResourceEntityType)...)
 
@@ -619,7 +618,7 @@ func updateApnConfiguration(c echo.Context) error {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
 	case err != nil:
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load existing APN"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load existing APN: %w", err))
 	}
 
 	err = configurator.CreateOrUpdateEntityConfig(reqCtx, networkID, lte.APNEntityType, apnName, payload.ApnConfiguration, serdes.Entity)
@@ -670,7 +669,7 @@ func AddNetworkWideSubscriberRuleName(c echo.Context) error {
 	}
 	err := addToNetworkSubscriberConfig(c.Request().Context(), networkID, params[0], "")
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -686,7 +685,7 @@ func AddNetworkWideSubscriberBaseName(c echo.Context) error {
 	}
 	err := addToNetworkSubscriberConfig(c.Request().Context(), networkID, "", params[0])
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -702,7 +701,7 @@ func RemoveNetworkWideSubscriberRuleName(c echo.Context) error {
 	}
 	err := removeFromNetworkSubscriberConfig(c.Request().Context(), networkID, params[0], "")
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -718,7 +717,7 @@ func RemoveNetworkWideSubscriberBaseName(c echo.Context) error {
 	}
 	err := removeFromNetworkSubscriberConfig(c.Request().Context(), networkID, "", params[0])
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -883,7 +882,7 @@ func updateGatewayPoolHandler(c echo.Context) error {
 	// 404 if pool doesn't exist
 	exists, err := configurator.DoesEntityExist(reqCtx, networkID, lte.CellularGatewayPoolEntityType, gatewayPoolID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Error while checking if gateway pool exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Error while checking if gateway pool exists: %w", err))
 	}
 	if !exists {
 		return echo.ErrNotFound

--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 
 	"github.com/go-openapi/swag"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/lte/cloud/go/lte"
@@ -307,7 +306,7 @@ func (m *MutableLteGateway) getAPNResourceChanges(
 	oldIDs := existingGateway.Associations.Filter(lte.APNResourceEntityType).Keys()
 	oldByAPN, err := LoadAPNResources(ctx, existingGateway.NetworkID, oldIDs)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "error loading existing APN resources")
+		return nil, nil, fmt.Errorf("error loading existing APN resources: %w", err)
 	}
 	oldResources := oldByAPN.GetByID()
 	newResources := m.ApnResources.GetByID()

--- a/lte/cloud/go/services/lte/obsidian/models/validate.go
+++ b/lte/cloud/go/services/lte/obsidian/models/validate.go
@@ -15,6 +15,7 @@ package models
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	"magma/orc8r/cloud/go/services/configurator"

--- a/lte/cloud/go/services/lte/obsidian/models/validate.go
+++ b/lte/cloud/go/services/lte/obsidian/models/validate.go
@@ -83,7 +83,7 @@ func (m FegNetworkID) ValidateModel(ctx context.Context) error {
 	if !swag.IsZero(m) {
 		exists, err := configurator.DoesNetworkExist(ctx, string(m))
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Failed to search for network %s", string(m)))
+			return fmt.Errorf(fmt.Sprintf("Failed to search for network %s: %w", string(m)), err)
 		}
 		if !exists {
 			return errors.New(fmt.Sprintf("Network: %s does not exist", string(m)))

--- a/lte/cloud/go/services/lte/obsidian/models/validate.go
+++ b/lte/cloud/go/services/lte/obsidian/models/validate.go
@@ -151,14 +151,14 @@ func (m *NetworkRanConfigs) ValidateModel(context.Context) error {
 	}
 
 	if tddConfigSet && band.Mode != lte.TDDMode {
-		return errors.Errorf("band %d not a TDD band", band.ID)
+		return fmt.Errorf("band %d not a TDD band", band.ID)
 	}
 	if fddConfigSet {
 		if band.Mode != lte.FDDMode {
-			return errors.Errorf("band %d not a FDD band", band.ID)
+			return fmt.Errorf("band %d not a FDD band", band.ID)
 		}
 		if !band.EarfcnULInRange(m.FddConfig.Earfcnul) {
-			return errors.Errorf("EARFCNUL=%d invalid for band %d (%d, %d)", m.FddConfig.Earfcnul, band.ID, band.StartEarfcnUl, band.StartEarfcnDl)
+			return fmt.Errorf("EARFCNUL=%d invalid for band %d (%d, %d)", m.FddConfig.Earfcnul, band.ID, band.StartEarfcnUl, band.StartEarfcnDl)
 		}
 	}
 

--- a/lte/cloud/go/services/lte/protos/validate.go
+++ b/lte/cloud/go/services/lte/protos/validate.go
@@ -14,7 +14,7 @@
 package protos
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 func (m *GetEnodebStateRequest) Validate() error {

--- a/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
@@ -322,7 +322,7 @@ func getPipelineDServicesConfig(networkServices []string) ([]lte_mconfig.Pipelin
 	for _, service := range networkServices {
 		mc, found := networkServicesByName[service]
 		if !found {
-			return nil, errors.Errorf("unknown network service name %s", service)
+			return nil, fmt.Errorf("unknown network service name %s", service)
 		}
 		apps = append(apps, mc)
 	}

--- a/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
@@ -15,6 +15,7 @@ package servicers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/feg/cloud/go/feg"

--- a/lte/cloud/go/services/lte/servicers/protected/indexer_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/protected/indexer_servicer.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -103,12 +102,12 @@ func setEnodebState(ctx context.Context, networkID string, states state_types.St
 		}
 		gwEnt, err := configurator.LoadEntityForPhysicalID(ctx, st.ReporterID, configurator.EntityLoadCriteria{}, serdes.Entity)
 		if err != nil {
-			stateErrors[id] = errors.Wrap(err, "error loading gatewayID")
+			stateErrors[id] = fmt.Errorf("error loading gatewayID: %w", err)
 			continue
 		}
 		err = lte_api.SetEnodebState(ctx, networkID, gwEnt.Key, id.DeviceID, serializedState)
 		if err != nil {
-			stateErrors[id] = errors.Wrap(err, "error setting enodeb state")
+			stateErrors[id] = fmt.Errorf("error setting enodeb state: %w", err)
 			continue
 		}
 		glog.V(2).Infof("successfully stored ENB state for eNB SN: %s, gatewayID: %s:w", id.DeviceID, gwEnt.Key)

--- a/lte/cloud/go/services/lte/servicers/protected/lookup.go
+++ b/lte/cloud/go/services/lte/servicers/protected/lookup.go
@@ -15,8 +15,8 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -62,7 +62,7 @@ func (l *lookupServicer) SetEnodebState(ctx context.Context, req *protos.SetEnod
 }
 
 func makeErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	code := codes.Internal
 	if err == merrors.ErrNotFound {
 		code = codes.NotFound

--- a/lte/cloud/go/services/lte/storage/enodeb_state_lookup.go
+++ b/lte/cloud/go/services/lte/storage/enodeb_state_lookup.go
@@ -15,9 +15,9 @@ package storage
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/lib/go/merrors"
@@ -66,7 +66,7 @@ func (l *enodebStateLookup) Initialize() error {
 			Unique(nidCol, gidCol, enbSnCol, enbStateCol).
 			RunWith(tx).
 			Exec()
-		return nil, errors.Wrap(err, "initialize enodeb state lookup table")
+		return nil, fmt.Errorf("initialize enodeb state lookup table: %w", err)
 	}
 	_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
 	return err
@@ -81,7 +81,7 @@ func (l *enodebStateLookup) GetEnodebState(networkID string, gatewayID string, e
 			RunWith(tx).
 			Query()
 		if err != nil {
-			return nil, errors.Wrapf(err, "select EnodebState for gatewayID, enodebSN %v, %v", gatewayID, enodebSN)
+			return nil, fmt.Errorf("select EnodebState for gatewayID, enodebSN %v, %v: %w", gatewayID, enodebSN, err)
 		}
 		defer sqorc.CloseRowsLogOnError(rows, "GetEnodebState")
 
@@ -89,14 +89,14 @@ func (l *enodebStateLookup) GetEnodebState(networkID string, gatewayID string, e
 		for rows.Next() {
 			err = rows.Scan(&serializedState)
 			if err != nil {
-				return nil, errors.Wrap(err, "select EnodebState for (gatewayID, enodebSN), SQL row scan error")
+				return nil, fmt.Errorf("select EnodebState for (gatewayID, enodebSN), SQL row scan error: %w", err)
 			}
 			// always return the first record as all cols are unique
 			break
 		}
 		err = rows.Err()
 		if err != nil {
-			return nil, errors.Wrap(err, "select EnodebState for (gatewayID, enodebSN), SQL rows error")
+			return nil, fmt.Errorf("select EnodebState for (gatewayID, enodebSN), SQL rows error: %w", err)
 		}
 		return serializedState, nil
 	}
@@ -127,7 +127,7 @@ func (l *enodebStateLookup) SetEnodebState(networkID string, gatewayID string, e
 			RunWith(sc).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrapf(err, "insert EnodbeState %+v", enodebState)
+			return nil, fmt.Errorf("insert EnodbeState %+v: %w", enodebState, err)
 		}
 		return nil, nil
 	}

--- a/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
@@ -14,13 +14,13 @@
 package handlers
 
 import (
+	"fmt"
 	"math/rand"
 	"net/http"
 	"time"
 
 	strfmt "github.com/go-openapi/strfmt"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/serdes"
@@ -75,7 +75,7 @@ func listNetworkProbeTasks(c echo.Context) error {
 		return echo.ErrNotFound
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load existing NetworkProbeTasks"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load existing NetworkProbeTasks: %w", err))
 	}
 
 	ret := make(map[string]*models.NetworkProbeTask, len(ents))
@@ -115,7 +115,7 @@ func getCreateNetworkProbeTaskHandlerFunc(storage storage.NProbeStorage) echo.Ha
 
 		taskID := string(payload.TaskID)
 		if err := storage.StoreNProbeData(networkID, taskID, data); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to store NetworkProbeData"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to store NetworkProbeData: %w", err))
 		}
 
 		_, err := configurator.CreateEntity(

--- a/lte/cloud/go/services/nprobe/storage/storage_blobstore.go
+++ b/lte/cloud/go/services/nprobe/storage/storage_blobstore.go
@@ -16,8 +16,6 @@ package storage
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"magma/lte/cloud/go/services/nprobe/obsidian/models"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
@@ -40,7 +38,7 @@ type nprobeBlobStore struct {
 func (c *nprobeBlobStore) StoreNProbeData(networkID, taskID string, data models.NetworkProbeData) error {
 	store, err := c.factory.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -51,7 +49,7 @@ func (c *nprobeBlobStore) StoreNProbeData(networkID, taskID string, data models.
 
 	err = store.Write(networkID, blobstore.Blobs{dataBlob})
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to store nprobe data  %s", taskID))
+		return fmt.Errorf(fmt.Sprintf("failed to store nprobe data  %s: %w", taskID), err)
 	}
 	return store.Commit()
 }
@@ -60,7 +58,7 @@ func (c *nprobeBlobStore) StoreNProbeData(networkID, taskID string, data models.
 func (c *nprobeBlobStore) GetNProbeData(networkID, taskID string) (*models.NetworkProbeData, error) {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start transaction")
+		return nil, fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -69,7 +67,7 @@ func (c *nprobeBlobStore) GetNProbeData(networkID, taskID string) (*models.Netwo
 		storage.TK{Type: NProbeBlobType, Key: taskID},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to get nprobe data %s", taskID))
+		return nil, fmt.Errorf(fmt.Sprintf("failed to get nprobe data %s: %w", taskID), err)
 	}
 
 	data, err := nprobeDataFromBlob(blob)
@@ -83,7 +81,7 @@ func (c *nprobeBlobStore) GetNProbeData(networkID, taskID string) (*models.Netwo
 func (c *nprobeBlobStore) DeleteNProbeData(networkID, taskID string) error {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -94,7 +92,7 @@ func (c *nprobeBlobStore) DeleteNProbeData(networkID, taskID string) error {
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to delete nprobe data %s", taskID))
+		return fmt.Errorf(fmt.Sprintf("failed to delete nprobe data %s: %w", taskID), err)
 	}
 	return store.Commit()
 }
@@ -102,7 +100,7 @@ func (c *nprobeBlobStore) DeleteNProbeData(networkID, taskID string) error {
 func nprobeDataToBlob(taskID string, data models.NetworkProbeData) (blobstore.Blob, error) {
 	marshaledData, err := data.MarshalBinary()
 	if err != nil {
-		return blobstore.Blob{}, errors.Wrap(err, "Error marshaling NetworkProbeData")
+		return blobstore.Blob{}, fmt.Errorf("Error marshaling NetworkProbeData: %w", err)
 	}
 	return blobstore.Blob{
 		Type:  NProbeBlobType,
@@ -115,7 +113,7 @@ func nprobeDataFromBlob(blob blobstore.Blob) (models.NetworkProbeData, error) {
 	data := models.NetworkProbeData{}
 	err := data.UnmarshalBinary(blob.Value)
 	if err != nil {
-		return models.NetworkProbeData{}, errors.Wrap(err, "Error unmarshaling NetworkProbeData")
+		return models.NetworkProbeData{}, fmt.Errorf("Error unmarshaling NetworkProbeData: %w", err)
 	}
 	return data, nil
 }

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
@@ -14,6 +14,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -108,7 +109,7 @@ func CreateBaseName(c echo.Context) error {
 		}
 	}
 	if err := configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to create base name"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to create base name: %w", err))
 	}
 
 	return c.JSON(http.StatusCreated, string(bnr.Name))
@@ -159,7 +160,7 @@ func UpdateBaseName(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to check if base name exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to check if base name exists: %w", err))
 	}
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -198,7 +199,7 @@ func UpdateBaseName(c echo.Context) error {
 	}
 
 	if err = configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to update base name"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update base name: %w", err))
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -296,7 +297,7 @@ func CreateRule(c echo.Context) error {
 	}
 
 	if err := configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to create policy"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to create policy: %w", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -351,7 +352,7 @@ func UpdateRule(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to check if policy exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to check if policy exists: %w", err))
 	}
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -398,7 +399,7 @@ func UpdateRule(c echo.Context) error {
 	}
 
 	if err = configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to update policy rule"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update policy rule: %w", err))
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
@@ -14,13 +14,13 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/serdes"

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
@@ -14,11 +14,11 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-openapi/swag"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/serdes"
@@ -122,7 +122,7 @@ func UpdateRatingGroup(c echo.Context) error {
 	// 404 if rating group doesn't exist
 	exists, err := configurator.DoesEntityExist(reqCtx, networkID, lte.RatingGroupEntityType, ratingGroupID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to check if rating group exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to check if rating group exists: %w", err))
 	}
 	if !exists {
 		return echo.ErrNotFound

--- a/lte/cloud/go/services/policydb/obsidian/models/validate.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/validate.go
@@ -15,9 +15,9 @@ package models
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/pkg/errors"
 )
 
 func (m BaseNames) ValidateModel(context.Context) error {

--- a/lte/cloud/go/services/smsd/servicers/southbound/smsd.go
+++ b/lte/cloud/go/services/smsd/servicers/southbound/smsd.go
@@ -15,10 +15,10 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -87,7 +87,7 @@ func (s *smsdServicer) ReportDelivery(ctx context.Context, request *lteProtos.Re
 
 	decoded, err := s.serde.DecodeDelivery(request.Report.NasMessageContainer)
 	if err != nil {
-		return ret, errors.Wrap(err, "failed to decode report")
+		return ret, fmt.Errorf("failed to decode report: %w", err)
 	}
 
 	delivered, failed := map[string][]storage.SMSRef{}, map[string][]storage.SMSFailureReport{}
@@ -102,7 +102,7 @@ func (s *smsdServicer) ReportDelivery(ctx context.Context, request *lteProtos.Re
 
 	err = s.store.ReportDelivery(networkID, delivered, failed)
 	if err != nil {
-		return ret, errors.Wrap(err, "failed to report delivery")
+		return ret, fmt.Errorf("failed to report delivery: %w", err)
 	}
 	return ret, nil
 }

--- a/lte/cloud/go/services/subscriberdb/digest.go
+++ b/lte/cloud/go/services/subscriberdb/digest.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	lte_protos "magma/lte/cloud/go/protos"
@@ -85,7 +84,7 @@ func GetPerSubscriberDigests(network string) ([]*orc8r_protos.LeafDigest, error)
 		for _, subProto := range subProtos {
 			digest, err := mproto.HashDeterministic(subProto)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to generate digest for subscriber %+v of network %+v", subProto.Sid.Id, network)
+				return nil, fmt.Errorf("Failed to generate digest for subscriber %+v of network %+v: %w", subProto.Sid.Id, network, err)
 			}
 			leafDigest := &orc8r_protos.LeafDigest{
 				Id:     lte_protos.SidString(subProto.Sid),

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -563,7 +563,7 @@ func validateSubscriberProfiles(ctx context.Context, networkID string, profiles 
 	errs := &multierror.Error{}
 	for _, p := range nonDefaultProfiles {
 		if _, ok := networkProfiles[p]; !ok {
-			errs = multierror.Append(errs, errors.Errorf("subscriber profile '%s' does not exist for the network", p))
+			errs = multierror.Append(errs, fmt.Errorf("subscriber profile '%s' does not exist for the network", p))
 		}
 	}
 	err = errs.ErrorOrNil()
@@ -694,7 +694,7 @@ func createSubscribers(ctx context.Context, networkID string, subs ...*subscribe
 
 	if len(uniqueIDs) != len(ids) {
 		duplicates := funk.FilterString(ids, func(s string) bool { return uniqueIDs[s] > 1 })
-		return echo.NewHTTPError(http.StatusBadRequest, errors.Errorf("found multiple subscriber models for IDs: %+v", duplicates))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("found multiple subscriber models for IDs: %+v", duplicates))
 	}
 
 	// TODO(hcgatewood) iterate over this to remove "too many placeholders" error
@@ -704,7 +704,7 @@ func createSubscribers(ctx context.Context, networkID string, subs ...*subscribe
 		return obsidian.MakeHTTPError(err, http.StatusInternalServerError)
 	}
 	if len(found) != 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, errors.Errorf("found %v existing subscribers which would have been overwritten: %+v", len(found), found.TKs()))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("found %v existing subscribers which would have been overwritten: %+v", len(found), found.TKs()))
 	}
 
 	_, err = configurator.CreateEntities(ctx, networkID, ents, serdes.Entity)

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -15,6 +15,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -24,7 +25,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/lte/cloud/go/lte"

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -467,7 +467,7 @@ func updateSubscriberProfile(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to update profile"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update profile: %w", err))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -618,7 +618,7 @@ func loadSubscribers(ctx context.Context, networkID string, includeSub subscribe
 	for _, key := range keys {
 		sub, err := loadSubscriber(ctx, networkID, key)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error loading subscriber %s", key)
+			return nil, fmt.Errorf("error loading subscriber %s: %w", key, err)
 		}
 		if includeSub(sub) {
 			subs[string(sub.ID)] = sub

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/validate.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/validate.go
@@ -15,10 +15,10 @@ package models
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/obsidian/models"
@@ -61,7 +61,7 @@ func (m *MutableSubscriber) ValidateModel(context.Context) error {
 	apnSet := funk.Map(m.ActiveApns, func(apn string) (string, bool) { return apn, true }).(map[string]bool)
 	for apn := range m.StaticIps {
 		if _, exists := apnSet[apn]; !exists {
-			return errors.Errorf("static IP assigned to APN %s which is not active for the subscriber", apn)
+			return fmt.Errorf("static IP assigned to APN %s which is not active for the subscriber", apn)
 		}
 	}
 	return nil

--- a/lte/cloud/go/services/subscriberdb/protos/validate.go
+++ b/lte/cloud/go/services/subscriberdb/protos/validate.go
@@ -14,6 +14,8 @@
 package protos
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 )
 
@@ -60,13 +62,13 @@ func (m *SetIPsRequest) Validate() error {
 	}
 	for _, mapping := range m.IpMappings {
 		if mapping.Ip == "" {
-			return errors.Errorf("ip cannot be empty in mapping %v", mapping)
+			return fmt.Errorf("ip cannot be empty in mapping %v", mapping)
 		}
 		if mapping.Imsi == "" {
-			return errors.Errorf("imsi cannot be empty in mapping %v", mapping)
+			return fmt.Errorf("imsi cannot be empty in mapping %v", mapping)
 		}
 		if mapping.Apn == "" {
-			return errors.Errorf("apn cannot be empty in mapping %v", mapping)
+			return fmt.Errorf("apn cannot be empty in mapping %v", mapping)
 		}
 	}
 	return nil

--- a/lte/cloud/go/services/subscriberdb/protos/validate.go
+++ b/lte/cloud/go/services/subscriberdb/protos/validate.go
@@ -14,9 +14,8 @@
 package protos
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 func (m *GetMSISDNsRequest) Validate() error {

--- a/lte/cloud/go/services/subscriberdb/servicers/protected/indexer_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/protected/indexer_servicer.go
@@ -15,9 +15,9 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -124,7 +124,7 @@ func setIPMappings(ctx context.Context, networkID string, states state_types.Sta
 
 	err := subscriberdb.SetIMSIsForIPs(ctx, networkID, ipMappings)
 	if err != nil {
-		return stateErrors, errors.Wrapf(err, "update directoryd mapping of session IDs to IMSIs %+v", ipMappings)
+		return stateErrors, fmt.Errorf("update directoryd mapping of session IDs to IMSIs %+v: %w", ipMappings, err)
 	}
 
 	return stateErrors, nil

--- a/lte/cloud/go/services/subscriberdb/servicers/protected/lookup.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/protected/lookup.go
@@ -15,8 +15,8 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -161,7 +161,7 @@ func (l *lookupServicer) SetIPs(ctx context.Context, req *protos.SetIPsRequest) 
 }
 
 func makeErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	code := codes.Internal
 	if err == merrors.ErrNotFound {
 		code = codes.NotFound

--- a/lte/cloud/go/services/subscriberdb/servicers/southbound/subscriberdb_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/southbound/subscriberdb_servicer.go
@@ -15,12 +15,12 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -128,7 +128,7 @@ func (s *subscriberdbServicer) Sync(
 	for _, subProto := range renewed {
 		anyVal, err := ptypes.MarshalAny(subProto)
 		if err != nil {
-			return nil, errors.Wrapf(err, "marshal subscriber protos for network %+v", networkID)
+			return nil, fmt.Errorf("marshal subscriber protos for network %+v: %w", networkID, err)
 		}
 		renewedMarshaled = append(renewedMarshaled, anyVal)
 	}
@@ -220,7 +220,7 @@ func (s *subscriberdbServicer) ListSuciProfiles(ctx context.Context, req *protos
 	var suciProtos []*lte_protos.SuciProfile
 	suciProtos, err := subscriberdb.LoadSuciProtos(ctx, networkID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading suciProfiles in network failed %s", networkID)
+		return nil, fmt.Errorf("loading suciProfiles in network failed %s: %w", networkID, err)
 	}
 
 	res := &lte_protos.SuciProfileList{
@@ -319,7 +319,7 @@ func loadAPNs(ctx context.Context, gateway *protos.Identity_Gateway) (map[string
 		serdes.Entity,
 	)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "load cellular gateway for gateway %s", gatewayID)
+		return nil, nil, fmt.Errorf("load cellular gateway for gateway %s: %w", gatewayID, err)
 	}
 
 	apnsByName, err := subscriberdb.LoadApnsByName(networkID)

--- a/lte/cloud/go/services/subscriberdb/state/extract.go
+++ b/lte/cloud/go/services/subscriberdb/state/extract.go
@@ -68,7 +68,7 @@ func GetAssignedIPAddress(mobilitydState state.ArbitraryJSON) (string, error) {
 func GetIMSIAndAPNFromMobilitydStateKey(key string) (string, string, error) {
 	matches := imsiAPNRegex.FindStringSubmatch(key)
 	if len(matches) != imsiAPNExpectedMatchCount {
-		return "", "", errors.Errorf("mobilityd state key %s did not match regex", key)
+		return "", "", fmt.Errorf("mobilityd state key %s did not match regex", key)
 	}
 	imsi, apn := matches[1], matches[2]
 	return imsi, apn, nil
@@ -80,7 +80,7 @@ func base64DecodeIPAddress(encodedIP string) (string, error) {
 		return "", fmt.Errorf("failed to decode mobilityd IP address: %w", err)
 	}
 	if len(ipBytes) != 4 {
-		return "", errors.Errorf("expected IP address to decode to 4 bytes, got %d", len(ipBytes))
+		return "", fmt.Errorf("expected IP address to decode to 4 bytes, got %d", len(ipBytes))
 	}
 	return net.IPv4(ipBytes[0], ipBytes[1], ipBytes[2], ipBytes[3]).String(), nil
 }

--- a/lte/cloud/go/services/subscriberdb/state/extract.go
+++ b/lte/cloud/go/services/subscriberdb/state/extract.go
@@ -15,6 +15,7 @@ package state
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net"
 	"regexp"
 
@@ -76,7 +77,7 @@ func GetIMSIAndAPNFromMobilitydStateKey(key string) (string, string, error) {
 func base64DecodeIPAddress(encodedIP string) (string, error) {
 	ipBytes, err := base64.StdEncoding.DecodeString(encodedIP)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to decode mobilityd IP address")
+		return "", fmt.Errorf("failed to decode mobilityd IP address: %w", err)
 	}
 	if len(ipBytes) != 4 {
 		return "", errors.Errorf("expected IP address to decode to 4 bytes, got %d", len(ipBytes))

--- a/lte/cloud/go/services/subscriberdb/state/extract.go
+++ b/lte/cloud/go/services/subscriberdb/state/extract.go
@@ -15,11 +15,10 @@ package state
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
-
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/state"
 )

--- a/lte/cloud/go/services/subscriberdb/storage/ip_lookup.go
+++ b/lte/cloud/go/services/subscriberdb/storage/ip_lookup.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 
 	"github.com/Masterminds/squirrel"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/services/subscriberdb/protos"
 	"magma/lte/cloud/go/services/subscriberdb/state"
@@ -66,7 +65,7 @@ func (l *ipLookup) Initialize() error {
 			Unique(ipLookupNidCol, ipLookupImsiCol).
 			RunWith(tx).
 			Exec()
-		return nil, errors.Wrap(err, "initialize IP lookup table")
+		return nil, fmt.Errorf("initialize IP lookup table: %w", err)
 	}
 	_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
 	return err
@@ -81,7 +80,7 @@ func (l *ipLookup) GetIPs(networkID string, ips []string) ([]*protos.IPMapping, 
 			RunWith(tx).
 			Query()
 		if err != nil {
-			return nil, errors.Wrapf(err, "select IMSIs for IPs %v", ips)
+			return nil, fmt.Errorf("select IMSIs for IPs %v: %w", ips, err)
 		}
 		defer sqorc.CloseRowsLogOnError(rows, "GetIPs")
 
@@ -91,7 +90,7 @@ func (l *ipLookup) GetIPs(networkID string, ips []string) ([]*protos.IPMapping, 
 			imsiVal := ""
 			err = rows.Scan(&m.Ip, &imsiVal)
 			if err != nil {
-				return nil, errors.Wrap(err, "select IMSIs for IPs, SQL row scan error")
+				return nil, fmt.Errorf("select IMSIs for IPs, SQL row scan error: %w", err)
 			}
 			m.Imsi, m.Apn, err = state.GetIMSIAndAPNFromMobilitydStateKey(imsiVal)
 			if err != nil {
@@ -101,7 +100,7 @@ func (l *ipLookup) GetIPs(networkID string, ips []string) ([]*protos.IPMapping, 
 		}
 		err = rows.Err()
 		if err != nil {
-			return nil, errors.Wrap(err, "select IMSIs for IPs, SQL rows error")
+			return nil, fmt.Errorf("select IMSIs for IPs, SQL rows error: %w", err)
 		}
 
 		sort.Slice(mappings, func(i, j int) bool { return mappings[i].String() < mappings[j].String() })
@@ -132,7 +131,7 @@ func (l *ipLookup) SetIPs(networkID string, mappings []*protos.IPMapping) error 
 				RunWith(sc).
 				Exec()
 			if err != nil {
-				return nil, errors.Wrapf(err, "insert IP mapping %+v", m)
+				return nil, fmt.Errorf("insert IP mapping %+v: %w", m, err)
 			}
 		}
 

--- a/lte/cloud/go/services/subscriberdb/streamer/providers.go
+++ b/lte/cloud/go/services/subscriberdb/streamer/providers.go
@@ -15,11 +15,11 @@ package streamer
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	lte_protos "magma/lte/cloud/go/protos"
@@ -38,7 +38,7 @@ type SubscribersProvider struct{}
 func (p *SubscribersProvider) GetUpdates(ctx context.Context, gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
 	magmadGateway, err := configurator.LoadEntityForPhysicalID(ctx, gatewayId, configurator.EntityLoadCriteria{LoadAssocsFromThis: true}, serdes.Entity)
 	if err != nil {
-		return nil, errors.Wrapf(err, "load magmad gateway for physical ID %s", gatewayId)
+		return nil, fmt.Errorf("load magmad gateway for physical ID %s: %w", gatewayId, err)
 	}
 	gateway, err := configurator.LoadEntity(
 		ctx,
@@ -47,7 +47,7 @@ func (p *SubscribersProvider) GetUpdates(ctx context.Context, gatewayId string, 
 		serdes.Entity,
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "load cellular gateway from magmad gateway %s", magmadGateway.Key)
+		return nil, fmt.Errorf("load cellular gateway from magmad gateway %s: %w", magmadGateway.Key, err)
 	}
 	subEnts, _, err := configurator.LoadAllEntitiesOfType(
 		ctx,
@@ -56,7 +56,7 @@ func (p *SubscribersProvider) GetUpdates(ctx context.Context, gatewayId string, 
 		serdes.Entity,
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "load all subscribers in network of gateway %s", gateway.Key)
+		return nil, fmt.Errorf("load all subscribers in network of gateway %s: %w", gateway.Key, err)
 	}
 	apnsByName, apnResourcesByAPN, err := loadAPNs(ctx, gateway)
 	if err != nil {

--- a/lte/cloud/go/services/subscriberdb_cache/config.go
+++ b/lte/cloud/go/services/subscriberdb_cache/config.go
@@ -14,8 +14,9 @@
 package subscriberdb_cache
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 )
 
 type Config struct {
@@ -28,10 +29,10 @@ type Config struct {
 func (config Config) Validate() error {
 	errs := &multierror.Error{}
 	if config.SleepIntervalSecs <= 0 {
-		errs = multierror.Append(errs, errors.Errorf("invalid worker sleep interval"))
+		errs = multierror.Append(errs, fmt.Errorf("invalid worker sleep interval"))
 	}
 	if config.UpdateIntervalSecs < 60 {
-		errs = multierror.Append(errs, errors.Errorf("worker update interval smaller than 1 minute"))
+		errs = multierror.Append(errs, fmt.Errorf("worker update interval smaller than 1 minute"))
 	}
 	return errs.ErrorOrNil()
 }

--- a/lte/cloud/go/tools/migrations/m006_subscribers/main.go
+++ b/lte/cloud/go/tools/migrations/m006_subscribers/main.go
@@ -17,13 +17,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -47,12 +47,12 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "error opening tx"))
+		log.Fatal(fmt.Errorf("error opening tx: %w", err))
 	}
 
 	defer func() {
@@ -91,13 +91,13 @@ func main() {
 		var conf []byte
 
 		if err = rows.Scan(&pk, &conf); err != nil {
-			err = errors.Wrap(err, "could not scan row")
+			err = fmt.Errorf("could not scan row: %w", err)
 			return
 		}
 
 		legacySub := &legacySubscriber{}
 		if err = json.Unmarshal(conf, legacySub); err != nil {
-			err = errors.Wrapf(err, "could not unmarshal subscriber config %s", pk)
+			err = fmt.Errorf("could not unmarshal subscriber config %s: %w", pk, err)
 			return
 		}
 		legacySubs[pk] = legacySub
@@ -109,7 +109,7 @@ func main() {
 			Where(squirrel.Eq{pkCol: pk}).
 			Exec()
 		if err != nil {
-			err = errors.Wrapf(err, "error updating subscriber %s", pk)
+			err = fmt.Errorf("error updating subscriber %s: %w", pk, err)
 			return
 		}
 	}

--- a/lte/cloud/go/tools/migrations/m007_na_cleanup/main.go
+++ b/lte/cloud/go/tools/migrations/m007_na_cleanup/main.go
@@ -24,7 +24,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -49,12 +48,12 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "error opening tx"))
+		log.Fatal(fmt.Errorf("error opening tx: %w", err))
 	}
 
 	defer func() {

--- a/lte/cloud/go/tools/migrations/m010_default_apns/main.go
+++ b/lte/cloud/go/tools/migrations/m010_default_apns/main.go
@@ -140,7 +140,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 	builder := sqorc.GetSqlBuilder()
 
@@ -189,7 +189,7 @@ func getNetworks(tx *sql.Tx, builder sqorc.StatementBuilder) ([]string, error) {
 		Where(squirrel.NotEq{nwIDCol: internalNetworkID}).
 		RunWith(tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "getNetworks: select networks")
+		return nil, fmt.Errorf("getNetworks: select networks: %w", err)
 	}
 
 	var networks []string
@@ -197,13 +197,13 @@ func getNetworks(tx *sql.Tx, builder sqorc.StatementBuilder) ([]string, error) {
 		var n string
 		err = rows.Scan(&n)
 		if err != nil {
-			return nil, errors.Wrap(err, "getNetworks: scan network ID")
+			return nil, fmt.Errorf("getNetworks: scan network ID: %w", err)
 		}
 		networks = append(networks, n)
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "getNetworks: SQL rows error")
+		return nil, fmt.Errorf("getNetworks: SQL rows error: %w", err)
 	}
 
 	return networks, nil
@@ -238,7 +238,7 @@ func createDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err = b.RunWith(tx).Exec()
 	if err != nil {
-		return ent{}, errors.Wrap(err, "createDefaultAPNIfNotExist: insert error")
+		return ent{}, fmt.Errorf("createDefaultAPNIfNotExist: insert error: %w", err)
 	}
 
 	newAPN := ent{pk: pk, typ: apnEntType, graphID: gid}
@@ -256,7 +256,7 @@ func getDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string) (
 		).
 		RunWith(tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "getDefaultAPN: select existing default APN")
+		return nil, fmt.Errorf("getDefaultAPN: select existing default APN: %w", err)
 	}
 
 	var apns []*ent
@@ -264,13 +264,13 @@ func getDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string) (
 		apn := &ent{}
 		err = rows.Scan(&apn.pk, &apn.graphID)
 		if err != nil {
-			return nil, errors.Wrap(err, "getDefaultAPN: scan APN")
+			return nil, fmt.Errorf("getDefaultAPN: scan APN: %w", err)
 		}
 		apns = append(apns, apn)
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "getDefaultAPN: SQL rows error")
+		return nil, fmt.Errorf("getDefaultAPN: SQL rows error: %w", err)
 	}
 
 	if len(apns) > 1 {
@@ -333,7 +333,7 @@ func getSubscribersMissingAPN(tx *sql.Tx, builder sqorc.StatementBuilder, networ
 		).
 		RunWith(tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "getSubscribersMissingAPN: select subscribers")
+		return nil, fmt.Errorf("getSubscribersMissingAPN: select subscribers: %w", err)
 	}
 
 	assocs := map[ent][]ent{}
@@ -342,13 +342,13 @@ func getSubscribersMissingAPN(tx *sql.Tx, builder sqorc.StatementBuilder, networ
 		pkB, typeB := &sql.NullString{}, &sql.NullString{}
 		err = rows.Scan(&a.graphID, &a.pk, pkB, typeB)
 		if err != nil {
-			return nil, errors.Wrap(err, "getSubscribersMissingAPN: scan subscriber")
+			return nil, fmt.Errorf("getSubscribersMissingAPN: scan subscriber: %w", err)
 		}
 		assocs[a] = append(assocs[a], ent{pk: pkB.String, typ: typeB.String})
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "getSubscribersMissingAPN: SQL rows error")
+		return nil, fmt.Errorf("getSubscribersMissingAPN: SQL rows error: %w", err)
 	}
 
 	var subsMissingAPN []ent
@@ -376,7 +376,7 @@ func mapSubscribersToAPN(tx *sql.Tx, builder sqorc.StatementBuilder, apnPK strin
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err := b.RunWith(tx).Exec()
 	if err != nil {
-		return errors.Wrap(err, "mapSubscribersToAPN: insert error")
+		return fmt.Errorf("mapSubscribersToAPN: insert error: %w", err)
 	}
 
 	return nil
@@ -394,7 +394,7 @@ func mergeGraphs(tx *sql.Tx, builder sqorc.StatementBuilder, gids []string) erro
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err := b.RunWith(tx).Exec()
 	if err != nil {
-		return errors.Wrap(err, "mergeGraphs: update error")
+		return fmt.Errorf("mergeGraphs: update error: %w", err)
 	}
 
 	return nil
@@ -496,7 +496,7 @@ func getSubscribersInDefaultAPNGraph(db *sql.DB, builder sqorc.StatementBuilder,
 			).
 			RunWith(tx).Query()
 		if err != nil {
-			return nil, errors.Wrap(err, "getSubscribersInDefaultAPNGraph: select subscribers")
+			return nil, fmt.Errorf("getSubscribersInDefaultAPNGraph: select subscribers: %w", err)
 		}
 
 		var subs []string
@@ -504,13 +504,13 @@ func getSubscribersInDefaultAPNGraph(db *sql.DB, builder sqorc.StatementBuilder,
 			key := ""
 			err = rows.Scan(&key)
 			if err != nil {
-				return nil, errors.Wrap(err, "getSubscribersInDefaultAPNGraph: scan subscriber PK")
+				return nil, fmt.Errorf("getSubscribersInDefaultAPNGraph: scan subscriber PK: %w", err)
 			}
 			subs = append(subs, key)
 		}
 		err = rows.Err()
 		if err != nil {
-			return nil, errors.Wrap(err, "getSubscribersInDefaultAPNGraph: SQL rows error")
+			return nil, fmt.Errorf("getSubscribersInDefaultAPNGraph: SQL rows error: %w", err)
 		}
 
 		return subs, nil

--- a/lte/cloud/go/tools/migrations/m010_default_apns/main.go
+++ b/lte/cloud/go/tools/migrations/m010_default_apns/main.go
@@ -57,6 +57,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"sort"
@@ -66,7 +67,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/lte/cloud/go/tools/migrations/m010_default_apns/types"

--- a/lte/cloud/go/tools/migrations/m011_subscriber_config/main.go
+++ b/lte/cloud/go/tools/migrations/m011_subscriber_config/main.go
@@ -16,10 +16,10 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -45,7 +45,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	_, err = migrations.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, doMigration)
@@ -66,7 +66,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 		Where(squirrel.Eq{typeCol: subscriberType}).
 		Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "error loading subscriber configs")
+		return nil, fmt.Errorf("error loading subscriber configs: %w", err)
 	}
 
 	newConfsByPk := map[string][]byte{}
@@ -75,7 +75,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 		var oldConf []byte
 
 		if err = rows.Scan(&pk, &oldConf); err != nil {
-			return nil, errors.Wrap(err, "error scanning subscriber row")
+			return nil, fmt.Errorf("error scanning subscriber row: %w", err)
 		}
 		shouldMigrate, err := shouldMigrateConf(oldConf)
 		if err != nil {
@@ -88,7 +88,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 		newConf := SubscriberConfig{Lte: oldConf}
 		newConfBytes, err := json.Marshal(newConf)
 		if err != nil {
-			return nil, errors.Wrap(err, "error marshalling new subscriber config")
+			return nil, fmt.Errorf("error marshaling new subscriber config: %w", err)
 		}
 		newConfsByPk[pk] = newConfBytes
 	}
@@ -100,7 +100,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 			Where(squirrel.Eq{pkCol: pk}).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrapf(err, "error updating subscriber %s", pk)
+			return nil, fmt.Errorf("error updating subscriber %s: %w", pk, err)
 		}
 	}
 	return nil, nil
@@ -112,7 +112,7 @@ func shouldMigrateConf(oldConf []byte) (bool, error) {
 	parsedMessage := map[string]interface{}{}
 	err := json.Unmarshal(oldConf, &parsedMessage)
 	if err != nil {
-		return false, errors.Wrap(err, "could not unmarshal legacy config")
+		return false, fmt.Errorf("could not unmarshal legacy config: %w", err)
 	}
 
 	_, alreadyMigrated := parsedMessage["lte"]

--- a/lte/cloud/go/tools/migrations/m012_policy_qos/main.go
+++ b/lte/cloud/go/tools/migrations/m012_policy_qos/main.go
@@ -37,6 +37,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"flag"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
@@ -100,7 +101,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	_, err = migrations.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, doMigration)
@@ -151,7 +152,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		Where(squirrel.Eq{entTypeCol: policyEntType}).
 		RunWith(tx).Query()
 	if err != nil {
-		return errors.Wrap(err, "get policy ents")
+		return fmt.Errorf("get policy ents: %w", err)
 	}
 	oldByKey := map[string]policyEnt{}
 	for rows.Next() {
@@ -160,17 +161,17 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		var confBytes []byte
 		err = rows.Scan(&old.pk, &key, &old.network, &old.gid, &confBytes)
 		if err != nil {
-			return errors.Wrap(err, "scan policy")
+			return fmt.Errorf("scan policy: %w", err)
 		}
 		err = json.Unmarshal(confBytes, &old.config)
 		if err != nil {
-			return errors.Wrap(err, "unmarshal existing policy rule config")
+			return fmt.Errorf("unmarshal existing policy rule config: %w", err)
 		}
 		oldByKey[key] = old
 	}
 	err = rows.Err()
 	if err != nil {
-		return errors.Wrap(err, "get existing assocs: SQL rows error")
+		return fmt.Errorf("get existing assocs: SQL rows error: %w", err)
 	}
 
 	// Convert policy configs to {new config, policy_qos_profile ent}
@@ -192,7 +193,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		}
 		newBytes, err := json.Marshal(newConf)
 		if err != nil {
-			return errors.Wrap(err, "marshal updated policy config")
+			return fmt.Errorf("marshal updated policy config: %w", err)
 		}
 		updateConfByKey[key] = newBytes
 
@@ -208,7 +209,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		}
 		profileBytes, err := json.Marshal(profileConf)
 		if err != nil {
-			return errors.Wrap(err, "marshal new policy_qos_profile config")
+			return fmt.Errorf("marshal new policy_qos_profile config: %w", err)
 		}
 		createProfileByKey[key] = profileBytes
 	}
@@ -228,7 +229,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bu.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error updating policy ent")
+			return fmt.Errorf("error updating policy ent: %w", err)
 		}
 
 		qosProfilePK := migrations.MakePK()
@@ -241,7 +242,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bi.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error inserting policy_qos_profile ent")
+			return fmt.Errorf("error inserting policy_qos_profile ent: %w", err)
 		}
 
 		bi = builder.
@@ -252,7 +253,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bi.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error inserting policy->policy_qos_profile assoc")
+			return fmt.Errorf("error inserting policy->policy_qos_profile assoc: %w", err)
 		}
 	}
 

--- a/lte/cloud/go/tools/migrations/m012_policy_qos/main.go
+++ b/lte/cloud/go/tools/migrations/m012_policy_qos/main.go
@@ -36,6 +36,7 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 
@@ -43,7 +44,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/tools/migrations/m012_policy_qos/types"
 	"magma/orc8r/cloud/go/sqorc"

--- a/lte/cloud/go/tools/migrations/m013_policy_ipv6/main.go
+++ b/lte/cloud/go/tools/migrations/m013_policy_ipv6/main.go
@@ -25,6 +25,7 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 
@@ -32,7 +33,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/tools/migrations/m013_policy_ipv6/types"
 	"magma/orc8r/cloud/go/sqorc"

--- a/lte/cloud/go/tools/migrations/m013_policy_ipv6/main.go
+++ b/lte/cloud/go/tools/migrations/m013_policy_ipv6/main.go
@@ -26,6 +26,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"flag"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
@@ -79,7 +80,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	_, err = migrations.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, doMigration)
@@ -117,7 +118,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		Where(squirrel.Eq{entTypeCol: policyEntType}).
 		RunWith(tx).Query()
 	if err != nil {
-		return errors.Wrap(err, "get policy ents")
+		return fmt.Errorf("get policy ents: %w", err)
 	}
 	oldByKey := map[string]policyEnt{}
 	for rows.Next() {
@@ -126,17 +127,17 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		var confBytes []byte
 		err = rows.Scan(&old.pk, &key, &confBytes)
 		if err != nil {
-			return errors.Wrap(err, "scan policy")
+			return fmt.Errorf("scan policy: %w", err)
 		}
 		err = json.Unmarshal(confBytes, &old.config)
 		if err != nil {
-			return errors.Wrap(err, "unmarshal existing policy rule config")
+			return fmt.Errorf("unmarshal existing policy rule config: %w", err)
 		}
 		oldByKey[key] = old
 	}
 	err = rows.Err()
 	if err != nil {
-		return errors.Wrap(err, "get existing assocs: SQL rows error")
+		return fmt.Errorf("get existing assocs: SQL rows error: %w", err)
 	}
 
 	// Convert policy configs to {new config}
@@ -175,7 +176,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 
 		newBytes, err := json.Marshal(newConf)
 		if err != nil {
-			return errors.Wrap(err, "marshal updated policy config")
+			return fmt.Errorf("marshal updated policy config: %w", err)
 		}
 		updateConfByKey[key] = newBytes
 	}
@@ -189,7 +190,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bu.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error updating policy ent")
+			return fmt.Errorf("error updating policy ent: %w", err)
 		}
 	}
 

--- a/lte/cloud/go/tools/migrations/m013_relay_split/main.go
+++ b/lte/cloud/go/tools/migrations/m013_relay_split/main.go
@@ -27,6 +27,7 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 
@@ -34,7 +35,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/tools/migrations/m013_relay_split/types"
 	"magma/orc8r/cloud/go/sqorc"

--- a/lte/cloud/go/tools/migrations/m013_relay_split/main.go
+++ b/lte/cloud/go/tools/migrations/m013_relay_split/main.go
@@ -28,6 +28,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"flag"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
@@ -73,7 +74,7 @@ func main() {
 
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	_, err = migrations.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, doMigration)
@@ -113,7 +114,7 @@ func migrateNetworkEpcConfigs(tx *sql.Tx, builder squirrel.StatementBuilderType)
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	rows, err := b.RunWith(tx).Query()
 	if err != nil {
-		return errors.Wrap(err, "get lte_network configs")
+		return fmt.Errorf("get lte_network configs: %w", err)
 	}
 	oldByNid := map[string]types.OldNetworkCellularConfigs{}
 	for rows.Next() {
@@ -121,18 +122,18 @@ func migrateNetworkEpcConfigs(tx *sql.Tx, builder squirrel.StatementBuilderType)
 		var confBytes []byte
 		err = rows.Scan(&nid, &confBytes)
 		if err != nil {
-			return errors.Wrap(err, "scan lte_network config")
+			return fmt.Errorf("scan lte_network config: %w", err)
 		}
 		old := types.OldNetworkCellularConfigs{}
 		err = json.Unmarshal(confBytes, &old)
 		if err != nil {
-			return errors.Wrap(err, "unmarshal existing lte_network config")
+			return fmt.Errorf("unmarshal existing lte_network config: %w", err)
 		}
 		oldByNid[nid] = old
 	}
 	err = rows.Err()
 	if err != nil {
-		return errors.Wrap(err, "get existing lte_network configs: SQL rows error")
+		return fmt.Errorf("get existing lte_network configs: SQL rows error: %w", err)
 	}
 
 	// Convert network configs to new versions
@@ -159,7 +160,7 @@ func migrateNetworkEpcConfigs(tx *sql.Tx, builder squirrel.StatementBuilderType)
 		}
 		newBytes, err := json.Marshal(newConf)
 		if err != nil {
-			return errors.Wrap(err, "marshal updated lte_network config")
+			return fmt.Errorf("marshal updated lte_network config: %w", err)
 		}
 		updateConfByNid[nid] = newBytes
 	}
@@ -174,7 +175,7 @@ func migrateNetworkEpcConfigs(tx *sql.Tx, builder squirrel.StatementBuilderType)
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bu.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error updating lte_network config")
+			return fmt.Errorf("error updating lte_network config: %w", err)
 		}
 	}
 

--- a/orc8r/cloud/go/blobstore/blobstore_sql.go
+++ b/orc8r/cloud/go/blobstore/blobstore_sql.go
@@ -16,12 +16,12 @@ package blobstore
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/sqorc"

--- a/orc8r/cloud/go/blobstore/blobstore_sql.go
+++ b/orc8r/cloud/go/blobstore/blobstore_sql.go
@@ -167,7 +167,7 @@ func (store *sqlStore) GetMany(networkID string, ids storage.TKs) (Blobs, error)
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 	return blobs, nil
 }
@@ -207,7 +207,7 @@ func (store *sqlStore) Search(filter SearchFilter, criteria LoadCriteria) (map[s
 		RunWith(store.tx).
 		Query()
 	if err != nil {
-		return ret, errors.Wrap(err, "failed to query DB")
+		return ret, fmt.Errorf("failed to query DB: %w", err)
 	}
 	defer sqorc.CloseRowsLogOnError(rows, "GetMany")
 
@@ -222,7 +222,7 @@ func (store *sqlStore) Search(filter SearchFilter, criteria LoadCriteria) (map[s
 
 		err = rows.Scan(scanArgs...)
 		if err != nil {
-			return ret, errors.Wrap(err, "failed to scan blob row")
+			return ret, fmt.Errorf("failed to scan blob row: %w", err)
 		}
 
 		nidCol := ret[nid]
@@ -231,7 +231,7 @@ func (store *sqlStore) Search(filter SearchFilter, criteria LoadCriteria) (map[s
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 	return ret, nil
 }
@@ -293,7 +293,7 @@ func (store *sqlStore) GetExistingKeys(keys []string, filter SearchFilter) ([]st
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 	return scannedKeys, nil
 }
@@ -330,7 +330,7 @@ func (store *sqlStore) IncrementVersion(networkID string, id storage.TK) error {
 		RunWith(store.tx).
 		Exec()
 	if err != nil {
-		return errors.Wrapf(err, "Error incrementing version on network %s with type %s and key %s", networkID, id.Type, id.Key)
+		return fmt.Errorf("Error incrementing version on network %s with type %s and key %s: %w", networkID, id.Type, id.Key, err)
 	}
 	return nil
 }
@@ -382,7 +382,7 @@ func (store *sqlStore) insertNewBlobs(networkID string, blobs Blobs) error {
 	}
 	_, err := insertBuilder.RunWith(store.tx).Exec()
 	if err != nil {
-		return errors.Wrap(err, "error creating blobs")
+		return fmt.Errorf("error creating blobs: %w", err)
 	}
 	return nil
 }

--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.9
 	github.com/olivere/elastic/v7 v7.0.6
 	github.com/ory/go-acc v0.2.8
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.17.0
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
@@ -134,6 +133,7 @@ require (
 	github.com/ory/viper v1.7.5 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/tsdb v0.10.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect

--- a/orc8r/cloud/go/obsidian/handler.go
+++ b/orc8r/cloud/go/obsidian/handler.go
@@ -15,13 +15,13 @@ package obsidian
 
 import (
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	"magma/orc8r/lib/go/util"

--- a/orc8r/cloud/go/obsidian/handler.go
+++ b/orc8r/cloud/go/obsidian/handler.go
@@ -202,7 +202,7 @@ func CheckNetworkAccess(c echo.Context, networkId string) *echo.HTTPError {
 
 	cert := getCert(c)
 	if cert == nil {
-		err := errors.Errorf("Client certificate with valid SANs is required for network: %s", networkId)
+		err := fmt.Errorf("Client certificate with valid SANs is required for network: %s", networkId)
 		return echo.NewHTTPError(http.StatusForbidden, err)
 	}
 

--- a/orc8r/cloud/go/obsidian/handler.go
+++ b/orc8r/cloud/go/obsidian/handler.go
@@ -328,7 +328,7 @@ func GetPaginationParams(c echo.Context) (uint64, string, error) {
 	}
 	pageSize, err := strconv.ParseUint(pageSizeStr, 10, 32)
 	if err != nil {
-		err := errors.Wrap(err, "invalid page size parameter")
+		err := fmt.Errorf("invalid page size parameter: %w", err)
 		return 0, pageToken, echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	return pageSize, pageToken, nil

--- a/orc8r/cloud/go/obsidian/swagger/handlers/handlers.go
+++ b/orc8r/cloud/go/obsidian/swagger/handlers/handlers.go
@@ -15,6 +15,7 @@ package handlers
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -23,7 +24,6 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/swagger"

--- a/orc8r/cloud/go/obsidian/swagger/handlers/handlers.go
+++ b/orc8r/cloud/go/obsidian/swagger/handlers/handlers.go
@@ -15,6 +15,7 @@ package handlers
 
 import (
 	"bytes"
+	"fmt"
 	"html/template"
 	"net/http"
 	"sort"
@@ -160,7 +161,7 @@ func registerSpecHandlers(e *echo.Echo, trailSlashMiddleware echo.MiddlewareFunc
 func registerUIHandlers(e *echo.Echo, trailSlashMiddleware echo.MiddlewareFunc) error {
 	tmpl, err := template.ParseFiles(obsidian.StaticFolder + "/swagger/v1/ui/index.html")
 	if err != nil {
-		return errors.Wrap(err, "retrieve Swagger template")
+		return fmt.Errorf("retrieve Swagger template: %w", err)
 	}
 
 	e.GET(obsidian.StaticURLPrefix+"/v1/ui/", GetUIHandler(tmpl))

--- a/orc8r/cloud/go/obsidian/swagger/poll.go
+++ b/orc8r/cloud/go/obsidian/swagger/poll.go
@@ -14,8 +14,9 @@
 package swagger
 
 import (
+	"fmt"
+
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian/swagger/spec"
 	"magma/orc8r/cloud/go/parallel"
@@ -41,7 +42,7 @@ func GetCombinedSpec(yamlCommon string) (string, error) {
 		if err != nil {
 			// Swallow error because the polling should continue
 			// even if it fails to receive from a single servicer
-			err = errors.Wrapf(err, "get Swagger spec from %s service", s.GetService())
+			err = fmt.Errorf("get Swagger spec from %s service: %w", s.GetService(), err)
 			glog.Error(err)
 		}
 		return yamlSpec, nil

--- a/orc8r/cloud/go/obsidian/swagger/spec/combine.go
+++ b/orc8r/cloud/go/obsidian/swagger/spec/combine.go
@@ -14,11 +14,11 @@
 package spec
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
 	"magma/orc8r/cloud/go/swagger"
@@ -178,7 +178,7 @@ func combineTags(common []swagger.TagDefinition, others [][]swagger.TagDefinitio
 func merge(a, b map[string]interface{}, fieldName string, errs error) {
 	for k, v := range b {
 		if _, ok := a[k]; ok {
-			errs = multierror.Append(errs, errors.Errorf("overwriting spec key '%s' in field '%s'", k, fieldName))
+			errs = multierror.Append(errs, fmt.Errorf("overwriting spec key '%s' in field '%s'", k, fieldName))
 		}
 		a[k] = v
 	}
@@ -188,7 +188,7 @@ func merge(a, b map[string]interface{}, fieldName string, errs error) {
 func mergeTags(a map[string]string, b []swagger.TagDefinition, errs error) {
 	for _, tag := range b {
 		if _, ok := a[tag.Name]; ok {
-			errs = multierror.Append(errs, errors.Errorf("overwriting tag '%s'", tag.Name))
+			errs = multierror.Append(errs, fmt.Errorf("overwriting tag '%s'", tag.Name))
 		}
 		a[tag.Name] = tag.Description
 	}

--- a/orc8r/cloud/go/parallel/map.go
+++ b/orc8r/cloud/go/parallel/map.go
@@ -14,8 +14,9 @@
 package parallel
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -46,7 +47,7 @@ func MapInToString(inputs []In, nWorkers int, f Func) ([]string, error) {
 	for _, s := range outsI {
 		ss, ok := s.(string)
 		if !ok {
-			return nil, errors.Errorf("could not convert returned item of type '%T' to string: '%+v'", s, s)
+			return nil, fmt.Errorf("could not convert returned item of type '%T' to string: '%+v'", s, s)
 		}
 		outs = append(outs, ss)
 	}

--- a/orc8r/cloud/go/serde/registry.go
+++ b/orc8r/cloud/go/serde/registry.go
@@ -15,8 +15,6 @@ package serde
 
 import (
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 // Registry provides a serde registry.
@@ -65,7 +63,7 @@ func (r registry) MustMerge(rr Registry) Registry {
 func (r registry) GetSerde(typ string) (Serde, error) {
 	serde, ok := r[typ]
 	if !ok {
-		return nil, errors.Errorf("no serde in registry for type %s", typ)
+		return nil, fmt.Errorf("no serde in registry for type %s", typ)
 	}
 	return serde, nil
 }

--- a/orc8r/cloud/go/serde/serde.go
+++ b/orc8r/cloud/go/serde/serde.go
@@ -16,9 +16,8 @@ package serde
 import (
 	"context"
 	"encoding"
+	"fmt"
 	"reflect"
-
-	"github.com/pkg/errors"
 )
 
 // Serde (SERializer-DEserializer) implements logic to serialize/deserialize
@@ -84,7 +83,7 @@ func (s *binarySerde) GetType() string {
 func (s *binarySerde) Serialize(in interface{}) ([]byte, error) {
 	bm, ok := in.(BinaryConvertible)
 	if !ok {
-		return nil, errors.Errorf("type %T structure does not implement BinaryConvertible", in)
+		return nil, fmt.Errorf("type %T structure does not implement BinaryConvertible", in)
 	}
 	return bm.MarshalBinary()
 }

--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -26,7 +27,6 @@ import (
 	"github.com/golang/glog"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	"magma/orc8r/cloud/go/orc8r"

--- a/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
+++ b/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
@@ -2,6 +2,7 @@ package calculations
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -39,7 +40,7 @@ func (x *LogsMetricCalculation) Calculate(prometheusClient query_api.PrometheusA
 	q := elasticQuery(x.Hours, x.LogConfig)
 	logCount, err := x.ElasticClient.Count().Index("").Query(q).Do(context.Background())
 	if err != nil {
-		err = errors.Wrapf(err, "Error %v querying elastic search for query %v", err, q)
+		err = fmt.Errorf("Error %v querying elastic search for query %v: %w", err, q, err)
 		return nil, err
 	}
 

--- a/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
+++ b/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
@@ -2,12 +2,12 @@ package calculations
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/olivere/elastic/v7"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/storage.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/storage.go
@@ -14,6 +14,8 @@ limitations under the License.
 package registration
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/blobstore"
@@ -150,7 +152,7 @@ func (b *blobstoreStore) isNonceUnique(store blobstore.Store, nonce string) (boo
 func tokenInfoToBlob(blobType bootstrapper.BlobType, key string, tokenInfo *protos.TokenInfo) (blobstore.Blob, error) {
 	marshaledTokenInfo, err := protos.Marshal(tokenInfo)
 	if err != nil {
-		return blobstore.Blob{}, errors.Wrap(err, "Error marshaling protobuf")
+		return blobstore.Blob{}, fmt.Errorf("Error marshaling protobuf: %w", err)
 	}
 	blob := blobstore.Blob{
 		Type:  string(blobType),
@@ -164,7 +166,7 @@ func tokenInfoFromBlob(blob blobstore.Blob) (*protos.TokenInfo, error) {
 	tokenInfo := protos.TokenInfo{}
 	err := protos.Unmarshal(blob.Value, &tokenInfo)
 	if err != nil {
-		return &protos.TokenInfo{}, errors.Wrap(err, "Error unmarshaling protobuf")
+		return &protos.TokenInfo{}, fmt.Errorf("Error unmarshaling protobuf: %w", err)
 	}
 	return &tokenInfo, nil
 }

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/storage.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/storage.go
@@ -16,8 +16,6 @@ package registration
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/services/bootstrapper"
 	"magma/orc8r/cloud/go/storage"
@@ -56,7 +54,7 @@ func (b *blobstoreStore) SetTokenInfo(tokenInfo *protos.TokenInfo) error {
 		return err
 	}
 	if !isUnique {
-		return errors.Errorf("token is not unique")
+		return fmt.Errorf("token is not unique")
 	}
 
 	// Write to 2 blobstores so that we can key for tokenInfo with both the logicalID and the nonce

--- a/orc8r/cloud/go/services/bootstrapper/servicers/southbound/bootstrapper.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/southbound/bootstrapper.go
@@ -231,7 +231,7 @@ func generateRandomText(length int) ([]byte, error) {
 
 // verify response with echo "encryption" method
 func verifyEcho(resp *protos.Response) error {
-	response := resp.GetEchoResponse() //.Response
+	response := resp.GetEchoResponse() // .Response
 	if response == nil {
 		return fmt.Errorf("Wrong type of response, expected Echo")
 	}
@@ -256,7 +256,7 @@ func verifySoftwareRSASHA256(resp *protos.Response, key []byte) error {
 	hashed := sha256.Sum256(resp.Challenge)
 	err = rsa.VerifyPKCS1v15(publicKey.(*rsa.PublicKey), crypto.SHA256, hashed[:], response.Signature)
 	if err != nil {
-		return errors.Wrap(err, signedChallengeMismatch)
+		return fmt.Errorf(signedChallengeMismatch+": %w", err)
 	}
 
 	return nil

--- a/orc8r/cloud/go/services/bootstrapper/servicers/southbound/bootstrapper.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/southbound/bootstrapper.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -74,7 +73,7 @@ type BootstrapperServer struct {
 func NewBootstrapperServer(privKey *rsa.PrivateKey) (*BootstrapperServer, error) {
 	srv := &BootstrapperServer{}
 	if privKey.N.BitLen() < MinKeyLength {
-		return nil, errorLogger(errors.Errorf("private key is too short: actual len (%d) is less than minimum len (%d)", privKey.N.BitLen(), MinKeyLength))
+		return nil, errorLogger(fmt.Errorf("private key is too short: actual len (%d) is less than minimum len (%d)", privKey.N.BitLen(), MinKeyLength))
 	}
 	srv.privKey = privKey
 	return srv, nil

--- a/orc8r/cloud/go/services/certifier/analytics/calculations/lifespan.go
+++ b/orc8r/cloud/go/services/certifier/analytics/calculations/lifespan.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"magma/orc8r/cloud/go/services/analytics/calculations"
@@ -75,7 +74,7 @@ func calculateCertLifespanHours(certsDirectory string, certName string, metricCo
 	}
 	cert, err := x509.ParseCertificate(dat)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to parse x509 certificate data for %s", certName))
+		return nil, fmt.Errorf(fmt.Sprintf("failed to parse x509 certificate data for %s: %w", certName), err)
 	}
 	// Hours remaining
 	hoursLeft := math.Floor(time.Until(cert.NotAfter).Hours())
@@ -99,7 +98,7 @@ func calculateCertLifespanHours(certsDirectory string, certName string, metricCo
 func getCert(certPath string) ([]byte, error) {
 	dat, err := ioutil.ReadFile(certPath)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to read cert file %s", certPath))
+		return nil, fmt.Errorf(fmt.Sprintf("failed to read cert file %s: %w", certPath), err)
 	}
 	if strings.HasSuffix(certPath, ".pem") || strings.HasSuffix(certPath, ".crt") {
 		block, _ := pem.Decode(dat)

--- a/orc8r/cloud/go/services/certifier/protos/helpers.go
+++ b/orc8r/cloud/go/services/certifier/protos/helpers.go
@@ -1,10 +1,10 @@
 package protos
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/services/certifier/obsidian/models"
@@ -111,7 +111,7 @@ func convertTenantResourceIDs(ids []string) ([]int64, error) {
 	for _, i := range ids {
 		j, err := strconv.ParseInt(i, 10, 64)
 		if err != nil {
-			return []int64{}, errors.Wrapf(err, "failed to convert tenant IDs to integers")
+			return []int64{}, fmt.Errorf("failed to convert tenant IDs to integers: %w", err)
 		}
 		intIDs = append(intIDs, j)
 	}

--- a/orc8r/cloud/go/services/certifier/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/certifier/storage/storage_blobstore.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -49,13 +48,13 @@ func NewCertifierBlobstore(factory blobstore.StoreFactory) CertifierStorage {
 func (c *certifierBlobstore) ListSerialNumbers() ([]string, error) {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start transaction")
+		return nil, fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
 	serialNumbers, err := blobstore.ListKeys(store, placeholderNetworkID, constants.CertInfoType)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list keys")
+		return nil, fmt.Errorf("failed to list keys: %w", err)
 	}
 
 	return serialNumbers, store.Commit()
@@ -75,14 +74,14 @@ func (c *certifierBlobstore) GetCertInfo(serialNumber string) (*protos.Certifica
 func (c *certifierBlobstore) GetManyCertInfo(serialNumbers []string) (map[string]*protos.CertificateInfo, error) {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start transaction")
+		return nil, fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
 	tks := storage.MakeTKs(constants.CertInfoType, serialNumbers)
 	blobs, err := store.GetMany(placeholderNetworkID, tks)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get many certificate info")
+		return nil, fmt.Errorf("failed to get many certificate info: %w", err)
 	}
 
 	ret := make(map[string]*protos.CertificateInfo)
@@ -90,7 +89,7 @@ func (c *certifierBlobstore) GetManyCertInfo(serialNumbers []string) (map[string
 		info := &protos.CertificateInfo{}
 		err = proto.Unmarshal(blob.Value, info)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal cert info")
+			return nil, fmt.Errorf("failed to unmarshal cert info: %w", err)
 		}
 		ret[blob.Key] = info
 	}
@@ -103,13 +102,13 @@ func (c *certifierBlobstore) GetAllCertInfo() (map[string]*protos.CertificateInf
 
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start transaction")
+		return nil, fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
 	serialNumbers, err := blobstore.ListKeys(store, placeholderNetworkID, constants.CertInfoType)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list keys")
+		return nil, fmt.Errorf("failed to list keys: %w", err)
 	}
 
 	if len(serialNumbers) == 0 {
@@ -119,14 +118,14 @@ func (c *certifierBlobstore) GetAllCertInfo() (map[string]*protos.CertificateInf
 	tks := storage.MakeTKs(constants.CertInfoType, serialNumbers)
 	blobs, err := store.GetMany(placeholderNetworkID, tks)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get many certificate info")
+		return nil, fmt.Errorf("failed to get many certificate info: %w", err)
 	}
 
 	for _, blob := range blobs {
 		info := &protos.CertificateInfo{}
 		err = proto.Unmarshal(blob.Value, info)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal cert info")
+			return nil, fmt.Errorf("failed to unmarshal cert info: %w", err)
 		}
 		infos[blob.Key] = info
 	}
@@ -137,19 +136,19 @@ func (c *certifierBlobstore) GetAllCertInfo() (map[string]*protos.CertificateInf
 func (c *certifierBlobstore) PutCertInfo(serialNumber string, certInfo *protos.CertificateInfo) error {
 	store, err := c.factory.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
 	marshaledCertInfo, err := proto.Marshal(certInfo)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal cert info")
+		return fmt.Errorf("failed to marshal cert info: %w", err)
 	}
 
 	blob := blobstore.Blob{Type: constants.CertInfoType, Key: serialNumber, Value: marshaledCertInfo}
 	err = store.Write(placeholderNetworkID, blobstore.Blobs{blob})
 	if err != nil {
-		return errors.Wrap(err, "failed to put certificate info")
+		return fmt.Errorf("failed to put certificate info: %w", err)
 	}
 
 	return store.Commit()
@@ -158,14 +157,14 @@ func (c *certifierBlobstore) PutCertInfo(serialNumber string, certInfo *protos.C
 func (c *certifierBlobstore) DeleteCertInfo(serialNumber string) error {
 	store, err := c.factory.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
 	tk := storage.TK{Type: constants.CertInfoType, Key: serialNumber}
 	err = store.Delete(placeholderNetworkID, storage.TKs{tk})
 	if err != nil {
-		return errors.Wrap(err, "failed to delete certificate info")
+		return fmt.Errorf("failed to delete certificate info: %w", err)
 	}
 
 	return store.Commit()
@@ -174,13 +173,13 @@ func (c *certifierBlobstore) DeleteCertInfo(serialNumber string) error {
 func (c *certifierBlobstore) ListUser() ([]string, error) {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start transaction")
+		return nil, fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
 	users, err := blobstore.ListKeys(store, placeholderNetworkID, constants.UserType)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list keys")
+		return nil, fmt.Errorf("failed to list keys: %w", err)
 	}
 
 	return users, store.Commit()
@@ -217,7 +216,7 @@ func (c *certifierBlobstore) PutUser(username string, user *protos.User) error {
 
 	err = store.Write(placeholderNetworkID, blobstore.Blobs{userBlob})
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to update password for user %s", username))
+		return fmt.Errorf(fmt.Sprintf("failed to update password for user %s: %w", username), err)
 	}
 
 	return store.Commit()
@@ -273,7 +272,7 @@ func (c *certifierBlobstore) PutPolicy(token string, policy *protos.PolicyList) 
 
 	err = store.Write(placeholderNetworkID, blobstore.Blobs{policyBlob})
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to create or update policy for token %s", token))
+		return fmt.Errorf(fmt.Sprintf("failed to create or update policy for token %s: %w", token), err)
 	}
 
 	return store.Commit()
@@ -288,14 +287,14 @@ func (c *certifierBlobstore) ListUsers() ([]*protos.User, error) {
 	defer store.Rollback()
 	blobs, err := blobstore.GetAllOfType(store, placeholderNetworkID, constants.UserType)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get all users")
+		return nil, fmt.Errorf("failed to get all users: %w", err)
 	}
 	users := make([]*protos.User, len(blobs))
 	for i, blob := range blobs {
 		user := &protos.User{}
 		err = proto.Unmarshal(blob.Value, user)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal user")
+			return nil, fmt.Errorf("failed to unmarshal user: %w", err)
 		}
 		users[i] = user
 	}

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/serde"
@@ -281,7 +280,7 @@ func WriteEntities(ctx context.Context, networkID string, writes []EntityWriteOp
 			}
 			req.Writes = append(req.Writes, &protos.WriteEntityRequest{Request: &protos.WriteEntityRequest_Update{Update: protoEuc}})
 		default:
-			return errors.Errorf("unrecognized entity write operation %T", op)
+			return fmt.Errorf("unrecognized entity write operation %T", op)
 		}
 	}
 
@@ -510,7 +509,7 @@ func LoadEntityForPhysicalID(ctx context.Context, physicalID string, criteria En
 		return ret, merrors.ErrNotFound
 	}
 	if len(loaded) > 1 {
-		return ret, errors.Errorf("expected one entity from query, found %d", len(loaded))
+		return ret, fmt.Errorf("expected one entity from query, found %d", len(loaded))
 	}
 	return loaded[0], nil
 }

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -15,6 +15,7 @@ package configurator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -525,7 +526,7 @@ func LoadEntities(ctx context.Context, networkID string, typeFilter *string, key
 	}
 	ret, err := (NetworkEntities{}).fromProtos(protoEnts, serdes)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "request succeeded but deserialization failed")
+		return nil, nil, fmt.Errorf("request succeeded but deserialization failed: %w", err)
 	}
 	return ret, entIDsToTKs(notFound), nil
 }
@@ -682,7 +683,7 @@ func LoadAllEntitiesOfType(ctx context.Context, networkID string, entityType str
 
 	ret, err := (NetworkEntities{}).fromProtos(res.Entities, serdes)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "request succeeded but deserialization failed")
+		return nil, "", fmt.Errorf("request succeeded but deserialization failed: %w", err)
 	}
 
 	return ret, res.NextPageToken, nil

--- a/orc8r/cloud/go/services/configurator/graph.go
+++ b/orc8r/cloud/go/services/configurator/graph.go
@@ -14,7 +14,7 @@
 package configurator
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"magma/orc8r/cloud/go/storage"
 	"magma/orc8r/lib/go/merrors"
@@ -53,7 +53,7 @@ func (eg *EntityGraph) GetFirstAncestorOfType(start NetworkEntity, targetType st
 
 	start, found := eg.entsByTK[start.GetTK()]
 	if !found {
-		return NetworkEntity{}, errors.Errorf("entity %s is not in graph", start.GetTK())
+		return NetworkEntity{}, fmt.Errorf("entity %s is not in graph", start.GetTK())
 	}
 
 	ancestor := eg.upwardsDFSForType(start.GetTK(), targetType, map[storage.TK]bool{})
@@ -68,7 +68,7 @@ func (eg *EntityGraph) GetAllChildrenOfType(parent NetworkEntity, targetType str
 
 	start, found := eg.entsByTK[parent.GetTK()]
 	if !found {
-		return nil, errors.Errorf("entity %s is not in graph", start.GetTK())
+		return nil, fmt.Errorf("entity %s is not in graph", start.GetTK())
 	}
 
 	ret := []NetworkEntity{}

--- a/orc8r/cloud/go/services/configurator/mconfig/build.go
+++ b/orc8r/cloud/go/services/configurator/mconfig/build.go
@@ -20,7 +20,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/configurator/storage"
 	"magma/orc8r/lib/go/protos"
@@ -40,7 +39,7 @@ func CreateMconfigJSON(network *storage.Network, graph *storage.EntityGraph, gat
 	for _, b := range builders {
 		partialConfig, err := b.Build(network, graph, gatewayID)
 		if err != nil {
-			return nil, errors.Wrapf(err, "mconfig builder %+v error", b)
+			return nil, fmt.Errorf("mconfig builder %+v error: %w", b, err)
 		}
 		for key, config := range partialConfig {
 			_, ok := configs[key]

--- a/orc8r/cloud/go/services/configurator/mconfig/marshal.go
+++ b/orc8r/cloud/go/services/configurator/mconfig/marshal.go
@@ -19,7 +19,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/lib/go/protos"
 )
@@ -29,7 +28,7 @@ func MarshalConfigs(configs map[string]proto.Message) (ConfigsByKey, error) {
 	for k, v := range configs {
 		anyVal, err := ptypes.MarshalAny(v)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 		bytesVal, err := protos.MarshalJSON(anyVal)
 		if err != nil {

--- a/orc8r/cloud/go/services/configurator/mconfig/marshal.go
+++ b/orc8r/cloud/go/services/configurator/mconfig/marshal.go
@@ -14,6 +14,8 @@
 package mconfig
 
 import (
+	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
@@ -44,15 +46,15 @@ func UnmarshalConfigs(configs ConfigsByKey) (map[string]proto.Message, error) {
 		anyVal := &any.Any{}
 		err := protos.Unmarshal(v, anyVal)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unmarshal mconfig from bytes to proto for key %s and bytes %v", k, v)
+			return nil, fmt.Errorf("unmarshal mconfig from bytes to proto for key %s and bytes %v: %w", k, v, err)
 		}
 		msgVal, err := ptypes.Empty(anyVal)
 		if err != nil {
-			return nil, errors.Wrapf(err, "create concrete proto.Message, for proto.Any %+v", anyVal)
+			return nil, fmt.Errorf("create concrete proto.Message, for proto.Any %+v: %w", anyVal, err)
 		}
 		err = ptypes.UnmarshalAny(anyVal, msgVal)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unmarshal proto.Any into proto.Message, for proto.Any %+v", anyVal)
+			return nil, fmt.Errorf("unmarshal proto.Any into proto.Message, for proto.Any %+v: %w", anyVal, err)
 		}
 		ret[k] = msgVal
 	}

--- a/orc8r/cloud/go/services/configurator/storage/sql.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql.go
@@ -482,7 +482,7 @@ func (store *sqlConfiguratorStorage) CreateEntity(networkID string, entity *Netw
 		return &NetworkEntity{}, err
 	}
 	if exists {
-		return &NetworkEntity{}, errors.Errorf("an entity '%s' already exists", entityCopy.GetTK())
+		return &NetworkEntity{}, fmt.Errorf("an entity '%s' already exists", entityCopy.GetTK())
 	}
 
 	// Physical ID must be unique across all networks, since we use a gateway's
@@ -492,7 +492,7 @@ func (store *sqlConfiguratorStorage) CreateEntity(networkID string, entity *Netw
 		return &NetworkEntity{}, err
 	}
 	if physicalIDExists {
-		return &NetworkEntity{}, errors.Errorf("an entity with physical ID '%s' already exists", entityCopy.GetPhysicalID())
+		return &NetworkEntity{}, fmt.Errorf("an entity with physical ID '%s' already exists", entityCopy.GetPhysicalID())
 	}
 
 	// First insert the associations as graph edges. This step involves a
@@ -598,7 +598,7 @@ func (store *sqlConfiguratorStorage) LoadGraphForEntity(networkID string, entity
 		ent = e
 	}
 	if ent == nil {
-		return &EntityGraph{}, errors.Errorf("could not find requested entity (%s) for graph query", entityIDCopy.String())
+		return &EntityGraph{}, fmt.Errorf("could not find requested entity (%s) for graph query", entityIDCopy.String())
 	}
 
 	internalGraph, err := store.loadGraphInternal(networkID, ent.GraphID, loadCriteriaCopy)
@@ -608,7 +608,7 @@ func (store *sqlConfiguratorStorage) LoadGraphForEntity(networkID string, entity
 
 	rootPKs := findRootNodes(internalGraph)
 	if funk.IsEmpty(rootPKs) {
-		return &EntityGraph{}, errors.Errorf("graph does not have root nodes")
+		return &EntityGraph{}, fmt.Errorf("graph does not have root nodes")
 	}
 
 	edges, err := updateEntitiesWithAssocs(internalGraph.entsByTK, internalGraph.edges)

--- a/orc8r/cloud/go/services/configurator/storage/sql.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql.go
@@ -108,7 +108,7 @@ func (fact *sqlConfiguratorStorageFactory) InitializeServiceStorage() (err error
 		RunWith(tx).
 		Exec()
 	if err != nil {
-		err = errors.Wrap(err, "failed to create networks table")
+		err = fmt.Errorf("failed to create networks table: %w", err)
 		return
 	}
 
@@ -119,7 +119,7 @@ func (fact *sqlConfiguratorStorageFactory) InitializeServiceStorage() (err error
 	// special case sqlite3 because ADD COLUMN IF NOT EXISTS is not supported
 	// and we only run sqlite3 for unit tests
 	if err != nil && os.Getenv("SQL_DRIVER") != "sqlite3" {
-		err = errors.Wrap(err, "failed to add 'type' field to networks table")
+		err = fmt.Errorf("failed to add 'type' field to networks table: %w", err)
 	}
 
 	_, err = fact.builder.CreateIndex("type_idx").
@@ -129,7 +129,7 @@ func (fact *sqlConfiguratorStorageFactory) InitializeServiceStorage() (err error
 		RunWith(tx).
 		Exec()
 	if err != nil {
-		err = errors.Wrap(err, "failed to create network type index")
+		err = fmt.Errorf("failed to create network type index: %w", err)
 		return
 	}
 
@@ -143,7 +143,7 @@ func (fact *sqlConfiguratorStorageFactory) InitializeServiceStorage() (err error
 		RunWith(tx).
 		Exec()
 	if err != nil {
-		err = errors.Wrap(err, "failed to create network configs table")
+		err = fmt.Errorf("failed to create network configs table: %w", err)
 		return
 	}
 
@@ -167,7 +167,7 @@ func (fact *sqlConfiguratorStorageFactory) InitializeServiceStorage() (err error
 		RunWith(tx).
 		Exec()
 	if err != nil {
-		err = errors.Wrap(err, "failed to create entities table")
+		err = fmt.Errorf("failed to create entities table: %w", err)
 		return
 	}
 
@@ -181,7 +181,7 @@ func (fact *sqlConfiguratorStorageFactory) InitializeServiceStorage() (err error
 		RunWith(tx).
 		Exec()
 	if err != nil {
-		err = errors.Wrap(err, "failed to create entity assoc table")
+		err = fmt.Errorf("failed to create entity assoc table: %w", err)
 		return
 	}
 
@@ -193,7 +193,7 @@ func (fact *sqlConfiguratorStorageFactory) InitializeServiceStorage() (err error
 		RunWith(tx).
 		Exec()
 	if err != nil {
-		err = errors.Wrap(err, "failed to create graph ID index")
+		err = fmt.Errorf("failed to create graph ID index: %w", err)
 		return
 	}
 
@@ -205,7 +205,7 @@ func (fact *sqlConfiguratorStorageFactory) InitializeServiceStorage() (err error
 		RunWith(tx).
 		Exec()
 	if err != nil {
-		err = errors.Wrap(err, "error creating internal networks")
+		err = fmt.Errorf("error creating internal networks: %w", err)
 		return
 	}
 
@@ -352,7 +352,7 @@ func (store *sqlConfiguratorStorage) CreateNetwork(network *Network) (*Network, 
 	}
 	_, err = insertBuilder.RunWith(store.tx).Exec()
 	if err != nil {
-		return &Network{}, errors.Wrap(err, "error inserting network configs")
+		return &Network{}, fmt.Errorf("error inserting network configs: %w", err)
 	}
 
 	return networkCopy, nil
@@ -388,13 +388,13 @@ func (store *sqlConfiguratorStorage) UpdateNetworks(updates []*NetworkUpdateCrit
 		RunWith(store.tx).
 		Exec()
 	if err != nil {
-		return errors.Wrap(err, "failed to delete configs associated with networks")
+		return fmt.Errorf("failed to delete configs associated with networks: %w", err)
 	}
 	_, err = store.builder.Delete(networksTable).Where(sq.Eq{nwIDCol: networksToDelete}).
 		RunWith(store.tx).
 		Exec()
 	if err != nil {
-		return errors.Wrap(err, "failed to delete networks")
+		return fmt.Errorf("failed to delete networks: %w", err)
 	}
 	return nil
 }
@@ -538,7 +538,7 @@ func (store *sqlConfiguratorStorage) UpdateEntity(networkID string, update *Enti
 	emptyRet := &NetworkEntity{Type: update.Type, Key: update.Key}
 	entToUpdate, err := store.loadEntToUpdate(networkID, updateCopy)
 	if err != nil && !updateCopy.DeleteEntity {
-		return emptyRet, errors.Wrap(err, "failed to load entity being updated")
+		return emptyRet, fmt.Errorf("failed to load entity being updated: %w", err)
 	}
 	if entToUpdate == nil {
 		return emptyRet, nil
@@ -555,13 +555,13 @@ func (store *sqlConfiguratorStorage) UpdateEntity(networkID string, update *Enti
 			RunWith(store.tx).
 			Exec()
 		if err != nil {
-			return emptyRet, errors.Wrapf(err, "failed to delete entity (%s, %s)", updateCopy.Type, updateCopy.Key)
+			return emptyRet, fmt.Errorf("failed to delete entity (%s, %s): %w", updateCopy.Type, updateCopy.Key, err)
 		}
 
 		// Deleting a node could partition its graph
 		err = store.fixGraph(networkID, entToUpdate.GraphID, entToUpdate)
 		if err != nil {
-			return emptyRet, errors.Wrap(err, "failed to fix entity graph after deletion")
+			return emptyRet, fmt.Errorf("failed to fix entity graph after deletion: %w", err)
 		}
 
 		return emptyRet, nil
@@ -590,7 +590,7 @@ func (store *sqlConfiguratorStorage) LoadGraphForEntity(networkID string, entity
 	// load criteria
 	singleEnt, err := store.loadEntities(networkID, &EntityLoadFilter{IDs: []*EntityID{entityIDCopy}}, &EntityLoadCriteria{})
 	if err != nil {
-		return &EntityGraph{}, errors.Wrap(err, "failed to load entity for graph query")
+		return &EntityGraph{}, fmt.Errorf("failed to load entity for graph query: %w", err)
 	}
 
 	var ent *NetworkEntity
@@ -613,7 +613,7 @@ func (store *sqlConfiguratorStorage) LoadGraphForEntity(networkID string, entity
 
 	edges, err := updateEntitiesWithAssocs(internalGraph.entsByTK, internalGraph.edges)
 	if err != nil {
-		return &EntityGraph{}, errors.Wrap(err, "failed to construct graph after loading")
+		return &EntityGraph{}, fmt.Errorf("failed to construct graph after loading: %w", err)
 	}
 
 	// To make testing easier, we'll order the returned entities by TK

--- a/orc8r/cloud/go/services/configurator/storage/sql.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 	"google.golang.org/protobuf/proto"
 
@@ -380,7 +379,7 @@ func (store *sqlConfiguratorStorage) UpdateNetworks(updates []*NetworkUpdateCrit
 	for _, update := range networksToUpdate {
 		err := store.updateNetwork(update, stmtCache)
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 	}
 
@@ -571,13 +570,13 @@ func (store *sqlConfiguratorStorage) UpdateEntity(networkID string, update *Enti
 	entToUpdate.NetworkID = networkID
 	err = store.processEntityFieldsUpdate(entToUpdate.Pk, updateCopy, entToUpdate)
 	if err != nil {
-		return entToUpdate, errors.WithStack(err)
+		return entToUpdate, err
 	}
 
 	// Finally, process edge updates for the graph
 	err = store.processEdgeUpdates(networkID, updateCopy, entToUpdate)
 	if err != nil {
-		return entToUpdate, errors.WithStack(err)
+		return entToUpdate, err
 	}
 
 	return entToUpdate, nil
@@ -603,7 +602,7 @@ func (store *sqlConfiguratorStorage) LoadGraphForEntity(networkID string, entity
 
 	internalGraph, err := store.loadGraphInternal(networkID, ent.GraphID, loadCriteriaCopy)
 	if err != nil {
-		return &EntityGraph{}, errors.WithStack(err)
+		return &EntityGraph{}, err
 	}
 
 	rootPKs := findRootNodes(internalGraph)

--- a/orc8r/cloud/go/services/configurator/storage/sql_entity_load_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_entity_load_helpers.go
@@ -61,7 +61,7 @@ func (store *sqlConfiguratorStorage) loadEntities(networkID string, filter *Enti
 
 	rows, err := builder.RunWith(store.tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "error querying for entities")
+		return nil, fmt.Errorf("error querying for entities: %w", err)
 	}
 	defer sqorc.CloseRowsLogOnError(rows, "loadEntities")
 
@@ -74,7 +74,7 @@ func (store *sqlConfiguratorStorage) loadEntities(networkID string, filter *Enti
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 
 	return entsByTK, nil
@@ -94,7 +94,7 @@ func (store *sqlConfiguratorStorage) loadAssocs(networkID string, filter *Entity
 
 	rows, err := builder.RunWith(store.tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "error querying for entities")
+		return nil, fmt.Errorf("error querying for entities: %w", err)
 	}
 	defer sqorc.CloseRowsLogOnError(rows, "loadAssocs")
 
@@ -107,7 +107,7 @@ func (store *sqlConfiguratorStorage) loadAssocs(networkID string, filter *Entity
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 
 	return assocs, nil
@@ -245,7 +245,7 @@ func scanEntityRow(rows *sql.Rows, criteria *EntityLoadCriteria) (*NetworkEntity
 
 	err := rows.Scan(scanArgs...)
 	if err != nil {
-		return &NetworkEntity{}, errors.Wrap(err, "error while scanning entity row")
+		return &NetworkEntity{}, fmt.Errorf("error while scanning entity row: %w", err)
 	}
 
 	ent := &NetworkEntity{
@@ -280,7 +280,7 @@ func scanAssocRow(rows *sql.Rows, loadTyp loadType) (loadedAssoc, error) {
 
 	err := rows.Scan(scanArgs...)
 	if err != nil {
-		return loadedAssoc{}, errors.Wrap(err, "error while scanning entity row")
+		return loadedAssoc{}, fmt.Errorf("error while scanning entity row: %w", err)
 	}
 
 	return a, nil

--- a/orc8r/cloud/go/services/configurator/storage/sql_entity_load_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_entity_load_helpers.go
@@ -22,7 +22,6 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/sqorc"
@@ -82,7 +81,7 @@ func (store *sqlConfiguratorStorage) loadEntities(networkID string, filter *Enti
 
 func (store *sqlConfiguratorStorage) loadAssocs(networkID string, filter *EntityLoadFilter, criteria *EntityLoadCriteria, loadTyp loadType) (loadedAssocs, error) {
 	if loadTyp != loadChildren && loadTyp != loadParents {
-		return nil, errors.Errorf("wrong load type received: '%v'", loadTyp)
+		return nil, fmt.Errorf("wrong load type received: '%v'", loadTyp)
 	}
 
 	assocs := loadedAssocs{}

--- a/orc8r/cloud/go/services/configurator/storage/sql_entity_write_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_entity_write_helpers.go
@@ -132,7 +132,7 @@ func (store *sqlConfiguratorStorage) loadEntitiesFromIDs(networkID string, idsTo
 
 	entsNotFound := calculateIDsNotFound(loaded, idsToLoad)
 	if funk.NotEmpty(entsNotFound) {
-		return nil, errors.Errorf("could not find entities matching %v", entsNotFound)
+		return nil, fmt.Errorf("could not find entities matching %v", entsNotFound)
 	}
 
 	return loaded, nil
@@ -193,7 +193,7 @@ func (store *sqlConfiguratorStorage) loadEntToUpdate(networkID string, update *E
 	}
 	// don't error on deleting an entity which doesn't exist
 	if len(loaded) != 1 && !update.DeleteEntity {
-		return nil, errors.Errorf("expected to load 1 ent for update, got %d", len(loaded))
+		return nil, fmt.Errorf("expected to load 1 ent for update, got %d", len(loaded))
 	}
 
 	if funk.IsEmpty(loaded) {

--- a/orc8r/cloud/go/services/configurator/storage/sql_entity_write_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_entity_write_helpers.go
@@ -64,7 +64,7 @@ func (store *sqlConfiguratorStorage) doesPhysicalIDExist(physicalID string) (boo
 		return false, nil
 	}
 	if err != nil {
-		return false, errors.Wrapf(err, "check for existence of physical ID %s", physicalID)
+		return false, fmt.Errorf("check for existence of physical ID %s: %w", physicalID, err)
 	}
 
 	return count > 0, nil
@@ -81,7 +81,7 @@ func (store *sqlConfiguratorStorage) insertIntoEntityTable(networkID string, ent
 		RunWith(store.tx).
 		Exec()
 	if err != nil {
-		return &NetworkEntity{}, errors.Wrapf(err, "error creating entity %s", entCopy.GetTK())
+		return &NetworkEntity{}, fmt.Errorf("error creating entity %s: %w", entCopy.GetTK(), err)
 	}
 	return entCopy, nil
 }
@@ -110,7 +110,7 @@ func (store *sqlConfiguratorStorage) createEdges(networkID string, entity *Netwo
 	}
 	_, err = insertBuilder.RunWith(store.tx).Exec()
 	if err != nil {
-		return entsByTk, errors.Wrap(err, "error creating assocs")
+		return entsByTk, fmt.Errorf("error creating assocs: %w", err)
 	}
 	return entsByTk, nil
 }
@@ -175,7 +175,7 @@ func (store *sqlConfiguratorStorage) mergeGraphs(createdEntity *NetworkEntity, a
 			RunWith(sc).
 			Exec()
 		if err != nil {
-			return "", errors.Wrap(err, "error updating entity graphs")
+			return "", fmt.Errorf("error updating entity graphs: %w", err)
 		}
 	}
 
@@ -189,7 +189,7 @@ func (store *sqlConfiguratorStorage) loadEntToUpdate(networkID string, update *E
 		&EntityLoadCriteria{},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to load entity to update")
+		return nil, fmt.Errorf("failed to load entity to update: %w", err)
 	}
 	// don't error on deleting an entity which doesn't exist
 	if len(loaded) != 1 && !update.DeleteEntity {
@@ -213,7 +213,7 @@ func (store *sqlConfiguratorStorage) processEntityFieldsUpdate(pk string, update
 		RunWith(store.tx).
 		Exec()
 	if err != nil {
-		return errors.Wrap(err, "failed to update entity fields")
+		return fmt.Errorf("failed to update entity fields: %w", err)
 	}
 
 	if update.NewName != nil {
@@ -248,7 +248,7 @@ func (store *sqlConfiguratorStorage) processEdgeUpdates(networkID string, update
 			RunWith(store.tx).
 			Exec()
 		if err != nil {
-			return errors.Wrap(err, "failed to delete existing edges")
+			return fmt.Errorf("failed to delete existing edges: %w", err)
 		}
 	}
 
@@ -323,7 +323,7 @@ func (store *sqlConfiguratorStorage) deleteEdges(networkID string, edgesToDelete
 	// Get PKs to delete
 	loaded, err := store.loadEntitiesFromIDs(networkID, edgesToDelete)
 	if err != nil {
-		return errors.Wrap(err, "could not load entities matching associations to delete")
+		return fmt.Errorf("could not load entities matching associations to delete: %w", err)
 	}
 
 	orClause := make(sq.Or, 0, len(edgesToDelete))
@@ -339,7 +339,7 @@ func (store *sqlConfiguratorStorage) deleteEdges(networkID string, edgesToDelete
 		RunWith(store.tx).
 		Exec()
 	if err != nil {
-		return errors.Wrap(err, "failed to delete assocs")
+		return fmt.Errorf("failed to delete assocs: %w", err)
 	}
 
 	if funk.IsEmpty(entToUpdateOut.Associations) {

--- a/orc8r/cloud/go/services/configurator/storage/sql_entity_write_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_entity_write_helpers.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 	"google.golang.org/protobuf/proto"
 
@@ -118,7 +117,7 @@ func (store *sqlConfiguratorStorage) createEdges(networkID string, entity *Netwo
 func (store *sqlConfiguratorStorage) loadEntsFromEdges(networkID string, targetEntity *NetworkEntity) (EntitiesByTK, error) {
 	loadedEntsByTk, err := store.loadEntitiesFromIDs(networkID, targetEntity.Associations)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	loadedEntsByTk[targetEntity.GetTK()] = targetEntity
 	return loadedEntsByTk, nil
@@ -259,20 +258,20 @@ func (store *sqlConfiguratorStorage) processEdgeUpdates(networkID string, update
 	newlyAssociatedEntsByTk, err := store.createEdges(networkID, entToUpdateOut)
 	if err != nil {
 		entToUpdateOut.Associations = nil
-		return errors.WithStack(err)
+		return err
 	}
 
 	// Just like entity creation, we might need to merge graphs after adding
 	newGraphID, err := store.mergeGraphs(entToUpdateOut, newlyAssociatedEntsByTk)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	entToUpdateOut.GraphID = newGraphID
 
 	// Now delete edges
 	err = store.deleteEdges(networkID, update.AssociationsToDelete, entToUpdateOut)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	// Finally, we need to load the entire graph corresponding to this node's
@@ -288,7 +287,7 @@ func (store *sqlConfiguratorStorage) processEdgeUpdates(networkID string, update
 
 	err = store.fixGraph(networkID, newGraphID, entToUpdateOut)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil

--- a/orc8r/cloud/go/services/configurator/storage/sql_network_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_network_helpers.go
@@ -166,7 +166,7 @@ func (store *sqlConfiguratorStorage) updateNetwork(update *NetworkUpdateCriteria
 	updateBuilder = updateBuilder.Set(nwVerCol, sq.Expr(fmt.Sprintf("%s.%s+1", networksTable, nwVerCol)))
 	_, err := updateBuilder.RunWith(stmtCache).Exec()
 	if err != nil {
-		return errors.Wrapf(err, "error updating network %s", update.ID)
+		return fmt.Errorf("error updating network %s: %w", update.ID, err)
 	}
 
 	// Sort config keys for deterministic behavior on upserts
@@ -187,7 +187,7 @@ func (store *sqlConfiguratorStorage) updateNetwork(update *NetworkUpdateCriteria
 			RunWith(stmtCache).
 			Exec()
 		if err != nil {
-			return errors.Wrapf(err, "error updating config %s on network %s", configType, update.ID)
+			return fmt.Errorf("error updating config %s on network %s: %w", configType, update.ID, err)
 		}
 	}
 
@@ -202,7 +202,7 @@ func (store *sqlConfiguratorStorage) updateNetwork(update *NetworkUpdateCriteria
 	}
 	_, err = store.builder.Delete(networkConfigTable).Where(orClause).RunWith(store.tx).Exec()
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete configs for network %s", update.ID)
+		return fmt.Errorf("failed to delete configs for network %s: %w", update.ID, err)
 	}
 
 	return nil

--- a/orc8r/cloud/go/services/configurator/storage/sql_network_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_network_helpers.go
@@ -15,12 +15,12 @@ package storage
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/sqorc"

--- a/orc8r/cloud/go/services/configurator/storage/storage.go
+++ b/orc8r/cloud/go/services/configurator/storage/storage.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 	"google.golang.org/protobuf/proto"
 
@@ -109,7 +108,7 @@ type ConfiguratorStorage interface {
 func RollbackLogOnError(store ConfiguratorStorage) {
 	err := store.Rollback()
 	if err != nil {
-		glog.Errorf("Error while rolling back tx: %+v", errors.WithStack(err))
+		glog.Errorf("Error while rolling back tx: %+v", err)
 	}
 }
 
@@ -118,7 +117,7 @@ func RollbackLogOnError(store ConfiguratorStorage) {
 func CommitLogOnError(store ConfiguratorStorage) {
 	err := store.Commit()
 	if err != nil {
-		glog.Errorf("Error while committing tx: %+v", errors.WithStack(err))
+		glog.Errorf("Error while committing tx: %+v", err)
 	}
 }
 

--- a/orc8r/cloud/go/services/configurator/types.go
+++ b/orc8r/cloud/go/services/configurator/types.go
@@ -14,10 +14,10 @@
 package configurator
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/serde"

--- a/orc8r/cloud/go/services/configurator/types.go
+++ b/orc8r/cloud/go/services/configurator/types.go
@@ -54,7 +54,7 @@ func (n Network) ToProto(serdes serde.Registry) (*storage.Network, error) {
 	}
 	bConfigs, err := marshalConfigs(n.Configs, serdes)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error serializing network %s", n.ID)
+		return nil, fmt.Errorf("error serializing network %s: %w", n.ID, err)
 	}
 	ret.Configs = bConfigs
 	return ret, nil
@@ -64,7 +64,7 @@ func (n Network) ToProto(serdes serde.Registry) (*storage.Network, error) {
 func (n Network) FromProto(protoNet *storage.Network, serdes serde.Registry) (Network, error) {
 	iConfigs, err := unmarshalConfigs(protoNet.Configs, serdes)
 	if err != nil {
-		return n, errors.Wrapf(err, "error deserializing network %s", protoNet.ID)
+		return n, fmt.Errorf("error deserializing network %s: %w", protoNet.ID, err)
 	}
 
 	n.ID = protoNet.ID
@@ -101,7 +101,7 @@ type NetworkUpdateCriteria struct {
 func (nuc NetworkUpdateCriteria) toProto(serdes serde.Registry) (*storage.NetworkUpdateCriteria, error) {
 	bConfigs, err := marshalConfigs(nuc.ConfigsToAddOrUpdate, serdes)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal update")
+		return nil, fmt.Errorf("failed to marshal update: %w", err)
 	}
 
 	ret := &storage.NetworkUpdateCriteria{
@@ -180,7 +180,7 @@ func (ent NetworkEntity) toProto(serdes serde.Registry) (*storage.NetworkEntity,
 	if ent.Config != nil {
 		bConfigs, err := serde.Serialize(ent.Config, ent.Type, serdes)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to serialize entity %s", ent.GetTK())
+			return nil, fmt.Errorf("failed to serialize entity %s: %w", ent.GetTK(), err)
 		}
 		ret.Config = bConfigs
 	}
@@ -194,7 +194,7 @@ func (ent NetworkEntity) fromProto(p *storage.NetworkEntity, serdes serde.Regist
 	if len(p.Config) != 0 {
 		iConfig, err := serde.Deserialize(p.Config, e.Type, serdes)
 		if err != nil {
-			return ent, errors.Wrapf(err, "failed to deserialize entity %s", ent.GetTK())
+			return ent, fmt.Errorf("failed to deserialize entity %s: %w", ent.GetTK(), err)
 		}
 		e.Config = iConfig
 		e.isSerialized = false
@@ -366,7 +366,7 @@ func (eg EntityGraph) FromProto(protoGraph *storage.EntityGraph, serdes serde.Re
 	for _, protoEnt := range protoGraph.Entities {
 		ent, err := (NetworkEntity{}).fromProtoWithDefault(protoEnt, serdes)
 		if err != nil {
-			return eg, errors.Wrapf(err, "failed to deserialize entity %s", protoEnt.GetTK())
+			return eg, fmt.Errorf("failed to deserialize entity %s: %w", protoEnt.GetTK(), err)
 		}
 		eg.Entities = append(eg.Entities, ent)
 	}
@@ -386,7 +386,7 @@ func (eg EntityGraph) ToProto(serdes serde.Registry) (*storage.EntityGraph, erro
 	for _, ent := range eg.Entities {
 		protoEnt, err := ent.toProto(serdes)
 		if err != nil {
-			return protoGraph, errors.Wrapf(err, "failed to convert entity %s to storage proto", ent.GetTK())
+			return protoGraph, fmt.Errorf("failed to convert entity %s to storage proto: %w", ent.GetTK(), err)
 		}
 		protoGraph.Entities = append(protoGraph.Entities, protoEnt)
 	}
@@ -552,7 +552,7 @@ func (euc EntityUpdateCriteria) toProto(serdes serde.Registry) (*storage.EntityU
 	if euc.NewConfig != nil {
 		bConfig, err := serde.Serialize(euc.NewConfig, euc.Type, serdes)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to serialize update %s", euc.GetTK())
+			return nil, fmt.Errorf("failed to serialize update %s: %w", euc.GetTK(), err)
 		}
 		ret.NewConfig = &wrappers.BytesValue{Value: bConfig}
 	}
@@ -578,7 +578,7 @@ func marshalConfigs(configs map[string]interface{}, serdes serde.Registry) (map[
 
 		sConfig, err := serde.Serialize(iConfig, configType, serdes)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to serialize config %s", configType)
+			return nil, fmt.Errorf("failed to serialize config %s: %w", configType, err)
 		}
 		ret[configType] = sConfig
 	}
@@ -595,7 +595,7 @@ func unmarshalConfigs(configs map[string][]byte, serdes serde.Registry) (map[str
 		}
 		iConfig, err := serde.Deserialize(config, typ, serdes)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to deserialize network config %s", typ)
+			return nil, fmt.Errorf("failed to deserialize network config %s: %w", typ, err)
 		}
 		ret[typ] = iConfig
 	}

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/gateway_api.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/gateway_api.go
@@ -15,10 +15,10 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/gateway_api.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/gateway_api.go
@@ -43,7 +43,7 @@ func NewGwCtracedClient() GwCtracedClient {
 func getGWCtracedClient(ctx context.Context, networkID string, gatewayID string) (protos.CallTraceServiceClient, context.Context, error) {
 	hwID, err := configurator.GetPhysicalIDOfEntity(ctx, networkID, orc8r.MagmadGatewayType, gatewayID)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, fmt.Sprintf("gateway not found, network-id: %s, gateway-id: %s", networkID, gatewayID))
+		return nil, nil, fmt.Errorf(fmt.Sprintf("gateway not found, network-id: %s, gateway-id: %s: %w", networkID, gatewayID), err)
 	}
 	conn, gatewayCtx, err := gateway_registry.GetGatewayConnection(gateway_registry.GwCtraced, hwID)
 	if err != nil {
@@ -63,7 +63,7 @@ func (c gwCtracedClientImpl) StartCallTrace(ctx context.Context, networkId strin
 	}
 	resp, err := client.StartCallTrace(gatewayCtx, req)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start call trace, gRPC client received error")
+		return nil, fmt.Errorf("failed to start call trace, gRPC client received error: %w", err)
 	}
 	return resp, err
 }
@@ -77,7 +77,7 @@ func (c gwCtracedClientImpl) EndCallTrace(ctx context.Context, networkId string,
 	}
 	resp, err := client.EndCallTrace(gatewayCtx, req)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to end call trace, gRPC client received error")
+		return nil, fmt.Errorf("failed to end call trace, gRPC client received error: %w", err)
 	}
 	return resp, err
 }

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
@@ -15,11 +15,11 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
@@ -112,12 +112,12 @@ func getCreateCallTraceHandlerFunc(client GwCtracedClient) echo.HandlerFunc {
 
 		req, err := buildStartTraceRequest(cfg)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to build call trace request"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to build call trace request: %w", err))
 		}
 
 		resp, err := client.StartCallTrace(reqCtx, networkID, cfg.GatewayID, req)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to start call trace"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to start call trace: %w", err))
 		}
 		if !resp.Success {
 			return echo.NewHTTPError(http.StatusInternalServerError, errors.New("failed to start call trace"))
@@ -126,7 +126,7 @@ func getCreateCallTraceHandlerFunc(client GwCtracedClient) echo.HandlerFunc {
 		createdEntity := ctr.ToEntity()
 		_, err = configurator.CreateEntity(reqCtx, networkID, createdEntity, serdes.Entity)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to create call trace"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to create call trace: %w", err))
 		}
 		return c.JSON(http.StatusCreated, cfg.TraceID)
 	}
@@ -177,7 +177,7 @@ func getUpdateCallTraceHandlerFunc(client GwCtracedClient, storage storage.Ctrac
 
 		err = storage.StoreCallTrace(networkID, callTraceID, resp.TraceContent)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, fmt.Sprintf("failed to save call trace data, network-id: %s, gateway-id: %s, calltrace-id: %s", networkID, callTrace.Config.GatewayID, callTraceID)))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf(fmt.Sprintf("failed to save call trace data, network-id: %s, gateway-id: %s, calltrace-id: %s: %w", networkID, callTrace.Config.GatewayID, callTraceID)), err)
 		}
 
 		_, err = configurator.UpdateEntity(reqCtx, networkID, mutableCallTrace.ToEntityUpdateCriteria(callTraceID, *callTrace), serdes.Entity)
@@ -197,7 +197,7 @@ func getDeleteCallTraceHandlerFunc(client GwCtracedClient, storage storage.Ctrac
 
 		err := storage.DeleteCallTrace(networkID, callTraceID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to delete call trace data"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to delete call trace data: %w", err))
 		}
 
 		err = configurator.DeleteEntity(c.Request().Context(), networkID, orc8r.CallTraceEntityType, callTraceID)
@@ -217,7 +217,7 @@ func getDownloadCallTraceHandlerFunc(storage storage.CtracedStorage) echo.Handle
 
 		callTrace, err := storage.GetCallTrace(networkID, callTraceID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to retrieve call trace data"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to retrieve call trace data: %w", err))
 		}
 
 		res := c.Response()

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
@@ -16,8 +16,6 @@ package storage
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
 	"magma/orc8r/lib/go/merrors"
@@ -45,7 +43,7 @@ type ctracedBlobStore struct {
 func (c *ctracedBlobStore) StoreCallTrace(networkID string, callTraceID string, data []byte) error {
 	store, err := c.factory.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -56,7 +54,7 @@ func (c *ctracedBlobStore) StoreCallTrace(networkID string, callTraceID string, 
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to store call trace %s", callTraceID))
+		return fmt.Errorf(fmt.Sprintf("failed to store call trace %s: %w", callTraceID), err)
 	}
 
 	return store.Commit()
@@ -66,7 +64,7 @@ func (c *ctracedBlobStore) StoreCallTrace(networkID string, callTraceID string, 
 func (c *ctracedBlobStore) GetCallTrace(networkID string, callTraceID string) ([]byte, error) {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start transaction")
+		return nil, fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -78,7 +76,7 @@ func (c *ctracedBlobStore) GetCallTrace(networkID string, callTraceID string) ([
 		return nil, err
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to get call trace %s", callTraceID))
+		return nil, fmt.Errorf(fmt.Sprintf("failed to get call trace %s: %w", callTraceID), err)
 	}
 
 	return blob.Value, store.Commit()
@@ -88,7 +86,7 @@ func (c *ctracedBlobStore) GetCallTrace(networkID string, callTraceID string) ([
 func (c *ctracedBlobStore) DeleteCallTrace(networkID string, callTraceID string) error {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -99,7 +97,7 @@ func (c *ctracedBlobStore) DeleteCallTrace(networkID string, callTraceID string)
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to delete call trace %s", callTraceID))
+		return fmt.Errorf(fmt.Sprintf("failed to delete call trace %s: %w", callTraceID), err)
 	}
 
 	return store.Commit()

--- a/orc8r/cloud/go/services/device/client_api.go
+++ b/orc8r/cloud/go/services/device/client_api.go
@@ -15,9 +15,9 @@ package device
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/serde"
@@ -127,7 +127,7 @@ func GetDevices(networkID string, deviceType string, deviceIDs []string, serdes 
 	for k, val := range res.DeviceMap {
 		iVal, err := serde.Deserialize(val.Info, deviceType, serdes)
 		if err != nil {
-			return map[string]interface{}{}, errors.Wrapf(err, "failed to deserialize device %s", k)
+			return map[string]interface{}{}, fmt.Errorf("failed to deserialize device %s: %w", k, err)
 		}
 		ret[k] = iVal
 	}

--- a/orc8r/cloud/go/services/directoryd/client_api.go
+++ b/orc8r/cloud/go/services/directoryd/client_api.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/serdes"
@@ -52,7 +51,7 @@ func getDirectorydClient() (protos.DirectoryLookupClient, error) {
 func GetHostnameForHWID(ctx context.Context, hwid string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	res, err := client.GetHostnameForHWID(ctx, &protos.GetHostnameForHWIDRequest{Hwid: hwid})
@@ -74,7 +73,7 @@ func MapHWIDToHostname(ctx context.Context, hwid, hostname string) error {
 func MapHWIDsToHostnames(ctx context.Context, hwidToHostname map[string]string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.MapHWIDsToHostnames(ctx, &protos.MapHWIDToHostnameRequest{HwidToHostname: hwidToHostname})
@@ -90,7 +89,7 @@ func MapHWIDsToHostnames(ctx context.Context, hwidToHostname map[string]string) 
 func UnmapHWIDsToHostnames(ctx context.Context, hwids []string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.UnmapHWIDsToHostnames(ctx, &protos.UnmapHWIDToHostnameRequest{Hwids: hwids})
@@ -108,7 +107,7 @@ func UnmapHWIDsToHostnames(ctx context.Context, hwids []string) error {
 func GetIMSIForSessionID(ctx context.Context, networkID, sessionID string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	res, err := client.GetIMSIForSessionID(ctx, &protos.GetIMSIForSessionIDRequest{
@@ -127,7 +126,7 @@ func GetIMSIForSessionID(ctx context.Context, networkID, sessionID string) (stri
 func MapSessionIDsToIMSIs(ctx context.Context, networkID string, sessionIDToIMSI map[string]string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.MapSessionIDsToIMSIs(ctx, &protos.MapSessionIDToIMSIRequest{
@@ -146,7 +145,7 @@ func MapSessionIDsToIMSIs(ctx context.Context, networkID string, sessionIDToIMSI
 func UnmapSessionIDsToIMSIs(ctx context.Context, networkID string, sessionIDs []string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.UnmapSessionIDsToIMSIs(ctx, &protos.UnmapSessionIDToIMSIRequest{
@@ -168,7 +167,7 @@ func UnmapSessionIDsToIMSIs(ctx context.Context, networkID string, sessionIDs []
 func GetHWIDForSgwCTeid(ctx context.Context, networkID, teid string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	res, err := client.GetHWIDForSgwCTeid(ctx, &protos.GetHWIDForSgwCTeidRequest{
@@ -186,7 +185,7 @@ func GetHWIDForSgwCTeid(ctx context.Context, networkID, teid string) (string, er
 func MapSgwCTeidToHWID(ctx context.Context, networkID string, teidToHWID map[string]string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.MapSgwCTeidToHWID(ctx, &protos.MapSgwCTeidToHWIDRequest{
@@ -204,7 +203,7 @@ func MapSgwCTeidToHWID(ctx context.Context, networkID string, teidToHWID map[str
 func UnmapSgwCTeidToHWID(ctx context.Context, networkID string, teids []string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.UnmapSgwCTeidToHWID(ctx, &protos.UnmapSgwCTeidToHWIDRequest{
@@ -222,7 +221,7 @@ func UnmapSgwCTeidToHWID(ctx context.Context, networkID string, teids []string) 
 func GetNewSgwCTeid(ctx context.Context, networkID string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 	res, err := client.GetNewSgwCTeid(ctx, &protos.GetNewSgwCTeidRequest{NetworkID: networkID})
 	if err != nil {
@@ -239,7 +238,7 @@ func GetNewSgwCTeid(ctx context.Context, networkID string) (string, error) {
 func GetHWIDForSgwUTeid(ctx context.Context, networkID, teid string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	res, err := client.GetHWIDForSgwUTeid(ctx, &protos.GetHWIDForSgwUTeidRequest{
@@ -257,7 +256,7 @@ func GetHWIDForSgwUTeid(ctx context.Context, networkID, teid string) (string, er
 func MapSgwUTeidToHWID(ctx context.Context, networkID string, teidToHWID map[string]string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.MapSgwUTeidToHWID(ctx, &protos.MapSgwUTeidToHWIDRequest{
@@ -275,7 +274,7 @@ func MapSgwUTeidToHWID(ctx context.Context, networkID string, teidToHWID map[str
 func UnmapSgwUTeidToHWID(ctx context.Context, networkID string, teids []string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.UnmapSgwUTeidToHWID(ctx, &protos.UnmapSgwUTeidToHWIDRequest{
@@ -293,7 +292,7 @@ func UnmapSgwUTeidToHWID(ctx context.Context, networkID string, teids []string) 
 func GetNewSgwUTeid(ctx context.Context, networkID string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 	res, err := client.GetNewSgwUTeid(ctx, &protos.GetNewSgwUTeidRequest{NetworkID: networkID})
 	if err != nil {

--- a/orc8r/cloud/go/services/directoryd/client_api.go
+++ b/orc8r/cloud/go/services/directoryd/client_api.go
@@ -31,9 +31,9 @@ import (
 
 const ServiceName = "directoryd"
 
-//-------------------------------
+// -------------------------------
 // Directoryd service client APIs
-//-------------------------------
+// -------------------------------
 
 // getDirectorydClient returns an RPC connection to the directoryd service.
 func getDirectorydClient() (protos.DirectoryLookupClient, error) {
@@ -301,9 +301,9 @@ func GetNewSgwUTeid(ctx context.Context, networkID string) (string, error) {
 	return res.Teid, nil
 }
 
-//--------------------------
+// --------------------------
 // State service client APIs
-//--------------------------
+// --------------------------
 
 // GetHWIDForIMSI returns the HWID mapped to by the IMSI.
 // Primary state, stored in state service.

--- a/orc8r/cloud/go/services/directoryd/servicers/protected/servicer.go
+++ b/orc8r/cloud/go/services/directoryd/servicers/protected/servicer.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	directoryd_protos "magma/orc8r/cloud/go/services/directoryd/protos"
 	"magma/orc8r/cloud/go/services/directoryd/storage"
@@ -45,7 +44,7 @@ func (d *directoryLookupServicer) GetHostnameForHWID(
 ) (*directoryd_protos.GetHostnameForHWIDResponse, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetHostnameForHWIDRequest")
+		return nil, fmt.Errorf("failed to validate GetHostnameForHWIDRequest: %w", err)
 	}
 
 	hostname, err := d.store.GetHostnameForHWID(req.Hwid)
@@ -57,7 +56,7 @@ func (d *directoryLookupServicer) GetHostnameForHWID(
 func (d *directoryLookupServicer) MapHWIDsToHostnames(ctx context.Context, req *directoryd_protos.MapHWIDToHostnameRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate MapHWIDToHostnameRequest")
+		return nil, fmt.Errorf("failed to validate MapHWIDToHostnameRequest: %w", err)
 	}
 
 	err = d.store.MapHWIDsToHostnames(req.HwidToHostname)
@@ -68,7 +67,7 @@ func (d *directoryLookupServicer) MapHWIDsToHostnames(ctx context.Context, req *
 func (d *directoryLookupServicer) UnmapHWIDsToHostnames(ctx context.Context, req *directoryd_protos.UnmapHWIDToHostnameRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate UnmapHWIDToHostnameRequest")
+		return nil, fmt.Errorf("failed to validate UnmapHWIDToHostnameRequest: %w", err)
 	}
 
 	err = d.store.UnmapHWIDsToHostnames(req.Hwids)
@@ -82,7 +81,7 @@ func (d *directoryLookupServicer) GetIMSIForSessionID(
 	err := req.Validate()
 
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetIMSIForSessionIDRequest")
+		return nil, fmt.Errorf("failed to validate GetIMSIForSessionIDRequest: %w", err)
 	}
 
 	imsi, err := d.store.GetIMSIForSessionID(req.NetworkID, req.SessionID)
@@ -94,7 +93,7 @@ func (d *directoryLookupServicer) GetIMSIForSessionID(
 func (d *directoryLookupServicer) MapSessionIDsToIMSIs(ctx context.Context, req *directoryd_protos.MapSessionIDToIMSIRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate MapSessionIDToIMSIRequest")
+		return nil, fmt.Errorf("failed to validate MapSessionIDToIMSIRequest: %w", err)
 	}
 
 	err = d.store.MapSessionIDsToIMSIs(req.NetworkID, req.SessionIDToIMSI)
@@ -105,7 +104,7 @@ func (d *directoryLookupServicer) MapSessionIDsToIMSIs(ctx context.Context, req 
 func (d *directoryLookupServicer) UnmapSessionIDsToIMSIs(ctx context.Context, req *directoryd_protos.UnmapSessionIDToIMSIRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate UnmapSessionIDToIMSIRequest")
+		return nil, fmt.Errorf("failed to validate UnmapSessionIDToIMSIRequest: %w", err)
 	}
 
 	err = d.store.UnmapSessionIDsToIMSIs(req.NetworkID, req.SessionIDs)
@@ -116,7 +115,7 @@ func (d *directoryLookupServicer) UnmapSessionIDsToIMSIs(ctx context.Context, re
 func (d *directoryLookupServicer) MapSgwCTeidToHWID(ctx context.Context, req *directoryd_protos.MapSgwCTeidToHWIDRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate MapSgwCTeidToHWIDRequest")
+		return nil, fmt.Errorf("failed to validate MapSgwCTeidToHWIDRequest: %w", err)
 	}
 
 	err = d.store.MapSgwCTeidToHWID(req.NetworkID, req.TeidToHwid)
@@ -127,7 +126,7 @@ func (d *directoryLookupServicer) MapSgwCTeidToHWID(ctx context.Context, req *di
 func (d *directoryLookupServicer) UnmapSgwCTeidToHWID(ctx context.Context, req *directoryd_protos.UnmapSgwCTeidToHWIDRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate UnmapSgwCTeidToHWIDRequest")
+		return nil, fmt.Errorf("failed to validate UnmapSgwCTeidToHWIDRequest: %w", err)
 	}
 
 	err = d.store.UnmapSgwCTeidToHWID(req.NetworkID, req.Teids)
@@ -140,7 +139,7 @@ func (d *directoryLookupServicer) GetHWIDForSgwCTeid(
 ) (*directoryd_protos.GetHWIDForSgwCTeidResponse, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetHWIDForSgwCTeidRequest")
+		return nil, fmt.Errorf("failed to validate GetHWIDForSgwCTeidRequest: %w", err)
 	}
 
 	hwid, err := d.store.GetHWIDForSgwCTeid(req.NetworkID, req.Teid)
@@ -152,7 +151,7 @@ func (d *directoryLookupServicer) GetHWIDForSgwCTeid(
 func (d *directoryLookupServicer) GetNewSgwCTeid(ctx context.Context, req *directoryd_protos.GetNewSgwCTeidRequest) (*directoryd_protos.GetNewSgwCTeidResponse, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetNewSgwCTeid")
+		return nil, fmt.Errorf("failed to validate GetNewSgwCTeid: %w", err)
 	}
 
 	sgwCTeid, err := d.sgwCteidGen.GetUniqueId(req.NetworkID, d.store.GetHWIDForSgwCTeid)
@@ -167,7 +166,7 @@ func (d *directoryLookupServicer) GetNewSgwCTeid(ctx context.Context, req *direc
 func (d *directoryLookupServicer) MapSgwUTeidToHWID(ctx context.Context, req *directoryd_protos.MapSgwUTeidToHWIDRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate MapSgwUTeidToHWIDRequest")
+		return nil, fmt.Errorf("failed to validate MapSgwUTeidToHWIDRequest: %w", err)
 	}
 
 	err = d.store.MapSgwUTeidToHWID(req.NetworkID, req.TeidToHwid)
@@ -178,7 +177,7 @@ func (d *directoryLookupServicer) MapSgwUTeidToHWID(ctx context.Context, req *di
 func (d *directoryLookupServicer) UnmapSgwUTeidToHWID(ctx context.Context, req *directoryd_protos.UnmapSgwUTeidToHWIDRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate UnmapSgwUTeidToHWIDRequest")
+		return nil, fmt.Errorf("failed to validate UnmapSgwUTeidToHWIDRequest: %w", err)
 	}
 
 	err = d.store.UnmapSgwUTeidToHWID(req.NetworkID, req.Teids)
@@ -191,7 +190,7 @@ func (d *directoryLookupServicer) GetHWIDForSgwUTeid(
 ) (*directoryd_protos.GetHWIDForSgwUTeidResponse, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetHWIDForSgwUTeidRequest")
+		return nil, fmt.Errorf("failed to validate GetHWIDForSgwUTeidRequest: %w", err)
 	}
 
 	hwid, err := d.store.GetHWIDForSgwUTeid(req.NetworkID, req.Teid)
@@ -203,7 +202,7 @@ func (d *directoryLookupServicer) GetHWIDForSgwUTeid(
 func (d *directoryLookupServicer) GetNewSgwUTeid(ctx context.Context, req *directoryd_protos.GetNewSgwUTeidRequest) (*directoryd_protos.GetNewSgwUTeidResponse, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetNewSgwUTeid")
+		return nil, fmt.Errorf("failed to validate GetNewSgwUTeid: %w", err)
 	}
 
 	SgwUTeid, err := d.sgwUteidGen.GetUniqueId(req.NetworkID, d.store.GetHWIDForSgwUTeid)

--- a/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
@@ -14,10 +14,10 @@ limitations under the License.
 package storage
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
@@ -129,7 +129,7 @@ func (d *directorydBlobstore) UnmapSgwUTeidToHWID(networkID string, teids []stri
 func (d *directorydBlobstore) getFromStore(networkID, tkType, key string) (string, error) {
 	store, err := d.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to start transaction to get %s for tkKey %s", key, tkType)
+		return "", fmt.Errorf("failed to start transaction to get %s for tkKey %s: %w", key, tkType, err)
 	}
 	defer store.Rollback()
 
@@ -138,7 +138,7 @@ func (d *directorydBlobstore) getFromStore(networkID, tkType, key string) (strin
 		return "", err
 	}
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get %s from %s", key, tkType)
+		return "", fmt.Errorf("failed to get %s from %s: %w", key, tkType, err)
 	}
 	return string(blob.Value), store.Commit()
 }
@@ -146,14 +146,14 @@ func (d *directorydBlobstore) getFromStore(networkID, tkType, key string) (strin
 func (d *directorydBlobstore) mapToStore(networkID, tkType string, keyToValueMap map[string]string) error {
 	store, err := d.factory.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to start transaction mapToStore with map %+v for tkKey %s", keyToValueMap, tkType)
+		return fmt.Errorf("failed to start transaction mapToStore with map %+v for tkKey %s: %w", keyToValueMap, tkType, err)
 	}
 	defer store.Rollback()
 
 	blobs := convertKVToBlobs(tkType, keyToValueMap)
 	err = store.Write(networkID, blobs)
 	if err != nil {
-		return errors.Wrapf(err, "failed to mapToStore with map %+v for tkKey %s", keyToValueMap, tkType)
+		return fmt.Errorf("failed to mapToStore with map %+v for tkKey %s: %w", keyToValueMap, tkType, err)
 	}
 	return store.Commit()
 }
@@ -161,13 +161,13 @@ func (d *directorydBlobstore) mapToStore(networkID, tkType string, keyToValueMap
 func (d *directorydBlobstore) unmapFromStore(networkID, tkType string, keys []string) error {
 	store, err := d.factory.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to start transaction unmapFromStore with key %s for tkKey %s", keys, tkType)
+		return fmt.Errorf("failed to start transaction unmapFromStore with key %s for tkKey %s: %w", keys, tkType, err)
 	}
 	defer store.Rollback()
 
 	err = store.Delete(networkID, storage.MakeTKs(tkType, keys))
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmapFromStore with keys %s for tkKey %s", keys, tkType)
+		return fmt.Errorf("failed to unmapFromStore with keys %s for tkKey %s: %w", keys, tkType, err)
 	}
 	return store.Commit()
 }

--- a/orc8r/cloud/go/services/dispatcher/servicers/sync_rpc_service_test.go
+++ b/orc8r/cloud/go/services/dispatcher/servicers/sync_rpc_service_test.go
@@ -15,12 +15,12 @@ package servicers_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"testing"
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
@@ -80,7 +80,7 @@ func TestSyncRPC(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			if protos.TestMarshal(in) != protos.TestMarshal(syncRPCReq) {
-				err := errors.Errorf(
+				err := fmt.Errorf(
 					"req received at gateway is different from req sent on the service: received: %v, sent: %v\n",
 					in, syncRPCReq,
 				)

--- a/orc8r/cloud/go/services/metricsd/collection/gatherer.go
+++ b/orc8r/cloud/go/services/metricsd/collection/gatherer.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	prometheus_proto "github.com/prometheus/client_model/go"
 
 	"magma/orc8r/lib/go/registry"
@@ -79,7 +78,7 @@ func (g *MetricsGatherer) getCollectors() []MetricCollector {
 
 	services, err := registry.ListAllServices()
 	if err != nil {
-		err = errors.Wrap(err, "error getting metrics collectors: list all services")
+		err = fmt.Errorf("error getting metrics collectors: list all services: %w", err)
 		glog.Warning(err)
 		return collectors
 	}

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/facebookincubator/prometheus-configmanager/prometheus/alert"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 
@@ -156,11 +155,11 @@ func sendConfig(payload interface{}, url string, method string, client HttpClien
 
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(requestBody))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "create http request"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("create http request: %w", err))
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrapf(err, "make %s request", method))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("make %s request: %w", method), err)
 	}
 	defer resp.Body.Close()
 
@@ -263,11 +262,11 @@ func sendBulkConfig(payload interface{}, url string, client HttpClient) (string,
 
 	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(requestBody))
 	if err != nil {
-		return "", echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "create http request"))
+		return "", echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("create http request: %w", err))
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "make PUT request"))
+		return "", echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("make PUT request: %w", err))
 	}
 	defer resp.Body.Close()
 

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_silencing_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_silencing_handlers.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/api/v2/client/silence"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/pkg/parse"
@@ -79,7 +78,7 @@ func postSilencer(networkID, silencerURL string, c echo.Context, client HttpClie
 
 	newSilencerBytes, err := json.Marshal(silencer)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "make silencer"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("make silencer: %w", err))
 	}
 
 	resp, err := client.Post(silencerURL, "application/json", bytes.NewBuffer(newSilencerBytes))

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
@@ -340,12 +339,12 @@ func GetTenantPromSeriesHandler(api PrometheusAPI, useCache bool) func(c echo.Co
 		startStr := c.QueryParam(utils.ParamRangeStart)
 		startTime, err := utils.ParseTime(startStr, &defaultStartTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.Wrapf(err, "parse start time: %s", startStr))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse start time: %s: %w", startStr), err)
 		}
 		endStr := c.QueryParam(utils.ParamRangeEnd)
 		endTime, err := utils.ParseTime(endStr, &defaultEndTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.Wrapf(err, "parse end time: %s", endStr))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse end time: %s: %w", endStr), err)
 		}
 
 		res, _, err := api.Series(reqCtx, seriesMatches, startTime, endTime)
@@ -435,11 +434,11 @@ func GetTenantPromValuesHandler(api PrometheusAPI) func(c echo.Context) error {
 		endStr := c.QueryParam(utils.ParamRangeEnd)
 		startTime, err := utils.ParseTime(startStr, &defaultStartTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.Wrapf(err, "parse start time: %s", startStr))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse start time: %s: %w", startStr), err)
 		}
 		endTime, err := utils.ParseTime(endStr, &maxTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.Wrapf(err, "parse end time: %s", endStr))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse end time: %s: %w", endStr), err)
 		}
 
 		res, _, err := api.Series(reqCtx, seriesMatchers, startTime, endTime)

--- a/orc8r/cloud/go/services/metricsd/servicers/southbound/servicer.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/southbound/servicer.go
@@ -15,9 +15,9 @@ package southbound
 
 import (
 	"context"
+	"errors"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	prom_proto "github.com/prometheus/client_model/go"
 
 	"magma/orc8r/cloud/go/serdes"

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory.go
@@ -15,10 +15,10 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
@@ -277,11 +277,11 @@ func GetListGatewaysHandler(path string, gateway MagmadEncompassingGateway, make
 			}
 			devicesByID, err := device.GetDevices(nid, orc8r.AccessGatewayRecordType, deviceIDs, deviceSerdes)
 			if err != nil {
-				return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load devices"), http.StatusInternalServerError)
+				return obsidian.MakeHTTPError(fmt.Errorf("failed to load devices: %w", err), http.StatusInternalServerError)
 			}
 			statusesByID, err := wrappers.GetGatewayStatuses(reqCtx, nid, deviceIDs)
 			if err != nil {
-				return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load statuses"), http.StatusInternalServerError)
+				return obsidian.MakeHTTPError(fmt.Errorf("failed to load statuses: %w", err), http.StatusInternalServerError)
 			}
 
 			gateways := makeTypedGateways(entsByTK, devicesByID, statusesByID)

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
@@ -242,7 +241,7 @@ func registerDevice(ctx context.Context, networkID string, gateway *models.Magma
 		assignedEnt, err := configurator.LoadEntityForPhysicalID(ctx, deviceID, configurator.EntityLoadCriteria{}, entitySerdes)
 		switch {
 		case err == nil:
-			return obsidian.MakeHTTPError(errors.Errorf("device %s is already mapped to gateway %s", deviceID, assignedEnt.Key), http.StatusBadRequest)
+			return obsidian.MakeHTTPError(fmt.Errorf("device %s is already mapped to gateway %s", deviceID, assignedEnt.Key), http.StatusBadRequest)
 		case err != merrors.ErrNotFound:
 			return obsidian.MakeHTTPError(fmt.Errorf("failed to check for existing device assignment: %w", err), http.StatusInternalServerError)
 		}

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers.go
@@ -136,11 +136,11 @@ func listGatewaysHandler(c echo.Context) error {
 
 	devicesByID, err := device.GetDevices(nid, orc8r.AccessGatewayRecordType, deviceIDs, serdes.Device)
 	if err != nil {
-		return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load devices"), http.StatusInternalServerError)
+		return obsidian.MakeHTTPError(fmt.Errorf("failed to load devices: %w", err), http.StatusInternalServerError)
 	}
 	statusesByID, err := wrappers.GetGatewayStatuses(reqCtx, nid, deviceIDs)
 	if err != nil {
-		return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load statuses"), http.StatusInternalServerError)
+		return obsidian.MakeHTTPError(fmt.Errorf("failed to load statuses: %w", err), http.StatusInternalServerError)
 	}
 	gateways := makeGateways(entsByTK, devicesByID, statusesByID)
 
@@ -182,7 +182,7 @@ func CreateGateway(c echo.Context, model MagmadEncompassingGateway, entitySerdes
 	// Must associate to an existing tier
 	tierExists, err := configurator.DoesEntityExist(reqCtx, nid, orc8r.UpgradeTierEntityType, string(mdGateway.Tier))
 	if err != nil {
-		return obsidian.MakeHTTPError(errors.Wrap(err, "failed to check for tier existence"), http.StatusInternalServerError)
+		return obsidian.MakeHTTPError(fmt.Errorf("failed to check for tier existence: %w", err), http.StatusInternalServerError)
 	}
 	if !tierExists {
 		return echo.NewHTTPError(http.StatusBadRequest, "requested tier does not exist")
@@ -213,7 +213,7 @@ func CreateGateway(c echo.Context, model MagmadEncompassingGateway, entitySerdes
 	}
 
 	if err = configurator.WriteEntities(reqCtx, nid, writes, entitySerdes); err != nil {
-		return obsidian.MakeHTTPError(errors.Wrap(err, "error creating gateway"), http.StatusInternalServerError)
+		return obsidian.MakeHTTPError(fmt.Errorf("error creating gateway: %w", err), http.StatusInternalServerError)
 	}
 	return nil
 }
@@ -234,21 +234,21 @@ func registerDevice(ctx context.Context, networkID string, gateway *models.Magma
 	case err == merrors.ErrNotFound:
 		err = device.RegisterDevice(ctx, networkID, orc8r.AccessGatewayRecordType, deviceID, gateway.Device, deviceSerdes)
 		if err != nil {
-			return obsidian.MakeHTTPError(errors.Wrap(err, "failed to register physical device"), http.StatusInternalServerError)
+			return obsidian.MakeHTTPError(fmt.Errorf("failed to register physical device: %w", err), http.StatusInternalServerError)
 		}
 	case err != nil:
-		return obsidian.MakeHTTPError(errors.Wrap(err, "failed to check if physical device is already registered"), http.StatusConflict)
+		return obsidian.MakeHTTPError(fmt.Errorf("failed to check if physical device is already registered: %w", err), http.StatusConflict)
 	default: // err == nil
 		assignedEnt, err := configurator.LoadEntityForPhysicalID(ctx, deviceID, configurator.EntityLoadCriteria{}, entitySerdes)
 		switch {
 		case err == nil:
 			return obsidian.MakeHTTPError(errors.Errorf("device %s is already mapped to gateway %s", deviceID, assignedEnt.Key), http.StatusBadRequest)
 		case err != merrors.ErrNotFound:
-			return obsidian.MakeHTTPError(errors.Wrap(err, "failed to check for existing device assignment"), http.StatusInternalServerError)
+			return obsidian.MakeHTTPError(fmt.Errorf("failed to check for existing device assignment: %w", err), http.StatusInternalServerError)
 		}
 
 		if err := device.UpdateDevice(ctx, networkID, orc8r.AccessGatewayRecordType, deviceID, gateway.Device, deviceSerdes); err != nil {
-			return obsidian.MakeHTTPError(errors.Wrap(err, "failed to update device record"), http.StatusInternalServerError)
+			return obsidian.MakeHTTPError(fmt.Errorf("failed to update device record: %w", err), http.StatusInternalServerError)
 		}
 	}
 	return nil
@@ -348,7 +348,7 @@ func UpdateGateway(c echo.Context, nid string, gid string, model MagmadEncompass
 		entitySerdes,
 	)
 	if err != nil {
-		return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load gateway before update"), http.StatusInternalServerError)
+		return obsidian.MakeHTTPError(fmt.Errorf("failed to load gateway before update: %w", err), http.StatusInternalServerError)
 	}
 
 	writes, nerr := getUpdateWrites(reqCtx, subGateway, loadedEnts)
@@ -365,7 +365,7 @@ func UpdateGateway(c echo.Context, nid string, gid string, model MagmadEncompass
 	// configurator write was successful
 	err = device.UpdateDevice(reqCtx, nid, orc8r.AccessGatewayRecordType, mdGateway.Device.HardwareID, mdGateway.Device, deviceSerdes)
 	if err != nil {
-		return obsidian.MakeHTTPError(errors.Wrap(err, "failed to update device info"), http.StatusInternalServerError)
+		return obsidian.MakeHTTPError(fmt.Errorf("failed to update device info: %w", err), http.StatusInternalServerError)
 	}
 
 	return nil
@@ -380,7 +380,7 @@ func getUpdateWrites(ctx context.Context, payload MagmadEncompassingGateway, loa
 	case err == merrors.ErrNotFound:
 		return writes, echo.ErrNotFound
 	case err != nil:
-		return writes, obsidian.MakeHTTPError(errors.Wrap(err, "failed to get update operations from magmad model"), http.StatusInternalServerError)
+		return writes, obsidian.MakeHTTPError(fmt.Errorf("failed to get update operations from magmad model: %w", err), http.StatusInternalServerError)
 	}
 
 	// Short circuit if this is the magmad gateway
@@ -394,7 +394,7 @@ func getUpdateWrites(ctx context.Context, payload MagmadEncompassingGateway, loa
 	case err == merrors.ErrNotFound:
 		return writes, echo.ErrNotFound
 	case err != nil:
-		return writes, obsidian.MakeHTTPError(errors.Wrap(err, "failed to get update operations from payload model"), http.StatusInternalServerError)
+		return writes, obsidian.MakeHTTPError(fmt.Errorf("failed to get update operations from payload model: %w", err), http.StatusInternalServerError)
 	}
 
 	writes = append(writes, mdGwWrites...)
@@ -426,7 +426,7 @@ func DeleteMagmadGateway(ctx context.Context, networkID, gatewayID string, addit
 
 	err = configurator.DeleteEntities(ctx, networkID, deletes)
 	if err != nil {
-		return obsidian.MakeHTTPError(errors.Wrap(err, "error deleting gateway"), http.StatusInternalServerError)
+		return obsidian.MakeHTTPError(fmt.Errorf("error deleting gateway: %w", err), http.StatusInternalServerError)
 	}
 
 	// Now we delete the associated device. Even though we error out
@@ -436,7 +436,7 @@ func DeleteMagmadGateway(ctx context.Context, networkID, gatewayID string, addit
 	if mdGw.PhysicalID != "" {
 		err = device.DeleteDevice(ctx, networkID, orc8r.AccessGatewayRecordType, mdGw.PhysicalID)
 		if err != nil {
-			return obsidian.MakeHTTPError(errors.Wrap(err, "failed to delete device for gateway. no further action is required"), http.StatusInternalServerError)
+			return obsidian.MakeHTTPError(fmt.Errorf("failed to delete device for gateway. no further action is required: %w", err), http.StatusInternalServerError)
 		}
 	}
 

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/serde"
@@ -272,7 +271,7 @@ func getUpdateTypedNetworkHandler(path string, networkType string, networkModel 
 				return c.NoContent(http.StatusNotFound)
 			}
 			if err != nil {
-				return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load network to check type"), http.StatusInternalServerError)
+				return obsidian.MakeHTTPError(fmt.Errorf("failed to load network to check type: %w", err), http.StatusInternalServerError)
 			}
 			if network.Type != networkType {
 				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("network %s is not a <%s> network", nid, networkType))
@@ -303,7 +302,7 @@ func getDeleteTypedNetworkHandler(path string, networkType string, serdes serde.
 				return c.NoContent(http.StatusNotFound)
 			}
 			if err != nil {
-				return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load network to check type"), http.StatusInternalServerError)
+				return obsidian.MakeHTTPError(fmt.Errorf("failed to load network to check type: %w", err), http.StatusInternalServerError)
 			}
 			if network.Type != networkType {
 				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("network %s is not a <%s> network", nid, networkType))

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/conversion.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/conversion.go
@@ -15,11 +15,11 @@ package models
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-openapi/swag"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/models"

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/conversion.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/conversion.go
@@ -383,7 +383,7 @@ func (m *TierID) ToUpdateCriteria(ctx context.Context, networkID string, gateway
 
 	exists, err := configurator.DoesEntityExist(ctx, networkID, orc8r.UpgradeTierEntityType, tierID)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to look up tier")
+		return nil, fmt.Errorf("Failed to look up tier: %w", err)
 	}
 	if !exists {
 		return nil, fmt.Errorf("Tier %s does not exist", tierID)

--- a/orc8r/cloud/go/services/orchestrator/servicers/protected/builder_servicer.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/protected/builder_servicer.go
@@ -50,7 +50,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 	for _, b := range localBuilders {
 		partialConfig, err := b.Build(request.Network, request.Graph, request.GatewayId)
 		if err != nil {
-			return nil, errors.Wrapf(err, "sub-builder %+v error", b)
+			return nil, fmt.Errorf("sub-builder %+v error: %w", b, err)
 		}
 		for key, config := range partialConfig {
 			_, ok := ret.ConfigsByKey[key]
@@ -75,7 +75,7 @@ func (b *baseOrchestratorBuilder) Build(network *storage.Network, graph *storage
 
 	net, err := (configurator.Network{}).FromProto(network, serdes.Network)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not find network %s in graph", networkID)
+		return nil, fmt.Errorf("could not find network %s in graph: %w", networkID, err)
 	}
 
 	// Gateway must be present in the graph
@@ -140,7 +140,7 @@ func getPackageVersionAndImages(magmadGateway *configurator.NetworkEntity, graph
 		return "0.0.0-0", []*mconfig_protos.ImageSpec{}, nil
 	}
 	if err != nil {
-		return "0.0.0-0", []*mconfig_protos.ImageSpec{}, errors.Wrap(err, "failed to load upgrade tier")
+		return "0.0.0-0", []*mconfig_protos.ImageSpec{}, fmt.Errorf("failed to load upgrade tier: %w", err)
 	}
 
 	tierConfig := tier.Config.(*models.Tier)

--- a/orc8r/cloud/go/services/orchestrator/servicers/protected/builder_servicer.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/protected/builder_servicer.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/orc8r/math"
@@ -81,7 +80,7 @@ func (b *baseOrchestratorBuilder) Build(network *storage.Network, graph *storage
 	// Gateway must be present in the graph
 	gateway, err := nativeGraph.GetEntity(orc8r.MagmadGatewayType, gatewayID)
 	if err == merrors.ErrNotFound {
-		return nil, errors.Errorf("could not find magmad gateway %s in graph", gatewayID)
+		return nil, fmt.Errorf("could not find magmad gateway %s in graph", gatewayID)
 	}
 	if err != nil {
 		return nil, err

--- a/orc8r/cloud/go/services/orchestrator/servicers/protected/grpc_exporter_servicer.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/protected/grpc_exporter_servicer.go
@@ -13,9 +13,9 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
 	edge_hub "github.com/facebookincubator/prometheus-edge-hub/grpc"
-	"github.com/pkg/errors"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"google.golang.org/grpc"
 
@@ -77,7 +77,7 @@ func (s *GRPCPushExporterServicer) pushFamilies(families []*io_prometheus_client
 func (s *GRPCPushExporterServicer) getClient() (edge_hub.MetricsControllerClient, error) {
 	conn, err := s.registry.GetConnectionWithOptions(serviceName, lib_protos.ServiceType_SOUTHBOUND, dialOpts...)
 	if err != nil {
-		return nil, errors.Wrap(err, "get exporter client connection")
+		return nil, fmt.Errorf("get exporter client connection: %w", err)
 	}
 	client := edge_hub.NewMetricsControllerClient(conn)
 	return client, nil

--- a/orc8r/cloud/go/services/service_registry/servicers/protected/kubernetes_servicer.go
+++ b/orc8r/cloud/go/services/service_registry/servicers/protected/kubernetes_servicer.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/robfig/cron/v3"
 	corev1types "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,7 +193,7 @@ func (k *KubernetesServiceRegistryServicer) refreshServicesCache() {
 	services, err := k.client.Services(k.namespace).List(opts)
 	if err != nil {
 		// Log error and leave previous cache intact
-		err = errors.Wrap(err, "refresh service registry cache of K8s services")
+		err = fmt.Errorf("refresh service registry cache of K8s services: %w", err)
 		glog.Error(err)
 		return
 	}

--- a/orc8r/cloud/go/services/state/error.go
+++ b/orc8r/cloud/go/services/state/error.go
@@ -14,12 +14,13 @@
 package state
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func InternalErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	return status.Error(codes.Internal, e.Error())
 }

--- a/orc8r/cloud/go/services/state/indexer/index/index.go
+++ b/orc8r/cloud/go/services/state/indexer/index/index.go
@@ -14,11 +14,11 @@ limitations under the License.
 package index
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/clock"
 	"magma/orc8r/cloud/go/services/state/indexer"

--- a/orc8r/cloud/go/services/state/indexer/index/index.go
+++ b/orc8r/cloud/go/services/state/indexer/index/index.go
@@ -200,5 +200,5 @@ func wrap(err error, sentinel Error, indexerID string) error {
 	default:
 		wrap = fmt.Sprintf("%s for idx %s", sentinel, indexerID)
 	}
-	return errors.Wrap(err, wrap)
+	return fmt.Errorf(wrap+": %w", err)
 }

--- a/orc8r/cloud/go/services/state/indexer/index/index_test.go
+++ b/orc8r/cloud/go/services/state/indexer/index/index_test.go
@@ -14,9 +14,9 @@ limitations under the License.
 package index_test
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"magma/orc8r/cloud/go/clock"
@@ -33,7 +33,7 @@ import (
 )
 
 func init() {
-	//_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
+	// _ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestIndexImpl_HappyPath(t *testing.T) {

--- a/orc8r/cloud/go/services/state/indexer/registry.go
+++ b/orc8r/cloud/go/services/state/indexer/registry.go
@@ -17,11 +17,11 @@ limitations under the License.
 package indexer
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/orc8r"
@@ -33,7 +33,7 @@ import (
 func GetIndexer(serviceName string) (Indexer, error) {
 	x, err := getIndexer(serviceName)
 	if err != nil {
-		return NewEmptyIndexer(serviceName), errors.Wrapf(err, "indexer not found for service %s", serviceName)
+		return NewEmptyIndexer(serviceName), fmt.Errorf("indexer not found for service %s: %w", serviceName, err)
 	}
 	return x, nil
 }
@@ -82,10 +82,10 @@ func getIndexer(serviceName string) (Indexer, error) {
 	}
 	versionInt, err := strconv.ParseInt(versionVal, 10, 32)
 	if err != nil {
-		return nil, errors.Wrapf(err, "convert indexer version %v to int for service %s", versionVal, serviceName)
+		return nil, fmt.Errorf("convert indexer version %v to int for service %s: %w", versionVal, serviceName, err)
 	}
 	if versionInt < 0 || versionInt > math.MaxUint32 {
-		return nil, errors.Wrapf(err, "number %d is outside the boundaries of uint32 type", versionInt)
+		return nil, fmt.Errorf("number %d is outside the boundaries of uint32 type: %w", versionInt, err)
 	}
 	version, err := NewIndexerVersion(versionInt)
 	if err != nil {

--- a/orc8r/cloud/go/services/state/indexer/reindex/queue_sql.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue_sql.go
@@ -178,7 +178,7 @@ func (s *sqlJobQueue) ClaimAvailableJob() (*Job, error) {
 	idx, err := indexer.GetIndexer(job.id)
 	if err != nil {
 		failed := &Job{Idx: idx, From: job.from, To: job.to}
-		completeErr := s.CompleteJob(failed, errors.Wrap(err, "error claiming available job"))
+		completeErr := s.CompleteJob(failed, fmt.Errorf("error claiming available job: %w", err))
 		if completeErr != nil {
 			glog.Errorf("Error completing job after failing to claim it: %+v", completeErr)
 		}
@@ -223,7 +223,7 @@ func (s *sqlJobQueue) CompleteJob(job *Job, withErr error) error {
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrapf(err, "update reindex job status to complete %+v", job)
+			return nil, fmt.Errorf("update reindex job status to complete %+v: %w", job, err)
 		}
 
 		return nil, nil
@@ -237,7 +237,7 @@ func (s *sqlJobQueue) GetJobInfos() (map[string]JobInfo, error) {
 	txFn := func(tx *sql.Tx) (interface{}, error) {
 		rows, err := s.selectAll().From(queueTableName).RunWith(tx).Query()
 		if err != nil {
-			return nil, errors.Wrap(err, "select all reindex job infos")
+			return nil, fmt.Errorf("select all reindex job infos: %w", err)
 		}
 		defer sqorc.CloseRowsLogOnError(rows, "GetJobInfos")
 
@@ -276,7 +276,7 @@ func (s *sqlJobQueue) initQueueTable() error {
 			Column(errorCol).Type(sqorc.ColumnTypeText).Default("''").NotNull().EndColumn().
 			RunWith(tx).
 			Exec()
-		return nil, errors.Wrap(err, "initialize reindex job queue table")
+		return nil, fmt.Errorf("initialize reindex job queue table: %w", err)
 	}
 	_, err := sqorc.ExecInTx(s.db, &sql.TxOptions{Isolation: sql.LevelRepeatableRead}, nil, txFn)
 	return err
@@ -291,7 +291,7 @@ func (s *sqlJobQueue) addJobs(tx *sql.Tx, newJobs []*reindexJob) error {
 
 	_, err = s.builder.Delete(queueTableName).RunWith(tx).Exec()
 	if err != nil {
-		return errors.Wrap(err, "add reindex jobs, delete existing table contents")
+		return fmt.Errorf("add reindex jobs, delete existing table contents: %w", err)
 	}
 
 	builder := s.builder.Insert(queueTableName).Columns(idCol, fromCol, toCol, lastChangeCol)
@@ -301,7 +301,7 @@ func (s *sqlJobQueue) addJobs(tx *sql.Tx, newJobs []*reindexJob) error {
 
 	_, err = builder.RunWith(tx).Exec()
 	if err != nil {
-		return errors.Wrapf(err, "add reindex jobs, insert new jobs %+v", jobsToInsert)
+		return fmt.Errorf("add reindex jobs, insert new jobs %+v: %w", jobsToInsert, err)
 	}
 
 	return nil
@@ -369,7 +369,7 @@ func (s *sqlJobQueue) getExistingIncompleteJobs(tx *sql.Tx) (map[string]*reindex
 		RunWith(tx).
 		Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "select existing incomplete reindex jobs")
+		return nil, fmt.Errorf("select existing incomplete reindex jobs: %w", err)
 	}
 	defer sqorc.CloseRowsLogOnError(rows, "getExistingIncompleteJobs")
 
@@ -411,7 +411,7 @@ func (s *sqlJobQueue) claimAvailableJob() (*reindexJob, error) {
 			Query()
 
 		if err != nil {
-			return nil, errors.Wrap(err, "claim available reindex job, select available job")
+			return nil, fmt.Errorf("claim available reindex job, select available job: %w", err)
 		}
 		defer sqorc.CloseRowsLogOnError(rows, "ClaimAvailableJob")
 
@@ -429,7 +429,7 @@ func (s *sqlJobQueue) claimAvailableJob() (*reindexJob, error) {
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrapf(err, "claim available reindex job, update job status for %+v", job)
+			return nil, fmt.Errorf("claim available reindex job, update job status for %+v: %w", job, err)
 		}
 
 		return job, nil
@@ -475,7 +475,7 @@ func scanJobs(rows *sql.Rows) (map[string]*reindexJob, error) {
 		var lastChangeVal int64
 		err = rows.Scan(&job.id, &job.from, &job.to, &job.status, &job.attempts, &job.error, &lastChangeVal)
 		if err != nil {
-			return nil, errors.Wrap(err, "scan reindex job, SQL row scan error")
+			return nil, fmt.Errorf("scan reindex job, SQL row scan error: %w", err)
 		}
 		job.lastChange = time.Unix(lastChangeVal, 0)
 
@@ -483,7 +483,7 @@ func scanJobs(rows *sql.Rows) (map[string]*reindexJob, error) {
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "scan reindex job, SQL rows error")
+		return nil, fmt.Errorf("scan reindex job, SQL rows error: %w", err)
 	}
 
 	return jobs, nil

--- a/orc8r/cloud/go/services/state/indexer/reindex/queue_sql.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue_sql.go
@@ -15,13 +15,13 @@ package reindex
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/clock"
 	"magma/orc8r/cloud/go/services/state/indexer"

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
@@ -106,7 +106,7 @@ func executeJob(ctx context.Context, job *Job, batches []reindexBatch) error {
 		// Convert IDs to states -- silently ignore not-found (stale) state IDs
 		statesByID, err := state.GetSerializedStates(ctx, b.networkID, ids)
 		if err != nil {
-			err = errors.Wrap(err, "get states")
+			err = fmt.Errorf("get states: %w", err)
 			return wrap(err, ErrDefault, id)
 		}
 
@@ -180,5 +180,5 @@ func wrap(err error, sentinel Error, indexerID string) error {
 	default:
 		wrap = fmt.Sprintf("%s for idx %s", sentinel, indexerID)
 	}
-	return errors.Wrap(err, wrap)
+	return fmt.Errorf(wrap+": %w", err)
 }

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
@@ -15,11 +15,11 @@ package reindex
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/services/state/indexer"

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
@@ -21,12 +21,12 @@ package reindex_test
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 

--- a/orc8r/cloud/go/services/state/indexer/reindex/store.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/store.go
@@ -14,7 +14,8 @@ limitations under the License.
 package reindex
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -70,6 +71,6 @@ func blobsToIDs(byNetwork map[string]blobstore.Blobs) state_types.IDsByNetwork {
 }
 
 func internalErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	return status.Error(codes.Internal, e.Error())
 }

--- a/orc8r/cloud/go/services/state/indexer/reindex/versioner.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/versioner.go
@@ -15,10 +15,10 @@ package reindex
 
 import (
 	"database/sql"
+	"fmt"
 	"sort"
 
 	"github.com/Masterminds/squirrel"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/services/state/indexer"
@@ -43,7 +43,7 @@ func (v *versioner) Initialize() error {
 			Column(desiredColVersions).Type(sqorc.ColumnTypeInt).NotNull().EndColumn().
 			RunWith(tx).
 			Exec()
-		return nil, errors.Wrap(err, "initialize indexer versions table")
+		return nil, fmt.Errorf("initialize indexer versions table: %w", err)
 	}
 	_, err := sqorc.ExecInTx(v.db, &sql.TxOptions{Isolation: sql.LevelRepeatableRead}, nil, txFn)
 	return err
@@ -101,7 +101,7 @@ func setIndexerActualVersion(builder sqorc.StatementBuilder, tx *sql.Tx, indexer
 		RunWith(tx).
 		Exec()
 	if err != nil {
-		return errors.Wrapf(err, "update indexer actual version for %s to %d", indexerID, version)
+		return fmt.Errorf("update indexer actual version for %s to %d: %w", indexerID, version, err)
 	}
 	return nil
 }
@@ -114,7 +114,7 @@ func getTrackedVersions(builder sqorc.StatementBuilder, tx *sql.Tx) ([]*indexer.
 		RunWith(tx).
 		Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "get all indexer versions, select existing versions")
+		return nil, fmt.Errorf("get all indexer versions, select existing versions: %w", err)
 	}
 
 	defer sqorc.CloseRowsLogOnError(rows, "GetAllIndexerVersions")
@@ -124,7 +124,7 @@ func getTrackedVersions(builder sqorc.StatementBuilder, tx *sql.Tx) ([]*indexer.
 	for rows.Next() {
 		err = rows.Scan(&idVal, &actualVal, &desiredVal)
 		if err != nil {
-			return ret, errors.Wrap(err, "get all indexer versions, SQL row scan error")
+			return ret, fmt.Errorf("get all indexer versions, SQL row scan error: %w", err)
 		}
 		v, err := newVersions(idVal, actualVal, desiredVal)
 		if err != nil {
@@ -135,7 +135,7 @@ func getTrackedVersions(builder sqorc.StatementBuilder, tx *sql.Tx) ([]*indexer.
 
 	err = rows.Err()
 	if err != nil {
-		return ret, errors.Wrap(err, "get all indexer versions, SQL rows error")
+		return ret, fmt.Errorf("get all indexer versions, SQL rows error: %w", err)
 	}
 	sort.Slice(ret, func(i, j int) bool { return ret[i].IndexerID < ret[j].IndexerID }) // make deterministic
 	return ret, nil
@@ -144,7 +144,7 @@ func getTrackedVersions(builder sqorc.StatementBuilder, tx *sql.Tx) ([]*indexer.
 func overwriteAllVersions(builder sqorc.StatementBuilder, tx *sql.Tx, versions []*indexer.Versions) error {
 	_, err := builder.Delete(versionTableName).RunWith(tx).Exec()
 	if err != nil {
-		return errors.Wrap(err, "overwrite all indexer versions, delete existing versions")
+		return fmt.Errorf("overwrite all indexer versions, delete existing versions: %w", err)
 	}
 
 	if len(versions) == 0 {
@@ -157,7 +157,7 @@ func overwriteAllVersions(builder sqorc.StatementBuilder, tx *sql.Tx, versions [
 	}
 	_, err = b.RunWith(tx).Exec()
 	if err != nil {
-		return errors.Wrapf(err, "overwrite all indexer desired versions, insert new versions %+v", versions)
+		return fmt.Errorf("overwrite all indexer desired versions, insert new versions %+v: %w", versions, err)
 	}
 
 	return nil
@@ -212,11 +212,11 @@ func getIndexerVersionsByID() (map[string]indexer.Version, error) {
 func newVersions(indexerID string, actualVersion, desiredVersion int64) (*indexer.Versions, error) {
 	actual, err := indexer.NewIndexerVersion(actualVersion)
 	if err != nil {
-		return nil, errors.Wrapf(err, "new actual version for indexer %s", indexerID)
+		return nil, fmt.Errorf("new actual version for indexer %s: %w", indexerID, err)
 	}
 	desired, err := indexer.NewIndexerVersion(desiredVersion)
 	if err != nil {
-		return nil, errors.Wrapf(err, "new desired version for indexer %s", indexerID)
+		return nil, fmt.Errorf("new desired version for indexer %s: %w", indexerID, err)
 	}
 	v := &indexer.Versions{
 		IndexerID: indexerID,

--- a/orc8r/cloud/go/services/state/servicers/protected/indexer_mgr_servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/protected/indexer_mgr_servicer.go
@@ -15,8 +15,8 @@ package protected
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -82,6 +82,6 @@ func (srv *indexerServicer) validateReindexReq(req *indexer_protos.StartReindexR
 }
 
 func internalErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	return status.Error(codes.Internal, e.Error())
 }

--- a/orc8r/cloud/go/services/state/servicers/protected/indexer_mgr_servicer_test.go
+++ b/orc8r/cloud/go/services/state/servicers/protected/indexer_mgr_servicer_test.go
@@ -15,9 +15,9 @@ package protected_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"

--- a/orc8r/cloud/go/services/state/servicers/protected/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/protected/servicer.go
@@ -15,8 +15,8 @@ package protected
 
 import (
 	"context"
+	"errors"
 
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/orc8r/cloud/go/services/state/servicers/southbound/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/southbound/servicer.go
@@ -16,11 +16,11 @@ package servicers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/orc8r/cloud/go/services/state/servicers/southbound/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/southbound/servicer.go
@@ -16,6 +16,7 @@ package servicers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -232,7 +233,7 @@ func wrapStateWithAdditionalInfo(st *protos.State, hwID string, time uint64, cer
 	}
 	ret, err := json.Marshal(wrap)
 	if err != nil {
-		return nil, errors.Wrap(err, "json marshal state with meta")
+		return nil, fmt.Errorf("json marshal state with meta: %w", err)
 	}
 	return ret, nil
 }

--- a/orc8r/cloud/go/services/state/servicers/southbound/validate.go
+++ b/orc8r/cloud/go/services/state/servicers/southbound/validate.go
@@ -14,7 +14,8 @@
 package servicers
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/lib/go/protos"

--- a/orc8r/cloud/go/services/state/types/types.go
+++ b/orc8r/cloud/go/services/state/types/types.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/serde"
@@ -254,13 +253,13 @@ func MakeState(p *protos.State, serdes serde.Registry) (State, *protos.IDAndErro
 	}
 
 	if st.ReportedState == nil {
-		err = errors.Errorf("state {type: %s, key: %s} should not have nil SerializedReportedState value", p.Type, p.DeviceID)
+		err = fmt.Errorf("state {type: %s, key: %s} should not have nil SerializedReportedState value", p.Type, p.DeviceID)
 		sErr := &protos.IDAndError{Type: p.Type, DeviceID: p.DeviceID, Error: err.Error()}
 		return State{}, sErr, nil
 	}
 	model, ok := st.ReportedState.(serde.ValidateableBinaryConvertible)
 	if !ok {
-		err = errors.Errorf("could not convert state {type: %s, key: %s} to validateable model", p.Type, p.DeviceID)
+		err = fmt.Errorf("could not convert state {type: %s, key: %s} to validateable model", p.Type, p.DeviceID)
 		sErr := &protos.IDAndError{Type: p.Type, DeviceID: p.DeviceID, Error: err.Error()}
 		return State{}, sErr, nil
 	}

--- a/orc8r/cloud/go/services/state/types/types.go
+++ b/orc8r/cloud/go/services/state/types/types.go
@@ -177,7 +177,7 @@ func MakeProtoStates(states SerializedStatesByID) ([]*protos.State, error) {
 func MakeProtoState(id ID, st SerializedState) (*protos.State, error) {
 	bytes, err := json.Marshal(st)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal to json-encoded state proto value")
+		return nil, fmt.Errorf("failed to marshal to json-encoded state proto value: %w", err)
 	}
 	p := &protos.State{Type: id.Type, DeviceID: id.DeviceID, Value: bytes, Version: st.Version}
 	return p, nil
@@ -203,7 +203,7 @@ func MakeSerializedState(p *protos.State) (SerializedState, error) {
 	serialized := SerializedState{}
 	err := json.Unmarshal(p.Value, &serialized)
 	if err != nil {
-		return SerializedState{}, errors.Wrap(err, "error unmarshaling json-encoded state proto value")
+		return SerializedState{}, fmt.Errorf("error unmarshaling json-encoded state proto value: %w", err)
 	}
 	return serialized, nil
 }

--- a/orc8r/cloud/go/services/streamer/providers/registry.go
+++ b/orc8r/cloud/go/services/streamer/providers/registry.go
@@ -17,10 +17,10 @@ limitations under the License.
 package providers
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/orc8r"

--- a/orc8r/cloud/go/services/streamer/providers/servicers/protected/providers.go
+++ b/orc8r/cloud/go/services/streamer/providers/servicers/protected/providers.go
@@ -16,12 +16,12 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/lib/go/protos"
@@ -33,7 +33,7 @@ type MconfigProvider struct{}
 func (p *MconfigProvider) GetUpdates(ctx context.Context, gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
 	res, err := configurator.GetMconfigFor(ctx, gatewayId)
 	if err != nil {
-		return nil, errors.Wrap(err, "get mconfig from configurator")
+		return nil, fmt.Errorf("get mconfig from configurator: %w", err)
 	}
 
 	// TODO(#2310): add back support for extracting and comparing mconfig digest

--- a/orc8r/cloud/go/services/tenants/servicers/storage/storage.go
+++ b/orc8r/cloud/go/services/tenants/servicers/storage/storage.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/pkg/errors"
-
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/services/tenants"
 	tenant_protos "magma/orc8r/cloud/go/services/tenants/protos"
@@ -178,7 +176,7 @@ func (b *blobstoreStore) CreateOrUpdateControlProxy(tenantID int64, controlProxy
 func tenantToBlob(tenantID int64, tenant *tenant_protos.Tenant) (blobstore.Blob, error) {
 	marshaledTenant, err := protos.Marshal(tenant)
 	if err != nil {
-		return blobstore.Blob{}, errors.Wrap(err, "Error marshaling protobuf")
+		return blobstore.Blob{}, fmt.Errorf("Error marshaling protobuf: %w", err)
 	}
 	return blobstore.Blob{
 		Type:  tenants.TenantInfoType,
@@ -191,7 +189,7 @@ func tenantFromBlob(blob blobstore.Blob) (*tenant_protos.Tenant, error) {
 	tenant := tenant_protos.Tenant{}
 	err := protos.Unmarshal(blob.Value, &tenant)
 	if err != nil {
-		return &tenant_protos.Tenant{}, errors.Wrap(err, "Error unmarshaling protobuf")
+		return &tenant_protos.Tenant{}, fmt.Errorf("Error unmarshaling protobuf: %w", err)
 	}
 	return &tenant, nil
 }

--- a/orc8r/cloud/go/sqorc/table.go
+++ b/orc8r/cloud/go/sqorc/table.go
@@ -15,13 +15,13 @@ package sqorc
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/lann/builder"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 )
 

--- a/orc8r/cloud/go/sqorc/table.go
+++ b/orc8r/cloud/go/sqorc/table.go
@@ -330,7 +330,7 @@ func (d createTableData) ToSql() (string, []interface{}, error) {
 	for i, col := range d.Columns {
 		colSql, err := col.ToSql()
 		if err != nil {
-			return "", nil, errors.Wrapf(err, "could not sqlize column at position %d", i)
+			return "", nil, fmt.Errorf("could not sqlize column at position %d: %w", i, err)
 		}
 		colSqls = append(colSqls, colSql)
 	}

--- a/orc8r/cloud/go/sqorc/table.go
+++ b/orc8r/cloud/go/sqorc/table.go
@@ -88,9 +88,9 @@ const (
 	// Fill in other types as needed
 )
 
-//=============================================================================
+// =============================================================================
 // Tables
-//=============================================================================
+// =============================================================================
 
 // CreateTableBuilder is a builder for DDL table creation statements.
 // This builder is immutable and all operations will return a new instance
@@ -162,9 +162,9 @@ func (b CreateTableBuilder) columnTypeNames(m map[ColumnType]string) CreateTable
 	return builder.Set(b, "ColumnTypeNames", m).(CreateTableBuilder)
 }
 
-//=============================================================================
+// =============================================================================
 // Columns
-//=============================================================================
+// =============================================================================
 
 // ColumnBuilder is a builder for columns within a table creation statement
 // This builder is immutable and all methods will return a new instance of the
@@ -231,9 +231,9 @@ func (b ColumnBuilder) columnTypeNames(m map[ColumnType]string) ColumnBuilder {
 	return builder.Set(b, "ColumnTypeNames", m).(ColumnBuilder)
 }
 
-//=============================================================================
+// =============================================================================
 // Indexes
-//=============================================================================
+// =============================================================================
 
 // CreateIndexBuilder is a builder for CREATE INDEX statements
 type CreateIndexBuilder builder.Builder
@@ -275,9 +275,9 @@ func (b CreateIndexBuilder) ToSql() (string, []interface{}, error) {
 	return d.ToSql()
 }
 
-//=============================================================================
+// =============================================================================
 // Builder data types
-//=============================================================================
+// =============================================================================
 
 type foreignKey struct {
 	Table         string
@@ -361,7 +361,7 @@ func (d createTableData) ToSql() (string, []interface{}, error) {
 		case ColumnOnDeleteCascade:
 			sb.WriteString(" ON DELETE CASCADE")
 		default:
-			return "", nil, errors.Errorf("unrecognized on delete behavior %v", fk.OnDelete)
+			return "", nil, fmt.Errorf("unrecognized on delete behavior %v", fk.OnDelete)
 		}
 	}
 
@@ -398,13 +398,13 @@ func (d createColumnData) ToSql() (string, error) {
 		return "", errors.New("column type must be specified")
 	}
 	if _, typeOk := d.ColumnTypeNames[*d.Type]; !typeOk {
-		return "", errors.Errorf("column type %v not recognized", *d.Type)
+		return "", fmt.Errorf("column type %v not recognized", *d.Type)
 	}
 	if d.References != nil && (len(d.References[0]) == 0 || len(d.References[1]) == 0) {
-		return "", errors.Errorf("reference table name and column of foreign key must not be empty")
+		return "", fmt.Errorf("reference table name and column of foreign key must not be empty")
 	}
 	if d.OnDelete != nil && d.References == nil {
-		return "", errors.Errorf("cannot specify an ON DELETE without a REFERENCES")
+		return "", fmt.Errorf("cannot specify an ON DELETE without a REFERENCES")
 	}
 
 	sb := strings.Builder{}
@@ -430,7 +430,7 @@ func (d createColumnData) ToSql() (string, error) {
 		case ColumnOnDeleteCascade:
 			sb.WriteString(" ON DELETE CASCADE")
 		default:
-			return "", errors.Errorf("unrecognized on delete option %v", *d.OnDelete)
+			return "", fmt.Errorf("unrecognized on delete option %v", *d.OnDelete)
 		}
 	}
 	return sb.String(), nil

--- a/orc8r/cloud/go/sqorc/tx.go
+++ b/orc8r/cloud/go/sqorc/tx.go
@@ -18,7 +18,6 @@ import (
 	"database/sql"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // ExecInTx executes a callback inside a sql transaction on the provided DB.
@@ -64,6 +63,6 @@ func CloseRowsLogOnError(rows *sql.Rows, callsite string) {
 		return
 	}
 	if err := rows.Close(); err != nil {
-		glog.Errorf("Error closing sql rows in %s: %+v", callsite, errors.WithStack(err))
+		glog.Errorf("Error closing sql rows in %s: %+v", callsite, err)
 	}
 }

--- a/orc8r/cloud/go/syncstore/cache.go
+++ b/orc8r/cloud/go/syncstore/cache.go
@@ -72,7 +72,7 @@ func (l *cacheWriter) InsertMany(objects map[string][]byte) error {
 
 	txFn := func(tx *sql.Tx) (interface{}, error) {
 		_, err := insertQuery.RunWith(tx).Exec()
-		return nil, errors.Wrapf(err, "insert objs into store for network %+v", l.network)
+		return nil, fmt.Errorf("insert objs into store for network %+v: %w", l.network, err)
 	}
 	_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
 	return err
@@ -104,7 +104,7 @@ func (l *cacheWriter) Apply() error {
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrap(err, "clean up previous cached objs store table")
+			return nil, fmt.Errorf("clean up previous cached objs store table: %w", err)
 		}
 
 		// The upsert query should look something like
@@ -132,7 +132,7 @@ func (l *cacheWriter) Apply() error {
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrap(err, "populate cached objs store table")
+			return nil, fmt.Errorf("populate cached objs store table: %w", err)
 		}
 
 		_, err = l.builder.
@@ -140,7 +140,7 @@ func (l *cacheWriter) Apply() error {
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrap(err, "clean up tmp cached objs store table")
+			return nil, fmt.Errorf("clean up tmp cached objs store table: %w", err)
 		}
 		return nil, nil
 	}

--- a/orc8r/cloud/go/syncstore/cache.go
+++ b/orc8r/cloud/go/syncstore/cache.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 )
@@ -53,7 +52,7 @@ func (l *syncStore) NewCacheWriter(network string, id string) CacheWriter {
 // CacheWriter object.
 func (l *cacheWriter) InsertMany(objects map[string][]byte) error {
 	if l.invalid {
-		return errors.Errorf("attempt to insert into network %+v with invalid cache writer", l.network)
+		return fmt.Errorf("attempt to insert into network %+v with invalid cache writer", l.network)
 	}
 	if len(objects) == 0 {
 		return nil
@@ -80,7 +79,7 @@ func (l *cacheWriter) InsertMany(objects map[string][]byte) error {
 
 func (l *cacheWriter) Apply() error {
 	if l.invalid {
-		return errors.Errorf("attempt to apply updates to network %+v with invalid cache writer", l.network)
+		return fmt.Errorf("attempt to apply updates to network %+v with invalid cache writer", l.network)
 	}
 	txFn := func(tx *sql.Tx) (interface{}, error) {
 		// HACK: hard coding part of this sql query because there currently doesn't exist good support

--- a/orc8r/cloud/go/syncstore/config.go
+++ b/orc8r/cloud/go/syncstore/config.go
@@ -14,10 +14,10 @@
 package syncstore
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 )
 
 type Config struct {

--- a/orc8r/cloud/go/syncstore/config.go
+++ b/orc8r/cloud/go/syncstore/config.go
@@ -14,6 +14,8 @@
 package syncstore
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
@@ -37,7 +39,7 @@ func (config *Config) Validate(writer bool) error {
 		errs = multierror.Append(errs, errors.New("empty table name prefix for syncstore"))
 	}
 	if writer && config.CacheWriterValidIntervalSecs <= 0 {
-		errs = multierror.Append(errs, errors.Errorf("invalid cache writer valid interval: %+v", config.CacheWriterValidIntervalSecs))
+		errs = multierror.Append(errs, fmt.Errorf("invalid cache writer valid interval: %+v", config.CacheWriterValidIntervalSecs))
 	}
 	return errs.ErrorOrNil()
 }

--- a/orc8r/cloud/go/syncstore/store_reader.go
+++ b/orc8r/cloud/go/syncstore/store_reader.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/clock"
@@ -47,7 +46,7 @@ const (
 func NewSyncStoreReader(db *sql.DB, builder sqorc.StatementBuilder, fact blobstore.StoreFactory, config Config) (SyncStoreReader, error) {
 	err := config.Validate(false)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid configs for syncstore reader")
+		return nil, fmt.Errorf("invalid configs for syncstore reader: %w", err)
 	}
 	storeReader := &syncStore{
 		db:                           db,
@@ -73,7 +72,7 @@ func (l *syncStore) Initialize() error {
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrap(err, "initialize digest store table")
+			return nil, fmt.Errorf("initialize digest store table: %w", err)
 		}
 
 		_, err = l.builder.CreateTable(l.cacheTableName).
@@ -84,7 +83,7 @@ func (l *syncStore) Initialize() error {
 			PrimaryKey(nidCol, idCol).
 			RunWith(tx).
 			Exec()
-		return nil, errors.Wrap(err, "initialize cached obj store table")
+		return nil, fmt.Errorf("initialize cached obj store table: %w", err)
 	}
 	_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
 	return err
@@ -103,7 +102,7 @@ func (l *syncStore) GetDigests(networks []string, lastUpdatedBefore int64, loadL
 			RunWith(tx).
 			Query()
 		if err != nil {
-			return nil, errors.Wrapf(err, "get digests for networks %+v", networks)
+			return nil, fmt.Errorf("get digests for networks %+v: %w", networks, err)
 		}
 		defer sqorc.CloseRowsLogOnError(rows, "GetDigests")
 
@@ -112,7 +111,7 @@ func (l *syncStore) GetDigests(networks []string, lastUpdatedBefore int64, loadL
 			network, rootDigest, leafDigestsMarshaled, lastUpdatedTime := "", "", []byte{}, int64(0)
 			err = rows.Scan(&network, &rootDigest, &leafDigestsMarshaled, &lastUpdatedTime)
 			if err != nil {
-				return nil, errors.Wrapf(err, "get digests for network %+v, SQL row scan error", network)
+				return nil, fmt.Errorf("get digests for network %+v, SQL row scan error: %w", network, err)
 			}
 
 			digestTree := &protos.DigestTree{RootDigest: &protos.Digest{Md5Base64Digest: rootDigest}}
@@ -120,7 +119,7 @@ func (l *syncStore) GetDigests(networks []string, lastUpdatedBefore int64, loadL
 				leafDigests := &protos.LeafDigests{}
 				err = proto.Unmarshal(leafDigestsMarshaled, leafDigests)
 				if err != nil {
-					return nil, errors.Wrapf(err, "unmarshal leaf digests for network %+v", network)
+					return nil, fmt.Errorf("unmarshal leaf digests for network %+v: %w", network, err)
 				}
 				digestTree.LeafDigests = leafDigests.Digests
 			}
@@ -128,7 +127,7 @@ func (l *syncStore) GetDigests(networks []string, lastUpdatedBefore int64, loadL
 		}
 		err = rows.Err()
 		if err != nil {
-			return nil, errors.Wrap(err, "select digests for network, SQL rows error")
+			return nil, fmt.Errorf("select digests for network, SQL rows error: %w", err)
 		}
 		return digestTrees, nil
 	}
@@ -156,7 +155,7 @@ func (l *syncStore) GetCachedByID(network string, ids []string) ([][]byte, error
 			RunWith(tx).
 			Query()
 		if err != nil {
-			return nil, errors.Wrapf(err, "get cached objs by ID for network %+v", network)
+			return nil, fmt.Errorf("get cached objs by ID for network %+v: %w", network, err)
 		}
 		objs, _, err := parseRows(rows)
 		return objs, err
@@ -189,7 +188,7 @@ func (l *syncStore) GetCachedByPage(network string, token string, pageSize uint6
 			RunWith(tx).
 			Query()
 		if err != nil {
-			return nil, errors.Wrapf(err, "get page for network %+v with token %+v", network, token)
+			return nil, fmt.Errorf("get page for network %+v with token %+v: %w", network, token, err)
 		}
 		return parsePage(rows, pageSize)
 	}
@@ -204,7 +203,7 @@ func (l *syncStore) GetCachedByPage(network string, token string, pageSize uint6
 func (l *syncStore) GetLastResync(network string, gateway string) (int64, error) {
 	store, err := l.fact.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return int64(0), errors.Wrapf(err, "error starting transaction")
+		return int64(0), fmt.Errorf("error starting transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -214,7 +213,7 @@ func (l *syncStore) GetLastResync(network string, gateway string) (int64, error)
 		return int64(0), nil
 	}
 	if err != nil {
-		return int64(0), errors.Wrapf(err, "get last resync time of network %+v, gateway %+v from blobstore", network, gateway)
+		return int64(0), fmt.Errorf("get last resync time of network %+v, gateway %+v from blobstore: %w", network, gateway, err)
 	}
 
 	lastResync := binary.LittleEndian.Uint64(blob.Value)
@@ -256,7 +255,7 @@ func parsePage(rows *sql.Rows, pageSize uint64) (*pageInfo, error) {
 	nextToken := &configurator_storage.EntityPageToken{LastIncludedEntity: lastIncludedID}
 	nextTokenSerialized, err := configurator_storage.SerializePageToken(nextToken)
 	if err != nil {
-		return nil, errors.Wrap(err, "get next page token for cached objs store")
+		return nil, fmt.Errorf("get next page token for cached objs store: %w", err)
 	}
 	return &pageInfo{token: nextTokenSerialized, objects: objs}, nil
 }
@@ -267,14 +266,14 @@ func parseRows(rows *sql.Rows) ([][]byte, string, error) {
 		id, obj := "", []byte{}
 		err := rows.Scan(&id, &obj)
 		if err != nil {
-			return nil, "", errors.Wrap(err, "get serialized obj, SQL rows scan error")
+			return nil, "", fmt.Errorf("get serialized obj, SQL rows scan error: %w", err)
 		}
 		objs = append(objs, obj)
 		lastIncludedID = id
 	}
 	err := rows.Err()
 	if err != nil {
-		return nil, "", errors.Wrap(err, "parse cached objs in store, SQL rows error")
+		return nil, "", fmt.Errorf("parse cached objs in store, SQL rows error: %w", err)
 	}
 	return objs, lastIncludedID, nil
 }

--- a/orc8r/cloud/go/syncstore/store_writer.go
+++ b/orc8r/cloud/go/syncstore/store_writer.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/blobstore"
@@ -46,7 +45,7 @@ type syncStore struct {
 func NewSyncStore(db *sql.DB, builder sqorc.StatementBuilder, fact blobstore.StoreFactory, config Config) (SyncStore, error) {
 	err := config.Validate(true)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid configs for syncstore")
+		return nil, fmt.Errorf("invalid configs for syncstore: %w", err)
 	}
 	store := &syncStore{
 		db:                           db,
@@ -65,7 +64,7 @@ func (l *syncStore) SetDigest(network string, digests *protos.DigestTree) error 
 	leafDigestsToSerialize := &protos.LeafDigests{Digests: digests.GetLeafDigests()}
 	leafDigests, err := proto.Marshal(leafDigestsToSerialize)
 	if err != nil {
-		return errors.Wrapf(err, "marshal leaf digests for network %+v", network)
+		return fmt.Errorf("marshal leaf digests for network %+v: %w", network, err)
 	}
 	now := clock.Now().Unix()
 
@@ -85,7 +84,7 @@ func (l *syncStore) SetDigest(network string, digests *protos.DigestTree) error 
 			RunWith(tx).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrapf(err, "insert digests for network %+v", network)
+			return nil, fmt.Errorf("insert digests for network %+v: %w", network, err)
 		}
 		return nil, nil
 	}
@@ -105,7 +104,7 @@ func (l *syncStore) UpdateCache(network string) (CacheWriter, error) {
 			PrimaryKey(nidCol, idCol).
 			RunWith(tx).
 			Exec()
-		return nil, errors.Wrap(err, "create cached objs tmp table")
+		return nil, fmt.Errorf("create cached objs tmp table: %w", err)
 	}
 	_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
 	if err != nil {
@@ -115,7 +114,7 @@ func (l *syncStore) UpdateCache(network string) (CacheWriter, error) {
 	// The start time of cacheWriters is tracked by the store for garbage collection
 	err = l.recordCacheWriterStartTime(network, writerID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "record start time of cache writer %+v of network %+v", writerID, network)
+		return nil, fmt.Errorf("record start time of cache writer %+v of network %+v: %w", writerID, network, err)
 	}
 
 	return l.NewCacheWriter(network, writerID), nil
@@ -124,7 +123,7 @@ func (l *syncStore) UpdateCache(network string) (CacheWriter, error) {
 func (l *syncStore) RecordResync(network string, gateway string, t int64) error {
 	store, err := l.fact.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrapf(err, "error starting transaction")
+		return fmt.Errorf("error starting transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -134,7 +133,7 @@ func (l *syncStore) RecordResync(network string, gateway string, t int64) error 
 		Value: encodeInt64(t),
 	}})
 	if err != nil {
-		return errors.Wrapf(err, "set last resync time of network %+v, gateway %+v in blobstore", network, gateway)
+		return fmt.Errorf("set last resync time of network %+v, gateway %+v in blobstore: %w", network, gateway, err)
 	}
 
 	return store.Commit()
@@ -144,7 +143,7 @@ func (l *syncStore) RecordResync(network string, gateway string, t int64) error 
 func (l *syncStore) recordCacheWriterStartTime(network string, writerID string) error {
 	store, err := l.fact.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrapf(err, "error starting transaction")
+		return fmt.Errorf("error starting transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -154,7 +153,7 @@ func (l *syncStore) recordCacheWriterStartTime(network string, writerID string) 
 		Value: encodeInt64(clock.Now().Unix()),
 	}})
 	if err != nil {
-		return errors.Wrapf(err, "set start time of network %+v, cachewriter %+v in blobstore", network, writerID)
+		return fmt.Errorf("set start time of network %+v, cachewriter %+v in blobstore: %w", network, writerID, err)
 	}
 	return store.Commit()
 }
@@ -196,7 +195,9 @@ func (l *syncStore) collectGarbageSQL(tracked []string) error {
 			return nil, err
 		}
 		_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
-		errs = multierror.Append(errs, errors.Wrapf(err, "collect garbage for table %+v", tableName))
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("collect garbage for table %+v: %w", tableName), err)
+		}
 	}
 	return errs.ErrorOrNil()
 }
@@ -204,20 +205,20 @@ func (l *syncStore) collectGarbageSQL(tracked []string) error {
 func (l *syncStore) getStoredNetworksSQL(tx *sql.Tx, tableName string) ([]string, error) {
 	rows, err := l.builder.Select(nidCol).From(tableName).RunWith(tx).Query()
 	if err != nil {
-		return nil, errors.Wrapf(err, "get all networks in store %+v", tableName)
+		return nil, fmt.Errorf("get all networks in store %+v: %w", tableName, err)
 	}
 	var storedNetworks []string
 	for rows.Next() {
 		network := ""
 		err = rows.Scan(&network)
 		if err != nil {
-			return nil, errors.Wrapf(err, "get all networks in store %+v, SQL rows scan error", tableName)
+			return nil, fmt.Errorf("get all networks in store %+v, SQL rows scan error: %w", tableName, err)
 		}
 		storedNetworks = append(storedNetworks, network)
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrapf(err, "get all networks in store %+v, SQL rows error", tableName)
+		return nil, fmt.Errorf("get all networks in store %+v, SQL rows error: %w", tableName, err)
 	}
 	return storedNetworks, nil
 }
@@ -225,7 +226,7 @@ func (l *syncStore) getStoredNetworksSQL(tx *sql.Tx, tableName string) ([]string
 func getStoredNetworksBlobstore(store blobstore.Store) ([]string, error) {
 	keysByNetwork, err := blobstore.ListKeysByNetwork(store)
 	if err != nil {
-		return nil, errors.Wrap(err, "list blobstore keys by network")
+		return nil, fmt.Errorf("list blobstore keys by network: %w", err)
 	}
 	return funk.Keys(keysByNetwork).([]string), nil
 }
@@ -235,13 +236,13 @@ func getStoredNetworksBlobstore(store blobstore.Store) ([]string, error) {
 func (l *syncStore) collectGarbageLastResync(tracked []string) error {
 	store, err := l.fact.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrap(err, "error starting transaction")
+		return fmt.Errorf("error starting transaction: %w", err)
 	}
 	defer store.Rollback()
 
 	stored, err := getStoredNetworksBlobstore(store)
 	if err != nil {
-		return errors.Wrap(err, "get all networks in blobstore")
+		return fmt.Errorf("get all networks in blobstore: %w", err)
 	}
 	deleted, _ := funk.DifferenceString(stored, tracked)
 
@@ -265,19 +266,19 @@ func (l *syncStore) collectGarbageCacheWriter(tracked []string) error {
 
 	invalidByNetwork, err := l.getInvalidCacheWriter(tracked, l.cacheWriterValidIntervalSecs)
 	if err != nil {
-		errs = multierror.Append(errs, errors.Wrapf(err, "get invalid cache writers for tracked networks %+v", tracked))
+		errs = multierror.Append(errs, fmt.Errorf("get invalid cache writers for tracked networks %+v: %w", tracked), err)
 	}
 
 	// Attempt to drop the tmp tables of all invalid cacheWriters, and only delete the blobstore records of those
 	// whose tables have been successfully dropped; the rest is left to be garbage collected in future runs
 	deletedByNetwork, err := l.dropInvalidCaches(invalidByNetwork)
 	if err != nil {
-		errs = multierror.Append(errs, errors.Wrapf(err, "drop invalid cache writer tables %+v", invalidByNetwork))
+		errs = multierror.Append(errs, fmt.Errorf("drop invalid cache writer tables %+v: %w", invalidByNetwork), err)
 	}
 
 	err = l.deleteCacheWriterBlobstoreRecords(deletedByNetwork)
 	if err != nil {
-		errs = multierror.Append(errs, errors.Wrapf(err, "delete cache writer blobstore records %+v", deletedByNetwork))
+		errs = multierror.Append(errs, fmt.Errorf("delete cache writer blobstore records %+v: %w", deletedByNetwork), err)
 	}
 
 	return errs.ErrorOrNil()
@@ -288,13 +289,13 @@ func (l *syncStore) collectGarbageCacheWriter(tracked []string) error {
 func (l *syncStore) getInvalidCacheWriter(tracked []string, cacheWriterValidIntervalSecs int64) (map[string][]string, error) {
 	store, err := l.fact.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, errors.Wrap(err, "error starting transaction")
+		return nil, fmt.Errorf("error starting transaction: %w", err)
 	}
 	defer store.Rollback()
 
 	stored, err := getStoredNetworksBlobstore(store)
 	if err != nil {
-		return nil, errors.Wrap(err, "get all networks in blobstore")
+		return nil, fmt.Errorf("get all networks in blobstore: %w", err)
 	}
 
 	deleted, _ := funk.DifferenceString(stored, tracked)
@@ -304,7 +305,7 @@ func (l *syncStore) getInvalidCacheWriter(tracked []string, cacheWriterValidInte
 	for _, network := range deleted {
 		keys, err := blobstore.ListKeys(store, network, cacheWriterBlobstoreType)
 		if err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "list cache writers of deleted network %+v", network))
+			errs = multierror.Append(errs, fmt.Errorf("list cache writers of deleted network %+v: %w", network), err)
 			continue
 		}
 		invalidByNetwork[network] = keys
@@ -313,12 +314,12 @@ func (l *syncStore) getInvalidCacheWriter(tracked []string, cacheWriterValidInte
 	for _, network := range tracked {
 		keys, err := blobstore.ListKeys(store, network, cacheWriterBlobstoreType)
 		if err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "list all cache-writer-type blobstore keys of network %+v", network))
+			errs = multierror.Append(errs, fmt.Errorf("list all cache-writer-type blobstore keys of network %+v: %w", network), err)
 			continue
 		}
 		blobs, err := store.GetMany(network, storage.MakeTKs(cacheWriterBlobstoreType, keys))
 		if err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "get cache writer blobs of network %+v", network))
+			errs = multierror.Append(errs, fmt.Errorf("get cache writer blobs of network %+v: %w", network), err)
 			continue
 		}
 
@@ -346,7 +347,7 @@ func (l *syncStore) dropInvalidCaches(invalidByNetwork map[string][]string) (map
 		for _, tableName := range invalid {
 			txFn := func(tx *sql.Tx) (interface{}, error) {
 				_, err := tx.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
-				return nil, errors.Wrapf(err, "drop cache writer table %+v for network %+v", tableName, network)
+				return nil, fmt.Errorf("drop cache writer table %+v for network %+v: %w", tableName, network, err)
 			}
 			_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
 			if err != nil {
@@ -365,7 +366,7 @@ func (l *syncStore) dropInvalidCaches(invalidByNetwork map[string][]string) (map
 func (l *syncStore) deleteCacheWriterBlobstoreRecords(deletedByNetwork map[string][]string) error {
 	store, err := l.fact.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrap(err, "error starting transaction")
+		return fmt.Errorf("error starting transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -374,7 +375,7 @@ func (l *syncStore) deleteCacheWriterBlobstoreRecords(deletedByNetwork map[strin
 		tks := storage.MakeTKs(cacheWriterBlobstoreType, deleted)
 		err := store.Delete(network, tks)
 		if err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "delete blobstore cache writer records %+v for network %+v", deleted, network))
+			errs = multierror.Append(errs, fmt.Errorf("delete blobstore cache writer records %+v for network %+v: %w", deleted, network), err)
 		}
 	}
 	err = store.Commit()

--- a/orc8r/cloud/go/test_utils/test_db.go
+++ b/orc8r/cloud/go/test_utils/test_db.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"magma/orc8r/cloud/go/blobstore"
@@ -70,7 +69,7 @@ func NewSQLBlobstoreForServices(tableName string) (blobstore.StoreFactory, error
 	// to provide a clean slate across test cases
 	_, err = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
 	if err != nil {
-		return nil, errors.Wrapf(err, "drop test SQL blobstore table: %s", tableName)
+		return nil, fmt.Errorf("drop test SQL blobstore table: %s: %w", tableName, err)
 	}
 
 	store := blobstore.NewSQLStoreFactory(tableName, db, sqorc.GetSqlBuilder())

--- a/orc8r/cloud/go/tools/migrations/configurator.go
+++ b/orc8r/cloud/go/tools/migrations/configurator.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 )
 
 // Duplicated from configurator
@@ -96,7 +95,7 @@ func SetAssocDirections(builder squirrel.StatementBuilderType, edges []AssocDire
 		Where(where).
 		Query()
 	if err != nil {
-		return errors.Wrap(err, "get existing assocs to flip")
+		return fmt.Errorf("get existing assocs to flip: %w", err)
 	}
 
 	var assocs []assocPair
@@ -104,13 +103,13 @@ func SetAssocDirections(builder squirrel.StatementBuilderType, edges []AssocDire
 		assoc := assocPair{}
 		err = rows.Scan(&assoc.fromPk, &assoc.toPk)
 		if err != nil {
-			return errors.Wrap(err, "scan assocs")
+			return fmt.Errorf("scan assocs: %w", err)
 		}
 		assocs = append(assocs, assoc)
 	}
 	err = rows.Err()
 	if err != nil {
-		return errors.Wrap(err, "get existing assocs: SQL rows error")
+		return fmt.Errorf("get existing assocs: SQL rows error: %w", err)
 	}
 
 	glog.Infof("Flipping %d assocs", len(assocs))
@@ -134,7 +133,7 @@ func flipAssocDirection(builder squirrel.StatementBuilderType, assoc assocPair) 
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err := b.Exec()
 	if err != nil {
-		return errors.Wrap(err, "update error")
+		return fmt.Errorf("update error: %w", err)
 	}
 	return nil
 }

--- a/orc8r/cloud/go/tools/migrations/datastore_to_blobstore.go
+++ b/orc8r/cloud/go/tools/migrations/datastore_to_blobstore.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 )
@@ -67,13 +66,13 @@ func MigrateNetworkAgnosticServiceToBlobstore(nid, typ, oldTable, newTable strin
 	dbSource := GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	// Set up transaction
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "error opening tx"))
+		glog.Fatal(fmt.Errorf("error opening tx: %w", err))
 	}
 	defer func() {
 		if err != nil {
@@ -100,7 +99,7 @@ func MigrateNetworkAgnosticServiceToBlobstore(nid, typ, oldTable, newTable strin
 		Column(deletedCol).Type(sqorc.ColumnTypeBool).NotNull().Default("FALSE").EndColumn()
 	_, err = ob.RunWith(tx).Exec()
 	if err != nil {
-		err = errors.Wrap(err, "failed to create old table")
+		err = fmt.Errorf("failed to create old table: %w", err)
 		return
 	}
 
@@ -108,7 +107,7 @@ func MigrateNetworkAgnosticServiceToBlobstore(nid, typ, oldTable, newTable strin
 	query := fmt.Sprintf("DROP TABLE IF EXISTS %s", newTable)
 	_, err = tx.Exec(query)
 	if err != nil {
-		err = errors.Wrap(err, "failed to drop new table")
+		err = fmt.Errorf("failed to drop new table: %w", err)
 		return
 	}
 
@@ -122,7 +121,7 @@ func MigrateNetworkAgnosticServiceToBlobstore(nid, typ, oldTable, newTable strin
 		PrimaryKey(nidCol, typeCol, keyCol)
 	_, err = nb.RunWith(tx).Exec()
 	if err != nil {
-		err = errors.Wrap(err, "failed to create new table")
+		err = fmt.Errorf("failed to create new table: %w", err)
 		return
 	}
 
@@ -141,7 +140,7 @@ func MigrateNetworkAgnosticServiceToBlobstore(nid, typ, oldTable, newTable strin
 	glog.Info("[RUN] ", sqlStr)
 	_, err = ib.RunWith(tx).Exec()
 	if err != nil {
-		err = errors.Wrap(err, "failed to insert")
+		err = fmt.Errorf("failed to insert: %w", err)
 		return
 	}
 }

--- a/orc8r/cloud/go/tools/migrations/m005_certifier_to_blobstore/main.go
+++ b/orc8r/cloud/go/tools/migrations/m005_certifier_to_blobstore/main.go
@@ -16,11 +16,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	certifierprotos "magma/orc8r/cloud/go/services/certifier/protos"
@@ -79,19 +79,19 @@ func manuallyVerifyCertifierMigration() error {
 	certSrvAddr := "localhost:9086"
 	conn, err := grpc.Dial(certSrvAddr, grpc.WithInsecure())
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to certifier server")
+		return fmt.Errorf("failed to connect to certifier server: %w", err)
 	}
 	client := certifierprotos.NewCertifierClient(conn)
 
 	snsProto, err := client.ListCertificates(context.Background(), &protos.Void{})
 	if err != nil {
-		return errors.Wrap(err, "failed to list certificates")
+		return fmt.Errorf("failed to list certificates: %w", err)
 	}
 	glog.Infof("[manually verify] serial number count: %d", len(snsProto.GetSns()))
 
 	certInfos, err := client.GetAll(context.Background(), &protos.Void{})
 	if err != nil {
-		return errors.Wrap(err, "failed to get all certificates")
+		return fmt.Errorf("failed to get all certificates: %w", err)
 	}
 	maxToPrint := 5
 	i := 0

--- a/orc8r/cloud/go/tools/migrations/m008_accessd_to_blobstore/main.go
+++ b/orc8r/cloud/go/tools/migrations/m008_accessd_to_blobstore/main.go
@@ -16,11 +16,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	accessprotos "magma/orc8r/cloud/go/services/accessd/protos"
@@ -78,14 +78,14 @@ func manuallyVerifyAccessdMigration() error {
 	accessdSrvAddr := "localhost:9091"
 	conn, err := grpc.Dial(accessdSrvAddr, grpc.WithInsecure())
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to accessd server")
+		return fmt.Errorf("failed to connect to accessd server: %w", err)
 	}
 	client := accessprotos.NewAccessControlManagerClient(conn)
 	ctx := context.Background()
 
 	operators, err := client.ListOperators(ctx, &protos.Void{})
 	if err != nil {
-		return errors.Wrap(err, "failed to list operators")
+		return fmt.Errorf("failed to list operators: %w", err)
 	}
 	glog.Infof("[manually verify] number of operators: %d", len(operators.List))
 
@@ -97,7 +97,7 @@ func manuallyVerifyAccessdMigration() error {
 	operator := operators.List[0]
 	acl, err := client.GetOperatorACL(ctx, operator)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get operator ACL for operator: %+v", operator)
+		return fmt.Errorf("failed to get operator ACL for operator: %+v: %w", operator, err)
 	}
 	glog.Infof("[manually verify] operator-acl pair: {operator: %+v, acl: %+v}", operator, acl)
 

--- a/orc8r/cloud/go/tools/migrations/m009_directoryd_to_blobstore/main.go
+++ b/orc8r/cloud/go/tools/migrations/m009_directoryd_to_blobstore/main.go
@@ -22,7 +22,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -48,13 +47,13 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	// Set up transaction
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "error opening tx"))
+		glog.Fatal(fmt.Errorf("error opening tx: %w", err))
 	}
 	defer func() {
 		if err != nil {
@@ -75,7 +74,7 @@ func main() {
 	glog.Infof("[RUN] %s", query)
 	_, err = tx.Exec(query)
 	if err != nil {
-		err = errors.Wrap(err, "failed to drop new table")
+		err = fmt.Errorf("failed to drop new table: %w", err)
 		return
 	}
 

--- a/orc8r/cloud/go/tools/migrations/sql_operations.go
+++ b/orc8r/cloud/go/tools/migrations/sql_operations.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 func GetTableName(networkId string, baseName string) string {
@@ -61,7 +60,7 @@ func GetAllValuesFromTable(tx *sql.Tx, table string) (map[string][]byte, error) 
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 	return ret, nil
 }
@@ -93,7 +92,7 @@ func GetAllKeysFromTable(tx *sql.Tx, table string) ([]string, error) {
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 
 	sort.Strings(ret)

--- a/orc8r/cloud/go/tools/swaggergen/combine_swagger/generate/generate.go
+++ b/orc8r/cloud/go/tools/swaggergen/combine_swagger/generate/generate.go
@@ -14,11 +14,10 @@
 package generate
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian/swagger/spec"
 	"magma/orc8r/cloud/go/tools/swaggergen/swaggergen/generate"
@@ -50,7 +49,7 @@ func GenerateStandaloneSpecs(specDir string, rootDir string) error {
 func GenerateSpec(targetFilepath string, specs map[string]generate.MagmaSwaggerSpec, outPath string) error {
 	absTargetFilepath, err := filepath.Abs(targetFilepath)
 	if err != nil {
-		return errors.Wrapf(err, "target filepath %s is invalid", targetFilepath)
+		return fmt.Errorf("target filepath %s is invalid: %w", targetFilepath, err)
 	}
 
 	var yamlSpecs []string

--- a/orc8r/cloud/go/tools/swaggergen/swaggergen/generate/generate.go
+++ b/orc8r/cloud/go/tools/swaggergen/swaggergen/generate/generate.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
 	"magma/orc8r/cloud/go/swagger"
@@ -125,7 +124,7 @@ func GenerateModels(targetFilepath string, configFilepath string, rootDir string
 	// the filename specified by `dependent-filename`
 	err = StripAndWriteSwaggerSpecs(specs, tmpGenDir)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	// Shell out to go-swagger
@@ -167,7 +166,7 @@ func ParseSwaggerDependencyTree(rootFilepath string, rootDir string) (map[string
 
 	targetSpec, err := readSwaggerSpec(absRootFilepath)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	type mscAndPath struct {

--- a/orc8r/cloud/go/tools/swaggergen/swaggergen/generate/generate.go
+++ b/orc8r/cloud/go/tools/swaggergen/swaggergen/generate/generate.go
@@ -14,6 +14,7 @@
 package generate
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -111,12 +112,12 @@ type MagmaGenType struct {
 func GenerateModels(targetFilepath string, configFilepath string, rootDir string, specs map[string]MagmaSwaggerSpec) error {
 	absTargetFilepath, err := filepath.Abs(targetFilepath)
 	if err != nil {
-		return errors.Wrapf(err, "target filepath %s is invalid", targetFilepath)
+		return fmt.Errorf("target filepath %s is invalid: %w", targetFilepath, err)
 	}
 
 	tmpGenDir, err := ioutil.TempDir(".", "tmpgen")
 	if err != nil {
-		return errors.Wrap(err, "could not create temporary gen directory")
+		return fmt.Errorf("could not create temporary gen directory: %w", err)
 	}
 	defer os.RemoveAll(tmpGenDir)
 
@@ -148,7 +149,7 @@ func GenerateModels(targetFilepath string, configFilepath string, rootDir string
 
 	err = cmd.Run()
 	if err != nil {
-		return errors.Wrapf(err, "failed to generate models; stdout:\n%s\nstderr:\n%s", stdoutBuf.String(), stderrBuf.String())
+		return fmt.Errorf("failed to generate models; stdout:\n%s\nstderr:\n%s: %w", stdoutBuf.String(), stderrBuf.String(), err)
 	}
 
 	return nil
@@ -161,7 +162,7 @@ func GenerateModels(targetFilepath string, configFilepath string, rootDir string
 func ParseSwaggerDependencyTree(rootFilepath string, rootDir string) (map[string]MagmaSwaggerSpec, error) {
 	absRootFilepath, err := filepath.Abs(rootFilepath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "root filepath %s is invalid", rootFilepath)
+		return nil, fmt.Errorf("root filepath %s is invalid: %w", rootFilepath, err)
 	}
 
 	targetSpec, err := readSwaggerSpec(absRootFilepath)
@@ -187,7 +188,7 @@ func ParseSwaggerDependencyTree(rootFilepath string, rootDir string) (map[string
 		for _, dependencyPath := range nextSpec.MagmaGenMeta.Dependencies {
 			absDependencyPath, err := filepath.Abs(filepath.Join(rootDir, dependencyPath))
 			if err != nil {
-				return nil, errors.Wrapf(err, "dependency filepath %s is invalid", dependencyPath)
+				return nil, fmt.Errorf("dependency filepath %s is invalid: %w", dependencyPath, err)
 			}
 			if _, alreadyOpened := openedFiles[absDependencyPath]; alreadyOpened {
 				continue
@@ -196,7 +197,7 @@ func ParseSwaggerDependencyTree(rootFilepath string, rootDir string) (map[string
 
 			dependencySpec, err := readSwaggerSpec(absDependencyPath)
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to read dependency tree of swagger specs")
+				return nil, fmt.Errorf("failed to read dependency tree of swagger specs: %w", err)
 			}
 			specsToVisit = append(
 				specsToVisit,
@@ -215,12 +216,12 @@ func StripAndWriteSwaggerSpecs(specs map[string]MagmaSwaggerSpec, outDir string)
 		sanitized := msc.ToSwaggerSpec()
 		marshaledSanitized, err := yaml.Marshal(sanitized)
 		if err != nil {
-			return errors.Wrapf(err, "could not re-marshal swagger spec %s", path)
+			return fmt.Errorf("could not re-marshal swagger spec %s: %w", path, err)
 		}
 
 		err = ioutil.WriteFile(filepath.Join(outDir, msc.MagmaGenMeta.TempGenFilename), marshaledSanitized, 0666)
 		if err != nil {
-			return errors.Wrapf(err, "could not write dependency swagger spec %s", msc.MagmaGenMeta.TempGenFilename)
+			return fmt.Errorf("could not write dependency swagger spec %s: %w", msc.MagmaGenMeta.TempGenFilename, err)
 		}
 	}
 	return nil
@@ -229,13 +230,13 @@ func StripAndWriteSwaggerSpecs(specs map[string]MagmaSwaggerSpec, outDir string)
 func readSwaggerSpec(filepath string) (MagmaSwaggerSpec, error) {
 	fileContents, err := ioutil.ReadFile(filepath)
 	if err != nil {
-		return MagmaSwaggerSpec{}, errors.Wrapf(err, "could not open target file %s", filepath)
+		return MagmaSwaggerSpec{}, fmt.Errorf("could not open target file %s: %w", filepath, err)
 	}
 
 	spec := MagmaSwaggerSpec{}
 	err = yaml.Unmarshal(fileContents, &spec)
 	if err != nil {
-		return MagmaSwaggerSpec{}, errors.Wrapf(err, "could not parse target file %s as yml", filepath)
+		return MagmaSwaggerSpec{}, fmt.Errorf("could not parse target file %s as yml: %w", filepath, err)
 	}
 	return spec, nil
 }

--- a/orc8r/cloud/test/go.mod
+++ b/orc8r/cloud/test/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/go-openapi/runtime v0.21.1
 	github.com/go-openapi/swag v0.19.15
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.7.0
@@ -57,6 +56,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.mongodb.org/mongo-driver v1.8.2 // indirect

--- a/orc8r/cloud/test/go.sum
+++ b/orc8r/cloud/test/go.sum
@@ -394,7 +394,6 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/orc8r/cloud/test/testlib/cluster.go
+++ b/orc8r/cloud/test/testlib/cluster.go
@@ -18,14 +18,12 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/pkg/errors"
-
 	"magma/orc8r/cloud/go/parallel"
 )
 
 var clusterConfig = flag.String("cluster-config", "", "Location of the cluster config file")
 
-//Gateway gateway specific configuration of the cluster
+// Gateway gateway specific configuration of the cluster
 type Gateway struct {
 	ID         string `json:"gateway_id"`
 	HardwareID string `json:"hardware_id"`
@@ -42,12 +40,12 @@ func (g Gateways) Hostnames() []string {
 	return hh
 }
 
-//ClusterInternalConfig cluster's internal configuration
+// ClusterInternalConfig cluster's internal configuration
 type ClusterInternalConfig struct {
 	BastionIP string `json:"bastion_ip"`
 }
 
-//Cluster configuration of the cluster
+// Cluster configuration of the cluster
 type Cluster struct {
 	UUID           string                 `json:"uuid"`
 	ClusterType    int                    `json:"cluster_type"`
@@ -61,7 +59,7 @@ func (c *Cluster) RunCmdOnGateways(cmd string) ([]string, error) {
 		hostname := in.(string)
 		out, err := runRemoteCommand(hostname, c.InternalConfig.BastionIP, []string{cmd})
 		if err != nil {
-			return nil, errors.Wrapf(err, "run remote commands on gateway '%s'; out: %+v", hostname, out)
+			return nil, fmt.Errorf("run remote commands on gateway '%s'; out: %+v: %w", hostname, out, err)
 		}
 		return out, nil
 	})

--- a/orc8r/cloud/test/testlib/ssh.go
+++ b/orc8r/cloud/test/testlib/ssh.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -48,19 +47,19 @@ func runRemoteCommand(hostname string, bastionIP string, cmds []string) ([]strin
 	}
 	bastionConn, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", bastionIP, *sshPort), sshConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "connect to bastion host")
+		return nil, fmt.Errorf("connect to bastion host: %w", err)
 	}
 	defer bastionConn.Close()
 
 	tunnelConn, err := bastionConn.Dial("tcp", fmt.Sprintf("%s:%d", hostname, *sshPort))
 	if err != nil {
-		return nil, errors.Wrap(err, "connect to host through tunnel")
+		return nil, fmt.Errorf("connect to host through tunnel: %w", err)
 	}
 	defer tunnelConn.Close()
 
 	newClientConn, channels, sshRequest, err := ssh.NewClientConn(tunnelConn, hostname, sshConfig)
 	if err != nil {
-		return nil, errors.Wrapf(err, "establish ssh client connection to '%s'", hostname)
+		return nil, fmt.Errorf("establish ssh client connection to '%s': %w", hostname, err)
 	}
 	defer newClientConn.Close()
 

--- a/orc8r/cloud/test/testlib/ssh.go
+++ b/orc8r/cloud/test/testlib/ssh.go
@@ -14,10 +14,9 @@ limitations under the License.
 package testlib
 
 import (
-	"io/ioutil"
-
 	"flag"
 	"fmt"
+	"io/ioutil"
 
 	"golang.org/x/crypto/ssh"
 )

--- a/orc8r/gateway/go/go.mod
+++ b/orc8r/gateway/go/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.19.0 // indirect
-	github.com/pkg/errors v0.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/prometheus/common v0.2.0 // indirect

--- a/orc8r/gateway/go/go.sum
+++ b/orc8r/gateway/go/go.sum
@@ -104,7 +104,6 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/orc8r/lib/go/definitions/env.go
+++ b/orc8r/lib/go/definitions/env.go
@@ -14,9 +14,8 @@ limitations under the License.
 package definitions
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 // GetEnvWithDefault returns the string value of the environment variable,
@@ -34,7 +33,7 @@ func GetEnvWithDefault(variable string, defaultValue string) string {
 func MustGetEnv(variable string) string {
 	value := os.Getenv(variable)
 	if len(value) == 0 {
-		panic(errors.Errorf("%s env not found", variable))
+		panic(fmt.Errorf("%s env not found", variable))
 	}
 	return value
 }

--- a/orc8r/lib/go/go.mod
+++ b/orc8r/lib/go/go.mod
@@ -7,7 +7,6 @@ replace magma/orc8r/lib/go/protos => ./protos
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.2
-	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/client_model v0.2.0
 	github.com/stretchr/testify v1.7.0

--- a/orc8r/lib/go/go.sum
+++ b/orc8r/lib/go/go.sum
@@ -61,7 +61,6 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/orc8r/lib/go/registry/service_registry.go
+++ b/orc8r/lib/go/registry/service_registry.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/lib/go/service/config"
 )
@@ -70,7 +69,7 @@ func LoadServiceRegistryConfigs() ([]ServiceLocation, error) {
 		}
 		locations, err := convertToServiceLocations(rawMap)
 		if err != nil {
-			return nil, errors.Wrapf(err, "load service registry for %s:%s.yml", module, serviceRegistryFilename)
+			return nil, fmt.Errorf("load service registry for %s:%s.yml: %w", module, serviceRegistryFilename, err)
 		}
 		ret = append(ret, locations...)
 	}

--- a/orc8r/lib/go/service/config/service_config.go
+++ b/orc8r/lib/go/service/config/service_config.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
 	_ "magma/orc8r/lib/go/initflag"
@@ -69,7 +68,7 @@ func GetServiceConfigs(serviceName string) (map[string]*Map, error) {
 	for _, moduleName := range modules {
 		cfg, err := GetServiceConfig(moduleName, serviceName)
 		if err != nil {
-			return nil, errors.Wrapf(err, "get service config for %v.%v", moduleName, serviceName)
+			return nil, fmt.Errorf("get service config for %v.%v: %w", moduleName, serviceName, err)
 		}
 		ret[moduleName] = cfg
 	}
@@ -222,7 +221,7 @@ func updateMap(baseMap, overrides *Map) *Map {
 func getModules() ([]string, error) {
 	moduleFiles, err := ioutil.ReadDir(configDir)
 	if err != nil {
-		return nil, errors.Wrap(err, "read modules from config directory")
+		return nil, fmt.Errorf("read modules from config directory: %w", err)
 	}
 	var modules []string
 	for _, m := range moduleFiles {

--- a/orc8r/lib/go/service/service.go
+++ b/orc8r/lib/go/service/service.go
@@ -19,7 +19,6 @@ package service
 import (
 	"flag"
 	"fmt"
-	"github.com/pkg/errors"
 	"net"
 	"sync"
 	"time"
@@ -152,7 +151,7 @@ func (service *Service) Run() error {
 	service.State = protos.ServiceInfo_ALIVE
 	service.Health = protos.ServiceInfo_APP_HEALTHY
 	if err != nil || perr != nil {
-		return errors.Errorf("error running grpc server: %v; error running proteced grpc server: %v", err, perr)
+		return fmt.Errorf("error running grpc server: %v; error running proteced grpc server: %v", err, perr)
 	} else {
 		return nil
 	}

--- a/src/go/agwd/config/config.go
+++ b/src/go/agwd/config/config.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"github.com/magma/magma/src/go/protos/magma/config"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -199,21 +198,21 @@ func loadConfigFile(
 	path string,
 ) (*config.AgwD, error) {
 	if _, err := osStat(path); err != nil {
-		return nil, errors.Wrap(err, "path="+path)
+		return nil, fmt.Errorf("path=%s: %w", path, err)
 	}
 
 	bytes, err := readFile(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "path="+path)
+		return nil, fmt.Errorf("path=%s: %w", path, err)
 	}
 	filtered := []byte(filterJSONComments(string(bytes)))
 	config := &config.AgwD{}
 	if err := unmarshalProto(filtered, config); err != nil {
-		return nil, errors.Wrapf(
-			err,
-			"path=%s filtered=%s",
+		return nil, fmt.Errorf(
+			"path=%s filtered=%s: %w",
 			path,
-			string(filtered))
+			string(filtered),
+			err)
 	}
 	return config, nil
 }

--- a/src/go/agwd/config/config_test.go
+++ b/src/go/agwd/config/config_test.go
@@ -12,13 +12,13 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/protobuf/proto"
@@ -258,7 +258,7 @@ func TestNewConfigManager_DefaultNotFound(t *testing.T) {
 
 	cm := NewConfigManager()
 	err := LoadConfigFile(cm, filepath.Join("testdata", "doesnotexist.json"))
-	assert.True(t, os.IsNotExist(errors.Cause(err)))
+	assert.True(t, os.IsNotExist(errors.Unwrap(err)))
 	assert.True(t, proto.Equal(newDefaultConfig(), cm.Config()))
 }
 

--- a/src/go/agwd/server/server.go
+++ b/src/go/agwd/server/server.go
@@ -23,7 +23,6 @@ import (
 	configpb "github.com/magma/magma/src/go/protos/magma/config"
 	service_capture "github.com/magma/magma/src/go/service/capture"
 	service_config "github.com/magma/magma/src/go/service/config"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	"github.com/magma/magma/src/go/agwd/config"
@@ -63,7 +62,7 @@ func cleanupUnixSocket(
 		return nil
 	}
 	if err != nil {
-		return errors.Wrapf(err, "os.Stat(%s)", path)
+		return fmt.Errorf("os.Stat(%s): %w", path, err)
 	}
 
 	// attempt to connect to see if someone is still bound to the socket.
@@ -76,7 +75,7 @@ func cleanupUnixSocket(
 	}
 	logger.Warning().Printf("Removing existing socket file; previous unclean shutdown?")
 	if err := osRemove(path); err != nil {
-		return errors.Wrapf(err, "os.Stat(%s)", path)
+		return fmt.Errorf("os.Stat(%s): %w", path, err)
 	}
 
 	return nil
@@ -84,10 +83,10 @@ func cleanupUnixSocket(
 
 func cleanupUnixSocketOrDie(logger log.Logger, path string) {
 	if err := cleanupUnixSocket(logger, os.Stat, os.Remove, net.DialTimeout, path); err != nil {
-		panic(errors.Wrapf(
-			err,
-			"cleanupUnixSocket(logger=_, target.Endpoint=%s)",
-			path))
+		panic(fmt.Errorf(
+			"cleanupUnixSocket(logger=_, target.Endpoint=%s): %w",
+			path,
+			err))
 	}
 }
 
@@ -102,11 +101,11 @@ func startSctpdDownlinkServer(
 	listener, err := net.Listen(
 		target.Scheme, target.Endpoint)
 	if err != nil {
-		panic(errors.Wrapf(
-			err,
-			"net.Listen(network=%s, address=%s)",
+		panic(fmt.Errorf(
+			"net.Listen(network=%s, address=%s): %w",
 			target.Scheme,
-			target.Endpoint))
+			target.Endpoint,
+			err))
 	}
 
 	grpcServer := grpc.NewServer(so...)
@@ -114,11 +113,11 @@ func startSctpdDownlinkServer(
 	sctpdpb.RegisterSctpdDownlinkServer(grpcServer, sctpdDownlinkServer)
 	go func() {
 		if err := grpcServer.Serve(listener); err != nil {
-			panic(errors.Wrapf(
-				err,
-				"startSctpdDownlinkServer(network=%s, address=%s)",
+			panic(fmt.Errorf(
+				"startSctpdDownlinkServer(network=%s, address=%s): %w",
 				target.Scheme,
-				target.Endpoint))
+				target.Endpoint,
+				err))
 		}
 	}()
 }
@@ -133,11 +132,11 @@ func startSctpdUplinkServer(
 
 	listener, err := net.Listen(target.Scheme, target.Endpoint)
 	if err != nil {
-		panic(errors.Wrapf(
-			err,
-			"net.Listen(network=%s, address=%s)",
+		panic(fmt.Errorf(
+			"net.Listen(network=%s, address=%s): %w",
 			target.Scheme,
-			target.Endpoint))
+			target.Endpoint,
+			err))
 	}
 
 	grpcServer := grpc.NewServer(so...)
@@ -145,11 +144,11 @@ func startSctpdUplinkServer(
 	sctpdpb.RegisterSctpdUplinkServer(grpcServer, sctpdUplinkServer)
 	go func() {
 		if err := grpcServer.Serve(listener); err != nil {
-			panic(errors.Wrapf(
-				err,
-				"startSctpdUplinkServer(network=%s, address=%s)",
+			panic(fmt.Errorf(
+				"startSctpdUplinkServer(network=%s, address=%s): %w",
 				target.Scheme,
-				target.Endpoint))
+				target.Endpoint,
+				err))
 		}
 	}()
 }
@@ -159,22 +158,22 @@ func startPipelinedServer(cfgr config.Configer, logger log.Logger) {
 	listener, err := net.Listen(target.Scheme, target.Endpoint)
 
 	if err != nil {
-		panic(errors.Wrapf(
-			err,
-			"net.Listen(network=%s, address=%s)",
+		panic(fmt.Errorf(
+			"net.Listen(network=%s, address=%s): %w",
 			target.Scheme,
-			target.Endpoint))
+			target.Endpoint,
+			err))
 	}
 	grpcServer := grpc.NewServer()
 	pipelinedServer := pipelined.NewPipelinedServer(logger)
 	pipelinedpb.RegisterPipelinedServer(grpcServer, pipelinedServer)
 	go func() {
 		if err := grpcServer.Serve(listener); err != nil {
-			panic(errors.Wrapf(
-				err,
-				"startPipelinedServer(network=%s, address=%s)",
+			panic(fmt.Errorf(
+				"startPipelinedServer(network=%s, address=%s): %w",
 				target.Scheme,
-				target.Endpoint))
+				target.Endpoint,
+				err))
 		}
 	}()
 }
@@ -185,11 +184,11 @@ func startCaptureServer(
 	address := fmt.Sprintf(":%s", cfgr.Config().GetCaptureServicePort())
 	listener, err := net.Listen(config.TCP, address)
 	if err != nil {
-		panic(errors.Wrapf(
-			err,
-			"net.Listen(network=%s, address=%s)",
+		panic(fmt.Errorf(
+			"net.Listen(network=%s, address=%s): %w",
 			config.TCP,
-			address))
+			address,
+			err))
 	}
 
 	grpcServer := grpc.NewServer()
@@ -205,11 +204,11 @@ func startConfigServer(
 
 	listener, err := net.Listen(config.TCP, address)
 	if err != nil {
-		panic(errors.Wrapf(
-			err,
-			"net.Listen(network=%s, address=%s)",
+		panic(fmt.Errorf(
+			"net.Listen(network=%s, address=%s): %w",
 			config.TCP,
-			address))
+			address,
+			err))
 	}
 
 	grpcServer := grpc.NewServer()

--- a/src/go/crash/crash_test.go
+++ b/src/go/crash/crash_test.go
@@ -12,13 +12,13 @@
 package crash_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/magma/magma/src/go/crash"
 	mock_crash "github.com/magma/magma/src/go/crash/mock_crash"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/go/crash/sentry/sentry.go
+++ b/src/go/crash/sentry/sentry.go
@@ -12,11 +12,11 @@
 package sentry
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/magma/magma/src/go/crash"
-	"github.com/pkg/errors"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -source=sentry.go -package mock_sentry -destination mock_sentry/mock_sentry_hub.go sentryHub
@@ -37,7 +37,7 @@ type Crash struct {
 func NewCrash(options sentry.ClientOptions) crash.Crash {
 	client, err := sentry.NewClient(options)
 	if err != nil {
-		panic(errors.Wrapf(err, "sentry.ClientOptions=%+v", options))
+		panic(fmt.Errorf("sentry.ClientOptions=%+v: %w", options, err))
 	}
 	newHub := sentry.NewHub(client, sentry.NewScope())
 	return &Crash{

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -16,7 +16,6 @@ go 1.18
 require (
 	github.com/getsentry/sentry-go v0.11.0
 	github.com/golang/mock v1.6.0
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.0
 	google.golang.org/grpc v1.40.0

--- a/src/go/log/zap/zap.go
+++ b/src/go/log/zap/zap.go
@@ -26,7 +26,8 @@
 package zap
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -204,7 +205,7 @@ func NewLoggerAtLevel(lvl log.Level, paths ...string) *Logger {
 	}
 	ws, _, err := zap.Open(paths...)
 	if err != nil {
-		panic(errors.Wrapf(err, "paths=%s", paths))
+		panic(fmt.Errorf("paths=%s: %w", paths, err))
 	}
 
 	return New(


### PR DESCRIPTION
refactor: Remove more calls to pkg errors

## Summary

Also contains the changes of #12682 

Removes additional uses of "github.com/pkg/errors" so that it is no longer a dependency.

1. Removes the use of `errors.WithStack(err)` with `err`
2. Removes the use of `errors.WithMessage(err, mess)` and `errors.WithMessagef(err, mess, ...var)` with `fmt.Errorf(mess + ": %w", ...var, err)`
3. Replaces `errors.Cause` from "github.com/pkg/errors" with `errors.Unwrap` from GO "errors" package
4. Replaces "github.com/pkg/errors" with GO "errors" package for `errors.New`

This PR also reformats a few comment strings where they were not correctly formatted before. Additionally, the PR also rearranges some unrelated imports where they weren't following the correct convention before.

## Test Plan

Run Unit tests.

## Additional Information

This PR removes the dependency on "github.com/pkg/errors". 

- [ ] This change is backwards-breaking
