### PR TITLE
chore(ci): Make the AGW workflow use bazel remote cache

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -19,8 +19,7 @@ concurrency:
 env:
   DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latestv2"
   BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latestv2"
-  BAZEL_CACHE: bazel-cache
-  BAZEL_CACHE_REPO: bazel-cache-repo
+  CACHE_KEY: bazel-base-image
 
 jobs:
   path_filter:
@@ -158,30 +157,6 @@ jobs:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
         uses: actions/checkout@v2
-      - name: Bazel Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE }}
-          key: ${{ runner.os }}-${{ env.BAZEL_CACHE }}-c-cpp-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.BAZEL_CACHE }}-c-cpp-
-      - name: Bazel Cache Repo
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE_REPO }}
-          key: ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-
-      - name: Log cache size
-        run: |
-          du -sh .bazel-cache
-      - name: Ensure cache size (only on master)
-        if: github.event_name == 'push'
-        env:
-          BAZEL_CACHE_DIR: .${{ env.BAZEL_CACHE }}
-          BAZEL_CACHE_CUTOFF_MB: 6000
-        run: |
-          ./.github/workflows/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
       - name: Setup Bazel Base Image
         uses: addnab/docker-run-action@v3
         with:
@@ -210,16 +185,13 @@ jobs:
           options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
             cd /workspaces/magma
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* --config=asan --test_output=errors --cache_test_results=no
             TEST_RESULT=$?
             # copy out test results
             echo "Copying out test result XMLs for testing with ASAN"
             find bazel-out/k8-dbg/testlogs/ -name "*.xml" | while IFS= read -r f; do cp "$f" "c-cpp-test-results/asan_${f//\//_}"; done
             exit $TEST_RESULT
-      - name: Log cache size
-        if: always()
-        run: |
-          du -sh .bazel-cache
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -355,21 +327,9 @@ jobs:
           sudo rm -rf /opt/ghc
           echo "Available storage after:"
           df -h
-      - uses: actions/checkout@v2
-      - name: Bazel Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE }}
-          key: ${{ runner.os }}-${{ env.BAZEL_CACHE }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.BAZEL_CACHE }}-
-      - name: Bazel Cache Repo
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE_REPO }}
-          key: ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.BAZEL_CACHE_REPO }}-
+      - name: Check Out Repo
+        # This is necessary for overlays into the Docker container below.
+        uses: actions/checkout@v2
       - name: Setup Devcontainer Image
         uses: addnab/docker-run-action@v3
         with:
@@ -406,6 +366,7 @@ jobs:
           options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
             cd $MAGMA_ROOT
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178
             # Omit OAI coverage until it is tested. We need to determine what the behavior is for doing both CMake and Bazel based coverage at the same time
             # TODO: GH11936


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- The AGW workflow is modified to use the bazel remote cache
  - See also PR https://github.com/magma/magma/pull/12743
- Remove unnecessary GH caching steps and environment variables

## Test Plan

- [Workflow run on this PR (read-only access to the caches)
](https://github.com/magma/magma/actions/runs/2352710098)
- [Workflow runs on fork (without path filter; read-write access to the caches)
](https://github.com/LKreutzer/magma/actions/runs/2352556842)

## Additional Information

- [ ] This change is backwards-breaking