### PR TITLE
refactor(feg): replace deprecated errors module

### DIFF
--- a/feg/cloud/go/go.mod
+++ b/feg/cloud/go/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/magma/augmented-networks/accounting/protos v0.1.1
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/stretchr/testify v1.7.1
 	google.golang.org/grpc v1.43.0
@@ -81,6 +80,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olivere/elastic/v7 v7.0.6 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.9.1 // indirect

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/feg/cloud/go/feg"
 	"magma/feg/cloud/go/serdes"
@@ -128,7 +127,7 @@ func getGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load federation gateway"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load federation gateway: %w", err))
 	}
 
 	ret := &fegModels.FederationGateway{

--- a/feg/cloud/go/services/feg/obsidian/models/validate.go
+++ b/feg/cloud/go/services/feg/obsidian/models/validate.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/services/configurator"
 )
@@ -32,10 +31,10 @@ func (m FegNetworkID) ValidateModel(ctx context.Context) error {
 	if !swag.IsZero(m) {
 		exists, err := configurator.DoesNetworkExist(ctx, string(m))
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Failed to search for network %s", string(m)))
+			return fmt.Errorf("Failed to search for network %s: %w", string(m), err)
 		}
 		if !exists {
-			return errors.New(fmt.Sprintf("Network: %s does not exist", string(m)))
+			return fmt.Errorf("Network: %s does not exist", string(m))
 		}
 	}
 	return nil
@@ -49,7 +48,7 @@ func (m *FederatedNetworkConfigs) ValidateModel(ctx context.Context) error {
 	if !swag.IsZero(nid) {
 		exists, err := configurator.DoesNetworkExist(ctx, nid)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Failed to search for network %s", nid))
+			return fmt.Errorf("Failed to search for network %s: %w", nid, err)
 		}
 		if !exists {
 			return fmt.Errorf("Network: %s does not exist", nid)

--- a/feg/cloud/go/services/feg/servicers/protected/builder_servicer.go
+++ b/feg/cloud/go/services/feg/servicers/protected/builder_servicer.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/feg/cloud/go/feg"
 	feg_mconfig "magma/feg/cloud/go/protos/mconfig"
@@ -175,7 +174,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 func getFegConfig(gatewayID string, network configurator.Network, graph configurator.EntityGraph) (*models.GatewayFederationConfigs, error) {
 	fegGW, err := graph.GetEntity(feg.FegGatewayType, gatewayID)
 	if err != nil && err != merrors.ErrNotFound {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	// err can only be merrors.ErrNotFound at this point - if it's nil, we'll
 	// just return the feg gateway config if it exists

--- a/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
+++ b/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 
 	"magma/feg/cloud/go/feg"
@@ -93,7 +92,7 @@ func getFegCfg(ctx context.Context, networkID, gatewayID string) (*models.Gatewa
 		serdes.Entity,
 	)
 	if err != nil && err != merrors.ErrNotFound {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	if err == nil && fegGateway.Config != nil {
 		return fegGateway.Config.(*models.GatewayFederationConfigs), nil

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/magma/milenage v1.0.2
 	github.com/mennanov/fieldmask-utils v0.5.0
 	github.com/ory/go-acc v0.2.8
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0
@@ -122,6 +121,7 @@ require (
 	github.com/ory/viper v1.7.5 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/spf13/afero v1.8.0 // indirect

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cb.go
@@ -14,10 +14,10 @@ limitations under the License.
 package mock_pgw
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	"github.com/wmnsk/go-gtp/gtpv2"
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 	"github.com/wmnsk/go-gtp/gtpv2/message"
@@ -52,7 +52,7 @@ func (mPgw *MockPgw) CreateBearerRequest(req CreateBearerRequest) (chan CBReq, e
 
 	sgwTeidC, err := session.GetTEID(gtpv2.IFTypeS5S8SGWGTPC)
 	if err != nil {
-		err = errors.Wrap(err, "Error, couldnt find teid con Create Bearer Request")
+		err = fmt.Errorf("Error, couldnt find teid con Create Bearer Request: %w", err)
 		return nil, err
 	}
 

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/cs.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/wmnsk/go-gtp/gtpv2"
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 	"github.com/wmnsk/go-gtp/gtpv2/message"
@@ -50,7 +49,7 @@ func (mPgw *MockPgw) getHandleCreateSessionRequest() gtpv2.HandlerFunc {
 				case *gtpv2.UnknownIMSIError:
 					// whole new session. just ignore.
 				default:
-					return errors.Wrap(err2, "got something unexpected")
+					return fmt.Errorf("got something unexpected: %w", err2)
 				}
 			} else {
 				fmt.Printf("Existing IMSI during Create Session Request on PGW (%s). Deleting previous session\n", imsi)
@@ -409,7 +408,7 @@ func (mPgw *MockPgw) getHandleCreateSessionResponseWithMissingIE() gtpv2.Handler
 		csRspFromPGW := message.NewCreateSessionResponse(
 			sgwTEID.MustTEID(), msg.Sequence(),
 			ie.NewCause(gtpv2.CauseRequestAccepted, 0, 0, 0, nil),
-			//pgwFTEIDc,
+			// pgwFTEIDc,
 			ie.NewPDNAddressAllocation("10.1.2.3"),
 			ie.NewAPNRestriction(gtpv2.APNRestrictionPublic2),
 			ie.NewBearerContext(

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/db.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/db.go
@@ -14,10 +14,10 @@ limitations under the License.
 package mock_pgw
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	"github.com/wmnsk/go-gtp/gtpv2"
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 	"github.com/wmnsk/go-gtp/gtpv2/message"
@@ -41,7 +41,7 @@ func (mPgw *MockPgw) DeleteBearerRequest(req DeleteBearerRequest) (chan DBReq, e
 
 	sgwTeidC, err := session.GetTEID(gtpv2.IFTypeS5S8SGWGTPC)
 	if err != nil {
-		err = errors.Wrap(err, "Error, couldnt find teid on Dedicated Bearer Request")
+		err = fmt.Errorf("Error, couldnt find teid on Dedicated Bearer Request: %w", err)
 		return nil, err
 	}
 

--- a/feg/gateway/services/s8_proxy/servicers/mock_pgw/ds.go
+++ b/feg/gateway/services/s8_proxy/servicers/mock_pgw/ds.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	"github.com/wmnsk/go-gtp/gtpv2"
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 	"github.com/wmnsk/go-gtp/gtpv2/message"
@@ -42,7 +41,7 @@ func (mPgw *MockPgw) getHandleDeleteSessionRequest() gtpv2.HandlerFunc {
 		// get TEUD
 		sgwTeidC, err := session.GetTEID(gtpv2.IFTypeS5S8SGWGTPC)
 		if err != nil {
-			err = errors.Wrap(err, "Error")
+			err = fmt.Errorf("Error: %w", err)
 			return err
 		}
 

--- a/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
@@ -15,6 +15,7 @@ package mock_ocs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -25,7 +26,6 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/sm"
 	"github.com/fiorix/go-diameter/v4/diam/sm/smpeer"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
@@ -335,7 +335,7 @@ func (srv *OCSDiamServer) AbortSession(
 	srv.mux.Handle(diam.ASA, asaHandler)
 	err := sendASR(account.CurrentState, srv.mux.Settings())
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to send Gy ASR")
+		return nil, fmt.Errorf("Failed to send Gy ASR: %w", err)
 	}
 	select {
 	case asa := <-resp:

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
@@ -15,6 +15,7 @@ package mock_pcrf
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -25,7 +26,6 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/sm"
 	"github.com/fiorix/go-diameter/v4/diam/sm/smpeer"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
@@ -292,7 +292,7 @@ func (srv *PCRFServer) AbortSession(
 	srv.mux.Handle(diam.ASA, asaHandler)
 	err := sendASR(account.CurrentState, srv.mux.Settings())
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to send Gx ASR")
+		return nil, fmt.Errorf("Failed to send Gx ASR: %w", err)
 	}
 	select {
 	case asa := <-resp:

--- a/feg/radius/lib/go/http/auth/mac.go
+++ b/feg/radius/lib/go/http/auth/mac.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -29,8 +30,6 @@ import (
 	"time"
 
 	"fbc/lib/go/http/httputil"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -142,10 +141,10 @@ func (m *MACMiddleware) verify(r *http.Request) error {
 	}
 	n, err := strconv.ParseInt(ts, 10, 64)
 	if err != nil {
-		return errors.Wrapf(err, "parse timestamp: %v", ts)
+		return fmt.Errorf("parse timestamp: %v: %w", ts, err)
 	}
 	if ts := time.Unix(n, 0); abs(time.Since(ts)) > m.TimeSkew {
-		return errors.Errorf("stable timestamp: %v", ts)
+		return fmt.Errorf("stable timestamp: %v", ts)
 	}
 	h := m.Hash.New()
 	if err := hashRequest(h, r, ts); err != nil {
@@ -153,11 +152,11 @@ func (m *MACMiddleware) verify(r *http.Request) error {
 	}
 	pk, err := m.KeyGetter()
 	if err != nil {
-		return errors.Wrap(err, "failed to get public key")
+		return fmt.Errorf("failed to get public key: %w", err)
 	}
 	sig, err := base64.StdEncoding.DecodeString(sg)
 	if err != nil {
-		return errors.Wrap(err, "failed to decode signature header")
+		return fmt.Errorf("failed to decode signature header: %w", err)
 	}
 	if err := rsa.VerifyPKCS1v15(pk, m.Hash, h.Sum(nil), sig); err != nil {
 		return errors.New("unauthorized")
@@ -198,12 +197,12 @@ func hashRequest(h hash.Hash, r *http.Request, ts string) error {
 	b.WriteString(r.URL.RequestURI())
 	b.WriteString(ts)
 	if _, err := io.Copy(h, b); err != nil {
-		return errors.Wrap(err, "failed to copy request info")
+		return fmt.Errorf("failed to copy request info: %w", err)
 	}
 	if r.Body != nil {
 		b.Reset()
 		if _, err := io.Copy(io.MultiWriter(h, b), r.Body); err != nil {
-			return errors.Wrap(err, "failed to copy request body")
+			return fmt.Errorf("failed to copy request body: %w", err)
 		}
 		r.Body = ioutil.NopCloser(b)
 	}

--- a/feg/radius/lib/go/http/go.mod
+++ b/feg/radius/lib/go/http/go.mod
@@ -11,7 +11,6 @@ require (
 	fbc/lib/go/log v0.0.0
 	github.com/google/uuid v1.1.1
 	github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	go.opencensus.io v0.21.0
 	go.uber.org/multierr v1.1.0

--- a/feg/radius/lib/go/http/go.sum
+++ b/feg/radius/lib/go/http/go.sum
@@ -17,7 +17,6 @@ github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4 h1:xKkUL6QBojw
 github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da h1:5y58+OCjoHCYB8182mpf/dEsq0vwTKPOo4zGfH0xW9A=
 github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da/go.mod h1:oLH0CmIaxCGXD67VKGR5AacGXZSMznlmeqM8RzPrcY8=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/feg/radius/lib/go/http/server/config.go
+++ b/feg/radius/lib/go/http/server/config.go
@@ -14,9 +14,9 @@ limitations under the License.
 package server
 
 import (
+	"fmt"
 	"io"
 	"net/http"
-
 	// register pprof with default http mux
 	_ "net/http/pprof"
 
@@ -24,7 +24,6 @@ import (
 	"fbc/lib/go/log"
 
 	"github.com/justinas/alice"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -78,11 +77,11 @@ func (config *Config) createLogger() (*zap.Logger, error) {
 		}
 		logger, err = config.Build()
 	default:
-		err = errors.Errorf("unknown logger type: %q", lc.Type)
+		err = fmt.Errorf("unknown logger type: %q", lc.Type)
 	}
 
 	if err != nil {
-		return nil, errors.Wrap(err, "creating logger")
+		return nil, fmt.Errorf("creating logger: %w", err)
 	}
 
 	return logger.WithOptions(zap.AddStacktrace(zap.DPanicLevel)), nil

--- a/feg/radius/lib/go/http/server/server.go
+++ b/feg/radius/lib/go/http/server/server.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"net"
@@ -30,7 +31,6 @@ import (
 	"fbc/lib/go/log"
 
 	"github.com/justinas/alice"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
@@ -105,7 +105,7 @@ func New(config Config, options ...Option) (*Server, error) {
 	srv := &Server{Server: http.Server{Addr: config.Addr}}
 	err := srv.Apply(options[:idx]...)
 	if err != nil {
-		return nil, errors.Wrap(err, "applying early options")
+		return nil, fmt.Errorf("applying early options: %w", err)
 	}
 
 	if srv.Logger == nil {
@@ -119,7 +119,7 @@ func New(config Config, options ...Option) (*Server, error) {
 	srv.Mux, srv.Handler = config.createServeMux(srv.Logger)
 	err = srv.Apply(options[idx:]...)
 	if err != nil {
-		return nil, errors.Wrap(err, "applying late options")
+		return nil, fmt.Errorf("applying late options: %w", err)
 	}
 
 	return srv, nil

--- a/feg/radius/lib/go/libgraphql/client.go
+++ b/feg/radius/lib/go/libgraphql/client.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -85,7 +84,7 @@ func (c *Client) Do(op Op) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return errors.Errorf("libgraphql: invalid status code: %s", res.Status)
+		return fmt.Errorf("libgraphql: invalid status code: %s", res.Status)
 	}
 	if err := json.NewDecoder(res.Body).Decode(op); err != nil {
 		return err

--- a/feg/radius/lib/go/libgraphql/go.mod
+++ b/feg/radius/lib/go/libgraphql/go.mod
@@ -1,8 +1,5 @@
 module libgraphql
 
-require (
-	github.com/google/uuid v1.1.1
-	github.com/pkg/errors v0.8.1
-)
+require github.com/google/uuid v1.1.1
 
 go 1.18

--- a/feg/radius/lib/go/libgraphql/go.sum
+++ b/feg/radius/lib/go/libgraphql/go.sum
@@ -1,4 +1,2 @@
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/feg/radius/lib/go/log/config.go
+++ b/feg/radius/lib/go/log/config.go
@@ -14,7 +14,8 @@ limitations under the License.
 package log
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -40,18 +41,18 @@ func (cfg Config) Build() (Factory, error) {
 	case "json":
 		c = zap.NewProductionConfig()
 	default:
-		return nil, errors.Errorf("unsupported logging format: %q", cfg.Format)
+		return nil, fmt.Errorf("unsupported logging format: %q", cfg.Format)
 	}
 
 	var level zapcore.Level
 	if err := level.Set(cfg.Level); err != nil {
-		return nil, errors.Wrap(err, "setting log level")
+		return nil, fmt.Errorf("setting log level: %w", err)
 	}
 	c.Level = zap.NewAtomicLevelAt(level)
 
 	logger, err := c.Build(zap.AddStacktrace(zap.DPanicLevel))
 	if err != nil {
-		return nil, errors.Wrap(err, "creating logger")
+		return nil, fmt.Errorf("creating logger: %w", err)
 	}
 	return NewFactory(logger), nil
 }

--- a/feg/radius/lib/go/log/go.mod
+++ b/feg/radius/lib/go/log/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	go.opencensus.io v0.21.0
 	go.uber.org/zap v1.10.0
@@ -14,6 +13,7 @@ require (
 
 require (
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/feg/radius/lib/go/oc/exporters/ods.go
+++ b/feg/radius/lib/go/oc/exporters/ods.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -29,6 +28,7 @@ import (
 	"time"
 
 	"fbc/lib/go/oc"
+
 	"github.com/kelseyhightower/envconfig"
 	"go.opencensus.io/stats/view"
 )
@@ -114,13 +114,13 @@ func PostToODS(metricsData map[string]string, cfg Config) error {
 	}
 	req, err := http.NewRequest(http.MethodPost, cfg.GraphURL, strings.NewReader(urlValues.Encode()))
 	if err != nil {
-		return errors.WithMessage(err, "failed to create http post request")
+		return fmt.Errorf("failed to create http post request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := oc.DefaultClient.Do(req)
 
 	if err != nil {
-		return errors.WithMessage(err, "failed to post form")
+		return fmt.Errorf("failed to post form: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -139,7 +139,7 @@ func getURLValues(datapoints []Datapoint, cfg Config) (url.Values, error) {
 	urlValues := url.Values{}
 	datapointsJSON, err := json.Marshal(datapoints)
 	if err != nil {
-		return urlValues, errors.WithMessage(err, "error marshaling datapoints")
+		return urlValues, fmt.Errorf("error marshaling datapoints: %w", err)
 	}
 
 	urlValues.Add("access_token", cfg.Token)

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -17,7 +17,6 @@ require (
 	fbc/lib/go/oc/helpers v0.0.0
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
 	github.com/kelseyhightower/envconfig v1.3.0
-	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/stretchr/testify v1.3.0
 	go.opencensus.io v0.21.0

--- a/feg/radius/lib/go/oc/go.sum
+++ b/feg/radius/lib/go/oc/go.sum
@@ -72,7 +72,6 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/feg/radius/src/go.mod
+++ b/feg/radius/src/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/stretchr/testify v1.7.0
 	go.opencensus.io v0.21.0

--- a/feg/radius/src/modules/analytics/graphql/client.go
+++ b/feg/radius/src/modules/analytics/graphql/client.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -85,7 +84,7 @@ func (c *Client) Do(op Op) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return errors.Errorf("libgraphql: invalid status code: %s", res.Status)
+		return fmt.Errorf("libgraphql: invalid status code: %s", res.Status)
 	}
 	if err := json.NewDecoder(res.Body).Decode(op); err != nil {
 		return err

--- a/feg/radius/src/modules/coafixedip/coa_fixed_ip.go
+++ b/feg/radius/src/modules/coafixedip/coa_fixed_ip.go
@@ -15,10 +15,11 @@ package coafixedip
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 
 	"fbc/cwf/radius/modules"
 	"fbc/lib/go/radius"
@@ -56,7 +57,7 @@ func Init(logger *zap.Logger, config modules.ModuleConfig) (modules.Context, err
 	}
 
 	if nil == net.ParseIP(host) {
-		return nil, errors.Wrap(err, "Invalid ip address specified")
+		return nil, fmt.Errorf("Invalid ip address specified: %w", err)
 	}
 
 	return ModuleCtx{target: coaConfig.Target}, nil

--- a/feg/radius/src/monitoring/census/with.go
+++ b/feg/radius/src/monitoring/census/with.go
@@ -1,8 +1,9 @@
 package census
 
 import (
+	"fmt"
+
 	ocprom "contrib.go.opencensus.io/exporter/prometheus"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
@@ -31,7 +32,7 @@ func WithProcessCollector() Option {
 		if err := opts.Registry.Register(prometheus.NewProcessCollector(
 			prometheus.ProcessCollectorOpts{Namespace: opts.Namespace},
 		)); err != nil {
-			return errors.Wrap(err, "registering process collector")
+			return fmt.Errorf("registering process collector: %w", err)
 		}
 		return nil
 	}
@@ -41,7 +42,7 @@ func WithProcessCollector() Option {
 func WithGoCollector() Option {
 	return func(opts *ocprom.Options) error {
 		if err := opts.Registry.Register(prometheus.NewGoCollector()); err != nil {
-			return errors.Wrap(err, "registering go collector")
+			return fmt.Errorf("registering go collector: %w", err)
 		}
 		return nil
 	}

--- a/feg/radius/src/monitoring/init.go
+++ b/feg/radius/src/monitoring/init.go
@@ -1,11 +1,13 @@
 package monitoring
 
 import (
+	"errors"
+
 	"fbc/cwf/radius/config"
 	"fbc/cwf/radius/monitoring/census"
 	"fbc/cwf/radius/monitoring/ods"
 	"fbc/cwf/radius/monitoring/scuba"
-	"github.com/pkg/errors"
+
 	"go.uber.org/zap"
 )
 

--- a/feg/radius/src/monitoring/ods/ods.go
+++ b/feg/radius/src/monitoring/ods/ods.go
@@ -16,7 +16,6 @@ package ods
 import (
 	"crypto/tls"
 	"encoding/json"
-	"fbc/cwf/radius/config"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -27,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
+	"fbc/cwf/radius/config"
 
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats/view"
@@ -88,12 +87,12 @@ func PostToODS(metricsData map[string]string, cfg config.Ods) error {
 		strings.NewReader(urlValues.Encode()),
 	)
 	if err != nil {
-		return errors.WithMessage(err, "failed to create http post request")
+		return fmt.Errorf("failed to create http post request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := DefaultClient.Do(req)
 	if err != nil {
-		return errors.WithMessage(err, "failed to post form")
+		return fmt.Errorf("failed to post form: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -116,7 +115,7 @@ func getURLValues(datapoints []Datapoint, cfg config.Ods) (url.Values, error) {
 	urlValues := url.Values{}
 	datapointsJSON, err := json.Marshal(datapoints)
 	if err != nil {
-		return urlValues, errors.WithMessage(err, "error marshaling datapoints")
+		return urlValues, fmt.Errorf("error marshaling datapoints: %w", err)
 	}
 
 	urlValues.Add("access_token", cfg.Token)


### PR DESCRIPTION
Replace functions `errors.Wrap` and `errors.Wrapf` from the
github.com/pgk/errors package with `fmt.Errorsf`. Created in pairing
with Moritz Huebner.

Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR implements the proposed solutions of ticket #12632 for the feg module.

## Test Plan

Perform unit tests

## Additional Information

Worked in pairing with @MoritzThomasHuebner

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
