### PR TITLE
chore: Bazelify the remaining 2 LTE Python service tests

### DIFF
--- a/bazel/scripts/check_py_bazel.sh
+++ b/bazel/scripts/check_py_bazel.sh
@@ -66,9 +66,6 @@ DENY_LIST_NOT_YET_BAZELIFIED=(
   # this needs to be refactored when make is not used anymore
   "./lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py"
   "./lte/gateway/python/magma/pipelined/tests/script/ip-packet.py"
-  # TODO: GH12759 needs to be bazelified
-  "./lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py"
-  "./lte/gateway/python/magma/enodebd/tr069/tests/models_tests.py"
   # TODO: GH12765 dead code
   "./lte/gateway/python/magma/pipelined/openflow/events.py"
   "./lte/gateway/python/magma/enodebd/state_machines/enb_acs_pointer.py"

--- a/lte/gateway/python/magma/enodebd/tr069/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/enodebd/tr069/tests/BUILD.bazel
@@ -1,0 +1,24 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:python_test.bzl", "pytest_test")
+
+MAGMA_ROOT = "../../../../../../../"
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+pytest_test(
+    name = "models_tests",
+    size = "small",
+    srcs = ["models_tests.py"],
+    imports = [LTE_ROOT],
+    deps = ["//lte/gateway/python/magma/enodebd/tr069:models"],
+)

--- a/lte/gateway/python/magma/mobilityd/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/tests/BUILD.bazel
@@ -130,3 +130,18 @@ pytest_test(
         requirement("fakeredis"),
     ],
 )
+
+pytest_test(
+    name = "rpc_servicer_tests",
+    size = "small",
+    srcs = ["rpc_servicer_tests.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = [
+        "//lte/gateway/python/magma/mobilityd:mobilityd_lib",
+        requirement("fakeredis"),
+        requirement("grpcio"),
+    ],
+)


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

There were 2 tests inside `lte/gateway/python/magma` that were not bazelified. This PR fixed this.

## Test Plan

CI and:
`bazel test lte/gateway/python/magma/mobilityd/tests:rpc_servicer_tests`
`bazel test lte/gateway/python/magma/enodebd/tr069/tests:models_tests`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
