### PR TITLE
fix(pipelined): Remove problematic type annotation

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -15,7 +15,7 @@ import logging
 import threading
 import traceback
 from enum import Enum
-from typing import Dict, List, Tuple  # noqa
+from typing import Any, Dict, List, Tuple  # noqa
 
 from lte.protos.policydb_pb2 import FlowMatch
 from magma.common.redis.client import get_default_client
@@ -155,7 +155,7 @@ class SubscriberState(object):
     def find_rule(self, rule_num: int):
         return self.rules.get(rule_num)
 
-    def get_all_rules(self) -> Dict[int, List[Tuple[FlowMatch.Direction, str]]]:
+    def get_all_rules(self) -> Dict[int, List[Tuple[Any, str]]]:
         return self.rules
 
     def get_all_empty_sessions(self) -> List:


### PR DESCRIPTION
## Summary

The annotation breaks sudo tests that don't run in the CI even though it's actually correct. Must be some issue with the generated protobuf types.

## Test Plan

```
sudo /home/vagrant/build/python/bin/nosetests -s magma/pipelined/tests/test_service_manager.py
```

## Additional Information

- [ ] This change is backwards-breaking
