### PR TITLE
refactor(cwg): replace deprecated errors module

### DIFF
--- a/cwf/cloud/go/go.mod
+++ b/cwf/cloud/go/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.2
 	github.com/labstack/echo v3.3.10+incompatible
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.7.1
@@ -82,6 +81,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olivere/elastic/v7 v7.0.6 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect

--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/cwf/cloud/go/cwf"
 	"magma/cwf/cloud/go/serdes"
@@ -151,7 +150,7 @@ func getGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load cwf gateway"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load cwf gateway: %w", err))
 	}
 
 	ret := &cwfModels.CwfGateway{
@@ -417,7 +416,7 @@ func updateHAPairHandler(c echo.Context) error {
 	// 404 if pair doesn't exist
 	exists, err := configurator.DoesEntityExist(reqCtx, networkID, cwf.CwfHAPairType, haPairID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to check if ha pair exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to check if ha pair exists: %w", err))
 	}
 	if !exists {
 		return echo.ErrNotFound

--- a/cwf/cloud/go/services/cwf/obsidian/models/validate.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/validate.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/pkg/errors"
 )
 
 func (m *CwfNetwork) ValidateModel(context.Context) error {
@@ -45,7 +44,7 @@ func (m *GatewayCwfConfigs) ValidateModel(context.Context) error {
 	for _, peer := range m.AllowedGrePeers {
 		for _, key := range set[peer.IP] {
 			if swag.Uint32Value(peer.Key) == key {
-				return errors.New(fmt.Sprintf("Found duplicate peer %s with key %d", peer.IP, key))
+				return fmt.Errorf("Found duplicate peer %s with key %d", peer.IP, key)
 			}
 		}
 		set[peer.IP] = append(set[peer.IP], swag.Uint32Value(peer.Key))

--- a/cwf/cloud/go/services/cwf/servicers/protected/builder_servicer.go
+++ b/cwf/cloud/go/services/cwf/servicers/protected/builder_servicer.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/cwf/cloud/go/cwf"
 	cwf_mconfig "magma/cwf/cloud/go/protos/mconfig"
@@ -90,7 +89,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 	}
 	vals, err := buildFromConfigs(nwConfig, gwConfig.Config.(*models.GatewayCwfConfigs), haPairConfigs)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	ret.ConfigsByKey, err = mconfig.MarshalConfigs(vals)
 	if err != nil {

--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -36,8 +36,8 @@ require (
 	github.com/go-redis/redis v6.15.5+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.2
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/magma/milenage v1.0.2
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/shirou/gopsutil/v3 v3.21.5
 	github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c
@@ -86,7 +86,6 @@ require (
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -109,6 +108,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olivere/elastic/v7 v7.0.6 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect

--- a/cwf/gateway/integ_tests/service_wrappers.go
+++ b/cwf/gateway/integ_tests/service_wrappers.go
@@ -15,6 +15,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"magma/cwf/gateway/registry"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/go-redis/redis"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/magma/milenage"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"fbc/lib/go/radius"
@@ -162,7 +161,7 @@ func (tr *TestRunner) ConfigUEsPerInstance(IMSIs []string, pcrfInstance, ocsInst
 	for _, imsi := range IMSIs {
 		// If IMSIs were generated properly they should never give an error here
 		if _, present := tr.imsis[imsi]; present {
-			return nil, errors.Errorf("IMSI %s already exist in database, use generateRandomIMSIS(num, tr.imsis) to create unique list", imsi)
+			return nil, fmt.Errorf("IMSI %s already exist in database, use generateRandomIMSIS(num, tr.imsis) to create unique list", imsi)
 		}
 		key, opc, err := getRandKeyOpcFromOp([]byte(Op))
 		if err != nil {

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -175,19 +175,19 @@ func (tr *TestRunner) ConfigUEsPerInstance(IMSIs []string, pcrfInstance, ocsInst
 
 		err = uesim.AddUE(ue)
 		if err != nil {
-			return nil, errors.Wrap(err, "Error adding UE to UESimServer")
+			return nil, fmt.Errorf("Error adding UE to UESimServer: %w", err)
 		}
 		err = addSubscriberToHSS(sub)
 		if err != nil {
-			return nil, errors.Wrap(err, "Error adding Subscriber to HSS")
+			return nil, fmt.Errorf("Error adding Subscriber to HSS: %w", err)
 		}
 		err = addSubscriberToPCRFPerInstance(pcrfInstance, sub.GetSid())
 		if err != nil {
-			return nil, errors.Wrap(err, "Error adding Subscriber to PCRF")
+			return nil, fmt.Errorf("Error adding Subscriber to PCRF: %w", err)
 		}
 		err = addSubscriberToOCSPerInstance(ocsInstance, sub.GetSid())
 		if err != nil {
-			return nil, errors.Wrap(err, "Error adding Subscriber to OCS")
+			return nil, fmt.Errorf("Error adding Subscriber to OCS: %w", err)
 		}
 
 		ues = append(ues, ue)
@@ -211,7 +211,7 @@ func (tr *TestRunner) Authenticate(imsi, calledStationID string) (*radius.Packet
 	encoded := res.GetRadiusPacket()
 	radiusP, err := radius.Parse(encoded, []byte(Secret))
 	if err != nil {
-		err = errors.Wrap(err, "Error while parsing encoded Radius packet")
+		err = fmt.Errorf("Error while parsing encoded Radius packet: %w", err)
 		fmt.Println(err)
 		return &radius.Packet{}, err
 	}
@@ -230,7 +230,7 @@ func (tr *TestRunner) Disconnect(imsi, calledStationID string) (*radius.Packet, 
 	encoded := res.GetRadiusPacket()
 	radiusP, err := radius.Parse(encoded, []byte(Secret))
 	if err != nil {
-		err = errors.Wrap(err, "Error while parsing encoded Radius packet")
+		err = fmt.Errorf("Error while parsing encoded Radius packet: %w", err)
 		fmt.Println(err)
 		return &radius.Packet{}, err
 	}

--- a/cwf/gateway/services/uesim/servicers/config.go
+++ b/cwf/gateway/services/uesim/servicers/config.go
@@ -15,13 +15,13 @@ package servicers
 
 import (
 	"encoding/hex"
+	"fmt"
 	"net"
 
 	"magma/cwf/gateway/registry"
 	"magma/orc8r/lib/go/service/config"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -41,7 +41,7 @@ var (
 func GetUESimConfig() (*UESimConfig, error) {
 	uecfg, err := config.GetServiceConfig("", registry.UeSim)
 	if err != nil {
-		glog.Error(errors.Wrap(err, "No service config found, using default config"))
+		glog.Error(fmt.Errorf("No service config found, using default config: %w", err))
 		return getDefaultUESimConfig(), nil
 	}
 	authAddr, err := uecfg.GetString("radius_auth_address")

--- a/cwf/gateway/services/uesim/servicers/eap.go
+++ b/cwf/gateway/services/uesim/servicers/eap.go
@@ -14,6 +14,8 @@
 package servicers
 
 import (
+	"fmt"
+
 	cwfprotos "magma/cwf/cloud/go/protos"
 	fegprotos "magma/feg/gateway/services/aaa/protos"
 	"magma/feg/gateway/services/eap"
@@ -30,7 +32,7 @@ const (
 func (srv *UESimServer) HandleEap(ue *cwfprotos.UEConfig, req eap.Packet) (eap.Packet, error) {
 	err := req.Validate()
 	if err != nil {
-		return nil, errors.Wrap(err, "Error validating EAP packet")
+		return nil, fmt.Errorf("Error validating EAP packet: %w", err)
 	}
 
 	switch fegprotos.EapType(req.Type()) {

--- a/cwf/gateway/services/uesim/servicers/eap.go
+++ b/cwf/gateway/services/uesim/servicers/eap.go
@@ -19,8 +19,6 @@ import (
 	cwfprotos "magma/cwf/cloud/go/protos"
 	fegprotos "magma/feg/gateway/services/aaa/protos"
 	"magma/feg/gateway/services/eap"
-
-	"github.com/pkg/errors"
 )
 
 // todo Replace constants with configurable fields
@@ -41,7 +39,7 @@ func (srv *UESimServer) HandleEap(ue *cwfprotos.UEConfig, req eap.Packet) (eap.P
 	case fegprotos.EapType_AKA:
 		return srv.handleEapAka(ue, req)
 	}
-	return nil, errors.Errorf("Unsupported Eap Type: %d", req[eap.EapMsgMethodType])
+	return nil, fmt.Errorf("Unsupported Eap Type: %d", req[eap.EapMsgMethodType])
 }
 
 func (srv *UESimServer) eapIdentityRequest(ue *cwfprotos.UEConfig, req eap.Packet) (res eap.Packet, err error) {

--- a/cwf/gateway/services/uesim/servicers/eap_aka.go
+++ b/cwf/gateway/services/uesim/servicers/eap_aka.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/magma/milenage"
-	"github.com/pkg/errors"
 
 	"magma/cwf/cloud/go/protos"
 	"magma/feg/gateway/services/eap"
@@ -54,7 +53,7 @@ func (srv *UESimServer) handleEapAka(ue *protos.UEConfig, req eap.Packet) (eap.P
 	case aka.SubtypeChallenge:
 		return srv.eapAkaChallengeRequest(ue, req)
 	default:
-		return nil, errors.Errorf("Unsupported Subtype: %d", req[eap.EapSubtype])
+		return nil, fmt.Errorf("Unsupported Subtype: %d", req[eap.EapSubtype])
 	}
 }
 
@@ -113,7 +112,7 @@ func (srv *UESimServer) eapAkaChallengeRequest(ue *protos.UEConfig, req eap.Pack
 		return nil, fmt.Errorf("Error while parsing attributes of request packet: %w", err)
 	}
 	if attrs.rand == nil || attrs.autn == nil || attrs.mac == nil {
-		return nil, errors.Errorf("Missing one or more expected attributes\nRAND: %s\nAUTN: %s\nMAC: %s\n", attrs.rand, attrs.autn, attrs.mac)
+		return nil, fmt.Errorf("Missing one or more expected attributes\nRAND: %s\nAUTN: %s\nMAC: %s\n", attrs.rand, attrs.autn, attrs.mac)
 	}
 
 	// Parse out RAND, expected AUTN, and expected MAC values.

--- a/cwf/gateway/services/uesim/servicers/radius.go
+++ b/cwf/gateway/services/uesim/servicers/radius.go
@@ -25,8 +25,6 @@ import (
 	"fbc/lib/go/radius/rfc2866"
 	"fbc/lib/go/radius/rfc2869"
 	"magma/feg/gateway/services/eap"
-
-	"github.com/pkg/errors"
 )
 
 // todo Replace constants with configurable fields
@@ -41,12 +39,12 @@ func (srv *UESimServer) HandleRadius(imsi string, calledStationID string, p *rad
 	// Extract EAP packet.
 	eapMessage, err := packet.NewPacketFromRadius(p)
 	if err != nil {
-		err = errors.Wrap(err, "Error extracting EAP message from Radius packet")
+		err = fmt.Errorf("Error extracting EAP message from Radius packet: %w", err)
 		return nil, err
 	}
 	eapBytes, err := eapMessage.Bytes()
 	if err != nil {
-		err = errors.Wrap(err, "Error converting EAP packet to bytes")
+		err = fmt.Errorf("Error converting EAP packet to bytes: %w", err)
 		return nil, err
 	}
 
@@ -97,7 +95,7 @@ func (srv *UESimServer) EapToRadius(eapP eap.Packet, imsi string, calledStationI
 
 	encoded, err := radiusP.Encode()
 	if err != nil {
-		return nil, errors.Wrap(err, "Error encoding Radius packet")
+		return nil, fmt.Errorf("Error encoding Radius packet: %w", err)
 	}
 
 	// Add Message-Authenticator Attribute.

--- a/cwf/gateway/services/uesim/servicers/ue_store_utils.go
+++ b/cwf/gateway/services/uesim/servicers/ue_store_utils.go
@@ -14,18 +14,18 @@
 package servicers
 
 import (
+	"fmt"
+
 	cwfprotos "magma/cwf/cloud/go/protos"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/lib/go/protos"
-
-	"github.com/pkg/errors"
 )
 
 func addUeToStore(srvstore blobstore.StoreFactory, ue *cwfprotos.UEConfig) {
 	blob, err := ueToBlob(ue)
 	store, err := srvstore.StartTransaction(nil)
 	if err != nil {
-		err = errors.Wrap(err, "Error while starting transaction")
+		err = fmt.Errorf("Error while starting transaction: %w", err)
 		err = ConvertStorageErrorToGrpcStatus(err)
 		return
 	}
@@ -33,12 +33,12 @@ func addUeToStore(srvstore blobstore.StoreFactory, ue *cwfprotos.UEConfig) {
 		switch err {
 		case nil:
 			if commitErr := store.Commit(); commitErr != nil {
-				err = errors.Wrap(err, "Error while committing transaction")
+				err = fmt.Errorf("Error while committing transaction: %w", err)
 				err = ConvertStorageErrorToGrpcStatus(err)
 			}
 		default:
 			if rollbackErr := store.Rollback(); rollbackErr != nil {
-				err = errors.Wrap(err, "Error while rolling back transaction")
+				err = fmt.Errorf("Error while rolling back transaction: %w", err)
 				err = ConvertStorageErrorToGrpcStatus(err)
 			}
 		}

--- a/cwf/gateway/services/uesim/servicers/uesim.go
+++ b/cwf/gateway/services/uesim/servicers/uesim.go
@@ -31,7 +31,6 @@ import (
 	"magma/orc8r/lib/go/protos"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -188,7 +187,7 @@ func (srv *UESimServer) Authenticate(ctx context.Context, id *cwfprotos.Authenti
 
 	resultBytes, err := result.Encode()
 	if err != nil {
-		return &cwfprotos.AuthenticateResponse{}, errors.Wrap(err, "Error encoding Radius packet")
+		return &cwfprotos.AuthenticateResponse{}, fmt.Errorf("Error encoding Radius packet: %w", err)
 	}
 	radiusPacket := &cwfprotos.AuthenticateResponse{RadiusPacket: resultBytes}
 
@@ -198,15 +197,15 @@ func (srv *UESimServer) Authenticate(ctx context.Context, id *cwfprotos.Authenti
 func (srv *UESimServer) Disconnect(ctx context.Context, id *cwfprotos.DisconnectRequest) (*cwfprotos.DisconnectResponse, error) {
 	radiusP, err := srv.MakeAccountingStopRequest(id.GetCalledStationID())
 	if err != nil {
-		return nil, errors.Wrap(err, "Error making Accounting Stop Radius message")
+		return nil, fmt.Errorf("Error making Accounting Stop Radius message: %w", err)
 	}
 	response, err := radius.Exchange(context.Background(), radiusP, srv.cfg.radiusAcctAddress)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error exchanging Radius message")
+		return nil, fmt.Errorf("Error exchanging Radius message: %w", err)
 	}
 	encoded, err := response.Encode()
 	if err != nil {
-		return nil, errors.Wrap(err, "Error encoding Radius packet")
+		return nil, fmt.Errorf("Error encoding Radius packet: %w", err)
 	}
 	return &cwfprotos.DisconnectResponse{RadiusPacket: encoded}, nil
 }
@@ -263,14 +262,14 @@ func blobToUE(blob blobstore.Blob) (*cwfprotos.UEConfig, error) {
 func getUE(blobStoreFactory blobstore.StoreFactory, imsi string) (ue *cwfprotos.UEConfig, err error) {
 	store, err := blobStoreFactory.StartTransaction(nil)
 	if err != nil {
-		err = errors.Wrap(err, "Error while starting transaction")
+		err = fmt.Errorf("Error while starting transaction: %w", err)
 		return
 	}
 	defer func() {
 		switch err {
 		case nil:
 			if commitErr := store.Commit(); commitErr != nil {
-				err = errors.Wrap(err, "Error while committing transaction")
+				err = fmt.Errorf("Error while committing transaction: %w", err)
 			}
 		default:
 			if rollbackErr := store.Rollback(); rollbackErr != nil {
@@ -281,7 +280,7 @@ func getUE(blobStoreFactory blobstore.StoreFactory, imsi string) (ue *cwfprotos.
 
 	blob, err := store.Get(networkIDPlaceholder, storage.TK{Type: blobTypePlaceholder, Key: imsi})
 	if err != nil {
-		err = errors.Wrap(err, "Error getting UE with specified IMSI")
+		err = fmt.Errorf("Error getting UE with specified IMSI: %w", err)
 		return
 	}
 	ue, err = blobToUE(blob)
@@ -397,9 +396,9 @@ func executeCommand(command string, argList []string) (*IperfResponse, error) {
 	rawOutput, err := cmd.Output()
 	output, _ := (&IperfResponse{}).FromBytes(rawOutput)
 	if err != nil {
-		newError := errors.Wrap(err, fmt.Sprintf(
+		newError := fmt.Errorf(fmt.Sprintf(
 			"error while executing \"%s %s\"\n output:\n%v",
-			command, strings.Join(argList, " "), string(rawOutput)))
+			command, strings.Join(argList, " "), string(rawOutput))+": %w", err)
 		glog.Error(newError)
 		return output, newError
 	}


### PR DESCRIPTION
Fixes #12632 for description

## Summary

Remove dependency on "github.com/pkg/errors"

- Replace use of `errors.Wrap[f]` with `fmt.Errorf`
- Replace use of pkg `errors.New` with standard lib `errors.New`
- Update go.mod files
- Replace use of `errors.New(fmt.Sprintf(...))` with `fmt.Errorf`
- The error handling in `addToStore` in `ue_store_utils.go` and in `getUE` in `uesim.go` was incorrect.
  - In these database transactions `commitErr` and `rollbackErr` were not logged.
  - We restructured the switch/case logic to if/else
  - In the else bracket  (`err != nil`), we now use a `multierror` to propagate both `err` and `rollbackErr`. The logic here is that the rollback should only be triggered if an error happened before, so both errors should be logged.
## Test Plan

Run unit tests

## Additional Information

Worked in pairing with @wolfseb 

- [ ] This change is backwards-breaking