### PR TITLE
fix(nms): allow todate in the copyright

### DIFF
--- a/nms/.eslintrc.js
+++ b/nms/.eslintrc.js
@@ -15,9 +15,9 @@
 
 // enforces copyright header to be present in every file
 // eslint-disable-next-line max-len
-const openSourcePattern = /\*\n \* Copyright 2020 The Magma Authors\.\n \*\n \* This source code is licensed under the BSD-style license found in the\n \* LICENSE file in the root directory of this source tree\.\n \*\n \* Unless required by applicable law or agreed to in writing, software\n \* distributed under the License is distributed on an "AS IS" BASIS,\n \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.\n \* See the License for the specific language governing permissions and\n \* limitations under the License\.\n \*\n/;
+const openSourcePattern = /\*\n \* Copyright \d{4} The Magma Authors\.\n \*\n \* This source code is licensed under the BSD-style license found in the\n \* LICENSE file in the root directory of this source tree\.\n \*\n \* Unless required by applicable law or agreed to in writing, software\n \* distributed under the License is distributed on an "AS IS" BASIS,\n \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.\n \* See the License for the specific language governing permissions and\n \* limitations under the License\.\n \*\n/;
 // eslint-disable-next-line max-len
-const newOpenSourcePattern = /Copyright 2020 The Magma Authors\./;
+const newOpenSourcePattern = /Copyright \d{4} The Magma Authors\./;
 const combinedOpenSourcePattern = new RegExp(
   '(' + newOpenSourcePattern.source + ')|(' + openSourcePattern.source + ')',
 );


### PR DESCRIPTION
## Summary

Allows to take some other year than just `2020` in the copyright notice for NMS.

## Test Plan

- `yarn run eslint . --quiet` with a `2022` in one header file
