### PR TITLE
refactor(nms): configure `import 'jest-dom/extend-expect'` globally

### DIFF
--- a/nms/app/components/__tests__/AccountSettings-test.js
+++ b/nms/app/components/__tests__/AccountSettings-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import * as React from 'react';
 import AccountSettings from '../AccountSettings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/app/components/__tests__/AppSideBar-test.js
+++ b/nms/app/components/__tests__/AppSideBar-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import AppSideBar from '../AppSideBar';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import React from 'react';

--- a/nms/app/components/__tests__/DashboardAlertTableTest.js
+++ b/nms/app/components/__tests__/DashboardAlertTableTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 import DashboardAlertTable from '../DashboardAlertTable';
 import MagmaAPIBindings from '../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/app/components/__tests__/DataGrid-test.js
+++ b/nms/app/components/__tests__/DataGrid-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import DataGrid from '../DataGrid';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';

--- a/nms/app/components/__tests__/EventAlertChartTest.js
+++ b/nms/app/components/__tests__/EventAlertChartTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 import EventAlertChart from '../EventAlertChart';
 import MagmaAPIBindings from '../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/app/components/__tests__/GatewayCommandTest.js
+++ b/nms/app/components/__tests__/GatewayCommandTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 import MagmaAPIBindings from '../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';

--- a/nms/app/components/__tests__/KPI-test.js
+++ b/nms/app/components/__tests__/KPI-test.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 import EnodebContext from '../context/EnodebContext';
 import EnodebKPIs from '../EnodebKPIs';
 import GatewayContext from '../context/GatewayContext';

--- a/nms/app/components/__tests__/Main-test.js
+++ b/nms/app/components/__tests__/Main-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import MagmaAPIBindings from '../../../generated/MagmaAPIBindings';
 import Main from '../Main';
 import React from 'react';

--- a/nms/app/components/__tests__/NetworkSelector-test.js
+++ b/nms/app/components/__tests__/NetworkSelector-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import MagmaAPIBindings from '../../../generated/MagmaAPIBindings';
 import NetworkContext from '../context/NetworkContext';
 import NetworkSelector from '../NetworkSelector';

--- a/nms/app/components/__tests__/ProfileButton-test.js
+++ b/nms/app/components/__tests__/ProfileButton-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import ProfileButton from '../ProfileButton';
 import React, {useState} from 'react';

--- a/nms/app/components/cwf/__tests__/CWFGateways-test.js
+++ b/nms/app/components/cwf/__tests__/CWFGateways-test.js
@@ -23,7 +23,6 @@ import {SnackbarProvider} from 'notistack';
 import type {cwf_gateway} from '../../../../generated/MagmaAPIBindings';
 import type {cwf_ha_pair} from '../../../../generated/MagmaAPIBindings';
 
-import 'jest-dom/extend-expect';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';

--- a/nms/app/components/feg/__tests__/FEGGatewaysTest.js
+++ b/nms/app/components/feg/__tests__/FEGGatewaysTest.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import FEGGateways from '../FEGGateways';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/app/views/alarms/components/alertmanager/AlertDetails/__tests__/AlertDetailsPane-test.js
+++ b/nms/app/views/alarms/components/alertmanager/AlertDetails/__tests__/AlertDetailsPane-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import * as React from 'react';
 import AlertDetailsPane from '../AlertDetailsPane';
 import {act, fireEvent, render} from '@testing-library/react';

--- a/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/AddEditReceiver-test.js
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/AddEditReceiver-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import * as React from 'react';
 import AddEditReceiver from '../AddEditReceiver';
 import {act, fireEvent, render} from '@testing-library/react';

--- a/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/GlobalConfig-test.js
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/GlobalConfig-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import GlobalConfig from '../GlobalConfig';
 import React from 'react';
 import {act, fireEvent, render} from '@testing-library/react';

--- a/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/Receivers-test.js
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/Receivers-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import * as React from 'react';
 import Receivers from '../Receivers';
 import {

--- a/nms/app/views/alarms/components/alertmanager/__tests__/FiringAlerts-test.js
+++ b/nms/app/views/alarms/components/alertmanager/__tests__/FiringAlerts-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import * as React from 'react';
 import FiringAlerts from '../FiringAlerts';
 import {act, fireEvent, render} from '@testing-library/react';

--- a/nms/app/views/alarms/components/rules/PrometheusEditor/__tests__/PrometheusEditor-test.js
+++ b/nms/app/views/alarms/components/rules/PrometheusEditor/__tests__/PrometheusEditor-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import * as React from 'react';
 import PrometheusEditor from '../PrometheusEditor';
 import {alarmTestUtil} from '../../../../test/testHelpers';

--- a/nms/app/views/alarms/components/table/__tests__/SimpleTable-test.js
+++ b/nms/app/views/alarms/components/table/__tests__/SimpleTable-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import * as React from 'react';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import SimpleTable, {LabelsCell} from '../SimpleTable';

--- a/nms/app/views/alarms/legacy/__tests__/Alarms-test.js
+++ b/nms/app/views/alarms/legacy/__tests__/Alarms-test.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import * as React from 'react';
 import Alarms from '../Alarms';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/app/views/equipment/__tests__/EnodebConfigTest.js
+++ b/nms/app/views/equipment/__tests__/EnodebConfigTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 
 import AddEditEnodeButton from '../EnodebDetailConfigEdit';
 import EnodebConfig from '../EnodebDetailConfig';

--- a/nms/app/views/equipment/__tests__/EnodebDetailMainTest.js
+++ b/nms/app/views/equipment/__tests__/EnodebDetailMainTest.js
@@ -15,7 +15,6 @@
  */
 import type {promql_return_object} from '../../../../generated/MagmaAPIBindings';
 
-import 'jest-dom/extend-expect';
 import * as hooks from '../../../components/context/RefreshContext';
 import EnodebContext from '../../../components/context/EnodebContext';
 import EnodebDetail from '../EnodebDetailMain';

--- a/nms/app/views/equipment/__tests__/EquipmentEnodebTest.js
+++ b/nms/app/views/equipment/__tests__/EquipmentEnodebTest.js
@@ -15,7 +15,6 @@
  */
 import type {promql_return_object} from '../../../../generated/MagmaAPIBindings';
 
-import 'jest-dom/extend-expect';
 import Enodeb from '../EquipmentEnodeb';
 import EnodebContext from '../../../components/context/EnodebContext';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';

--- a/nms/app/views/equipment/__tests__/EquipmentGatewayPoolTest.js
+++ b/nms/app/views/equipment/__tests__/EquipmentGatewayPoolTest.js
@@ -15,7 +15,6 @@
  */
 import type {lte_gateway} from '../../../../generated/MagmaAPIBindings';
 
-import 'jest-dom/extend-expect';
 import AddEditGatewayPoolButton from '../GatewayPoolEdit';
 import GatewayContext from '../../../components/context/GatewayContext';
 import GatewayPools from '../EquipmentGatewayPools';

--- a/nms/app/views/equipment/__tests__/EquipmentGatewayTest.js
+++ b/nms/app/views/equipment/__tests__/EquipmentGatewayTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 import Gateway from '../EquipmentGateway';
 import GatewayContext from '../../../components/context/GatewayContext';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';

--- a/nms/app/views/equipment/__tests__/FEGEquipmentGatewayTest.js
+++ b/nms/app/views/equipment/__tests__/FEGEquipmentGatewayTest.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import FEGEquipmentGateway from '../FEGEquipmentGateway';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings.js';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/app/views/equipment/__tests__/FEGGatewayConnectionStatusTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayConnectionStatusTest.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import FEGGatewayConnectionStatus from '../FEGGatewayConnectionStatus';
 import FEGGatewayContext from '../../../components/context/FEGGatewayContext';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import FEGGatewayContext from '../../../components/context/FEGGatewayContext';
 import FEGGatewayDetailConfig from '../FEGGatewayDetailConfig';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import * as hooks from '../../../components/context/RefreshContext';
 import FEGGatewayContext from '../../../components/context/FEGGatewayContext';
 import FEGGatewayDetailStatus from '../FEGGatewayDetailStatus';

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailSubscribersTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailSubscribersTest.js
@@ -20,7 +20,6 @@ import type {
   subscriber_state,
 } from '../../../../generated/MagmaAPIBindings';
 
-import 'jest-dom/extend-expect';
 import FEGGatewayDetailSubscribers from '../FEGGatewayDetailSubscribers';
 import FEGSubscriberContext from '../../../components/context/FEGSubscriberContext';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';

--- a/nms/app/views/equipment/__tests__/FEGGatewaySummaryTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewaySummaryTest.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import FEGGatewayContext from '../../../components/context/FEGGatewayContext';
 import FEGGatewaySummary from '../FEGGatewaySummary';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -19,8 +19,6 @@ import type {
   lte_network,
 } from '../../../../generated/MagmaAPIBindings';
 
-import 'jest-dom/extend-expect';
-
 import AddEditGatewayButton from '../GatewayDetailConfigEdit';
 import ApnContext from '../../../components/context/ApnContext';
 import GatewayConfig from '../GatewayDetailConfig';

--- a/nms/app/views/equipment/__tests__/GatewayLogsTest.js
+++ b/nms/app/views/equipment/__tests__/GatewayLogsTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 
 import * as customHistogram from '../../../components/CustomMetrics';
 import GatewayLogs from '../GatewayLogs';

--- a/nms/app/views/equipment/__tests__/GatewaySummaryTest.js
+++ b/nms/app/views/equipment/__tests__/GatewaySummaryTest.js
@@ -15,8 +15,6 @@
  */
 import type {lte_gateway} from '../../../../generated/MagmaAPIBindings';
 
-import 'jest-dom/extend-expect';
-
 import GatewaySummary from '../GatewaySummary';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';

--- a/nms/app/views/events/__tests__/EventsTableTest.js
+++ b/nms/app/views/events/__tests__/EventsTableTest.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import EventsTable from '../EventsTable';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/app/views/network/__tests__/FEGServicingAccessGatewayTableTest.js
+++ b/nms/app/views/network/__tests__/FEGServicingAccessGatewayTableTest.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import FEGNetworkContext from '../../../components/context/FEGNetworkContext';
 import FEGServicingAccessGatewaysTable from '../FEGServicingAccessGatewayTable';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';

--- a/nms/app/views/network/__tests__/NetworkTest.js
+++ b/nms/app/views/network/__tests__/NetworkTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 
 import ApnContext from '../../../components/context/ApnContext';
 import EnodebContext from '../../../components/context/EnodebContext';

--- a/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 import * as hooks from '../../../components/context/RefreshContext';
 
 import ApnContext from '../../../components/context/ApnContext';

--- a/nms/app/views/subscriber/__tests__/SubscriberChartTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberChartTest.js
@@ -14,7 +14,6 @@
  * @format
  */
 
-import 'jest-dom/extend-expect';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MomentUtils from '@date-io/moment';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/app/views/subscriber/__tests__/SubscriberTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import NetworkContext from '../../../components/context/NetworkContext';

--- a/nms/app/views/traffic/__tests__/ApnAddTest.js
+++ b/nms/app/views/traffic/__tests__/ApnAddTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import NetworkContext from '../../../components/context/NetworkContext';

--- a/nms/app/views/traffic/__tests__/PolicyAddEditTest.js
+++ b/nms/app/views/traffic/__tests__/PolicyAddEditTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import NetworkContext from '../../../components/context/NetworkContext';

--- a/nms/app/views/traffic/__tests__/TrafficOverviewTest.js
+++ b/nms/app/views/traffic/__tests__/TrafficOverviewTest.js
@@ -13,7 +13,6 @@
  * @flow strict-local
  * @format
  */
-import 'jest-dom/extend-expect';
 import ApnContext from '../../../components/context/ApnContext';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';

--- a/nms/jest.config.js
+++ b/nms/jest.config.js
@@ -40,6 +40,7 @@ module.exports = {
       transform: {
         '^.+\\.js$': 'babel-jest',
       },
+      setupFilesAfterEnv: ['./jest.setup.app.js'],
     },
   ],
   testEnvironment: 'jsdom',

--- a/nms/jest.setup.app.js
+++ b/nms/jest.setup.app.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2022 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import 'jest-dom/extend-expect';


### PR DESCRIPTION
## Summary

Using a configuration file one can globally define to use the `jest-dom/extend-expect` library.

## Test Plan

- `yarn test --maxWorkers=2`

## Additional information

- Should be merged after https://github.com/magma/magma/pull/12712. Will have conflicts with that PR (which are easily resolvable).