### PR TITLE
chore: all ansible files use same go installation from artifactory

### DIFF
--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -39,8 +39,8 @@
     - role: ovs
     - role: golang
       vars:
-        golang_tar: go1.18.1.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334'
+        golang_tar: go1.18.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f'
     - role: cwag
 
   tasks:

--- a/cwf/gateway/deploy/cwag_dev_centos7.yml
+++ b/cwf/gateway/deploy/cwag_dev_centos7.yml
@@ -32,8 +32,8 @@
     - role: ovs
     - role: golang
       vars:
-        golang_tar: go1.18.1.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334'
+        golang_tar: go1.18.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f'
 #    - role: cwag
 
   tasks:

--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -30,8 +30,8 @@
         override_nameserver: 8.8.8.8
     - role: golang
       vars:
-        golang_tar: go1.18.1.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334'
+        golang_tar: go1.18.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f'
     - role: cwag_test
   tasks:
     - name: Set build environment variables

--- a/lte/gateway/deploy/roles/magma/vars/all.yaml
+++ b/lte/gateway/deploy/roles/magma/vars/all.yaml
@@ -1,2 +1,2 @@
 WORK_DIR: "~/"
-GO_VERSION: "1.18.1"
+GO_VERSION: "1.18"

--- a/orc8r/cloud/deploy/roles/golang/defaults/main.yml
+++ b/orc8r/cloud/deploy/roles/golang/defaults/main.yml
@@ -10,10 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  golang_tar: go1.18.1.linux-amd64.tar.gz
-  golang_tar_checksum: 'sha256:b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499'
-  go_install_path: /usr/local
-  gopath: '/home/{{ user }}/go'
-  gobin: '/home/{{ user }}/go/bin'
-  go_bin_path: '{{ go_install_path }}/go/bin:{{ gobin }}'
-  makebin: '/home/{{ user }}/magma/orc8r/cloud/go/bin'
+golang_tar: go1.18.linux-amd64.tar.gz
+golang_tar_checksum: 'sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f'
+go_install_path: /usr/local
+gopath: '/home/{{ user }}/go'
+gobin: '/home/{{ user }}/go/bin'
+go_bin_path: '{{ go_install_path }}/go/bin:{{ gobin }}'
+makebin: '/home/{{ user }}/magma/orc8r/cloud/go/bin'
+goproxy: "https://proxy.golang.org"

--- a/orc8r/cloud/deploy/roles/golang/tasks/main.yml
+++ b/orc8r/cloud/deploy/roles/golang/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Download Golang
   get_url:
-    url: "https://dl.google.com/go/{{ golang_tar }}"
+    url: "https://artifactory.magmacore.org/artifactory/generic/{{ golang_tar }}"
     dest: "/home/{{ user }}/{{ golang_tar }}"
     checksum: "{{ golang_tar_checksum }}"
   when: preburn

--- a/orc8r/tools/ansible/roles/golang/defaults/main.yml
+++ b/orc8r/tools/ansible/roles/golang/defaults/main.yml
@@ -10,11 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  golang_tar: go1.18.1.linux-amd64.tar.gz
-  golang_tar_checksum: 'sha256:d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5'
-  go_install_path: /usr/local
-  gopath: '/home/{{ user }}/go'
-  gobin: '/home/{{ user }}/go/bin'
-  go_bin_path: '{{ go_install_path }}/go/bin:{{ gobin }}'
-  makebin: '/home/{{ user }}/magma/feg/go/bin'
-  goproxy: "https://proxy.golang.org"
+golang_tar: go1.18.linux-amd64.tar.gz
+golang_tar_checksum: 'sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f'
+go_install_path: /usr/local
+gopath: '/home/{{ user }}/go'
+gobin: '/home/{{ user }}/go/bin'
+go_bin_path: '{{ go_install_path }}/go/bin:{{ gobin }}'
+makebin: '/home/{{ user }}/magma/feg/go/bin'
+goproxy: "https://proxy.golang.org"

--- a/orc8r/tools/ansible/roles/golang/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/golang/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Download Golang
   get_url:
-    url: "https://dl.google.com/go/{{ golang_tar }}"
+    url: "https://artifactory.magmacore.org/artifactory/generic/{{ golang_tar }}"
     dest: "/home/{{ user }}/{{ golang_tar }}"
     checksum: "{{ golang_tar_checksum }}"
   when: full_provision


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary
As introduced in #12605 , only one Go version should be used in the Ansible files. Now, all files use now the Go binaries provided by the Magma Artifactory https://artifactory.magmacore.org/artifactory.

## Test Plan

* Integ tests
* Pass  CI

## Additional Information

- [ ] This change is backwards-breaking

