### PR TITLE
chore(agw): MME retun type fix in mme_app

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.c
@@ -1110,7 +1110,7 @@ status_code_e mme_app_handle_create_sess_resp(
   struct ue_mm_context_s* ue_context_p = NULL;
   bearer_context_t* current_bearer_p = NULL;
   ebi_t bearer_id = 0;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   if (create_sess_resp_pP == NULL) {
     OAILOG_ERROR(LOG_MME_APP,
@@ -2596,7 +2596,7 @@ status_code_e mme_app_send_s11_suspend_notification(
     struct ue_mm_context_s* const ue_context_pP, const pdn_cid_t pdn_index) {
   MessageDef* message_p = NULL;
   itti_s11_suspend_notification_t* suspend_notification_p = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
   if (ue_context_pP == NULL) {
@@ -2682,7 +2682,7 @@ status_code_e mme_app_handle_nas_extended_service_req(
     const mme_ue_s1ap_id_t ue_id, const uint8_t service_type,
     uint8_t csfb_response) {
   struct ue_mm_context_s* ue_context_p = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_detach.c
@@ -240,7 +240,7 @@ status_code_e mme_app_handle_nw_initiated_detach_request(mme_ue_s1ap_id_t ue_id,
   emm_cn_nw_initiated_detach.ue_id = ue_id;
   emm_cn_nw_initiated_detach.detach_type = detach_type;
 
-  int ret =
+  status_code_e ret =
       nas_proc_nw_initiated_detach_ue_request(&emm_cn_nw_initiated_detach);
   OAILOG_FUNC_RETURN(LOG_MME_APP, ret);
 }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_edns_emulation.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_edns_emulation.c
@@ -69,7 +69,7 @@ status_code_e mme_app_edns_add_sgw_entry(bstring id, struct in_addr in_addr) {
 
 //------------------------------------------------------------------------------
 status_code_e mme_app_edns_init(const mme_config_t* mme_config_p) {
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   g_e_dns_entries = obj_hashtable_create(OAI_MIN(32, MME_CONFIG_MAX_SGW), NULL,
                                          free_wrapper, free_wrapper, NULL);
   if (g_e_dns_entries) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_hss_reset.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_hss_reset.c
@@ -39,7 +39,7 @@
 
 status_code_e mme_app_handle_s6a_reset_req(
     const s6a_reset_req_t* const rsr_pP) {
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   struct ue_mm_context_s* ue_context_p = NULL;
   hash_node_t* node = NULL;
   unsigned int i = 0;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.c
@@ -62,7 +62,7 @@ status_code_e mme_app_send_s6a_update_location_req(
   OAILOG_FUNC_IN(LOG_MME_APP);
   MessageDef* message_p = NULL;
   s6a_update_location_req_t* s6a_ulr_p = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   OAILOG_INFO(
       TASK_MME_APP,
@@ -167,7 +167,7 @@ status_code_e mme_app_send_s6a_update_location_req(
 }
 
 status_code_e handle_ula_failure(struct ue_mm_context_s* ue_context_p) {
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
 
@@ -197,7 +197,7 @@ status_code_e mme_app_handle_s6a_update_location_ans(
   OAILOG_FUNC_IN(LOG_MME_APP);
   uint64_t imsi64 = 0;
   struct ue_mm_context_s* ue_mm_context = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   if (ula_pP == NULL) {
     OAILOG_ERROR(LOG_MME_APP,
@@ -487,7 +487,7 @@ status_code_e mme_app_send_s6a_cancel_location_ans(int cla_result,
                                                    void* msg_cla_p) {
   MessageDef* message_p = NULL;
   s6a_cancel_location_ans_t* s6a_cla_p = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_alert.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_alert.c
@@ -147,7 +147,7 @@ static status_code_e mme_app_send_sgsap_alert_reject(
     itti_sgsap_alert_request_t* const sgsap_alert_req_pP, SgsCause_t sgs_cause,
     uint64_t imsi64) {
   OAILOG_FUNC_IN(LOG_MME_APP);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   MessageDef* message_p = NULL;
   itti_sgsap_alert_reject_t* sgsap_alert_reject_pP = NULL;
 
@@ -190,7 +190,7 @@ static status_code_e mme_app_send_sgsap_alert_reject(
  ***********************************************************************************/
 static status_code_e mme_app_send_sgsap_alert_ack(
     itti_sgsap_alert_request_t* const sgsap_alert_req_pP, uint64_t imsi64) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   MessageDef* message_p = NULL;
   itti_sgsap_alert_ack_t* sgsap_alert_ack_pP = NULL;
   OAILOG_FUNC_IN(LOG_MME_APP);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_associated.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_associated.c
@@ -65,7 +65,7 @@
  **                                                                        **
  ***************************************************************************/
 status_code_e sgs_associated_handler(const sgs_fsm_t* evt) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   if (sgs_fsm_get_status(evt->ue_id, evt->ctx) != SGS_ASSOCIATED) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.c
@@ -606,7 +606,7 @@ status_code_e mme_app_handle_sgs_imsi_detach_ack(
     const itti_sgsap_imsi_detach_ack_t* const imsi_detach_ack_p) {
   imsi64_t imsi64 = INVALID_IMSI64;
   struct ue_mm_context_s* ue_context_p = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
   if (imsi_detach_ack_p == NULL) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_fsm.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_fsm.c
@@ -122,7 +122,7 @@ void sgs_fsm_initialize(void) {
  **                                                                        **
  ***************************************************************************/
 status_code_e sgs_fsm_process(const sgs_fsm_t* sgs_evt) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   sgs_fsm_state_t state;
   sgs_primitive_t primitive;
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_la_updated.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_la_updated.c
@@ -66,7 +66,7 @@
  ***************************************************************************/
 status_code_e sgs_la_update_requested_handler(const sgs_fsm_t* evt) {
   OAILOG_FUNC_IN(LOG_MME_APP);
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
 
   if (sgs_fsm_get_status(evt->ue_id, evt->ctx) != SGS_LA_UPDATE_REQUESTED) {
     OAILOG_ERROR(LOG_MME_APP,

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_null.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_null.c
@@ -64,7 +64,7 @@
  **                                                                        **
  ***************************************************************************/
 status_code_e sgs_null_handler(const sgs_fsm_t* evt) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   if (sgs_fsm_get_status(evt->ue_id, evt->ctx) != SGS_NULL) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_paging.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_paging.c
@@ -85,7 +85,7 @@ static int sgs_handle_paging_request_for_mt_sms_in_idle(
  **                                                                         **
  ******************************************************************************/
 status_code_e sgs_handle_associated_paging_request(const sgs_fsm_t* evt) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   itti_sgsap_paging_request_t* sgsap_paging_req_pP = NULL;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -123,7 +123,7 @@ status_code_e sgs_handle_associated_paging_request(const sgs_fsm_t* evt) {
  ******************************************************************************/
 static status_code_e sgs_handle_paging_request_for_mt_sms(
     const sgs_fsm_t* evt) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   ue_mm_context_t* ue_context_p = NULL;
   sgs_context_t* sgs_context = NULL;
   itti_sgsap_paging_request_t* sgsap_paging_req_pP = NULL;
@@ -189,7 +189,7 @@ static status_code_e sgs_handle_paging_request_for_mt_sms(
  *******************************************************************************/
 static status_code_e sgs_handle_paging_request_for_mt_call(
     const sgs_fsm_t* evt) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   ue_mm_context_t* ue_context_p = NULL;
   sgs_context_t* sgs_context = NULL;
   itti_sgsap_paging_request_t* sgsap_paging_req_pP = NULL;
@@ -277,7 +277,7 @@ static status_code_e sgs_handle_paging_request_for_mt_call(
 static status_code_e sgs_handle_paging_request_for_mt_call_in_connected(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   uint8_t paging_id = MME_APP_PAGING_ID_IMSI;
   bstring cli = NULL;
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -342,7 +342,7 @@ static status_code_e sgs_handle_paging_request_for_mt_call_in_connected(
 static status_code_e sgs_handle_paging_request_for_mt_sms_in_connected(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
   if (ue_context_p == NULL) {
@@ -394,7 +394,7 @@ static status_code_e sgs_handle_paging_request_for_mt_call_in_idle(
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP)
 
 {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   uint8_t paging_id = MME_APP_PAGING_ID_IMSI;
   OAILOG_FUNC_IN(LOG_MME_APP);
   if (ue_context_p == NULL) {
@@ -478,7 +478,7 @@ static status_code_e sgs_handle_paging_request_for_mt_sms_in_idle(
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP)
 
 {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   uint8_t paging_id = MME_APP_PAGING_ID_IMSI;
   OAILOG_FUNC_IN(LOG_MME_APP);
   if (ue_context_p == NULL) {
@@ -560,7 +560,7 @@ static status_code_e sgs_handle_paging_request_for_mt_sms_in_idle(
 
 status_code_e mme_app_send_sgsap_service_request(
     uint8_t service_indicator, struct ue_mm_context_s* ue_context_p) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   MessageDef* message_p = NULL;
   itti_sgsap_service_request_t* sgsap_service_req_pP = NULL;
 
@@ -627,7 +627,7 @@ status_code_e mme_app_send_sgsap_service_request(
 status_code_e mme_app_send_sgsap_paging_reject(
     struct ue_mm_context_s* ue_context_p, imsi64_t imsi, uint8_t imsi_len,
     SgsCause_t sgs_cause) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   MessageDef* message_p = NULL;
   itti_sgsap_paging_reject_t* sgsap_paging_reject_pP = NULL;
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -677,7 +677,7 @@ status_code_e mme_app_send_sgsap_paging_reject(
  ***********************************************************************************/
 
 status_code_e sgs_handle_null_paging_request(const sgs_fsm_t* evt) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   struct ue_mm_context_s* ue_context_p = NULL;
   itti_sgsap_paging_request_t* sgsap_paging_req_pP = NULL;
   imsi64_t imsi64 = INVALID_IMSI64;
@@ -729,7 +729,7 @@ status_code_e sgs_handle_null_paging_request(const sgs_fsm_t* evt) {
 
 static status_code_e mme_app_send_sgsap_ue_unreachable(
     struct ue_mm_context_s* ue_context_p, SgsCause_t sgs_cause) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   MessageDef* message_p = NULL;
   itti_sgsap_ue_unreachable_t* sgsap_ue_unreachable_pP = NULL;
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -782,7 +782,7 @@ static status_code_e mme_app_send_sgsap_ue_unreachable(
 static status_code_e sgsap_handle_paging_request_without_lai(
     ue_mm_context_t* ue_context_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   s1ap_cn_domain_t cn_domain = CN_DOMAIN_CS;
   uint8_t paging_id = MME_APP_PAGING_ID_IMSI;
 
@@ -860,7 +860,7 @@ status_code_e mme_app_handle_sgsap_paging_request(
     mme_app_desc_t* mme_app_desc_p,
     itti_sgsap_paging_request_t* const sgsap_paging_req_pP) {
   struct ue_mm_context_s* ue_context_p = NULL;
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   sgs_fsm_t sgs_fsm;
   imsi64_t imsi64 = INVALID_IMSI64;
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_reset.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_reset.c
@@ -63,7 +63,7 @@
  ***************************************************************************/
 status_code_e mme_app_handle_sgsap_reset_indication(
     itti_sgsap_vlr_reset_indication_t* const reset_indication_pP) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   OAILOG_FUNC_IN(LOG_MME_APP);
   OAILOG_INFO(LOG_MME_APP, " Received SGSAP-Reset Indication from VLR :%s \n",
               reset_indication_pP->vlr_name);
@@ -96,7 +96,7 @@ bool mme_app_handle_reset_indication(const hash_key_t keyP,
                                      void* const ue_context_pP,
                                      void* unused_param_pP,
                                      void** unused_result_pP) {
-  int rc = RETURNerror;
+  status_code_e rc = RETURNerror;
   sgs_fsm_t sgs_fsm;
   OAILOG_FUNC_IN(LOG_MME_APP);
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgsap_location_update.c
@@ -275,7 +275,7 @@ static status_code_e handle_cs_domain_loc_updt_acc(
     itti_sgsap_location_update_acc_t* const itti_sgsap_location_update_acc,
     struct ue_mm_context_s* ue_context_p) {
   OAILOG_FUNC_IN(LOG_MME_APP);
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   struct emm_context_s* emm_ctx_p = &ue_context_p->emm_context;
 
   if (!emm_ctx_p) {
@@ -423,7 +423,7 @@ status_code_e send_itti_sgsap_location_update_req(
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   MessageDef* message_p = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   uint8_t tau_updt_type = -1;
 
   message_p = DEPRECATEDitti_alloc_new_message_fatal(TASK_MME_APP,
@@ -550,7 +550,7 @@ status_code_e mme_app_handle_sgsap_location_update_acc(
     itti_sgsap_location_update_acc_t* const itti_sgsap_location_update_acc) {
   imsi64_t imsi64 = INVALID_IMSI64;
   struct ue_mm_context_s* ue_context_p = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   sgs_fsm_t sgs_fsm;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
@@ -599,7 +599,7 @@ status_code_e mme_app_handle_sgsap_location_update_rej(
     mme_app_desc_t* mme_app_desc_p,
     itti_sgsap_location_update_rej_t* const itti_sgsap_location_update_rej) {
   imsi64_t imsi64 = INVALID_IMSI64;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   struct ue_mm_context_s* ue_context_p = NULL;
   sgs_fsm_t sgs_fsm;
 
@@ -649,7 +649,7 @@ status_code_e mme_app_handle_sgsap_location_update_rej(
  **                                                                          **
  *******************************************************************************/
 status_code_e sgs_fsm_null_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   itti_sgsap_location_update_acc_t* itti_sgsap_location_update_acc_p = NULL;
   MobileIdentity_t* mobileid = NULL;
 
@@ -714,7 +714,7 @@ status_code_e sgs_fsm_null_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
  ** **
  ***********************************************************************************/
 status_code_e sgs_fsm_associated_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_MME_APP);
 
@@ -753,7 +753,7 @@ status_code_e sgs_fsm_associated_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
  **                                                                          **
  *******************************************************************************/
 status_code_e sgs_fsm_la_updt_req_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   itti_sgsap_location_update_acc_t* itti_sgsap_location_update_acc_p = NULL;
   struct ue_mm_context_s* ue_context_p = NULL;
   MobileIdentity_t* mobileid = NULL;
@@ -838,7 +838,7 @@ status_code_e sgs_fsm_la_updt_req_loc_updt_acc(const sgs_fsm_t* fsm_evt) {
  ** **
  ***********************************************************************************/
 status_code_e sgs_fsm_null_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   OAILOG_FUNC_IN(LOG_MME_APP);
   OAILOG_ERROR(LOG_MME_APP,
                "Dropping message as it is received in NULL state for UE %d",
@@ -858,7 +858,7 @@ status_code_e sgs_fsm_null_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
  ** **
  *****************************************************************************************/
 status_code_e sgs_fsm_la_updt_req_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   struct ue_mm_context_s* ue_context_p = NULL;
   itti_sgsap_location_update_rej_t* itti_sgsap_location_update_rej_p = NULL;
   imsi64_t imsi64 = INVALID_IMSI64;
@@ -957,7 +957,7 @@ status_code_e mme_app_handle_ts6_1_timer_expiry(zloop_t* loop, int timer_id,
  ** **
  ***********************************************************************************/
 status_code_e sgs_fsm_associated_loc_updt_rej(const sgs_fsm_t* fsm_evt) {
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   struct ue_mm_context_s* ue_context_p = NULL;
   itti_sgsap_location_update_rej_t* itti_sgsap_location_update_rej_p = NULL;
   imsi64_t imsi64 = INVALID_IMSI64;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_transport.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_transport.c
@@ -48,7 +48,7 @@ status_code_e mme_app_handle_nas_dl_req(const mme_ue_s1ap_id_t ue_id,
 {
   OAILOG_FUNC_IN(LOG_MME_APP);
   MessageDef* message_p = NULL;
-  int rc = RETURNok;
+  status_code_e rc = RETURNok;
   enb_ue_s1ap_id_t enb_ue_s1ap_id = 0;
 
   message_p = DEPRECATEDitti_alloc_new_message_fatal(TASK_MME_APP,


### PR DESCRIPTION
Fixes for #11199 
Signed-off-by: Vikram G <vikram.gurrappagaru@radisys.com>

## Summary
In order to use the protobuf map, it's required to migrate all c files to cpp. Doing so will result in huge changes. So we planned to commit a small chunk of changes. This PR returns the value as expected by the function prototype.

## Test Plan
make test_oai

## Additional Information

