### PR TITLE
refactor(nms): Remove tabs from organization and user entities

### DIFF
--- a/nms/shared/sequelize_models/index.js
+++ b/nms/shared/sequelize_models/index.js
@@ -140,19 +140,12 @@ export async function importFromDatabase(sourceConfig: Options) {
   const featureFlags = await sourceDb.FeatureFlag.findAll();
   await FeatureFlag.bulkCreate(getDataValues(featureFlags));
 
-  // NOTE: While the tabs field should be non-null, it does happen
   // $FlowIgnore findAll function exists for Organization
   const organizations = await sourceDb.Organization.findAll();
-  organizations.forEach(organization => {
-    organization.tabs = organization.tabs || [];
-  });
   await Organization.bulkCreate(getDataValues(organizations));
 
   // $FlowIgnore findAll function exists for User
   const users = await sourceDb.User.findAll();
-  users.forEach(user => {
-    user.tabs = user.tabs || [];
-  });
   await User.bulkCreate(getDataValues(users));
 }
 
@@ -189,16 +182,10 @@ export async function exportToDatabase(targetConfig: Options) {
   // NOTE: While the tabs field should be non-null, it does happen
   // $FlowIgnore findAll function exists for Organization
   const organizations = await Organization.findAll();
-  organizations.forEach(organization => {
-    organization.tabs = organization.tabs || [];
-  });
   await targetDb.Organization.bulkCreate(getDataValues(organizations));
 
   // $FlowIgnore findAll function exists for User
   const users = await User.findAll();
-  users.forEach(user => {
-    user.tabs = user.tabs || [];
-  });
   await targetDb.User.bulkCreate(getDataValues(users));
 
   await resetPgIdSeq(targetSequelize);

--- a/nms/shared/sequelize_models/migrations/20220512000000-drop-tabs.js
+++ b/nms/shared/sequelize_models/migrations/20220512000000-drop-tabs.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import type {DataTypes, QueryInterface, Transaction} from 'sequelize';
+
+/**
+ * This migration removes 'tabs' from organizations and users.
+ */
+module.exports = {
+  up: async (queryInterface: QueryInterface, _types: DataTypes) => {
+    return queryInterface.sequelize.transaction(
+      async (transaction: Transaction): Promise<void> => {
+        await queryInterface.removeColumn('Users', 'tabs', {transaction});
+        await queryInterface.removeColumn('Organizations', 'tabs', {
+          transaction,
+        });
+      },
+    );
+  },
+
+  down: async (queryInterface: QueryInterface, types: DataTypes) => {
+    return queryInterface.sequelize.transaction(
+      async (transaction: Transaction): Promise<void> => {
+        await queryInterface.addColumn(
+          'Users',
+          'tabs',
+          {
+            allowNull: true,
+            defaultValue: ['nms'],
+            type: types.JSON,
+          },
+          {transaction},
+        );
+
+        await queryInterface.addColumn(
+          'Organizations',
+          'tabs',
+          {
+            allowNull: true,
+            defaultValue: ['nms'],
+            type: types.JSON,
+          },
+          {transaction},
+        );
+      },
+    );
+  },
+};

--- a/nms/shared/sequelize_models/models/organization.js
+++ b/nms/shared/sequelize_models/models/organization.js
@@ -75,12 +75,6 @@ export default (
     'Organization',
     {
       name: types.STRING,
-      // Unused should be removed together with a migration as a breaking change
-      tabs: {
-        type: types.JSON,
-        allowNull: false,
-        defaultValue: ['nms'],
-      },
       csvCharset: types.STRING,
       customDomains: {
         type: types.JSON,

--- a/nms/shared/sequelize_models/models/user.js
+++ b/nms/shared/sequelize_models/models/user.js
@@ -63,15 +63,6 @@ export default (
           return this.getDataValue('networkIDs') || [];
         },
       },
-      // Unused should be removed together with a migration as a breaking change
-      tabs: {
-        type: types.JSON,
-        allowNull: true,
-        defaultValue: ['nms'],
-        get() {
-          return this.getDataValue('tabs') || ['nms'];
-        },
-      },
     },
     {
       getterMethods: {


### PR DESCRIPTION
## Summary

Adds a migration to remove tabs from organization and user entities. This can be reverted by adding `["nms"]` to every user and  organization.


## Test Plan
- Rebuild the docker container with a fresh DB
- Check the DB to make sure that there no tabs
- Test if the application still works.
- Also create a new organization and user and make sure the the navigation for those still works.
- Rollback the migration and test if the tabs columns are added back
