### PR TITLE
fix(amf): UE Registration failure

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -732,15 +732,13 @@ static int registration_accept_t3550_handler(zloop_t* loop, int timer_id,
           "T3550: timer has expired retransmitting registration accept\n");
       amf_send_registration_accept(amf_ctx);
     } else {
-      /* Abort the registration procedure */
-      OAILOG_ERROR(
-          LOG_NAS_AMF,
-          "T3550: Maximum retires:%d, for registration accept done hence Abort "
-          "the registration "
-          "procedure\n",
-          registration_proc->retransmission_count);
-      // To abort the registration procedure
-      amf_proc_registration_abort(amf_ctx, ue_amf_context);
+      // ETSI TS 124 501 V16.5.1 - sec 5.5.1.2.8 abnormal case on network side
+      // at 5th expiry of timer, amf enters into REGISTERED state
+      OAILOG_INFO(LOG_AMF_APP,
+                  "on 5th expiry of timer AMF enters into REGISTERED state");
+      ue_state_handle_message_initial(
+          COMMON_PROCEDURE_INITIATED2, STATE_EVENT_REG_COMPLETE, SESSION_NULL,
+          ue_amf_context, &ue_amf_context->amf_context);
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -684,4 +684,26 @@ int check_ue_context_state(amf_ue_ngap_id_t ue_id,
   OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNok);
 }
 
+// 5th expiry of t3550 during registration complete from UE
+// mimicing registration_accept_t3550_handler
+int unit_test_registration_accept_t3550(amf_ue_ngap_id_t ue_id) {
+  int rc = RETURNerror;
+  ue_m5gmm_context_s* ue_amf_context = NULL;
+
+  // assuming 5 times expiry of T3550 timer for registration accept
+  // Get the UE context
+  ue_amf_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  if (ue_amf_context == NULL) {
+    return RETURNerror;
+  }
+
+  // 5.5.1.2.8 abnormal case on network side
+  // at 5th expiry of timer, amf enters into REGISTERED state
+  rc = ue_state_handle_message_initial(
+      COMMON_PROCEDURE_INITIATED2, STATE_EVENT_REG_COMPLETE, SESSION_NULL,
+      ue_amf_context, &ue_amf_context->amf_context);
+
+  return (rc);
+}
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -153,4 +153,7 @@ int check_ue_context_state(amf_ue_ngap_id_t ue_id,
                            m5gmm_state_t expected_mm_state,
                            m5gcm_state_t expected_cm_state);
 
+// mimicing registration_accept_t3550_handler
+int unit_test_registration_accept_t3550(amf_ue_ngap_id_t ue_id);
+
 }  // namespace magma5g


### PR DESCRIPTION
Signed-off-by: aniket021997 <aniket.sonawane@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
UE Registration failure as AMF didn't received Registration-Complete message from UE
Removed registration abort functionality after 5th attempt of Registration accept message from AMF to UE( 5th time expiry of  T3550 timer).
Added change to switch UE status to REGISTERED_CONNECTED after 5th attempt of Registration-accept message as per 5.5.1.2.8 - Abnormal cases on the network side (T3550 time-out)

spec reference: ETSI TS 124 501 V16.5.1 (2020-08) 
section 5.5.1.2.8 - Abnormal cases on the network side:
c - T3550 time-out 

<!-- Enumerate changes you made and why you made them -->

## Test Plan

- Validated with UT - mimicked 5 registration accept attempts from amf to UE and verified service request is able to process successfully.
![test_oai](https://user-images.githubusercontent.com/95931489/170272380-f86ee3c4-e745-4e61-9ca1-f7a81df44afc.PNG)

- Basic sanity with UERANSIM
  Pcap snap:
![pcap_snap](https://user-images.githubusercontent.com/95931489/170272980-46bc94a6-2640-4a24-9c26-0e6de03e36dc.PNG)
  mme log:
[mme.log](https://github.com/magma/magma/files/8771571/mme.log)

- Pcap with Registration accept retries followed by service request
![pcap_reg_followed_by_service_req](https://user-images.githubusercontent.com/95931489/170273804-5437f197-d032-460f-93a4-6dbb7d546060.PNG)



<!-- 
what did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
