### PR TITLE
chore(ci): new images are created with latest tag

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 ################################################################
 # Devcontainer Image (for local development and CI)
 ################################################################
-FROM ghcr.io/magma/magma/bazel-base:latestv2 as devcontainer
+FROM ghcr.io/magma/magma/bazel-base:latest as devcontainer
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"

--- a/.github/workflows/composite/docker-builder/action.yml
+++ b/.github/workflows/composite/docker-builder/action.yml
@@ -31,15 +31,8 @@ runs:
         # defines the image stream the image is pushed to
         images: ${{ inputs.REGISTRY }}/${{ inputs.IMAGE_STREAM }}
         # defines the image tags added to the image
-        # TODO set a custom tag for now as a release strategy
-        # will be changed back in a follwoup PR
-        # tags: ${{ inputs.IMAGE_TAGS }}
-        tags: |
-          type=sha
-          type=raw,value=latestv2
-        # TODO do not set the latest tag for now so that jobs use the
-        # current latest build until new images are build.
-        flavor: latest=false
+        tags: ${{ inputs.IMAGE_TAGS }}
+        flavor: latest=true
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

This is the third PR of https://github.com/magma/magma/pull/12638. Newly created Bazel Base and Devcontainer images are tagged as "latest". 

Pre conditions:
* This change requires that sufficiently enough open PRs are rebased on #12731, i.e., workflow files in PRs are not relying on images before the Bazel Base and Devocontainer merge.

Still open:
* PR4: workflows will use the latest images

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
