### PR TITLE
docs: Fixing typo in docs

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.7.0/general/cloudstrapper_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/general/cloudstrapper_install.md
@@ -19,7 +19,7 @@ There are two basic options for setting up Magma Cloudstrapper within Amazon Web
     - In “Choose Action”, select “Launch from Website” (default)
     - The EC2 Instance Type dropdown will select “t2.medium” by default
     - Choose preferred values for other drop-boxes. Cloudstrapper will work fine deployed on the public subnet.
-    - Under “Security Group Settings” select a security group that at allows SSH traffic and any other rules that are relevant to your network.
+    - Under “Security Group Settings” select a security group that allows SSH traffic and any other rules that are relevant to your network.
     - Under “Key Pair Settings” select your preferred key pair.
 - Click on Launch
 - In order to ssh into your Cloudstrapper use the key pair .pem file and ubuntu in this format: ssh -i &lt;KeyPair&gt; ubuntu@&lt;InstanceIP&gt;
@@ -108,7 +108,7 @@ varFirstInstall: "false"
     - varBuildType: Using either ‘community’ or ‘custom’ binaries
     - varFirstInstall: Indicating if this is the first install of any kind of Magma or not, to skip some of the default, shared roles created
 
-- First change your directory to ~/magma-dev/magma/experimental/cloudstrapper/playbooks. Next, run the playbook to setup Orchestrator the deployment:
+- First change your directory to `~/magma-dev/magma/experimental/cloudstrapper/playbooks`. Next, run the playbook to set up the Orchestrator deployment:
 
 ```bash
 ansible-playbook orc8r.yaml -e '@<path to parameters file>'

--- a/docs/readmes/general/cloudstrapper_install.md
+++ b/docs/readmes/general/cloudstrapper_install.md
@@ -18,7 +18,7 @@ There are two basic options for setting up Magma Cloudstrapper within Amazon Web
     - In “Choose Action”, select “Launch from Website” (default)
     - The EC2 Instance Type dropdown will select “t2.medium” by default
     - Choose preferred values for other drop-boxes. Cloudstrapper will work fine deployed on the public subnet.
-    - Under “Security Group Settings” select a security group that at allows SSH traffic and any other rules that are relevant to your network.
+    - Under “Security Group Settings” select a security group that allows SSH traffic and any other rules that are relevant to your network.
     - Under “Key Pair Settings” select your preferred key pair.
 - Click on Launch
 - In order to ssh into your Cloudstrapper use the key pair .pem file and ubuntu in this format: ssh -i &lt;KeyPair&gt; ubuntu@&lt;InstanceIP&gt;
@@ -107,7 +107,7 @@ varFirstInstall: "false"
     - varBuildType: Using either ‘community’ or ‘custom’ binaries
     - varFirstInstall: Indicating if this is the first install of any kind of Magma or not, to skip some of the default, shared roles created
 
-- First change your directory to ~/magma-dev/magma/experimental/cloudstrapper/playbooks. Next, run the playbook to setup Orchestrator the deployment:
+- First change your directory to `~/magma-dev/magma/experimental/cloudstrapper/playbooks`. Next, run the playbook to set up the Orchestrator deployment:
 
 ```bash
 ansible-playbook orc8r.yaml -e '@<path to parameters file>'


### PR DESCRIPTION
This change fixes the typo in `Deploying Magma via Cloudstrapper`

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
