### PR TITLE
refactor(orc8r): Remove NewServiceWithOptionsImpl

### DIFF
--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -90,7 +90,7 @@ func NewOrchestratorService(moduleName string, serviceName string, serverOptions
 	grpc_prometheus.EnableHandlingTimeHistogram()
 	serverOptions = append(serverOptions, unary.GetInterceptorOpt())
 
-	platformService, err := platform_service.NewServiceWithOptionsImpl(moduleName, serviceName, serverOptions...)
+	platformService, err := platform_service.NewServiceWithOptions(moduleName, serviceName, serverOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/lib/go/service/service.go
+++ b/orc8r/lib/go/service/service.go
@@ -19,12 +19,12 @@ package service
 import (
 	"flag"
 	"fmt"
-	"github.com/pkg/errors"
 	"net"
 	"sync"
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 
@@ -93,13 +93,6 @@ type Service struct {
 // service303 with the specified grpc server options.
 // It will not instantiate the service with the identity checking middleware.
 func NewServiceWithOptions(moduleName string, serviceName string, serverOptions ...grpc.ServerOption) (*Service, error) {
-	return NewServiceWithOptionsImpl(moduleName, serviceName, serverOptions...)
-}
-
-// NewServiceWithOptionsImpl returns a new GRPC service implementing
-// service303 with the specified grpc server options. This will not instantiate
-// the service with the identity checking middleware.
-func NewServiceWithOptionsImpl(moduleName string, serviceName string, serverOptions ...grpc.ServerOption) (*Service, error) {
 	// Load config, in case it does not exist, log
 	configMap, err := config.GetServiceConfig(moduleName, serviceName)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Cameron Voisey <cameron.voisey@tngtech.com>

## Summary

In the orc8r lib, there are two functions, `NewServiceWithOptions` and `NewServiceWithOptionsImpl`, with the former being a wrapper around the latter. However, the wrapper seems to serve no purpose, so this PR removes `NewServiceWithOptionsImpl`, putting its functionality directly into `NewServiceWithOptions`.

## Test Plan

- [x] CI
