### PR TITLE
fix(nms): Sidebar version number overlaps with profile button

### DIFF
--- a/nms/app/components/AppSideBar.js
+++ b/nms/app/components/AppSideBar.js
@@ -46,7 +46,8 @@ const useStyles = makeStyles(() => ({
     width: '208px',
   },
   version: {
-    padding: '28px 0 0 28px',
+    display: 'block',
+    padding: '13px 0 0 28px',
     color: colors.primary.gullGray,
     whiteSpace: 'nowrap',
   },


### PR DESCRIPTION
## Summary
When the sidebar is expanded the version number partially overlaps with the profile button and blocks the lower part of the click area. 

![version-cover](https://user-images.githubusercontent.com/102796295/167790316-628303c8-314e-4215-9ed8-02828e451530.gif)


## Test Plan
Check that the bug described above is fixed. 