### PR TITLE
chore(ci): bazel workflows are using the latest image

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latestv2"
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latestv2"
+  DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   CACHE_KEY: bazel-base-image
 
 jobs:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -16,7 +16,7 @@ on:  # yamllint disable-line rule:truthy
     # Run four times a day to build bazel cache
     - cron: '0 0,6,12,18 * * *'
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latestv2"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   CACHE_KEY: bazel-base-image
 
 

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -22,7 +22,7 @@ on:
       - reopened
       - synchronize
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latestv2"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   BAZEL_CACHE: bazel-cache
   BAZEL_CACHE_REPO: bazel-cache-repo
   CACHE_SUB_KEY: build-warnings


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

This is the fourth and final PR for merging the bazel base and devcontainer Dockerfiles. Workflows are using images tagged as latest.
Privious PRs:
* https://github.com/magma/magma/pull/12638
* https://github.com/magma/magma/pull/12731
* https://github.com/magma/magma/pull/12769

## Test Plan

CI - especially runs for `GCC Warnings & Errors`, `Bazel Build & Test` and `agw-workflow`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
