### PR TITLE
refactor(nms): cleanup the jest configuration

### DIFF
--- a/nms/jest.config.js
+++ b/nms/jest.config.js
@@ -20,40 +20,27 @@ module.exports = {
     '!**/__tests__/**',
     '!**/node_modules/**',
   ],
-
   coverageReporters: ['json', 'html'],
-  modulePathIgnorePatterns: [],
   projects: [
     {
       name: 'server',
       testEnvironment: 'node',
       testMatch: [
-        '<rootDir>/__tests__/*.js',
         '<rootDir>/server/**/__tests__/*.js',
+        '<rootDir>/shared/**/__tests__/*.js',
       ],
       transform: {
         '^.+\\.js$': 'babel-jest',
       },
-      transformIgnorePatterns: ['/node_modules/'],
     },
     {
-      moduleNameMapper: {
-        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
-          '<rootDir>/__mocks__/fileMock.js',
-        '\\.(css|less)$': 'identity-obj-proxy',
-      },
       name: 'app',
       testEnvironment: 'jsdom',
-      testMatch: [
-        '<rootDir>/app/**/__tests__/*.js',
-        '<rootDir>/fbc_js_core/**/__tests__/*.js',
-      ],
+      testMatch: ['<rootDir>/app/**/__tests__/*.js'],
       transform: {
         '^.+\\.js$': 'babel-jest',
       },
-      transformIgnorePatterns: ['/node_modules/'],
     },
   ],
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: ['/node_modules/'],
 };


### PR DESCRIPTION
## Summary

- Cleanup unnecessary and/or default configuration items from jest config

## Test Plan

- `yarn test --maxWorkers=2 --no-cache`
  - Before change:
    ```
    Test Suites: 52 passed, 52 total
    Tests:       315 passed, 315 total
    Snapshots:   0 total
    Time:        186.049 s
    Ran all test suites in 2 projects.
    Done in 189.13s.
    ```
  - After change:
    ```
    Test Suites: 52 passed, 52 total
    Tests:       315 passed, 315 total
    Snapshots:   0 total
    Time:        189.606 s
    Ran all test suites in 2 projects.
    Done in 192.85s.
    ```
