### PR TITLE
chore(ci): workflows are using the updated bazel base and devcontainer images

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,8 +24,9 @@ build:vm --define=folly_so=1
 build:vm --config=specify_vm_cc
 
 # MAGMA-BUILDER DOCKER CONTAINER CONFIGS
-build:docker --disk_cache=/magma/.bazel-cache
-common:docker --repository_cache=/magma/.bazel-cache-repo
+build:docker --disk_cache=/workspaces/magma/.bazel-cache
+common:docker --repository_cache=/workspaces/magma/.bazel-cache-repo
+build:docker --define=folly_so=1
 
 # DEVCONTAINER CONFIGS
 build:devcontainer --disk_cache=/workspaces/magma/.bazel-cache

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latestv2"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latestv2"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
 
@@ -183,32 +183,33 @@ jobs:
         run: |
           ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
       - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
+          options: --pull always
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the devontainer image!"
       - name: Create a directory to store XML test results
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           shell: bash
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
-            cd /magma
+            cd /workspaces/magma
             mkdir -p c-cpp-test-results/
             echo "created c-cpp-test-results/ directory"
       - name: Run `bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* --config=asan`
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           shell: bash
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
-            cd /magma
+            cd /workspaces/magma
             bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* --config=asan --test_output=errors --cache_test_results=no
             TEST_RESULT=$?
             # copy out test results
@@ -242,7 +243,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run li agent tests
         timeout-minutes: 5
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -279,7 +280,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run sctpd tests with Debug build type
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -288,7 +289,7 @@ jobs:
             cd /workspaces/magma/lte/gateway
             make test_sctpd BUILD_TYPE=Debug
       - name: Run sctpd tests with RelWithDebInfo build type
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -297,7 +298,7 @@ jobs:
             cd /workspaces/magma/lte/gateway
             make test_sctpd BUILD_TYPE=RelWithDebInfo
       - name: Run mme tests with Debug build type
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -306,7 +307,7 @@ jobs:
             cd /workspaces/magma/lte/gateway
             make test_oai BUILD_TYPE=Debug;
       - name: Run mme tests with RelWithDebInfo build type
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -370,23 +371,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-
       - name: Setup Devcontainer Image
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the devontainer image!"
       - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
+          options: --pull always
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the bazel base image!"
             bazel # pull down bazel, if bazel download fails we can fail before we do all the lengthy work below
       - name: Run codecov with CMake (MME)
         if: always()
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -397,11 +399,11 @@ jobs:
             cp $C_BUILD/coverage.info $MAGMA_ROOT
       - name: Run coverage with Bazel (COMMON / SESSIOND / SCTPD / LIAGENT / CONNECTIOND)
         if: always()
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
             cd $MAGMA_ROOT
             # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178
@@ -474,7 +476,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run session_manager tests
         timeout-minutes: 20
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
     # Run four times a day to build bazel cache
     - cron: '0 0,6,12,18 * * *'
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latestv2"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
   CACHE_SUB_KEY_BUILD_ALL: build-all
@@ -128,9 +128,9 @@ jobs:
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma/
+          options: -v ${{ github.workspace }}:/workspaces/magma/
           run: |
-            cd /magma
+            cd /workspaces/magma
             bazel build //...
       - name: Build space left after run
         shell: bash
@@ -208,27 +208,27 @@ jobs:
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
-            cd /magma
+            cd /workspaces/magma
             bazel test //... --test_output=errors --cache_test_results=no
       - name: Run `bazel run //:check_starlark_format`
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma/
+          options: -v ${{ github.workspace }}:/workspaces/magma/
           run: |
-            cd /magma
+            cd /workspaces/magma
             bazel run //:check_starlark_format
       - name: Test python services for missing modules
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma/
+          options: -v ${{ github.workspace }}:/workspaces/magma/
           run: |
-            cd /magma
+            cd /workspaces/magma
             bazel/scripts/test_python_service_imports.sh
       - name: Build space left after run
         shell: bash

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -22,7 +22,7 @@ on:
       - reopened
       - synchronize
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latestv2"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
   CACHE_SUB_KEY: build-warnings
@@ -94,9 +94,10 @@ jobs:
         run: |
           ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
       - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
+          options: --pull always
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the bazel base image!"
@@ -109,13 +110,13 @@ jobs:
         with:
           format: 'csv'
       - name: Build and Apply GCC Problem Matcher
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma
+          options: -v ${{ github.workspace }}:/workspaces/magma
           run: |
-            cd /magma
+            cd /workspaces/magma
             ./.github/workflows/generate-gcc-warnings.sh "${{ steps.changed_files.outputs.all }}"
       - name: Load problem matcher
         # If needed https://github.com/microsoft/vscode-cpptools/issues/2266 for path fixups
@@ -128,12 +129,12 @@ jobs:
         # Therefore below I use `xo` to fixup our path emissions on gcc warnings.
         uses: electronjoe/gcc-problem-matcher@v1
       - name: Cat compilation log (filtered by file names)
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/magma
-          run: cat /magma/filtered-compile.log
+          options: -v ${{ github.workspace }}:/workspaces/magma
+          run: cat /workspaces/magma/filtered-compile.log
       - name: Store build_logs_c_full_log Artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

This is the second PR of https://github.com/magma/magma/pull/12638. All Bazel related workflows on the Bazel Base and Devcontainer image are using the images (tagged latestv2) created in #12638.

Pre condition: the latestv2 images were created successfully:
* run was successful: https://github.com/magma/magma/actions/runs/2330331689
* Basel Base image: https://github.com/magma/magma/pkgs/container/magma%2Fbazel-base
* Devcontainer image: https://github.com/magma/magma/pkgs/container/magma%2Fdevcontainer

Still open:
* PR3: CI creates again Bazel Base and Devcontainer images with latest tag (will be opened in a couple of days when sufficiently enough PRs are using the latestv2 images)
* PR4: workflows will use the latest images

## Test Plan

CI - the following workflows are using the latestv2 image and run successfully:
* bazel.yml - https://github.com/magma/magma/runs/6448318025?check_suite_focus=true
* agw-workflow.yml - https://github.com/magma/magma/runs/6448318494?check_suite_focus=true
* gcc-problems.yml - https://github.com/magma/magma/runs/6448323190?check_suite_focus=true

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
