### PR TITLE
refactor(pipelined): Simplify treatment of default parameters

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/ipfix.py
+++ b/lte/gateway/python/magma/pipelined/app/ipfix.py
@@ -234,9 +234,9 @@ class IPFIXController(MagmaController):
             )
 
     def add_ue_sample_flow(
-        self, imsi: str, msisdn: str,
-        apn_mac_addr: str, apn_name: str,
-        pdp_start_time: int,
+        self, imsi: str, apn_mac_addr: str,
+        apn_name: str, pdp_start_time: int,
+        msisdn: str = 'no_msisdn',
     ) -> None:
         """
         Install a flow to sample packets for IPFIX for specific imsi
@@ -262,9 +262,6 @@ class IPFIXController(MagmaController):
             apn_mac_bytes = [0, 0, 0, 0, 0, 0]
         else:
             apn_mac_bytes = [int(a, 16) for a in apn_mac_addr.split('-')]
-
-        if not msisdn:
-            msisdn = 'no_msisdn'
 
         actions = [
             parser.NXActionSample2(

--- a/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
@@ -22,7 +22,6 @@ from .types import QosInfo
 from .utils import IdManager
 
 LOG = logging.getLogger('pipelined.qos.qos_tc_impl')
-# LOG.setLevel(logging.DEBUG)
 
 # TODO - replace this implementation with pyroute2 tc
 ROOT_QID = 65534
@@ -48,15 +47,9 @@ class TrafficClass:
 
     @staticmethod
     def create_class(
-        intf: str, qid: int, max_bw: int, rate=None,
-        parent_qid=None, skip_filter=False,
+        intf: str, qid: int, max_bw: int, rate=DEFAULT_RATE,
+        parent_qid=ROOT_QID, skip_filter=False,
     ) -> int:
-        if not rate:
-            rate = DEFAULT_RATE
-
-        if not parent_qid:
-            parent_qid = ROOT_QID
-
         if parent_qid == qid:
             # parent qid should only be self for root case, everything else
             # should be the child of root class

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -600,8 +600,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             # Install trace flow
             self._loop.call_soon_threadsafe(
                 self._ipfix_app.add_ue_sample_flow, request.sid.id,
-                request.msisdn, request.ap_mac_addr, request.ap_name,
-                request.pdp_start_time,
+                request.ap_mac_addr, request.ap_name, request.pdp_start_time,
+                request.msisdn,
             )
 
         resp = FlowResponse()
@@ -704,10 +704,11 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         if self._service_manager.is_app_enabled(IPFIXController.APP_NAME):
             for req in request.requests:
                 self._ipfix_app.add_ue_sample_flow(
-                    req.sid.id, req.msisdn,
+                    req.sid.id,
                     req.ap_mac_addr,
                     req.ap_name,
                     req.pdp_start_time,
+                    req.msisdn,
                 )
 
         fut.set_result(res)

--- a/lte/gateway/python/magma/pipelined/tests/test_internal_pkt_ipfix_export.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_internal_pkt_ipfix_export.py
@@ -166,8 +166,8 @@ class InternalPktIpfixExportTest(unittest.TestCase):
             'base.ip.http.facebook', 'tbd',
         )
         self.ipfix_controller.add_ue_sample_flow(
-            imsi, "magma_is_awesome_msisdn",
-            "00:11:22:33:44:55", "apn_name123456789", 145,
+            imsi, "00:11:22:33:44:55", "apn_name123456789",
+            145, "magma_is_awesome_msisdn",
         )
 
         snapshot_verifier = SnapshotVerifier(

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -329,7 +329,6 @@ get_action_instruction",
             exp_id = id_list[i]
             k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
             exp_id_dict[k] = exp_id
-            # self.assertTrue(qos_mgr._redis_store[k] == exp_id)
             qid_info = get_data_json(get_subscriber_data(exp_id, 0, 0))
             self.assertEqual(qos_mgr._subscriber_state[imsi].rules[rule_num][0], (d, qid_info))
 


### PR DESCRIPTION
Signed-off-by: Cameron Voisey <cameron.voisey@tngtech.com>

## Summary

This tidies up a couple of cases in which default parameters are set in function bodies rather than being set when defining the function arguments. This also cleans up a couple of unnecessary comments I came across while making the changes.

## Test Plan

- [x] magma-dev: `make test_python_service UT_PATH=python/magma/pipelined/tests/`
