### PR TITLE
chore: Bazelify the configuration module

### DIFF
--- a/orc8r/gateway/python/magma/configuration/BUILD.bazel
+++ b/orc8r/gateway/python/magma/configuration/BUILD.bazel
@@ -34,9 +34,9 @@ py_library(
     srcs = [
         "events.py",
         "mconfig_managers.py",
-        "mconfigs.py",
     ],
     deps = [
+        ":mconfigs",
         "//orc8r/gateway/python/magma/common:serialization_utils",
         "//orc8r/gateway/python/magma/eventd:eventd_client",
         "//orc8r/protos:mconfig_python_proto",
@@ -47,4 +47,13 @@ py_library(
 py_library(
     name = "environment",
     srcs = ["environment.py"],
+)
+
+py_library(
+    name = "mconfigs",
+    srcs = ["mconfigs.py"],
+    deps = [
+        ":service_configs",
+        requirement("protobuf"),
+    ],
 )

--- a/orc8r/gateway/python/magma/configuration/tests/BUILD.bazel
+++ b/orc8r/gateway/python/magma/configuration/tests/BUILD.bazel
@@ -1,0 +1,39 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("//bazel:python_test.bzl", "pytest_test")
+
+MAGMA_ROOT = "../../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+pytest_test(
+    name = "mconfig_manager_impl_tests",
+    size = "small",
+    srcs = ["mconfig_manager_impl_tests.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/configuration:mconfig_managers",
+        requirement("protobuf"),
+    ],
+)
+
+pytest_test(
+    name = "mconfigs_tests",
+    size = "small",
+    srcs = ["mconfigs_tests.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/configuration:mconfigs",
+        requirement("protobuf"),
+    ],
+)


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Bazelify the remaining files in configuration module.

FYI: The following files are only used in scripts:
-   orc8r/gateway/python/magma/common/health/health_service.py
-   orc8r/gateway/python/magma/common/health/docker_health_service.py
-   orc8r/gateway/python/magma/common/health/entities.py


## Test Plan

`bazel test orc8r/gateway/python/magma/configuration/...`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
