### PR TITLE
refactor(orc8r): replace deprecated errors module

### DIFF
--- a/lte/cloud/go/go.mod
+++ b/lte/cloud/go/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/magma/milenage v1.0.2
 	github.com/olivere/elastic/v7 v7.0.6
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.7.1
@@ -91,6 +90,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect

--- a/lte/cloud/go/services/ha/servicers/southbound/servicer.go
+++ b/lte/cloud/go/services/ha/servicers/southbound/servicer.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -59,8 +58,7 @@ func (s *HAServicer) GetEnodebOffloadState(ctx context.Context, req *lte_protos.
 	}
 	cfg, err := configurator.LoadEntityConfig(ctx, secondaryGw.GetNetworkId(), lte.CellularGatewayEntityType, secondaryGw.LogicalId, lte_models.EntitySerdes)
 	if err != nil {
-		errors.Wrap(err, "unable to load cellular gateway configs to find primary gateway's in its pool")
-		return ret, err
+		return ret, fmt.Errorf("unable to load cellular gateway configs to find primary gateway's in its pool: %w", err)
 	}
 	cellularCfg, ok := cfg.(*lte_models.GatewayCellularConfigs)
 	if !ok {

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/lte/cloud/go/lte"
@@ -193,7 +192,7 @@ func getGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load cellular gateway"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load cellular gateway: %w", err))
 	}
 
 	ret := &lte_models.LteGateway{
@@ -219,7 +218,7 @@ func getGateway(c echo.Context) error {
 		case lte.APNResourceEntityType:
 			e, err := configurator.LoadEntity(reqCtx, nid, tk.Type, tk.Key, configurator.EntityLoadCriteria{LoadConfig: true}, serdes.Entity)
 			if err != nil {
-				return errors.Wrap(err, "error loading apn resource entity")
+				return fmt.Errorf("error loading apn resource entity: %w", err)
 			}
 			apnResource := (&lte_models.ApnResource{}).FromEntity(e)
 			ret.ApnResources[string(apnResource.ApnName)] = *apnResource
@@ -257,7 +256,7 @@ func deleteGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "error loading existing cellular gateway"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("error loading existing cellular gateway: %w", err))
 	}
 	deletes = append(deletes, gw.Associations.Filter(lte.APNResourceEntityType)...)
 
@@ -619,7 +618,7 @@ func updateApnConfiguration(c echo.Context) error {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
 	case err != nil:
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load existing APN"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load existing APN: %w", err))
 	}
 
 	err = configurator.CreateOrUpdateEntityConfig(reqCtx, networkID, lte.APNEntityType, apnName, payload.ApnConfiguration, serdes.Entity)
@@ -670,7 +669,7 @@ func AddNetworkWideSubscriberRuleName(c echo.Context) error {
 	}
 	err := addToNetworkSubscriberConfig(c.Request().Context(), networkID, params[0], "")
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -686,7 +685,7 @@ func AddNetworkWideSubscriberBaseName(c echo.Context) error {
 	}
 	err := addToNetworkSubscriberConfig(c.Request().Context(), networkID, "", params[0])
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -702,7 +701,7 @@ func RemoveNetworkWideSubscriberRuleName(c echo.Context) error {
 	}
 	err := removeFromNetworkSubscriberConfig(c.Request().Context(), networkID, params[0], "")
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -718,7 +717,7 @@ func RemoveNetworkWideSubscriberBaseName(c echo.Context) error {
 	}
 	err := removeFromNetworkSubscriberConfig(c.Request().Context(), networkID, "", params[0])
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -883,7 +882,7 @@ func updateGatewayPoolHandler(c echo.Context) error {
 	// 404 if pool doesn't exist
 	exists, err := configurator.DoesEntityExist(reqCtx, networkID, lte.CellularGatewayPoolEntityType, gatewayPoolID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Error while checking if gateway pool exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Error while checking if gateway pool exists: %w", err))
 	}
 	if !exists {
 		return echo.ErrNotFound

--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 
 	"github.com/go-openapi/swag"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/lte/cloud/go/lte"
@@ -307,7 +306,7 @@ func (m *MutableLteGateway) getAPNResourceChanges(
 	oldIDs := existingGateway.Associations.Filter(lte.APNResourceEntityType).Keys()
 	oldByAPN, err := LoadAPNResources(ctx, existingGateway.NetworkID, oldIDs)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "error loading existing APN resources")
+		return nil, nil, fmt.Errorf("error loading existing APN resources: %w", err)
 	}
 	oldResources := oldByAPN.GetByID()
 	newResources := m.ApnResources.GetByID()

--- a/lte/cloud/go/services/lte/obsidian/models/validate.go
+++ b/lte/cloud/go/services/lte/obsidian/models/validate.go
@@ -15,6 +15,7 @@ package models
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	"magma/orc8r/cloud/go/services/configurator"
@@ -83,10 +83,10 @@ func (m FegNetworkID) ValidateModel(ctx context.Context) error {
 	if !swag.IsZero(m) {
 		exists, err := configurator.DoesNetworkExist(ctx, string(m))
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Failed to search for network %s", string(m)))
+			return fmt.Errorf("Failed to search for network %s: %w", string(m), err)
 		}
 		if !exists {
-			return errors.New(fmt.Sprintf("Network: %s does not exist", string(m)))
+			return fmt.Errorf("Network: %s does not exist", string(m))
 		}
 	}
 	return nil
@@ -151,14 +151,14 @@ func (m *NetworkRanConfigs) ValidateModel(context.Context) error {
 	}
 
 	if tddConfigSet && band.Mode != lte.TDDMode {
-		return errors.Errorf("band %d not a TDD band", band.ID)
+		return fmt.Errorf("band %d not a TDD band", band.ID)
 	}
 	if fddConfigSet {
 		if band.Mode != lte.FDDMode {
-			return errors.Errorf("band %d not a FDD band", band.ID)
+			return fmt.Errorf("band %d not a FDD band", band.ID)
 		}
 		if !band.EarfcnULInRange(m.FddConfig.Earfcnul) {
-			return errors.Errorf("EARFCNUL=%d invalid for band %d (%d, %d)", m.FddConfig.Earfcnul, band.ID, band.StartEarfcnUl, band.StartEarfcnDl)
+			return fmt.Errorf("EARFCNUL=%d invalid for band %d (%d, %d)", m.FddConfig.Earfcnul, band.ID, band.StartEarfcnUl, band.StartEarfcnDl)
 		}
 	}
 

--- a/lte/cloud/go/services/lte/protos/validate.go
+++ b/lte/cloud/go/services/lte/protos/validate.go
@@ -14,7 +14,7 @@
 package protos
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 func (m *GetEnodebStateRequest) Validate() error {

--- a/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/protected/builder_servicer.go
@@ -15,6 +15,7 @@ package servicers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/feg/cloud/go/feg"
@@ -322,7 +322,7 @@ func getPipelineDServicesConfig(networkServices []string) ([]lte_mconfig.Pipelin
 	for _, service := range networkServices {
 		mc, found := networkServicesByName[service]
 		if !found {
-			return nil, errors.Errorf("unknown network service name %s", service)
+			return nil, fmt.Errorf("unknown network service name %s", service)
 		}
 		apps = append(apps, mc)
 	}

--- a/lte/cloud/go/services/lte/servicers/protected/indexer_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/protected/indexer_servicer.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -103,12 +102,12 @@ func setEnodebState(ctx context.Context, networkID string, states state_types.St
 		}
 		gwEnt, err := configurator.LoadEntityForPhysicalID(ctx, st.ReporterID, configurator.EntityLoadCriteria{}, serdes.Entity)
 		if err != nil {
-			stateErrors[id] = errors.Wrap(err, "error loading gatewayID")
+			stateErrors[id] = fmt.Errorf("error loading gatewayID: %w", err)
 			continue
 		}
 		err = lte_api.SetEnodebState(ctx, networkID, gwEnt.Key, id.DeviceID, serializedState)
 		if err != nil {
-			stateErrors[id] = errors.Wrap(err, "error setting enodeb state")
+			stateErrors[id] = fmt.Errorf("error setting enodeb state: %w", err)
 			continue
 		}
 		glog.V(2).Infof("successfully stored ENB state for eNB SN: %s, gatewayID: %s:w", id.DeviceID, gwEnt.Key)

--- a/lte/cloud/go/services/lte/servicers/protected/lookup.go
+++ b/lte/cloud/go/services/lte/servicers/protected/lookup.go
@@ -15,8 +15,8 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -62,7 +62,7 @@ func (l *lookupServicer) SetEnodebState(ctx context.Context, req *protos.SetEnod
 }
 
 func makeErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	code := codes.Internal
 	if err == merrors.ErrNotFound {
 		code = codes.NotFound

--- a/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
@@ -14,13 +14,13 @@
 package handlers
 
 import (
+	"fmt"
 	"math/rand"
 	"net/http"
 	"time"
 
 	strfmt "github.com/go-openapi/strfmt"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/serdes"
@@ -75,7 +75,7 @@ func listNetworkProbeTasks(c echo.Context) error {
 		return echo.ErrNotFound
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load existing NetworkProbeTasks"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load existing NetworkProbeTasks: %w", err))
 	}
 
 	ret := make(map[string]*models.NetworkProbeTask, len(ents))
@@ -115,7 +115,7 @@ func getCreateNetworkProbeTaskHandlerFunc(storage storage.NProbeStorage) echo.Ha
 
 		taskID := string(payload.TaskID)
 		if err := storage.StoreNProbeData(networkID, taskID, data); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to store NetworkProbeData"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to store NetworkProbeData: %w", err))
 		}
 
 		_, err := configurator.CreateEntity(

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
@@ -14,12 +14,13 @@
 package handlers
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/serdes"
@@ -108,7 +109,7 @@ func CreateBaseName(c echo.Context) error {
 		}
 	}
 	if err := configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to create base name"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to create base name: %w", err))
 	}
 
 	return c.JSON(http.StatusCreated, string(bnr.Name))
@@ -159,7 +160,7 @@ func UpdateBaseName(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to check if base name exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to check if base name exists: %w", err))
 	}
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -198,7 +199,7 @@ func UpdateBaseName(c echo.Context) error {
 	}
 
 	if err = configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to update base name"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update base name: %w", err))
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -296,7 +297,7 @@ func CreateRule(c echo.Context) error {
 	}
 
 	if err := configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to create policy"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to create policy: %w", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -351,7 +352,7 @@ func UpdateRule(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to check if policy exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to check if policy exists: %w", err))
 	}
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -398,7 +399,7 @@ func UpdateRule(c echo.Context) error {
 	}
 
 	if err = configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to update policy rule"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update policy rule: %w", err))
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
@@ -14,11 +14,11 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-openapi/swag"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/serdes"
@@ -122,7 +122,7 @@ func UpdateRatingGroup(c echo.Context) error {
 	// 404 if rating group doesn't exist
 	exists, err := configurator.DoesEntityExist(reqCtx, networkID, lte.RatingGroupEntityType, ratingGroupID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to check if rating group exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to check if rating group exists: %w", err))
 	}
 	if !exists {
 		return echo.ErrNotFound

--- a/lte/cloud/go/services/policydb/obsidian/models/validate.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/validate.go
@@ -15,9 +15,9 @@ package models
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/pkg/errors"
 )
 
 func (m BaseNames) ValidateModel(context.Context) error {

--- a/lte/cloud/go/services/smsd/servicers/southbound/smsd.go
+++ b/lte/cloud/go/services/smsd/servicers/southbound/smsd.go
@@ -15,10 +15,10 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -87,7 +87,7 @@ func (s *smsdServicer) ReportDelivery(ctx context.Context, request *lteProtos.Re
 
 	decoded, err := s.serde.DecodeDelivery(request.Report.NasMessageContainer)
 	if err != nil {
-		return ret, errors.Wrap(err, "failed to decode report")
+		return ret, fmt.Errorf("failed to decode report: %w", err)
 	}
 
 	delivered, failed := map[string][]storage.SMSRef{}, map[string][]storage.SMSFailureReport{}
@@ -102,7 +102,7 @@ func (s *smsdServicer) ReportDelivery(ctx context.Context, request *lteProtos.Re
 
 	err = s.store.ReportDelivery(networkID, delivered, failed)
 	if err != nil {
-		return ret, errors.Wrap(err, "failed to report delivery")
+		return ret, fmt.Errorf("failed to report delivery: %w", err)
 	}
 	return ret, nil
 }

--- a/lte/cloud/go/services/subscriberdb/digest.go
+++ b/lte/cloud/go/services/subscriberdb/digest.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	lte_protos "magma/lte/cloud/go/protos"
@@ -85,7 +84,7 @@ func GetPerSubscriberDigests(network string) ([]*orc8r_protos.LeafDigest, error)
 		for _, subProto := range subProtos {
 			digest, err := mproto.HashDeterministic(subProto)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to generate digest for subscriber %+v of network %+v", subProto.Sid.Id, network)
+				return nil, fmt.Errorf("Failed to generate digest for subscriber %+v of network %+v: %w", subProto.Sid.Id, network, err)
 			}
 			leafDigest := &orc8r_protos.LeafDigest{
 				Id:     lte_protos.SidString(subProto.Sid),

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/validate.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/validate.go
@@ -15,10 +15,10 @@ package models
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/obsidian/models"
@@ -61,7 +61,7 @@ func (m *MutableSubscriber) ValidateModel(context.Context) error {
 	apnSet := funk.Map(m.ActiveApns, func(apn string) (string, bool) { return apn, true }).(map[string]bool)
 	for apn := range m.StaticIps {
 		if _, exists := apnSet[apn]; !exists {
-			return errors.Errorf("static IP assigned to APN %s which is not active for the subscriber", apn)
+			return fmt.Errorf("static IP assigned to APN %s which is not active for the subscriber", apn)
 		}
 	}
 	return nil

--- a/lte/cloud/go/services/subscriberdb/protos/validate.go
+++ b/lte/cloud/go/services/subscriberdb/protos/validate.go
@@ -14,7 +14,8 @@
 package protos
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 )
 
 func (m *GetMSISDNsRequest) Validate() error {
@@ -60,13 +61,13 @@ func (m *SetIPsRequest) Validate() error {
 	}
 	for _, mapping := range m.IpMappings {
 		if mapping.Ip == "" {
-			return errors.Errorf("ip cannot be empty in mapping %v", mapping)
+			return fmt.Errorf("ip cannot be empty in mapping %v", mapping)
 		}
 		if mapping.Imsi == "" {
-			return errors.Errorf("imsi cannot be empty in mapping %v", mapping)
+			return fmt.Errorf("imsi cannot be empty in mapping %v", mapping)
 		}
 		if mapping.Apn == "" {
-			return errors.Errorf("apn cannot be empty in mapping %v", mapping)
+			return fmt.Errorf("apn cannot be empty in mapping %v", mapping)
 		}
 	}
 	return nil

--- a/lte/cloud/go/services/subscriberdb/servicers/protected/indexer_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/protected/indexer_servicer.go
@@ -15,9 +15,9 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -124,7 +124,7 @@ func setIPMappings(ctx context.Context, networkID string, states state_types.Sta
 
 	err := subscriberdb.SetIMSIsForIPs(ctx, networkID, ipMappings)
 	if err != nil {
-		return stateErrors, errors.Wrapf(err, "update directoryd mapping of session IDs to IMSIs %+v", ipMappings)
+		return stateErrors, fmt.Errorf("update directoryd mapping of session IDs to IMSIs %+v: %w", ipMappings, err)
 	}
 
 	return stateErrors, nil

--- a/lte/cloud/go/services/subscriberdb/servicers/protected/lookup.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/protected/lookup.go
@@ -15,8 +15,8 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -161,7 +161,7 @@ func (l *lookupServicer) SetIPs(ctx context.Context, req *protos.SetIPsRequest) 
 }
 
 func makeErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	code := codes.Internal
 	if err == merrors.ErrNotFound {
 		code = codes.NotFound

--- a/lte/cloud/go/services/subscriberdb/servicers/southbound/subscriberdb_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/southbound/subscriberdb_servicer.go
@@ -15,12 +15,12 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -128,7 +128,7 @@ func (s *subscriberdbServicer) Sync(
 	for _, subProto := range renewed {
 		anyVal, err := ptypes.MarshalAny(subProto)
 		if err != nil {
-			return nil, errors.Wrapf(err, "marshal subscriber protos for network %+v", networkID)
+			return nil, fmt.Errorf("marshal subscriber protos for network %+v: %w", networkID, err)
 		}
 		renewedMarshaled = append(renewedMarshaled, anyVal)
 	}
@@ -220,7 +220,7 @@ func (s *subscriberdbServicer) ListSuciProfiles(ctx context.Context, req *protos
 	var suciProtos []*lte_protos.SuciProfile
 	suciProtos, err := subscriberdb.LoadSuciProtos(ctx, networkID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading suciProfiles in network failed %s", networkID)
+		return nil, fmt.Errorf("loading suciProfiles in network failed %s: %w", networkID, err)
 	}
 
 	res := &lte_protos.SuciProfileList{
@@ -319,7 +319,7 @@ func loadAPNs(ctx context.Context, gateway *protos.Identity_Gateway) (map[string
 		serdes.Entity,
 	)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "load cellular gateway for gateway %s", gatewayID)
+		return nil, nil, fmt.Errorf("load cellular gateway for gateway %s: %w", gatewayID, err)
 	}
 
 	apnsByName, err := subscriberdb.LoadApnsByName(networkID)

--- a/lte/cloud/go/services/subscriberdb/state/extract.go
+++ b/lte/cloud/go/services/subscriberdb/state/extract.go
@@ -15,10 +15,10 @@ package state
 
 import (
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"net"
 	"regexp"
-
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/state"
 )
@@ -67,7 +67,7 @@ func GetAssignedIPAddress(mobilitydState state.ArbitraryJSON) (string, error) {
 func GetIMSIAndAPNFromMobilitydStateKey(key string) (string, string, error) {
 	matches := imsiAPNRegex.FindStringSubmatch(key)
 	if len(matches) != imsiAPNExpectedMatchCount {
-		return "", "", errors.Errorf("mobilityd state key %s did not match regex", key)
+		return "", "", fmt.Errorf("mobilityd state key %s did not match regex", key)
 	}
 	imsi, apn := matches[1], matches[2]
 	return imsi, apn, nil
@@ -76,10 +76,10 @@ func GetIMSIAndAPNFromMobilitydStateKey(key string) (string, string, error) {
 func base64DecodeIPAddress(encodedIP string) (string, error) {
 	ipBytes, err := base64.StdEncoding.DecodeString(encodedIP)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to decode mobilityd IP address")
+		return "", fmt.Errorf("failed to decode mobilityd IP address: %w", err)
 	}
 	if len(ipBytes) != 4 {
-		return "", errors.Errorf("expected IP address to decode to 4 bytes, got %d", len(ipBytes))
+		return "", fmt.Errorf("expected IP address to decode to 4 bytes, got %d", len(ipBytes))
 	}
 	return net.IPv4(ipBytes[0], ipBytes[1], ipBytes[2], ipBytes[3]).String(), nil
 }

--- a/lte/cloud/go/services/subscriberdb/streamer/providers.go
+++ b/lte/cloud/go/services/subscriberdb/streamer/providers.go
@@ -15,11 +15,11 @@ package streamer
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	lte_protos "magma/lte/cloud/go/protos"
@@ -38,7 +38,7 @@ type SubscribersProvider struct{}
 func (p *SubscribersProvider) GetUpdates(ctx context.Context, gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
 	magmadGateway, err := configurator.LoadEntityForPhysicalID(ctx, gatewayId, configurator.EntityLoadCriteria{LoadAssocsFromThis: true}, serdes.Entity)
 	if err != nil {
-		return nil, errors.Wrapf(err, "load magmad gateway for physical ID %s", gatewayId)
+		return nil, fmt.Errorf("load magmad gateway for physical ID %s: %w", gatewayId, err)
 	}
 	gateway, err := configurator.LoadEntity(
 		ctx,
@@ -47,7 +47,7 @@ func (p *SubscribersProvider) GetUpdates(ctx context.Context, gatewayId string, 
 		serdes.Entity,
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "load cellular gateway from magmad gateway %s", magmadGateway.Key)
+		return nil, fmt.Errorf("load cellular gateway from magmad gateway %s: %w", magmadGateway.Key, err)
 	}
 	subEnts, _, err := configurator.LoadAllEntitiesOfType(
 		ctx,
@@ -56,7 +56,7 @@ func (p *SubscribersProvider) GetUpdates(ctx context.Context, gatewayId string, 
 		serdes.Entity,
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "load all subscribers in network of gateway %s", gateway.Key)
+		return nil, fmt.Errorf("load all subscribers in network of gateway %s: %w", gateway.Key, err)
 	}
 	apnsByName, apnResourcesByAPN, err := loadAPNs(ctx, gateway)
 	if err != nil {

--- a/lte/cloud/go/services/subscriberdb_cache/config.go
+++ b/lte/cloud/go/services/subscriberdb_cache/config.go
@@ -14,8 +14,9 @@
 package subscriberdb_cache
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 )
 
 type Config struct {
@@ -28,10 +29,10 @@ type Config struct {
 func (config Config) Validate() error {
 	errs := &multierror.Error{}
 	if config.SleepIntervalSecs <= 0 {
-		errs = multierror.Append(errs, errors.Errorf("invalid worker sleep interval"))
+		errs = multierror.Append(errs, fmt.Errorf("invalid worker sleep interval"))
 	}
 	if config.UpdateIntervalSecs < 60 {
-		errs = multierror.Append(errs, errors.Errorf("worker update interval smaller than 1 minute"))
+		errs = multierror.Append(errs, fmt.Errorf("worker update interval smaller than 1 minute"))
 	}
 	return errs.ErrorOrNil()
 }

--- a/lte/cloud/go/tools/migrations/m006_subscribers/main.go
+++ b/lte/cloud/go/tools/migrations/m006_subscribers/main.go
@@ -17,13 +17,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -47,18 +47,18 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "error opening tx"))
+		log.Fatal(fmt.Errorf("error opening tx: %w", err))
 	}
 
 	defer func() {
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				glog.Errorf("tx failed to rollback: %s", err)
+				glog.Errorf("tx failed to rollback: %s", rollbackErr)
 			}
 			glog.Fatal(err)
 		}
@@ -91,13 +91,13 @@ func main() {
 		var conf []byte
 
 		if err = rows.Scan(&pk, &conf); err != nil {
-			err = errors.Wrap(err, "could not scan row")
+			err = fmt.Errorf("could not scan row: %w", err)
 			return
 		}
 
 		legacySub := &legacySubscriber{}
 		if err = json.Unmarshal(conf, legacySub); err != nil {
-			err = errors.Wrapf(err, "could not unmarshal subscriber config %s", pk)
+			err = fmt.Errorf("could not unmarshal subscriber config %s: %w", pk, err)
 			return
 		}
 		legacySubs[pk] = legacySub
@@ -109,7 +109,7 @@ func main() {
 			Where(squirrel.Eq{pkCol: pk}).
 			Exec()
 		if err != nil {
-			err = errors.Wrapf(err, "error updating subscriber %s", pk)
+			err = fmt.Errorf("error updating subscriber %s: %w", pk, err)
 			return
 		}
 	}

--- a/lte/cloud/go/tools/migrations/m007_na_cleanup/main.go
+++ b/lte/cloud/go/tools/migrations/m007_na_cleanup/main.go
@@ -24,7 +24,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -49,18 +48,18 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "error opening tx"))
+		log.Fatal(fmt.Errorf("error opening tx: %w", err))
 	}
 
 	defer func() {
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				glog.Errorf("tx failed to rollback: %s", err)
+				glog.Errorf("tx failed to rollback: %s", rollbackErr)
 			}
 			glog.Fatal(err)
 		}

--- a/lte/cloud/go/tools/migrations/m010_default_apns/main.go
+++ b/lte/cloud/go/tools/migrations/m010_default_apns/main.go
@@ -57,6 +57,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"sort"
@@ -66,7 +67,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/lte/cloud/go/tools/migrations/m010_default_apns/types"
@@ -140,7 +140,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 	builder := sqorc.GetSqlBuilder()
 
@@ -189,7 +189,7 @@ func getNetworks(tx *sql.Tx, builder sqorc.StatementBuilder) ([]string, error) {
 		Where(squirrel.NotEq{nwIDCol: internalNetworkID}).
 		RunWith(tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "getNetworks: select networks")
+		return nil, fmt.Errorf("getNetworks: select networks: %w", err)
 	}
 
 	var networks []string
@@ -197,13 +197,13 @@ func getNetworks(tx *sql.Tx, builder sqorc.StatementBuilder) ([]string, error) {
 		var n string
 		err = rows.Scan(&n)
 		if err != nil {
-			return nil, errors.Wrap(err, "getNetworks: scan network ID")
+			return nil, fmt.Errorf("getNetworks: scan network ID: %w", err)
 		}
 		networks = append(networks, n)
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "getNetworks: SQL rows error")
+		return nil, fmt.Errorf("getNetworks: SQL rows error: %w", err)
 	}
 
 	return networks, nil
@@ -238,7 +238,7 @@ func createDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err = b.RunWith(tx).Exec()
 	if err != nil {
-		return ent{}, errors.Wrap(err, "createDefaultAPNIfNotExist: insert error")
+		return ent{}, fmt.Errorf("createDefaultAPNIfNotExist: insert error: %w", err)
 	}
 
 	newAPN := ent{pk: pk, typ: apnEntType, graphID: gid}
@@ -256,7 +256,7 @@ func getDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string) (
 		).
 		RunWith(tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "getDefaultAPN: select existing default APN")
+		return nil, fmt.Errorf("getDefaultAPN: select existing default APN: %w", err)
 	}
 
 	var apns []*ent
@@ -264,13 +264,13 @@ func getDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string) (
 		apn := &ent{}
 		err = rows.Scan(&apn.pk, &apn.graphID)
 		if err != nil {
-			return nil, errors.Wrap(err, "getDefaultAPN: scan APN")
+			return nil, fmt.Errorf("getDefaultAPN: scan APN: %w", err)
 		}
 		apns = append(apns, apn)
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "getDefaultAPN: SQL rows error")
+		return nil, fmt.Errorf("getDefaultAPN: SQL rows error: %w", err)
 	}
 
 	if len(apns) > 1 {
@@ -333,7 +333,7 @@ func getSubscribersMissingAPN(tx *sql.Tx, builder sqorc.StatementBuilder, networ
 		).
 		RunWith(tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "getSubscribersMissingAPN: select subscribers")
+		return nil, fmt.Errorf("getSubscribersMissingAPN: select subscribers: %w", err)
 	}
 
 	assocs := map[ent][]ent{}
@@ -342,13 +342,13 @@ func getSubscribersMissingAPN(tx *sql.Tx, builder sqorc.StatementBuilder, networ
 		pkB, typeB := &sql.NullString{}, &sql.NullString{}
 		err = rows.Scan(&a.graphID, &a.pk, pkB, typeB)
 		if err != nil {
-			return nil, errors.Wrap(err, "getSubscribersMissingAPN: scan subscriber")
+			return nil, fmt.Errorf("getSubscribersMissingAPN: scan subscriber: %w", err)
 		}
 		assocs[a] = append(assocs[a], ent{pk: pkB.String, typ: typeB.String})
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "getSubscribersMissingAPN: SQL rows error")
+		return nil, fmt.Errorf("getSubscribersMissingAPN: SQL rows error: %w", err)
 	}
 
 	var subsMissingAPN []ent
@@ -376,7 +376,7 @@ func mapSubscribersToAPN(tx *sql.Tx, builder sqorc.StatementBuilder, apnPK strin
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err := b.RunWith(tx).Exec()
 	if err != nil {
-		return errors.Wrap(err, "mapSubscribersToAPN: insert error")
+		return fmt.Errorf("mapSubscribersToAPN: insert error: %w", err)
 	}
 
 	return nil
@@ -394,7 +394,7 @@ func mergeGraphs(tx *sql.Tx, builder sqorc.StatementBuilder, gids []string) erro
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err := b.RunWith(tx).Exec()
 	if err != nil {
-		return errors.Wrap(err, "mergeGraphs: update error")
+		return fmt.Errorf("mergeGraphs: update error: %w", err)
 	}
 
 	return nil
@@ -496,7 +496,7 @@ func getSubscribersInDefaultAPNGraph(db *sql.DB, builder sqorc.StatementBuilder,
 			).
 			RunWith(tx).Query()
 		if err != nil {
-			return nil, errors.Wrap(err, "getSubscribersInDefaultAPNGraph: select subscribers")
+			return nil, fmt.Errorf("getSubscribersInDefaultAPNGraph: select subscribers: %w", err)
 		}
 
 		var subs []string
@@ -504,13 +504,13 @@ func getSubscribersInDefaultAPNGraph(db *sql.DB, builder sqorc.StatementBuilder,
 			key := ""
 			err = rows.Scan(&key)
 			if err != nil {
-				return nil, errors.Wrap(err, "getSubscribersInDefaultAPNGraph: scan subscriber PK")
+				return nil, fmt.Errorf("getSubscribersInDefaultAPNGraph: scan subscriber PK: %w", err)
 			}
 			subs = append(subs, key)
 		}
 		err = rows.Err()
 		if err != nil {
-			return nil, errors.Wrap(err, "getSubscribersInDefaultAPNGraph: SQL rows error")
+			return nil, fmt.Errorf("getSubscribersInDefaultAPNGraph: SQL rows error: %w", err)
 		}
 
 		return subs, nil

--- a/lte/cloud/go/tools/migrations/m011_subscriber_config/main.go
+++ b/lte/cloud/go/tools/migrations/m011_subscriber_config/main.go
@@ -16,10 +16,10 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -45,7 +45,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	_, err = migrations.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, doMigration)
@@ -66,7 +66,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 		Where(squirrel.Eq{typeCol: subscriberType}).
 		Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "error loading subscriber configs")
+		return nil, fmt.Errorf("error loading subscriber configs: %w", err)
 	}
 
 	newConfsByPk := map[string][]byte{}
@@ -75,7 +75,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 		var oldConf []byte
 
 		if err = rows.Scan(&pk, &oldConf); err != nil {
-			return nil, errors.Wrap(err, "error scanning subscriber row")
+			return nil, fmt.Errorf("error scanning subscriber row: %w", err)
 		}
 		shouldMigrate, err := shouldMigrateConf(oldConf)
 		if err != nil {
@@ -88,7 +88,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 		newConf := SubscriberConfig{Lte: oldConf}
 		newConfBytes, err := json.Marshal(newConf)
 		if err != nil {
-			return nil, errors.Wrap(err, "error marshalling new subscriber config")
+			return nil, fmt.Errorf("error marshaling new subscriber config: %w", err)
 		}
 		newConfsByPk[pk] = newConfBytes
 	}
@@ -100,7 +100,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 			Where(squirrel.Eq{pkCol: pk}).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrapf(err, "error updating subscriber %s", pk)
+			return nil, fmt.Errorf("error updating subscriber %s: %w", pk, err)
 		}
 	}
 	return nil, nil
@@ -112,7 +112,7 @@ func shouldMigrateConf(oldConf []byte) (bool, error) {
 	parsedMessage := map[string]interface{}{}
 	err := json.Unmarshal(oldConf, &parsedMessage)
 	if err != nil {
-		return false, errors.Wrap(err, "could not unmarshal legacy config")
+		return false, fmt.Errorf("could not unmarshal legacy config: %w", err)
 	}
 
 	_, alreadyMigrated := parsedMessage["lte"]

--- a/lte/cloud/go/tools/migrations/m012_policy_qos/main.go
+++ b/lte/cloud/go/tools/migrations/m012_policy_qos/main.go
@@ -36,13 +36,14 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"flag"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/tools/migrations/m012_policy_qos/types"
 	"magma/orc8r/cloud/go/sqorc"
@@ -100,7 +101,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	_, err = migrations.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, doMigration)
@@ -151,7 +152,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		Where(squirrel.Eq{entTypeCol: policyEntType}).
 		RunWith(tx).Query()
 	if err != nil {
-		return errors.Wrap(err, "get policy ents")
+		return fmt.Errorf("get policy ents: %w", err)
 	}
 	oldByKey := map[string]policyEnt{}
 	for rows.Next() {
@@ -160,17 +161,17 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		var confBytes []byte
 		err = rows.Scan(&old.pk, &key, &old.network, &old.gid, &confBytes)
 		if err != nil {
-			return errors.Wrap(err, "scan policy")
+			return fmt.Errorf("scan policy: %w", err)
 		}
 		err = json.Unmarshal(confBytes, &old.config)
 		if err != nil {
-			return errors.Wrap(err, "unmarshal existing policy rule config")
+			return fmt.Errorf("unmarshal existing policy rule config: %w", err)
 		}
 		oldByKey[key] = old
 	}
 	err = rows.Err()
 	if err != nil {
-		return errors.Wrap(err, "get existing assocs: SQL rows error")
+		return fmt.Errorf("get existing assocs: SQL rows error: %w", err)
 	}
 
 	// Convert policy configs to {new config, policy_qos_profile ent}
@@ -192,7 +193,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		}
 		newBytes, err := json.Marshal(newConf)
 		if err != nil {
-			return errors.Wrap(err, "marshal updated policy config")
+			return fmt.Errorf("marshal updated policy config: %w", err)
 		}
 		updateConfByKey[key] = newBytes
 
@@ -208,7 +209,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		}
 		profileBytes, err := json.Marshal(profileConf)
 		if err != nil {
-			return errors.Wrap(err, "marshal new policy_qos_profile config")
+			return fmt.Errorf("marshal new policy_qos_profile config: %w", err)
 		}
 		createProfileByKey[key] = profileBytes
 	}
@@ -228,7 +229,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bu.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error updating policy ent")
+			return fmt.Errorf("error updating policy ent: %w", err)
 		}
 
 		qosProfilePK := migrations.MakePK()
@@ -241,7 +242,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bi.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error inserting policy_qos_profile ent")
+			return fmt.Errorf("error inserting policy_qos_profile ent: %w", err)
 		}
 
 		bi = builder.
@@ -252,7 +253,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bi.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error inserting policy->policy_qos_profile assoc")
+			return fmt.Errorf("error inserting policy->policy_qos_profile assoc: %w", err)
 		}
 	}
 

--- a/orc8r/cloud/go/blobstore/blobstore_sql.go
+++ b/orc8r/cloud/go/blobstore/blobstore_sql.go
@@ -16,12 +16,12 @@ package blobstore
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/sqorc"
@@ -167,7 +167,7 @@ func (store *sqlStore) GetMany(networkID string, ids storage.TKs) (Blobs, error)
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 	return blobs, nil
 }
@@ -207,7 +207,7 @@ func (store *sqlStore) Search(filter SearchFilter, criteria LoadCriteria) (map[s
 		RunWith(store.tx).
 		Query()
 	if err != nil {
-		return ret, errors.Wrap(err, "failed to query DB")
+		return ret, fmt.Errorf("failed to query DB: %w", err)
 	}
 	defer sqorc.CloseRowsLogOnError(rows, "GetMany")
 
@@ -222,7 +222,7 @@ func (store *sqlStore) Search(filter SearchFilter, criteria LoadCriteria) (map[s
 
 		err = rows.Scan(scanArgs...)
 		if err != nil {
-			return ret, errors.Wrap(err, "failed to scan blob row")
+			return ret, fmt.Errorf("failed to scan blob row: %w", err)
 		}
 
 		nidCol := ret[nid]
@@ -231,7 +231,7 @@ func (store *sqlStore) Search(filter SearchFilter, criteria LoadCriteria) (map[s
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 	return ret, nil
 }
@@ -293,7 +293,7 @@ func (store *sqlStore) GetExistingKeys(keys []string, filter SearchFilter) ([]st
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 	return scannedKeys, nil
 }
@@ -330,7 +330,7 @@ func (store *sqlStore) IncrementVersion(networkID string, id storage.TK) error {
 		RunWith(store.tx).
 		Exec()
 	if err != nil {
-		return errors.Wrapf(err, "Error incrementing version on network %s with type %s and key %s", networkID, id.Type, id.Key)
+		return fmt.Errorf("Error incrementing version on network %s with type %s and key %s: %w", networkID, id.Type, id.Key, err)
 	}
 	return nil
 }
@@ -382,7 +382,7 @@ func (store *sqlStore) insertNewBlobs(networkID string, blobs Blobs) error {
 	}
 	_, err := insertBuilder.RunWith(store.tx).Exec()
 	if err != nil {
-		return errors.Wrap(err, "error creating blobs")
+		return fmt.Errorf("error creating blobs: %w", err)
 	}
 	return nil
 }

--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.9
 	github.com/olivere/elastic/v7 v7.0.6
 	github.com/ory/go-acc v0.2.8
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.17.0
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
@@ -134,6 +133,7 @@ require (
 	github.com/ory/viper v1.7.5 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/tsdb v0.10.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect

--- a/orc8r/cloud/go/obsidian/handler.go
+++ b/orc8r/cloud/go/obsidian/handler.go
@@ -15,13 +15,13 @@ package obsidian
 
 import (
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	"magma/orc8r/lib/go/util"
@@ -202,7 +202,7 @@ func CheckNetworkAccess(c echo.Context, networkId string) *echo.HTTPError {
 
 	cert := getCert(c)
 	if cert == nil {
-		err := errors.Errorf("Client certificate with valid SANs is required for network: %s", networkId)
+		err := fmt.Errorf("Client certificate with valid SANs is required for network: %s", networkId)
 		return echo.NewHTTPError(http.StatusForbidden, err)
 	}
 
@@ -328,7 +328,7 @@ func GetPaginationParams(c echo.Context) (uint64, string, error) {
 	}
 	pageSize, err := strconv.ParseUint(pageSizeStr, 10, 32)
 	if err != nil {
-		err := errors.Wrap(err, "invalid page size parameter")
+		err := fmt.Errorf("invalid page size parameter: %w", err)
 		return 0, pageToken, echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	return pageSize, pageToken, nil

--- a/orc8r/cloud/go/obsidian/swagger/handlers/handlers.go
+++ b/orc8r/cloud/go/obsidian/swagger/handlers/handlers.go
@@ -15,6 +15,8 @@ package handlers
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"html/template"
 	"net/http"
 	"sort"
@@ -22,7 +24,6 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/swagger"
@@ -160,7 +161,7 @@ func registerSpecHandlers(e *echo.Echo, trailSlashMiddleware echo.MiddlewareFunc
 func registerUIHandlers(e *echo.Echo, trailSlashMiddleware echo.MiddlewareFunc) error {
 	tmpl, err := template.ParseFiles(obsidian.StaticFolder + "/swagger/v1/ui/index.html")
 	if err != nil {
-		return errors.Wrap(err, "retrieve Swagger template")
+		return fmt.Errorf("retrieve Swagger template: %w", err)
 	}
 
 	e.GET(obsidian.StaticURLPrefix+"/v1/ui/", GetUIHandler(tmpl))

--- a/orc8r/cloud/go/obsidian/swagger/poll.go
+++ b/orc8r/cloud/go/obsidian/swagger/poll.go
@@ -14,8 +14,9 @@
 package swagger
 
 import (
+	"fmt"
+
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian/swagger/spec"
 	"magma/orc8r/cloud/go/parallel"
@@ -41,7 +42,7 @@ func GetCombinedSpec(yamlCommon string) (string, error) {
 		if err != nil {
 			// Swallow error because the polling should continue
 			// even if it fails to receive from a single servicer
-			err = errors.Wrapf(err, "get Swagger spec from %s service", s.GetService())
+			err = fmt.Errorf("get Swagger spec from %s service: %w", s.GetService(), err)
 			glog.Error(err)
 		}
 		return yamlSpec, nil

--- a/orc8r/cloud/go/obsidian/swagger/spec/combine.go
+++ b/orc8r/cloud/go/obsidian/swagger/spec/combine.go
@@ -14,11 +14,11 @@
 package spec
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
 	"magma/orc8r/cloud/go/swagger"
@@ -178,7 +178,7 @@ func combineTags(common []swagger.TagDefinition, others [][]swagger.TagDefinitio
 func merge(a, b map[string]interface{}, fieldName string, errs error) {
 	for k, v := range b {
 		if _, ok := a[k]; ok {
-			errs = multierror.Append(errs, errors.Errorf("overwriting spec key '%s' in field '%s'", k, fieldName))
+			errs = multierror.Append(errs, fmt.Errorf("overwriting spec key '%s' in field '%s'", k, fieldName))
 		}
 		a[k] = v
 	}
@@ -188,7 +188,7 @@ func merge(a, b map[string]interface{}, fieldName string, errs error) {
 func mergeTags(a map[string]string, b []swagger.TagDefinition, errs error) {
 	for _, tag := range b {
 		if _, ok := a[tag.Name]; ok {
-			errs = multierror.Append(errs, errors.Errorf("overwriting tag '%s'", tag.Name))
+			errs = multierror.Append(errs, fmt.Errorf("overwriting tag '%s'", tag.Name))
 		}
 		a[tag.Name] = tag.Description
 	}

--- a/orc8r/cloud/go/parallel/map.go
+++ b/orc8r/cloud/go/parallel/map.go
@@ -14,8 +14,9 @@
 package parallel
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -46,7 +47,7 @@ func MapInToString(inputs []In, nWorkers int, f Func) ([]string, error) {
 	for _, s := range outsI {
 		ss, ok := s.(string)
 		if !ok {
-			return nil, errors.Errorf("could not convert returned item of type '%T' to string: '%+v'", s, s)
+			return nil, fmt.Errorf("could not convert returned item of type '%T' to string: '%+v'", s, s)
 		}
 		outs = append(outs, ss)
 	}

--- a/orc8r/cloud/go/serde/registry.go
+++ b/orc8r/cloud/go/serde/registry.go
@@ -15,8 +15,6 @@ package serde
 
 import (
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 // Registry provides a serde registry.
@@ -65,7 +63,7 @@ func (r registry) MustMerge(rr Registry) Registry {
 func (r registry) GetSerde(typ string) (Serde, error) {
 	serde, ok := r[typ]
 	if !ok {
-		return nil, errors.Errorf("no serde in registry for type %s", typ)
+		return nil, fmt.Errorf("no serde in registry for type %s", typ)
 	}
 	return serde, nil
 }

--- a/orc8r/cloud/go/serde/serde.go
+++ b/orc8r/cloud/go/serde/serde.go
@@ -16,9 +16,8 @@ package serde
 import (
 	"context"
 	"encoding"
+	"fmt"
 	"reflect"
-
-	"github.com/pkg/errors"
 )
 
 // Serde (SERializer-DEserializer) implements logic to serialize/deserialize
@@ -84,7 +83,7 @@ func (s *binarySerde) GetType() string {
 func (s *binarySerde) Serialize(in interface{}) ([]byte, error) {
 	bm, ok := in.(BinaryConvertible)
 	if !ok {
-		return nil, errors.Errorf("type %T structure does not implement BinaryConvertible", in)
+		return nil, fmt.Errorf("type %T structure does not implement BinaryConvertible", in)
 	}
 	return bm.MarshalBinary()
 }

--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -26,7 +27,6 @@ import (
 	"github.com/golang/glog"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	"magma/orc8r/cloud/go/orc8r"

--- a/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
+++ b/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
@@ -2,11 +2,12 @@ package calculations
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/olivere/elastic/v7"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/analytics/protos"
 	"magma/orc8r/cloud/go/services/analytics/query_api"
@@ -39,8 +40,7 @@ func (x *LogsMetricCalculation) Calculate(prometheusClient query_api.PrometheusA
 	q := elasticQuery(x.Hours, x.LogConfig)
 	logCount, err := x.ElasticClient.Count().Index("").Query(q).Do(context.Background())
 	if err != nil {
-		err = errors.Wrapf(err, "Error %v querying elastic search for query %v", err, q)
-		return nil, err
+		return nil, fmt.Errorf("Error querying elastic search for query %v: %w", q, err)
 	}
 
 	results = append(results, NewResult(float64(logCount), x.Name, x.Labels))

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/storage.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/storage.go
@@ -14,7 +14,7 @@ limitations under the License.
 package registration
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/services/bootstrapper"
@@ -54,7 +54,7 @@ func (b *blobstoreStore) SetTokenInfo(tokenInfo *protos.TokenInfo) error {
 		return err
 	}
 	if !isUnique {
-		return errors.Errorf("token is not unique")
+		return fmt.Errorf("token is not unique")
 	}
 
 	// Write to 2 blobstores so that we can key for tokenInfo with both the logicalID and the nonce
@@ -150,7 +150,7 @@ func (b *blobstoreStore) isNonceUnique(store blobstore.Store, nonce string) (boo
 func tokenInfoToBlob(blobType bootstrapper.BlobType, key string, tokenInfo *protos.TokenInfo) (blobstore.Blob, error) {
 	marshaledTokenInfo, err := protos.Marshal(tokenInfo)
 	if err != nil {
-		return blobstore.Blob{}, errors.Wrap(err, "Error marshaling protobuf")
+		return blobstore.Blob{}, fmt.Errorf("Error marshaling protobuf: %w", err)
 	}
 	blob := blobstore.Blob{
 		Type:  string(blobType),
@@ -164,7 +164,7 @@ func tokenInfoFromBlob(blob blobstore.Blob) (*protos.TokenInfo, error) {
 	tokenInfo := protos.TokenInfo{}
 	err := protos.Unmarshal(blob.Value, &tokenInfo)
 	if err != nil {
-		return &protos.TokenInfo{}, errors.Wrap(err, "Error unmarshaling protobuf")
+		return &protos.TokenInfo{}, fmt.Errorf("Error unmarshaling protobuf: %w", err)
 	}
 	return &tokenInfo, nil
 }

--- a/orc8r/cloud/go/services/bootstrapper/servicers/southbound/bootstrapper.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/southbound/bootstrapper.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -74,7 +73,7 @@ type BootstrapperServer struct {
 func NewBootstrapperServer(privKey *rsa.PrivateKey) (*BootstrapperServer, error) {
 	srv := &BootstrapperServer{}
 	if privKey.N.BitLen() < MinKeyLength {
-		return nil, errorLogger(errors.Errorf("private key is too short: actual len (%d) is less than minimum len (%d)", privKey.N.BitLen(), MinKeyLength))
+		return nil, errorLogger(fmt.Errorf("private key is too short: actual len (%d) is less than minimum len (%d)", privKey.N.BitLen(), MinKeyLength))
 	}
 	srv.privKey = privKey
 	return srv, nil
@@ -231,7 +230,7 @@ func generateRandomText(length int) ([]byte, error) {
 
 // verify response with echo "encryption" method
 func verifyEcho(resp *protos.Response) error {
-	response := resp.GetEchoResponse() //.Response
+	response := resp.GetEchoResponse() // .Response
 	if response == nil {
 		return fmt.Errorf("Wrong type of response, expected Echo")
 	}
@@ -256,7 +255,7 @@ func verifySoftwareRSASHA256(resp *protos.Response, key []byte) error {
 	hashed := sha256.Sum256(resp.Challenge)
 	err = rsa.VerifyPKCS1v15(publicKey.(*rsa.PublicKey), crypto.SHA256, hashed[:], response.Signature)
 	if err != nil {
-		return errors.Wrap(err, signedChallengeMismatch)
+		return fmt.Errorf(signedChallengeMismatch+": %w", err)
 	}
 
 	return nil

--- a/orc8r/cloud/go/services/certifier/analytics/calculations/lifespan.go
+++ b/orc8r/cloud/go/services/certifier/analytics/calculations/lifespan.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"magma/orc8r/cloud/go/services/analytics/calculations"
@@ -75,7 +74,7 @@ func calculateCertLifespanHours(certsDirectory string, certName string, metricCo
 	}
 	cert, err := x509.ParseCertificate(dat)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to parse x509 certificate data for %s", certName))
+		return nil, fmt.Errorf("failed to parse x509 certificate data for %s: %w", certName, err)
 	}
 	// Hours remaining
 	hoursLeft := math.Floor(time.Until(cert.NotAfter).Hours())
@@ -99,7 +98,7 @@ func calculateCertLifespanHours(certsDirectory string, certName string, metricCo
 func getCert(certPath string) ([]byte, error) {
 	dat, err := ioutil.ReadFile(certPath)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to read cert file %s", certPath))
+		return nil, fmt.Errorf("failed to read cert file %s: %w", certPath, err)
 	}
 	if strings.HasSuffix(certPath, ".pem") || strings.HasSuffix(certPath, ".crt") {
 		block, _ := pem.Decode(dat)

--- a/orc8r/cloud/go/services/certifier/protos/helpers.go
+++ b/orc8r/cloud/go/services/certifier/protos/helpers.go
@@ -1,10 +1,10 @@
 package protos
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/services/certifier/obsidian/models"
@@ -111,7 +111,7 @@ func convertTenantResourceIDs(ids []string) ([]int64, error) {
 	for _, i := range ids {
 		j, err := strconv.ParseInt(i, 10, 64)
 		if err != nil {
-			return []int64{}, errors.Wrapf(err, "failed to convert tenant IDs to integers")
+			return []int64{}, fmt.Errorf("failed to convert tenant IDs to integers: %w", err)
 		}
 		intIDs = append(intIDs, j)
 	}

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -15,10 +15,10 @@ package configurator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/serde"
@@ -280,7 +280,7 @@ func WriteEntities(ctx context.Context, networkID string, writes []EntityWriteOp
 			}
 			req.Writes = append(req.Writes, &protos.WriteEntityRequest{Request: &protos.WriteEntityRequest_Update{Update: protoEuc}})
 		default:
-			return errors.Errorf("unrecognized entity write operation %T", op)
+			return fmt.Errorf("unrecognized entity write operation %T", op)
 		}
 	}
 
@@ -509,7 +509,7 @@ func LoadEntityForPhysicalID(ctx context.Context, physicalID string, criteria En
 		return ret, merrors.ErrNotFound
 	}
 	if len(loaded) > 1 {
-		return ret, errors.Errorf("expected one entity from query, found %d", len(loaded))
+		return ret, fmt.Errorf("expected one entity from query, found %d", len(loaded))
 	}
 	return loaded[0], nil
 }
@@ -525,7 +525,7 @@ func LoadEntities(ctx context.Context, networkID string, typeFilter *string, key
 	}
 	ret, err := (NetworkEntities{}).fromProtos(protoEnts, serdes)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "request succeeded but deserialization failed")
+		return nil, nil, fmt.Errorf("request succeeded but deserialization failed: %w", err)
 	}
 	return ret, entIDsToTKs(notFound), nil
 }
@@ -682,7 +682,7 @@ func LoadAllEntitiesOfType(ctx context.Context, networkID string, entityType str
 
 	ret, err := (NetworkEntities{}).fromProtos(res.Entities, serdes)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "request succeeded but deserialization failed")
+		return nil, "", fmt.Errorf("request succeeded but deserialization failed: %w", err)
 	}
 
 	return ret, res.NextPageToken, nil

--- a/orc8r/cloud/go/services/configurator/graph.go
+++ b/orc8r/cloud/go/services/configurator/graph.go
@@ -14,7 +14,7 @@
 package configurator
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"magma/orc8r/cloud/go/storage"
 	"magma/orc8r/lib/go/merrors"
@@ -53,7 +53,7 @@ func (eg *EntityGraph) GetFirstAncestorOfType(start NetworkEntity, targetType st
 
 	start, found := eg.entsByTK[start.GetTK()]
 	if !found {
-		return NetworkEntity{}, errors.Errorf("entity %s is not in graph", start.GetTK())
+		return NetworkEntity{}, fmt.Errorf("entity %s is not in graph", start.GetTK())
 	}
 
 	ancestor := eg.upwardsDFSForType(start.GetTK(), targetType, map[storage.TK]bool{})
@@ -68,7 +68,7 @@ func (eg *EntityGraph) GetAllChildrenOfType(parent NetworkEntity, targetType str
 
 	start, found := eg.entsByTK[parent.GetTK()]
 	if !found {
-		return nil, errors.Errorf("entity %s is not in graph", start.GetTK())
+		return nil, fmt.Errorf("entity %s is not in graph", start.GetTK())
 	}
 
 	ret := []NetworkEntity{}

--- a/orc8r/cloud/go/services/configurator/mconfig/build.go
+++ b/orc8r/cloud/go/services/configurator/mconfig/build.go
@@ -20,7 +20,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/configurator/storage"
 	"magma/orc8r/lib/go/protos"
@@ -40,7 +39,7 @@ func CreateMconfigJSON(network *storage.Network, graph *storage.EntityGraph, gat
 	for _, b := range builders {
 		partialConfig, err := b.Build(network, graph, gatewayID)
 		if err != nil {
-			return nil, errors.Wrapf(err, "mconfig builder %+v error", b)
+			return nil, fmt.Errorf("mconfig builder %+v error: %w", b, err)
 		}
 		for key, config := range partialConfig {
 			_, ok := configs[key]

--- a/orc8r/cloud/go/services/configurator/mconfig/marshal.go
+++ b/orc8r/cloud/go/services/configurator/mconfig/marshal.go
@@ -14,10 +14,11 @@
 package mconfig
 
 import (
+	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/lib/go/protos"
 )
@@ -27,7 +28,7 @@ func MarshalConfigs(configs map[string]proto.Message) (ConfigsByKey, error) {
 	for k, v := range configs {
 		anyVal, err := ptypes.MarshalAny(v)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 		bytesVal, err := protos.MarshalJSON(anyVal)
 		if err != nil {
@@ -44,15 +45,15 @@ func UnmarshalConfigs(configs ConfigsByKey) (map[string]proto.Message, error) {
 		anyVal := &any.Any{}
 		err := protos.Unmarshal(v, anyVal)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unmarshal mconfig from bytes to proto for key %s and bytes %v", k, v)
+			return nil, fmt.Errorf("unmarshal mconfig from bytes to proto for key %s and bytes %v: %w", k, v, err)
 		}
 		msgVal, err := ptypes.Empty(anyVal)
 		if err != nil {
-			return nil, errors.Wrapf(err, "create concrete proto.Message, for proto.Any %+v", anyVal)
+			return nil, fmt.Errorf("create concrete proto.Message, for proto.Any %+v: %w", anyVal, err)
 		}
 		err = ptypes.UnmarshalAny(anyVal, msgVal)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unmarshal proto.Any into proto.Message, for proto.Any %+v", anyVal)
+			return nil, fmt.Errorf("unmarshal proto.Any into proto.Message, for proto.Any %+v: %w", anyVal, err)
 		}
 		ret[k] = msgVal
 	}

--- a/orc8r/cloud/go/services/configurator/storage/sql_entity_load_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_entity_load_helpers.go
@@ -22,7 +22,6 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/sqorc"
@@ -61,7 +60,7 @@ func (store *sqlConfiguratorStorage) loadEntities(networkID string, filter *Enti
 
 	rows, err := builder.RunWith(store.tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "error querying for entities")
+		return nil, fmt.Errorf("error querying for entities: %w", err)
 	}
 	defer sqorc.CloseRowsLogOnError(rows, "loadEntities")
 
@@ -74,7 +73,7 @@ func (store *sqlConfiguratorStorage) loadEntities(networkID string, filter *Enti
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 
 	return entsByTK, nil
@@ -82,7 +81,7 @@ func (store *sqlConfiguratorStorage) loadEntities(networkID string, filter *Enti
 
 func (store *sqlConfiguratorStorage) loadAssocs(networkID string, filter *EntityLoadFilter, criteria *EntityLoadCriteria, loadTyp loadType) (loadedAssocs, error) {
 	if loadTyp != loadChildren && loadTyp != loadParents {
-		return nil, errors.Errorf("wrong load type received: '%v'", loadTyp)
+		return nil, fmt.Errorf("wrong load type received: '%v'", loadTyp)
 	}
 
 	assocs := loadedAssocs{}
@@ -94,7 +93,7 @@ func (store *sqlConfiguratorStorage) loadAssocs(networkID string, filter *Entity
 
 	rows, err := builder.RunWith(store.tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "error querying for entities")
+		return nil, fmt.Errorf("error querying for entities: %w", err)
 	}
 	defer sqorc.CloseRowsLogOnError(rows, "loadAssocs")
 
@@ -107,7 +106,7 @@ func (store *sqlConfiguratorStorage) loadAssocs(networkID string, filter *Entity
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 
 	return assocs, nil
@@ -245,7 +244,7 @@ func scanEntityRow(rows *sql.Rows, criteria *EntityLoadCriteria) (*NetworkEntity
 
 	err := rows.Scan(scanArgs...)
 	if err != nil {
-		return &NetworkEntity{}, errors.Wrap(err, "error while scanning entity row")
+		return &NetworkEntity{}, fmt.Errorf("error while scanning entity row: %w", err)
 	}
 
 	ent := &NetworkEntity{
@@ -280,7 +279,7 @@ func scanAssocRow(rows *sql.Rows, loadTyp loadType) (loadedAssoc, error) {
 
 	err := rows.Scan(scanArgs...)
 	if err != nil {
-		return loadedAssoc{}, errors.Wrap(err, "error while scanning entity row")
+		return loadedAssoc{}, fmt.Errorf("error while scanning entity row: %w", err)
 	}
 
 	return a, nil

--- a/orc8r/cloud/go/services/configurator/storage/sql_network_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_network_helpers.go
@@ -15,12 +15,12 @@ package storage
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/sqorc"
@@ -166,7 +166,7 @@ func (store *sqlConfiguratorStorage) updateNetwork(update *NetworkUpdateCriteria
 	updateBuilder = updateBuilder.Set(nwVerCol, sq.Expr(fmt.Sprintf("%s.%s+1", networksTable, nwVerCol)))
 	_, err := updateBuilder.RunWith(stmtCache).Exec()
 	if err != nil {
-		return errors.Wrapf(err, "error updating network %s", update.ID)
+		return fmt.Errorf("error updating network %s: %w", update.ID, err)
 	}
 
 	// Sort config keys for deterministic behavior on upserts
@@ -187,7 +187,7 @@ func (store *sqlConfiguratorStorage) updateNetwork(update *NetworkUpdateCriteria
 			RunWith(stmtCache).
 			Exec()
 		if err != nil {
-			return errors.Wrapf(err, "error updating config %s on network %s", configType, update.ID)
+			return fmt.Errorf("error updating config %s on network %s: %w", configType, update.ID, err)
 		}
 	}
 
@@ -202,7 +202,7 @@ func (store *sqlConfiguratorStorage) updateNetwork(update *NetworkUpdateCriteria
 	}
 	_, err = store.builder.Delete(networkConfigTable).Where(orClause).RunWith(store.tx).Exec()
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete configs for network %s", update.ID)
+		return fmt.Errorf("failed to delete configs for network %s: %w", update.ID, err)
 	}
 
 	return nil

--- a/orc8r/cloud/go/services/configurator/storage/storage.go
+++ b/orc8r/cloud/go/services/configurator/storage/storage.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 	"google.golang.org/protobuf/proto"
 
@@ -109,7 +108,7 @@ type ConfiguratorStorage interface {
 func RollbackLogOnError(store ConfiguratorStorage) {
 	err := store.Rollback()
 	if err != nil {
-		glog.Errorf("Error while rolling back tx: %+v", errors.WithStack(err))
+		glog.Errorf("Error while rolling back tx: %+v", err)
 	}
 }
 
@@ -118,7 +117,7 @@ func RollbackLogOnError(store ConfiguratorStorage) {
 func CommitLogOnError(store ConfiguratorStorage) {
 	err := store.Commit()
 	if err != nil {
-		glog.Errorf("Error while committing tx: %+v", errors.WithStack(err))
+		glog.Errorf("Error while committing tx: %+v", err)
 	}
 }
 

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/gateway_api.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/gateway_api.go
@@ -15,10 +15,10 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
@@ -43,7 +43,7 @@ func NewGwCtracedClient() GwCtracedClient {
 func getGWCtracedClient(ctx context.Context, networkID string, gatewayID string) (protos.CallTraceServiceClient, context.Context, error) {
 	hwID, err := configurator.GetPhysicalIDOfEntity(ctx, networkID, orc8r.MagmadGatewayType, gatewayID)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, fmt.Sprintf("gateway not found, network-id: %s, gateway-id: %s", networkID, gatewayID))
+		return nil, nil, fmt.Errorf("gateway not found, network-id: %s, gateway-id: %s: %w", networkID, gatewayID, err)
 	}
 	conn, gatewayCtx, err := gateway_registry.GetGatewayConnection(gateway_registry.GwCtraced, hwID)
 	if err != nil {
@@ -63,7 +63,7 @@ func (c gwCtracedClientImpl) StartCallTrace(ctx context.Context, networkId strin
 	}
 	resp, err := client.StartCallTrace(gatewayCtx, req)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start call trace, gRPC client received error")
+		return nil, fmt.Errorf("failed to start call trace, gRPC client received error: %w", err)
 	}
 	return resp, err
 }
@@ -77,7 +77,7 @@ func (c gwCtracedClientImpl) EndCallTrace(ctx context.Context, networkId string,
 	}
 	resp, err := client.EndCallTrace(gatewayCtx, req)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to end call trace, gRPC client received error")
+		return nil, fmt.Errorf("failed to end call trace, gRPC client received error: %w", err)
 	}
 	return resp, err
 }

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
@@ -15,11 +15,11 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
@@ -101,7 +101,7 @@ func getCreateCallTraceHandlerFunc(client GwCtracedClient) echo.HandlerFunc {
 
 		exists, err := configurator.DoesEntityExist(reqCtx, networkID, orc8r.CallTraceEntityType, cfg.TraceID)
 		if exists {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.New(fmt.Sprintf("Call trace id: %s already exists", cfg.TraceID)))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Call trace id: %s already exists", cfg.TraceID))
 		}
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -112,12 +112,12 @@ func getCreateCallTraceHandlerFunc(client GwCtracedClient) echo.HandlerFunc {
 
 		req, err := buildStartTraceRequest(cfg)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to build call trace request"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to build call trace request: %w", err))
 		}
 
 		resp, err := client.StartCallTrace(reqCtx, networkID, cfg.GatewayID, req)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to start call trace"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to start call trace: %w", err))
 		}
 		if !resp.Success {
 			return echo.NewHTTPError(http.StatusInternalServerError, errors.New("failed to start call trace"))
@@ -126,7 +126,7 @@ func getCreateCallTraceHandlerFunc(client GwCtracedClient) echo.HandlerFunc {
 		createdEntity := ctr.ToEntity()
 		_, err = configurator.CreateEntity(reqCtx, networkID, createdEntity, serdes.Entity)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to create call trace"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to create call trace: %w", err))
 		}
 		return c.JSON(http.StatusCreated, cfg.TraceID)
 	}
@@ -177,7 +177,7 @@ func getUpdateCallTraceHandlerFunc(client GwCtracedClient, storage storage.Ctrac
 
 		err = storage.StoreCallTrace(networkID, callTraceID, resp.TraceContent)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, fmt.Sprintf("failed to save call trace data, network-id: %s, gateway-id: %s, calltrace-id: %s", networkID, callTrace.Config.GatewayID, callTraceID)))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to save call trace data, network-id: %s, gateway-id: %s, calltrace-id: %s: %w", networkID, callTrace.Config.GatewayID, callTraceID, err))
 		}
 
 		_, err = configurator.UpdateEntity(reqCtx, networkID, mutableCallTrace.ToEntityUpdateCriteria(callTraceID, *callTrace), serdes.Entity)
@@ -197,7 +197,7 @@ func getDeleteCallTraceHandlerFunc(client GwCtracedClient, storage storage.Ctrac
 
 		err := storage.DeleteCallTrace(networkID, callTraceID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to delete call trace data"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to delete call trace data: %w", err))
 		}
 
 		err = configurator.DeleteEntity(c.Request().Context(), networkID, orc8r.CallTraceEntityType, callTraceID)
@@ -217,7 +217,7 @@ func getDownloadCallTraceHandlerFunc(storage storage.CtracedStorage) echo.Handle
 
 		callTrace, err := storage.GetCallTrace(networkID, callTraceID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to retrieve call trace data"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to retrieve call trace data: %w", err))
 		}
 
 		res := c.Response()

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
@@ -16,8 +16,6 @@ package storage
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
 	"magma/orc8r/lib/go/merrors"
@@ -45,7 +43,7 @@ type ctracedBlobStore struct {
 func (c *ctracedBlobStore) StoreCallTrace(networkID string, callTraceID string, data []byte) error {
 	store, err := c.factory.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -56,7 +54,7 @@ func (c *ctracedBlobStore) StoreCallTrace(networkID string, callTraceID string, 
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to store call trace %s", callTraceID))
+		return fmt.Errorf("failed to store call trace %s: %w", callTraceID, err)
 	}
 
 	return store.Commit()
@@ -66,7 +64,7 @@ func (c *ctracedBlobStore) StoreCallTrace(networkID string, callTraceID string, 
 func (c *ctracedBlobStore) GetCallTrace(networkID string, callTraceID string) ([]byte, error) {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start transaction")
+		return nil, fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -78,7 +76,7 @@ func (c *ctracedBlobStore) GetCallTrace(networkID string, callTraceID string) ([
 		return nil, err
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to get call trace %s", callTraceID))
+		return nil, fmt.Errorf("failed to get call trace %s: %w", callTraceID, err)
 	}
 
 	return blob.Value, store.Commit()
@@ -88,7 +86,7 @@ func (c *ctracedBlobStore) GetCallTrace(networkID string, callTraceID string) ([
 func (c *ctracedBlobStore) DeleteCallTrace(networkID string, callTraceID string) error {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -99,7 +97,7 @@ func (c *ctracedBlobStore) DeleteCallTrace(networkID string, callTraceID string)
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to delete call trace %s", callTraceID))
+		return fmt.Errorf("failed to delete call trace %s: %w", callTraceID, err)
 	}
 
 	return store.Commit()

--- a/orc8r/cloud/go/services/device/client_api.go
+++ b/orc8r/cloud/go/services/device/client_api.go
@@ -15,9 +15,9 @@ package device
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/serde"
@@ -127,7 +127,7 @@ func GetDevices(networkID string, deviceType string, deviceIDs []string, serdes 
 	for k, val := range res.DeviceMap {
 		iVal, err := serde.Deserialize(val.Info, deviceType, serdes)
 		if err != nil {
-			return map[string]interface{}{}, errors.Wrapf(err, "failed to deserialize device %s", k)
+			return map[string]interface{}{}, fmt.Errorf("failed to deserialize device %s: %w", k, err)
 		}
 		ret[k] = iVal
 	}

--- a/orc8r/cloud/go/services/directoryd/client_api.go
+++ b/orc8r/cloud/go/services/directoryd/client_api.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/serdes"
@@ -52,7 +51,7 @@ func getDirectorydClient() (protos.DirectoryLookupClient, error) {
 func GetHostnameForHWID(ctx context.Context, hwid string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	res, err := client.GetHostnameForHWID(ctx, &protos.GetHostnameForHWIDRequest{Hwid: hwid})
@@ -74,7 +73,7 @@ func MapHWIDToHostname(ctx context.Context, hwid, hostname string) error {
 func MapHWIDsToHostnames(ctx context.Context, hwidToHostname map[string]string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.MapHWIDsToHostnames(ctx, &protos.MapHWIDToHostnameRequest{HwidToHostname: hwidToHostname})
@@ -90,7 +89,7 @@ func MapHWIDsToHostnames(ctx context.Context, hwidToHostname map[string]string) 
 func UnmapHWIDsToHostnames(ctx context.Context, hwids []string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.UnmapHWIDsToHostnames(ctx, &protos.UnmapHWIDToHostnameRequest{Hwids: hwids})
@@ -108,7 +107,7 @@ func UnmapHWIDsToHostnames(ctx context.Context, hwids []string) error {
 func GetIMSIForSessionID(ctx context.Context, networkID, sessionID string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	res, err := client.GetIMSIForSessionID(ctx, &protos.GetIMSIForSessionIDRequest{
@@ -127,7 +126,7 @@ func GetIMSIForSessionID(ctx context.Context, networkID, sessionID string) (stri
 func MapSessionIDsToIMSIs(ctx context.Context, networkID string, sessionIDToIMSI map[string]string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.MapSessionIDsToIMSIs(ctx, &protos.MapSessionIDToIMSIRequest{
@@ -146,7 +145,7 @@ func MapSessionIDsToIMSIs(ctx context.Context, networkID string, sessionIDToIMSI
 func UnmapSessionIDsToIMSIs(ctx context.Context, networkID string, sessionIDs []string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.UnmapSessionIDsToIMSIs(ctx, &protos.UnmapSessionIDToIMSIRequest{
@@ -168,7 +167,7 @@ func UnmapSessionIDsToIMSIs(ctx context.Context, networkID string, sessionIDs []
 func GetHWIDForSgwCTeid(ctx context.Context, networkID, teid string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	res, err := client.GetHWIDForSgwCTeid(ctx, &protos.GetHWIDForSgwCTeidRequest{
@@ -186,7 +185,7 @@ func GetHWIDForSgwCTeid(ctx context.Context, networkID, teid string) (string, er
 func MapSgwCTeidToHWID(ctx context.Context, networkID string, teidToHWID map[string]string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.MapSgwCTeidToHWID(ctx, &protos.MapSgwCTeidToHWIDRequest{
@@ -204,7 +203,7 @@ func MapSgwCTeidToHWID(ctx context.Context, networkID string, teidToHWID map[str
 func UnmapSgwCTeidToHWID(ctx context.Context, networkID string, teids []string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.UnmapSgwCTeidToHWID(ctx, &protos.UnmapSgwCTeidToHWIDRequest{
@@ -222,7 +221,7 @@ func UnmapSgwCTeidToHWID(ctx context.Context, networkID string, teids []string) 
 func GetNewSgwCTeid(ctx context.Context, networkID string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 	res, err := client.GetNewSgwCTeid(ctx, &protos.GetNewSgwCTeidRequest{NetworkID: networkID})
 	if err != nil {
@@ -239,7 +238,7 @@ func GetNewSgwCTeid(ctx context.Context, networkID string) (string, error) {
 func GetHWIDForSgwUTeid(ctx context.Context, networkID, teid string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	res, err := client.GetHWIDForSgwUTeid(ctx, &protos.GetHWIDForSgwUTeidRequest{
@@ -257,7 +256,7 @@ func GetHWIDForSgwUTeid(ctx context.Context, networkID, teid string) (string, er
 func MapSgwUTeidToHWID(ctx context.Context, networkID string, teidToHWID map[string]string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.MapSgwUTeidToHWID(ctx, &protos.MapSgwUTeidToHWIDRequest{
@@ -275,7 +274,7 @@ func MapSgwUTeidToHWID(ctx context.Context, networkID string, teidToHWID map[str
 func UnmapSgwUTeidToHWID(ctx context.Context, networkID string, teids []string) error {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get directoryd client")
+		return fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 
 	_, err = client.UnmapSgwUTeidToHWID(ctx, &protos.UnmapSgwUTeidToHWIDRequest{
@@ -293,7 +292,7 @@ func UnmapSgwUTeidToHWID(ctx context.Context, networkID string, teids []string) 
 func GetNewSgwUTeid(ctx context.Context, networkID string) (string, error) {
 	client, err := getDirectorydClient()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get directoryd client")
+		return "", fmt.Errorf("failed to get directoryd client: %w", err)
 	}
 	res, err := client.GetNewSgwUTeid(ctx, &protos.GetNewSgwUTeidRequest{NetworkID: networkID})
 	if err != nil {

--- a/orc8r/cloud/go/services/directoryd/servicers/protected/servicer.go
+++ b/orc8r/cloud/go/services/directoryd/servicers/protected/servicer.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	directoryd_protos "magma/orc8r/cloud/go/services/directoryd/protos"
 	"magma/orc8r/cloud/go/services/directoryd/storage"
@@ -45,7 +44,7 @@ func (d *directoryLookupServicer) GetHostnameForHWID(
 ) (*directoryd_protos.GetHostnameForHWIDResponse, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetHostnameForHWIDRequest")
+		return nil, fmt.Errorf("failed to validate GetHostnameForHWIDRequest: %w", err)
 	}
 
 	hostname, err := d.store.GetHostnameForHWID(req.Hwid)
@@ -57,7 +56,7 @@ func (d *directoryLookupServicer) GetHostnameForHWID(
 func (d *directoryLookupServicer) MapHWIDsToHostnames(ctx context.Context, req *directoryd_protos.MapHWIDToHostnameRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate MapHWIDToHostnameRequest")
+		return nil, fmt.Errorf("failed to validate MapHWIDToHostnameRequest: %w", err)
 	}
 
 	err = d.store.MapHWIDsToHostnames(req.HwidToHostname)
@@ -68,7 +67,7 @@ func (d *directoryLookupServicer) MapHWIDsToHostnames(ctx context.Context, req *
 func (d *directoryLookupServicer) UnmapHWIDsToHostnames(ctx context.Context, req *directoryd_protos.UnmapHWIDToHostnameRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate UnmapHWIDToHostnameRequest")
+		return nil, fmt.Errorf("failed to validate UnmapHWIDToHostnameRequest: %w", err)
 	}
 
 	err = d.store.UnmapHWIDsToHostnames(req.Hwids)
@@ -82,7 +81,7 @@ func (d *directoryLookupServicer) GetIMSIForSessionID(
 	err := req.Validate()
 
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetIMSIForSessionIDRequest")
+		return nil, fmt.Errorf("failed to validate GetIMSIForSessionIDRequest: %w", err)
 	}
 
 	imsi, err := d.store.GetIMSIForSessionID(req.NetworkID, req.SessionID)
@@ -94,7 +93,7 @@ func (d *directoryLookupServicer) GetIMSIForSessionID(
 func (d *directoryLookupServicer) MapSessionIDsToIMSIs(ctx context.Context, req *directoryd_protos.MapSessionIDToIMSIRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate MapSessionIDToIMSIRequest")
+		return nil, fmt.Errorf("failed to validate MapSessionIDToIMSIRequest: %w", err)
 	}
 
 	err = d.store.MapSessionIDsToIMSIs(req.NetworkID, req.SessionIDToIMSI)
@@ -105,7 +104,7 @@ func (d *directoryLookupServicer) MapSessionIDsToIMSIs(ctx context.Context, req 
 func (d *directoryLookupServicer) UnmapSessionIDsToIMSIs(ctx context.Context, req *directoryd_protos.UnmapSessionIDToIMSIRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate UnmapSessionIDToIMSIRequest")
+		return nil, fmt.Errorf("failed to validate UnmapSessionIDToIMSIRequest: %w", err)
 	}
 
 	err = d.store.UnmapSessionIDsToIMSIs(req.NetworkID, req.SessionIDs)
@@ -116,7 +115,7 @@ func (d *directoryLookupServicer) UnmapSessionIDsToIMSIs(ctx context.Context, re
 func (d *directoryLookupServicer) MapSgwCTeidToHWID(ctx context.Context, req *directoryd_protos.MapSgwCTeidToHWIDRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate MapSgwCTeidToHWIDRequest")
+		return nil, fmt.Errorf("failed to validate MapSgwCTeidToHWIDRequest: %w", err)
 	}
 
 	err = d.store.MapSgwCTeidToHWID(req.NetworkID, req.TeidToHwid)
@@ -127,7 +126,7 @@ func (d *directoryLookupServicer) MapSgwCTeidToHWID(ctx context.Context, req *di
 func (d *directoryLookupServicer) UnmapSgwCTeidToHWID(ctx context.Context, req *directoryd_protos.UnmapSgwCTeidToHWIDRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate UnmapSgwCTeidToHWIDRequest")
+		return nil, fmt.Errorf("failed to validate UnmapSgwCTeidToHWIDRequest: %w", err)
 	}
 
 	err = d.store.UnmapSgwCTeidToHWID(req.NetworkID, req.Teids)
@@ -140,7 +139,7 @@ func (d *directoryLookupServicer) GetHWIDForSgwCTeid(
 ) (*directoryd_protos.GetHWIDForSgwCTeidResponse, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetHWIDForSgwCTeidRequest")
+		return nil, fmt.Errorf("failed to validate GetHWIDForSgwCTeidRequest: %w", err)
 	}
 
 	hwid, err := d.store.GetHWIDForSgwCTeid(req.NetworkID, req.Teid)
@@ -152,7 +151,7 @@ func (d *directoryLookupServicer) GetHWIDForSgwCTeid(
 func (d *directoryLookupServicer) GetNewSgwCTeid(ctx context.Context, req *directoryd_protos.GetNewSgwCTeidRequest) (*directoryd_protos.GetNewSgwCTeidResponse, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetNewSgwCTeid")
+		return nil, fmt.Errorf("failed to validate GetNewSgwCTeid: %w", err)
 	}
 
 	sgwCTeid, err := d.sgwCteidGen.GetUniqueId(req.NetworkID, d.store.GetHWIDForSgwCTeid)
@@ -167,7 +166,7 @@ func (d *directoryLookupServicer) GetNewSgwCTeid(ctx context.Context, req *direc
 func (d *directoryLookupServicer) MapSgwUTeidToHWID(ctx context.Context, req *directoryd_protos.MapSgwUTeidToHWIDRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate MapSgwUTeidToHWIDRequest")
+		return nil, fmt.Errorf("failed to validate MapSgwUTeidToHWIDRequest: %w", err)
 	}
 
 	err = d.store.MapSgwUTeidToHWID(req.NetworkID, req.TeidToHwid)
@@ -178,7 +177,7 @@ func (d *directoryLookupServicer) MapSgwUTeidToHWID(ctx context.Context, req *di
 func (d *directoryLookupServicer) UnmapSgwUTeidToHWID(ctx context.Context, req *directoryd_protos.UnmapSgwUTeidToHWIDRequest) (*protos.Void, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate UnmapSgwUTeidToHWIDRequest")
+		return nil, fmt.Errorf("failed to validate UnmapSgwUTeidToHWIDRequest: %w", err)
 	}
 
 	err = d.store.UnmapSgwUTeidToHWID(req.NetworkID, req.Teids)
@@ -191,7 +190,7 @@ func (d *directoryLookupServicer) GetHWIDForSgwUTeid(
 ) (*directoryd_protos.GetHWIDForSgwUTeidResponse, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetHWIDForSgwUTeidRequest")
+		return nil, fmt.Errorf("failed to validate GetHWIDForSgwUTeidRequest: %w", err)
 	}
 
 	hwid, err := d.store.GetHWIDForSgwUTeid(req.NetworkID, req.Teid)
@@ -203,7 +202,7 @@ func (d *directoryLookupServicer) GetHWIDForSgwUTeid(
 func (d *directoryLookupServicer) GetNewSgwUTeid(ctx context.Context, req *directoryd_protos.GetNewSgwUTeidRequest) (*directoryd_protos.GetNewSgwUTeidResponse, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to validate GetNewSgwUTeid")
+		return nil, fmt.Errorf("failed to validate GetNewSgwUTeid: %w", err)
 	}
 
 	SgwUTeid, err := d.sgwUteidGen.GetUniqueId(req.NetworkID, d.store.GetHWIDForSgwUTeid)

--- a/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/directoryd/storage/storage_blobstore.go
@@ -14,10 +14,10 @@ limitations under the License.
 package storage
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
@@ -129,7 +129,7 @@ func (d *directorydBlobstore) UnmapSgwUTeidToHWID(networkID string, teids []stri
 func (d *directorydBlobstore) getFromStore(networkID, tkType, key string) (string, error) {
 	store, err := d.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to start transaction to get %s for tkKey %s", key, tkType)
+		return "", fmt.Errorf("failed to start transaction to get %s for tkKey %s: %w", key, tkType, err)
 	}
 	defer store.Rollback()
 
@@ -138,7 +138,7 @@ func (d *directorydBlobstore) getFromStore(networkID, tkType, key string) (strin
 		return "", err
 	}
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get %s from %s", key, tkType)
+		return "", fmt.Errorf("failed to get %s from %s: %w", key, tkType, err)
 	}
 	return string(blob.Value), store.Commit()
 }
@@ -146,14 +146,14 @@ func (d *directorydBlobstore) getFromStore(networkID, tkType, key string) (strin
 func (d *directorydBlobstore) mapToStore(networkID, tkType string, keyToValueMap map[string]string) error {
 	store, err := d.factory.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to start transaction mapToStore with map %+v for tkKey %s", keyToValueMap, tkType)
+		return fmt.Errorf("failed to start transaction mapToStore with map %+v for tkKey %s: %w", keyToValueMap, tkType, err)
 	}
 	defer store.Rollback()
 
 	blobs := convertKVToBlobs(tkType, keyToValueMap)
 	err = store.Write(networkID, blobs)
 	if err != nil {
-		return errors.Wrapf(err, "failed to mapToStore with map %+v for tkKey %s", keyToValueMap, tkType)
+		return fmt.Errorf("failed to mapToStore with map %+v for tkKey %s: %w", keyToValueMap, tkType, err)
 	}
 	return store.Commit()
 }
@@ -161,13 +161,13 @@ func (d *directorydBlobstore) mapToStore(networkID, tkType string, keyToValueMap
 func (d *directorydBlobstore) unmapFromStore(networkID, tkType string, keys []string) error {
 	store, err := d.factory.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to start transaction unmapFromStore with key %s for tkKey %s", keys, tkType)
+		return fmt.Errorf("failed to start transaction unmapFromStore with key %s for tkKey %s: %w", keys, tkType, err)
 	}
 	defer store.Rollback()
 
 	err = store.Delete(networkID, storage.MakeTKs(tkType, keys))
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmapFromStore with keys %s for tkKey %s", keys, tkType)
+		return fmt.Errorf("failed to unmapFromStore with keys %s for tkKey %s: %w", keys, tkType, err)
 	}
 	return store.Commit()
 }

--- a/orc8r/cloud/go/services/dispatcher/servicers/sync_rpc_service_test.go
+++ b/orc8r/cloud/go/services/dispatcher/servicers/sync_rpc_service_test.go
@@ -15,12 +15,12 @@ package servicers_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"testing"
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
@@ -80,7 +80,7 @@ func TestSyncRPC(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			if protos.TestMarshal(in) != protos.TestMarshal(syncRPCReq) {
-				err := errors.Errorf(
+				err := fmt.Errorf(
 					"req received at gateway is different from req sent on the service: received: %v, sent: %v\n",
 					in, syncRPCReq,
 				)

--- a/orc8r/cloud/go/services/metricsd/collection/gatherer.go
+++ b/orc8r/cloud/go/services/metricsd/collection/gatherer.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	prometheus_proto "github.com/prometheus/client_model/go"
 
 	"magma/orc8r/lib/go/registry"
@@ -79,7 +78,7 @@ func (g *MetricsGatherer) getCollectors() []MetricCollector {
 
 	services, err := registry.ListAllServices()
 	if err != nil {
-		err = errors.Wrap(err, "error getting metrics collectors: list all services")
+		err = fmt.Errorf("error getting metrics collectors: list all services: %w", err)
 		glog.Warning(err)
 		return collectors
 	}

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/facebookincubator/prometheus-configmanager/prometheus/alert"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 
@@ -156,11 +155,11 @@ func sendConfig(payload interface{}, url string, method string, client HttpClien
 
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(requestBody))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "create http request"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("create http request: %w", err))
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrapf(err, "make %s request", method))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("make %s request: %w", method, err))
 	}
 	defer resp.Body.Close()
 
@@ -263,11 +262,11 @@ func sendBulkConfig(payload interface{}, url string, client HttpClient) (string,
 
 	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(requestBody))
 	if err != nil {
-		return "", echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "create http request"))
+		return "", echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("create http request: %w", err))
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "make PUT request"))
+		return "", echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("make PUT request: %w", err))
 	}
 	defer resp.Body.Close()
 

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_silencing_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_silencing_handlers.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/api/v2/client/silence"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/pkg/parse"
@@ -79,7 +78,7 @@ func postSilencer(networkID, silencerURL string, c echo.Context, client HttpClie
 
 	newSilencerBytes, err := json.Marshal(silencer)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "make silencer"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("make silencer: %w", err))
 	}
 
 	resp, err := client.Post(silencerURL, "application/json", bytes.NewBuffer(newSilencerBytes))

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
@@ -340,12 +339,12 @@ func GetTenantPromSeriesHandler(api PrometheusAPI, useCache bool) func(c echo.Co
 		startStr := c.QueryParam(utils.ParamRangeStart)
 		startTime, err := utils.ParseTime(startStr, &defaultStartTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.Wrapf(err, "parse start time: %s", startStr))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse start time: %s: %w", startStr, err))
 		}
 		endStr := c.QueryParam(utils.ParamRangeEnd)
 		endTime, err := utils.ParseTime(endStr, &defaultEndTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.Wrapf(err, "parse end time: %s", endStr))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse end time: %s: %w", endStr, err))
 		}
 
 		res, _, err := api.Series(reqCtx, seriesMatches, startTime, endTime)
@@ -435,11 +434,11 @@ func GetTenantPromValuesHandler(api PrometheusAPI) func(c echo.Context) error {
 		endStr := c.QueryParam(utils.ParamRangeEnd)
 		startTime, err := utils.ParseTime(startStr, &defaultStartTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.Wrapf(err, "parse start time: %s", startStr))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse start time: %s: %w", startStr, err))
 		}
 		endTime, err := utils.ParseTime(endStr, &maxTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, errors.Wrapf(err, "parse end time: %s", endStr))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse end time: %s: %w", endStr, err))
 		}
 
 		res, _, err := api.Series(reqCtx, seriesMatchers, startTime, endTime)

--- a/orc8r/cloud/go/services/metricsd/servicers/southbound/servicer.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/southbound/servicer.go
@@ -15,9 +15,9 @@ package southbound
 
 import (
 	"context"
+	"errors"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	prom_proto "github.com/prometheus/client_model/go"
 
 	"magma/orc8r/cloud/go/serdes"

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory.go
@@ -15,10 +15,10 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
@@ -277,11 +277,11 @@ func GetListGatewaysHandler(path string, gateway MagmadEncompassingGateway, make
 			}
 			devicesByID, err := device.GetDevices(nid, orc8r.AccessGatewayRecordType, deviceIDs, deviceSerdes)
 			if err != nil {
-				return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load devices"), http.StatusInternalServerError)
+				return obsidian.MakeHTTPError(fmt.Errorf("failed to load devices: %w", err), http.StatusInternalServerError)
 			}
 			statusesByID, err := wrappers.GetGatewayStatuses(reqCtx, nid, deviceIDs)
 			if err != nil {
-				return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load statuses"), http.StatusInternalServerError)
+				return obsidian.MakeHTTPError(fmt.Errorf("failed to load statuses: %w", err), http.StatusInternalServerError)
 			}
 
 			gateways := makeTypedGateways(entsByTK, devicesByID, statusesByID)

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/serde"
@@ -272,7 +271,7 @@ func getUpdateTypedNetworkHandler(path string, networkType string, networkModel 
 				return c.NoContent(http.StatusNotFound)
 			}
 			if err != nil {
-				return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load network to check type"), http.StatusInternalServerError)
+				return obsidian.MakeHTTPError(fmt.Errorf("failed to load network to check type: %w", err), http.StatusInternalServerError)
 			}
 			if network.Type != networkType {
 				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("network %s is not a <%s> network", nid, networkType))
@@ -303,7 +302,7 @@ func getDeleteTypedNetworkHandler(path string, networkType string, serdes serde.
 				return c.NoContent(http.StatusNotFound)
 			}
 			if err != nil {
-				return obsidian.MakeHTTPError(errors.Wrap(err, "failed to load network to check type"), http.StatusInternalServerError)
+				return obsidian.MakeHTTPError(fmt.Errorf("failed to load network to check type: %w", err), http.StatusInternalServerError)
 			}
 			if network.Type != networkType {
 				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("network %s is not a <%s> network", nid, networkType))

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/conversion.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/conversion.go
@@ -15,11 +15,11 @@ package models
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-openapi/swag"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/models"
@@ -383,7 +383,7 @@ func (m *TierID) ToUpdateCriteria(ctx context.Context, networkID string, gateway
 
 	exists, err := configurator.DoesEntityExist(ctx, networkID, orc8r.UpgradeTierEntityType, tierID)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to look up tier")
+		return nil, fmt.Errorf("Failed to look up tier: %w", err)
 	}
 	if !exists {
 		return nil, fmt.Errorf("Tier %s does not exist", tierID)

--- a/orc8r/cloud/go/services/orchestrator/servicers/protected/grpc_exporter_servicer.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/protected/grpc_exporter_servicer.go
@@ -13,9 +13,9 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
 	edge_hub "github.com/facebookincubator/prometheus-edge-hub/grpc"
-	"github.com/pkg/errors"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"google.golang.org/grpc"
 
@@ -77,7 +77,7 @@ func (s *GRPCPushExporterServicer) pushFamilies(families []*io_prometheus_client
 func (s *GRPCPushExporterServicer) getClient() (edge_hub.MetricsControllerClient, error) {
 	conn, err := s.registry.GetConnectionWithOptions(serviceName, lib_protos.ServiceType_SOUTHBOUND, dialOpts...)
 	if err != nil {
-		return nil, errors.Wrap(err, "get exporter client connection")
+		return nil, fmt.Errorf("get exporter client connection: %w", err)
 	}
 	client := edge_hub.NewMetricsControllerClient(conn)
 	return client, nil

--- a/orc8r/cloud/go/services/service_registry/servicers/protected/kubernetes_servicer.go
+++ b/orc8r/cloud/go/services/service_registry/servicers/protected/kubernetes_servicer.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/robfig/cron/v3"
 	corev1types "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,7 +193,7 @@ func (k *KubernetesServiceRegistryServicer) refreshServicesCache() {
 	services, err := k.client.Services(k.namespace).List(opts)
 	if err != nil {
 		// Log error and leave previous cache intact
-		err = errors.Wrap(err, "refresh service registry cache of K8s services")
+		err = fmt.Errorf("refresh service registry cache of K8s services: %w", err)
 		glog.Error(err)
 		return
 	}

--- a/orc8r/cloud/go/services/state/error.go
+++ b/orc8r/cloud/go/services/state/error.go
@@ -14,12 +14,13 @@
 package state
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func InternalErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	return status.Error(codes.Internal, e.Error())
 }

--- a/orc8r/cloud/go/services/state/indexer/index/index.go
+++ b/orc8r/cloud/go/services/state/indexer/index/index.go
@@ -14,11 +14,11 @@ limitations under the License.
 package index
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/clock"
 	"magma/orc8r/cloud/go/services/state/indexer"
@@ -200,5 +200,5 @@ func wrap(err error, sentinel Error, indexerID string) error {
 	default:
 		wrap = fmt.Sprintf("%s for idx %s", sentinel, indexerID)
 	}
-	return errors.Wrap(err, wrap)
+	return fmt.Errorf(wrap+": %w", err)
 }

--- a/orc8r/cloud/go/services/state/indexer/index/index_test.go
+++ b/orc8r/cloud/go/services/state/indexer/index/index_test.go
@@ -14,9 +14,9 @@ limitations under the License.
 package index_test
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"magma/orc8r/cloud/go/clock"
@@ -33,7 +33,7 @@ import (
 )
 
 func init() {
-	//_ = flag.Set("logtostderr", "true") // uncomment to view logs during test
+	// _ = flag.Set("logtostderr", "true") // uncomment to view logs during test
 }
 
 func TestIndexImpl_HappyPath(t *testing.T) {

--- a/orc8r/cloud/go/services/state/indexer/registry.go
+++ b/orc8r/cloud/go/services/state/indexer/registry.go
@@ -17,11 +17,11 @@ limitations under the License.
 package indexer
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/orc8r"
@@ -33,7 +33,7 @@ import (
 func GetIndexer(serviceName string) (Indexer, error) {
 	x, err := getIndexer(serviceName)
 	if err != nil {
-		return NewEmptyIndexer(serviceName), errors.Wrapf(err, "indexer not found for service %s", serviceName)
+		return NewEmptyIndexer(serviceName), fmt.Errorf("indexer not found for service %s: %w", serviceName, err)
 	}
 	return x, nil
 }
@@ -82,10 +82,10 @@ func getIndexer(serviceName string) (Indexer, error) {
 	}
 	versionInt, err := strconv.ParseInt(versionVal, 10, 32)
 	if err != nil {
-		return nil, errors.Wrapf(err, "convert indexer version %v to int for service %s", versionVal, serviceName)
+		return nil, fmt.Errorf("convert indexer version %v to int for service %s: %w", versionVal, serviceName, err)
 	}
 	if versionInt < 0 || versionInt > math.MaxUint32 {
-		return nil, errors.Wrapf(err, "number %d is outside the boundaries of uint32 type", versionInt)
+		return nil, fmt.Errorf("number %d is outside the boundaries of uint32 type: %w", versionInt, err)
 	}
 	version, err := NewIndexerVersion(versionInt)
 	if err != nil {

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
@@ -15,11 +15,11 @@ package reindex
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/services/state/indexer"
@@ -106,7 +106,7 @@ func executeJob(ctx context.Context, job *Job, batches []reindexBatch) error {
 		// Convert IDs to states -- silently ignore not-found (stale) state IDs
 		statesByID, err := state.GetSerializedStates(ctx, b.networkID, ids)
 		if err != nil {
-			err = errors.Wrap(err, "get states")
+			err = fmt.Errorf("get states: %w", err)
 			return wrap(err, ErrDefault, id)
 		}
 
@@ -180,5 +180,5 @@ func wrap(err error, sentinel Error, indexerID string) error {
 	default:
 		wrap = fmt.Sprintf("%s for idx %s", sentinel, indexerID)
 	}
-	return errors.Wrap(err, wrap)
+	return fmt.Errorf(wrap+": %w", err)
 }

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_queue_test.go
@@ -21,12 +21,12 @@ package reindex_test
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 

--- a/orc8r/cloud/go/services/state/indexer/reindex/store.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/store.go
@@ -14,7 +14,8 @@ limitations under the License.
 package reindex
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -70,6 +71,6 @@ func blobsToIDs(byNetwork map[string]blobstore.Blobs) state_types.IDsByNetwork {
 }
 
 func internalErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	return status.Error(codes.Internal, e.Error())
 }

--- a/orc8r/cloud/go/services/state/servicers/protected/indexer_mgr_servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/protected/indexer_mgr_servicer.go
@@ -15,8 +15,8 @@ package protected
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -82,6 +82,6 @@ func (srv *indexerServicer) validateReindexReq(req *indexer_protos.StartReindexR
 }
 
 func internalErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	return status.Error(codes.Internal, e.Error())
 }

--- a/orc8r/cloud/go/services/state/servicers/protected/indexer_mgr_servicer_test.go
+++ b/orc8r/cloud/go/services/state/servicers/protected/indexer_mgr_servicer_test.go
@@ -15,9 +15,9 @@ package protected_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"

--- a/orc8r/cloud/go/services/state/servicers/protected/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/protected/servicer.go
@@ -15,8 +15,8 @@ package protected
 
 import (
 	"context"
+	"errors"
 
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/orc8r/cloud/go/services/state/servicers/southbound/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/southbound/servicer.go
@@ -16,10 +16,11 @@ package servicers
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -232,7 +233,7 @@ func wrapStateWithAdditionalInfo(st *protos.State, hwID string, time uint64, cer
 	}
 	ret, err := json.Marshal(wrap)
 	if err != nil {
-		return nil, errors.Wrap(err, "json marshal state with meta")
+		return nil, fmt.Errorf("json marshal state with meta: %w", err)
 	}
 	return ret, nil
 }

--- a/orc8r/cloud/go/services/state/servicers/southbound/validate.go
+++ b/orc8r/cloud/go/services/state/servicers/southbound/validate.go
@@ -14,7 +14,8 @@
 package servicers
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/lib/go/protos"

--- a/orc8r/cloud/go/services/state/types/types.go
+++ b/orc8r/cloud/go/services/state/types/types.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/serde"
@@ -177,7 +176,7 @@ func MakeProtoStates(states SerializedStatesByID) ([]*protos.State, error) {
 func MakeProtoState(id ID, st SerializedState) (*protos.State, error) {
 	bytes, err := json.Marshal(st)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal to json-encoded state proto value")
+		return nil, fmt.Errorf("failed to marshal to json-encoded state proto value: %w", err)
 	}
 	p := &protos.State{Type: id.Type, DeviceID: id.DeviceID, Value: bytes, Version: st.Version}
 	return p, nil
@@ -203,7 +202,7 @@ func MakeSerializedState(p *protos.State) (SerializedState, error) {
 	serialized := SerializedState{}
 	err := json.Unmarshal(p.Value, &serialized)
 	if err != nil {
-		return SerializedState{}, errors.Wrap(err, "error unmarshaling json-encoded state proto value")
+		return SerializedState{}, fmt.Errorf("error unmarshaling json-encoded state proto value: %w", err)
 	}
 	return serialized, nil
 }
@@ -254,13 +253,13 @@ func MakeState(p *protos.State, serdes serde.Registry) (State, *protos.IDAndErro
 	}
 
 	if st.ReportedState == nil {
-		err = errors.Errorf("state {type: %s, key: %s} should not have nil SerializedReportedState value", p.Type, p.DeviceID)
+		err = fmt.Errorf("state {type: %s, key: %s} should not have nil SerializedReportedState value", p.Type, p.DeviceID)
 		sErr := &protos.IDAndError{Type: p.Type, DeviceID: p.DeviceID, Error: err.Error()}
 		return State{}, sErr, nil
 	}
 	model, ok := st.ReportedState.(serde.ValidateableBinaryConvertible)
 	if !ok {
-		err = errors.Errorf("could not convert state {type: %s, key: %s} to validateable model", p.Type, p.DeviceID)
+		err = fmt.Errorf("could not convert state {type: %s, key: %s} to validateable model", p.Type, p.DeviceID)
 		sErr := &protos.IDAndError{Type: p.Type, DeviceID: p.DeviceID, Error: err.Error()}
 		return State{}, sErr, nil
 	}

--- a/orc8r/cloud/go/services/streamer/providers/registry.go
+++ b/orc8r/cloud/go/services/streamer/providers/registry.go
@@ -17,10 +17,10 @@ limitations under the License.
 package providers
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/orc8r/cloud/go/orc8r"

--- a/orc8r/cloud/go/services/streamer/providers/servicers/protected/providers.go
+++ b/orc8r/cloud/go/services/streamer/providers/servicers/protected/providers.go
@@ -16,12 +16,12 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/lib/go/protos"
@@ -33,7 +33,7 @@ type MconfigProvider struct{}
 func (p *MconfigProvider) GetUpdates(ctx context.Context, gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
 	res, err := configurator.GetMconfigFor(ctx, gatewayId)
 	if err != nil {
-		return nil, errors.Wrap(err, "get mconfig from configurator")
+		return nil, fmt.Errorf("get mconfig from configurator: %w", err)
 	}
 
 	// TODO(#2310): add back support for extracting and comparing mconfig digest

--- a/orc8r/cloud/go/services/tenants/servicers/storage/storage.go
+++ b/orc8r/cloud/go/services/tenants/servicers/storage/storage.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/pkg/errors"
-
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/services/tenants"
 	tenant_protos "magma/orc8r/cloud/go/services/tenants/protos"
@@ -178,7 +176,7 @@ func (b *blobstoreStore) CreateOrUpdateControlProxy(tenantID int64, controlProxy
 func tenantToBlob(tenantID int64, tenant *tenant_protos.Tenant) (blobstore.Blob, error) {
 	marshaledTenant, err := protos.Marshal(tenant)
 	if err != nil {
-		return blobstore.Blob{}, errors.Wrap(err, "Error marshaling protobuf")
+		return blobstore.Blob{}, fmt.Errorf("Error marshaling protobuf: %w", err)
 	}
 	return blobstore.Blob{
 		Type:  tenants.TenantInfoType,
@@ -191,7 +189,7 @@ func tenantFromBlob(blob blobstore.Blob) (*tenant_protos.Tenant, error) {
 	tenant := tenant_protos.Tenant{}
 	err := protos.Unmarshal(blob.Value, &tenant)
 	if err != nil {
-		return &tenant_protos.Tenant{}, errors.Wrap(err, "Error unmarshaling protobuf")
+		return &tenant_protos.Tenant{}, fmt.Errorf("Error unmarshaling protobuf: %w", err)
 	}
 	return &tenant, nil
 }

--- a/orc8r/cloud/go/sqorc/tx.go
+++ b/orc8r/cloud/go/sqorc/tx.go
@@ -18,7 +18,6 @@ import (
 	"database/sql"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // ExecInTx executes a callback inside a sql transaction on the provided DB.
@@ -64,6 +63,6 @@ func CloseRowsLogOnError(rows *sql.Rows, callsite string) {
 		return
 	}
 	if err := rows.Close(); err != nil {
-		glog.Errorf("Error closing sql rows in %s: %+v", callsite, errors.WithStack(err))
+		glog.Errorf("Error closing sql rows in %s: %+v", callsite, err)
 	}
 }

--- a/orc8r/cloud/go/syncstore/config.go
+++ b/orc8r/cloud/go/syncstore/config.go
@@ -14,8 +14,10 @@
 package syncstore
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 )
 
 type Config struct {
@@ -37,7 +39,7 @@ func (config *Config) Validate(writer bool) error {
 		errs = multierror.Append(errs, errors.New("empty table name prefix for syncstore"))
 	}
 	if writer && config.CacheWriterValidIntervalSecs <= 0 {
-		errs = multierror.Append(errs, errors.Errorf("invalid cache writer valid interval: %+v", config.CacheWriterValidIntervalSecs))
+		errs = multierror.Append(errs, fmt.Errorf("invalid cache writer valid interval: %+v", config.CacheWriterValidIntervalSecs))
 	}
 	return errs.ErrorOrNil()
 }

--- a/orc8r/cloud/go/test_utils/test_db.go
+++ b/orc8r/cloud/go/test_utils/test_db.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"magma/orc8r/cloud/go/blobstore"
@@ -70,7 +69,7 @@ func NewSQLBlobstoreForServices(tableName string) (blobstore.StoreFactory, error
 	// to provide a clean slate across test cases
 	_, err = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
 	if err != nil {
-		return nil, errors.Wrapf(err, "drop test SQL blobstore table: %s", tableName)
+		return nil, fmt.Errorf("drop test SQL blobstore table: %s: %w", tableName, err)
 	}
 
 	store := blobstore.NewSQLStoreFactory(tableName, db, sqorc.GetSqlBuilder())

--- a/orc8r/cloud/go/tools/migrations/configurator.go
+++ b/orc8r/cloud/go/tools/migrations/configurator.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 )
 
 // Duplicated from configurator
@@ -96,7 +95,7 @@ func SetAssocDirections(builder squirrel.StatementBuilderType, edges []AssocDire
 		Where(where).
 		Query()
 	if err != nil {
-		return errors.Wrap(err, "get existing assocs to flip")
+		return fmt.Errorf("get existing assocs to flip: %w", err)
 	}
 
 	var assocs []assocPair
@@ -104,13 +103,13 @@ func SetAssocDirections(builder squirrel.StatementBuilderType, edges []AssocDire
 		assoc := assocPair{}
 		err = rows.Scan(&assoc.fromPk, &assoc.toPk)
 		if err != nil {
-			return errors.Wrap(err, "scan assocs")
+			return fmt.Errorf("scan assocs: %w", err)
 		}
 		assocs = append(assocs, assoc)
 	}
 	err = rows.Err()
 	if err != nil {
-		return errors.Wrap(err, "get existing assocs: SQL rows error")
+		return fmt.Errorf("get existing assocs: SQL rows error: %w", err)
 	}
 
 	glog.Infof("Flipping %d assocs", len(assocs))
@@ -134,7 +133,7 @@ func flipAssocDirection(builder squirrel.StatementBuilderType, assoc assocPair) 
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err := b.Exec()
 	if err != nil {
-		return errors.Wrap(err, "update error")
+		return fmt.Errorf("update error: %w", err)
 	}
 	return nil
 }

--- a/orc8r/cloud/go/tools/migrations/m005_certifier_to_blobstore/main.go
+++ b/orc8r/cloud/go/tools/migrations/m005_certifier_to_blobstore/main.go
@@ -16,11 +16,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	certifierprotos "magma/orc8r/cloud/go/services/certifier/protos"
@@ -79,19 +79,19 @@ func manuallyVerifyCertifierMigration() error {
 	certSrvAddr := "localhost:9086"
 	conn, err := grpc.Dial(certSrvAddr, grpc.WithInsecure())
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to certifier server")
+		return fmt.Errorf("failed to connect to certifier server: %w", err)
 	}
 	client := certifierprotos.NewCertifierClient(conn)
 
 	snsProto, err := client.ListCertificates(context.Background(), &protos.Void{})
 	if err != nil {
-		return errors.Wrap(err, "failed to list certificates")
+		return fmt.Errorf("failed to list certificates: %w", err)
 	}
 	glog.Infof("[manually verify] serial number count: %d", len(snsProto.GetSns()))
 
 	certInfos, err := client.GetAll(context.Background(), &protos.Void{})
 	if err != nil {
-		return errors.Wrap(err, "failed to get all certificates")
+		return fmt.Errorf("failed to get all certificates: %w", err)
 	}
 	maxToPrint := 5
 	i := 0

--- a/orc8r/cloud/go/tools/migrations/m008_accessd_to_blobstore/main.go
+++ b/orc8r/cloud/go/tools/migrations/m008_accessd_to_blobstore/main.go
@@ -16,11 +16,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	accessprotos "magma/orc8r/cloud/go/services/accessd/protos"
@@ -78,14 +78,14 @@ func manuallyVerifyAccessdMigration() error {
 	accessdSrvAddr := "localhost:9091"
 	conn, err := grpc.Dial(accessdSrvAddr, grpc.WithInsecure())
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to accessd server")
+		return fmt.Errorf("failed to connect to accessd server: %w", err)
 	}
 	client := accessprotos.NewAccessControlManagerClient(conn)
 	ctx := context.Background()
 
 	operators, err := client.ListOperators(ctx, &protos.Void{})
 	if err != nil {
-		return errors.Wrap(err, "failed to list operators")
+		return fmt.Errorf("failed to list operators: %w", err)
 	}
 	glog.Infof("[manually verify] number of operators: %d", len(operators.List))
 
@@ -97,7 +97,7 @@ func manuallyVerifyAccessdMigration() error {
 	operator := operators.List[0]
 	acl, err := client.GetOperatorACL(ctx, operator)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get operator ACL for operator: %+v", operator)
+		return fmt.Errorf("failed to get operator ACL for operator: %+v: %w", operator, err)
 	}
 	glog.Infof("[manually verify] operator-acl pair: {operator: %+v, acl: %+v}", operator, acl)
 

--- a/orc8r/cloud/go/tools/migrations/m009_directoryd_to_blobstore/main.go
+++ b/orc8r/cloud/go/tools/migrations/m009_directoryd_to_blobstore/main.go
@@ -22,7 +22,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -48,18 +47,18 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	// Set up transaction
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "error opening tx"))
+		glog.Fatal(fmt.Errorf("error opening tx: %w", err))
 	}
 	defer func() {
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				glog.Errorf("tx failed to rollback: %s", err)
+				glog.Errorf("tx failed to rollback: %s", rollbackErr)
 			}
 			glog.Fatal(err)
 		}
@@ -75,7 +74,7 @@ func main() {
 	glog.Infof("[RUN] %s", query)
 	_, err = tx.Exec(query)
 	if err != nil {
-		err = errors.Wrap(err, "failed to drop new table")
+		err = fmt.Errorf("failed to drop new table: %w", err)
 		return
 	}
 

--- a/orc8r/cloud/go/tools/migrations/sql_operations.go
+++ b/orc8r/cloud/go/tools/migrations/sql_operations.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 func GetTableName(networkId string, baseName string) string {
@@ -61,7 +60,7 @@ func GetAllValuesFromTable(tx *sql.Tx, table string) (map[string][]byte, error) 
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 	return ret, nil
 }
@@ -93,7 +92,7 @@ func GetAllKeysFromTable(tx *sql.Tx, table string) ([]string, error) {
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "sql rows err")
+		return nil, fmt.Errorf("sql rows err: %w", err)
 	}
 
 	sort.Strings(ret)

--- a/orc8r/cloud/go/tools/swaggergen/combine_swagger/generate/generate.go
+++ b/orc8r/cloud/go/tools/swaggergen/combine_swagger/generate/generate.go
@@ -14,11 +14,10 @@
 package generate
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/obsidian/swagger/spec"
 	"magma/orc8r/cloud/go/tools/swaggergen/swaggergen/generate"
@@ -50,7 +49,7 @@ func GenerateStandaloneSpecs(specDir string, rootDir string) error {
 func GenerateSpec(targetFilepath string, specs map[string]generate.MagmaSwaggerSpec, outPath string) error {
 	absTargetFilepath, err := filepath.Abs(targetFilepath)
 	if err != nil {
-		return errors.Wrapf(err, "target filepath %s is invalid", targetFilepath)
+		return fmt.Errorf("target filepath %s is invalid: %w", targetFilepath, err)
 	}
 
 	var yamlSpecs []string

--- a/orc8r/cloud/test/go.mod
+++ b/orc8r/cloud/test/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/go-openapi/runtime v0.21.1
 	github.com/go-openapi/swag v0.19.15
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/orc8r/cloud/test/go.sum
+++ b/orc8r/cloud/test/go.sum
@@ -394,7 +394,6 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/orc8r/cloud/test/testlib/cluster.go
+++ b/orc8r/cloud/test/testlib/cluster.go
@@ -18,14 +18,12 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/pkg/errors"
-
 	"magma/orc8r/cloud/go/parallel"
 )
 
 var clusterConfig = flag.String("cluster-config", "", "Location of the cluster config file")
 
-//Gateway gateway specific configuration of the cluster
+// Gateway gateway specific configuration of the cluster
 type Gateway struct {
 	ID         string `json:"gateway_id"`
 	HardwareID string `json:"hardware_id"`
@@ -42,12 +40,12 @@ func (g Gateways) Hostnames() []string {
 	return hh
 }
 
-//ClusterInternalConfig cluster's internal configuration
+// ClusterInternalConfig cluster's internal configuration
 type ClusterInternalConfig struct {
 	BastionIP string `json:"bastion_ip"`
 }
 
-//Cluster configuration of the cluster
+// Cluster configuration of the cluster
 type Cluster struct {
 	UUID           string                 `json:"uuid"`
 	ClusterType    int                    `json:"cluster_type"`
@@ -61,7 +59,7 @@ func (c *Cluster) RunCmdOnGateways(cmd string) ([]string, error) {
 		hostname := in.(string)
 		out, err := runRemoteCommand(hostname, c.InternalConfig.BastionIP, []string{cmd})
 		if err != nil {
-			return nil, errors.Wrapf(err, "run remote commands on gateway '%s'; out: %+v", hostname, out)
+			return nil, fmt.Errorf("run remote commands on gateway '%s'; out: %+v: %w", hostname, out, err)
 		}
 		return out, nil
 	})

--- a/orc8r/cloud/test/testlib/ssh.go
+++ b/orc8r/cloud/test/testlib/ssh.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -48,19 +47,19 @@ func runRemoteCommand(hostname string, bastionIP string, cmds []string) ([]strin
 	}
 	bastionConn, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", bastionIP, *sshPort), sshConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "connect to bastion host")
+		return nil, fmt.Errorf("connect to bastion host: %w", err)
 	}
 	defer bastionConn.Close()
 
 	tunnelConn, err := bastionConn.Dial("tcp", fmt.Sprintf("%s:%d", hostname, *sshPort))
 	if err != nil {
-		return nil, errors.Wrap(err, "connect to host through tunnel")
+		return nil, fmt.Errorf("connect to host through tunnel: %w", err)
 	}
 	defer tunnelConn.Close()
 
 	newClientConn, channels, sshRequest, err := ssh.NewClientConn(tunnelConn, hostname, sshConfig)
 	if err != nil {
-		return nil, errors.Wrapf(err, "establish ssh client connection to '%s'", hostname)
+		return nil, fmt.Errorf("establish ssh client connection to '%s': %w", hostname, err)
 	}
 	defer newClientConn.Close()
 

--- a/orc8r/gateway/go/go.mod
+++ b/orc8r/gateway/go/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.19.0 // indirect
-	github.com/pkg/errors v0.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/prometheus/common v0.2.0 // indirect

--- a/orc8r/gateway/go/go.sum
+++ b/orc8r/gateway/go/go.sum
@@ -104,7 +104,6 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/orc8r/lib/go/definitions/env.go
+++ b/orc8r/lib/go/definitions/env.go
@@ -14,9 +14,8 @@ limitations under the License.
 package definitions
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 // GetEnvWithDefault returns the string value of the environment variable,
@@ -34,7 +33,7 @@ func GetEnvWithDefault(variable string, defaultValue string) string {
 func MustGetEnv(variable string) string {
 	value := os.Getenv(variable)
 	if len(value) == 0 {
-		panic(errors.Errorf("%s env not found", variable))
+		panic(fmt.Errorf("%s env not found", variable))
 	}
 	return value
 }

--- a/orc8r/lib/go/go.mod
+++ b/orc8r/lib/go/go.mod
@@ -7,7 +7,6 @@ replace magma/orc8r/lib/go/protos => ./protos
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.2
-	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/client_model v0.2.0
 	github.com/stretchr/testify v1.7.0

--- a/orc8r/lib/go/go.sum
+++ b/orc8r/lib/go/go.sum
@@ -61,7 +61,6 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/orc8r/lib/go/registry/service_registry.go
+++ b/orc8r/lib/go/registry/service_registry.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/lib/go/service/config"
 )
@@ -70,7 +69,7 @@ func LoadServiceRegistryConfigs() ([]ServiceLocation, error) {
 		}
 		locations, err := convertToServiceLocations(rawMap)
 		if err != nil {
-			return nil, errors.Wrapf(err, "load service registry for %s:%s.yml", module, serviceRegistryFilename)
+			return nil, fmt.Errorf("load service registry for %s:%s.yml: %w", module, serviceRegistryFilename, err)
 		}
 		ret = append(ret, locations...)
 	}

--- a/orc8r/lib/go/service/config/service_config.go
+++ b/orc8r/lib/go/service/config/service_config.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
 	_ "magma/orc8r/lib/go/initflag"
@@ -60,7 +59,7 @@ func GetServiceConfigs(serviceName string) (map[string]*Map, error) {
 	for _, moduleName := range modules {
 		cfg, err := GetServiceConfig(moduleName, serviceName)
 		if err != nil {
-			return nil, errors.Wrapf(err, "get service config for %v.%v", moduleName, serviceName)
+			return nil, fmt.Errorf("get service config for %v.%v: %w", moduleName, serviceName, err)
 		}
 		ret[moduleName] = cfg
 	}
@@ -206,7 +205,7 @@ func updateMap(baseMap, overrides *Map) *Map {
 func getModules() ([]string, error) {
 	moduleFiles, err := ioutil.ReadDir(configDir)
 	if err != nil {
-		return nil, errors.Wrap(err, "read modules from config directory")
+		return nil, fmt.Errorf("read modules from config directory: %w", err)
 	}
 	var modules []string
 	for _, m := range moduleFiles {

--- a/orc8r/lib/go/service/service.go
+++ b/orc8r/lib/go/service/service.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 
@@ -145,7 +144,7 @@ func (service *Service) Run() error {
 	service.State = protos.ServiceInfo_ALIVE
 	service.Health = protos.ServiceInfo_APP_HEALTHY
 	if err != nil || perr != nil {
-		return errors.Errorf("error running grpc server: %v; error running proteced grpc server: %v", err, perr)
+		return fmt.Errorf("error running grpc server: %v; error running proteced grpc server: %v", err, perr)
 	} else {
 		return nil
 	}


### PR DESCRIPTION
Replace functions from the github.com/pgk/errors package with
`fmt.Errorf`. Created in pairing with Moritz Huebner.

Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>


## Summary

This PR implements the proposed solutions of ticket #12632 for the orc8r module.

A few instances of broken rollback error handling next to the changes
in this PR are also fixed.

## Test Plan

Perform Unit tests

## Additional Information

Worked in pairing with @MoritzThomasHuebner 

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
