### PR TITLE
chore(agw): typo in session_manager/ is fixed

### DIFF
--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
@@ -111,7 +111,7 @@ void SessionProxyResponderHandlerImpl::PolicyReAuth(
                    << " with session_id " << session_id;
       PrintGrpcMessage(static_cast<const google::protobuf::Message&>(ans));
       ans.set_result(ReAuthResult::SESSION_NOT_FOUND);
-      Status status(grpc::NOT_FOUND, "Sesion Not found");
+      Status status(grpc::NOT_FOUND, "Session not found");
       response_callback(status, ans);
       return;
     }

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -436,7 +436,7 @@ void SetMessageManagerHandler::pdu_session_inactive(
   if (!session_it) {
     MLOG(MINFO) << " No session found for IMSI: " << imsi << " pdu id "
                 << pdu_id;
-    Status status(grpc::NOT_FOUND, "Sesion Not found");
+    Status status(grpc::NOT_FOUND, "Session not found");
     response_callback(status, SmContextVoid());
     return;
   }
@@ -509,7 +509,7 @@ void SetMessageManagerHandler::idle_mode_change_sessions_handle(
   }
   if (!count) {
     MLOG(MINFO) << " No Valid session found for IMSI: " << imsi;
-    Status status(grpc::NOT_FOUND, "Sesion Not found");
+    Status status(grpc::NOT_FOUND, "Session not found");
     response_callback(status, SmContextVoid());
     return;
   }
@@ -539,7 +539,7 @@ void SetMessageManagerHandler::service_handle_request_on_paging(
   auto session_it = session_store_.find_session(session_map, criteria);
   if (!session_it) {
     MLOG(MINFO) << " No Valid session found for IMSI: " << imsi;
-    Status status(grpc::NOT_FOUND, "Sesion Not found");
+    Status status(grpc::NOT_FOUND, "Session not found");
     response_callback(status, SmContextVoid());
     return;
   }
@@ -582,7 +582,7 @@ void SetMessageManagerHandler::request_modification_session(
   if (!session_it) {
     MLOG(MINFO) << " No session found for IMSI: " << imsi << " pdu id "
                 << pdu_id;
-    Status status(grpc::NOT_FOUND, "Sesion Not found");
+    Status status(grpc::NOT_FOUND, "Session not found");
     response_callback(status, SmContextVoid());
     return;
   }


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary
Fixes some small typos in `/session_manager/` files.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
