### PR TITLE
chore: Remove obsolete paths from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -66,9 +66,7 @@
 /.bazel-cache-repo/ @magma/approvers-bazel
 /.github/workflows/bazel-cache-push.yml @magma/approvers-bazel
 /.github/workflows/bazel.yml @magma/approvers-bazel
-/.github/workflows/docker-builder-bazel-base.yml @magma/approvers-bazel
 /bazel/ @magma/approvers-bazel
-/experimental/bazel-base/ @magma/approvers-bazel
 /.bazelignore @magma/approvers-bazel
 /.bazelrc @magma/approvers-bazel
 *.bazel @magma/approvers-bazel


### PR DESCRIPTION
## Summary

Removed paths that no longer exist
- experimental bazel folder
- docker bazel builder

## Test Plan

Run unit tests

## Additional Information

- [ ] This change is backwards-breaking
