### PR TITLE
fix(amf): cppcheck warning clean-up on amf code

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -396,7 +396,7 @@ int amf_registration_run_procedure(amf_context_t* amf_context) {
       } else {
         // force identification, even if not necessary
         rc = amf_proc_identification(
-            amf_context, (nas_amf_proc_t*)registration_proc,
+            amf_context, reinterpret_cast<nas_amf_proc_t*>(registration_proc),
             IDENTITY_TYPE_2_IMSI,
 
             amf_registration_success_identification_cb,
@@ -417,7 +417,7 @@ int amf_registration_run_procedure(amf_context_t* amf_context) {
       } else {
         /* If its first time GUTI Identify the IMSI */
         rc = amf_proc_identification(
-            amf_context, (nas_amf_proc_t*)registration_proc,
+            amf_context, reinterpret_cast<nas_amf_proc_t*>(registration_proc),
             IDENTITY_TYPE_2_IMSI, amf_registration_success_identification_cb,
             amf_registration_failure_identification_cb);
       }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -1097,9 +1097,7 @@ void amf_app_handle_resource_setup_response(
     /* This is success case and we need not to send message to SMF
      * and drop the message here
      */
-    amf_ue_ngap_id_t ue_id;
     amf_smf_establish_t amf_smf_grpc_ies;
-    ue_m5gmm_context_s* ue_context = nullptr;
     char imsi[IMSI_BCD_DIGITS_MAX + 1];
 
     ue_id = session_seup_resp.amf_ue_ngap_id;
@@ -1304,11 +1302,6 @@ static void amf_app_handle_ngap_ue_context_release(
                  "gnb_ue_ngap_id " GNB_UE_NGAP_ID_FMT
                  " amf_ue_ngap_id " AMF_UE_NGAP_ID_FMT "\n",
                  gnb_ue_ngap_id, amf_ue_ngap_id);
-    OAILOG_FUNC_OUT(LOG_AMF_APP);
-  }
-
-  if (!ue_context_p) {
-    OAILOG_ERROR(LOG_AMF_APP, "Context not found ");
     OAILOG_FUNC_OUT(LOG_AMF_APP);
   }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_state_manager.cpp
@@ -302,8 +302,8 @@ status_code_e AmfNasStateManager::read_ue_state_from_db() {
     state_ue_map.insert(ue_context_p->amf_ue_ngap_id, ue_context_p);
     OAILOG_DEBUG(log_task, "Reading UE state from db for %s", kv.first.c_str());
   }
-#endif
   OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNok);
+#endif
 }
 
 status_code_e AmfNasStateManager::read_state_from_db() {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -305,7 +305,6 @@ struct ue_m5gmm_context_s* amf_ue_context_exists_imsi(
  ***************************************************************************/
 ue_m5gmm_context_s* amf_get_ue_context_from_imsi(char* imsi) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
-  amf_context_t* amf_context_p = nullptr;
   imsi64_t imsi64 = INVALID_IMSI64;
 
   IMSI_STRING_TO_IMSI64((char*)imsi, &imsi64);
@@ -491,20 +490,6 @@ ue_m5gmm_context_s* lookup_ue_ctxt_by_imsi(imsi64_t imsi64) {
 
 /****************************************************************************
  **                                                                        **
- ** Name:    amf_app_state_free_ue_context()                               **
- **                                                                        **
- ** Description: Cleans up AMF context                                     **
- **                                                                        **
- **                                                                        **
- ***************************************************************************/
-void amf_app_state_free_ue_context(void** ue_context_node) {
-  OAILOG_FUNC_IN(LOG_AMF_APP);
-
-  OAILOG_FUNC_OUT(LOG_AMF_APP);
-}
-
-/****************************************************************************
- **                                                                        **
  ** Name:    amf_lookup_guti_by_ueid()                                     **
  **                                                                        **
  ** Description:  Fetch the guti based on ue id                            **
@@ -556,11 +541,9 @@ int amf_idle_mode_procedure(amf_context_t* amf_ctx) {
  ***************************************************************************/
 void amf_free_ue_context(ue_m5gmm_context_s* ue_context_p) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
-  magma::map_rc_t m_rc = magma::MAP_OK;
   amf_app_desc_t* amf_app_desc_p = get_amf_nas_state(false);
   amf_ue_context_t* amf_ue_context_p = &amf_app_desc_p->amf_ue_contexts;
   OAILOG_DEBUG(LOG_AMF_APP, "amf_free_ue_context \n");
-  map_uint64_ue_context_t* amf_state_ue_id_ht = get_amf_ue_state();
   if (!ue_context_p || !amf_ue_context_p) {
     return;
   }
@@ -847,7 +830,6 @@ void amf_ue_context_update_ue_sig_connection_state(
 static int amf_ue_context_release_complete_timer_handler(zloop_t* loop,
                                                          int timer_id,
                                                          void* output) {
-  amf_context_t* amf_ctx = NULL;
   amf_ue_ngap_id_t ue_id = 0;
   OAILOG_FUNC_IN(LOG_AMF_APP);
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
@@ -834,7 +834,6 @@ class nas_amf_smc_proc_t {
 
 nas_amf_smc_proc_t* get_nas5g_common_procedure_smc(const amf_context_t* ctxt);
 
-void amf_app_state_free_ue_context(void** ue_context_node);
 int amf_proc_security_mode_control(amf_context_t* amf_ctx,
                                    nas_amf_specific_proc_t* amf_specific_proc,
                                    ksi_t ksi, success_cb_t success,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -57,7 +57,7 @@ static int amf_as_security_req(const amf_as_security_t* msg,
 static int amf_as_security_rej(const amf_as_security_t* msg,
                                m5g_dl_info_transfer_req_t* as_msg);
 static int amf_as_establish_rej(const amf_as_establish_t* msg,
-                                nas5g_establish_rsp_t* amf_msg);
+                                nas5g_establish_rsp_t* as_msg);
 // Setup the security header of the given NAS message
 static AMFMsg* amf_as_set_header(amf_nas_message_t* msg,
                                  const amf_as_security_data_t* security);
@@ -670,7 +670,6 @@ uint16_t amf_as_data_req(const amf_as_data_t* msg,
   int is_encoded = false;
   amf_nas_message_t nas_msg = {0};
   nas_msg.security_protected.header = {0};
-  nas_msg.security_protected.plain.amf.header = {0};
   nas_msg.security_protected.plain.amf.header = {0};
 
   // Setup the AS message

--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -44,7 +44,7 @@ extern task_zmq_ctx_t amf_app_task_zmq_ctx;
 
 amf_as_data_t amf_data_sec_auth;
 static int authenthication_t3560_handler(zloop_t* loop, int timer_id,
-                                         void* output);
+                                         void* arg);
 
 nas_amf_smc_proc_t* get_nas5g_common_procedure_smc(const amf_context_t* ctxt) {
   return (nas_amf_smc_proc_t*)get_nas5g_common_procedure(ctxt,
@@ -180,7 +180,7 @@ status_code_e amf_authentication_request_sent(amf_ue_ngap_id_t ue_id) {
                 imsi_str);
     AMFClientServicer::getInstance().get_subs_auth_info(
         imsi_str, IMSI_LENGTH, reinterpret_cast<const char*>(snni), ue_id);
-  } else if (auth_proc->auts.data) {
+  } else {
     OAILOG_INFO(
         LOG_AMF_APP,
         "Sending msg(grpc) to :[subscriberdb] for ue: [%s] auth-info-resync\n",
@@ -932,8 +932,6 @@ int amf_send_authentication_request(amf_context_t* amf_ctx,
       auth_proc->T3560.id = amf_app_start_timer(
           AUTHENTICATION_TIMER_EXPIRY_MSECS, TIMER_REPEAT_ONCE,
           authenthication_t3560_handler, auth_proc->ue_id);
-    }
-    if (rc != RETURNerror) {
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_identity.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_identity.cpp
@@ -117,7 +117,6 @@ int amf_proc_identification_complete(const amf_ue_ngap_id_t ue_id,
                                      guti_m5_t* amf_ctx_guti) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   int rc = RETURNok;
-  amf_sap_t amf_sap = {};
   amf_context_t* amf_ctx = NULL;
 
   OAILOG_DEBUG(LOG_NAS_AMF,

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -90,8 +90,6 @@ int amf_handle_service_request(
       OAILOG_DEBUG(LOG_AMF_APP, "T3513: After stopping PAGING Timer\n");
     }
 
-    imsi64_t imsi64 = ue_context->amf_context.imsi64;
-
     if (msg->service_type.service_type_value == SERVICE_TYPE_SIGNALING) {
       OAILOG_DEBUG(LOG_NAS_AMF, "Service request type is signalling \n");
       if (ue_context->amf_context._security.eksi != KSI_NO_KEY_AVAILABLE) {
@@ -456,7 +454,6 @@ int amf_handle_registration_request(
 
         ue_context->amf_context.m5_guti.m_tmsi = amf_guti.m_tmsi;
         ue_context->amf_context.m5_guti.guamfi = amf_guti.guamfi;
-        imsi64_t imsi64 = amf_imsi_to_imsi64(params->imsi);
       } else {
         /*
          * Call subscriberdb to decode the SUPI or IMSI from SUCI as scheme
@@ -529,8 +526,6 @@ int amf_handle_registration_request(
 
       amf_ue_context_on_new_guti(ue_context, (guti_m5_t*)&amf_guti);
       ue_context->amf_context.m5_guti.m_tmsi = amf_guti.m_tmsi;
-
-      imsi64_t imsi64 = ue_context->amf_context.imsi64;
 
       params->guti = new (guti_m5_t)();
       memcpy(params->guti, &(ue_context->amf_context.m5_guti),
@@ -656,8 +651,6 @@ int amf_handle_identity_response(
      * TODO Note:currently adapting the way
      */
     amf_ctx_guti = (guti_m5_t*)&amf_guti;
-
-    imsi64_t imsi64 = amf_imsi_to_imsi64(&imsi);
 
     ue_m5gmm_context_s* ue_context =
         amf_ue_context_exists_amf_ue_ngap_id(ue_id);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_session_qos.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_session_qos.cpp
@@ -293,7 +293,6 @@ void amf_smf_session_set_default_qos_rule(qos_flow_list_t* pti_flow_list) {
 // For setting the default qos if nothing frmm sessiond
 void amf_smf_session_set_default_qos_info(
     std::shared_ptr<smf_context_t> smf_ctx) {
-  uint8_t procedure_trans_identity = smf_ctx->get_pti();
   qos_flow_list_t* pti_flow_list = smf_ctx->get_proc_flow_list();
 
   if (!pti_flow_list->maxNumOfQosFlows) {

--- a/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/deregistration_request.cpp
@@ -303,9 +303,6 @@ void clear_amf_ctxt(amf_context_t* amf_context) {
   if (!amf_context) {
     return;
   }
-  amf_ue_ngap_id_t ue_id =
-      PARENT_STRUCT(amf_context, struct ue_m5gmm_context_s, amf_context)
-          ->amf_ue_ngap_id;
 
   nas_delete_all_amf_procedures(amf_context);
 

--- a/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
@@ -65,14 +65,14 @@ static int _nas5g_message_protected_encode(
 
 /* Functions used to decrypt and encrypt layer 3 NAS messages */
 static int _nas5g_message_decrypt(
-    unsigned char* const dest, unsigned char* const src, uint8_t type,
-    uint32_t code, uint8_t seq, uint32_t length,
+    unsigned char* const dest, unsigned char* const src,
+    uint8_t security_header_type, uint32_t code, uint8_t seq, uint32_t length,
     amf_security_context_t* const amf_security_context,
     amf_nas_message_decode_status_t* status);
 
 static int _nas5g_message_encrypt(
-    unsigned char* dest, const unsigned char* src, uint8_t type, uint32_t code,
-    uint8_t seq, int const direction, uint32_t length,
+    unsigned char* dest, const unsigned char* src, uint8_t security_header_type,
+    uint32_t code, uint8_t seq, int const direction, uint32_t length,
     amf_security_context_t* const amf_security_context);
 
 /* Functions used for integrity protection of layer 3 NAS messages */

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -40,7 +40,7 @@ namespace magma5g {
 extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 AmfMsg amf_msg_obj;
 static int identification_t3570_handler(zloop_t* loop, int timer_id, void* arg);
-static int subs_auth_retry(zloop_t* loop, int timer_id, void* output);
+static int subs_auth_retry(zloop_t* loop, int timer_id, void* arg);
 int nas_proc_establish_ind(const amf_ue_ngap_id_t ue_id,
                            const bool is_mm_ctx_new,
                            const tai_t originating_tai, const ecgi_t ecgi,
@@ -324,6 +324,8 @@ static void nas5g_delete_cn_procedures(struct amf_context_s* amf_context) {
         case CN5G_PROC_AUTH_INFO:
           nas5g_delete_auth_info_procedure(amf_context,
                                            (nas5g_auth_info_proc_t**)&p1->proc);
+          break;
+        default:
           break;
       }
       LIST_REMOVE(p1, entries);
@@ -839,7 +841,6 @@ int amf_decrypt_msin_info_answer(itti_amf_decrypted_msin_info_ans_t* aia) {
   // Local imsi to be put in imsi defined in 3gpp_23.003.h
   supi_as_imsi_t supi_imsi;
   amf_guti_m5g_t amf_guti;
-  guti_and_amf_id_t guti_and_amf_id;
   const bool is_amf_ctx_new = true;
   OAILOG_FUNC_IN(LOG_AMF_APP);
 


### PR DESCRIPTION
Signed-off-by: priya-wavelabs <priya.agrawal@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Warning clean-up on amf code.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Verified with unit test:
![Screenshot 2022-05-16 113207](https://user-images.githubusercontent.com/102359835/168529942-03014652-8b93-4756-b5b1-43d7cb488e99.png)

Basic sanity with ueransim.
Pcap:
![Screenshot 2022-05-16 113352](https://user-images.githubusercontent.com/102359835/168530007-2d6b82ce-3f65-4889-8cc9-86bfe56c16f0.png)

MME Log:
[mme2.log](https://github.com/magma/magma/files/8697583/mme2.log)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
