### PR TITLE
fix(amf): Registration reject handling for mismatching plmn

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -96,6 +96,10 @@ class AMFAppProcedureTest : public ::testing::Test {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x2e,
       0x08, 0x80, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
+  const uint8_t initial_ue_plmn_mismatch_message_hexbuf[23] = {
+      0x7e, 0x00, 0x41, 0x79, 0x00, 0x0d, 0x01, 0x00, 0x91, 0x10, 0xf0, 0xff,
+      0x00, 0x00, 0x79, 0x56, 0x54, 0x66, 0xf4, 0x2e, 0x02, 0xf0, 0xf0};
+
   /* Guti based initial registration message */
   const uint8_t guti_initial_ue_message_hexbuf[98] = {
       0x7e, 0x01, 0x67, 0xb7, 0x6f, 0xc6, 0x03, 0x7e, 0x00, 0x41, 0x09,
@@ -391,6 +395,24 @@ TEST_F(AMFAppProcedureTest, TestRegistrationAuthSecurityCapabilityMismatch) {
       amf_ue_context_exists_amf_ue_ngap_id(ue_id);
   // ue context should not exist
   EXPECT_TRUE(ue_context_p == nullptr);
+}
+
+TEST_F(AMFAppProcedureTest, TestRegistrationPlmnMismatch) {
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{
+      AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,  // new registration notification
+                                            // indication to ngap
+      NGAP_NAS_DL_DATA_REQ,                 // Registration Reject
+      NGAP_UE_CONTEXT_RELEASE_COMMAND       // UEContextReleaseCommand
+  };
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(
+      amf_app_desc_p, 36, 1, 1, 0, plmn,
+      initial_ue_plmn_mismatch_message_hexbuf,
+      sizeof(initial_ue_plmn_mismatch_message_hexbuf));
+  EXPECT_EQ(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id), 0);
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
 }
 
 TEST_F(AMFAppProcedureTest, TestRegistrationProcNoTMSI) {

--- a/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_stateless.cpp
@@ -595,6 +595,13 @@ class AMFAppStatelessTest : public ::testing::Test {
     amf_config.use_stateless = true;
     amf_nas_state_init(&amf_config);
     create_state_matrix();
+    amf_config.guamfi.nb = 1;
+    amf_config.guamfi.guamfi[0].plmn = {.mcc_digit2 = 2,
+                                        .mcc_digit1 = 2,
+                                        .mnc_digit3 = 6,
+                                        .mcc_digit3 = 2,
+                                        .mnc_digit2 = 5,
+                                        .mnc_digit1 = 4};
 
     init_task_context(TASK_MAIN, nullptr, 0, NULL, &amf_app_task_zmq_ctx);
 


### PR DESCRIPTION
Signed-off-by: Sathyaj27 <sathya.jayadev@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

Fixing #12536 
Issue:
There was no mcc mnc validation at registration request.
Added the validation check

<!-- Enumerate changes you made and why you made them -->

## Test Plan

- Added UT. UT is passing
- Tested on spirent setup. Attached pcap :
<img width="911" alt="reject" src="https://user-images.githubusercontent.com/94469973/168566949-bbb39215-c57d-4ae3-ad3e-d2d69b3335ac.PNG">


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is not backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
