### PR TITLE
refactor(nms): remove `afterEach(cleanup);`

### DIFF
--- a/nms/app/components/__tests__/AccountSettings-test.js
+++ b/nms/app/components/__tests__/AccountSettings-test.js
@@ -22,7 +22,7 @@ import defaultTheme from '../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {SnackbarProvider} from 'notistack';
-import {cleanup, fireEvent, render} from '@testing-library/react';
+import {fireEvent, render} from '@testing-library/react';
 
 const Wrapper = (props: {children: React.Node}) => (
   <MemoryRouter initialEntries={['/nms/mynetwork/settings']} initialIndex={0}>
@@ -40,8 +40,6 @@ const Wrapper = (props: {children: React.Node}) => (
     </MuiThemeProvider>
   </MemoryRouter>
 );
-
-afterEach(cleanup);
 
 describe('<AccountSettings />', () => {
   it('Save button is disabled if form is not filled-out', () => {

--- a/nms/app/components/__tests__/DashboardAlertTableTest.js
+++ b/nms/app/components/__tests__/DashboardAlertTableTest.js
@@ -22,13 +22,11 @@ import axiosMock from 'axios';
 import defaultTheme from '../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 import type {
   gettable_alert,
   prom_firing_alert,
 } from '../../../generated/MagmaAPIBindings';
-
-afterEach(cleanup);
 
 const tbl_alert: gettable_alert = {
   name: 'null_receiver',

--- a/nms/app/components/__tests__/DataGrid-test.js
+++ b/nms/app/components/__tests__/DataGrid-test.js
@@ -20,10 +20,8 @@ import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
 import defaultTheme from '../../theme/default';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render} from '@testing-library/react';
+import {render} from '@testing-library/react';
 import type {DataRows} from '../DataGrid';
-
-afterEach(cleanup);
 
 const data: DataRows[] = [
   [

--- a/nms/app/components/__tests__/EventAlertChartTest.js
+++ b/nms/app/components/__tests__/EventAlertChartTest.js
@@ -24,10 +24,8 @@ import moment from 'moment';
 
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 import type {promql_return_object} from '../../../generated/MagmaAPIBindings';
-
-afterEach(cleanup);
 
 const mockMetricSt: promql_return_object = {
   status: 'success',

--- a/nms/app/components/__tests__/GatewayCommandTest.js
+++ b/nms/app/components/__tests__/GatewayCommandTest.js
@@ -22,9 +22,8 @@ import defaultTheme from '../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {TroubleshootingControl} from '../GatewayCommandFields';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 
-afterEach(cleanup);
 jest.mock('../../../generated/MagmaAPIBindings');
 jest.mock('../../../app/hooks/useSnackbar');
 

--- a/nms/app/components/__tests__/KPI-test.js
+++ b/nms/app/components/__tests__/KPI-test.js
@@ -26,14 +26,12 @@ import axiosMock from 'axios';
 import defaultTheme from '../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 import type {
   enodeb_state,
   feg_lte_network,
   lte_gateway,
 } from '../../../generated/MagmaAPIBindings';
-
-afterEach(cleanup);
 
 const mockFegLteNetworks: Array<string> = [
   'test_network1',

--- a/nms/app/components/__tests__/Main-test.js
+++ b/nms/app/components/__tests__/Main-test.js
@@ -20,7 +20,7 @@ import Main from '../Main';
 import React from 'react';
 import {AppContextProvider} from '../../../app/components/context/AppContext';
 import {MemoryRouter} from 'react-router-dom';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 
 jest.mock('../../../generated/MagmaAPIBindings');
 
@@ -39,8 +39,6 @@ const Wrapper = props => (
     <AppContextProvider>{props.children}</AppContextProvider>
   </MemoryRouter>
 );
-
-afterEach(cleanup);
 
 describe.each`
   path                | text                     | networks

--- a/nms/app/components/__tests__/ProfileButton-test.js
+++ b/nms/app/components/__tests__/ProfileButton-test.js
@@ -24,7 +24,7 @@ import {MemoryRouter} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {SnackbarProvider} from 'notistack';
 // $FlowFixMe[missing-export]
-import {cleanup, fireEvent, render, waitFor} from '@testing-library/react';
+import {fireEvent, render, waitFor} from '@testing-library/react';
 
 type Props = {
   expanded: boolean,
@@ -52,8 +52,6 @@ const WrappedProfileButton = (props: Props) => {
     </MemoryRouter>
   );
 };
-
-afterEach(cleanup);
 
 describe('<ProfileButton />', () => {
   it.each([true, false])('respects expanded=%s', expanded => {

--- a/nms/app/components/cwf/__tests__/CWFGateways-test.js
+++ b/nms/app/components/cwf/__tests__/CWFGateways-test.js
@@ -28,7 +28,7 @@ import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 
 const CWF_HA_GATEWAY_1: cwf_gateway = {
   magmad: {
@@ -124,8 +124,6 @@ const Wrapper = () => (
     </MuiThemeProvider>
   </MemoryRouter>
 );
-
-afterEach(cleanup);
 
 describe('<CWFGateways />', () => {
   beforeEach(() => {

--- a/nms/app/components/feg/__tests__/FEGGatewaysTest.js
+++ b/nms/app/components/feg/__tests__/FEGGatewaysTest.js
@@ -23,7 +23,7 @@ import defaultTheme from '../../../theme/default';
 import {FEGGatewayContextProvider} from '../../../components/feg/FEGContext';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 import type {
   federation_gateway,
   federation_gateway_health_status,
@@ -33,7 +33,6 @@ import type {
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
 
 const mockGw0: federation_gateway = {
   id: 'test_feg_gw0',

--- a/nms/app/views/alarms/legacy/__tests__/Alarms-test.js
+++ b/nms/app/views/alarms/legacy/__tests__/Alarms-test.js
@@ -23,7 +23,7 @@ import {MagmaAlarmsApiUtil} from '../../../../state/AlarmsApiUtil';
 import {MemoryRouter} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {SnackbarProvider} from 'notistack';
-import {cleanup, render} from '@testing-library/react';
+import {render} from '@testing-library/react';
 
 jest.mock('../../../../../app/hooks/useSnackbar');
 const useSnackbar = require('../../../../../app/hooks/useSnackbar');
@@ -53,7 +53,6 @@ const Wrapper = (props: {route: string, children: React.Node}) => (
 const AlarmsWrapper = () => <Alarms apiUtil={MagmaAlarmsApiUtil} />;
 
 afterEach(() => {
-  cleanup();
   useMagmaAPIMock.mockClear();
 });
 

--- a/nms/app/views/equipment/__tests__/EnodebConfigTest.js
+++ b/nms/app/views/equipment/__tests__/EnodebConfigTest.js
@@ -26,13 +26,13 @@ import defaultTheme from '../../../theme/default.js';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {SetEnodebState} from '../../../state/lte/EquipmentState';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 import {useState} from 'react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
+
 const enqueueSnackbarMock = jest.fn();
 jest
   .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')

--- a/nms/app/views/equipment/__tests__/EnodebDetailMainTest.js
+++ b/nms/app/views/equipment/__tests__/EnodebDetailMainTest.js
@@ -29,7 +29,7 @@ import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiPickersUtilsProvider} from '@material-ui/pickers';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 
 const enqueueSnackbarMock = jest.fn();
 jest.mock('axios');
@@ -37,7 +37,6 @@ jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest
   .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
   .mockReturnValue(enqueueSnackbarMock);
-afterEach(cleanup);
 
 const mockThroughput: promql_return_object = {
   status: 'success',

--- a/nms/app/views/equipment/__tests__/EquipmentEnodebTest.js
+++ b/nms/app/views/equipment/__tests__/EquipmentEnodebTest.js
@@ -29,7 +29,7 @@ import * as hooks from '../../../components/context/RefreshContext';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiPickersUtilsProvider} from '@material-ui/pickers';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 
 const enqueueSnackbarMock = jest.fn();
 jest.mock('axios');
@@ -37,7 +37,6 @@ jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest
   .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
   .mockReturnValue(enqueueSnackbarMock);
-afterEach(cleanup);
 
 const mockThroughput: promql_return_object = {
   status: 'success',

--- a/nms/app/views/equipment/__tests__/EquipmentGatewayPoolTest.js
+++ b/nms/app/views/equipment/__tests__/EquipmentGatewayPoolTest.js
@@ -31,7 +31,7 @@ import {
   SetGatewayPoolsState,
   UpdateGatewayPoolRecords,
 } from '../../../state/lte/EquipmentState';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 import {useState} from 'react';
 
 jest.mock('axios');
@@ -41,8 +41,6 @@ const enqueueSnackbarMock = jest.fn();
 jest
   .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
   .mockReturnValue(enqueueSnackbarMock);
-
-afterEach(cleanup);
 
 const gwPoolStateMock = {
   pool1: {

--- a/nms/app/views/equipment/__tests__/EquipmentGatewayTest.js
+++ b/nms/app/views/equipment/__tests__/EquipmentGatewayTest.js
@@ -23,7 +23,7 @@ import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 import type {
   lte_gateway,
   promql_return_object,
@@ -35,8 +35,6 @@ jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest
   .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
   .mockReturnValue(enqueueSnackbarMock);
-afterEach(cleanup);
-
 const mockCheckinMetric: promql_return_object = {
   status: 'success',
   data: {

--- a/nms/app/views/equipment/__tests__/FEGEquipmentGatewayTest.js
+++ b/nms/app/views/equipment/__tests__/FEGEquipmentGatewayTest.js
@@ -25,7 +25,7 @@ import moment from 'moment';
 import {FEGGatewayContextProvider} from '../../../components/feg/FEGContext';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 import type {
   csfb,
   federation_gateway,
@@ -45,8 +45,6 @@ jest
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
-
 const mockGx: gx = {
   server: {
     address: '174.16.1.14:3868',

--- a/nms/app/views/equipment/__tests__/FEGGatewayConnectionStatusTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayConnectionStatusTest.js
@@ -22,14 +22,12 @@ import React from 'react';
 import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 import type {federation_gateway} from '../../../../generated/MagmaAPIBindings';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
-
 const mockGw0: federation_gateway = {
   id: 'test_feg_gw0',
   name: 'test_gateway',

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
@@ -24,7 +24,7 @@ import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {SetGatewayState} from '../../../state/feg/EquipmentState';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 import {useEnqueueSnackbar} from '../../../../app/hooks/useSnackbar';
 import {useState} from 'react';
 import type {
@@ -39,8 +39,6 @@ import type {
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
-
 const mockGx: gx = {
   server: {
     address: '174.16.1.14:3868',

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.js
@@ -25,7 +25,7 @@ import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 import type {
   federation_gateway,
   promql_return_object,
@@ -34,7 +34,6 @@ import type {
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
 
 const mockCheckinTime = new Date();
 

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailSubscribersTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailSubscribersTest.js
@@ -31,13 +31,11 @@ import defaultTheme from '../../../theme/default';
 
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
-
 const mockSubscriberIds: Array<subscriber_id> = [
   'IMSI001011234565000',
   'IMSI001011234565001',

--- a/nms/app/views/equipment/__tests__/FEGGatewaySummaryTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewaySummaryTest.js
@@ -22,13 +22,12 @@ import React from 'react';
 import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 import type {federation_gateway} from '../../../../generated/MagmaAPIBindings';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
 
 const mockHardwareId = 'c9439d30-61ef-46c7-93f2-e01fc131244d';
 

--- a/nms/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -38,13 +38,12 @@ import {
   SetGatewayState,
   UpdateGateway,
 } from '../../../state/lte/EquipmentState';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 import {useState} from 'react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
 const enqueueSnackbarMock = jest.fn();
 jest
   .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')

--- a/nms/app/views/equipment/__tests__/GatewayLogsTest.js
+++ b/nms/app/views/equipment/__tests__/GatewayLogsTest.js
@@ -26,14 +26,12 @@ import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiPickersUtilsProvider} from '@material-ui/pickers';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
 jest.spyOn(customHistogram, 'default').mockImplementation(() => <></>);
-afterEach(cleanup);
-
 const LogTableWrapper = () => (
   <MemoryRouter
     initialEntries={['/nms/mynetwork/gateway/mygateway/logs']}

--- a/nms/app/views/equipment/__tests__/GatewaySummaryTest.js
+++ b/nms/app/views/equipment/__tests__/GatewaySummaryTest.js
@@ -23,13 +23,11 @@ import React from 'react';
 import defaultTheme from '../../../theme/default.js';
 
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render} from '@testing-library/react';
+import {render} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-
-afterEach(cleanup);
 
 const mockGatewaySt: lte_gateway = {
   cellular: {

--- a/nms/app/views/events/__tests__/EventsTableTest.js
+++ b/nms/app/views/events/__tests__/EventsTableTest.js
@@ -24,12 +24,11 @@ import defaultTheme from '../../../theme/default.js';
 
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
 const enqueueSnackbarMock = jest.fn();
 jest
   .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')

--- a/nms/app/views/network/__tests__/FEGServicingAccessGatewayTableTest.js
+++ b/nms/app/views/network/__tests__/FEGServicingAccessGatewayTableTest.js
@@ -24,14 +24,12 @@ import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 import type {
   feg_lte_network,
   feg_network,
   lte_gateway,
 } from '../../../../generated/MagmaAPIBindings';
-
-afterEach(cleanup);
 
 const mockFegLteNetworks: Array<string> = [
   'test_network1',

--- a/nms/app/views/network/__tests__/NetworkTest.js
+++ b/nms/app/views/network/__tests__/NetworkTest.js
@@ -34,14 +34,13 @@ import {CoreNetworkTypes} from '../../subscriber/SubscriberUtils';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {UpdateNetworkState} from '../../../state/lte/NetworkState';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 
 import type {feg_network} from '../../../../generated/MagmaAPIBindings';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
 const enqueueSnackbarMock = jest.fn();
 const forbiddenNetworkTypes = Object.keys(CoreNetworkTypes).map(
   key => CoreNetworkTypes[key],

--- a/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.js
@@ -30,14 +30,13 @@ import defaultTheme from '../../../theme/default.js';
 import {CoreNetworkTypes} from '../SubscriberUtils';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 import {setSubscriberState} from '../../../state/lte/SubscriberState';
 import {useState} from 'react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
 const enqueueSnackbarMock = jest.fn();
 const forbiddenNetworkTypes = Object.keys(CoreNetworkTypes).map(
   key => CoreNetworkTypes[key],

--- a/nms/app/views/subscriber/__tests__/SubscriberChartTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberChartTest.js
@@ -26,12 +26,11 @@ import defaultTheme from '../../../theme/default.js';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiPickersUtilsProvider} from '@material-ui/pickers';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, render, wait} from '@testing-library/react';
+import {render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
 const enqueueSnackbarMock = jest.fn();
 jest
   .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')

--- a/nms/app/views/subscriber/__tests__/SubscriberTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberTest.js
@@ -25,12 +25,11 @@ import defaultTheme from '../../../theme/default.js';
 import {CoreNetworkTypes} from '../SubscriberUtils';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
 const enqueueSnackbarMock = jest.fn();
 const forbiddenNetworkTypes = Object.keys(CoreNetworkTypes).map(
   key => CoreNetworkTypes[key],

--- a/nms/app/views/traffic/__tests__/ApnAddTest.js
+++ b/nms/app/views/traffic/__tests__/ApnAddTest.js
@@ -28,7 +28,7 @@ import {
 } from '../../../components/lte/LteContext';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
@@ -36,8 +36,6 @@ const enqueueSnackbarMock = jest.fn();
 jest
   .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
   .mockReturnValue(enqueueSnackbarMock);
-afterEach(cleanup);
-
 const apns = {
   apn_0: {
     apn_configuration: {

--- a/nms/app/views/traffic/__tests__/PolicyAddEditTest.js
+++ b/nms/app/views/traffic/__tests__/PolicyAddEditTest.js
@@ -30,7 +30,7 @@ import {
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 // $FlowFixMe Upgrade react-testing-library
-import {cleanup, fireEvent, render, waitFor} from '@testing-library/react';
+import {fireEvent, render, waitFor} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
@@ -38,8 +38,6 @@ const enqueueSnackbarMock = jest.fn();
 jest
   .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
   .mockReturnValue(enqueueSnackbarMock);
-afterEach(cleanup);
-
 const policies = {
   policy_0: {
     flow_list: [],

--- a/nms/app/views/traffic/__tests__/TrafficOverviewTest.js
+++ b/nms/app/views/traffic/__tests__/TrafficOverviewTest.js
@@ -31,13 +31,11 @@ import {
   SetQosProfileState,
   SetRatingGroupState,
 } from '../../../state/PolicyState';
-import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
 jest.mock('../../../../app/hooks/useSnackbar');
-afterEach(cleanup);
-
 const apns = {
   apn_0: {
     apn_configuration: {


### PR DESCRIPTION
## Summary

...which is unnecessary since react-testing-library v9.0.0.
https://github.com/testing-library/react-testing-library/releases/tag/v9.0.0

## Test Plan

- `yarn run eslint . --quiet --fix`
- `yarn test --maxWorkers=2`
