### PR TITLE
refactor(nms): Reset and restore mocks automatically after every test

### DIFF
--- a/nms/app/components/__tests__/DashboardAlertTableTest.js
+++ b/nms/app/components/__tests__/DashboardAlertTableTest.js
@@ -17,7 +17,6 @@ import DashboardAlertTable from '../DashboardAlertTable';
 import MagmaAPIBindings from '../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
-import axiosMock from 'axios';
 import defaultTheme from '../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
@@ -130,10 +129,6 @@ describe('<DashboardAlertTable />', () => {
     MagmaAPIBindings.getNetworksByNetworkIdAlerts.mockResolvedValue(
       mockAlertSt,
     );
-  });
-
-  afterEach(() => {
-    axiosMock.get.mockClear();
   });
 
   const Wrapper = () => (

--- a/nms/app/components/__tests__/EventAlertChartTest.js
+++ b/nms/app/components/__tests__/EventAlertChartTest.js
@@ -17,7 +17,6 @@ import EventAlertChart from '../EventAlertChart';
 import MagmaAPIBindings from '../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
-import axiosMock from 'axios';
 import defaultTheme from '../../theme/default';
 import moment from 'moment';
 
@@ -56,11 +55,6 @@ describe('<EventAlertChart/>', () => {
     );
   });
 
-  afterEach(() => {
-    axiosMock.get.mockClear();
-    MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mockClear();
-  });
-
   const testCases = [
     {
       startDate: moment().subtract(2, 'hours'),
@@ -82,52 +76,50 @@ describe('<EventAlertChart/>', () => {
     },
   ];
 
-  testCases.forEach((tc, _) => {
-    it('renders', async () => {
-      // const endDate = moment();
-      // const startDate = moment().subtract(3, 'hours');
-      const Wrapper = () => (
-        <MemoryRouter initialEntries={['/nms/mynetwork']} initialIndex={0}>
-          <MuiThemeProvider theme={defaultTheme}>
-            <MuiStylesThemeProvider theme={defaultTheme}>
-              <Routes>
-                <Route
-                  path="/nms/:networkId"
-                  element={
-                    <EventAlertChart startEnd={[tc.startDate, tc.endDate]} />
-                  }
-                />
-              </Routes>
-            </MuiStylesThemeProvider>
-          </MuiThemeProvider>
-        </MemoryRouter>
-      );
-      render(<Wrapper />);
-      await wait();
-      if (tc.valid) {
-        expect(
-          MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mock
-            .calls[0][0].start,
-        ).toEqual(tc.startDate.toISOString());
-        expect(
-          MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mock
-            .calls[0][0].end,
-        ).toEqual(tc.endDate.toISOString());
-        expect(
-          MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mock
-            .calls[0][0].step,
-        ).toEqual(tc.step);
-      } else {
-        // negative test for invalid start end use default timerange
-        const defaultStep = '5m';
-        expect(
-          MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mock
-            .calls[0][0].step,
-        ).toEqual(defaultStep);
-      }
-    });
+  it.each(testCases)('renders', async tc => {
+    // const endDate = moment();
+    // const startDate = moment().subtract(3, 'hours');
+    const Wrapper = () => (
+      <MemoryRouter initialEntries={['/nms/mynetwork']} initialIndex={0}>
+        <MuiThemeProvider theme={defaultTheme}>
+          <MuiStylesThemeProvider theme={defaultTheme}>
+            <Routes>
+              <Route
+                path="/nms/:networkId"
+                element={
+                  <EventAlertChart startEnd={[tc.startDate, tc.endDate]} />
+                }
+              />
+            </Routes>
+          </MuiStylesThemeProvider>
+        </MuiThemeProvider>
+      </MemoryRouter>
+    );
+    render(<Wrapper />);
+    await wait();
+    if (tc.valid) {
+      expect(
+        MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mock
+          .calls[0][0].start,
+      ).toEqual(tc.startDate.toISOString());
+      expect(
+        MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mock
+          .calls[0][0].end,
+      ).toEqual(tc.endDate.toISOString());
+      expect(
+        MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mock
+          .calls[0][0].step,
+      ).toEqual(tc.step);
+    } else {
+      // negative test for invalid start end use default timerange
+      const defaultStep = '5m';
+      expect(
+        MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mock
+          .calls[0][0].step,
+      ).toEqual(defaultStep);
+    }
   });
 });

--- a/nms/app/components/__tests__/GatewayCommandTest.js
+++ b/nms/app/components/__tests__/GatewayCommandTest.js
@@ -57,11 +57,6 @@ describe('<verify successful aggregation validation/>', () => {
     MagmaAPIBindings.getEventsByNetworkIdAboutCount.mockResolvedValue(0);
   });
 
-  afterEach(() => {
-    MagmaAPIBindings.postNetworksByNetworkIdGatewaysByGatewayIdCommandGeneric.mockClear();
-    MagmaAPIBindings.getEventsByNetworkIdAboutCount.mockClear();
-  });
-
   it('', async () => {
     const {getByTestId, getAllByTestId} = render(<Wrapper />);
     await wait();
@@ -93,11 +88,6 @@ describe('<verify control proxy validation failure/>', () => {
     MagmaAPIBindings.getEventsByNetworkIdAboutCount.mockResolvedValue(0);
   });
 
-  afterEach(() => {
-    MagmaAPIBindings.postNetworksByNetworkIdGatewaysByGatewayIdCommandGeneric.mockClear();
-    MagmaAPIBindings.getEventsByNetworkIdAboutCount.mockClear();
-  });
-
   it('', async () => {
     const {getByTestId, getAllByTestId} = render(<Wrapper />);
     await wait();
@@ -121,11 +111,6 @@ describe('<verify api validation failure/>', () => {
     MagmaAPIBindings.getEventsByNetworkIdAboutCount.mockRejectedValueOnce(
       new Error('error'),
     );
-  });
-
-  afterEach(() => {
-    MagmaAPIBindings.postNetworksByNetworkIdGatewaysByGatewayIdCommandGeneric.mockClear();
-    MagmaAPIBindings.getEventsByNetworkIdAboutCount.mockClear();
   });
 
   it('', async () => {

--- a/nms/app/components/__tests__/KPI-test.js
+++ b/nms/app/components/__tests__/KPI-test.js
@@ -21,7 +21,6 @@ import MagmaAPIBindings from '../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
 import ServicingAccessGatewaysKPI from '../FEGServicingAccessGatewayKPIs';
-import axiosMock from 'axios';
 import defaultTheme from '../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
@@ -255,9 +254,6 @@ describe('<ServicingAccessGatewaysKPI />', () => {
       .mockResolvedValue({[mockGwSt.id]: mockGwSt});
   });
 
-  afterEach(() => {
-    axiosMock.get.mockClear();
-  });
   const Wrapper = () => {
     return (
       <MemoryRouter initialEntries={['/nms/mynetwork']} initialIndex={0}>

--- a/nms/app/components/__tests__/Main-test.js
+++ b/nms/app/components/__tests__/Main-test.js
@@ -57,10 +57,6 @@ describe.each`
     MagmaAPIBindings.getNetworks.mockResolvedValueOnce(networks);
   });
 
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
-
   it(`renders for ${path} path`, async () => {
     global.CONFIG = {
       appData: {

--- a/nms/app/components/cwf/__tests__/CWFGateways-test.js
+++ b/nms/app/components/cwf/__tests__/CWFGateways-test.js
@@ -141,10 +141,6 @@ describe('<CWFGateways />', () => {
     ]);
   });
 
-  afterEach(() => {
-    axiosMock.get.mockClear();
-  });
-
   it('renders', async () => {
     const {getByTitle, getAllByTitle, getAllByRole} = render(<Wrapper />);
 

--- a/nms/app/components/feg/__tests__/FEGGatewaysTest.js
+++ b/nms/app/components/feg/__tests__/FEGGatewaysTest.js
@@ -133,10 +133,6 @@ describe('<FEGGatewaysTest />', () => {
     );
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   const Wrapper = () => (
     <MemoryRouter initialEntries={['/nms/mynetwork/gateways']} initialIndex={0}>
       <MuiThemeProvider theme={defaultTheme}>

--- a/nms/app/components/layout/__tests__/useSections-test.js
+++ b/nms/app/components/layout/__tests__/useSections-test.js
@@ -19,14 +19,10 @@ import NetworkContext from '../../context/NetworkContext';
 import React from 'react';
 import useSections from '../useSections';
 
-import {AppContextProvider} from '../../../../app/components/context/AppContext';
+import {AppContextProvider} from '../../context/AppContext';
 import {act, renderHook} from '@testing-library/react-hooks';
 
-const enqueueSnackbarMock = jest.fn();
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
 
 import {CWF, FEG, FEG_LTE, LTE, XWFM} from '../../../../shared/types/network';
 
@@ -98,13 +94,12 @@ const testCases: {[string]: TestCase} = {
   },
 };
 
-const AllNetworkTypes = [CWF, FEG, LTE, FEG_LTE, XWFM];
-AllNetworkTypes.forEach(networkType => {
+describe.each([CWF, FEG, LTE, FEG_LTE, XWFM])('Should render', networkType => {
   const testCase = testCases[networkType];
   // XWF-M network selection in NMS creates a CWF network on the API just with
   // different config defaults
   const apiNetworkType = networkType === XWFM ? CWF : networkType;
-  test('Should render ' + networkType, async () => {
+  it(networkType, async () => {
     MagmaAPIBindings.getNetworksByNetworkIdType.mockResolvedValue(
       apiNetworkType,
     );
@@ -123,7 +118,5 @@ AllNetworkTypes.forEach(networkType => {
 
     const paths = result.current[1].map(r => r.path);
     expect(paths).toStrictEqual(testCase.sections);
-
-    MagmaAPIBindings.getNetworksByNetworkIdType.mockClear();
   });
 });

--- a/nms/app/views/alarms/components/alertmanager/AlertDetails/__tests__/AlertDetailsPane-test.js
+++ b/nms/app/views/alarms/components/alertmanager/AlertDetails/__tests__/AlertDetailsPane-test.js
@@ -19,138 +19,159 @@ import AlertDetailsPane from '../AlertDetailsPane';
 import {act, fireEvent, render} from '@testing-library/react';
 import {alarmTestUtil} from '../../../../test/testHelpers';
 import {mockAlert, mockRuleInterface} from '../../../../test/testData';
+import type {AlarmsWrapperProps} from '../../../../test/testHelpers';
 import type {AlertViewerProps} from '../../../rules/RuleInterface';
+import type {ApiUtil} from '../../../AlarmsApi';
 
-const {apiUtil, AlarmsWrapper} = alarmTestUtil();
-const commonProps = {
-  alert: mockAlert({labels: {alertname: '<<test alert>>'}}),
-  onClose: jest.fn(),
-};
+describe('AlertDetailsPane', () => {
+  let AlarmsWrapper: React.ComponentType<$Shape<AlarmsWrapperProps>>;
+  let apiUtil: ApiUtil;
 
-describe('Basics', () => {
-  test('renders with default props', () => {
-    const {getByText, getByTestId} = render(
-      <AlarmsWrapper>
-        <AlertDetailsPane {...commonProps} />
-      </AlarmsWrapper>,
-    );
-    expect(getByTestId('alert-details-pane')).toBeInTheDocument();
-    expect(getByTestId('metric-alert-viewer')).toBeInTheDocument();
-    expect(getByText('<<test alert>>')).toBeInTheDocument();
+  const commonProps = {
+    alert: mockAlert({labels: {alertname: '<<test alert>>'}}),
+    onClose: jest.fn(),
+  };
+
+  beforeEach(() => {
+    ({apiUtil, AlarmsWrapper} = alarmTestUtil());
   });
 
-  test('clicking the close button invokes onclose callback', () => {
-    const {getByTestId} = render(
-      <AlarmsWrapper>
-        <AlertDetailsPane {...commonProps} />
-      </AlarmsWrapper>,
-    );
-
-    const closeButton = getByTestId('alert-details-close');
-    expect(closeButton).toBeInTheDocument();
-    act(() => {
-      fireEvent.click(closeButton);
+  describe('Basics', () => {
+    it('renders with default props', () => {
+      const {getByText, getByTestId} = render(
+        <AlarmsWrapper>
+          <AlertDetailsPane {...commonProps} />
+        </AlarmsWrapper>,
+      );
+      expect(getByTestId('alert-details-pane')).toBeInTheDocument();
+      expect(getByTestId('metric-alert-viewer')).toBeInTheDocument();
+      expect(getByText('<<test alert>>')).toBeInTheDocument();
     });
-    expect(commonProps.onClose).toHaveBeenCalled();
+
+    it('clicking the close button invokes onclose callback', () => {
+      const {getByTestId} = render(
+        <AlarmsWrapper>
+          <AlertDetailsPane {...commonProps} />
+        </AlarmsWrapper>,
+      );
+
+      const closeButton = getByTestId('alert-details-close');
+      expect(closeButton).toBeInTheDocument();
+      act(() => {
+        fireEvent.click(closeButton);
+      });
+      expect(commonProps.onClose).toHaveBeenCalled();
+    });
+
+    it('shows extra labels', () => {
+      const alert = mockAlert({labels: {testLabel: 'testValue'}});
+      const {getByText} = render(
+        <AlarmsWrapper>
+          <AlertDetailsPane {...commonProps} alert={alert} />
+        </AlarmsWrapper>,
+      );
+      expect(getByText(/testLabel/i)).toBeInTheDocument();
+      expect(getByText(/testValue/i)).toBeInTheDocument();
+    });
+
+    it('shows extra annotations', () => {
+      const alert = mockAlert({annotations: {testAnnotation: 'testValue'}});
+      const {getByText} = render(
+        <AlarmsWrapper>
+          <AlertDetailsPane {...commonProps} alert={alert} />
+        </AlarmsWrapper>,
+      );
+      expect(getByText(/testAnnotation/i)).toBeInTheDocument();
+      expect(getByText(/testValue/i)).toBeInTheDocument();
+    });
   });
 
-  test('shows extra labels', () => {
+  it('shows troubleshooting link', () => {
     const alert = mockAlert({labels: {testLabel: 'testValue'}});
+    jest.spyOn(apiUtil, 'getTroubleshootingLink').mockReturnValue({
+      link: 'www.example.com',
+      title: 'View troubleshooting documentation',
+    });
+
     const {getByText} = render(
       <AlarmsWrapper>
         <AlertDetailsPane {...commonProps} alert={alert} />
       </AlarmsWrapper>,
     );
-    expect(getByText(/testLabel/i)).toBeInTheDocument();
-    expect(getByText(/testValue/i)).toBeInTheDocument();
+    expect(
+      getByText(/View troubleshooting documentation/i),
+    ).toBeInTheDocument();
   });
 
-  test('shows extra annotations', () => {
-    const alert = mockAlert({annotations: {testAnnotation: 'testValue'}});
-    const {getByText} = render(
-      <AlarmsWrapper>
-        <AlertDetailsPane {...commonProps} alert={alert} />
-      </AlarmsWrapper>,
-    );
-    expect(getByText(/testAnnotation/i)).toBeInTheDocument();
-    expect(getByText(/testValue/i)).toBeInTheDocument();
-  });
-});
+  describe('Alert type selection', () => {
+    let AlarmsWrapper: React.ComponentType<$Shape<AlarmsWrapperProps>>;
 
-test('shows troubleshooting link', () => {
-  const alert = mockAlert({labels: {testLabel: 'testValue'}});
-  jest.spyOn(apiUtil, 'getTroubleshootingLink').mockReturnValue({
-    link: 'www.example.com',
-    title: 'View troubleshooting documentation',
-  });
-  const {getByText} = render(
-    <AlarmsWrapper>
-      <AlertDetailsPane {...commonProps} alert={alert} />
-    </AlarmsWrapper>,
-  );
-  expect(getByText(/View troubleshooting documentation/i)).toBeInTheDocument();
-});
+    beforeEach(() => {
+      ({AlarmsWrapper} = alarmTestUtil());
+    });
 
-describe('Alert type selection', () => {
-  test('by default, use the MetricAlertViewer', () => {
-    const {getByTestId} = render(
-      <AlarmsWrapper>
-        <AlertDetailsPane {...commonProps} />
-      </AlarmsWrapper>,
-    );
-    expect(getByTestId('metric-alert-viewer')).toBeInTheDocument();
-  });
-  test(
-    'if getAlertType returns an unconfigured alert source, ' +
-      'fallback to the default',
-    () => {
-      const getAlertTypeMock = jest.fn(() => 'unconfigured-source');
-      const alert = mockAlert();
+    it('by default, use the MetricAlertViewer', () => {
       const {getByTestId} = render(
-        <AlarmsWrapper getAlertType={getAlertTypeMock}>
-          <AlertDetailsPane {...commonProps} alert={alert} />
+        <AlarmsWrapper>
+          <AlertDetailsPane {...commonProps} />
         </AlarmsWrapper>,
       );
-      expect(getAlertTypeMock).toHaveBeenCalledWith(alert);
       expect(getByTestId('metric-alert-viewer')).toBeInTheDocument();
-    },
-  );
-  test(
-    'if getAlertType returns a alert source without an AlertViewer, ' +
-      'fallback to default',
-    () => {
-      const getAlertTypeMock = jest.fn(() => 'prometheus');
-      const alert = mockAlert();
-      const {getByTestId} = render(
-        <AlarmsWrapper getAlertType={getAlertTypeMock}>
-          <AlertDetailsPane {...commonProps} alert={alert} />
-        </AlarmsWrapper>,
-      );
-      expect(getAlertTypeMock).toHaveBeenCalledWith(alert);
-      expect(getByTestId('metric-alert-viewer')).toBeInTheDocument();
-    },
-  );
-  test(
-    'if getAlertType returns an alert source with an AlertViewer, ' +
-      'renders the AlertViewer',
-    () => {
-      const mockAlertType = 'test';
-      const getAlertTypeMock = jest.fn(() => mockAlertType);
-      function MockAlertViewer(_props: AlertViewerProps) {
-        return <div data-testid="mock-alert-viewer" />;
-      }
-      const alert = mockAlert();
-      const {getByTestId} = render(
-        <AlarmsWrapper
-          getAlertType={getAlertTypeMock}
-          ruleMap={{
-            [mockAlertType]: mockRuleInterface({AlertViewer: MockAlertViewer}),
-          }}>
-          <AlertDetailsPane {...commonProps} alert={alert} />
-        </AlarmsWrapper>,
-      );
-      expect(getAlertTypeMock).toHaveBeenCalledWith(alert);
-      expect(getByTestId('mock-alert-viewer')).toBeInTheDocument();
-    },
-  );
+    });
+    it(
+      'if getAlertType returns an unconfigured alert source, ' +
+        'fallback to the default',
+      () => {
+        const getAlertTypeMock = jest.fn(() => 'unconfigured-source');
+        const alert = mockAlert();
+        const {getByTestId} = render(
+          <AlarmsWrapper getAlertType={getAlertTypeMock}>
+            <AlertDetailsPane {...commonProps} alert={alert} />
+          </AlarmsWrapper>,
+        );
+        expect(getAlertTypeMock).toHaveBeenCalledWith(alert);
+        expect(getByTestId('metric-alert-viewer')).toBeInTheDocument();
+      },
+    );
+    it(
+      'if getAlertType returns a alert source without an AlertViewer, ' +
+        'fallback to default',
+      () => {
+        const getAlertTypeMock = jest.fn(() => 'prometheus');
+        const alert = mockAlert();
+        const {getByTestId} = render(
+          <AlarmsWrapper getAlertType={getAlertTypeMock}>
+            <AlertDetailsPane {...commonProps} alert={alert} />
+          </AlarmsWrapper>,
+        );
+        expect(getAlertTypeMock).toHaveBeenCalledWith(alert);
+        expect(getByTestId('metric-alert-viewer')).toBeInTheDocument();
+      },
+    );
+    it(
+      'if getAlertType returns an alert source with an AlertViewer, ' +
+        'renders the AlertViewer',
+      () => {
+        const mockAlertType = 'test';
+        const getAlertTypeMock = jest.fn(() => mockAlertType);
+        function MockAlertViewer(_props: AlertViewerProps) {
+          return <div data-testid="mock-alert-viewer" />;
+        }
+        const alert = mockAlert();
+        const {getByTestId} = render(
+          <AlarmsWrapper
+            getAlertType={getAlertTypeMock}
+            ruleMap={{
+              [mockAlertType]: mockRuleInterface({
+                AlertViewer: MockAlertViewer,
+              }),
+            }}>
+            <AlertDetailsPane {...commonProps} alert={alert} />
+          </AlarmsWrapper>,
+        );
+        expect(getAlertTypeMock).toHaveBeenCalledWith(alert);
+        expect(getByTestId('mock-alert-viewer')).toBeInTheDocument();
+      },
+    );
+  });
 });

--- a/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/GlobalConfig-test.js
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/GlobalConfig-test.js
@@ -19,9 +19,10 @@ import React from 'react';
 import {act, fireEvent, render} from '@testing-library/react';
 import {alarmTestUtil} from '../../../../test/testHelpers';
 
+import type {AlarmsWrapperProps} from '../../../../test/testHelpers';
 import type {AlertManagerGlobalConfig} from '../../../AlarmAPIType';
-
-const {AlarmsWrapper, apiUtil} = alarmTestUtil();
+import type {ApiUtil} from '../../../AlarmsApi';
+import type {ComponentType} from 'react';
 
 const commonProps = {
   onExit: jest.fn(),
@@ -58,138 +59,147 @@ const defaultResponse: AlertManagerGlobalConfig = {
   },
 };
 
-test('renders', () => {
-  const {getByText} = render(
-    <AlarmsWrapper>
-      <GlobalConfig {...commonProps} />
-    </AlarmsWrapper>,
-  );
-  expect(getByText(/global receiver settings/i)).toBeInTheDocument();
-});
+describe('GlobalConfig', () => {
+  let AlarmsWrapper: ComponentType<$Shape<AlarmsWrapperProps>>;
+  let apiUtil: ApiUtil;
 
-test('fills form inputs with values from backend', () => {
-  jest.spyOn(apiUtil, 'getGlobalConfig').mockReturnValue(defaultResponse);
-  const {getByTestId} = render(
-    <AlarmsWrapper>
-      <GlobalConfig {...commonProps} />
-    </AlarmsWrapper>,
-  );
-
-  expect(getByTestId('resolve_timeout')).toHaveValue(
-    defaultResponse.resolve_timeout,
-  );
-  expect(getByTestId('slack_api_url')).toHaveValue(
-    defaultResponse.slack_api_url,
-  );
-  expect(getByTestId('pagerduty_url')).toHaveValue(
-    defaultResponse.pagerduty_url,
-  );
-  expect(getByTestId('smtp_from')).toHaveValue(defaultResponse.smtp_from);
-  expect(getByTestId('smtp_hello')).toHaveValue(defaultResponse.smtp_hello);
-  expect(getByTestId('smtp_smarthost')).toHaveValue(
-    defaultResponse.smtp_smarthost,
-  );
-  expect(getByTestId('smtp_auth_username')).toHaveValue(
-    defaultResponse.smtp_auth_username,
-  );
-  expect(getByTestId('smtp_auth_password')).toHaveValue(
-    defaultResponse.smtp_auth_password,
-  );
-  expect(getByTestId('smtp_auth_secret')).toHaveValue(
-    defaultResponse.smtp_auth_secret,
-  );
-  expect(getByTestId('smtp_auth_identity')).toHaveValue(
-    defaultResponse.smtp_auth_identity,
-  );
-  expect(getByTestId('opsgenie_api_url')).toHaveValue(
-    defaultResponse.opsgenie_api_url,
-  );
-  expect(getByTestId('opsgenie_api_key')).toHaveValue(
-    defaultResponse.opsgenie_api_key,
-  );
-  expect(getByTestId('hipchat_api_url')).toHaveValue(
-    defaultResponse.hipchat_api_url,
-  );
-  expect(getByTestId('hipchat_auth_token')).toHaveValue(
-    defaultResponse.hipchat_auth_token,
-  );
-  expect(getByTestId('wechat_api_url')).toHaveValue(
-    defaultResponse.wechat_api_url,
-  );
-  expect(getByTestId('wechat_api_secret')).toHaveValue(
-    defaultResponse.wechat_api_secret,
-  );
-  expect(getByTestId('wechat_api_corp_id')).toHaveValue(
-    defaultResponse.wechat_api_corp_id,
-  );
-  expect(getByTestId('victorops_api_url')).toHaveValue(
-    defaultResponse.victorops_api_url,
-  );
-  expect(getByTestId('victorops_api_key')).toHaveValue(
-    defaultResponse.victorops_api_key,
-  );
-  expect(getByTestId('http_config_bearer_token')).toHaveValue(
-    defaultResponse.http_config.bearer_token,
-  );
-  expect(getByTestId('http_config_proxy_url')).toHaveValue(
-    defaultResponse.http_config?.proxy_url,
-  );
-  expect(getByTestId('basic_auth_username')).toHaveValue(
-    defaultResponse.http_config?.basic_auth?.username,
-  );
-  expect(getByTestId('basic_auth_password')).toHaveValue(
-    defaultResponse.http_config?.basic_auth?.password,
-  );
-});
-
-test('submitting form submits updated values to backend', async () => {
-  jest.spyOn(apiUtil, 'getGlobalConfig').mockReturnValue({});
-  const editConfigMock = jest
-    .spyOn(apiUtil, 'editGlobalConfig')
-    .mockImplementationOnce(() => Promise.resolve());
-  const {getByTestId} = render(
-    <AlarmsWrapper>
-      <GlobalConfig {...commonProps} />
-    </AlarmsWrapper>,
-  );
-  act(() => {
-    fireEvent.change(getByTestId('resolve_timeout'), {target: {value: '5m'}});
+  beforeEach(() => {
+    ({apiUtil, AlarmsWrapper} = alarmTestUtil());
   });
-  act(() => {
-    fireEvent.change(getByTestId('slack_api_url'), {
-      target: {value: 'https://hooks.slack.com'},
+
+  it('renders', () => {
+    const {getByText} = render(
+      <AlarmsWrapper>
+        <GlobalConfig {...commonProps} />
+      </AlarmsWrapper>,
+    );
+    expect(getByText(/global receiver settings/i)).toBeInTheDocument();
+  });
+
+  it('fills form inputs with values from backend', () => {
+    jest.spyOn(apiUtil, 'getGlobalConfig').mockReturnValue(defaultResponse);
+    const {getByTestId} = render(
+      <AlarmsWrapper>
+        <GlobalConfig {...commonProps} />
+      </AlarmsWrapper>,
+    );
+
+    expect(getByTestId('resolve_timeout')).toHaveValue(
+      defaultResponse.resolve_timeout,
+    );
+    expect(getByTestId('slack_api_url')).toHaveValue(
+      defaultResponse.slack_api_url,
+    );
+    expect(getByTestId('pagerduty_url')).toHaveValue(
+      defaultResponse.pagerduty_url,
+    );
+    expect(getByTestId('smtp_from')).toHaveValue(defaultResponse.smtp_from);
+    expect(getByTestId('smtp_hello')).toHaveValue(defaultResponse.smtp_hello);
+    expect(getByTestId('smtp_smarthost')).toHaveValue(
+      defaultResponse.smtp_smarthost,
+    );
+    expect(getByTestId('smtp_auth_username')).toHaveValue(
+      defaultResponse.smtp_auth_username,
+    );
+    expect(getByTestId('smtp_auth_password')).toHaveValue(
+      defaultResponse.smtp_auth_password,
+    );
+    expect(getByTestId('smtp_auth_secret')).toHaveValue(
+      defaultResponse.smtp_auth_secret,
+    );
+    expect(getByTestId('smtp_auth_identity')).toHaveValue(
+      defaultResponse.smtp_auth_identity,
+    );
+    expect(getByTestId('opsgenie_api_url')).toHaveValue(
+      defaultResponse.opsgenie_api_url,
+    );
+    expect(getByTestId('opsgenie_api_key')).toHaveValue(
+      defaultResponse.opsgenie_api_key,
+    );
+    expect(getByTestId('hipchat_api_url')).toHaveValue(
+      defaultResponse.hipchat_api_url,
+    );
+    expect(getByTestId('hipchat_auth_token')).toHaveValue(
+      defaultResponse.hipchat_auth_token,
+    );
+    expect(getByTestId('wechat_api_url')).toHaveValue(
+      defaultResponse.wechat_api_url,
+    );
+    expect(getByTestId('wechat_api_secret')).toHaveValue(
+      defaultResponse.wechat_api_secret,
+    );
+    expect(getByTestId('wechat_api_corp_id')).toHaveValue(
+      defaultResponse.wechat_api_corp_id,
+    );
+    expect(getByTestId('victorops_api_url')).toHaveValue(
+      defaultResponse.victorops_api_url,
+    );
+    expect(getByTestId('victorops_api_key')).toHaveValue(
+      defaultResponse.victorops_api_key,
+    );
+    expect(getByTestId('http_config_bearer_token')).toHaveValue(
+      defaultResponse.http_config.bearer_token,
+    );
+    expect(getByTestId('http_config_proxy_url')).toHaveValue(
+      defaultResponse.http_config?.proxy_url,
+    );
+    expect(getByTestId('basic_auth_username')).toHaveValue(
+      defaultResponse.http_config?.basic_auth?.username,
+    );
+    expect(getByTestId('basic_auth_password')).toHaveValue(
+      defaultResponse.http_config?.basic_auth?.password,
+    );
+  });
+
+  it('submitting form submits updated values to backend', async () => {
+    jest.spyOn(apiUtil, 'getGlobalConfig').mockReturnValue({});
+    const editConfigMock = jest
+      .spyOn(apiUtil, 'editGlobalConfig')
+      .mockImplementationOnce(() => Promise.resolve());
+    const {getByTestId} = render(
+      <AlarmsWrapper>
+        <GlobalConfig {...commonProps} />
+      </AlarmsWrapper>,
+    );
+    act(() => {
+      fireEvent.change(getByTestId('resolve_timeout'), {target: {value: '5m'}});
+    });
+    act(() => {
+      fireEvent.change(getByTestId('slack_api_url'), {
+        target: {value: 'https://hooks.slack.com'},
+      });
+    });
+    expect(editConfigMock).not.toHaveBeenCalled();
+    await act(async () => {
+      fireEvent.click(getByTestId('editor-submit-button'));
+    });
+
+    expect(editConfigMock).toHaveBeenCalledWith({
+      config: {resolve_timeout: '5m', slack_api_url: 'https://hooks.slack.com'},
     });
   });
-  expect(editConfigMock).not.toHaveBeenCalled();
-  await act(async () => {
-    fireEvent.click(getByTestId('editor-submit-button'));
-  });
 
-  expect(editConfigMock).toHaveBeenCalledWith({
-    config: {resolve_timeout: '5m', slack_api_url: 'https://hooks.slack.com'},
-  });
-});
-
-test('erasing values from form removes keys from request', async () => {
-  jest.spyOn(apiUtil, 'getGlobalConfig').mockReturnValue({
-    resolve_timeout: '5m',
-    slack_api_url: 'https://hooks.slack.com',
-  });
-  const editConfigMock = jest
-    .spyOn(apiUtil, 'editGlobalConfig')
-    .mockImplementationOnce(() => Promise.resolve());
-  const {getByTestId} = render(
-    <AlarmsWrapper>
-      <GlobalConfig {...commonProps} />
-    </AlarmsWrapper>,
-  );
-  act(() => {
-    fireEvent.change(getByTestId('resolve_timeout'), {target: {value: ''}});
-  });
-  await act(async () => {
-    fireEvent.click(getByTestId('editor-submit-button'));
-  });
-  expect(editConfigMock).toHaveBeenCalledWith({
-    config: {slack_api_url: 'https://hooks.slack.com'},
+  it('erasing values from form removes keys from request', async () => {
+    jest.spyOn(apiUtil, 'getGlobalConfig').mockReturnValue({
+      resolve_timeout: '5m',
+      slack_api_url: 'https://hooks.slack.com',
+    });
+    const editConfigMock = jest
+      .spyOn(apiUtil, 'editGlobalConfig')
+      .mockImplementationOnce(() => Promise.resolve());
+    const {getByTestId} = render(
+      <AlarmsWrapper>
+        <GlobalConfig {...commonProps} />
+      </AlarmsWrapper>,
+    );
+    act(() => {
+      fireEvent.change(getByTestId('resolve_timeout'), {target: {value: ''}});
+    });
+    await act(async () => {
+      fireEvent.click(getByTestId('editor-submit-button'));
+    });
+    expect(editConfigMock).toHaveBeenCalledWith({
+      config: {slack_api_url: 'https://hooks.slack.com'},
+    });
   });
 });

--- a/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/Receivers-test.js
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/Receivers-test.js
@@ -23,112 +23,116 @@ import {
   wait,
   waitForElement,
 } from '@testing-library/react';
-import {alarmTestUtil, useMagmaAPIMock} from '../../../../test/testHelpers';
+import {alarmTestUtil} from '../../../../test/testHelpers';
+import type {AlarmsWrapperProps} from '../../../../test/testHelpers';
+import type {ApiUtil} from '../../../AlarmsApi';
 
-const enqueueSnackbarMock = jest.fn();
-jest
-  .spyOn(require('../../../../../../hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+describe('Receivers', () => {
+  let AlarmsWrapper: React.ComponentType<$Shape<AlarmsWrapperProps>>;
+  let apiUtil: ApiUtil;
 
-const {AlarmsWrapper} = alarmTestUtil();
+  beforeEach(() => {
+    ({AlarmsWrapper, apiUtil} = alarmTestUtil());
+  });
 
-test('renders', () => {
-  render(
-    <AlarmsWrapper>
-      <Receivers />
-    </AlarmsWrapper>,
-  );
-});
+  it('renders', () => {
+    render(
+      <AlarmsWrapper>
+        <Receivers />
+      </AlarmsWrapper>,
+    );
+  });
 
-test('clicking the View button on a row shows the view dialog', async () => {
-  useMagmaAPIMock.mockReturnValueOnce({
-    response: [
-      {
-        name: 'test_receiver',
-        slack_configs: [
-          {
-            api_url: 'test.com',
-            channel: '#test',
-            text: '{{text}}',
-            title: '{{title}}',
-          },
-        ],
-      },
-    ],
-  });
-  const {getByText, getAllByText, queryByText, getAllByTitle} = render(
-    <AlarmsWrapper>
-      <Receivers />
-    </AlarmsWrapper>,
-  );
-  const actionMenu = getAllByTitle('Actions');
-  expect(actionMenu[0]).toBeInTheDocument();
-  act(() => {
-    fireEvent.click(actionMenu[0]);
-  });
-  act(() => {
-    fireEvent.click(getAllByText('View')[0]);
-  });
-  // clicking View should open the dialog
-  await waitForElement(() => getByText(/View Receiver/i));
-  expect(getByText(/View Receiver/i)).toBeInTheDocument();
+  it('clicking the View button on a row shows the view dialog', async () => {
+    jest.spyOn(apiUtil, 'useAlarmsApi').mockReturnValueOnce({
+      response: [
+        {
+          name: 'test_receiver',
+          slack_configs: [
+            {
+              api_url: 'test.com',
+              channel: '#test',
+              text: '{{text}}',
+              title: '{{title}}',
+            },
+          ],
+        },
+      ],
+    });
+    const {getByText, getAllByText, queryByText, getAllByTitle} = render(
+      <AlarmsWrapper>
+        <Receivers />
+      </AlarmsWrapper>,
+    );
+    const actionMenu = getAllByTitle('Actions');
+    expect(actionMenu[0]).toBeInTheDocument();
+    act(() => {
+      fireEvent.click(actionMenu[0]);
+    });
+    act(() => {
+      fireEvent.click(getAllByText('View')[0]);
+    });
+    // clicking View should open the dialog
+    await waitForElement(() => getByText(/View Receiver/i));
+    expect(getByText(/View Receiver/i)).toBeInTheDocument();
 
-  // clicking Close should close the dialog
-  act(() => {
-    fireEvent.click(getByText(/close/i));
+    // clicking Close should close the dialog
+    act(() => {
+      fireEvent.click(getByText(/close/i));
+    });
+    await wait(() => {
+      expect(queryByText(/View Receiver/i)).not.toBeInTheDocument();
+    });
   });
-  await wait(() => {
-    expect(queryByText(/View Receiver/i)).not.toBeInTheDocument();
-  });
-});
 
-test('clicking edit button should show AddEditReceiver in edit mode', () => {
-  useMagmaAPIMock.mockReturnValueOnce({
-    response: [
-      {
-        name: 'test_receiver',
-        slack_configs: [
-          {
-            api_url: 'test.com',
-            channel: '#test',
-            text: '{{text}}',
-            title: '{{title}}',
-          },
-        ],
-      },
-    ],
-  });
-  const {getAllByText, getByTestId, queryByTestId, getAllByTitle} = render(
-    <AlarmsWrapper>
-      <Receivers />
-    </AlarmsWrapper>,
-  );
+  it('clicking edit button should show AddEditReceiver in edit mode', () => {
+    jest.spyOn(apiUtil, 'useAlarmsApi').mockReturnValueOnce({
+      response: [
+        {
+          name: 'test_receiver',
+          slack_configs: [
+            {
+              api_url: 'test.com',
+              channel: '#test',
+              text: '{{text}}',
+              title: '{{title}}',
+            },
+          ],
+        },
+      ],
+    });
+    const {getAllByText, getByTestId, queryByTestId, getAllByTitle} = render(
+      <AlarmsWrapper>
+        <Receivers />
+      </AlarmsWrapper>,
+    );
 
-  const actionMenu = getAllByTitle('Actions');
-  expect(actionMenu[0]).toBeInTheDocument();
-  act(() => {
-    fireEvent.click(actionMenu[0]);
+    const actionMenu = getAllByTitle('Actions');
+    expect(actionMenu[0]).toBeInTheDocument();
+    act(() => {
+      fireEvent.click(actionMenu[0]);
+    });
+    expect(queryByTestId('add-edit-receiver')).not.toBeInTheDocument();
+    act(() => {
+      fireEvent.click(getAllByText('Edit')[0]);
+    });
+    expect(getByTestId('add-edit-receiver')).toBeInTheDocument();
   });
-  expect(queryByTestId('add-edit-receiver')).not.toBeInTheDocument();
-  act(() => {
-    fireEvent.click(getAllByText('Edit')[0]);
-  });
-  expect(getByTestId('add-edit-receiver')).toBeInTheDocument();
-});
 
-test('clicking add button should show AddEditReceiver', () => {
-  useMagmaAPIMock.mockReturnValueOnce({
-    response: [],
-  });
-  const {getByTestId, queryByTestId} = render(
-    <AlarmsWrapper>
-      <Receivers />
-    </AlarmsWrapper>,
-  );
+  it('clicking add button should show AddEditReceiver', () => {
+    jest.spyOn(apiUtil, 'useAlarmsApi').mockReturnValueOnce({
+      response: [],
+    });
+    const {getByTestId, queryByTestId} = render(
+      <AlarmsWrapper>
+        <Receivers />
+      </AlarmsWrapper>,
+    );
 
-  expect(queryByTestId('add-edit-receiver')).not.toBeInTheDocument();
-  act(() => {
-    fireEvent.click(getByTestId('add-receiver-button'));
+    expect(queryByTestId('add-edit-receiver')).not.toBeInTheDocument();
+    act(() => {
+      fireEvent.click(getByTestId('add-receiver-button'));
+    });
+    expect(getByTestId('add-edit-receiver')).toBeInTheDocument();
   });
-  expect(getByTestId('add-edit-receiver')).toBeInTheDocument();
 });

--- a/nms/app/views/alarms/components/alertmanager/__tests__/FiringAlerts-test.js
+++ b/nms/app/views/alarms/components/alertmanager/__tests__/FiringAlerts-test.js
@@ -19,51 +19,60 @@ import FiringAlerts from '../FiringAlerts';
 import {act, fireEvent, render} from '@testing-library/react';
 import {alarmTestUtil} from '../../../test/testHelpers';
 
+import type {AlarmsWrapperProps} from '../../../test/testHelpers';
+import type {ApiUtil} from '../../AlarmsApi';
 import type {FiringAlarm} from '../../AlarmAPIType';
 
-const {apiUtil, AlarmsWrapper} = alarmTestUtil();
+describe('FiringAlerts', () => {
+  let AlarmsWrapper: React.ComponentType<$Shape<AlarmsWrapperProps>>;
+  let apiUtil: ApiUtil;
 
-test('renders with default props', () => {
-  const {getByText} = render(
-    <AlarmsWrapper>
-      <FiringAlerts />
-    </AlarmsWrapper>,
-  );
-  expect(getByText(/Start creating alert rules/i)).toBeInTheDocument();
-  expect(getByText(/Add Alert Rule/i)).toBeInTheDocument();
-});
-
-test('renders firing alerts', () => {
-  const firingAlarms: Array<$Shape<FiringAlarm>> = [
-    {
-      labels: {alertname: '<<testalert>>', severity: 'INFO'},
-    },
-  ];
-  jest.spyOn(apiUtil, 'viewFiringAlerts').mockReturnValue(firingAlarms);
-  const {getByText} = render(
-    <AlarmsWrapper>
-      <FiringAlerts />
-    </AlarmsWrapper>,
-  );
-  expect(getByText('<<testalert>>')).toBeInTheDocument();
-  expect(getByText(/info/i)).toBeInTheDocument();
-});
-
-test('clicking view alert shows alert details pane', async () => {
-  const firingAlarms: Array<$Shape<FiringAlarm>> = [
-    {
-      labels: {alertname: '<<testalert>>', severity: 'INFO'},
-    },
-  ];
-  jest.spyOn(apiUtil, 'viewFiringAlerts').mockReturnValue(firingAlarms);
-  const {getByText, getByTestId} = render(
-    <AlarmsWrapper>
-      <FiringAlerts />
-    </AlarmsWrapper>,
-  );
-  act(() => {
-    fireEvent.click(getByText('<<testalert>>'));
+  beforeEach(() => {
+    ({apiUtil, AlarmsWrapper} = alarmTestUtil());
   });
 
-  expect(getByTestId('alert-details-pane')).toBeInTheDocument();
+  it('renders with default props', () => {
+    const {getByText} = render(
+      <AlarmsWrapper>
+        <FiringAlerts />
+      </AlarmsWrapper>,
+    );
+    expect(getByText(/Start creating alert rules/i)).toBeInTheDocument();
+    expect(getByText(/Add Alert Rule/i)).toBeInTheDocument();
+  });
+
+  it('renders firing alerts', () => {
+    const firingAlarms: Array<$Shape<FiringAlarm>> = [
+      {
+        labels: {alertname: '<<testalert>>', severity: 'INFO'},
+      },
+    ];
+    jest.spyOn(apiUtil, 'viewFiringAlerts').mockReturnValue(firingAlarms);
+    const {getByText} = render(
+      <AlarmsWrapper>
+        <FiringAlerts />
+      </AlarmsWrapper>,
+    );
+    expect(getByText('<<testalert>>')).toBeInTheDocument();
+    expect(getByText(/info/i)).toBeInTheDocument();
+  });
+
+  it('clicking view alert shows alert details pane', async () => {
+    const firingAlarms: Array<$Shape<FiringAlarm>> = [
+      {
+        labels: {alertname: '<<testalert>>', severity: 'INFO'},
+      },
+    ];
+    jest.spyOn(apiUtil, 'viewFiringAlerts').mockReturnValue(firingAlarms);
+    const {getByText, getByTestId} = render(
+      <AlarmsWrapper>
+        <FiringAlerts />
+      </AlarmsWrapper>,
+    );
+    act(() => {
+      fireEvent.click(getByText('<<testalert>>'));
+    });
+
+    expect(getByTestId('alert-details-pane')).toBeInTheDocument();
+  });
 });

--- a/nms/app/views/alarms/components/rules/PrometheusEditor/__tests__/PrometheusEditor-test.js
+++ b/nms/app/views/alarms/components/rules/PrometheusEditor/__tests__/PrometheusEditor-test.js
@@ -20,17 +20,10 @@ import {alarmTestUtil} from '../../../../test/testHelpers';
 import {parseTimeString} from '../PrometheusEditor';
 import {render} from '@testing-library/react';
 
+import type {AlarmsWrapperProps} from '../../../../test/testHelpers';
 import type {AlertConfig} from '../../../AlarmAPIType';
+import type {ApiUtil} from '../../../AlarmsApi';
 import type {GenericRule} from '../../RuleInterface';
-
-jest.mock('../../../../../../hooks/useSnackbar');
-
-const {AlarmsWrapper, apiUtil} = alarmTestUtil();
-
-const enqueueSnackbarMock = jest.fn();
-jest
-  .spyOn(require('../../../../../../hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
 
 // TextField select is difficult to test so replace it with an Input
 jest.mock('@material-ui/core/TextField', () => {
@@ -43,61 +36,70 @@ jest.mock('@material-ui/core/TextField', () => {
   );
 });
 
-const commonProps = {
-  onRuleUpdated: () => {},
-  onExit: () => {},
-  isNew: false,
-  onRuleSaved: jest.fn(),
-};
+describe('PrometheusEditor', () => {
+  let AlarmsWrapper: React.ComponentType<$Shape<AlarmsWrapperProps>>;
+  let apiUtil: ApiUtil;
 
-test('editing a threshold alert opens the PrometheusEditor with the threshold expression editor enabled', async () => {
-  jest.spyOn(apiUtil, 'getMetricSeries').mockResolvedValue([]);
-  const testThresholdRule: GenericRule<AlertConfig> = {
-    severity: '',
-    ruleType: '',
-    rawRule: {alert: '', expr: 'metric > 123'},
-    period: '',
-    name: '',
-    description: '',
-    expression: 'metric > 123',
+  beforeEach(() => {
+    ({apiUtil, AlarmsWrapper} = alarmTestUtil());
+  });
+
+  const commonProps = {
+    onRuleUpdated: () => {},
+    onExit: () => {},
+    isNew: false,
+    onRuleSaved: jest.fn(),
   };
-  const {getByDisplayValue} = render(
-    <AlarmsWrapper thresholdEditorEnabled={true}>
-      <PrometheusEditor {...commonProps} rule={testThresholdRule} />
-    </AlarmsWrapper>,
-  );
-  expect(getByDisplayValue('metric')).toBeInTheDocument();
-  expect(getByDisplayValue('123')).toBeInTheDocument();
-});
 
-test('editing a non-threshold alert opens the PrometheusEditor with the advanced editor enabled', async () => {
-  const testThresholdRule: GenericRule<AlertConfig> = {
-    severity: '',
-    ruleType: '',
-    rawRule: {alert: '', expr: 'vector(1)'},
-    period: '',
-    name: '',
-    description: '',
-    expression: 'vector(1)',
-  };
-  const {getByDisplayValue} = render(
-    <AlarmsWrapper thresholdEditorEnabled={true}>
-      <PrometheusEditor {...commonProps} rule={testThresholdRule} />
-    </AlarmsWrapper>,
-  );
-  expect(getByDisplayValue('vector(1)')).toBeInTheDocument();
-});
+  test('editing a threshold alert opens the PrometheusEditor with the threshold expression editor enabled', async () => {
+    jest.spyOn(apiUtil, 'getMetricSeries').mockResolvedValue([]);
+    const testThresholdRule: GenericRule<AlertConfig> = {
+      severity: '',
+      ruleType: '',
+      rawRule: {alert: '', expr: 'metric > 123'},
+      period: '',
+      name: '',
+      description: '',
+      expression: 'metric > 123',
+    };
+    const {getByDisplayValue} = render(
+      <AlarmsWrapper thresholdEditorEnabled={true}>
+        <PrometheusEditor {...commonProps} rule={testThresholdRule} />
+      </AlarmsWrapper>,
+    );
+    expect(getByDisplayValue('metric')).toBeInTheDocument();
+    expect(getByDisplayValue('123')).toBeInTheDocument();
+  });
 
-describe('Duration Parser', () => {
-  const testCases = [
-    ['empty input', '', {hours: 0, minutes: 0, seconds: 0}],
-    ['out of order units', '1s2m3h', {hours: 0, minutes: 0, seconds: 0}],
-    ['all units', '1h2m3s', {hours: 1, minutes: 2, seconds: 3}],
-    ['hour', '1h', {hours: 1, minutes: 0, seconds: 0}],
-    ['minute', '1m', {hours: 0, minutes: 1, seconds: 0}],
-    ['second', '1s', {hours: 0, minutes: 0, seconds: 1}],
-  ];
-  test.each(testCases)('%s', (name, input, expectedDuration) => {
-    expect(parseTimeString(input)).toEqual(expectedDuration);
+  test('editing a non-threshold alert opens the PrometheusEditor with the advanced editor enabled', async () => {
+    const testThresholdRule: GenericRule<AlertConfig> = {
+      severity: '',
+      ruleType: '',
+      rawRule: {alert: '', expr: 'vector(1)'},
+      period: '',
+      name: '',
+      description: '',
+      expression: 'vector(1)',
+    };
+    const {getByDisplayValue} = render(
+      <AlarmsWrapper thresholdEditorEnabled={true}>
+        <PrometheusEditor {...commonProps} rule={testThresholdRule} />
+      </AlarmsWrapper>,
+    );
+    expect(getByDisplayValue('vector(1)')).toBeInTheDocument();
+  });
+
+  describe('Duration Parser', () => {
+    const testCases = [
+      ['empty input', '', {hours: 0, minutes: 0, seconds: 0}],
+      ['out of order units', '1s2m3h', {hours: 0, minutes: 0, seconds: 0}],
+      ['all units', '1h2m3s', {hours: 1, minutes: 2, seconds: 3}],
+      ['hour', '1h', {hours: 1, minutes: 0, seconds: 0}],
+      ['minute', '1m', {hours: 0, minutes: 1, seconds: 0}],
+      ['second', '1s', {hours: 0, minutes: 0, seconds: 1}],
+    ];
+    test.each(testCases)('%s', (name, input, expectedDuration) => {
+      expect(parseTimeString(input)).toEqual(expectedDuration);
+    });
   });
 });

--- a/nms/app/views/alarms/components/rules/__tests__/AddEditRule-test.js
+++ b/nms/app/views/alarms/components/rules/__tests__/AddEditRule-test.js
@@ -44,10 +44,6 @@ const commonProps = {
   onExit: jest.fn(),
 };
 
-afterEach(() => {
-  jest.resetAllMocks();
-});
-
 describe('Receiver select', () => {
   function assertType<T, I>(value: ?T, shouldBe: Class<I>): I {
     if (value instanceof shouldBe) {

--- a/nms/app/views/alarms/components/rules/__tests__/LabelsEditor-test.js
+++ b/nms/app/views/alarms/components/rules/__tests__/LabelsEditor-test.js
@@ -22,9 +22,6 @@ const commonProps = {
   labels: {},
   onChange: jest.fn(),
 };
-afterEach(() => {
-  jest.resetAllMocks();
-});
 
 test('clicking the add button adds new textboxes', () => {
   const {getByTestId, queryAllByPlaceholderText} = render(

--- a/nms/app/views/alarms/components/table/__tests__/SimpleTable-test.js
+++ b/nms/app/views/alarms/components/table/__tests__/SimpleTable-test.js
@@ -21,10 +21,6 @@ import defaultTheme from '../../../../../theme/default';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {render} from '@testing-library/react';
 
-afterEach(() => {
-  jest.resetAllMocks();
-});
-
 // replace the default chip with a more easily queryable version
 jest.mock('@material-ui/core/Chip', () => ({label, ...props}) => (
   <div data-chip {...props} children={label} />

--- a/nms/app/views/alarms/legacy/__tests__/Alarms-test.js
+++ b/nms/app/views/alarms/legacy/__tests__/Alarms-test.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @flow strict-local
+ * @flow
  * @format
  */
 
@@ -18,26 +18,14 @@ import * as React from 'react';
 import Alarms from '../Alarms';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import defaultTheme from '../../../../theme/default';
+import useMagmaAPI from '../../../../../api/useMagmaAPI';
 import {MagmaAlarmsApiUtil} from '../../../../state/AlarmsApiUtil';
 import {MemoryRouter} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {SnackbarProvider} from 'notistack';
 import {render} from '@testing-library/react';
 
-jest.mock('../../../../../app/hooks/useSnackbar');
-const useSnackbar = require('../../../../../app/hooks/useSnackbar');
-const snackbarsMock = {error: jest.fn(), success: jest.fn()};
-jest
-  .spyOn(useSnackbar, 'useSnackbars')
-  .mockReturnValue(jest.fn(() => snackbarsMock));
-
-const useSnackbarsMock = jest.fn();
-jest
-  .spyOn(require('../../../../../app/hooks/useSnackbar'), 'useSnackbars')
-  .mockReturnValue(useSnackbarsMock);
-const useMagmaAPIMock = jest
-  .spyOn(require('../../../../../api/useMagmaAPI'), 'default')
-  .mockReturnValue({response: []});
+jest.mock('../../../../../api/useMagmaAPI');
 
 const Wrapper = (props: {route: string, children: React.Node}) => (
   <MemoryRouter initialEntries={[props.route || '/alarms']} initialIndex={0}>
@@ -50,10 +38,6 @@ const Wrapper = (props: {route: string, children: React.Node}) => (
 );
 
 const AlarmsWrapper = () => <Alarms apiUtil={MagmaAlarmsApiUtil} />;
-
-afterEach(() => {
-  useMagmaAPIMock.mockClear();
-});
 
 describe('react router tests', () => {
   test('/alerts renders the no alerts icon', () => {
@@ -70,7 +54,8 @@ describe('react router tests', () => {
 
 describe('Firing Alerts', () => {
   test('renders currently firing alerts if api returns alerts', () => {
-    useMagmaAPIMock.mockReturnValue({
+    // eslint-disable-next-line flowtype/no-weak-types
+    (useMagmaAPI: any).mockReturnValue({
       response: [
         {
           labels: {alertname: '<<TEST ALERT>>', team: '<<TEST TEAM>>'},

--- a/nms/app/views/alarms/test/testHelpers.js
+++ b/nms/app/views/alarms/test/testHelpers.js
@@ -28,29 +28,29 @@ import type {ApiUtil} from '../components/AlarmsApi';
 import type {RuleInterfaceMap} from '../components/rules/RuleInterface';
 
 /**
- * I don't understand how to properly type these mocks so using any for now.
- * The consuming code is all strongly typed, this shouldn't be much of an issue.
- */
-// eslint-disable-next-line flowtype/no-weak-types
-export const useMagmaAPIMock = jest.fn<any, any>(
-  <TParams, TResponse>(
-    func: TParams => Promise<TResponse>,
-    params: TParams,
-    _cacheCounter?: string | number,
-  ) => ({
-    isLoading: false,
-    response: func(params),
-    error: null,
-  }),
-);
-
-/**
  * Make sure when adding new functions to ApiUtil to add their mocks here
  */
 export function mockApiUtil(merge?: $Shape<ApiUtil>): ApiUtil {
+  /**
+   * I don't understand how to properly type these mocks so using any for now.
+   * The consuming code is all strongly typed, this shouldn't be much of an issue.
+   */
+  // eslint-disable-next-line flowtype/no-weak-types
+  const useAlarmsApi = jest.fn<any, any>(
+    <TParams, TResponse>(
+      func: TParams => Promise<TResponse>,
+      params: TParams,
+      _cacheCounter?: string | number,
+    ) => ({
+      isLoading: false,
+      response: func(params),
+      error: null,
+    }),
+  );
+
   return Object.assign(
     {
-      useAlarmsApi: useMagmaAPIMock,
+      useAlarmsApi,
       viewFiringAlerts: jest.fn(),
       viewMatchingAlerts: jest.fn(),
       getTroubleshootingLink: jest.fn(),
@@ -86,7 +86,7 @@ export async function renderAsync(...renderArgs: Array<any>): Promise<any> {
   return result;
 }
 
-type AlarmsWrapperProps = {|
+export type AlarmsWrapperProps = {|
   children: React.Node,
   ...$Shape<AlarmContextType>,
 |};

--- a/nms/app/views/equipment/__tests__/EnodebConfigTest.js
+++ b/nms/app/views/equipment/__tests__/EnodebConfigTest.js
@@ -26,16 +26,12 @@ import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {SetEnodebState} from '../../../state/lte/EquipmentState';
 import {fireEvent, render, wait} from '@testing-library/react';
+import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 import {useState} from 'react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest.mock('../../../../app/hooks/useSnackbar');
-
-const enqueueSnackbarMock = jest.fn();
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+jest.mock('../../../hooks/useSnackbar');
 
 describe('<AddEditEnodeButton />', () => {
   const ran = {
@@ -96,9 +92,11 @@ describe('<AddEditEnodeButton />', () => {
     },
   };
 
-  afterEach(() => {
-    MagmaAPIBindings.postLteByNetworkIdEnodebs.mockClear();
-    MagmaAPIBindings.putLteByNetworkIdEnodebsByEnodebSerial.mockClear();
+  beforeEach(() => {
+    (useEnqueueSnackbar: JestMockFn<
+      Array<empty>,
+      $Call<typeof useEnqueueSnackbar>,
+    >).mockReturnValue(jest.fn());
   });
 
   const AddWrapper = () => {

--- a/nms/app/views/equipment/__tests__/EnodebDetailMainTest.js
+++ b/nms/app/views/equipment/__tests__/EnodebDetailMainTest.js
@@ -22,7 +22,6 @@ import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MomentUtils from '@date-io/moment';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
-import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
@@ -30,12 +29,9 @@ import {MuiPickersUtilsProvider} from '@material-ui/pickers';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {render, wait} from '@testing-library/react';
 
-const enqueueSnackbarMock = jest.fn();
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+jest.mock('../../../hooks/useSnackbar');
 
 const mockThroughput: promql_return_object = {
   status: 'success',
@@ -59,9 +55,6 @@ describe('<Enodeb />', () => {
     MagmaAPIBindings.getNetworks.mockResolvedValue([]);
   });
 
-  afterEach(() => {
-    axiosMock.get.mockClear();
-  });
   const enbInfo = {
     testEnodebSerial0: {
       enb: {

--- a/nms/app/views/equipment/__tests__/EquipmentEnodebTest.js
+++ b/nms/app/views/equipment/__tests__/EquipmentEnodebTest.js
@@ -21,21 +21,19 @@ import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MomentUtils from '@date-io/moment';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
-import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 
 import * as hooks from '../../../components/context/RefreshContext';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiPickersUtilsProvider} from '@material-ui/pickers';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {render, wait} from '@testing-library/react';
 
-const enqueueSnackbarMock = jest.fn();
+// $FlowFixMe Upgrade react-testing-library
+import {render, waitFor} from '@testing-library/react';
+
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+jest.mock('../../../hooks/useSnackbar');
 
 const mockThroughput: promql_return_object = {
   status: 'success',
@@ -53,15 +51,11 @@ const mockThroughput: promql_return_object = {
 const currTime = Date.now();
 
 describe('<Enodeb />', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mockResolvedValue(
       mockThroughput,
     );
-    //   MagmaAPIBindings.getLteByNetworkIdEnodebs.mockResolvedValue(enbInfo);
-  });
-
-  afterEach(() => {
-    axiosMock.get.mockClear();
+    MagmaAPIBindings.getLteByNetworkIdEnodebs.mockResolvedValue(enbInfo);
   });
 
   const enbInfo0 = {
@@ -153,36 +147,35 @@ describe('<Enodeb />', () => {
 
   it('renders', async () => {
     const {getAllByRole} = render(<Wrapper />);
-    await wait();
+    await waitFor(() => {
+      expect(
+        MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange,
+      ).toHaveBeenCalledTimes(1);
 
-    // TODO(andreilee): Figure out what's broken with this expectation
-    //expect(
-    //  MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange,
-    //).toHaveBeenCalledTimes(1);
+      const rowItems = getAllByRole('row');
 
-    const rowItems = await getAllByRole('row');
+      // first row is the header
+      expect(rowItems[0]).toHaveTextContent('Name');
+      expect(rowItems[0]).toHaveTextContent('Serial Number');
+      expect(rowItems[0]).toHaveTextContent('Session State Name');
+      expect(rowItems[0]).toHaveTextContent('Health');
+      expect(rowItems[0]).toHaveTextContent('Reported Time');
 
-    // first row is the header
-    expect(rowItems[0]).toHaveTextContent('Name');
-    expect(rowItems[0]).toHaveTextContent('Serial Number');
-    expect(rowItems[0]).toHaveTextContent('Session State Name');
-    expect(rowItems[0]).toHaveTextContent('Health');
-    expect(rowItems[0]).toHaveTextContent('Reported Time');
+      expect(rowItems[1]).toHaveTextContent('testEnodeb0');
+      expect(rowItems[1]).toHaveTextContent('testEnodebSerial0');
+      expect(rowItems[1]).toHaveTextContent(
+        'Completed provisioning eNB. Awaiting new Inform.',
+      );
+      expect(rowItems[1]).toHaveTextContent('Bad');
+      expect(rowItems[1]).toHaveTextContent(new Date(0).toLocaleDateString());
 
-    expect(rowItems[1]).toHaveTextContent('testEnodeb0');
-    expect(rowItems[1]).toHaveTextContent('testEnodebSerial0');
-    expect(rowItems[1]).toHaveTextContent(
-      'Completed provisioning eNB. Awaiting new Inform.',
-    );
-    expect(rowItems[1]).toHaveTextContent('Bad');
-    expect(rowItems[1]).toHaveTextContent(new Date(0).toLocaleDateString());
-
-    expect(rowItems[2]).toHaveTextContent('testEnodeb1');
-    expect(rowItems[2]).toHaveTextContent('testEnodebSerial1');
-    expect(rowItems[2]).toHaveTextContent('initializing');
-    expect(rowItems[2]).toHaveTextContent('Good');
-    expect(rowItems[2]).toHaveTextContent(
-      new Date(currTime).toLocaleDateString(),
-    );
+      expect(rowItems[2]).toHaveTextContent('testEnodeb1');
+      expect(rowItems[2]).toHaveTextContent('testEnodebSerial1');
+      expect(rowItems[2]).toHaveTextContent('initializing');
+      expect(rowItems[2]).toHaveTextContent('Good');
+      expect(rowItems[2]).toHaveTextContent(
+        new Date(currTime).toLocaleDateString(),
+      );
+    });
   });
 });

--- a/nms/app/views/equipment/__tests__/EquipmentGatewayPoolTest.js
+++ b/nms/app/views/equipment/__tests__/EquipmentGatewayPoolTest.js
@@ -31,15 +31,12 @@ import {
   UpdateGatewayPoolRecords,
 } from '../../../state/lte/EquipmentState';
 import {fireEvent, render, wait} from '@testing-library/react';
+import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 import {useState} from 'react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest.mock('../../../../app/hooks/useSnackbar');
-const enqueueSnackbarMock = jest.fn();
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+jest.mock('../../../hooks/useSnackbar');
 
 const gwPoolStateMock = {
   pool1: {
@@ -238,11 +235,11 @@ describe('<GatewayPools />', () => {
 });
 
 describe('<AddEditGatewayPoolButton />', () => {
-  afterEach(() => {
-    MagmaAPIBindings.postLteByNetworkIdGatewayPools.mockClear();
-    MagmaAPIBindings.putLteByNetworkIdGatewaysByGatewayIdCellularPooling.mockClear();
-  });
   beforeEach(() => {
+    (useEnqueueSnackbar: JestMockFn<
+      Array<empty>,
+      $Call<typeof useEnqueueSnackbar>,
+    >).mockReturnValue(jest.fn());
     MagmaAPIBindings.getLteByNetworkIdGatewayPoolsByGatewayPoolId.mockResolvedValue(
       {
         config: {mme_group_id: 4},

--- a/nms/app/views/equipment/__tests__/EquipmentGatewayTest.js
+++ b/nms/app/views/equipment/__tests__/EquipmentGatewayTest.js
@@ -18,7 +18,6 @@ import GatewayContext from '../../../components/context/GatewayContext';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
-import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
@@ -28,12 +27,10 @@ import type {
   promql_return_object,
 } from '../../../../generated/MagmaAPIBindings';
 
-const enqueueSnackbarMock = jest.fn();
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+jest.mock('../../../hooks/useSnackbar');
+
 const mockCheckinMetric: promql_return_object = {
   status: 'success',
   data: {
@@ -119,10 +116,6 @@ describe('<Gateway />', () => {
     );
   });
 
-  afterEach(() => {
-    axiosMock.get.mockClear();
-  });
-
   const mockGw1 = {
     ...mockGw0,
     id: 'test_gw1',
@@ -169,10 +162,9 @@ describe('<Gateway />', () => {
     const {getByTestId, getAllByRole, getAllByTitle} = render(<Wrapper />);
     await wait();
 
-    // TODO(andreilee): Figure out why this expectation is broken
-    // expect(
-    //   MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange,
-    // ).toHaveBeenCalledTimes(1);
+    expect(
+      MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange,
+    ).toHaveBeenCalledTimes(1);
 
     expect(
       MagmaAPIBindings.getNetworksByNetworkIdPrometheusQuery,

--- a/nms/app/views/equipment/__tests__/FEGEquipmentGatewayTest.js
+++ b/nms/app/views/equipment/__tests__/FEGEquipmentGatewayTest.js
@@ -18,7 +18,6 @@ import FEGEquipmentGateway from '../FEGEquipmentGateway';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings.js';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
-import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 import moment from 'moment';
 import {FEGGatewayContextProvider} from '../../../components/feg/FEGContext';
@@ -37,13 +36,10 @@ import type {
   swx,
 } from '../../../../generated/MagmaAPIBindings.js';
 
-const enqueueSnackbarMock = jest.fn();
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings');
-jest.mock('../../../../app/hooks/useSnackbar');
+jest.mock('../../../hooks/useSnackbar');
+
 const mockGx: gx = {
   server: {
     address: '174.16.1.14:3868',
@@ -252,10 +248,6 @@ describe('<FEGEquipmentGateway />', () => {
     MagmaAPIBindings.getNetworksByNetworkIdPrometheusQuery.mockResolvedValue(
       mockFalloverStatus,
     );
-  });
-
-  afterEach(() => {
-    axiosMock.get.mockClear();
   });
 
   const Wrapper = () => (

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.js
@@ -158,9 +158,7 @@ describe('<FEGGatewayDetailConfig />', () => {
     // Mocking value because it is called by FEGGatewayDialogue / Edit Gateway Page
     MagmaAPIBindings.getNetworksByNetworkIdTiers.mockResolvedValue([]);
   });
-  afterEach(() => {
-    MagmaAPIBindings.putFegByNetworkIdGatewaysByGatewayId.mockClear();
-  });
+
   const Wrapper = () => (
     <MemoryRouter
       initialEntries={[

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.js
@@ -20,7 +20,6 @@ import FEGGatewayDetailStatus from '../FEGGatewayDetailStatus';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
-import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
@@ -134,10 +133,6 @@ describe('<FEGGatewayDetailStatus />', () => {
     MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mockResolvedValue(
       mockCPUUsage,
     );
-  });
-
-  afterEach(() => {
-    axiosMock.get.mockClear();
   });
 
   const Wrapper = () => (

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailSubscribersTest.js
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailSubscribersTest.js
@@ -25,7 +25,6 @@ import FEGSubscriberContext from '../../../components/context/FEGSubscriberConte
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
-import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
@@ -142,10 +141,6 @@ describe('<FEGGatewayDetailSubscribers />', () => {
     MagmaAPIBindings.getLteByNetworkIdSubscribersBySubscriberId
       .mockReturnValueOnce(mockSubscribers[0])
       .mockResolvedValue(mockSubscribers[1]);
-  });
-
-  afterEach(() => {
-    axiosMock.get.mockClear();
   });
 
   const Wrapper = () => (

--- a/nms/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -37,15 +37,12 @@ import {
   UpdateGateway,
 } from '../../../state/lte/EquipmentState';
 import {fireEvent, render, wait} from '@testing-library/react';
+import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 import {useState} from 'react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest.mock('../../../../app/hooks/useSnackbar');
-const enqueueSnackbarMock = jest.fn();
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+jest.mock('../../../hooks/useSnackbar');
 
 const mockGw0: lte_gateway = {
   apn_resources: {},
@@ -189,12 +186,11 @@ const mockApns: {[string]: apn} = {
 };
 
 describe('<AddEditGatewayButton />', () => {
-  afterEach(() => {
-    MagmaAPIBindings.getLteByNetworkIdGateways.mockResolvedValue({
-      testGatewayId0: mockGw0,
-    });
-    MagmaAPIBindings.postLteByNetworkIdGateways.mockClear();
-    MagmaAPIBindings.putLteByNetworkIdGatewaysByGatewayIdCellularDns.mockClear();
+  beforeEach(() => {
+    (useEnqueueSnackbar: JestMockFn<
+      Array<empty>,
+      $Call<typeof useEnqueueSnackbar>,
+    >).mockReturnValue(jest.fn());
   });
 
   const AddWrapper = () => {

--- a/nms/app/views/equipment/__tests__/GatewayLogsTest.js
+++ b/nms/app/views/equipment/__tests__/GatewayLogsTest.js
@@ -20,7 +20,6 @@ import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MomentUtils from '@date-io/moment';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
-import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiPickersUtilsProvider} from '@material-ui/pickers';
@@ -135,10 +134,6 @@ describe('<GatewayLogs />', () => {
     MagmaAPIBindings.getNetworksByNetworkIdLogsSearch.mockResolvedValue(
       mockLogs,
     );
-  });
-
-  afterEach(() => {
-    axiosMock.get.mockClear();
   });
 
   it('verify gateway logs rendering', async () => {

--- a/nms/app/views/events/__tests__/EventsTableTest.js
+++ b/nms/app/views/events/__tests__/EventsTableTest.js
@@ -27,11 +27,7 @@ import {render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest.mock('../../../../app/hooks/useSnackbar');
-const enqueueSnackbarMock = jest.fn();
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+jest.mock('../../../hooks/useSnackbar');
 
 const mockEvents = [
   {
@@ -118,10 +114,6 @@ describe('<EventsTable />', () => {
       mockEvents.length,
     );
     MagmaAPIBindings.getEventsByNetworkId.mockResolvedValue(mockEvents);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
   });
 
   const Wrapper = () => {

--- a/nms/app/views/network/__tests__/FEGServicingAccessGatewayTableTest.js
+++ b/nms/app/views/network/__tests__/FEGServicingAccessGatewayTableTest.js
@@ -19,7 +19,6 @@ import FEGServicingAccessGatewaysTable from '../FEGServicingAccessGatewayTable';
 import MagmaAPIBindings from '../../../../generated/MagmaAPIBindings';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
-import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
@@ -160,10 +159,6 @@ describe('<ServicingAccessGatewaysInfo />', () => {
         [mockGw2.id]: mockGw2,
       })
       .mockResolvedValue({[mockGw3.id]: mockGw3});
-  });
-
-  afterEach(() => {
-    axiosMock.get.mockClear();
   });
 
   const Wrapper = () => {

--- a/nms/app/views/network/__tests__/NetworkTest.js
+++ b/nms/app/views/network/__tests__/NetworkTest.js
@@ -34,19 +34,17 @@ import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {UpdateNetworkState} from '../../../state/lte/NetworkState';
 import {fireEvent, render, wait} from '@testing-library/react';
+import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 
 import type {feg_network} from '../../../../generated/MagmaAPIBindings';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest.mock('../../../../app/hooks/useSnackbar');
-const enqueueSnackbarMock = jest.fn();
+jest.mock('../../../hooks/useSnackbar');
+
 const forbiddenNetworkTypes = Object.keys(CoreNetworkTypes).map(
   key => CoreNetworkTypes[key],
 );
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
 
 describe('<NetworkDashboard />', () => {
   const testNetwork = {
@@ -257,6 +255,11 @@ describe('<NetworkDashboard />', () => {
   };
 
   beforeEach(() => {
+    (useEnqueueSnackbar: JestMockFn<
+      Array<empty>,
+      $Call<typeof useEnqueueSnackbar>,
+    >).mockReturnValue(jest.fn());
+
     axiosMock.post.mockImplementation(() =>
       Promise.resolve({data: {success: true}}),
     );
@@ -273,16 +276,6 @@ describe('<NetworkDashboard />', () => {
       Promise.resolve({data: {success: true}}),
     );
     MagmaAPIBindings.getNetworks.mockImplementation(() => Promise.resolve([]));
-  });
-
-  afterEach(() => {
-    axiosMock.get.mockClear();
-    MagmaAPIBindings.getLteByNetworkId.mockClear();
-    MagmaAPIBindings.getNetworksByNetworkId.mockClear();
-    MagmaAPIBindings.putLteByNetworkId.mockClear();
-    MagmaAPIBindings.putLteByNetworkIdCellularEpc.mockClear();
-    MagmaAPIBindings.putLteByNetworkIdCellularRan.mockClear();
-    MagmaAPIBindings.putLteByNetworkIdDns.mockClear();
   });
 
   const Wrapper = () => {
@@ -722,6 +715,11 @@ describe('<FEGNetworkDashboard />', () => {
       records: [],
     },
   };
+
+  beforeEach(() => {
+    MagmaAPIBindings.getNetworks.mockImplementation(() => Promise.resolve([]));
+  });
+
   const Wrapper = () => {
     const networkCtx = {
       state: {

--- a/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.js
@@ -31,18 +31,16 @@ import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {fireEvent, render, wait} from '@testing-library/react';
 import {setSubscriberState} from '../../../state/lte/SubscriberState';
+import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 import {useState} from 'react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest.mock('../../../../app/hooks/useSnackbar');
-const enqueueSnackbarMock = jest.fn();
+jest.mock('../../../hooks/useSnackbar');
+
 const forbiddenNetworkTypes = Object.keys(CoreNetworkTypes).map(
   key => CoreNetworkTypes[key],
 );
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
 
 const subscribersMock = {
   IMSI00000000001002: {
@@ -212,11 +210,11 @@ const ran = {
 };
 
 describe('<AddSubscriberButton />', () => {
-  afterEach(() => {
-    MagmaAPIBindings.postLteByNetworkIdSubscribers.mockClear();
-    MagmaAPIBindings.putLteByNetworkIdSubscribersBySubscriberId.mockClear();
-  });
   beforeEach(() => {
+    (useEnqueueSnackbar: JestMockFn<
+      Array<empty>,
+      $Call<typeof useEnqueueSnackbar>,
+    >).mockReturnValue(jest.fn());
     MagmaAPIBindings.getLteByNetworkIdSubscriberConfigBaseNames.mockResolvedValue(
       [],
     );

--- a/nms/app/views/subscriber/__tests__/SubscriberChartTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberChartTest.js
@@ -29,11 +29,7 @@ import {render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest.mock('../../../../app/hooks/useSnackbar');
-const enqueueSnackbarMock = jest.fn();
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+jest.mock('../../../hooks/useSnackbar');
 
 const mockAvgCurDataUsage = {
   status: 'success',
@@ -98,10 +94,6 @@ describe('<SubscriberChart />', () => {
       .mockReturnValueOnce(mockAvgMonthlyDataUsage)
       // avg data usage in the past 1 year
       .mockReturnValueOnce(mockEmptyDataset);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
   });
 
   const Wrapper = () => {

--- a/nms/app/views/subscriber/__tests__/SubscriberTest.js
+++ b/nms/app/views/subscriber/__tests__/SubscriberTest.js
@@ -28,14 +28,12 @@ import {fireEvent, render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-jest.mock('../../../../app/hooks/useSnackbar');
-const enqueueSnackbarMock = jest.fn();
+jest.mock('../../../hooks/useSnackbar');
+
 const forbiddenNetworkTypes = Object.keys(CoreNetworkTypes).map(
   key => CoreNetworkTypes[key],
 );
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+
 const subscribers = {
   IMSI0000000000: {
     name: 'subscriber0',

--- a/nms/app/views/traffic/__tests__/ApnAddTest.js
+++ b/nms/app/views/traffic/__tests__/ApnAddTest.js
@@ -31,10 +31,8 @@ import {fireEvent, render, wait} from '@testing-library/react';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-const enqueueSnackbarMock = jest.fn();
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+jest.mock('../../../hooks/useSnackbar');
+
 const apns = {
   apn_0: {
     apn_configuration: {
@@ -69,10 +67,6 @@ const apns = {
 };
 
 describe('<TrafficDashboard />', () => {
-  afterEach(() => {
-    MagmaAPIBindings.postLteByNetworkIdApns.mockClear();
-    MagmaAPIBindings.putLteByNetworkIdApnsByApnName.mockClear();
-  });
   beforeEach(() => {
     MagmaAPIBindings.getLteByNetworkIdApns.mockResolvedValue(apns);
     MagmaAPIBindings.getNetworks.mockResolvedValue([]);

--- a/nms/app/views/traffic/__tests__/PolicyAddEditTest.js
+++ b/nms/app/views/traffic/__tests__/PolicyAddEditTest.js
@@ -30,13 +30,12 @@ import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 // $FlowFixMe Upgrade react-testing-library
 import {fireEvent, render, waitFor} from '@testing-library/react';
+import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 
 jest.mock('axios');
 jest.mock('../../../../generated/MagmaAPIBindings.js');
-const enqueueSnackbarMock = jest.fn();
-jest
-  .spyOn(require('../../../../app/hooks/useSnackbar'), 'useEnqueueSnackbar')
-  .mockReturnValue(enqueueSnackbarMock);
+jest.mock('../../../hooks/useSnackbar');
+
 const policies = {
   policy_0: {
     flow_list: [],
@@ -150,14 +149,11 @@ const feg_lte_network = {
 };
 
 describe('<TrafficDashboard />', () => {
-  afterEach(() => {
-    MagmaAPIBindings.getFegLteByNetworkId.mockClear();
-    MagmaAPIBindings.postNetworksByNetworkIdPoliciesRules.mockClear();
-    MagmaAPIBindings.putFegLteByNetworkIdSubscriberConfig.mockClear();
-    MagmaAPIBindings.putFegByNetworkIdSubscriberConfig.mockClear();
-    MagmaAPIBindings.putLteByNetworkIdSubscriberConfig.mockClear();
-  });
   beforeEach(() => {
+    (useEnqueueSnackbar: JestMockFn<
+      Array<empty>,
+      $Call<typeof useEnqueueSnackbar>,
+    >).mockReturnValue(jest.fn());
     MagmaAPIBindings.getFegLteByNetworkId.mockResolvedValue(feg_lte_network);
     MagmaAPIBindings.getFegByNetworkId.mockResolvedValue(feg_network);
     MagmaAPIBindings.getLteByNetworkIdPolicyQosProfiles.mockResolvedValue({});

--- a/nms/app/views/traffic/__tests__/TrafficOverviewTest.js
+++ b/nms/app/views/traffic/__tests__/TrafficOverviewTest.js
@@ -19,7 +19,6 @@ import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import PolicyContext from '../../../components/context/PolicyContext';
 import React from 'react';
 import TrafficDashboard from '../TrafficOverview';
-import axiosMock from 'axios';
 import defaultTheme from '../../../theme/default';
 
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
@@ -311,7 +310,6 @@ describe('<TrafficDashboard />', () => {
       networkId: 'test',
       ruleId: 'policy_0',
     });
-    axiosMock.delete.mockClear();
   });
   it('shows prompt when remove profile is clicked', async () => {
     MagmaAPIBindings.deleteLteByNetworkIdPolicyQosProfilesByProfileId.mockResolvedValueOnce(
@@ -341,7 +339,6 @@ describe('<TrafficDashboard />', () => {
       networkId: 'test',
       profileId: 'profile_1',
     });
-    axiosMock.delete.mockClear();
   });
   it('shows prompt when remove rating group is clicked', async () => {
     MagmaAPIBindings.deleteNetworksByNetworkIdRatingGroupsByRatingGroupId.mockResolvedValueOnce(
@@ -371,12 +368,15 @@ describe('<TrafficDashboard />', () => {
       networkId: 'test',
       ratingGroupId: 0,
     });
-    axiosMock.delete.mockClear();
   });
 });
 
 describe('<TrafficDashboard APNs/>', () => {
   const {location} = window;
+  beforeEach(() => {
+    MagmaAPIBindings.getNetworks.mockResolvedValue([]);
+  });
+
   beforeAll((): void => {
     delete window.location;
     window.location = {
@@ -508,6 +508,5 @@ describe('<TrafficDashboard APNs/>', () => {
       networkId: 'test',
       apnName: 'apn_0',
     });
-    axiosMock.delete.mockClear();
   });
 });

--- a/nms/jest.config.js
+++ b/nms/jest.config.js
@@ -32,6 +32,8 @@ module.exports = {
       transform: {
         '^.+\\.js$': 'babel-jest',
       },
+      resetMocks: true,
+      restoreMocks: true,
     },
     {
       name: 'app',
@@ -41,6 +43,8 @@ module.exports = {
         '^.+\\.js$': 'babel-jest',
       },
       setupFilesAfterEnv: ['./jest.setup.app.js'],
+      resetMocks: true,
+      restoreMocks: true,
     },
   ],
   testEnvironment: 'jsdom',


### PR DESCRIPTION
## Summary

Resets and restores jest mocks after every test per configuration option.
This makes sure that no test silently depends on mocking or calling of mocks in another test.

## Test Plan

```
yarn test
...
Test Suites: 52 passed, 52 total
Tests:       315 passed, 315 total
Snapshots:   0 total
Time:        18.444 s
Ran all test suites in 2 projects.
✨  Done in 20.20s.
```