### PR TITLE
fix(orc8r): Run fluentd as root in container

### DIFF
--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -5,4 +5,4 @@ RUN gem install \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \
     --no-document
-USER fluent
+ENV FLUENT_UID=0


### PR DESCRIPTION
## Summary

I was trying to look into fluentd and the container refused to start using docker-compose.

I am not sure about this change. Maybe running as root can be avoided? Are other people able to run the container on master?

## Test Plan

On master, starting orc8r via `run.py` results in the following error in the fluentd container:
```
fluentd  | 2022-05-23T12:32:59.087158391Z 2022-05-23 12:32:59 +0000 [info]: parsing config file is succeeded path="/fluentd/etc/fluent.conf"
fluentd  | 2022-05-23T12:32:59.280937065Z 2022-05-23 12:32:59 +0000 [info]: 'flush_interval' is configured at out side of <buffer>. 'flush_mode' is set to 'interval' to keep existing behaviour
fluentd  | 2022-05-23T12:32:59.296948160Z 2022-05-23 12:32:59 +0000 [info]: 'flush_interval' is configured at out side of <buffer>. 'flush_mode' is set to 'interval' to keep existing behaviour
fluentd  | 2022-05-23T12:32:59.300765388Z 2022-05-23 12:32:59 +0000 [info]: 'flush_interval' is configured at out side of <buffer>. 'flush_mode' is set to 'interval' to keep existing behaviour
fluentd  | 2022-05-23T12:32:59.308469985Z 2022-05-23 12:32:59 +0000 [warn]: For security reason, setting private_key_passphrase is recommended when cert_path is specified
fluentd  | 2022-05-23T12:32:59.308572808Z /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/plugin_helper/cert_option.rb:79:in `read': Permission denied @ rb_sysopen - /var/opt/magma/certs/controller.key (Errno::EACCES)
fluentd  | 2022-05-23T12:32:59.308580182Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/plugin_helper/cert_option.rb:79:in `cert_option_load'
fluentd  | 2022-05-23T12:32:59.308583148Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/plugin_helper/cert_option.rb:55:in `cert_option_server_validate!'
fluentd  | 2022-05-23T12:32:59.308585051Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/plugin_helper/server.rb:316:in `configure'
fluentd  | 2022-05-23T12:32:59.308586765Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/plugin/in_forward.rb:102:in `configure'
fluentd  | 2022-05-23T12:32:59.308588879Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/plugin.rb:164:in `configure'
fluentd  | 2022-05-23T12:32:59.308590582Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/root_agent.rb:320:in `add_source'
fluentd  | 2022-05-23T12:32:59.308592205Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/root_agent.rb:160:in `block in configure'
fluentd  | 2022-05-23T12:32:59.308593838Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/root_agent.rb:156:in `each'
fluentd  | 2022-05-23T12:32:59.308595551Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/root_agent.rb:156:in `configure'
fluentd  | 2022-05-23T12:32:59.308597164Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/engine.rb:131:in `configure'
fluentd  | 2022-05-23T12:32:59.308598767Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/engine.rb:96:in `run_configure'
fluentd  | 2022-05-23T12:32:59.308600420Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/supervisor.rb:812:in `run_configure'
fluentd  | 2022-05-23T12:32:59.308602194Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/supervisor.rb:589:in `dry_run'
fluentd  | 2022-05-23T12:32:59.308603897Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/supervisor.rb:607:in `supervise'
fluentd  | 2022-05-23T12:32:59.308605520Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/supervisor.rb:512:in `run_supervisor'
fluentd  | 2022-05-23T12:32:59.308607163Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/command/fluentd.rb:324:in `<top (required)>'
fluentd  | 2022-05-23T12:32:59.308618795Z       from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
fluentd  | 2022-05-23T12:32:59.308620688Z       from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
fluentd  | 2022-05-23T12:32:59.308622331Z       from /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/bin/fluentd:8:in `<top (required)>'
fluentd  | 2022-05-23T12:32:59.308624666Z       from /usr/bin/fluentd:23:in `load'
fluentd  | 2022-05-23T12:32:59.308626309Z       from /usr/bin/fluentd:23:in `<main>'
```

With this change, the container runs successfully:
```
fluentd  | 2022-05-23T12:33:47.995505683Z 2022-05-23 12:33:47 +0000 [warn]: #0 For security reason, setting private_key_passphrase is recommended when cert_path is specified
fluentd  | 2022-05-23T12:33:47.996215806Z 2022-05-23 12:33:47 +0000 [info]: #0 starting fluentd worker pid=15 ppid=7 worker=0
fluentd  | 2022-05-23T12:33:47.997300203Z 2022-05-23 12:33:47 +0000 [info]: #0 listening port port=24224 bind="0.0.0.0"
fluentd  | 2022-05-23T12:33:47.997333926Z 2022-05-23 12:33:47 +0000 [warn]: #0 For security reason, setting private_key_passphrase is recommended when cert_path is specified
fluentd  | 2022-05-23T12:33:47.998495657Z 2022-05-23 12:33:47 +0000 [info]: #0 listening port port=24225 bind="0.0.0.0"
fluentd  | 2022-05-23T12:33:47.998708908Z 2022-05-23 12:33:47 +0000 [info]: #0 fluentd worker is now running worker=0
fluentd  | 2022-05-23T12:33:48.099525959Z 2022-05-23 12:33:47.998667861 +0000 fluent.info: {"worker":0,"message":"fluentd worker is now running worker=0"}
```

## Additional Information

- [ ] This change is backwards-breaking
