### PR TITLE
chore(ci): Check c and c++ for bazelification

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -246,3 +246,14 @@ jobs:
         shell: bash
         run: |
           ./bazel/scripts/check_py_bazel.sh
+
+  c_cpp_file_check:
+    name: Check if there are non-bazelified c or c++ files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Execute check
+        shell: bash
+        run: |
+          ./bazel/scripts/check_c_cpp_bazel.sh

--- a/bazel/scripts/check_c_cpp_bazel.sh
+++ b/bazel/scripts/check_c_cpp_bazel.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -euo pipefail
+
+###############################################################################
+# VARIABLES SECTION
+###############################################################################
+
+# Folders and files that should not be relevant for bazel.
+DENY_LIST_NOT_RELEVANT=(
+  "./build"
+  # the following files are test suites that are not to be modeled by bazel
+  "./lte/gateway/c/core/oai/test/amf/test_amf.cpp"
+  "./lte/gateway/c/core/oai/test/sgw_s8_task/sgw_s8_test.cpp"
+  "./lte/gateway/c/core/oai/test/ngap/ngap_test.cpp"
+  "./lte/gateway/c/core/oai/test/s1ap_task/s1ap_test.cpp"
+  "./lte/gateway/c/core/oai/test/mme_app_task/mme_app_test.cpp"
+)
+
+# Folders and files that are relevant for building with bazel.
+# This list needs to be updated if respected structures are bazelified.
+DENY_LIST_NOT_YET_BAZELIFIED=(
+  "./lte/gateway/python/magma/pipelined/ebpf/ebpf_ul_handler.c"
+  "./lte/gateway/python/magma/pipelined/ebpf/ebpf_dl_handler.c"
+  "./lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.hpp"
+  "./lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.cpp"
+  "./lte/gateway/c/core/oai/test/s1ap_task/mock_s1ap_op.h"
+  "./lte/gateway/c/core/oai/test/s1ap_task/mock_s1ap_op.cpp"
+  "./lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers_with_injected_state.cpp"
+  "./lte/gateway/c/session_manager/test/test_async_service.cpp"
+  "./lte/gateway/c/session_manager/test/test_session_state_5g.cpp"
+  "./lte/gateway/c/session_manager/test/SessionStateTester5g.hpp"
+  # dead code?
+  "./lte/gateway/c/session_manager/upf-demo-struct.h"
+)
+
+DENY_LIST=( "${DENY_LIST_NOT_RELEVANT[@]}" "${DENY_LIST_NOT_YET_BAZELIFIED[@]}" )
+
+C_ROOT="."
+
+declare -a BUILD_FILES
+mapfile -t BUILD_FILES < <(find "${C_ROOT}" -name "BUILD.bazel")
+
+###############################################################################
+# FUNCTIONS SECTION
+###############################################################################
+
+get_all_c_cpp_files() {
+  DENY=()
+  FIRST_ITERATION=true
+  for entry in "${DENY_LIST[@]}"
+  do
+    if [[ "${FIRST_ITERATION}" = true ]]
+    then
+      DENY+=( "-path" "$entry" )
+      FIRST_ITERATION=false
+    else
+      DENY+=( "-o" "-path" "$entry" )
+    fi
+  done
+  find "${C_ROOT}" \( "${DENY[@]}" \) -prune -o \( -iname "*.cpp" -or -iname "*.c" -or -iname "*.h" -or -iname "*.hpp" \) -print0
+}
+
+check_c_cpp_files() {
+  while IFS= read -r -d '' file
+  do
+    check_c_cpp_file "$file"
+  done 
+}
+
+check_c_cpp_file() {
+  local file=$1
+  SRC_FILE=$(basename "$file")
+
+  if ! (grep -F -q "$SRC_FILE" "${BUILD_FILES[@]}")
+  then
+    echo "$file"
+  fi
+}
+
+report_problematic_files() {
+  local files
+  files="$(cat)"
+
+  if [[ -z "$files" ]]
+  then
+    echo "All c and c++ files are either covered by a BUILD.bazel file or excluded from this check."
+    exit 0
+  else
+    cat <<EOF
+The following files are not covered by a BUILD.bazel file:
+
+$files
+
+Either add the files to the bazel build system or to the deny list in $0.
+Feel free to get support in slack #bazel.
+EOF
+    exit 1
+  fi
+}
+
+###############################################################################
+# SCRIPT SECTION
+###############################################################################
+
+get_all_c_cpp_files | check_c_cpp_files | report_problematic_files


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
This PR adds a script that checks all c/c++ files if they are already bazelified or still need some work. The script is added to the CI. 

## Test Plan

CI should suffice
* test failing run: https://github.com/magma/magma/runs/6453406136?check_suite_focus=true
* successful run: https://github.com/magma/magma/runs/6453495394?check_suite_focus=true

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
