### PR TITLE
fix(amf): Support for 5GS network feature support

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -493,6 +493,27 @@ int amf_reg_acceptmsg(const guti_m5_t* guti, amf_nas_message_t* nas_msg) {
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg.gprs_timer
       .timervalue = 6;
 
+  nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
+      .network_feature.iei = 0x21;
+  nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
+      .network_feature.len = 2;
+  nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
+      .network_feature.MPSI = 0;
+  nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
+      .network_feature.IWK_N26 = 0;
+  nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
+      .network_feature.EMF = 0;
+  nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
+      .network_feature.EMC = 0;
+  nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
+      .network_feature.IMS_VoPS_N3GPP = 1;
+  nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
+      .network_feature.IMS_VoPS_3GPP = 1;
+  nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
+      .network_feature.MCSI = 0;
+  nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
+      .network_feature.EMCN3 = 0;
+
   size += MOBILE_IDENTITY_MAX_LENGTH;
   size += 20;
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, size);

--- a/lte/gateway/c/core/oai/tasks/nas5g/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/nas5g/CMakeLists.txt
@@ -88,6 +88,7 @@ set(libnas_ies_OBJS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/ies/M5GGprsTimer2.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/ies/M5GRequestType.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/ies/M5GMaxNumOfSupportedPacketFilters.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/ies/M5GNetworkFeatureSupport.cpp
     )
 
 add_library(LIB_NAS5G

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationAccept.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationAccept.h
@@ -21,6 +21,7 @@
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNSSAI.h"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GGprsTimer3.h"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GTAIList.h"
+#include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNetworkFeatureSupport.h"
 
 namespace magma5g {
 class RegistrationAcceptMsg {
@@ -35,6 +36,7 @@ class RegistrationAcceptMsg {
   TAIListMsg tai_list;
   NSSAIMsgList allowed_nssai;
   GPRSTimer3Msg gprs_timer;
+  NetworkFeatureSupportMsg network_feature;
 #define REGISTRATION_ACCEPT_MINIMUM_LENGTH 5
 
   RegistrationAcceptMsg();

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNetworkFeatureSupport.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNetworkFeatureSupport.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * */
+#pragma once
+#include <sstream>
+#include <cstdint>
+namespace magma5g {
+class NetworkFeatureSupportMsg {
+ public:
+#define NETWORK_FEATURE_MINIMUM_LENGTH 3
+#define NETWORK_FEATURE_MAXIMUM_LENGTH 5
+
+  uint8_t iei;
+  uint8_t len;
+  uint8_t IMS_VoPS_3GPP : 1;
+  uint8_t IMS_VoPS_N3GPP : 1;
+  uint8_t EMC : 2;
+  uint8_t EMF : 2;
+  uint8_t IWK_N26 : 1;
+  uint8_t MPSI : 1;
+  uint8_t EMCN3 : 1;
+  uint8_t MCSI : 1;
+  NetworkFeatureSupportMsg();
+  ~NetworkFeatureSupportMsg();
+
+  int EncodeNetworkFeatureSupportMsg(NetworkFeatureSupportMsg* networkfeature,
+                                     uint8_t iei, uint8_t* buffer,
+                                     uint32_t len);
+
+  int DecodeNetworkFeatureSupportMsg(NetworkFeatureSupportMsg* networkfeature,
+                                     uint8_t iei, uint8_t* buffer,
+                                     uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GRegistrationAccept.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GRegistrationAccept.cpp
@@ -123,6 +123,13 @@ int RegistrationAcceptMsg::EncodeRegistrationAcceptMsg(
     return encoded_result;
   else
     encoded += encoded_result;
+  if ((encoded_result =
+           reg_accept->network_feature.EncodeNetworkFeatureSupportMsg(
+               &reg_accept->network_feature, 0x21, buffer + encoded,
+               len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
   if ((encoded_result = reg_accept->gprs_timer.EncodeGPRSTimer3Msg(
            &reg_accept->gprs_timer, 0x5E, buffer + encoded, len - encoded)) < 0)
     return encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNetworkFeatureSupport.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNetworkFeatureSupport.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "lte/gateway/c/core/oai/common/log.h"
+#ifdef __cplusplus
+}
+#endif
+#include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNetworkFeatureSupport.h"
+#include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GCommonDefs.h"
+
+namespace magma5g {
+NetworkFeatureSupportMsg::NetworkFeatureSupportMsg(){};
+NetworkFeatureSupportMsg::~NetworkFeatureSupportMsg(){};
+
+int NetworkFeatureSupportMsg::DecodeNetworkFeatureSupportMsg(
+    NetworkFeatureSupportMsg* networkfeature, uint8_t iei, uint8_t* buffer,
+    uint32_t len) {
+  int decoded = 0;
+
+  if (iei > 0) {
+    CHECK_IEI_DECODER(iei, *buffer);
+    networkfeature->iei = *buffer;
+    decoded++;
+  }
+  networkfeature->len = *(buffer + decoded);
+  decoded++;
+
+  networkfeature->MPSI = (*(buffer + decoded) >> 7) & 0x01;
+  networkfeature->IWK_N26 = (*(buffer + decoded) >> 6) & 0x01;
+  networkfeature->EMF = (*(buffer + decoded) >> 4) & 0x03;
+  networkfeature->EMC = (*(buffer + decoded) >> 2) & 0x03;
+  networkfeature->IMS_VoPS_N3GPP = (*(buffer + decoded) >> 1) & 0x01;
+  networkfeature->IMS_VoPS_3GPP = *(buffer + decoded) & 0x01;
+  decoded++;
+
+  networkfeature->MCSI = (*(buffer + decoded) >> 1) & 0x01;
+  networkfeature->EMCN3 = (*(buffer + decoded)) & 0x01;
+  decoded++;
+
+  return decoded;
+};
+
+int NetworkFeatureSupportMsg::EncodeNetworkFeatureSupportMsg(
+    NetworkFeatureSupportMsg* networkfeature, uint8_t iei, uint8_t* buffer,
+    uint32_t len) {
+  uint32_t encoded = 0;
+
+  /*
+   * Checking IEI and pointer
+   */
+  CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, NETWORK_FEATURE_MINIMUM_LENGTH,
+                                       len);
+
+  if (iei > 0) {
+    CHECK_IEI_ENCODER(iei, (unsigned char)networkfeature->iei);
+    *buffer = iei;
+    encoded++;
+  }
+
+  *(buffer + encoded) = networkfeature->len;
+  encoded++;
+  *(buffer + encoded) = 0x00 | ((networkfeature->MPSI & 0x01) << 7) |
+                        ((networkfeature->IWK_N26 & 0x01) << 6) |
+                        ((networkfeature->EMF & 0x03) << 4) |
+                        ((networkfeature->EMC & 0x03) << 2) |
+                        ((networkfeature->IMS_VoPS_N3GPP & 0x01) << 1) |
+                        (networkfeature->IMS_VoPS_3GPP & 0x01);
+  encoded++;
+  *(buffer + encoded) = 0x00 | ((networkfeature->MCSI & 0x01) << 1) |
+                        (networkfeature->EMCN3 & 0x01);
+  encoded++;
+  return encoded;
+};
+
+}  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_encode_decode.cpp
@@ -1579,4 +1579,42 @@ TEST(test_PDUAddressMsg, test_pdu_session_accept_optional_addressinfo) {
   EXPECT_TRUE(msg.address_info[0] == 0xc0);
   EXPECT_TRUE(msg.address_info[1] == 0xa8);
 }
+TEST(test_network_feature, test_network_feature) {
+  NetworkFeatureSupportMsg networkfeature;
+  NetworkFeatureSupportMsg decoded_networkfeature;
+  networkfeature.iei = 0x21;
+  uint8_t iei = networkfeature.iei;
+
+  networkfeature.len = 2;
+  networkfeature.IMS_VoPS_3GPP = 1;
+  networkfeature.IMS_VoPS_N3GPP = 0;
+  networkfeature.EMC = 2;
+  networkfeature.EMF = 3;
+  networkfeature.IWK_N26 = 1;
+  networkfeature.MPSI = 0;
+  networkfeature.EMCN3 = 1;
+  networkfeature.MCSI = 0;
+
+  uint8_t network_feature_buffer[4096];
+
+  int encoded_network_feature = networkfeature.EncodeNetworkFeatureSupportMsg(
+      &networkfeature, iei, network_feature_buffer, 4096);
+  EXPECT_EQ(encoded_network_feature, 4);
+
+  int decoded_network_feature = networkfeature.DecodeNetworkFeatureSupportMsg(
+      &decoded_networkfeature, iei, network_feature_buffer, 4096);
+  EXPECT_EQ(decoded_network_feature, 4);
+
+  EXPECT_EQ(networkfeature.iei, decoded_networkfeature.iei);
+  EXPECT_EQ(networkfeature.len, decoded_networkfeature.len);
+  EXPECT_EQ(networkfeature.IMS_VoPS_3GPP, decoded_networkfeature.IMS_VoPS_3GPP);
+  EXPECT_EQ(networkfeature.IMS_VoPS_N3GPP,
+            decoded_networkfeature.IMS_VoPS_N3GPP);
+  EXPECT_EQ(networkfeature.EMC, decoded_networkfeature.EMC);
+  EXPECT_EQ(networkfeature.EMF, decoded_networkfeature.EMF);
+  EXPECT_EQ(networkfeature.IWK_N26, decoded_networkfeature.IWK_N26);
+  EXPECT_EQ(networkfeature.MPSI, decoded_networkfeature.MPSI);
+  EXPECT_EQ(networkfeature.EMCN3, decoded_networkfeature.EMCN3);
+  EXPECT_EQ(networkfeature.MCSI, decoded_networkfeature.MCSI);
+}
 }  // namespace magma5g


### PR DESCRIPTION
Signed-off-by: sreedharkumartn <sreedhar.kumar@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Added IE in registration accept to support for 5GS network feature support.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Verified with Unit Test.
![ut](https://user-images.githubusercontent.com/89978170/170002773-db42c6d4-7f55-4286-b062-c95e9494b3be.jpg)
- Done basic sanity (basic registration, pdu session accept, traffic flow) with UERANSIM, Network feature support field is added to the registration accept message.
- Screen shot of the PCAP.
![image](https://user-images.githubusercontent.com/89978170/170003380-22c0006b-0186-4dc3-855f-6eba96bff460.png)
- mme log.
[mme_network_feature_support.log](https://github.com/magma/magma/files/8761518/mme_network_feature_support.log)
- PCAP in zip file.
[Packet_network_feature_support.zip](https://github.com/magma/magma/files/8761525/Packet_network_feature_support.zip)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
