### PR TITLE
feat(dp): Convert height type to upper case in AMC

### DIFF
--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/registration.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/registration.go
@@ -38,7 +38,7 @@ func buildRegistrationRequest(cbsd *active_mode.Cbsd) *registrationRequest {
 			Latitude:         installation.GetLatitudeDeg(),
 			Longitude:        installation.GetLongitudeDeg(),
 			Height:           installation.GetHeightM(),
-			HeightType:       installation.GetHeightType(),
+			HeightType:       strings.ToUpper(installation.GetHeightType()),
 			IndoorDeployment: installation.GetIndoorDeployment(),
 			AntennaGain:      installation.GetAntennaGainDbi(),
 		},

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/registration_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/registration_test.go
@@ -43,7 +43,7 @@ func TestRegistrationRequestGenerator(t *testing.T) {
 				LatitudeDeg:      12,
 				LongitudeDeg:     34,
 				HeightM:          5,
-				HeightType:       "AGL",
+				HeightType:       "agl",
 				IndoorDeployment: true,
 				AntennaGainDbi:   15,
 			},


### PR DESCRIPTION
## Summary
In the database lower case names are stored,
so they have to be converted to upper case required by SAS. 

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>