### PR TITLE
chore(pipelined): Fix selection of mypy errors

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/classifier.py
+++ b/lte/gateway/python/magma/pipelined/app/classifier.py
@@ -14,6 +14,7 @@ import ipaddress
 import socket
 import subprocess
 from collections import namedtuple
+from typing import Optional
 
 import grpc
 from lte.protos.mobilityd_pb2 import IPAddress
@@ -262,7 +263,7 @@ class Classifier(MagmaController):
 
     def _install_uplink_tunnel_flows(
         self, priority: int, i_teid: int,
-        gtp_portno: int, sid: int, o_teid: int,
+        gtp_portno: int, sid: Optional[int], o_teid: int,
     ):
 
         parser = self._datapath.ofproto_parser
@@ -301,7 +302,7 @@ class Classifier(MagmaController):
         self, priority: int, i_teid: int,
         o_teid: int, in_port: int,
         ue_ip_adr: IPAddress, enodeb_ip_addr: str,
-        gtp_portno: int, sid: int, ng_flag: bool, ue_ipv6_adr: IPAddress = None,
+        gtp_portno: int, sid: Optional[int], ng_flag: bool, ue_ipv6_adr: IPAddress = None,
     ):
 
         parser = self._datapath.ofproto_parser
@@ -324,7 +325,7 @@ class Classifier(MagmaController):
 
     def _install_downlink_arp_flows(
         self, priority: int, in_port: int,
-        ue_ip_adr: IPAddress, sid: int,
+        ue_ip_adr: IPAddress, sid: Optional[int],
     ):
 
         parser = self._datapath.ofproto_parser
@@ -347,7 +348,7 @@ class Classifier(MagmaController):
     def add_tunnel_flows(
         self, precedence: int, i_teid: int,
         o_teid: int, enodeb_ip_addr: str,
-        ue_ip_adr: IPAddress = None, sid: int = None,
+        ue_ip_adr: IPAddress = None, sid: Optional[int] = None,
         ng_flag: bool = True,
         ue_ipv6_address: IPAddress = None,
         unused_apn: str = None, unused_vlan: int = 0,
@@ -824,8 +825,8 @@ class Classifier(MagmaController):
     def add_s8_tunnel_flows(
         self, precedence: int, i_teid: int,
         o_teid: int, ue_ip_adr: IPAddress,
-        enodeb_ip_addr: str, sid: int = None,
-        pgw_ip_addr: str = None,
+        enodeb_ip_addr: str, sid: Optional[int] = None,
+        pgw_ip_addr: Optional[str] = None,
         pgw_gtp_port: int = 0,
         ng_flag: bool = True,
         unused_ue_ipv6_address: IPAddress = None,
@@ -883,8 +884,8 @@ class Classifier(MagmaController):
 
     def _install_uplink_s8_tunnel_flows(
         self, priority: int, i_teid: int,
-        o_teid: int, pgw_ip_addr: str,
-        gtp_portno: int, sid: int,
+        o_teid: int, pgw_ip_addr: Optional[str],
+        gtp_portno: int, sid: Optional[int],
         pgw_gtp_port: int,
     ):
 

--- a/lte/gateway/python/magma/pipelined/app/he.py
+++ b/lte/gateway/python/magma/pipelined/app/he.py
@@ -104,8 +104,8 @@ class HeaderEnrichmentController(MagmaController):
     APP_NAME = "proxy"
     APP_TYPE = ControllerType.PHYSICAL
 
-    UplinkConfig = namedtuple(
-        'heConfig',
+    UplinkHEConfig = namedtuple(
+        'UplinkHEConfig',
         [
             'he_proxy_port',
             'he_enabled',
@@ -154,7 +154,7 @@ class HeaderEnrichmentController(MagmaController):
             hash_function = mconfig.he_config.hashFunction
             encoding_type = mconfig.he_config.encodingType
 
-        return self.UplinkConfig(
+        return self.UplinkHEConfig(
             gtp_port=config_dict['ovs_gtp_port_number'],
             he_proxy_port=he_proxy_port,
             he_enabled=he_enabled,

--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -41,7 +41,7 @@ class UplinkBridgeController(MagmaController):
     DEFAULT_DEV_VLAN_OUT = 'vlan_pop_out'
     SGI_INGRESS_FLOW_UPDATE_FREQ = 60
 
-    UplinkConfig = namedtuple(
+    UplinkBridgeConfig = namedtuple(
         'UplinkBridgeConfig',
         [
             'uplink_bridge', 'uplink_eth_port_name', 'uplink_patch',
@@ -97,7 +97,7 @@ class UplinkBridgeController(MagmaController):
         sgi_management_iface_ipv6_gw = config_dict.get('sgi_management_iface_ipv6_gw', "")
         sgi_ip_monitoring = config_dict.get('sgi_ip_monitoring', True)
 
-        return self.UplinkConfig(
+        return self.UplinkBridgeConfig(
             enable_nat=enable_nat,
             uplink_bridge=bridge_name,
             uplink_eth_port_name=uplink_eth_port_name,

--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -479,8 +479,9 @@ class UplinkBridgeController(MagmaController):
             ["pgrep", "-f", "^/sbin/dhclient.*" + if_name],
             stdout=subprocess.PIPE,
         )
-        for pid in pgrep_out.stdout.readlines():
-            subprocess.check_call(["kill", pid.strip()])
+        if pgrep_out.stdout is not None:
+            for pid in pgrep_out.stdout.readlines():
+                subprocess.check_call(["kill", pid.strip()])
 
     def _restart_dhclient(self, if_name: str, af_inet: int):
         if af_inet != netifaces.AF_INET:

--- a/lte/gateway/python/magma/pipelined/bridge_util.py
+++ b/lte/gateway/python/magma/pipelined/bridge_util.py
@@ -71,10 +71,11 @@ class BridgeTools:
             ["ovs-ofctl", "show", bridge],
             stdout=subprocess.PIPE,
         )
-        for line1 in dump1.stdout.readlines():
-            if interface_name not in str(line1):
-                continue
-            return True
+        if dump1.stdout is not None:
+            for line1 in dump1.stdout.readlines():
+                if interface_name not in str(line1):
+                    continue
+                return True
         return False
 
     @staticmethod

--- a/lte/gateway/python/magma/pipelined/directoryd_client.py
+++ b/lte/gateway/python/magma/pipelined/directoryd_client.py
@@ -58,7 +58,7 @@ def update_record(imsi: str, ip_addr: str) -> None:
         )
 
 
-def get_record(imsi: str, field: str) -> str:
+def get_record(imsi: str, field: str) -> Optional[str]:
     """
     Make RPC call to 'GetDirectoryField' method of local directoryD service
     """

--- a/lte/gateway/python/magma/pipelined/directoryd_client.py
+++ b/lte/gateway/python/magma/pipelined/directoryd_client.py
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import logging
+from typing import List, Optional
 
 import grpc
 from magma.common.service_registry import ServiceRegistry
@@ -88,7 +89,7 @@ def get_record(imsi: str, field: str) -> str:
     return None
 
 
-def get_all_records(retries: int = 3, sleep_time: float = 0.1) -> [dict]:
+def get_all_records(retries: int = 3, sleep_time: float = 0.1) -> Optional[List[dict]]:
     """
     Make RPC call to 'GetAllDirectoryRecords' method of local directoryD service
     """

--- a/lte/gateway/python/magma/pipelined/directoryd_client.py
+++ b/lte/gateway/python/magma/pipelined/directoryd_client.py
@@ -69,7 +69,7 @@ def get_record(imsi: str, field: str) -> Optional[str]:
         )
     except ValueError:
         logging.error('Cant get RPC channel to %s', DIRECTORYD_SERVICE_NAME)
-        return
+        return None
     client = GatewayDirectoryServiceStub(chan)
     if not imsi.startswith("IMSI"):
         imsi = "IMSI" + imsi
@@ -100,7 +100,7 @@ def get_all_records(retries: int = 3, sleep_time: float = 0.1) -> Optional[List[
         )
     except ValueError:
         logging.error('Cant get RPC channel to %s', DIRECTORYD_SERVICE_NAME)
-        return
+        return None
     client = GatewayDirectoryServiceStub(chan)
     for _ in range(0, retries):
         try:

--- a/lte/gateway/python/magma/pipelined/encoding.py
+++ b/lte/gateway/python/magma/pipelined/encoding.py
@@ -118,7 +118,7 @@ def decrypt_str(data: str, key: bytes, encryption_algorithm, mac) -> str:
 
 
 def get_hash(s: str, hash_function) -> bytes:
-    hash_bytes = ""
+    hash_bytes = bytes()
     if hash_function == PipelineD.HEConfig.MD5:
         m = hashlib.md5()
         m.update(s.encode('utf-8'))
@@ -135,7 +135,7 @@ def get_hash(s: str, hash_function) -> bytes:
     return hash_bytes
 
 
-def encode_str(s: str, encoding_type) -> bytes:
+def encode_str(s: str, encoding_type) -> str:
     if encoding_type == PipelineD.HEConfig.BASE64:
         s = codecs.encode(codecs.decode(s, 'hex'), 'base64').decode()
     elif encoding_type == PipelineD.HEConfig.HEX2BIN:

--- a/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager_util.py
+++ b/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager_util.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 from lte.protos.pipelined_pb2 import (
     ActivateFlowsRequest,
@@ -21,7 +21,7 @@ from lte.protos.pipelined_pb2 import (
 class FARRuleEntry(NamedTuple):
     apply_action: int
     o_teid: int
-    gnb_ip_addr: str
+    gnb_ip_addr: Optional[str]
 
 
 class PDRRuleEntry(NamedTuple):
@@ -30,11 +30,11 @@ class PDRRuleEntry(NamedTuple):
     pdr_state: int
     precedence: int
     local_f_teid: int
-    ue_ip_addr: str
+    ue_ip_addr: Optional[str]
     del_qos_enforce_rule: DeactivateFlowsRequest
     add_qos_enforce_rule: ActivateFlowsRequest
-    far_action: FARRuleEntry
-    ue_ipv6_addr: str
+    far_action: Optional[FARRuleEntry]
+    ue_ipv6_addr: Optional[str]
 
 # Create the Named tuple for the FAR entry
 

--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -15,7 +15,7 @@ import logging
 import threading
 import traceback
 from enum import Enum
-from typing import Dict, List  # noqa
+from typing import Dict, List, Tuple  # noqa
 
 from lte.protos.policydb_pb2 import FlowMatch
 from magma.common.redis.client import get_default_client
@@ -155,7 +155,7 @@ class SubscriberState(object):
     def find_rule(self, rule_num: int):
         return self.rules.get(rule_num)
 
-    def get_all_rules(self) -> List:
+    def get_all_rules(self) -> Dict[int, List[Tuple[FlowMatch.Direction, str]]]:
         return self.rules
 
     def get_all_empty_sessions(self) -> List:

--- a/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
@@ -187,6 +187,7 @@ class TrafficClass:
                 LOG.error("could not find rate: %s", output)
         except subprocess.CalledProcessError:
             LOG.error("Exception dumping Qos State for %s", tc_cmd)
+        return None
 
     @staticmethod
     def _get_qdisc_type(intf: str) -> Optional[str]:
@@ -203,6 +204,7 @@ class TrafficClass:
                 LOG.error("could not qdisc type: %s", output)
         except subprocess.CalledProcessError:
             LOG.error("Exception dumping Qos State for %s", tc_cmd)
+        return None
 
 
 class TCManager(object):

--- a/lte/gateway/python/magma/pipelined/qos/utils.py
+++ b/lte/gateway/python/magma/pipelined/qos/utils.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 import logging
 from collections import deque
+from typing import Optional
 
 from magma.common.redis.containers import RedisHashDict
 from magma.common.redis.serializers import (
@@ -65,7 +66,7 @@ class IdManager(object):
                 self._free_idx_list.append(idx)
         self._restore_done = True
 
-    def _get_free_idx(self) -> int:
+    def _get_free_idx(self) -> Optional[int]:
         if self._free_idx_list:
             return self._free_idx_list.popleft()
         return None

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -1169,10 +1169,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
 def _retrieve_failed_results(
     activate_flow_result: ActivateFlowsResult,
-) -> Tuple[
-    List[RuleModResult],
-    List[RuleModResult],
-]:
+) -> List[RuleModResult]:
     failed_policies_results = \
         [
             result for result in

--- a/lte/gateway/python/magma/pipelined/rule_mappers.py
+++ b/lte/gateway/python/magma/pipelined/rule_mappers.py
@@ -120,7 +120,7 @@ class SessionRuleToVersionMapper:
 
     def save_version(
         self, imsi: str, ip_addr: IPAddress,
-        rule_id: [str], version: int,
+        rule_id: str, version: int,
     ):
         """
         Increment the version number for a given subscriber and rule. If the

--- a/lte/gateway/python/magma/pipelined/tests/app/flow_query.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/flow_query.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 from ryu.lib import hub
 
 FlowStats = namedtuple(
-    'FlowData', [
+    'FlowStats', [
         'packets', 'bytes', 'duration_sec',
         'cookie',
     ],

--- a/lte/gateway/python/magma/pipelined/tests/app/subscriber.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/subscriber.py
@@ -21,7 +21,7 @@ from magma.pipelined.policy_converters import convert_ip_str_to_ip_proto
 from ryu.lib import hub
 
 SubContextConfig = namedtuple(
-    'ContextConfig', [
+    'SubContextConfig', [
         'imsi', 'ip', 'ambr',
         'table_id',
     ],

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -50,7 +50,7 @@ these functions can be seen in pipelined/tests/test_*.py files
 """
 
 SubTest = namedtuple('SubTest', ['context', 'isolator', 'flowtest_list'])
-PktsToSend = namedtuple('PacketToSend', ['pkt', 'num'])
+PktsToSend = namedtuple('PktsToSend', ['pkt', 'num'])
 QueryMatch = namedtuple('QueryMatch', ['pkts', 'flow_count'])
 
 SNAPSHOT_DIR = 'snapshots/'

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -693,7 +693,7 @@ class SnapshotVerifier:
         )
 
 
-def get_ovsdb_port_tag(port_name: str) -> str:
+def get_ovsdb_port_tag(port_name: str) -> Optional[str]:
     dump1 = subprocess.Popen(
         ["ovsdb-client", "dump", "Port", "name", "tag"],
         stdout=subprocess.PIPE,
@@ -706,6 +706,7 @@ def get_ovsdb_port_tag(port_name: str) -> str:
             return tokens[1]
         except ValueError:
             pass
+    return None
 
 
 def get_iface_ipv4(iface: str) -> List[str]:

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 from concurrent.futures import Future
 from datetime import datetime
 from difflib import unified_diff
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from unittest import TestCase, mock
 from unittest.mock import MagicMock
 
@@ -491,7 +491,7 @@ def expected_snapshot(
     bridge_name: str,
     current_snapshot,
     snapshot_name: Optional[str] = None,
-) -> bool:
+) -> Tuple[str, List[str]]:
     if snapshot_name is not None:
         combined_name = '{}.{}{}'.format(
             test_case.id(), snapshot_name,

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -538,7 +538,7 @@ def mocked_setmacbyip6(ipv6_addr: str, mac: str):
 def mocked_getmacbyip6(ipv6_addr: str) -> str:
     global ipv6_mac_table
     with gw_info_lock:
-        return ipv6_mac_table.get(ipv6_addr, None)
+        return ipv6_mac_table.get(ipv6_addr)
 
 
 class InOutTestNonNATBasicFlowsIPv6(unittest.TestCase):

--- a/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
@@ -998,7 +998,7 @@ def validate_routing_table(dst: str, dev_name: str) -> Optional[str]:
             continue
         try:
             if dev_name in str(line):
-                return
+                return None
         except ValueError:
             pass
     logging.error("could not find route to %s via %s", dst, dev_name)

--- a/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
@@ -15,6 +15,7 @@ import subprocess
 import unittest
 import warnings
 from concurrent.futures import Future
+from typing import Optional
 
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.tests.app.start_pipelined import (
@@ -987,7 +988,7 @@ def check_connectivity_v6(dst: str):
         logging.warning("Error while ping: %s", e)
 
 
-def validate_routing_table(dst: str, dev_name: str) -> str:
+def validate_routing_table(dst: str, dev_name: str) -> Optional[str]:
     dump1 = subprocess.Popen(
         ["ip", "r", "get", dst],
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary

Running `mypy --ignore-missing-imports magma/lte/gateway/python/magma/pipelined` leads to 154 errors on master, which is reduced to 105 with this PR. This PR addresses many of the simpler fixes, with further fixes to come in a subsequent PR.

## Test Plan

- [x] magma-dev: `make test_python_service UT_PATH=python/magma/pipelined/tests/`