### PR TITLE
 fix(orc8r) Updating orc8r to work for MacOS M1

### DIFF
--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - fluentd
     command: ["/bin/sh", "-c", "/usr/local/bin/wait-for-it.sh -s -t 30 postgres:5432 && /usr/bin/supervisord"]
     restart: always
+    platform: linux/x86_64
   # If you want to use log aggregation on a Mac or Windows host, uncomment
   # the below block as-is
   # KP: host.docker.internal does not resolve to anything in Docker for linux


### PR DESCRIPTION
Signed-off-by: Varun <varun27@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
orc8r does not create admin_operator keys since it requires an x86 architecture and MacOS with M1 does not support this. The fix was to specify the platform inside the docker-compose as linux/x86_64. 

More details available at: https://github.com/magma/magma/discussions/12794
<!-- Enumerate changes you made and why you made them -->

## Test Plan
admin_operator files are now created upon specifying the platform. Attaching screenshot below:

<img width="209" alt="Screen Shot 2022-05-19 at 2 54 24 PM" src="https://user-images.githubusercontent.com/105877840/169410937-4f5cfdce-8b57-44ce-bd2a-c42529555c97.png">

