### PR TITLE
chore: docker images use same go installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,9 +77,11 @@ RUN echo "Install general purpose packages" && \
 
 # Install golang 1.18
 WORKDIR /usr/local
-RUN curl https://artifactory.magmacore.org/artifactory/generic/go1.18.linux-amd64.tar.gz --remote-name --location && \
-    tar -xzf go1.18.linux-amd64.tar.gz && \
-    rm go1.18.linux-amd64.tar.gz
+ARG GOLANG_VERSION="1.18"
+RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
+ && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
+ && tar -xzf ${GO_TARBALL} \
+ && rm ${GO_TARBALL}
 ENV PATH=$PATH:/usr/local/go/bin
 
 RUN echo "Install 3rd party dependencies" && \

--- a/cwf/gateway/docker/go/Dockerfile
+++ b/cwf/gateway/docker/go/Dockerfile
@@ -38,9 +38,12 @@ RUN apt-get update && apt-get install -y \
 
 # Golang 1.18
 WORKDIR /usr/local
-RUN curl https://artifactory.magmacore.org/artifactory/generic/go1.18.linux-amd64.tar.gz --remote-name --location && \
-    tar -xzf go1.18.linux-amd64.tar.gz && \
-    cp -r go/bin/* /usr/local/bin/
+ARG GOLANG_VERSION="1.18"
+RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
+ && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
+ && tar -xzf ${GO_TARBALL} \
+ && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+ && rm ${GO_TARBALL}
 
 # Install protobuf compiler.
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \

--- a/cwf/k8s/cwf_operator/docker/Dockerfile
+++ b/cwf/k8s/cwf_operator/docker/Dockerfile
@@ -20,9 +20,12 @@ RUN apt-get update && apt-get install -y bzr curl daemontools gcc
 
 # Install Golang 1.18
 WORKDIR /usr/local
-RUN curl https://artifactory.magmacore.org/artifactory/generic/go1.18.linux-amd64.tar.gz --remote-name --location && \
-    tar -xzf go1.18.linux-amd64.tar.gz && \
-    cp -r go/bin/* /usr/local/bin/
+ARG GOLANG_VERSION="1.18"
+RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
+ && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
+ && tar -xzf ${GO_TARBALL} \
+ && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+ && rm ${GO_TARBALL}
 
 ENV GOBIN /var/opt/magma/bin
 ENV PATH ${PATH}:${GOBIN}

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -41,11 +41,14 @@ RUN apt-get update && apt-get install -y \
 
 # Golang 1.18
 WORKDIR /usr/local
-RUN curl https://artifactory.magmacore.org/artifactory/generic/go1.18.linux-amd64.tar.gz --remote-name --location && \
-    tar -xzf go1.18.linux-amd64.tar.gz && \
-    cp -r go/bin/* /usr/local/bin/
+ARG GOLANG_VERSION="1.18"
+RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
+ && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
+ && tar -xzf ${GO_TARBALL} \
+ && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+ && rm ${GO_TARBALL}
 
-# Install protobuf compiler.
+# Install protobuf compiler.y
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
     unzip protoc3.zip -d protoc3 && \
     mv protoc3/bin/protoc /bin/protoc && \

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -25,9 +25,12 @@ RUN apt-get update && apt-get install -y \
 
 # Golang 1.18
 WORKDIR /usr/local
-RUN curl https://artifactory.magmacore.org/artifactory/generic/go1.18.linux-amd64.tar.gz --remote-name --location && \
-    tar -xzf go1.18.linux-amd64.tar.gz && \
-    cp -r go/bin/* /usr/local/bin/
+ARG GOLANG_VERSION="1.18"
+RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
+ && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
+ && tar -xzf ${GO_TARBALL} \
+ && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+ && rm ${GO_TARBALL}
 
 # Install goimports
 # RUN go get golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary
As introduced in #12605 , only one Go version should be used in the Dockerfiles. Now, all Dockerfiles use the Go binaries provided by the Magma Artifactory https://artifactory.magmacore.org/artifactory.

## Test Plan

* Build and start the DevContainer locally
* Pass  CI

## Additional Information

- [ ] This change is backwards-breaking
