### PR TITLE
feat(nms): use proper check in status from orcestrator for lteGateways

### DIFF
--- a/nms/app/components/FEGServicingAccessGatewayKPIs.js
+++ b/nms/app/components/FEGServicingAccessGatewayKPIs.js
@@ -132,7 +132,7 @@ export default function ServicingAccessGatewayKPIs() {
       {
         category: 'Gateway Count',
         value: servicedAccessGatewaysCount,
-        tooltip: 'Number of gateways checked in within last 5 minutes',
+        tooltip: 'Number of gateways checked in recently',
       },
     ],
   ];

--- a/nms/app/components/GatewayKPIs.js
+++ b/nms/app/components/GatewayKPIs.js
@@ -21,7 +21,6 @@ import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DataGrid from './DataGrid';
 import GatewayContext from './context/GatewayContext';
 import React from 'react';
-import isGatewayHealthy from './GatewayUtils';
 
 import {useContext} from 'react';
 
@@ -32,7 +31,7 @@ function gatewayStatus(gatewaySt: {[string]: lte_gateway}): [number, number] {
     .map((k: string) => gatewaySt[k])
     .filter((g: lte_gateway) => g.cellular && g.id)
     .map(function (gateway: lte_gateway) {
-      isGatewayHealthy(gateway) ? upCount++ : downCount++;
+      gateway.checked_in_recently ? upCount++ : downCount++;
     });
   return [upCount, downCount];
 }

--- a/nms/app/components/GatewayKPIs.js
+++ b/nms/app/components/GatewayKPIs.js
@@ -54,12 +54,12 @@ export default function GatewayKPIs() {
       {
         category: 'Connected',
         value: upCount || 0,
-        tooltip: 'Number of gateways checked in within last 5 minutes',
+        tooltip: 'Number of gateways checked in recently',
       },
       {
         category: 'Disconnected',
         value: downCount || 0,
-        tooltip: 'Number of gateways not checked in within last 5 minutes',
+        tooltip: 'Number of gateways not checked in recently',
       },
     ],
   ];

--- a/nms/app/components/GatewayUtils.js
+++ b/nms/app/components/GatewayUtils.js
@@ -188,8 +188,6 @@ export type FederationGatewayHealthStatus = {
   },
 };
 
-const GATEWAY_KEEPALIVE_TIMEOUT_MS = 1000 * 5 * 60;
-
 export const GatewayTypeEnum = Object.freeze({
   HEALTHY_GATEWAY: 'Good',
   UNHEALTHY_GATEWAY: 'Bad',
@@ -198,7 +196,6 @@ export const GatewayTypeEnum = Object.freeze({
 
 // health status used for federation gateways
 export const HEALTHY_STATUS = 'HEALTHY';
-
 export const UNHEALTHY_STATUS = 'UNHEALTHY';
 
 // availability status of federation gateway health service
@@ -210,16 +207,6 @@ export const ServiceTypeEnum = Object.freeze({
   UNENABLED_SERVICE: 'Not Enabled',
   UNAVAILABLE_SERVICE: 'N/A',
 });
-
-export default function isGatewayHealthy({status}: lte_gateway): boolean {
-  if (status != null) {
-    const checkin = status.checkin_time;
-    if (checkin != null) {
-      return Date.now() - checkin < GATEWAY_KEEPALIVE_TIMEOUT_MS;
-    }
-  }
-  return false;
-}
 
 /**
  * Returns health status of the federation gateway.

--- a/nms/app/components/__tests__/KPI-test.js
+++ b/nms/app/components/__tests__/KPI-test.js
@@ -125,15 +125,12 @@ jest.mock('../../../app/hooks/useSnackbar');
 
 describe('<GatewaysKPIs />', () => {
   const Wrapper = () => {
-    const mockUpSt = Object.assign({}, mockGwSt);
-    mockUpSt['status'] = {
-      checkin_time: Date.now(),
-      meta: {
-        gps_latitude: '0',
-        gps_longitude: '0',
-        gps_connected: '0',
-        enodeb_connected: '0',
-        mme_connected: '0',
+    const mockUpSt = {
+      ...mockGwSt,
+      checked_in_recently: true,
+      status: {
+        ...mockGwSt.status,
+        checkin_time: Date.now(),
       },
     };
     const gatewayCtx = {

--- a/nms/app/views/equipment/EquipmentGateway.js
+++ b/nms/app/views/equipment/EquipmentGateway.js
@@ -35,7 +35,6 @@ import React, {useContext, useEffect, useState} from 'react';
 import SubscriberContext from '../../components/context/SubscriberContext';
 import Text from '../../theme/design-system/Text';
 import TypedSelect from '../../components/TypedSelect';
-import isGatewayHealthy from '../../components/GatewayUtils';
 import nullthrows from '../../../shared/util/nullthrows';
 import withAlert from '../../components/Alert/withAlert';
 
@@ -350,7 +349,7 @@ function GatewayStatusTable(props: WithAlert & {refresh: boolean}) {
         num_subscribers:
           // $FlowIgnore: gateway.device should be present
           gwSubscriberMap?.[gateway.device.hardware_id]?.length ?? 0,
-        health: isGatewayHealthy(gateway) ? 'Good' : 'Bad',
+        health: gateway.checked_in_recently ? 'Good' : 'Bad',
         checkInTime: checkInTime,
       });
     });

--- a/nms/app/views/equipment/EquipmentGatewayKPIs.js
+++ b/nms/app/views/equipment/EquipmentGatewayKPIs.js
@@ -23,7 +23,6 @@ import DataGrid from '../../components/DataGrid';
 import GatewayContext from '../../components/context/GatewayContext';
 import MagmaV1API from '../../../generated/WebClient';
 import React from 'react';
-import isGatewayHealthy from '../../components/GatewayUtils';
 import nullthrows from '../../../shared/util/nullthrows';
 import useMagmaAPI from '../../../api/useMagmaAPI';
 
@@ -97,7 +96,7 @@ export default function EquipmentGatewayKPIs() {
     .map((gwId: string) => lteGateways[gwId])
     .filter((g: lte_gateway) => g.cellular && g.id)
     .map((gateway: lte_gateway) => {
-      isGatewayHealthy(gateway) ? upCount++ : downCount++;
+      gateway.checked_in_recently ? upCount++ : downCount++;
     });
   let pctHealthyGw = 0;
   if (upCount > 0 && upCount + downCount > 0) {

--- a/nms/app/views/equipment/EquipmentGatewayKPIs.js
+++ b/nms/app/views/equipment/EquipmentGatewayKPIs.js
@@ -129,7 +129,7 @@ export default function EquipmentGatewayKPIs() {
       {
         category: '% Healthy Gateways',
         value: pctHealthyGw,
-        tooltip: '% of gateways which have checked in within last 5 minutes',
+        tooltip: '% of gateways which have checked in recently',
       },
     ],
   ];

--- a/nms/app/views/equipment/GatewayDetailStatus.js
+++ b/nms/app/views/equipment/GatewayDetailStatus.js
@@ -89,7 +89,7 @@ export default function GatewayDetailStatus({refresh}: {refresh: boolean}) {
         status: gwInfo.checked_in_recently,
         tooltip: gwInfo.checked_in_recently
           ? 'Gateway checked in recently'
-          : "Gateway hasn't checked in within last 5 minutes",
+          : 'Gateway has not checked in recently',
       },
       {
         category: 'Last Check in',

--- a/nms/app/views/equipment/GatewayDetailStatus.js
+++ b/nms/app/views/equipment/GatewayDetailStatus.js
@@ -13,6 +13,7 @@
  * @flow strict-local
  * @format
  */
+
 import type {DataRows} from '../../components/DataGrid';
 
 import DataGrid from '../../components/DataGrid';
@@ -20,9 +21,9 @@ import GatewayContext from '../../components/context/GatewayContext';
 import LoadingFiller from '../../components/LoadingFiller';
 import MagmaV1API from '../../../generated/WebClient';
 import React from 'react';
-import isGatewayHealthy, {DynamicServices} from '../../components/GatewayUtils';
 import nullthrows from '../../../shared/util/nullthrows';
 import useMagmaAPI from '../../../api/useMagmaAPI';
+import {DynamicServices} from '../../components/GatewayUtils';
 
 import {
   REFRESH_INTERVAL,
@@ -79,15 +80,14 @@ export default function GatewayDetailStatus({refresh}: {refresh: boolean}) {
     !!gwInfo.magmad.dynamic_services &&
     gwInfo.magmad.dynamic_services.includes(DynamicServices.MONITORD);
 
-  const isHealthy = isGatewayHealthy(gwInfo);
   const data: DataRows[] = [
     [
       {
         category: 'Health',
-        value: isHealthy ? 'Good' : 'Bad',
+        value: gwInfo.checked_in_recently ? 'Good' : 'Bad',
         statusCircle: true,
-        status: isGatewayHealthy(gwInfo),
-        tooltip: isHealthy
+        status: gwInfo.checked_in_recently,
+        tooltip: gwInfo.checked_in_recently
           ? 'Gateway checked in recently'
           : "Gateway hasn't checked in within last 5 minutes",
       },

--- a/nms/app/views/equipment/__tests__/EquipmentGatewayTest.js
+++ b/nms/app/views/equipment/__tests__/EquipmentGatewayTest.js
@@ -123,17 +123,19 @@ describe('<Gateway />', () => {
     axiosMock.get.mockClear();
   });
 
-  const mockGw1 = Object.assign({}, mockGw0);
-  const mockGw2 = Object.assign({}, mockGw0);
-  mockGw1.id = 'test_gw1';
-  mockGw1.name = 'test_gateway1';
-  mockGw1.connected_enodeb_serials = ['xxx', 'yyy'];
-
-  mockGw2.id = 'test_gw2';
-  mockGw2.name = 'test_gateway2';
-  mockGw2.connected_enodeb_serials = ['xxx'];
-  mockGw2.status = {
-    checkin_time: currTime,
+  const mockGw1 = {
+    ...mockGw0,
+    id: 'test_gw1',
+    name: 'test_gateway1',
+    connected_enodeb_serials: ['xxx', 'yyy'],
+  };
+  const mockGw2 = {
+    ...mockGw0,
+    id: 'test_gw2',
+    name: 'test_gateway2',
+    checked_in_recently: true,
+    connected_enodeb_serials: ['xxx'],
+    status: {...mockGw0.status, checkin_time: currTime},
   };
   const lteGateways = {
     test1: mockGw0,

--- a/nms/app/views/network/FEGServicingAccessGatewayTable.js
+++ b/nms/app/views/network/FEGServicingAccessGatewayTable.js
@@ -28,7 +28,6 @@ import ActionTable from '../../components/ActionTable';
 import Link from '@material-ui/core/Link';
 import LoadingFiller from '../../components/LoadingFiller';
 import React, {useEffect, useState} from 'react';
-import isGatewayHealthy from '../../components/GatewayUtils';
 import nullthrows from '../../../shared/util/nullthrows';
 
 import {FetchGateways} from '../../state/lte/EquipmentState';
@@ -79,9 +78,8 @@ async function getServicedAccessGatewaysInfo(
         gatewayId: servicedAccessGatewayId,
         gatewayName:
           servicedAccessGateways[servicedAccessGatewayId]?.name || '',
-        gatewayHealth: isGatewayHealthy(
-          servicedAccessGateways[servicedAccessGatewayId] || {},
-        )
+        gatewayHealth: servicedAccessGateways[servicedAccessGatewayId]
+          ?.checked_in_recently
           ? GatewayTypeEnum.HEALTHY_GATEWAY
           : GatewayTypeEnum.UNHEALTHY_GATEWAY,
       };

--- a/nms/app/views/network/__tests__/FEGServicingAccessGatewayTableTest.js
+++ b/nms/app/views/network/__tests__/FEGServicingAccessGatewayTableTest.js
@@ -145,6 +145,7 @@ describe('<ServicingAccessGatewaysInfo />', () => {
     ...mockGw1,
     id: 'test_gw3',
     name: 'test gateway3',
+    checked_in_recently: true,
     status: {checkin_time: Date.now()},
   };
   beforeEach(() => {


### PR DESCRIPTION
:warning: Commit wise review recommended. ~~First Commit is part of #12699 and will vanish after its merge and a rebase.~~

## Summary

Within https://github.com/magma/magma/pull/12699 a orc8r calculated status was implemented.
This PR provides the implementation to actually display this status and not calculate it (wrongly) in the front-end.

As the health is dependent on the configured check-in interval, one cannot give an exact time period in the tool-tip, but has to stay more vague in the tool-tip description.

## Test Plan

- `yarn flow`
- `yarn run eslint . --quiet --fix`
- `yarn test --maxWorkers=2`

## Additional Information

- [ ] Requires https://github.com/magma/magma/pull/12699.