### PR TITLE
feat(ci): Add cwag formatting to ci

### DIFF
--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -58,6 +58,10 @@ jobs:
             make -C ${MAGMA_ROOT}/cwf/gateway precommit
             cd ${MAGMA_ROOT}/cwf/gateway
             make -C ${MAGMA_ROOT}/cwf/gateway/integ_tests precommit
+      - name: Check precommit has not generated formatting changes
+        run: |
+            git status
+            git diff-index --quiet HEAD
       - name: Extract commit title
         if: failure() && github.event_name == 'push'
         id: commit

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -54,14 +54,13 @@ jobs:
           timeout_minutes: 10
       - name: Run precommit
         run: |
-            cd ${MAGMA_ROOT}/cwf/gateway
             make -C ${MAGMA_ROOT}/cwf/gateway precommit
-            cd ${MAGMA_ROOT}/cwf/gateway
             make -C ${MAGMA_ROOT}/cwf/gateway/integ_tests precommit
       - name: Check precommit has not generated formatting changes
         run: |
             echo "Checking for changes caused by 'make -C \${MAGMA_ROOT}/cwf/gateway precommit' and 'make -C \${MAGMA_ROOT}/cwf/gateway/integ_tests precommit'."\
                  "Run these commands locally to see the respective changes."
+            cd ${MAGMA_ROOT}
             git status
             git diff-index --quiet HEAD
       - name: Extract commit title

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -60,6 +60,8 @@ jobs:
             make -C ${MAGMA_ROOT}/cwf/gateway/integ_tests precommit
       - name: Check precommit has not generated formatting changes
         run: |
+            echo "Checking for changes caused by 'make -C \${MAGMA_ROOT}/cwf/gateway precommit' and 'make -C \${MAGMA_ROOT}/cwf/gateway/integ_tests precommit'."\
+                 "Run these commands locally to see the respective changes."
             git status
             git diff-index --quiet HEAD
       - name: Extract commit title


### PR DESCRIPTION
Signed-off-by: Cameron Voisey <cameron.voisey@tngtech.com>

## Summary

The cwag precommit check generates formatting changes on master that don't seem to be checked in the CI: see https://github.com/magma/magma/pull/12749. This attempts to check whether such changes are generated in the cwag workflow.

## Test Plan

Confirm that cwag-workflow is red and then turns green upon adding the changes in https://github.com/magma/magma/pull/12749.
