### PR TITLE
docs: Updated onboarding documentation

### DIFF
--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -60,7 +60,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
 1. Install the following tools
    1. [Docker](https://docs.docker.com/engine/install/ubuntu/) and [Docker Compose](https://docs.docker.com/compose/install/)
    2. [VirtualBox](https://www.virtualbox.org/wiki/Linux_Downloads)
-   3. [Vagrant](https://www.vagrantup.com/downloads)
+   3. [Vagrant](https://www.vagrantup.com/downloads) (Install by downloading the `.deb` file. Installing via the command line using `apt-get` can currently cause an issue with OpenSSL.)
 2. Install golang version 18.
 
    1. Download the tar file.
@@ -107,6 +107,8 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
       apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev  libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
       ```
 
+      **Note**: For Ubuntu 22.04 use `python3-openssl` instead of `python-openssl`.
+
    3. Clone `pyenv` repository.
 
       ```bash
@@ -129,6 +131,8 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
       pyenv global 3.7.3
       ```
 
+        **Note**: Python 3.7.3 cannot be installed on Ubuntu 22.04 this way. Use Python 3.10.4 instead.
+
 4. Install `pip3` and its dependencies.
 
    1. Install `pip3`.
@@ -140,7 +144,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    2. Install the following dependencies
 
       ```bash
-      pip3 install ansible fabric3 jsonpickle requests PyYAML
+      pip3 install ansible 'fabric<2.0' jsonpickle requests PyYAML
       ```
 
 5. Install `vagrant` necessary plugin.
@@ -148,6 +152,8 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    ```bash
    vagrant plugin install vagrant-vbguest
    ```
+
+    Make sure `virtualbox` is the default provider for `vagrant` by adding the following line to your `.bashrc` (or equivalent) and restart your shell: `export VAGRANT_DEFAULT_PROVIDER="virtualbox"`
 
 ## Downloading Magma
 

--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -60,7 +60,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
 1. Install the following tools
    1. [Docker](https://docs.docker.com/engine/install/ubuntu/) and [Docker Compose](https://docs.docker.com/compose/install/)
    2. [VirtualBox](https://www.virtualbox.org/wiki/Linux_Downloads)
-   3. [Vagrant](https://www.vagrantup.com/downloads) (Install by downloading the `.deb` file. Installing via the command line using `apt-get` can currently cause an issue with OpenSSL.)
+   3. [Vagrant](https://www.vagrantup.com/downloads) (Install by downloading the `.deb` file. Installing via the command line using `apt-get` can currently cause an issue with OpenSSL. See also [this discussion](https://github.com/hashicorp/vagrant/issues/12751).)
 2. Install golang version 18.
 
    1. Download the tar file.
@@ -107,7 +107,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
       apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev  libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
       ```
 
-      **Note**: For Ubuntu 22.04 use `python3-openssl` instead of `python-openssl`.
+      **Note**: For Ubuntu 22.04, use `python3-openssl` instead of `python-openssl`.
 
    3. Clone `pyenv` repository.
 
@@ -131,7 +131,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
       pyenv global 3.7.3
       ```
 
-        **Note**: Python 3.7.3 cannot be installed on Ubuntu 22.04 this way. Use Python 3.10.4 instead.
+        **Note**: The `pyenv` installation [might fail with a segmentation fault](https://github.com/pyenv/pyenv/issues/2046). Try using `CFLAGS="-O2" pyenv install 3.7.3` in that case.
 
 4. Install `pip3` and its dependencies.
 
@@ -144,7 +144,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    2. Install the following dependencies
 
       ```bash
-      pip3 install ansible 'fabric<2.0' jsonpickle requests PyYAML
+      pip3 install ansible fabric3 jsonpickle requests PyYAML
       ```
 
 5. Install `vagrant` necessary plugin.
@@ -153,7 +153,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    vagrant plugin install vagrant-vbguest
    ```
 
-    Make sure `virtualbox` is the default provider for `vagrant` by adding the following line to your `.bashrc` (or equivalent) and restart your shell: `export VAGRANT_DEFAULT_PROVIDER="virtualbox"`
+    Make sure `virtualbox` is the default provider for `vagrant` by adding the following line to your `.bashrc` (or equivalent) and restart your shell: `export VAGRANT_DEFAULT_PROVIDER="virtualbox"`.
 
 ## Downloading Magma
 

--- a/docs/readmes/basics/quick_start_guide.md
+++ b/docs/readmes/basics/quick_start_guide.md
@@ -133,7 +133,7 @@ Creating orc8r_controller_1       ... done
 
 The Orchestrator application containers will bootstrap certificates on startup
 which are cached for future runs. Watch the directory `magma/.cache/test_certs`
-for a file `admin_operator.pfx` to show up (this may take a minute or 2), then:
+for a file `admin_operator.pfx` to show up (this may take a minute or 2).
 
 ```bash
 HOST [magma/orc8r/cloud/docker]$ ls ../../../.cache/test_certs
@@ -141,7 +141,19 @@ HOST [magma/orc8r/cloud/docker]$ ls ../../../.cache/test_certs
 admin_operator.key.pem  bootstrapper.key        controller.crt          rootCA.key
 admin_operator.pem      certifier.key           controller.csr          rootCA.pem
 admin_operator.pfx      certifier.pem           controller.key          rootCA.srl
+```
 
+The owner and group of `admin_cert.key.pem` and `admin_cert.pfx` in `/magma/.cache/test_certs/` are `root`.
+You need to change ownership of these files to your user with `chown`, e.g.
+
+```bash
+HOST [magma/orc8r/cloud/docker] sudo chown username:username ../../../.cache/test_certs/admin_cert.key.pem
+HOST [magma/orc8r/cloud/docker] sudo chown username:username ../../../.cache/test_certs/admin_cert.pfx
+```
+
+Replace `username` with your username, then:
+
+```bash
 HOST [magma/orc8r/cloud/docker]$ open ../../../.cache/test_certs
 ```
 
@@ -214,7 +226,8 @@ NMS can take upto 60 seconds to finish starting up.
 You will probably want to enable this organization (magma-test) to access all networks,
 so go to [host.localhost](https://host.localhost) and login with the same credentials.
 Once there, you can click on the "Organizations" tab on the left sidebar, choose
-`magma-test`, and then check "Enable all networks" in the subsequent pop-up window.
+`magma-test` (the three dots on the right) &rarr; View &rarr; Edit &rarr; Advanced Settings
+and then check "Enable all networks" in the subsequent pop-up window.
 
 **Note**: If you want to test the access gateway VM with a physical eNB and UE,
 refer to

--- a/docs/readmes/basics/quick_start_guide.md
+++ b/docs/readmes/basics/quick_start_guide.md
@@ -133,7 +133,7 @@ Creating orc8r_controller_1       ... done
 
 The Orchestrator application containers will bootstrap certificates on startup
 which are cached for future runs. Watch the directory `magma/.cache/test_certs`
-for a file `admin_operator.pfx` to show up (this may take a minute or 2).
+for a file `admin_operator.pfx` to show up (this may take a minute or two).
 
 ```bash
 HOST [magma/orc8r/cloud/docker]$ ls ../../../.cache/test_certs


### PR DESCRIPTION
## Summary

Updates the onboarding documentation for setting up magma with Ubuntu 22.04

- Added instructions about how to install Vagrant to avoid issues
- `python-ssl` -> `python3-ssl`
- Updated python version to be installed
- Corrected the `fabric` version since `fabric3` can not actually be used
- Added instructions to add `VAGRANT_DEFAULT_PROVIDER` environment variable
- Added information that browser certificate ownership needs to be changed to the user as they are created with root ownership
- Added more detailed instructions as to how to check "Enable all networks" in the NMM, as the option is somewhat hidden.

## Test Plan

Run unit tests

## Additional Information

- [ ] This change is backwards-breaking
