### PR TITLE
chore: Add size attribute to all bazel test targets

### DIFF
--- a/lte/gateway/c/core/oai/test/gtpv2-c/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/gtpv2-c/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//visibility:private"])
 
 cc_test(
     name = "gtpv2_fteid_test",
+    size = "small",
     srcs = [
         "test_fteid.cpp",
     ],

--- a/lte/gateway/c/core/oai/test/itti/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/itti/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
 
 cc_test(
     name = "itti_test",
+    size = "small",
     srcs = [
         "test_itti.cpp",
     ],

--- a/lte/gateway/c/core/oai/test/lib/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/lib/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
 
 cc_test(
     name = "lib_3gpp_test",
+    size = "small",
     srcs = [
         "test_3gpp.cpp",
     ],
@@ -27,6 +28,7 @@ cc_test(
 
 cc_test(
     name = "lib_bstr_test",
+    size = "small",
     srcs = [
         "test_bstr.cpp",
     ],

--- a/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/mme_app_task/BUILD.bazel
@@ -29,6 +29,7 @@ cc_library(
 
 cc_test(
     name = "sgw_config_test",
+    size = "small",
     srcs = [
         "test_sgw_config.cpp",
     ],
@@ -40,6 +41,7 @@ cc_test(
 
 cc_test(
     name = "mme_app_config_test",
+    size = "small",
     srcs = [
         "test_mme_app_config.cpp",
     ],
@@ -51,6 +53,7 @@ cc_test(
 
 cc_test(
     name = "mme_app_esm_encode_decode_test",
+    size = "small",
     srcs = [
         "test_mme_app_esm_encode_decode.cpp",
     ],
@@ -63,6 +66,7 @@ cc_test(
 
 cc_test(
     name = "mme_app_emm_encode_decode_test",
+    size = "small",
     srcs = [
         "test_mme_app_emm_encode_decode.cpp",
     ],
@@ -75,6 +79,7 @@ cc_test(
 
 cc_test(
     name = "apn_aggregate_maximum_bit_rate_test",
+    size = "small",
     srcs = [
         "test_ApnAggregateMaximumBitRate.cpp",
     ],
@@ -86,6 +91,7 @@ cc_test(
 
 cc_test(
     name = "eps_quality_of_service_test",
+    size = "small",
     srcs = [
         "test_EPSQualityOfService.cpp",
     ],
@@ -98,6 +104,7 @@ cc_test(
 
 cc_test(
     name = "mme_app_nas_encode_decode_test",
+    size = "small",
     srcs = [
         "test_mme_app_nas_encode_decode.cpp",
     ],
@@ -120,6 +127,7 @@ cc_library(
 
 cc_test(
     name = "mme_procedures_test",
+    size = "medium",
     srcs = [
         "test_mme_procedures.cpp",
     ],

--- a/lte/gateway/c/core/oai/test/n11/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/n11/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
 
 cc_test(
     name = "n11_auth_service_client_test",
+    size = "small",
     srcs = [
         "test_auth_service_client.cpp",
     ],
@@ -26,6 +27,7 @@ cc_test(
 
 cc_test(
     name = "n11_smf_service_client_test",
+    size = "small",
     srcs = [
         "test_smf_service_client.cpp",
     ],

--- a/lte/gateway/c/core/oai/test/nas/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/nas/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//lte/gateway/c/core/oai/test:__subpackages__"])
 
 cc_test(
     name = "nas_converter_test",
+    size = "small",
     srcs = [
         "test_nas_converter.cpp",
     ],

--- a/lte/gateway/c/core/oai/test/openflow/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/openflow/BUILD.bazel
@@ -22,6 +22,7 @@ cc_library(
 
 cc_test(
     name = "gtp_app_test",
+    size = "small",
     srcs = [
         "test_gtp_app.cpp",
     ],
@@ -35,6 +36,7 @@ cc_test(
 
 cc_test(
     name = "imsi_encoder_test",
+    size = "small",
     srcs = [
         "test_imsi_encoder.cpp",
     ],
@@ -46,6 +48,7 @@ cc_test(
 
 cc_test(
     name = "openflow_controller_test",
+    size = "small",
     srcs = [
         "test_openflow_controller.cpp",
     ],

--- a/lte/gateway/c/core/oai/test/pipelined_client/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/pipelined_client/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//visibility:private"])
 
 cc_test(
     name = "pipelined_client_test",
+    size = "small",
     srcs = [
         "test_pipelined_client.cpp",
     ],

--- a/lte/gateway/c/core/oai/test/sgw_s8_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/sgw_s8_task/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//lte/gateway/c/core/test:__subpackages__"])
 
 cc_test(
     name = "sgw_dedicated_bearer_test",
+    size = "medium",
     srcs = [
         "sgw_dedicated_bearer.cpp",
     ],
@@ -41,6 +42,7 @@ cc_library(
 
 cc_test(
     name = "sgw_s8_recv_grpc_messages_test",
+    size = "small",
     srcs = [
         "sgw_s8_recv_grpc_messages.cpp",
     ],
@@ -53,6 +55,7 @@ cc_test(
 
 cc_test(
     name = "sgw_s8_test_attach_proc_test",
+    size = "medium",
     srcs = [
         "sgw_s8_test_attach_proc.cpp",
     ],

--- a/src/go/agwd/config/BUILD.bazel
+++ b/src/go/agwd/config/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 
 go_test(
     name = "config_test",
+    size = "small",
     srcs = ["config_test.go"],
     data = glob(["testdata/**"]),
     embed = [":config"],

--- a/src/go/agwd/config/internal/grpcutil/BUILD.bazel
+++ b/src/go/agwd/config/internal/grpcutil/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
 
 go_test(
     name = "grpcutil_test",
+    size = "small",
     srcs = ["target_test.go"],
     embed = [":grpcutil"],
     deps = ["@org_golang_google_grpc//resolver"],

--- a/src/go/agwd/server/BUILD.bazel
+++ b/src/go/agwd/server/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
 
 go_test(
     name = "server_test",
+    size = "small",
     srcs = [
         "server_notwindows_test.go",
         "server_windows_test.go",

--- a/src/go/capture/BUILD.bazel
+++ b/src/go/capture/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
 
 go_test(
     name = "capture_test",
+    size = "small",
     srcs = [
         "buffer_test.go",
         "middleware_test.go",

--- a/src/go/crash/BUILD.bazel
+++ b/src/go/crash/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
 
 go_test(
     name = "crash_test",
+    size = "small",
     srcs = ["crash_test.go"],
     deps = [
         ":crash",

--- a/src/go/crash/sentry/BUILD.bazel
+++ b/src/go/crash/sentry/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
 
 go_test(
     name = "sentry_test",
+    size = "small",
     srcs = ["sentry_test.go"],
     embed = [":sentry"],
     deps = [

--- a/src/go/log/BUILD.bazel
+++ b/src/go/log/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
 
 go_test(
     name = "log_test",
+    size = "small",
     srcs = [
         "log_test.go",
         "mock_logger_test.go",

--- a/src/go/log/zap/BUILD.bazel
+++ b/src/go/log/zap/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 
 go_test(
     name = "zap_test",
+    size = "small",
     srcs = [
         "zap_integ_test.go",
         "zap_test.go",

--- a/src/go/service/BUILD.bazel
+++ b/src/go/service/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
 
 go_test(
     name = "service_test",
+    size = "small",
     srcs = ["router_test.go"],
     embed = [":service"],
     deps = [

--- a/src/go/service/capture/BUILD.bazel
+++ b/src/go/service/capture/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
 
 go_test(
     name = "capture_test",
+    size = "small",
     srcs = ["capture_server_integ_test.go"],
     embed = [":capture"],
     deps = [

--- a/src/go/service/config/BUILD.bazel
+++ b/src/go/service/config/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
 
 go_test(
     name = "config_test",
+    size = "small",
     srcs = ["config_server_integ_test.go"],
     embed = [":config"],
     deps = [

--- a/src/go/service/pipelined/BUILD.bazel
+++ b/src/go/service/pipelined/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
 
 go_test(
     name = "pipelined_test",
+    size = "small",
     srcs = ["pipelined_server_integ_test.go"],
     deps = [
         ":pipelined",

--- a/src/go/service/sctpd/BUILD.bazel
+++ b/src/go/service/sctpd/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 
 go_test(
     name = "sctpd_test",
+    size = "small",
     srcs = [
         "proxy_downlink_server_integ_test.go",
         "proxy_uplink_server_integ_test.go",


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Add "size" attribute to every bazel test target.
- This sets the correct timeouts for all unit tests - see [bazel docs](https://bazel.build/reference/be/common-definitions#size).
- If a test took >~10s I used the "medium" label in order to avoid a one minute timeout on slow machines.

## Test Plan

- Check that all tests have the attribute:
```
bazel query 'attr(size, small , tests(//...))' > tests-with-size.txt && \
bazel query 'attr(size, medium , tests(//...))' >> tests-with-size.txt && \ 
bazel query 'attr(size, large , tests(//...))' >> tests-with-size.txt && \
bazel query 'kind(".*_test", attr("name",".*","//..."))' > anytest.txt && \ 
diff tests-with-size.txt anytest.txt
```
- Run all unit tests `bazel test //...`
- CI

## Additional Information

- [ ] This change is backwards-breaking


