### PR TITLE
fix(nms): Enable type checking for organizations and fix issues

### DIFF
--- a/nms/.flowconfig
+++ b/nms/.flowconfig
@@ -35,7 +35,6 @@ esproposal.optional_chaining=enable
 .*/flow-typed/npm/@testing-library/.*
 .*/node_modules/react-beautiful-dnd/.*
 .*/node_modules/express/.*
-.*/app/views/organizations/.*
 
 [lints]
 all=warn

--- a/nms/app/views/organizations/OrganizationDialog.js
+++ b/nms/app/views/organizations/OrganizationDialog.js
@@ -13,9 +13,12 @@
  * @flow strict-local
  * @format
  */
-import AppContext from '../../../app/components/context/AppContext';
+
+import type {EditUser} from './OrganizationEdit';
+import type {Organization} from './Organizations';
 import type {OrganizationPlainAttributes} from '../../../shared/sequelize_models/models/organization';
 
+import AppContext from '../../components/context/AppContext';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -29,7 +32,7 @@ import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 
 import {UserRoles} from '../../../shared/roles';
-import {colors} from '../../../app/theme/default';
+import {colors} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
 import {useAxios} from '../../../app/hooks';
 import {useContext, useEffect, useState} from 'react';
@@ -87,7 +90,6 @@ type Props = {
   organization: ?OrganizationPlainAttributes,
   // flag to display advanced fields
   hideAdvancedFields: boolean,
-  error: string,
 };
 
 type CreateUserType = {

--- a/nms/app/views/organizations/OrganizationEdit.js
+++ b/nms/app/views/organizations/OrganizationEdit.js
@@ -15,6 +15,7 @@
  */
 
 import type {Organization} from './Organizations';
+import type {OrganizationPlainAttributes} from '../../../shared/sequelize_models/models/organization';
 import type {WithAlert} from '../../components/Alert/withAlert';
 
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
@@ -35,12 +36,12 @@ import Text from '../../../app/theme/design-system/Text';
 import axios from 'axios';
 import withAlert from '../../components/Alert/withAlert';
 
-import {AltFormField} from '../../../app/components/FormField';
+import {AltFormField} from '../../components/FormField';
 import {makeStyles} from '@material-ui/styles';
 import {useAxios} from '../../../app/hooks';
 import {useCallback, useState} from 'react';
-import {useEnqueueSnackbar} from '../../../app/hooks/useSnackbar';
-import {useParams} from 'react-router-dom';
+import {useEnqueueSnackbar} from '../../hooks/useSnackbar';
+import {useNavigate, useParams} from 'react-router-dom';
 
 const useStyles = makeStyles(_ => ({
   arrowBack: {
@@ -98,6 +99,14 @@ type Props = {
   hideAdvancedFields?: boolean,
 };
 
+type DialogConfirmationProps = {
+  title: string,
+  message: string,
+  confirmationPhrase: string,
+  onClose: () => void,
+  onConfirm: () => void | Promise<void>,
+};
+
 function DialogWithConfirmationPhrase(props: DialogConfirmationProps) {
   const [confirmationPhrase, setConfirmationPhrase] = useState('');
   const {title, message, onClose, onConfirm} = props;
@@ -141,6 +150,7 @@ function DialogWithConfirmationPhrase(props: DialogConfirmationProps) {
  */
 function OrganizationEdit(props: WithAlert & Props) {
   const params = useParams();
+  const navigate = useNavigate();
   const [addingUserFor, setAddingUserFor] = useState<?Organization>(null);
   const classes = useStyles();
   const enqueueSnackbar = useEnqueueSnackbar();
@@ -248,7 +258,7 @@ function OrganizationEdit(props: WithAlert & Props) {
             }
           }}
         />
-        {(organizationToDelete ?? false) && (
+        {organizationToDelete !== null && (
           <DialogWithConfirmationPhrase
             title="Warning"
             message={`Please type the Organization name below to remove it.`}
@@ -260,7 +270,7 @@ function OrganizationEdit(props: WithAlert & Props) {
               await axios.delete(
                 `/host/organization/async/${organization?.id || ''}`,
               );
-              history.push('/host/organizations');
+              navigate('/host/organizations');
               setOrganizationToDelete(null);
             }}
           />
@@ -271,7 +281,7 @@ function OrganizationEdit(props: WithAlert & Props) {
               <Grid container alignItems="center">
                 <Grid>
                   <IconButton
-                    onClick={() => history.goBack()}
+                    onClick={() => navigate(-1)}
                     className={classes.arrowBack}
                     color="primary">
                     <ArrowBackIcon />
@@ -290,7 +300,9 @@ function OrganizationEdit(props: WithAlert & Props) {
                 variant="contained"
                 color="primary"
                 onClick={() => {
-                  setOrganizationToDelete(organization?.name);
+                  if (organization) {
+                    setOrganizationToDelete(organization.name);
+                  }
                 }}>
                 Remove Organization
               </Button>

--- a/nms/app/views/organizations/OrganizationSummary.js
+++ b/nms/app/views/organizations/OrganizationSummary.js
@@ -14,14 +14,14 @@
  * @format
  */
 
-import type {DataRows} from '../../../app/components/DataGrid';
+import type {DataRows} from '../../components/DataGrid';
 
-import DataGrid from '../../../app/components/DataGrid';
+import DataGrid from '../../components/DataGrid';
 import React from 'react';
 
 type OverviewProps = {
-  name: string,
-  networkIds: Set<string>,
+  name?: string,
+  networkIds?: Array<string>,
 };
 
 /**
@@ -35,7 +35,7 @@ export default function OrganizationSummary(props: OverviewProps) {
     [
       {
         category: 'Organization Name',
-        value: name,
+        value: name || '',
       },
     ],
     [

--- a/nms/app/views/organizations/OrganizationUsersTable.js
+++ b/nms/app/views/organizations/OrganizationUsersTable.js
@@ -15,20 +15,20 @@
  */
 import ActionTable from '../../components/ActionTable';
 import React from 'react';
-import Text from '../../../app/theme/design-system/Text';
+import Text from '../../theme/design-system/Text';
 import axios from 'axios';
 import withAlert from '../../components/Alert/withAlert';
 import type {EditUser} from './OrganizationEdit';
 import type {WithAlert} from '../../components/Alert/withAlert';
 
 import {UserRoles} from '../../../shared/roles';
-import {useEnqueueSnackbar} from '../../../app/hooks/useSnackbar';
+import {useEnqueueSnackbar} from '../../hooks/useSnackbar';
 import {useParams} from 'react-router-dom';
 import {useState} from 'react';
 
 type OrganizationUsersTableProps = WithAlert & {
   editUser: (user: ?EditUser) => void,
-  tableRef: {current: null | React.ElementRef<ElementType>},
+  tableRef: {current: null | {onQueryChange(): void}},
 };
 
 /**
@@ -59,7 +59,7 @@ function OrganizationUsersTable(props: OrganizationUsersTableProps) {
               props.tableRef.current?.onQueryChange();
             })
             .catch(() => {
-              enqueueSnackbar(`Unable to delete user: ${user.name}`, {
+              enqueueSnackbar(`Unable to delete user: ${user.id}`, {
                 variant: 'error',
               });
             });

--- a/nms/app/views/organizations/Organizations.js
+++ b/nms/app/views/organizations/Organizations.js
@@ -14,6 +14,7 @@
  * @format
  */
 
+import type {EnqueueSnackbarOptions} from 'notistack';
 import type {OrganizationPlainAttributes} from '../../../shared/sequelize_models/models/organization';
 import type {UserType} from '../../../shared/sequelize_models/models/user.js';
 import type {WithAlert} from '../../components/Alert/withAlert';


### PR DESCRIPTION
## Summary

The organizations were part of `fbc_js_core` for which type checking was disabled. When integrating `fbc_js_core` we noticed that there were many type errors in organizations so we temporarily disabled the type checker.

This PR re-enables the type checking and fixes the issues.
   
## Test Plan
Checked that creating, deleting and editing an organizations still works. 