### PR TITLE
chore: sctpd can be packaged via bazel into a deb file

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -165,6 +165,54 @@ jobs:
           echo "Available storage:"
           df -h
 
+  bazel_package:
+    needs: path_filter
+    # Only run workflow if this is a scheduled run on master branch,
+    # or a pull_request that skip-duplicate-action wants to run again.
+    if: |
+      (github.event_name == `schedule` && github.ref == 'refs/heads/master')
+        || ${{ needs.path_filter.outputs.files_changed == 'true' }}
+    name: Bazel Package Job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Maximize build space
+        shell: bash
+        run: |
+          echo "Available storage before:"
+          df -h
+          echo "Removing /usr/share/dotnet, /usr/local/lib/android, /opt/ghc"
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          echo "Available storage after:"
+          df -h
+      - name: Check Out Repo
+        # This is necessary for overlays into the Docker container below.
+        uses: actions/checkout@v2
+      - name: Setup Bazel Base Image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          options: --pull always
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the bazel base image!"
+      - name: Build .deb Packages
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+            bazel build lte/gateway/release:sctpd_deb_pkg --config=production
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h
+
   python_file_check:
     name: Check if there are not bazelified python files
     runs-on: ubuntu-latest

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -143,3 +143,16 @@ load_swagger_repositories()
 load("//bazel:python_repositories.bzl", "python_repositories")
 
 python_repositories()
+
+http_archive(
+    name = "rules_pkg",
+    sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
+    ],
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()

--- a/lte/gateway/c/sctpd/src/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/BUILD.bazel
@@ -17,6 +17,7 @@ cc_binary(
     name = "sctpd",
     srcs = ["sctpd.cpp"],
     linkstatic = True,
+    visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":config",
         ":sctpd_downlink_impl",

--- a/lte/gateway/deploy/roles/magma/files/systemd/BUILD.bazel
+++ b/lte/gateway/deploy/roles/magma/files/systemd/BUILD.bazel
@@ -1,0 +1,12 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exports_files(["sctpd.service"])

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -1,0 +1,78 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Artifacts in this package should be build with the production
+configuration:
+bazel build lte/gateway/release:sctpd_deb_pkg --config=production
+"""
+
+load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+SCTPD_PKGNAME = "magma-sctpd"
+
+VERSION = "1.8.0"
+
+ARCH = "amd64"
+
+FILE_NAME = "{name}_{ver}_{arch}".format(
+    name = SCTPD_PKGNAME,
+    arch = ARCH,
+    ver = VERSION,
+)
+
+genrule(
+    name = "gen_sctpd_version",
+    outs = ["version"],
+    cmd = "echo \"{ver}\" > \"$@\"".format(ver = VERSION),
+)
+
+pkg_files(
+    name = "sctpd_version",
+    srcs = [":gen_sctpd_version"],
+    prefix = "/usr/local/share/sctpd/",
+)
+
+pkg_files(
+    name = "sctpd_service_definition",
+    srcs = ["//lte/gateway/deploy/roles/magma/files/systemd:sctpd.service"],
+    prefix = "/etc/systemd/system/",
+)
+
+pkg_files(
+    name = "sctpd_binary",
+    srcs = ["//lte/gateway/c/sctpd/src:sctpd"],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "/usr/local/sbin",
+)
+
+pkg_tar(
+    name = "sctpd_content",
+    srcs = [
+        ":sctpd_binary",
+        ":sctpd_service_definition",
+        ":sctpd_version",
+    ],
+    package_dir = "./",
+    package_file_name = "{fname}.tar".format(fname = FILE_NAME),
+)
+
+pkg_deb(
+    name = "sctpd_deb_pkg",
+    data = ":sctpd_content",
+    description = "Magma SCTPD",
+    maintainer = "Copyright (c) 2022 The Magma Authors",
+    package = SCTPD_PKGNAME,
+    package_file_name = "{fname}.deb".format(fname = FILE_NAME),
+    version = VERSION,
+)


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

This change allows to build an sctpd debian package with Bazel as in `lte/gateway/release/build-magma.sh`. The package is currently not used (uploaded etc) but build regularly with the Bazel workflow in bazel.yml (`bazel build ...` builds everything).

This first step introduces Bazel rules for building packages. It is planned to use these mechanics also for the magma debian package and the third party packages that are distributed in the magma artifactory.

There are certain differences between a script created package [1] and a package created with Bazel [2]:
* the bazel file has no timestamp in it's file name - in order to create reproducible builds
* Bazel sets all timestamps to `2000-01-01` - in order to create reproducible builds
* Bazel does not package changelog.gz - this seems to happen automatically with `fpm` - there was no relevant content in the make created changelog.gz

[1] `$ dpkg -c magma-sctpd_1.8.0-1653290604-_amd64.deb`
```
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./etc/
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./etc/systemd/
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./etc/systemd/system/
-rw-r--r-- 0/0            1224 2021-06-18 01:45 ./etc/systemd/system/sctpd.service
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./usr/
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./usr/local/
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./usr/local/sbin/
-rwxr-xr-x 0/0        20385568 2022-05-23 09:19 ./usr/local/sbin/sctpd
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./usr/local/share/
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./usr/local/share/sctpd/
-rw------- 0/0              18 2022-05-23 09:27 ./usr/local/share/sctpd/version
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./usr/share/
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./usr/share/doc/
drwxr-xr-x 0/0               0 2022-05-23 09:27 ./usr/share/doc/magma-sctpd/
-rw-r--r-- 0/0             153 2022-05-23 09:27 ./usr/share/doc/magma-sctpd/changelog.gz
```

[2] `$ dpkg -c bazel-bin/lte/gateway/release/magma-sctpd_1.8.0_amd64.deb`
```
drwxr-xr-x 0/0               0 2000-01-01 00:00 ./etc/
drwxr-xr-x 0/0               0 2000-01-01 00:00 ./etc/systemd/
drwxr-xr-x 0/0               0 2000-01-01 00:00 ./etc/systemd/system/
-rw-r--r-- 0/0            1224 2000-01-01 00:00 ./etc/systemd/system/sctpd.service
drwxr-xr-x 0/0               0 2000-01-01 00:00 ./usr/
drwxr-xr-x 0/0               0 2000-01-01 00:00 ./usr/local/
drwxr-xr-x 0/0               0 2000-01-01 00:00 ./usr/local/sbin/
-rwxr-xr-x 0/0       119582032 2000-01-01 00:00 ./usr/local/sbin/sctpd
drwxr-xr-x 0/0               0 2000-01-01 00:00 ./usr/local/share/
drwxr-xr-x 0/0               0 2000-01-01 00:00 ./usr/local/share/sctpd/
-rw-r--r-- 0/0               6 2000-01-01 00:00 ./usr/local/share/sctpd/version
```

## Test Plan

* Build: `bazel build lte/gateway/release:sctpd_deb_pkg`
* Creates files:
```
$ ll bazel-bin/lte/gateway/release/
-r-xr-xr-x 1 vscode vscode  715 May 29 16:37 magma-sctpd_1.8.0_amd64.changes*
-r-xr-xr-x 1 vscode vscode 115M May 29 16:37 magma-sctpd_1.8.0_amd64.deb*
-r-xr-xr-x 1 vscode vscode 115M May 29 16:37 magma-sctpd_1.8.0_amd64.tar*
-r-xr-xr-x 1 vscode vscode  324 May 29 16:37 sctpd_content.manifest*
lrwxrwxrwx 1 vscode vscode   97 May 29 16:37 sctpd_deb_pkg.deb -> /tmp/bazel/execroot/__main__/bazel-out/k8-dbg/bin/lte/gateway/release/magma-sctpd_1.8.0_amd64.deb*
-r-xr-xr-x 1 vscode vscode    6 May 29 16:37 version*
```
* Install on (e.g.) magma vm: apt install `./magma-sctpd_1.8.0_amd64.deb`
* see that files are setup as in [2] - start sctpd service and check logging

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
