### PR TITLE
refactor: replace deprecated errors module in src

### DIFF
--- a/src/go/README.md
+++ b/src/go/README.md
@@ -74,24 +74,12 @@ client/server implementation. Tightly coupled with protobuf.
 
 Considered alternatives: Thrift, Swagger, JSON-RPC
 
-### github.com/pkg/errors
-
-BSD-2 license.
-
-Very lightweight library, does not have any transitive dependencies. A well-
-reasoned extension to built-in errors, this package provides stack tracing and
-error wrap/unwrapping. Some of this functionality was added to the built-in
-errors package as of Golang 1.13 (and this package influenced part of that
-design), but the built-in is lacking easy stack trace support.
-
-Considered alternatives: built-in errors, github.com/cockroachdb/errors
-
 ### Uber Zap
 
 MIT license.
 
 Medium weight, pulls in a few transitive dependencies, but has a large overlap
-with dependencies we also use (github.com/pkg/errors, testify). Provides
+with testify. Provides
 scoped/named loggers and parameterized logging while achieving better
 performance than other libraries proven via benchmarks.
 

--- a/src/go/agwd/config/config.go
+++ b/src/go/agwd/config/config.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"github.com/magma/magma/src/go/protos/magma/config"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -199,21 +198,21 @@ func loadConfigFile(
 	path string,
 ) (*config.AgwD, error) {
 	if _, err := osStat(path); err != nil {
-		return nil, errors.Wrap(err, "path="+path)
+		return nil, fmt.Errorf("path=%s: %w", path, err)
 	}
 
 	bytes, err := readFile(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "path="+path)
+		return nil, fmt.Errorf("path=%s: %w", path, err)
 	}
 	filtered := []byte(filterJSONComments(string(bytes)))
 	config := &config.AgwD{}
 	if err := unmarshalProto(filtered, config); err != nil {
-		return nil, errors.Wrapf(
-			err,
-			"path=%s filtered=%s",
+		return nil, fmt.Errorf(
+			"path=%s filtered=%s: %w",
 			path,
-			string(filtered))
+			string(filtered),
+			err)
 	}
 	return config, nil
 }

--- a/src/go/agwd/config/config_test.go
+++ b/src/go/agwd/config/config_test.go
@@ -12,13 +12,13 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/protobuf/proto"
@@ -258,7 +258,7 @@ func TestNewConfigManager_DefaultNotFound(t *testing.T) {
 
 	cm := NewConfigManager()
 	err := LoadConfigFile(cm, filepath.Join("testdata", "doesnotexist.json"))
-	assert.True(t, os.IsNotExist(errors.Cause(err)))
+	assert.True(t, os.IsNotExist(errors.Unwrap(err)))
 	assert.True(t, proto.Equal(newDefaultConfig(), cm.Config()))
 }
 

--- a/src/go/agwd/server/server.go
+++ b/src/go/agwd/server/server.go
@@ -23,7 +23,6 @@ import (
 	configpb "github.com/magma/magma/src/go/protos/magma/config"
 	service_capture "github.com/magma/magma/src/go/service/capture"
 	service_config "github.com/magma/magma/src/go/service/config"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	"github.com/magma/magma/src/go/agwd/config"
@@ -63,7 +62,7 @@ func cleanupUnixSocket(
 		return nil
 	}
 	if err != nil {
-		return errors.Wrapf(err, "os.Stat(%s)", path)
+		return fmt.Errorf("os.Stat(%s): %w", path, err)
 	}
 
 	// attempt to connect to see if someone is still bound to the socket.
@@ -76,7 +75,7 @@ func cleanupUnixSocket(
 	}
 	logger.Warning().Printf("Removing existing socket file; previous unclean shutdown?")
 	if err := osRemove(path); err != nil {
-		return errors.Wrapf(err, "os.Stat(%s)", path)
+		return fmt.Errorf("os.Stat(%s): %w", path, err)
 	}
 
 	return nil
@@ -84,10 +83,10 @@ func cleanupUnixSocket(
 
 func cleanupUnixSocketOrDie(logger log.Logger, path string) {
 	if err := cleanupUnixSocket(logger, os.Stat, os.Remove, net.DialTimeout, path); err != nil {
-		panic(errors.Wrapf(
-			err,
-			"cleanupUnixSocket(logger=_, target.Endpoint=%s)",
-			path))
+		panic(fmt.Errorf(
+			"cleanupUnixSocket(logger=_, target.Endpoint=%s): %w",
+			path,
+			err))
 	}
 }
 
@@ -102,11 +101,11 @@ func startSctpdDownlinkServer(
 	listener, err := net.Listen(
 		target.Scheme, target.Endpoint)
 	if err != nil {
-		panic(errors.Wrapf(
-			err,
-			"net.Listen(network=%s, address=%s)",
+		panic(fmt.Errorf(
+			"net.Listen(network=%s, address=%s): %w",
 			target.Scheme,
-			target.Endpoint))
+			target.Endpoint,
+			err))
 	}
 
 	grpcServer := grpc.NewServer(so...)
@@ -114,11 +113,11 @@ func startSctpdDownlinkServer(
 	sctpdpb.RegisterSctpdDownlinkServer(grpcServer, sctpdDownlinkServer)
 	go func() {
 		if err := grpcServer.Serve(listener); err != nil {
-			panic(errors.Wrapf(
-				err,
-				"startSctpdDownlinkServer(network=%s, address=%s)",
+			panic(fmt.Errorf(
+				"startSctpdDownlinkServer(network=%s, address=%s): %w",
 				target.Scheme,
-				target.Endpoint))
+				target.Endpoint,
+				err))
 		}
 	}()
 }
@@ -133,11 +132,11 @@ func startSctpdUplinkServer(
 
 	listener, err := net.Listen(target.Scheme, target.Endpoint)
 	if err != nil {
-		panic(errors.Wrapf(
-			err,
-			"net.Listen(network=%s, address=%s)",
+		panic(fmt.Errorf(
+			"net.Listen(network=%s, address=%s): %w",
 			target.Scheme,
-			target.Endpoint))
+			target.Endpoint,
+			err))
 	}
 
 	grpcServer := grpc.NewServer(so...)
@@ -145,11 +144,11 @@ func startSctpdUplinkServer(
 	sctpdpb.RegisterSctpdUplinkServer(grpcServer, sctpdUplinkServer)
 	go func() {
 		if err := grpcServer.Serve(listener); err != nil {
-			panic(errors.Wrapf(
-				err,
-				"startSctpdUplinkServer(network=%s, address=%s)",
+			panic(fmt.Errorf(
+				"startSctpdUplinkServer(network=%s, address=%s): %w",
 				target.Scheme,
-				target.Endpoint))
+				target.Endpoint,
+				err))
 		}
 	}()
 }
@@ -159,22 +158,22 @@ func startPipelinedServer(cfgr config.Configer, logger log.Logger) {
 	listener, err := net.Listen(target.Scheme, target.Endpoint)
 
 	if err != nil {
-		panic(errors.Wrapf(
-			err,
-			"net.Listen(network=%s, address=%s)",
+		panic(fmt.Errorf(
+			"net.Listen(network=%s, address=%s): %w",
 			target.Scheme,
-			target.Endpoint))
+			target.Endpoint,
+			err))
 	}
 	grpcServer := grpc.NewServer()
 	pipelinedServer := pipelined.NewPipelinedServer(logger)
 	pipelinedpb.RegisterPipelinedServer(grpcServer, pipelinedServer)
 	go func() {
 		if err := grpcServer.Serve(listener); err != nil {
-			panic(errors.Wrapf(
-				err,
-				"startPipelinedServer(network=%s, address=%s)",
+			panic(fmt.Errorf(
+				"startPipelinedServer(network=%s, address=%s): %w",
 				target.Scheme,
-				target.Endpoint))
+				target.Endpoint,
+				err))
 		}
 	}()
 }
@@ -185,11 +184,11 @@ func startCaptureServer(
 	address := fmt.Sprintf(":%s", cfgr.Config().GetCaptureServicePort())
 	listener, err := net.Listen(config.TCP, address)
 	if err != nil {
-		panic(errors.Wrapf(
-			err,
-			"net.Listen(network=%s, address=%s)",
+		panic(fmt.Errorf(
+			"net.Listen(network=%s, address=%s): %w",
 			config.TCP,
-			address))
+			address,
+			err))
 	}
 
 	grpcServer := grpc.NewServer()
@@ -205,11 +204,11 @@ func startConfigServer(
 
 	listener, err := net.Listen(config.TCP, address)
 	if err != nil {
-		panic(errors.Wrapf(
-			err,
-			"net.Listen(network=%s, address=%s)",
+		panic(fmt.Errorf(
+			"net.Listen(network=%s, address=%s): %w",
 			config.TCP,
-			address))
+			address,
+			err))
 	}
 
 	grpcServer := grpc.NewServer()

--- a/src/go/crash/crash_test.go
+++ b/src/go/crash/crash_test.go
@@ -12,13 +12,13 @@
 package crash_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/magma/magma/src/go/crash"
 	mock_crash "github.com/magma/magma/src/go/crash/mock_crash"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/go/crash/sentry/sentry.go
+++ b/src/go/crash/sentry/sentry.go
@@ -12,11 +12,11 @@
 package sentry
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/magma/magma/src/go/crash"
-	"github.com/pkg/errors"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -source=sentry.go -package mock_sentry -destination mock_sentry/mock_sentry_hub.go sentryHub
@@ -37,7 +37,7 @@ type Crash struct {
 func NewCrash(options sentry.ClientOptions) crash.Crash {
 	client, err := sentry.NewClient(options)
 	if err != nil {
-		panic(errors.Wrapf(err, "sentry.ClientOptions=%+v", options))
+		panic(fmt.Errorf("sentry.ClientOptions=%+v: %w", options, err))
 	}
 	newHub := sentry.NewHub(client, sentry.NewScope())
 	return &Crash{

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -16,7 +16,6 @@ go 1.18
 require (
 	github.com/getsentry/sentry-go v0.11.0
 	github.com/golang/mock v1.6.0
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.0
 	google.golang.org/grpc v1.40.0

--- a/src/go/log/zap/zap.go
+++ b/src/go/log/zap/zap.go
@@ -26,7 +26,8 @@
 package zap
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -204,7 +205,7 @@ func NewLoggerAtLevel(lvl log.Level, paths ...string) *Logger {
 	}
 	ws, _, err := zap.Open(paths...)
 	if err != nil {
-		panic(errors.Wrapf(err, "paths=%s", paths))
+		panic(fmt.Errorf("paths=%s: %w", paths, err))
 	}
 
 	return New(


### PR DESCRIPTION
## Summary

See #12632 for description

Remove dependency on "github.com/pkg/errors"

- Replace use of `errors.Wrap[f]` with `fmt.Errorf`
- Replace use of pkg `errors.New` with standard lib `errors.New`
- Replace a use of pkg `errors.Cause` with standard lib `errors.Unwrap`
- Update go.mod files

## Test Plan

Run unit tests

## Additional Information

Worked in pairing with @wolfseb 

- [ ] This change is backwards-breaking