### PR TITLE
chore(orc8r): Adapt bootstrap test script to run on Linux

### DIFF
--- a/orc8r/tools/scripts/bootstrap.bash
+++ b/orc8r/tools/scripts/bootstrap.bash
@@ -53,7 +53,11 @@ challenge=$(grpcurl \
 
 openssl genrsa -out /tmp/magma_protos/gateway.key 2048
 openssl req -new -key /tmp/magma_protos/gateway.key -out /tmp/magma_protos/gateway.csr.der -outform DER -subj "/C=US/CN=${hwid}"
-csr_bytes=$(base64 -i /tmp/magma_protos/gateway.csr.der)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  csr_bytes=$(base64 -i -w0 /tmp/magma_protos/gateway.csr.der)
+else
+  csr_bytes=$(base64 -i /tmp/magma_protos/gateway.csr.der)
+fi
 
 req="
 {
@@ -85,7 +89,11 @@ cert_der=$(grpcurl \
   magma.orc8r.Bootstrapper/RequestSign \
   | jq -r .certDer
 )
-echo -n ${cert_der} | base64 -D | openssl x509 -inform der -out /tmp/magma_protos/gateway.crt
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  echo -n ${cert_der} | base64 -d | openssl x509 -inform der -out /tmp/magma_protos/gateway.crt
+else
+  echo -n ${cert_der} | base64 -D | openssl x509 -inform der -out /tmp/magma_protos/gateway.crt
+fi
 
 echo ''
 echo 'Success'

--- a/orc8r/tools/scripts/consolidate_protos.bash
+++ b/orc8r/tools/scripts/consolidate_protos.bash
@@ -24,12 +24,18 @@ include=/usr/local/include
 
 ignore=( -not -path '*/migrations/*' )
 
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  CPIO_FLAGS="-pdm"
+else
+  CPIO_FLAGS="-pdm --insecure"
+fi
+
 pushd ${magma}
-find -L . -name '*.proto' "${ignore[@]}" | cpio -pdm --insecure ${outdir}
+find -L . -name '*.proto' "${ignore[@]}" | cpio ${CPIO_FLAGS} ${outdir}
 popd
 
 pushd ${include}
-find -L . -name '*.proto' "${ignore[@]}" | cpio -pdm --insecure ${outdir}
+find -L . -name '*.proto' "${ignore[@]}" | cpio ${CPIO_FLAGS} ${outdir}
 popd
 
 echo


### PR DESCRIPTION
## Summary

Some of the orc8r [interface testing tools](https://docs.magmacore.org/docs/orc8r/dev_security#debug-tools) were not compatible with Linux commands before.

## Test Plan

I tested that it runs on Linux now.

```
cd $MAGMA_ROOT/orc8r/tools/scripts/
bash bootstrap.bash $HWID
```

## Additional Information

- [ ] This change is backwards-breaking