### PR TITLE
fix(dp): Use retry for log fetching in tests

### DIFF
--- a/dp/cloud/python/magma/test_runner/tests/integration_testcase.py
+++ b/dp/cloud/python/magma/test_runner/tests/integration_testcase.py
@@ -19,21 +19,10 @@ class DomainProxyIntegrationTestCase(TestCase):
             f"{config.GRPC_SERVICE}:{config.GRPC_PORT}",
         )
         cls.dp_client = DPServiceStub(grpc_channel)
-        wait_for_elastic_to_start()
 
     @classmethod
     def tearDownClass(cls) -> None:
         _delete_dp_elasticsearch_indices()
-
-
-@retry(stop_max_attempt_number=30, wait_fixed=1000)
-def wait_for_elastic_to_start() -> None:
-    requests.get(f'{config.ELASTICSEARCH_URL}/_status')
-
-
-def when_elastic_indexes_data():
-    # TODO use retrying instead
-    sleep(15)
 
 
 def _delete_dp_elasticsearch_indices() -> None:

--- a/dp/cloud/python/magma/test_runner/tests/test_active_mode_controller.py
+++ b/dp/cloud/python/magma/test_runner/tests/test_active_mode_controller.py
@@ -160,7 +160,3 @@ class ActiveModeControllerTestCase(DomainProxyIntegrationTestCase):
     @staticmethod
     def _build_empty_state_result() -> CBSDStateResult:
         return CBSDStateResult(radio_enabled=False)
-
-
-def _delete_dp_elasticsearch_indices():
-    requests.delete(f"{config.ELASTICSEARCH_URL}/{config.ELASTICSEARCH_INDEX}*")


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>

ElasticSearch integration tests should use retry for log fetching
