### PR TITLE
fix(pipelined): use precise match filter for searching dhclient process.

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -476,7 +476,7 @@ class UplinkBridgeController(MagmaController):
 
         # Kill dhclient if running.
         pgrep_out = subprocess.Popen(
-            ["pgrep", "-f", "dhclient.*" + if_name],
+            ["pgrep", "-f", "^/sbin/dhclient.*" + if_name],
             stdout=subprocess.PIPE,
         )
         for pid in pgrep_out.stdout.readlines():
@@ -512,7 +512,7 @@ class UplinkBridgeController(MagmaController):
         if af_inet != netifaces.AF_INET:
             self.logger.debug("DHCP for IPv6 is not supported: %s", if_name)
             return
-        release_eth_ip = ["dhclient", "-r", if_name]
+        release_eth_ip = ["/sbin/dhclient", "-r", if_name]
         try:
             subprocess.check_call(release_eth_ip)
         except subprocess.CalledProcessError as ex:
@@ -539,7 +539,7 @@ class UplinkBridgeController(MagmaController):
             self.logger.debug("DHCP for IPv6 is not supported: %s", if_name)
             return
 
-        setup_dhclient = ["dhclient", if_name]
+        setup_dhclient = ["/sbin/dhclient", if_name]
         try:
             subprocess.check_call(setup_dhclient)
             # delay to get DHCP address


### PR DESCRIPTION
On some hosts pgrep is returning self process ID, which can result
in exception when pipelineD tries to kill the process.
Following PR improves the pgrep match criteria to fix the issue.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
