### PR TITLE
feat(enodebd): Send CBSD parameters to Domain Proxy

### DIFF
--- a/dp/protos/BUILD.bazel
+++ b/dp/protos/BUILD.bazel
@@ -28,3 +28,19 @@ python_grpc_library(
     name = "enodebd_dp_python_grpc",
     protos = [":enodebd_dp_proto"],
 )
+
+proto_library(
+    name = "cbsd_proto",
+    srcs = ["cbsd.proto"],
+    deps = ["@com_google_protobuf//:wrappers_proto"],
+)
+
+python_proto_library(
+    name = "cbsd_python_proto",
+    protos = [":cbsd_proto"],
+)
+
+python_grpc_library(
+    name = "cbsd_python_grpc",
+    protos = [":cbsd_proto"],
+)

--- a/lte/gateway/python/magma/enodebd/BUILD.bazel
+++ b/lte/gateway/python/magma/enodebd/BUILD.bazel
@@ -101,7 +101,10 @@ py_library(
     name = "dp_client",
     srcs = ["dp_client.py"],
     visibility = ["//visibility:public"],
-    deps = ["//dp/protos:enodebd_dp_python_grpc"],
+    deps = [
+        "//dp/protos:cbsd_python_grpc",
+        "//dp/protos:enodebd_dp_python_grpc",
+    ],
 )
 
 py_library(

--- a/lte/gateway/python/magma/enodebd/data_models/data_model_parameters.py
+++ b/lte/gateway/python/magma/enodebd/data_models/data_model_parameters.py
@@ -32,6 +32,13 @@ class ParameterName():
     SERIAL_NUMBER = 'Serial number'
     CELL_ID = 'Cell ID'
 
+    ANTENNA_HEIGHT = 'Antenna height'
+    ANTENNA_HEIGHT_TYPE = 'Antenna height type'
+    ANTENNA_GAIN = 'Antenna gain'
+
+    CBSD_CATEGORY = 'CBSD category'
+    INDOOR_DEPLOYMENT = 'Indoor deployment'
+
     # Capabilities
     DUPLEX_MODE_CAPABILITY = 'Duplex mode capability'
     BAND_CAPABILITY = 'Band capability'

--- a/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
+++ b/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
@@ -37,7 +37,11 @@ from magma.enodebd.device_config.enodeb_config_postprocessor import (
 )
 from magma.enodebd.device_config.enodeb_configuration import EnodebConfiguration
 from magma.enodebd.devices.device_utils import EnodebDeviceName
-from magma.enodebd.dp_client import get_cbsd_state
+from magma.enodebd.dp_client import (
+    build_enodebd_update_cbsd_request,
+    enodebd_update_cbsd,
+    get_cbsd_state,
+)
 from magma.enodebd.exceptions import ConfigurationError
 from magma.enodebd.logger import EnodebdLogger
 from magma.enodebd.state_machines.acs_state_utils import (
@@ -1425,6 +1429,17 @@ class FreedomFiOneNotifyDPState(NotifyDPState):
         ff_one_update_desired_config_from_cbsd_state(
             state, self.acs.desired_cfg,
         )
+        enodebd_update_cbsd_request = build_enodebd_update_cbsd_request(
+            serial_number=self.acs.device_cfg.get_parameter(ParameterName.SERIAL_NUMBER),
+            latitude_deg=self.acs.device_cfg.get_parameter(ParameterName.GPS_LAT),
+            longitude_deg=self.acs.device_cfg.get_parameter(ParameterName.GPS_LONG),
+            indoor_deployment=self.acs.device_cfg.get_parameter(SASParameters.SAS_LOCATION),
+            antenna_height=None,
+            antenna_height_type=self.acs.device_cfg.get_parameter(SASParameters.SAS_HEIGHT_TYPE),
+            antenna_gain=str(ANTENNA_GAIN_DBI),
+            cbsd_category=self.acs.device_cfg.get_parameter(SASParameters.SAS_CATEGORY),
+        )
+        enodebd_update_cbsd(enodebd_update_cbsd_request)
 
 
 def ff_one_update_desired_config_from_cbsd_state(state: CBSDStateResult, config: EnodebConfiguration) -> None:

--- a/lte/gateway/python/magma/enodebd/dp_client.py
+++ b/lte/gateway/python/magma/enodebd/dp_client.py
@@ -11,14 +11,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import grpc
+from dp.protos.cbsd_pb2 import (
+    EnodebdUpdateCbsdRequest,
+    InstallationParam,
+    UpdateCbsdResponse,
+)
+from dp.protos.cbsd_pb2_grpc import CbsdManagementStub
 from dp.protos.enodebd_dp_pb2 import CBSDRequest, CBSDStateResult
 from dp.protos.enodebd_dp_pb2_grpc import DPServiceStub
+from google.protobuf.wrappers_pb2 import BoolValue, DoubleValue, StringValue
 from magma.common.service_registry import ServiceRegistry
 from magma.enodebd.logger import EnodebdLogger
 
 logger = EnodebdLogger
 
 DP_SERVICE_NAME = "dp_service"
+DP_ORC8R_SERVICE_NAME = "dp"
 DEFAULT_GRPC_TIMEOUT = 20
 
 
@@ -32,7 +40,7 @@ def get_cbsd_state(request: CBSDRequest) -> CBSDStateResult:
             ServiceRegistry.CLOUD,
         )
     except ValueError:
-        logger.error('Cant get RPC channel to %s', DP_SERVICE_NAME)
+        logger.error("Can't get RPC channel to %s", DP_SERVICE_NAME)
         return CBSDStateResult(radio_enabled=False)
     client = DPServiceStub(chan)
     try:
@@ -44,4 +52,71 @@ def get_cbsd_state(request: CBSDRequest) -> CBSDStateResult:
             err.details(),
         )
         return CBSDStateResult(radio_enabled=False)
+    return res
+
+
+def _indoortobool(s: str):
+    return s.lower() in ['true', 't', '1', 'yes', 'indoor']
+
+
+def build_enodebd_update_cbsd_request(
+    serial_number: str,
+    latitude_deg: str,
+    longitude_deg: str,
+    indoor_deployment: str,
+    antenna_height: str,
+    antenna_height_type: str,
+    antenna_gain: str,
+    cbsd_category: str,
+) -> EnodebdUpdateCbsdRequest:
+    # cbsd category and antenna height type should be converted to lowercase
+    # for the gRPC call
+    antenna_height_type = antenna_height_type.lower()
+    cbsd_category = cbsd_category.lower()
+    # lat and long values are part of tr181 specification, but they are kept in device config
+    # transformed and eventually kept within the device config as strings representing degrees
+    latitude_deg_float = float(latitude_deg)
+    longitude_deg_float = float(longitude_deg)
+
+    indoor_deployment_bool = _indoortobool(indoor_deployment)
+    antenna_gain_float = float(antenna_gain)
+
+    installation_param = InstallationParam(
+        latitude_deg=DoubleValue(value=latitude_deg_float),
+        longitude_deg=DoubleValue(value=longitude_deg_float),
+        indoor_deployment=BoolValue(value=indoor_deployment_bool),
+        height_m=DoubleValue(value=float(antenna_height)) if antenna_height else None,
+        height_type=StringValue(value=antenna_height_type),
+        antenna_gain=DoubleValue(value=antenna_gain_float),
+    )
+
+    return EnodebdUpdateCbsdRequest(
+        serial_number=serial_number,
+        installation_param=installation_param,
+        cbsd_category=cbsd_category,
+    )
+
+
+def enodebd_update_cbsd(request: EnodebdUpdateCbsdRequest) -> UpdateCbsdResponse:
+    """
+    Make RPC call to 'EnodebdUpdateCbsd' method of dp orc8r service
+    """
+    try:
+        chan = ServiceRegistry.get_rpc_channel(
+            DP_ORC8R_SERVICE_NAME,
+            ServiceRegistry.CLOUD,
+        )
+    except ValueError:
+        logger.error("Can't get RPC channel to %s", DP_ORC8R_SERVICE_NAME)
+        return UpdateCbsdResponse()
+    client = CbsdManagementStub(chan)
+    try:
+        res = client.EnodebdUpdateCbsd(request, DEFAULT_GRPC_TIMEOUT)
+    except grpc.RpcError as err:
+        logger.warning(
+            "EnodebdUpdateCbsd error: [%s] %s",
+            err.code(),
+            err.details(),
+        )
+        return UpdateCbsdResponse()
     return res

--- a/lte/gateway/python/magma/enodebd/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/enodebd/tests/BUILD.bazel
@@ -59,6 +59,7 @@ pytest_test(
         ORC8R_ROOT,
     ],
     deps = [
+        "//dp/protos:cbsd_python_proto",
         "//dp/protos:enodebd_dp_python_proto",
         "//lte/gateway/python/magma/enodebd/data_models:data_model",
         "//lte/gateway/python/magma/enodebd/device_config:configuration_init",
@@ -221,6 +222,7 @@ pytest_test(
         ORC8R_ROOT,
     ],
     deps = [
+        "//dp/protos:cbsd_python_proto",
         "//dp/protos:enodebd_dp_python_proto",
         "//lte/gateway/python/magma/enodebd/data_models:data_model_parameters",
         "//lte/gateway/python/magma/enodebd/device_config:cbrs_consts",


### PR DESCRIPTION
* Extended dp_client with new gRPC method for sending CBSD parameters to
DProxy
* Added extra TR parameter names
* Extended baicells QRTB device model with extra parameters
* Added sending parameters to Domain Proxy by QRTB device model
* Added sending parameters to Domain Proxy by FreedomFi One device model
* Added unit tests

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

Added support for sending eNB installation parameters to Domain Proxy. Currently supported device models are BaiCells QRTB and FreedomFi One

This change depends on https://github.com/magma/magma/pull/12804
## Additional Information

- [ ] This change is backwards-breaking