### PR TITLE
chore(ci): Modify the bazel workflow to use remote caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,20 @@ build:devcontainer --disk_cache=/workspaces/magma/.bazel-cache
 common:devcontainer --repository_cache=/workspaces/magma/.bazel-cache-repo
 build:devcontainer --define=folly_so=1
 
+# REMOTE CACHING READ AND WRITE CONFIGS
+# The file bazel/bazelrcs/remote_caching_rw.bazelrc is templated in CI
+# The full config is then written to remote-cache.bazelrc
+build:remote_caching_rw --remote_download_toplevel
+
+# REMOTE CACHING READ-ONLY CONFIGS
+# The file bazel/bazelrcs/remote_caching_ro.bazelrc is templated in CI
+# The full config is then written to remote-cache.bazelrc
+build:remote_caching_ro --remote_download_toplevel
+build:remote_caching_ro --remote_upload_local_results=false 
+
+# Try importing the bazel remote caching config (relevant in CI)
+try-import remote-cache.bazelrc
+
 # TEST CONFIGS
 # Bazel test runtime default: PATH=/bin:/usr/bin:/usr/local/bin
 # Some python tests require access to /usr/sbin binaries (e.g. route, ifconfig)

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,6 +1,7 @@
 ---
 name: "Bazel Build & Test"
 on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
   pull_request:
     types:
       - opened
@@ -16,10 +17,8 @@ on:  # yamllint disable-line rule:truthy
     - cron: '0 0,6,12,18 * * *'
 env:
   BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latestv2"
-  BAZEL_CACHE: bazel-cache
-  BAZEL_CACHE_REPO: bazel-cache-repo
-  CACHE_SUB_KEY_BUILD_ALL: build-all
-  CACHE_SUB_KEY_TEST_ALL: test-all
+  CACHE_KEY: bazel-base-image
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -73,48 +72,6 @@ jobs:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
         uses: actions/checkout@v2
-      - name: Bazel Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE }}
-          key: ${{ runner.os }}-${{ env.BAZEL_CACHE }}-${{ env.CACHE_SUB_KEY_BUILD_ALL }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.BAZEL_CACHE }}-${{ env.CACHE_SUB_KEY_BUILD_ALL }}-
-
-      - name: Bazel Cache Repo
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE_REPO }}
-          key: ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-
-
-      # This check is needed to ensure that Bazel's unbounded cache growth doesn't result in a
-      # situation where the cache never updates (e.g. due to exceeding GitHub's cache size limit)
-      # thereby only ever using the last successful cache version. This solution will result in a
-      # few slower CI actions around the time cache is detected to be too large, but it should
-      # incrementally improve thereafter.
-      - name: Ensure cache size BAZEL_CACHE
-        # Only run on master to avoid slow build on PRs
-        if: github.event_name == 'schedule' || github.event_name == 'push'
-        env:
-          BAZEL_CACHE_DIR: .${{ env.BAZEL_CACHE }}
-          # Use a 6.5GB threshold since actions/cache compresses the results, and Bazel caches seem
-          # to only increase by a few hundred megabytes across changes for unrelated branches.
-          # Uncompressed cache on master is looking to be around 6GB (from observing jobs on master)
-          BAZEL_CACHE_CUTOFF_MB: 6500
-        run: |
-          ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
-      - name: Ensure cache size BAZEL_CACHE_REPO
-        # Only run on master to avoid slow build on PRs
-        if: github.event_name == 'schedule' || github.event_name == 'push'
-        env:
-          BAZEL_CACHE_REPO_DIR: .${{ env.BAZEL_CACHE_REPO }}
-          # Use a 600 threshold since actions/cache compresses the results, and the repository cache should not increase unless we add more dependencies
-          # Uncompressed cache on master is looking to be around 400MB (from observing jobs on master)
-          BAZEL_CACHE_REPO_CUTOFF_MB: 600
-        run: |
-          ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_REPO_DIR" "$BAZEL_CACHE_REPO_CUTOFF_MB"
       - name: Setup Bazel Base Image
         uses: addnab/docker-run-action@v3
         with:
@@ -131,6 +88,7 @@ jobs:
           options: -v ${{ github.workspace }}:/workspaces/magma/
           run: |
             cd /workspaces/magma
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             bazel build //...
       - name: Build space left after run
         shell: bash
@@ -162,39 +120,6 @@ jobs:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
         uses: actions/checkout@v2
-      - name: Bazel Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE }}
-          key: ${{ runner.os }}-${{ env.BAZEL_CACHE }}-${{ env.CACHE_SUB_KEY_TEST_ALL }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.BAZEL_CACHE }}-${{ env.CACHE_SUB_KEY_TEST_ALL }}-
-
-      - name: Bazel Cache Repo
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE_REPO }}
-          key: ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-
-
-      # This check is needed to ensure that Bazel's unbounded cache growth doesn't result in a
-      # situation where the cache never updates (e.g. due to exceeding GitHub's cache size limit)
-      # thereby only ever using the last successful cache version. This solution will result in a
-      # few slower CI actions around the time cache is detected to be too large, but it should
-      # incrementally improve thereafter.
-      - name: Ensure cache size BAZEL_CACHE
-        # Only run on master to avoid slow build on PRs
-        if: github.event_name == 'schedule' || github.event_name == 'push'
-        env:
-          BAZEL_CACHE_DIR: .${{ env.BAZEL_CACHE }}
-          # Use a 6.5GB threshold since actions/cache compresses the results, and Bazel caches seem
-          # to only increase by a few hundred megabytes across changes for unrelated branches.
-          # Uncompressed cache on master is looking to be around 6GB (from observing jobs on master)
-          BAZEL_CACHE_CUTOFF_MB: 6500
-        run: |
-          ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
-      # Letting the Build job above handle cache clean up for bazel-cache-repo
       - name: Setup Bazel Base Image
         uses: addnab/docker-run-action@v3
         with:
@@ -211,7 +136,10 @@ jobs:
           options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
             cd /workspaces/magma
-            bazel test //... --test_output=errors --cache_test_results=no
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+            bazel test //... \
+              --cache_test_results=no \
+              --test_output=errors
       - name: Run `bazel run //:check_starlark_format`
         uses: addnab/docker-run-action@v3
         with:
@@ -229,6 +157,7 @@ jobs:
           options: -v ${{ github.workspace }}:/workspaces/magma/
           run: |
             cd /workspaces/magma
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             bazel/scripts/test_python_service_imports.sh
       - name: Build space left after run
         shell: bash

--- a/bazel/bazelrcs/remote_caching_ro.bazelrc
+++ b/bazel/bazelrcs/remote_caching_ro.bazelrc
@@ -1,0 +1,4 @@
+# This file is templated in CI (see e.g. .github/workflows/bazel.yml)
+# The full config is then written to remote-cache.bazelrc which is imported in the .bazelrc
+build --config=remote_caching_ro
+build:remote_caching_ro --remote_cache="https://bazel-remote-cache.magmacore-ci.org:9090/~~CACHE_KEY~~"

--- a/bazel/bazelrcs/remote_caching_rw.bazelrc
+++ b/bazel/bazelrcs/remote_caching_rw.bazelrc
@@ -1,0 +1,4 @@
+# This file is templated in CI (see e.g. .github/workflows/bazel.yml)
+# The full config is then written to remote-cache.bazelrc which is imported in the .bazelrc
+build --config=remote_caching_rw
+build:remote_caching_rw --remote_cache="https://bazelbuild:~~BAZEL_REMOTE_PASSWORD~~@bazel-remote-cache.magmacore-ci.org:9090/~~CACHE_KEY~~"

--- a/bazel/scripts/remote_cache_bazelrc_setup.sh
+++ b/bazel/scripts/remote_cache_bazelrc_setup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+set -euo pipefail
+
+###############################################################################
+# VARIABLES SECTION
+###############################################################################
+
+# The CACHE_KEY is the mandatory first argument.
+CACHE_KEY=${1:-}
+
+if [[ -z "$CACHE_KEY" ]]
+then
+  echo "Required argument CACHE_KEY not set!" >&2
+  exit 1
+fi
+
+# The BAZEL_REMOTE_PASSWORD is an optional second argument.
+BAZEL_REMOTE_PASSWORD=${2:-}
+
+###############################################################################
+# FUNCTIONS SECTION
+###############################################################################
+
+create_config () {
+  local cache_key=$1
+  local bazel_remote_password=$2
+  if [[ -n "$bazel_remote_password" ]]
+  then
+    create_config_for_rw_remote_cache "$cache_key" "$bazel_remote_password"
+  else
+    create_config_for_ro_remote_cache "$cache_key"
+  fi
+}
+
+create_config_for_rw_remote_cache () {
+  local cache_key=$1
+  local bazel_remote_password=$2
+  sed \
+    -e s/~~CACHE_KEY~~/"$cache_key"/ \
+    -e s/~~BAZEL_REMOTE_PASSWORD~~/"$bazel_remote_password"/ \
+    bazel/bazelrcs/remote_caching_rw.bazelrc
+}
+
+create_config_for_ro_remote_cache () {
+  local cache_key=$1
+  sed \
+    -e s/~~CACHE_KEY~~/"$cache_key"/ \
+    bazel/bazelrcs/remote_caching_ro.bazelrc
+}
+
+###############################################################################
+# SCRIPT SECTION
+###############################################################################
+
+create_config "$CACHE_KEY" "$BAZEL_REMOTE_PASSWORD" > remote-cache.bazelrc


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- The bazel workflow is modified to use the [remote cache](https://github.com/magma/magma/issues/12458) instead of the GH caches.
  - GH caching steps are removed.
  - If the secret is present read + write access is used, else read-only access is used.
  - The files `bazel/bazelrcs/remote_caching_rw.bazelrc` and `bazel/bazelrcs/remote_caching_ro.bazelrc` are templates which are filled in the workflow and then imported in the `.bazelrc`.
- A `workflow_dispatch` trigger is added to the workflow (for ease of testing).

## Test Plan

- CI
- See [run on this PR with read-only access](https://github.com/magma/magma/runs/6466203486?check_suite_focus=true).
- See [run on fork with secret present](https://github.com/LKreutzer/magma/actions/runs/2333026996).

One can check that the import of the templated `bazelrc` file works by finding a line like 
```
INFO: Found applicable config definition build:remote_caching_rw in file /workspaces/magma/remote-cache.bazelrc: --remote_cache=***bazel-remote-cache.magmacore-ci.org:9090/bazel-base-image
```
 at the beginning of the bazel output.

If there were remote cache hits one will find a statement similar to:
```
INFO: Elapsed time: 407.457s, Critical Path: 41.39s
INFO: 7188 processes: 5309 remote cache hit, 1614 internal, 2 local, 263 processwrapper-sandbox.
INFO: Build completed successfully, 7188 total actions
```
at the end of the bazel output, which lists `remote cache hit`s. 


## Additional Information

- See [Wiki page on remote cache disaster recovery](https://github.com/magma/magma/wiki/Bazel-remote-caching-disaster-recovery-plan) in case of poisoned caches or other issues with the remote cache.

- [ ] This change is backwards-breaking


