### PR TITLE
refactor(lte): replace deprecated errors module

### DIFF
--- a/lte/cloud/go/services/ha/servicers/southbound/servicer.go
+++ b/lte/cloud/go/services/ha/servicers/southbound/servicer.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -59,7 +58,7 @@ func (s *HAServicer) GetEnodebOffloadState(ctx context.Context, req *lte_protos.
 	}
 	cfg, err := configurator.LoadEntityConfig(ctx, secondaryGw.GetNetworkId(), lte.CellularGatewayEntityType, secondaryGw.LogicalId, lte_models.EntitySerdes)
 	if err != nil {
-		errors.Wrap(err, "unable to load cellular gateway configs to find primary gateway's in its pool")
+		fmt.Errorf("unable to load cellular gateway configs to find primary gateway's in its pool: %w", err)
 		return ret, err
 	}
 	cellularCfg, ok := cfg.(*lte_models.GatewayCellularConfigs)

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/lte/cloud/go/lte"
@@ -193,7 +192,7 @@ func getGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load cellular gateway"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load cellular gateway: %w", err))
 	}
 
 	ret := &lte_models.LteGateway{
@@ -219,7 +218,7 @@ func getGateway(c echo.Context) error {
 		case lte.APNResourceEntityType:
 			e, err := configurator.LoadEntity(reqCtx, nid, tk.Type, tk.Key, configurator.EntityLoadCriteria{LoadConfig: true}, serdes.Entity)
 			if err != nil {
-				return errors.Wrap(err, "error loading apn resource entity")
+				return fmt.Errorf("error loading apn resource entity: %w", err)
 			}
 			apnResource := (&lte_models.ApnResource{}).FromEntity(e)
 			ret.ApnResources[string(apnResource.ApnName)] = *apnResource
@@ -257,7 +256,7 @@ func deleteGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "error loading existing cellular gateway"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("error loading existing cellular gateway: %w", err))
 	}
 	deletes = append(deletes, gw.Associations.Filter(lte.APNResourceEntityType)...)
 
@@ -619,7 +618,7 @@ func updateApnConfiguration(c echo.Context) error {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
 	case err != nil:
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load existing APN"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load existing APN: %w", err))
 	}
 
 	err = configurator.CreateOrUpdateEntityConfig(reqCtx, networkID, lte.APNEntityType, apnName, payload.ApnConfiguration, serdes.Entity)
@@ -670,7 +669,7 @@ func AddNetworkWideSubscriberRuleName(c echo.Context) error {
 	}
 	err := addToNetworkSubscriberConfig(c.Request().Context(), networkID, params[0], "")
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -686,7 +685,7 @@ func AddNetworkWideSubscriberBaseName(c echo.Context) error {
 	}
 	err := addToNetworkSubscriberConfig(c.Request().Context(), networkID, "", params[0])
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -702,7 +701,7 @@ func RemoveNetworkWideSubscriberRuleName(c echo.Context) error {
 	}
 	err := removeFromNetworkSubscriberConfig(c.Request().Context(), networkID, params[0], "")
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -718,7 +717,7 @@ func RemoveNetworkWideSubscriberBaseName(c echo.Context) error {
 	}
 	err := removeFromNetworkSubscriberConfig(c.Request().Context(), networkID, "", params[0])
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to update config"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to update config: %w", err))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -883,7 +882,7 @@ func updateGatewayPoolHandler(c echo.Context) error {
 	// 404 if pool doesn't exist
 	exists, err := configurator.DoesEntityExist(reqCtx, networkID, lte.CellularGatewayPoolEntityType, gatewayPoolID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Error while checking if gateway pool exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Error while checking if gateway pool exists: %w", err))
 	}
 	if !exists {
 		return echo.ErrNotFound

--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 
 	"github.com/go-openapi/swag"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 
 	"magma/lte/cloud/go/lte"
@@ -307,7 +306,7 @@ func (m *MutableLteGateway) getAPNResourceChanges(
 	oldIDs := existingGateway.Associations.Filter(lte.APNResourceEntityType).Keys()
 	oldByAPN, err := LoadAPNResources(ctx, existingGateway.NetworkID, oldIDs)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "error loading existing APN resources")
+		return nil, nil, fmt.Errorf("error loading existing APN resources: %w", err)
 	}
 	oldResources := oldByAPN.GetByID()
 	newResources := m.ApnResources.GetByID()

--- a/lte/cloud/go/services/lte/obsidian/models/validate.go
+++ b/lte/cloud/go/services/lte/obsidian/models/validate.go
@@ -83,7 +83,7 @@ func (m FegNetworkID) ValidateModel(ctx context.Context) error {
 	if !swag.IsZero(m) {
 		exists, err := configurator.DoesNetworkExist(ctx, string(m))
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("Failed to search for network %s", string(m)))
+			return fmt.Errorf(fmt.Sprintf("Failed to search for network %s: %w", string(m)), err)
 		}
 		if !exists {
 			return errors.New(fmt.Sprintf("Network: %s does not exist", string(m)))

--- a/lte/cloud/go/services/lte/servicers/protected/indexer_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/protected/indexer_servicer.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -103,12 +102,12 @@ func setEnodebState(ctx context.Context, networkID string, states state_types.St
 		}
 		gwEnt, err := configurator.LoadEntityForPhysicalID(ctx, st.ReporterID, configurator.EntityLoadCriteria{}, serdes.Entity)
 		if err != nil {
-			stateErrors[id] = errors.Wrap(err, "error loading gatewayID")
+			stateErrors[id] = fmt.Errorf("error loading gatewayID: %w", err)
 			continue
 		}
 		err = lte_api.SetEnodebState(ctx, networkID, gwEnt.Key, id.DeviceID, serializedState)
 		if err != nil {
-			stateErrors[id] = errors.Wrap(err, "error setting enodeb state")
+			stateErrors[id] = fmt.Errorf("error setting enodeb state: %w", err)
 			continue
 		}
 		glog.V(2).Infof("successfully stored ENB state for eNB SN: %s, gatewayID: %s:w", id.DeviceID, gwEnt.Key)

--- a/lte/cloud/go/services/lte/servicers/protected/lookup.go
+++ b/lte/cloud/go/services/lte/servicers/protected/lookup.go
@@ -15,8 +15,8 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -62,7 +62,7 @@ func (l *lookupServicer) SetEnodebState(ctx context.Context, req *protos.SetEnod
 }
 
 func makeErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	code := codes.Internal
 	if err == merrors.ErrNotFound {
 		code = codes.NotFound

--- a/lte/cloud/go/services/lte/storage/enodeb_state_lookup.go
+++ b/lte/cloud/go/services/lte/storage/enodeb_state_lookup.go
@@ -15,9 +15,9 @@ package storage
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/lib/go/merrors"
@@ -66,7 +66,7 @@ func (l *enodebStateLookup) Initialize() error {
 			Unique(nidCol, gidCol, enbSnCol, enbStateCol).
 			RunWith(tx).
 			Exec()
-		return nil, errors.Wrap(err, "initialize enodeb state lookup table")
+		return nil, fmt.Errorf("initialize enodeb state lookup table: %w", err)
 	}
 	_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
 	return err
@@ -81,7 +81,7 @@ func (l *enodebStateLookup) GetEnodebState(networkID string, gatewayID string, e
 			RunWith(tx).
 			Query()
 		if err != nil {
-			return nil, errors.Wrapf(err, "select EnodebState for gatewayID, enodebSN %v, %v", gatewayID, enodebSN)
+			return nil, fmt.Errorf("select EnodebState for gatewayID, enodebSN %v, %v: %w", gatewayID, enodebSN, err)
 		}
 		defer sqorc.CloseRowsLogOnError(rows, "GetEnodebState")
 
@@ -89,14 +89,14 @@ func (l *enodebStateLookup) GetEnodebState(networkID string, gatewayID string, e
 		for rows.Next() {
 			err = rows.Scan(&serializedState)
 			if err != nil {
-				return nil, errors.Wrap(err, "select EnodebState for (gatewayID, enodebSN), SQL row scan error")
+				return nil, fmt.Errorf("select EnodebState for (gatewayID, enodebSN), SQL row scan error: %w", err)
 			}
 			// always return the first record as all cols are unique
 			break
 		}
 		err = rows.Err()
 		if err != nil {
-			return nil, errors.Wrap(err, "select EnodebState for (gatewayID, enodebSN), SQL rows error")
+			return nil, fmt.Errorf("select EnodebState for (gatewayID, enodebSN), SQL rows error: %w", err)
 		}
 		return serializedState, nil
 	}
@@ -127,7 +127,7 @@ func (l *enodebStateLookup) SetEnodebState(networkID string, gatewayID string, e
 			RunWith(sc).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrapf(err, "insert EnodbeState %+v", enodebState)
+			return nil, fmt.Errorf("insert EnodbeState %+v: %w", enodebState, err)
 		}
 		return nil, nil
 	}

--- a/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
@@ -14,13 +14,13 @@
 package handlers
 
 import (
+	"fmt"
 	"math/rand"
 	"net/http"
 	"time"
 
 	strfmt "github.com/go-openapi/strfmt"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/serdes"
@@ -75,7 +75,7 @@ func listNetworkProbeTasks(c echo.Context) error {
 		return echo.ErrNotFound
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to load existing NetworkProbeTasks"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load existing NetworkProbeTasks: %w", err))
 	}
 
 	ret := make(map[string]*models.NetworkProbeTask, len(ents))
@@ -115,7 +115,7 @@ func getCreateNetworkProbeTaskHandlerFunc(storage storage.NProbeStorage) echo.Ha
 
 		taskID := string(payload.TaskID)
 		if err := storage.StoreNProbeData(networkID, taskID, data); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to store NetworkProbeData"))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to store NetworkProbeData: %w", err))
 		}
 
 		_, err := configurator.CreateEntity(

--- a/lte/cloud/go/services/nprobe/storage/storage_blobstore.go
+++ b/lte/cloud/go/services/nprobe/storage/storage_blobstore.go
@@ -16,8 +16,6 @@ package storage
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"magma/lte/cloud/go/services/nprobe/obsidian/models"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
@@ -40,7 +38,7 @@ type nprobeBlobStore struct {
 func (c *nprobeBlobStore) StoreNProbeData(networkID, taskID string, data models.NetworkProbeData) error {
 	store, err := c.factory.StartTransaction(nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -51,7 +49,7 @@ func (c *nprobeBlobStore) StoreNProbeData(networkID, taskID string, data models.
 
 	err = store.Write(networkID, blobstore.Blobs{dataBlob})
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to store nprobe data  %s", taskID))
+		return fmt.Errorf(fmt.Sprintf("failed to store nprobe data  %s: %w", taskID), err)
 	}
 	return store.Commit()
 }
@@ -60,7 +58,7 @@ func (c *nprobeBlobStore) StoreNProbeData(networkID, taskID string, data models.
 func (c *nprobeBlobStore) GetNProbeData(networkID, taskID string) (*models.NetworkProbeData, error) {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start transaction")
+		return nil, fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -69,7 +67,7 @@ func (c *nprobeBlobStore) GetNProbeData(networkID, taskID string) (*models.Netwo
 		storage.TK{Type: NProbeBlobType, Key: taskID},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to get nprobe data %s", taskID))
+		return nil, fmt.Errorf(fmt.Sprintf("failed to get nprobe data %s: %w", taskID), err)
 	}
 
 	data, err := nprobeDataFromBlob(blob)
@@ -83,7 +81,7 @@ func (c *nprobeBlobStore) GetNProbeData(networkID, taskID string) (*models.Netwo
 func (c *nprobeBlobStore) DeleteNProbeData(networkID, taskID string) error {
 	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
 	if err != nil {
-		return errors.Wrap(err, "failed to start transaction")
+		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer store.Rollback()
 
@@ -94,7 +92,7 @@ func (c *nprobeBlobStore) DeleteNProbeData(networkID, taskID string) error {
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to delete nprobe data %s", taskID))
+		return fmt.Errorf(fmt.Sprintf("failed to delete nprobe data %s: %w", taskID), err)
 	}
 	return store.Commit()
 }
@@ -102,7 +100,7 @@ func (c *nprobeBlobStore) DeleteNProbeData(networkID, taskID string) error {
 func nprobeDataToBlob(taskID string, data models.NetworkProbeData) (blobstore.Blob, error) {
 	marshaledData, err := data.MarshalBinary()
 	if err != nil {
-		return blobstore.Blob{}, errors.Wrap(err, "Error marshaling NetworkProbeData")
+		return blobstore.Blob{}, fmt.Errorf("Error marshaling NetworkProbeData: %w", err)
 	}
 	return blobstore.Blob{
 		Type:  NProbeBlobType,
@@ -115,7 +113,7 @@ func nprobeDataFromBlob(blob blobstore.Blob) (models.NetworkProbeData, error) {
 	data := models.NetworkProbeData{}
 	err := data.UnmarshalBinary(blob.Value)
 	if err != nil {
-		return models.NetworkProbeData{}, errors.Wrap(err, "Error unmarshaling NetworkProbeData")
+		return models.NetworkProbeData{}, fmt.Errorf("Error unmarshaling NetworkProbeData: %w", err)
 	}
 	return data, nil
 }

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
@@ -14,6 +14,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -108,7 +109,7 @@ func CreateBaseName(c echo.Context) error {
 		}
 	}
 	if err := configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to create base name"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to create base name: %w", err))
 	}
 
 	return c.JSON(http.StatusCreated, string(bnr.Name))
@@ -159,7 +160,7 @@ func UpdateBaseName(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to check if base name exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to check if base name exists: %w", err))
 	}
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -198,7 +199,7 @@ func UpdateBaseName(c echo.Context) error {
 	}
 
 	if err = configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to update base name"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update base name: %w", err))
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -296,7 +297,7 @@ func CreateRule(c echo.Context) error {
 	}
 
 	if err := configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to create policy"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to create policy: %w", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -351,7 +352,7 @@ func UpdateRule(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to check if policy exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to check if policy exists: %w", err))
 	}
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -398,7 +399,7 @@ func UpdateRule(c echo.Context) error {
 	}
 
 	if err = configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to update policy rule"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update policy rule: %w", err))
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
@@ -14,11 +14,11 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-openapi/swag"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/serdes"
@@ -122,7 +122,7 @@ func UpdateRatingGroup(c echo.Context) error {
 	// 404 if rating group doesn't exist
 	exists, err := configurator.DoesEntityExist(reqCtx, networkID, lte.RatingGroupEntityType, ratingGroupID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "Failed to check if rating group exists"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to check if rating group exists: %w", err))
 	}
 	if !exists {
 		return echo.ErrNotFound

--- a/lte/cloud/go/services/smsd/servicers/southbound/smsd.go
+++ b/lte/cloud/go/services/smsd/servicers/southbound/smsd.go
@@ -15,10 +15,10 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -87,7 +87,7 @@ func (s *smsdServicer) ReportDelivery(ctx context.Context, request *lteProtos.Re
 
 	decoded, err := s.serde.DecodeDelivery(request.Report.NasMessageContainer)
 	if err != nil {
-		return ret, errors.Wrap(err, "failed to decode report")
+		return ret, fmt.Errorf("failed to decode report: %w", err)
 	}
 
 	delivered, failed := map[string][]storage.SMSRef{}, map[string][]storage.SMSFailureReport{}
@@ -102,7 +102,7 @@ func (s *smsdServicer) ReportDelivery(ctx context.Context, request *lteProtos.Re
 
 	err = s.store.ReportDelivery(networkID, delivered, failed)
 	if err != nil {
-		return ret, errors.Wrap(err, "failed to report delivery")
+		return ret, fmt.Errorf("failed to report delivery: %w", err)
 	}
 	return ret, nil
 }

--- a/lte/cloud/go/services/subscriberdb/digest.go
+++ b/lte/cloud/go/services/subscriberdb/digest.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	lte_protos "magma/lte/cloud/go/protos"
@@ -85,7 +84,7 @@ func GetPerSubscriberDigests(network string) ([]*orc8r_protos.LeafDigest, error)
 		for _, subProto := range subProtos {
 			digest, err := mproto.HashDeterministic(subProto)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to generate digest for subscriber %+v of network %+v", subProto.Sid.Id, network)
+				return nil, fmt.Errorf("Failed to generate digest for subscriber %+v of network %+v: %w", subProto.Sid.Id, network, err)
 			}
 			leafDigest := &orc8r_protos.LeafDigest{
 				Id:     lte_protos.SidString(subProto.Sid),

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -467,7 +467,7 @@ func updateSubscriberProfile(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.Wrap(err, "failed to update profile"))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update profile: %w", err))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -618,7 +618,7 @@ func loadSubscribers(ctx context.Context, networkID string, includeSub subscribe
 	for _, key := range keys {
 		sub, err := loadSubscriber(ctx, networkID, key)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error loading subscriber %s", key)
+			return nil, fmt.Errorf("error loading subscriber %s: %w", key, err)
 		}
 		if includeSub(sub) {
 			subs[string(sub.ID)] = sub

--- a/lte/cloud/go/services/subscriberdb/servicers/protected/indexer_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/protected/indexer_servicer.go
@@ -15,9 +15,9 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -124,7 +124,7 @@ func setIPMappings(ctx context.Context, networkID string, states state_types.Sta
 
 	err := subscriberdb.SetIMSIsForIPs(ctx, networkID, ipMappings)
 	if err != nil {
-		return stateErrors, errors.Wrapf(err, "update directoryd mapping of session IDs to IMSIs %+v", ipMappings)
+		return stateErrors, fmt.Errorf("update directoryd mapping of session IDs to IMSIs %+v: %w", ipMappings, err)
 	}
 
 	return stateErrors, nil

--- a/lte/cloud/go/services/subscriberdb/servicers/protected/lookup.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/protected/lookup.go
@@ -15,8 +15,8 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -161,7 +161,7 @@ func (l *lookupServicer) SetIPs(ctx context.Context, req *protos.SetIPsRequest) 
 }
 
 func makeErr(err error, wrap string) error {
-	e := errors.Wrap(err, wrap)
+	e := fmt.Errorf(wrap+": %w", err)
 	code := codes.Internal
 	if err == merrors.ErrNotFound {
 		code = codes.NotFound

--- a/lte/cloud/go/services/subscriberdb/servicers/southbound/subscriberdb_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/southbound/subscriberdb_servicer.go
@@ -15,12 +15,12 @@ package servicers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -128,7 +128,7 @@ func (s *subscriberdbServicer) Sync(
 	for _, subProto := range renewed {
 		anyVal, err := ptypes.MarshalAny(subProto)
 		if err != nil {
-			return nil, errors.Wrapf(err, "marshal subscriber protos for network %+v", networkID)
+			return nil, fmt.Errorf("marshal subscriber protos for network %+v: %w", networkID, err)
 		}
 		renewedMarshaled = append(renewedMarshaled, anyVal)
 	}
@@ -220,7 +220,7 @@ func (s *subscriberdbServicer) ListSuciProfiles(ctx context.Context, req *protos
 	var suciProtos []*lte_protos.SuciProfile
 	suciProtos, err := subscriberdb.LoadSuciProtos(ctx, networkID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "loading suciProfiles in network failed %s", networkID)
+		return nil, fmt.Errorf("loading suciProfiles in network failed %s: %w", networkID, err)
 	}
 
 	res := &lte_protos.SuciProfileList{
@@ -319,7 +319,7 @@ func loadAPNs(ctx context.Context, gateway *protos.Identity_Gateway) (map[string
 		serdes.Entity,
 	)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "load cellular gateway for gateway %s", gatewayID)
+		return nil, nil, fmt.Errorf("load cellular gateway for gateway %s: %w", gatewayID, err)
 	}
 
 	apnsByName, err := subscriberdb.LoadApnsByName(networkID)

--- a/lte/cloud/go/services/subscriberdb/state/extract.go
+++ b/lte/cloud/go/services/subscriberdb/state/extract.go
@@ -15,6 +15,7 @@ package state
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net"
 	"regexp"
 
@@ -76,7 +77,7 @@ func GetIMSIAndAPNFromMobilitydStateKey(key string) (string, string, error) {
 func base64DecodeIPAddress(encodedIP string) (string, error) {
 	ipBytes, err := base64.StdEncoding.DecodeString(encodedIP)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to decode mobilityd IP address")
+		return "", fmt.Errorf("failed to decode mobilityd IP address: %w", err)
 	}
 	if len(ipBytes) != 4 {
 		return "", errors.Errorf("expected IP address to decode to 4 bytes, got %d", len(ipBytes))

--- a/lte/cloud/go/services/subscriberdb/storage/ip_lookup.go
+++ b/lte/cloud/go/services/subscriberdb/storage/ip_lookup.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 
 	"github.com/Masterminds/squirrel"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/services/subscriberdb/protos"
 	"magma/lte/cloud/go/services/subscriberdb/state"
@@ -66,7 +65,7 @@ func (l *ipLookup) Initialize() error {
 			Unique(ipLookupNidCol, ipLookupImsiCol).
 			RunWith(tx).
 			Exec()
-		return nil, errors.Wrap(err, "initialize IP lookup table")
+		return nil, fmt.Errorf("initialize IP lookup table: %w", err)
 	}
 	_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
 	return err
@@ -81,7 +80,7 @@ func (l *ipLookup) GetIPs(networkID string, ips []string) ([]*protos.IPMapping, 
 			RunWith(tx).
 			Query()
 		if err != nil {
-			return nil, errors.Wrapf(err, "select IMSIs for IPs %v", ips)
+			return nil, fmt.Errorf("select IMSIs for IPs %v: %w", ips, err)
 		}
 		defer sqorc.CloseRowsLogOnError(rows, "GetIPs")
 
@@ -91,7 +90,7 @@ func (l *ipLookup) GetIPs(networkID string, ips []string) ([]*protos.IPMapping, 
 			imsiVal := ""
 			err = rows.Scan(&m.Ip, &imsiVal)
 			if err != nil {
-				return nil, errors.Wrap(err, "select IMSIs for IPs, SQL row scan error")
+				return nil, fmt.Errorf("select IMSIs for IPs, SQL row scan error: %w", err)
 			}
 			m.Imsi, m.Apn, err = state.GetIMSIAndAPNFromMobilitydStateKey(imsiVal)
 			if err != nil {
@@ -101,7 +100,7 @@ func (l *ipLookup) GetIPs(networkID string, ips []string) ([]*protos.IPMapping, 
 		}
 		err = rows.Err()
 		if err != nil {
-			return nil, errors.Wrap(err, "select IMSIs for IPs, SQL rows error")
+			return nil, fmt.Errorf("select IMSIs for IPs, SQL rows error: %w", err)
 		}
 
 		sort.Slice(mappings, func(i, j int) bool { return mappings[i].String() < mappings[j].String() })
@@ -132,7 +131,7 @@ func (l *ipLookup) SetIPs(networkID string, mappings []*protos.IPMapping) error 
 				RunWith(sc).
 				Exec()
 			if err != nil {
-				return nil, errors.Wrapf(err, "insert IP mapping %+v", m)
+				return nil, fmt.Errorf("insert IP mapping %+v: %w", m, err)
 			}
 		}
 

--- a/lte/cloud/go/services/subscriberdb/streamer/providers.go
+++ b/lte/cloud/go/services/subscriberdb/streamer/providers.go
@@ -15,11 +15,11 @@ package streamer
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/pkg/errors"
 
 	"magma/lte/cloud/go/lte"
 	lte_protos "magma/lte/cloud/go/protos"
@@ -38,7 +38,7 @@ type SubscribersProvider struct{}
 func (p *SubscribersProvider) GetUpdates(ctx context.Context, gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
 	magmadGateway, err := configurator.LoadEntityForPhysicalID(ctx, gatewayId, configurator.EntityLoadCriteria{LoadAssocsFromThis: true}, serdes.Entity)
 	if err != nil {
-		return nil, errors.Wrapf(err, "load magmad gateway for physical ID %s", gatewayId)
+		return nil, fmt.Errorf("load magmad gateway for physical ID %s: %w", gatewayId, err)
 	}
 	gateway, err := configurator.LoadEntity(
 		ctx,
@@ -47,7 +47,7 @@ func (p *SubscribersProvider) GetUpdates(ctx context.Context, gatewayId string, 
 		serdes.Entity,
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "load cellular gateway from magmad gateway %s", magmadGateway.Key)
+		return nil, fmt.Errorf("load cellular gateway from magmad gateway %s: %w", magmadGateway.Key, err)
 	}
 	subEnts, _, err := configurator.LoadAllEntitiesOfType(
 		ctx,
@@ -56,7 +56,7 @@ func (p *SubscribersProvider) GetUpdates(ctx context.Context, gatewayId string, 
 		serdes.Entity,
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "load all subscribers in network of gateway %s", gateway.Key)
+		return nil, fmt.Errorf("load all subscribers in network of gateway %s: %w", gateway.Key, err)
 	}
 	apnsByName, apnResourcesByAPN, err := loadAPNs(ctx, gateway)
 	if err != nil {

--- a/lte/cloud/go/tools/migrations/m006_subscribers/main.go
+++ b/lte/cloud/go/tools/migrations/m006_subscribers/main.go
@@ -17,13 +17,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -47,12 +47,12 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "error opening tx"))
+		log.Fatal(fmt.Errorf("error opening tx: %w", err))
 	}
 
 	defer func() {
@@ -91,13 +91,13 @@ func main() {
 		var conf []byte
 
 		if err = rows.Scan(&pk, &conf); err != nil {
-			err = errors.Wrap(err, "could not scan row")
+			err = fmt.Errorf("could not scan row: %w", err)
 			return
 		}
 
 		legacySub := &legacySubscriber{}
 		if err = json.Unmarshal(conf, legacySub); err != nil {
-			err = errors.Wrapf(err, "could not unmarshal subscriber config %s", pk)
+			err = fmt.Errorf("could not unmarshal subscriber config %s: %w", pk, err)
 			return
 		}
 		legacySubs[pk] = legacySub
@@ -109,7 +109,7 @@ func main() {
 			Where(squirrel.Eq{pkCol: pk}).
 			Exec()
 		if err != nil {
-			err = errors.Wrapf(err, "error updating subscriber %s", pk)
+			err = fmt.Errorf("error updating subscriber %s: %w", pk, err)
 			return
 		}
 	}

--- a/lte/cloud/go/tools/migrations/m007_na_cleanup/main.go
+++ b/lte/cloud/go/tools/migrations/m007_na_cleanup/main.go
@@ -24,7 +24,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -49,12 +48,12 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "error opening tx"))
+		log.Fatal(fmt.Errorf("error opening tx: %w", err))
 	}
 
 	defer func() {

--- a/lte/cloud/go/tools/migrations/m010_default_apns/main.go
+++ b/lte/cloud/go/tools/migrations/m010_default_apns/main.go
@@ -140,7 +140,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 	builder := sqorc.GetSqlBuilder()
 
@@ -189,7 +189,7 @@ func getNetworks(tx *sql.Tx, builder sqorc.StatementBuilder) ([]string, error) {
 		Where(squirrel.NotEq{nwIDCol: internalNetworkID}).
 		RunWith(tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "getNetworks: select networks")
+		return nil, fmt.Errorf("getNetworks: select networks: %w", err)
 	}
 
 	var networks []string
@@ -197,13 +197,13 @@ func getNetworks(tx *sql.Tx, builder sqorc.StatementBuilder) ([]string, error) {
 		var n string
 		err = rows.Scan(&n)
 		if err != nil {
-			return nil, errors.Wrap(err, "getNetworks: scan network ID")
+			return nil, fmt.Errorf("getNetworks: scan network ID: %w", err)
 		}
 		networks = append(networks, n)
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "getNetworks: SQL rows error")
+		return nil, fmt.Errorf("getNetworks: SQL rows error: %w", err)
 	}
 
 	return networks, nil
@@ -238,7 +238,7 @@ func createDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err = b.RunWith(tx).Exec()
 	if err != nil {
-		return ent{}, errors.Wrap(err, "createDefaultAPNIfNotExist: insert error")
+		return ent{}, fmt.Errorf("createDefaultAPNIfNotExist: insert error: %w", err)
 	}
 
 	newAPN := ent{pk: pk, typ: apnEntType, graphID: gid}
@@ -256,7 +256,7 @@ func getDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string) (
 		).
 		RunWith(tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "getDefaultAPN: select existing default APN")
+		return nil, fmt.Errorf("getDefaultAPN: select existing default APN: %w", err)
 	}
 
 	var apns []*ent
@@ -264,13 +264,13 @@ func getDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string) (
 		apn := &ent{}
 		err = rows.Scan(&apn.pk, &apn.graphID)
 		if err != nil {
-			return nil, errors.Wrap(err, "getDefaultAPN: scan APN")
+			return nil, fmt.Errorf("getDefaultAPN: scan APN: %w", err)
 		}
 		apns = append(apns, apn)
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "getDefaultAPN: SQL rows error")
+		return nil, fmt.Errorf("getDefaultAPN: SQL rows error: %w", err)
 	}
 
 	if len(apns) > 1 {
@@ -333,7 +333,7 @@ func getSubscribersMissingAPN(tx *sql.Tx, builder sqorc.StatementBuilder, networ
 		).
 		RunWith(tx).Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "getSubscribersMissingAPN: select subscribers")
+		return nil, fmt.Errorf("getSubscribersMissingAPN: select subscribers: %w", err)
 	}
 
 	assocs := map[ent][]ent{}
@@ -342,13 +342,13 @@ func getSubscribersMissingAPN(tx *sql.Tx, builder sqorc.StatementBuilder, networ
 		pkB, typeB := &sql.NullString{}, &sql.NullString{}
 		err = rows.Scan(&a.graphID, &a.pk, pkB, typeB)
 		if err != nil {
-			return nil, errors.Wrap(err, "getSubscribersMissingAPN: scan subscriber")
+			return nil, fmt.Errorf("getSubscribersMissingAPN: scan subscriber: %w", err)
 		}
 		assocs[a] = append(assocs[a], ent{pk: pkB.String, typ: typeB.String})
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, errors.Wrap(err, "getSubscribersMissingAPN: SQL rows error")
+		return nil, fmt.Errorf("getSubscribersMissingAPN: SQL rows error: %w", err)
 	}
 
 	var subsMissingAPN []ent
@@ -376,7 +376,7 @@ func mapSubscribersToAPN(tx *sql.Tx, builder sqorc.StatementBuilder, apnPK strin
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err := b.RunWith(tx).Exec()
 	if err != nil {
-		return errors.Wrap(err, "mapSubscribersToAPN: insert error")
+		return fmt.Errorf("mapSubscribersToAPN: insert error: %w", err)
 	}
 
 	return nil
@@ -394,7 +394,7 @@ func mergeGraphs(tx *sql.Tx, builder sqorc.StatementBuilder, gids []string) erro
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	_, err := b.RunWith(tx).Exec()
 	if err != nil {
-		return errors.Wrap(err, "mergeGraphs: update error")
+		return fmt.Errorf("mergeGraphs: update error: %w", err)
 	}
 
 	return nil
@@ -496,7 +496,7 @@ func getSubscribersInDefaultAPNGraph(db *sql.DB, builder sqorc.StatementBuilder,
 			).
 			RunWith(tx).Query()
 		if err != nil {
-			return nil, errors.Wrap(err, "getSubscribersInDefaultAPNGraph: select subscribers")
+			return nil, fmt.Errorf("getSubscribersInDefaultAPNGraph: select subscribers: %w", err)
 		}
 
 		var subs []string
@@ -504,13 +504,13 @@ func getSubscribersInDefaultAPNGraph(db *sql.DB, builder sqorc.StatementBuilder,
 			key := ""
 			err = rows.Scan(&key)
 			if err != nil {
-				return nil, errors.Wrap(err, "getSubscribersInDefaultAPNGraph: scan subscriber PK")
+				return nil, fmt.Errorf("getSubscribersInDefaultAPNGraph: scan subscriber PK: %w", err)
 			}
 			subs = append(subs, key)
 		}
 		err = rows.Err()
 		if err != nil {
-			return nil, errors.Wrap(err, "getSubscribersInDefaultAPNGraph: SQL rows error")
+			return nil, fmt.Errorf("getSubscribersInDefaultAPNGraph: SQL rows error: %w", err)
 		}
 
 		return subs, nil

--- a/lte/cloud/go/tools/migrations/m011_subscriber_config/main.go
+++ b/lte/cloud/go/tools/migrations/m011_subscriber_config/main.go
@@ -16,10 +16,10 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/tools/migrations"
@@ -45,7 +45,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sqorc.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	_, err = migrations.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, doMigration)
@@ -66,7 +66,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 		Where(squirrel.Eq{typeCol: subscriberType}).
 		Query()
 	if err != nil {
-		return nil, errors.Wrap(err, "error loading subscriber configs")
+		return nil, fmt.Errorf("error loading subscriber configs: %w", err)
 	}
 
 	newConfsByPk := map[string][]byte{}
@@ -75,7 +75,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 		var oldConf []byte
 
 		if err = rows.Scan(&pk, &oldConf); err != nil {
-			return nil, errors.Wrap(err, "error scanning subscriber row")
+			return nil, fmt.Errorf("error scanning subscriber row: %w", err)
 		}
 		shouldMigrate, err := shouldMigrateConf(oldConf)
 		if err != nil {
@@ -88,7 +88,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 		newConf := SubscriberConfig{Lte: oldConf}
 		newConfBytes, err := json.Marshal(newConf)
 		if err != nil {
-			return nil, errors.Wrap(err, "error marshalling new subscriber config")
+			return nil, fmt.Errorf("error marshaling new subscriber config: %w", err)
 		}
 		newConfsByPk[pk] = newConfBytes
 	}
@@ -100,7 +100,7 @@ func doMigration(tx *sql.Tx) (interface{}, error) {
 			Where(squirrel.Eq{pkCol: pk}).
 			Exec()
 		if err != nil {
-			return nil, errors.Wrapf(err, "error updating subscriber %s", pk)
+			return nil, fmt.Errorf("error updating subscriber %s: %w", pk, err)
 		}
 	}
 	return nil, nil
@@ -112,7 +112,7 @@ func shouldMigrateConf(oldConf []byte) (bool, error) {
 	parsedMessage := map[string]interface{}{}
 	err := json.Unmarshal(oldConf, &parsedMessage)
 	if err != nil {
-		return false, errors.Wrap(err, "could not unmarshal legacy config")
+		return false, fmt.Errorf("could not unmarshal legacy config: %w", err)
 	}
 
 	_, alreadyMigrated := parsedMessage["lte"]

--- a/lte/cloud/go/tools/migrations/m012_policy_qos/main.go
+++ b/lte/cloud/go/tools/migrations/m012_policy_qos/main.go
@@ -37,6 +37,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"flag"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
@@ -100,7 +101,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	_, err = migrations.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, doMigration)
@@ -151,7 +152,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		Where(squirrel.Eq{entTypeCol: policyEntType}).
 		RunWith(tx).Query()
 	if err != nil {
-		return errors.Wrap(err, "get policy ents")
+		return fmt.Errorf("get policy ents: %w", err)
 	}
 	oldByKey := map[string]policyEnt{}
 	for rows.Next() {
@@ -160,17 +161,17 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		var confBytes []byte
 		err = rows.Scan(&old.pk, &key, &old.network, &old.gid, &confBytes)
 		if err != nil {
-			return errors.Wrap(err, "scan policy")
+			return fmt.Errorf("scan policy: %w", err)
 		}
 		err = json.Unmarshal(confBytes, &old.config)
 		if err != nil {
-			return errors.Wrap(err, "unmarshal existing policy rule config")
+			return fmt.Errorf("unmarshal existing policy rule config: %w", err)
 		}
 		oldByKey[key] = old
 	}
 	err = rows.Err()
 	if err != nil {
-		return errors.Wrap(err, "get existing assocs: SQL rows error")
+		return fmt.Errorf("get existing assocs: SQL rows error: %w", err)
 	}
 
 	// Convert policy configs to {new config, policy_qos_profile ent}
@@ -192,7 +193,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		}
 		newBytes, err := json.Marshal(newConf)
 		if err != nil {
-			return errors.Wrap(err, "marshal updated policy config")
+			return fmt.Errorf("marshal updated policy config: %w", err)
 		}
 		updateConfByKey[key] = newBytes
 
@@ -208,7 +209,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		}
 		profileBytes, err := json.Marshal(profileConf)
 		if err != nil {
-			return errors.Wrap(err, "marshal new policy_qos_profile config")
+			return fmt.Errorf("marshal new policy_qos_profile config: %w", err)
 		}
 		createProfileByKey[key] = profileBytes
 	}
@@ -228,7 +229,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bu.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error updating policy ent")
+			return fmt.Errorf("error updating policy ent: %w", err)
 		}
 
 		qosProfilePK := migrations.MakePK()
@@ -241,7 +242,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bi.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error inserting policy_qos_profile ent")
+			return fmt.Errorf("error inserting policy_qos_profile ent: %w", err)
 		}
 
 		bi = builder.
@@ -252,7 +253,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bi.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error inserting policy->policy_qos_profile assoc")
+			return fmt.Errorf("error inserting policy->policy_qos_profile assoc: %w", err)
 		}
 	}
 

--- a/lte/cloud/go/tools/migrations/m013_policy_ipv6/main.go
+++ b/lte/cloud/go/tools/migrations/m013_policy_ipv6/main.go
@@ -26,6 +26,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"flag"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
@@ -79,7 +80,7 @@ func main() {
 	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	_, err = migrations.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, doMigration)
@@ -117,7 +118,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		Where(squirrel.Eq{entTypeCol: policyEntType}).
 		RunWith(tx).Query()
 	if err != nil {
-		return errors.Wrap(err, "get policy ents")
+		return fmt.Errorf("get policy ents: %w", err)
 	}
 	oldByKey := map[string]policyEnt{}
 	for rows.Next() {
@@ -126,17 +127,17 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		var confBytes []byte
 		err = rows.Scan(&old.pk, &key, &confBytes)
 		if err != nil {
-			return errors.Wrap(err, "scan policy")
+			return fmt.Errorf("scan policy: %w", err)
 		}
 		err = json.Unmarshal(confBytes, &old.config)
 		if err != nil {
-			return errors.Wrap(err, "unmarshal existing policy rule config")
+			return fmt.Errorf("unmarshal existing policy rule config: %w", err)
 		}
 		oldByKey[key] = old
 	}
 	err = rows.Err()
 	if err != nil {
-		return errors.Wrap(err, "get existing assocs: SQL rows error")
+		return fmt.Errorf("get existing assocs: SQL rows error: %w", err)
 	}
 
 	// Convert policy configs to {new config}
@@ -175,7 +176,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 
 		newBytes, err := json.Marshal(newConf)
 		if err != nil {
-			return errors.Wrap(err, "marshal updated policy config")
+			return fmt.Errorf("marshal updated policy config: %w", err)
 		}
 		updateConfByKey[key] = newBytes
 	}
@@ -189,7 +190,7 @@ func migratePolicyRules(tx *sql.Tx, builder squirrel.StatementBuilderType) error
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bu.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error updating policy ent")
+			return fmt.Errorf("error updating policy ent: %w", err)
 		}
 	}
 

--- a/lte/cloud/go/tools/migrations/m013_relay_split/main.go
+++ b/lte/cloud/go/tools/migrations/m013_relay_split/main.go
@@ -28,6 +28,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"flag"
+	"fmt"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
@@ -73,7 +74,7 @@ func main() {
 
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {
-		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+		glog.Fatal(fmt.Errorf("could not open db connection: %w", err))
 	}
 
 	_, err = migrations.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, doMigration)
@@ -113,7 +114,7 @@ func migrateNetworkEpcConfigs(tx *sql.Tx, builder squirrel.StatementBuilderType)
 	glog.Infof("[RUN] %s %v", sqlStr, args)
 	rows, err := b.RunWith(tx).Query()
 	if err != nil {
-		return errors.Wrap(err, "get lte_network configs")
+		return fmt.Errorf("get lte_network configs: %w", err)
 	}
 	oldByNid := map[string]types.OldNetworkCellularConfigs{}
 	for rows.Next() {
@@ -121,18 +122,18 @@ func migrateNetworkEpcConfigs(tx *sql.Tx, builder squirrel.StatementBuilderType)
 		var confBytes []byte
 		err = rows.Scan(&nid, &confBytes)
 		if err != nil {
-			return errors.Wrap(err, "scan lte_network config")
+			return fmt.Errorf("scan lte_network config: %w", err)
 		}
 		old := types.OldNetworkCellularConfigs{}
 		err = json.Unmarshal(confBytes, &old)
 		if err != nil {
-			return errors.Wrap(err, "unmarshal existing lte_network config")
+			return fmt.Errorf("unmarshal existing lte_network config: %w", err)
 		}
 		oldByNid[nid] = old
 	}
 	err = rows.Err()
 	if err != nil {
-		return errors.Wrap(err, "get existing lte_network configs: SQL rows error")
+		return fmt.Errorf("get existing lte_network configs: SQL rows error: %w", err)
 	}
 
 	// Convert network configs to new versions
@@ -159,7 +160,7 @@ func migrateNetworkEpcConfigs(tx *sql.Tx, builder squirrel.StatementBuilderType)
 		}
 		newBytes, err := json.Marshal(newConf)
 		if err != nil {
-			return errors.Wrap(err, "marshal updated lte_network config")
+			return fmt.Errorf("marshal updated lte_network config: %w", err)
 		}
 		updateConfByNid[nid] = newBytes
 	}
@@ -174,7 +175,7 @@ func migrateNetworkEpcConfigs(tx *sql.Tx, builder squirrel.StatementBuilderType)
 		glog.Infof("[RUN] %s %v", sqlStr, args)
 		_, err = bu.RunWith(tx).Exec()
 		if err != nil {
-			return errors.Wrap(err, "error updating lte_network config")
+			return fmt.Errorf("error updating lte_network config: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Replace functions `errors.Wrap` and `errors.Wrapf` from the
github.com/pgk/errors package with `fmt.Errorsf`. Created in pairing
with Moritz Huebner.

Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>

## Summary

This PR implements the proposed solutions of ticket #12632 for the lte module.

## Test Plan

Perform Unit tests.

## Additional Information

- [ ] This change is backwards-breaking


