### PR TITLE
chore(ci): Update codecov-action to v2

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           name: Unit Test Results
           path: /var/tmp/test_results
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           files: /var/tmp/codecovs/cover_lte.xml,/var/tmp/codecovs/cover_orc8r.xml
           flags: lte-test
@@ -413,7 +413,7 @@ jobs:
       - name: Upload code coverage
         if: always()
         id: c-cpp-codecov-upload
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: c_cpp
       - name: Extract commit title

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/orc8r/cloud/docker
           python3 build.py --coverage
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         if: always() && steps.cloud-lint-cov.outcome=='success'
         id: cloud-lint-codecov
         with:

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -105,7 +105,7 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: unittests,configuration-controller
           name: codecov-configuration-controller
@@ -148,7 +148,7 @@ jobs:
           go test ./... -v -race -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: unittests,active-mode-controller
           name: codecov-active-mode-controller
@@ -230,7 +230,7 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: unittests,radio-controller
           name: codecov-radio-controller
@@ -331,7 +331,7 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: unittests,db-service
           name: codecov-db-service

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
               cd ${MAGMA_ROOT}/feg/gateway
               make -C ${MAGMA_ROOT}/feg/gateway cover
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         if: always()
         id: feg-lint-codecov
         with:


### PR DESCRIPTION
Signed-off-by: Cameron Voisey <cameron.voisey@tngtech.com>

## Summary

According to https://github.com/codecov/codecov-action, "As of February 1, 2022, v1 has been fully sunset and no longer functions", so this updates the uses in the CI from v1 to v2.

## Test Plan

- [x] CI
