### PR TITLE
feat(ci): Add cwag formatting to ci and apply formatting changes

### DIFF
--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -58,6 +58,10 @@ jobs:
             make -C ${MAGMA_ROOT}/cwf/gateway precommit
             cd ${MAGMA_ROOT}/cwf/gateway
             make -C ${MAGMA_ROOT}/cwf/gateway/integ_tests precommit
+      - name: Check precommit has not generated formatting changes
+        run: |
+            git status
+            git diff-index --quiet HEAD
       - name: Extract commit title
         if: failure() && github.event_name == 'push'
         id: commit

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -54,14 +54,13 @@ jobs:
           timeout_minutes: 10
       - name: Run precommit
         run: |
-            cd ${MAGMA_ROOT}/cwf/gateway
             make -C ${MAGMA_ROOT}/cwf/gateway precommit
-            cd ${MAGMA_ROOT}/cwf/gateway
             make -C ${MAGMA_ROOT}/cwf/gateway/integ_tests precommit
       - name: Check precommit has not generated formatting changes
         run: |
             echo "Checking for changes caused by 'make -C \${MAGMA_ROOT}/cwf/gateway precommit' and 'make -C \${MAGMA_ROOT}/cwf/gateway/integ_tests precommit'."\
                  "Run these commands locally to see the respective changes."
+            cd ${MAGMA_ROOT}
             git status
             git diff-index --quiet HEAD
       - name: Extract commit title

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -60,6 +60,8 @@ jobs:
             make -C ${MAGMA_ROOT}/cwf/gateway/integ_tests precommit
       - name: Check precommit has not generated formatting changes
         run: |
+            echo "Checking for changes caused by 'make -C \${MAGMA_ROOT}/cwf/gateway precommit' and 'make -C \${MAGMA_ROOT}/cwf/gateway/integ_tests precommit'."\
+                 "Run these commands locally to see the respective changes."
             git status
             git diff-index --quiet HEAD
       - name: Extract commit title

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -993,7 +993,7 @@ func TestGyWithTransientErrorCode(t *testing.T) {
 	fmt.Println("RG 1 should now be UN-suspended")
 	// check rule is able to track traffic again
 	req = &cwfprotos.GenTrafficRequest{Imsi: imsi}
-	_, err = tr.GenULTrafficBasedOnPolicyUsage(req, "static-pass-all-ocs2", 200 * KiloBytes, 40 * time.Second)
+	_, err = tr.GenULTrafficBasedOnPolicyUsage(req, "static-pass-all-ocs2", 200*KiloBytes, 40*time.Second)
 	assert.NoError(t, err)
 
 	// trigger disconnection

--- a/cwf/gateway/integ_tests/gy_reauth_test.go
+++ b/cwf/gateway/integ_tests/gy_reauth_test.go
@@ -54,9 +54,9 @@ func TestGyReAuth(t *testing.T) {
 
 	err = setNewOCSConfig(
 		&fegprotos.OCSConfig{
-			MaxUsageOctets: &fegprotos.Octets{OutputOctets: ReAuthMaxUsageBytes},
-			MaxUsageTime:   ReAuthMaxUsageTimeSec,
-			ValidityTime:   ReAuthValidityTime,
+			MaxUsageOctets:     &fegprotos.Octets{OutputOctets: ReAuthMaxUsageBytes},
+			MaxUsageTime:       ReAuthMaxUsageTimeSec,
+			ValidityTime:       ReAuthValidityTime,
 			GrantTypeProcedure: fegprotos.OCSConfig_TxOnly,
 		},
 	)
@@ -98,7 +98,7 @@ func TestGyReAuth(t *testing.T) {
 		Volume:  &wrappers.StringValue{Value: "2M"},
 		Bitrate: &wrappers.StringValue{Value: "1M"}}
 	_, err = tr.GenULTrafficBasedOnPolicyUsage(req,
-		"static-pass-all-ocs2", uint64(math.Round(800 * KiloBytes)), 40*time.Second)
+		"static-pass-all-ocs2", uint64(math.Round(800*KiloBytes)), 40*time.Second)
 	require.NoError(t, err)
 
 	require.Eventually(t,
@@ -129,11 +129,11 @@ func TestGyReAuth(t *testing.T) {
 	// Send more traffic to see rule is not removed
 	req = &cwfprotos.GenTrafficRequest{Imsi: imsi}
 	_, err = tr.GenULTrafficBasedOnPolicyUsage(req,
-		"static-pass-all-ocs2", uint64(math.Round(1.5 * MegaBytes)), 40*time.Second)
+		"static-pass-all-ocs2", uint64(math.Round(1.5*MegaBytes)), 40*time.Second)
 	require.NoError(t, err)
 
 	require.Eventually(t,
-		tr.WaitForEnforcementStatsForRuleGreaterThan(imsi, "static-pass-all-ocs2", uint64(math.Round(1.5 * MegaBytes))),
+		tr.WaitForEnforcementStatsForRuleGreaterThan(imsi, "static-pass-all-ocs2", uint64(math.Round(1.5*MegaBytes))),
 		20*time.Second,
 		2*time.Second)
 

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -281,14 +281,14 @@ func (tr *TestRunner) GenULTrafficBasedOnPolicyUsage(req *cwfprotos.GenTrafficRe
 	for start := time.Now(); time.Since(start) < waitFor; {
 		startGenTrafficTime := time.Now()
 		res, err = uesim.GenTrafficWithReatempts(req)
-		if err != nil{
+		if err != nil {
 			return res, fmt.Errorf("GenULTrafficBasedOnPolicyUsage failed during GenTraffic: %s", err)
 		}
-		completeCycle := time.Now().Sub(startGenTrafficTime)%time.Second
-		if  waitNeeded {
+		completeCycle := time.Now().Sub(startGenTrafficTime) % time.Second
+		if waitNeeded {
 			// this wait makes sure the time passes is exact in seconds. This way
 			// we make sure policies had time to sync
-			time.Sleep(completeCycle + 200 * time.Millisecond)
+			time.Sleep(completeCycle + 200*time.Millisecond)
 			waitNeeded = false
 		}
 		time.Sleep(2200 * time.Millisecond)
@@ -306,19 +306,21 @@ func (tr *TestRunner) GenULTrafficBasedOnPolicyUsage(req *cwfprotos.GenTrafficRe
 		req.Bitrate = &wrappers.StringValue{Value: "10M"}
 		if remaining > 100*KiloBytes {
 			newVolume = uint64(float64(remaining) * 0.95)
-			if newVolume > 5 * MegaBytes {
+			if newVolume > 5*MegaBytes {
 				newVolume = 5 * MegaBytes
 			}
 			// only add wait for the bigger chunks
 			waitNeeded = true
 		}
-		if newVolume < 1000 {newVolume = 1000}
+		if newVolume < 1000 {
+			newVolume = 1000
+		}
 		newVolumeStr := fmt.Sprintf("%dK", newVolume/1000)
 
 		req.Volume = &wrappers.StringValue{Value: newVolumeStr}
 		fmt.Printf("- not enough traffic genereted, sending %dKB more. Will be around %d%% of volume requested\n",
 			newVolume/1000,
-			100 * (record.BytesTx+newVolume)/totalVolume,
+			100*(record.BytesTx+newVolume)/totalVolume,
 		)
 	}
 	return res, fmt.Errorf("error: not enough traffic generated to fullfil GenULTrafficBasedOnPolicyUsage requieriment: %s", err)
@@ -477,32 +479,32 @@ func (tr *TestRunner) WaitForEnforcementStatsForRuleGreaterThanOrDoesNotExist(im
 	}
 }
 
- func (tr *TestRunner) WaitForEnforcementStatsForRuleGreaterThanOrDoesNotExistFunc (imsi, ruleID string, min uint64)(*lteprotos.RuleRecord, bool) {
-		fmt.Printf("\tWaiting until %s, %s has more than %d bytes in enforcement stats or rule does not exist ...\n", imsi, ruleID, min)
-		records, err := tr.GetPolicyUsage()
-		if err != nil {
-			return nil, false
-		}
-		imsi = prependIMSIPrefix(imsi)
-		if records[imsi] == nil {
-			// Session is gone
-			fmt.Printf("\tSession for %s, does not exist...\n", imsi)
-			return nil, true
-		}
-		record := records[imsi][ruleID]
-		if record == nil {
-			// Session is gone
-			fmt.Printf("\tRule %s for %s, does not exist...\n", ruleID, imsi)
-			return nil, true
-		}
-		txBytes := record.BytesTx
-		if record.BytesTx < min {
-			return record, false
-		}
-		fmt.Printf("\t\u2713 %s, %s now passed %d > %d in enforcement stats!(%d%%)\n",
-			imsi, ruleID, txBytes, min, 100* txBytes/min)
-		return record, true
+func (tr *TestRunner) WaitForEnforcementStatsForRuleGreaterThanOrDoesNotExistFunc(imsi, ruleID string, min uint64) (*lteprotos.RuleRecord, bool) {
+	fmt.Printf("\tWaiting until %s, %s has more than %d bytes in enforcement stats or rule does not exist ...\n", imsi, ruleID, min)
+	records, err := tr.GetPolicyUsage()
+	if err != nil {
+		return nil, false
 	}
+	imsi = prependIMSIPrefix(imsi)
+	if records[imsi] == nil {
+		// Session is gone
+		fmt.Printf("\tSession for %s, does not exist...\n", imsi)
+		return nil, true
+	}
+	record := records[imsi][ruleID]
+	if record == nil {
+		// Session is gone
+		fmt.Printf("\tRule %s for %s, does not exist...\n", ruleID, imsi)
+		return nil, true
+	}
+	txBytes := record.BytesTx
+	if record.BytesTx < min {
+		return record, false
+	}
+	fmt.Printf("\t\u2713 %s, %s now passed %d > %d in enforcement stats!(%d%%)\n",
+		imsi, ruleID, txBytes, min, 100*txBytes/min)
+	return record, true
+}
 
 //WaitForPolicyReAuthToProcess returns a method which checks for reauth answer and
 // if it has sessionID which contains the IMSI

--- a/cwf/gateway/services/uesim/client_api.go
+++ b/cwf/gateway/services/uesim/client_api.go
@@ -93,7 +93,7 @@ func GenTrafficWithReatempts(req *cwfprotos.GenTrafficRequest) (*cwfprotos.GenTr
 		resp, err = GenTraffic(req)
 		if err != nil &&
 			(strings.Contains(strings.ToLower(err.Error()), "connection refused") ||
-				strings.Contains(err.Error(),"DeadlineExceeded")) {
+				strings.Contains(err.Error(), "DeadlineExceeded")) {
 			// try again due to connection error
 			fmt.Printf("genTrafficSingleAttempt failed, retrying: %s\n", err)
 			continue

--- a/cwf/gateway/services/uesim/servicers/uesim.go
+++ b/cwf/gateway/services/uesim/servicers/uesim.go
@@ -381,7 +381,7 @@ func executeCommandWithRetries(command string, argList []string) (*IperfResponse
 		if !isIperfErrorDueToControlMessage(err) {
 			break
 		}
-		glog.Warning( "Retried IPERF command due to an specific error")
+		glog.Warning("Retried IPERF command due to an specific error")
 		time.Sleep(300 * time.Millisecond)
 	}
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Cameron Voisey <cameron.voisey@tngtech.com>

## Summary

Running the precommit check `make -C ${MAGMA_ROOT}/cwf/gateway precommit` on master on the cwag_test VM leads to some formatting changes. This PR adds these changes, as well as adding a check to the CI to make sure that such formatting problems aren't introduced in the future.

To test the modification to the CI, I created a PR in which only the CI is modified: https://github.com/magma/magma/pull/12753. As expected, cwag-workflow breaks on this PR due to there being unstaged files: https://github.com/magma/magma/runs/6472265618?check_suite_focus=true, while the corresponding check is green on this PR, due to the files being added.

## Test Plan

- [x] cwag_test:  `make -C ${MAGMA_ROOT}/cwf/gateway test`
- [x] Host: `cd $MAGMA_ROOT/cwf/gateway && fab integ_test`
- [x] CI