### PR TITLE
refactor(orc8r): split function SetIdentityFromContext in middleware

### DIFF
--- a/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
+++ b/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
@@ -85,7 +85,6 @@ func init() {
 // SetIdentityFromContext will bypass the Identity checks for local callers
 // (other services on the cloud) and allowlisted RPCs (methods in
 // identityDecoratorBypassList)
-// TODO(hcgatewood): refactor this to clean up the convoluted logic
 func SetIdentityFromContext(ctx context.Context, _ interface{}, info *grpc.UnaryServerInfo) (newCtx context.Context, newReq interface{}, resp interface{}, err error) {
 	// There are 5 possible outcomes:
 	// 1. !ok -> type assertion: mdIncomingKey{} is present, but it's not of MD type
@@ -102,80 +101,120 @@ func SetIdentityFromContext(ctx context.Context, _ interface{}, info *grpc.Unary
 
 	ctxMetadata, ok := metadata.FromIncomingContext(ctx)
 	if !ok || ctxMetadata == nil {
-		glog.Info(ERROR_MSG_NO_METADATA)
 		// Metadata should always be present for GRPC client calls
 		// If we want to enable ANY calls from local clients, we need to
 		// change the return statement to:
 		//   return newCtx, newReq, resp, ensureLocalPeer(ctx)
-		// but, it may present a se3curity risk
-		err = status.Error(codes.Unauthenticated, ERROR_MSG_NO_METADATA)
-		return newCtx, newReq, resp, err
+		// but, it may present a security risk
+		return newCtx, newReq, resp, noMetadata()
 	}
 
-	// First, try to find the caller's identity
 	snlist, snok := ctxMetadata[CLIENT_CERT_SN_KEY]
-	if snok { // there is a certificate serial number (CSN) list in CTX
-		if len(snlist) != 1 {
-			// there can be only one CSN, error out if not
-			glog.Infof("Multiple CSNs found in metadata: %+v", ctxMetadata)
-			err = status.Error(codes.Unauthenticated, "Multiple CSNs present")
-		} else {
-			// One CSN is found, find Identity associated with it
-			var gwIdentity *protos.Identity
-			var certExpTime int64
-			// Check if SN is the reserved value used for all inter-orc8r calls
-			if snlist[0] == registry.ORC8R_CLIENT_CERT_VALUE {
-				return newCtx, newReq, resp, nil
-			}
-			gwIdentity, certExpTime, err = findGatewayIdentity(ctx, snlist[0], ctxMetadata)
-			if err == nil {
-				// If a valid GW Identity is found, add it into CTX for use
-				// by the callee
-				newCtx = gwIdentity.NewContextWithIdentity(protos.NewContextWithCertExpiration(ctx, certExpTime))
-				return newCtx, newReq, resp, err
-			}
-		}
+	if snok {
+		newCtx, err = findIdentity(ctx, snlist, ctxMetadata, info)
+		return newCtx, newReq, resp, err
+	} else if noCCNHeader(ctxMetadata) {
+		return newCtx, newReq, resp, checkLocalClientCall(ctx, info)
 	} else {
-		// No CSNs found, check there is also no Certificate Common Names
-		if _, ok = ctxMetadata[CLIENT_CERT_CN_KEY]; ok {
-			// CN header is present while SN header is missing - possible
-			// security hack, either both or neither of the headers should be
-			// set
-			glog.Infof("CCN is present without SCN in metadata: %+v", ctxMetadata)
-			err = status.Error(codes.Unauthenticated, "Inconsistent Request Signature")
-		}
+		return newCtx, newReq, resp, unexpectedHeaders(ctxMetadata, info)
 	}
+}
 
+func findIdentity(ctx context.Context, snlist []string, ctxMetadata metadata.MD, info *grpc.UnaryServerInfo) (newCtx context.Context, err error) {
+	newCtx, err = findIdentityFromCSNList(ctx, snlist, ctxMetadata)
+	if err == nil || isAllowlistedCall(info) {
+		return newCtx, nil
+	}
+	return newCtx, err
+}
+
+func findIdentityFromCSNList(ctx context.Context, snlist []string, ctxMetadata metadata.MD) (context.Context, error) {
+	if len(snlist) == 1 {
+		// One CSN is found, find Caller's Identity associated with it
+		return findIdentityFromUniqueCSN(ctx, snlist[0], ctxMetadata)
+	} else {
+		// there is a certificate serial number (CSN) list in CTX
+		// there can be only one CSN, error out if not
+		return nil, multipleCSN(ctxMetadata)
+	}
+}
+
+func findIdentityFromUniqueCSN(ctx context.Context, sn string, ctxMetadata metadata.MD) (newCtx context.Context, err error) {
+	// Check if SN is the reserved value used for all inter-orc8r calls
+	if sn == registry.ORC8R_CLIENT_CERT_VALUE {
+		return newCtx, nil
+	}
+	var gwIdentity *protos.Identity
+	var certExpTime int64
+	gwIdentity, certExpTime, err = findGatewayIdentity(ctx, sn, ctxMetadata)
+	if err == nil {
+		// If a valid GW Identity is found, add it into CTX for use
+		// by the callee
+		return gwIdentity.NewContextWithIdentity(protos.NewContextWithCertExpiration(ctx, certExpTime)), nil
+	}
+	return newCtx, err
+}
+
+func unexpectedHeaders(ctxMetadata metadata.MD, info *grpc.UnaryServerInfo) error {
+	// CN header is present while SN header is missing - possible
+	// security hack, either both or neither of the headers should be
+	// set
+	glog.Infof("CCN is present without SCN in metadata: %+v", ctxMetadata)
+	if isAllowlistedCall(info) {
+		return nil
+	}
+	return status.Error(codes.Unauthenticated, "Inconsistent Request Signature")
+}
+
+func noMetadata() error {
+	glog.Info(ERROR_MSG_NO_METADATA)
+	return status.Error(codes.Unauthenticated, ERROR_MSG_NO_METADATA)
+}
+
+func noCCNHeader(ctxMetadata metadata.MD) bool {
+	_, ok := ctxMetadata[CLIENT_CERT_CN_KEY]
+	return !ok
+}
+
+func multipleCSN(ctxMetadata metadata.MD) error {
+	glog.Infof("Multiple CSNs found in metadata: %+v", ctxMetadata)
+	return status.Error(codes.Unauthenticated, "Multiple CSNs present")
+}
+
+func checkLocalClientCall(ctx context.Context, info *grpc.UnaryServerInfo) (err error) {
+	// We assume that only external calls forwarded by cloud proxy (or unit
+	// tests) will have CSN & CCN headers set. The absence of the headers
+	// along with client IP verification will indicate a local service to
+	// service or Obsidian to service call
+	if isAllowlistedCall(info) {
+		return nil
+	}
+	// For internal calls, no identity verification needed, just make sure
+	// it's a local client
+	err = ensureLocalPeer(ctx)
+	if err != nil {
+		var rpc string
+		if info != nil {
+			rpc = info.FullMethod
+		} else {
+			rpc = "Undefined"
+		}
+		glog.Infof("Empty CTX Metadata from non-local %s client: %v", rpc, err)
+	}
+	return err
+}
+
+func isAllowlistedCall(info *grpc.UnaryServerInfo) bool {
 	if info != nil {
 		// Check if the call is for a allowlisted method - anything is allowed
 		// do this check past possible identity decoration to still allow to add
 		// valid identity even to allowlisted requests
-		if _, ok := identityDecoratorBypassList[info.FullMethod]; ok {
-			// Bypass method (Bootstrapper & Co.), shortcut...
-			return newCtx, newReq, resp, nil
-		}
-	}
+		_, ok := identityDecoratorBypassList[info.FullMethod]
 
-	// Only allow local clients if there is no previous errors (snok == false)
-	if err == nil {
-		// We assume that only external calls forwarded by cloud proxy (or unit
-		// tests) will have CSN & CCN headers set. The absence of the headers
-		// along with client IP verification will indicate a local service to
-		// service or Obsidian to service call
-		// For internal calls, no identity verification needed, just make sure
-		// it's a local client
-		err = ensureLocalPeer(ctx)
-		if err != nil {
-			var rpc string
-			if info != nil {
-				rpc = info.FullMethod
-			} else {
-				rpc = "Undefined"
-			}
-			glog.Infof("Empty CTX Metadata from non-local %s client: %v", rpc, err)
-		}
+		// Bypass method (Bootstrapper & Co.), shortcut...
+		return ok
 	}
-	return newCtx, newReq, resp, err
+	return false
 }
 
 // findGatewayIdentity returns 'decorated' Gateway Identity corresponding to the

--- a/orc8r/cloud/go/service/middleware/unary/identity_decorator_test.go
+++ b/orc8r/cloud/go/service/middleware/unary/identity_decorator_test.go
@@ -21,12 +21,17 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/service"
+	"magma/orc8r/cloud/go/service/middleware/unary"
 	"magma/orc8r/cloud/go/service/middleware/unary/test"
 	"magma/orc8r/cloud/go/services/configurator"
 	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
@@ -36,6 +41,7 @@ import (
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
+	unarylib "magma/orc8r/lib/go/service/middleware/unary"
 )
 
 const testAgHwID = "Test-AGW-Hw-Id"
@@ -191,4 +197,146 @@ func TestIdentityInjector(t *testing.T) {
 		t,
 		"rpc error: code = PermissionDenied desc = Unregistered Gateway Test-AGW-Hw-Id",
 		err.Error())
+}
+
+type testAddr string
+
+func (a testAddr) String() string {
+	return string(a)
+}
+
+func (a testAddr) Network() string {
+	return string(a)
+}
+
+type testCase struct {
+	ctx                context.Context
+	serverInfo         *grpc.UnaryServerInfo
+	expectedError      error
+	expectedContextNil bool
+	reachesAllowCheck  bool
+}
+
+func TestSetIdentityFromContext(t *testing.T) {
+	csn := test.StartMockGwAccessControl(t, []string{testAgHwID})
+
+	testCases := []testCase{
+		{
+			// Return an error when context metadata is missing.
+			// This means the call is not authenticated. Return an error.
+			ctx:                context.Background(),
+			serverInfo:         &grpc.UnaryServerInfo{},
+			expectedError:      status.Error(codes.Unauthenticated, unary.ERROR_MSG_NO_METADATA),
+			expectedContextNil: true,
+			reachesAllowCheck:  false,
+		}, {
+			// Context metadata exists but empty. No CSN is given and the call
+			// cannot be authenticated. Return error since this
+			// is not a local client call.
+			ctx:                metadata.NewIncomingContext(context.Background(), nil),
+			serverInfo:         &grpc.UnaryServerInfo{},
+			expectedError:      status.Error(codes.PermissionDenied, unary.ERROR_MSG_UNKNOWN_CLIENT),
+			expectedContextNil: true,
+			reachesAllowCheck:  true,
+		}, {
+			// Context metadata exists but empty. No CSN is given and the call
+			// cannot be authenticated. Return an error since this
+			// is not a local client call. `serverInfo` is nil, make no
+			// allowList check. Logs "Undefined" instead of
+			// `serverInfo.FullMethod`.
+			ctx:                metadata.NewIncomingContext(context.Background(), nil),
+			serverInfo:         nil,
+			expectedError:      status.Error(codes.PermissionDenied, unary.ERROR_MSG_UNKNOWN_CLIENT),
+			expectedContextNil: true,
+			reachesAllowCheck:  false,
+		}, {
+			// Context metadata exists but empty. No CSN is given and the call
+			// cannot be authenticated. Return an error since this is a
+			// local client call.
+			ctx:                metadata.NewIncomingContext(peer.NewContext(context.Background(), &peer.Peer{Addr: testAddr("127.168.0.1:4567"), AuthInfo: nil}), nil),
+			serverInfo:         &grpc.UnaryServerInfo{},
+			expectedError:      nil,
+			expectedContextNil: true,
+			reachesAllowCheck:  true,
+		}, {
+			// If the context contains the CN key but not the right value,
+			// return an error.
+			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unary.CLIENT_CERT_CN_KEY, "val")),
+			serverInfo:         &grpc.UnaryServerInfo{},
+			expectedError:      status.Error(codes.Unauthenticated, "Inconsistent Request Signature"),
+			expectedContextNil: true,
+			reachesAllowCheck:  true,
+		}, {
+			// If the context contains keys different from CN and SN, return
+			// an error
+			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs("key", "val")),
+			serverInfo:         &grpc.UnaryServerInfo{},
+			expectedError:      status.Error(codes.PermissionDenied, unary.ERROR_MSG_UNKNOWN_CLIENT),
+			expectedContextNil: true,
+			reachesAllowCheck:  true,
+		}, {
+			// If the SN key is present with the right value, return no error.
+			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unarylib.CLIENT_CERT_SN_KEY, unarylib.ORC8R_CLIENT_CERT_VALUE)),
+			serverInfo:         &grpc.UnaryServerInfo{},
+			expectedError:      nil,
+			expectedContextNil: true,
+			reachesAllowCheck:  false,
+		}, {
+			// If multiple SN keys are present, return an error.
+			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unarylib.CLIENT_CERT_SN_KEY, unarylib.ORC8R_CLIENT_CERT_VALUE, unarylib.CLIENT_CERT_SN_KEY, "other value")),
+			serverInfo:         &grpc.UnaryServerInfo{},
+			expectedError:      status.Error(codes.Unauthenticated, "Multiple CSNs present"),
+			expectedContextNil: true,
+			reachesAllowCheck:  true,
+		}, {
+			// If CN key is present with the value, return no error.
+			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unarylib.CLIENT_CERT_SN_KEY, csn[0])),
+			serverInfo:         &grpc.UnaryServerInfo{},
+			expectedError:      nil,
+			expectedContextNil: false,
+			reachesAllowCheck:  false,
+		}, {
+			// If CN key is present with the wrong value, return an error.
+			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unarylib.CLIENT_CERT_SN_KEY, "wrong CSN")),
+			serverInfo:         &grpc.UnaryServerInfo{},
+			expectedError:      status.Error(codes.PermissionDenied, "Unknown Client Certificate"),
+			expectedContextNil: true,
+			reachesAllowCheck:  true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCaseSetIdentityFromContext(t, testCase)
+	}
+}
+
+func testCaseSetIdentityFromContext(t *testing.T, tc testCase) {
+	newCtx, newReq, resp, err := unary.SetIdentityFromContext(tc.ctx, nil, tc.serverInfo)
+
+	if tc.expectedContextNil {
+		assert.Nil(t, newCtx)
+	} else {
+		// Don't explicitly check what a non-nil context might look like.
+		// This depends on things such as system time.
+		assert.NotNil(t, newCtx)
+	}
+	assert.Nil(t, newReq) // newReq is always nil
+	assert.Nil(t, resp)   // resp is always nil
+	if tc.expectedError == nil {
+		assert.NoError(t, err)
+	} else {
+		assert.EqualError(t, err, tc.expectedError.Error())
+	}
+
+	if tc.reachesAllowCheck {
+		// Check that the behavior is correct if the FullMethod is on the
+		// Allow list.
+		serverInfo := grpc.UnaryServerInfo{FullMethod: "/magma.orc8r.Bootstrapper/GetChallenge"}
+		newCtx, newReq, resp, err = unary.SetIdentityFromContext(tc.ctx, nil, &serverInfo)
+		assert.Nil(t, newCtx)
+		assert.Nil(t, newReq)
+		assert.Nil(t, resp)
+		assert.NoError(t, err)
+	}
+
 }

--- a/orc8r/cloud/go/service/middleware/unary/identity_decorator_test.go
+++ b/orc8r/cloud/go/service/middleware/unary/identity_decorator_test.go
@@ -41,7 +41,6 @@ import (
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/registry"
-	unarylib "magma/orc8r/lib/go/service/middleware/unary"
 )
 
 const testAgHwID = "Test-AGW-Hw-Id"
@@ -276,28 +275,28 @@ func TestSetIdentityFromContext(t *testing.T) {
 			reachesAllowCheck:  true,
 		}, {
 			// If the SN key is present with the right value, return no error.
-			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unarylib.CLIENT_CERT_SN_KEY, unarylib.ORC8R_CLIENT_CERT_VALUE)),
+			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unary.CLIENT_CERT_SN_KEY, registry.ORC8R_CLIENT_CERT_VALUE)),
 			serverInfo:         &grpc.UnaryServerInfo{},
 			expectedError:      nil,
 			expectedContextNil: true,
 			reachesAllowCheck:  false,
 		}, {
 			// If multiple SN keys are present, return an error.
-			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unarylib.CLIENT_CERT_SN_KEY, unarylib.ORC8R_CLIENT_CERT_VALUE, unarylib.CLIENT_CERT_SN_KEY, "other value")),
+			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unary.CLIENT_CERT_SN_KEY, registry.ORC8R_CLIENT_CERT_VALUE, unary.CLIENT_CERT_SN_KEY, "other value")),
 			serverInfo:         &grpc.UnaryServerInfo{},
 			expectedError:      status.Error(codes.Unauthenticated, "Multiple CSNs present"),
 			expectedContextNil: true,
 			reachesAllowCheck:  true,
 		}, {
 			// If CN key is present with the value, return no error.
-			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unarylib.CLIENT_CERT_SN_KEY, csn[0])),
+			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unary.CLIENT_CERT_SN_KEY, csn[0])),
 			serverInfo:         &grpc.UnaryServerInfo{},
 			expectedError:      nil,
 			expectedContextNil: false,
 			reachesAllowCheck:  false,
 		}, {
 			// If CN key is present with the wrong value, return an error.
-			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unarylib.CLIENT_CERT_SN_KEY, "wrong CSN")),
+			ctx:                metadata.NewIncomingContext(context.Background(), metadata.Pairs(unary.CLIENT_CERT_SN_KEY, "wrong CSN")),
 			serverInfo:         &grpc.UnaryServerInfo{},
 			expectedError:      status.Error(codes.PermissionDenied, "Unknown Client Certificate"),
 			expectedContextNil: true,


### PR DESCRIPTION
## Summary

Refactor parts of the function `SetIdentityFromContext` in orc8r middleware to separate functions to increase readability.
A Test for the function has also been created. The test cases are oriented by

- the possible cases described in the comment at the start of the function
- additional possible cases given in the code

The tests were first benchmarked on the original logic to ensure the refactoring did not change any potential outcome.

![original_logic](https://user-images.githubusercontent.com/104822369/172283001-664fb1be-d0a1-493b-9482-0688b7cdb2b2.png)

![refactored_logic](https://user-images.githubusercontent.com/104822369/172300111-b37c7a25-fec6-448a-a04a-786400c3348a.png)

## Test Plan

Run unit tests and newly created test to ensure the same outcomes as before the refactoring.

## Additional Information

Created in pairing with @MoritzThomasHuebner 

- [ ] This change is backwards-breaking
