### PR TITLE
chore(orc8r): duplicate entries in setup.py are removed

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -94,19 +94,7 @@ setup(
         "rfc3987>=1.3.0",
         "webcolors>=1.11.1",
         'systemd-python>=234',
-        'itsdangerous>=0.24',
-        'click>=5.1',
-        'pycares>=2.3.0',
-        'python-dateutil>=1.4',
-        # force same requests version as lte/gateway/python/setup.py
-        'requests==2.22.0',
-        'jsonpickle',
-        'bravado-core==5.16.1',
-        'jsonschema==3.1.0',
-        "strict-rfc3339>=0.7",
-        "rfc3987>=1.3.0",
         "jsonpointer>=1.14",
-        "webcolors>=1.11.1",
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

This PR removes duplicate, identical entries in the `orc8r/gateway/python/setup.py`.
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
