### PR TITLE
fix(ci): go 1.18 is used in ghz builds in order to be compatible to ghz v0.109.0

### DIFF
--- a/lte/gateway/docker/ghz/Dockerfile
+++ b/lte/gateway/docker/ghz/Dockerfile
@@ -8,9 +8,18 @@ FROM ${REPO_LOCATION}/agw_gateway_c AS c_builder
 ARG GHZ_REPO=https://github.com/bojand/ghz
 
 RUN apt-get update && apt-get install -y \
+  curl \
   git \
-  golang \
   build-essential
+
+# Install golang 1.18
+WORKDIR /usr/local
+ARG GOLANG_VERSION="1.18"
+RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
+ && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
+ && tar -xzf ${GO_TARBALL} \
+ && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+ && rm ${GO_TARBALL}
 
 WORKDIR ${MAGMA_ROOT}
 
@@ -25,9 +34,18 @@ FROM ${REPO_LOCATION}/agw_gateway_python as python_builder
 ARG GHZ_REPO=https://github.com/bojand/ghz
 
 RUN apt-get update && apt-get install -y \
+  curl \
   git \
-  golang \
   build-essential
+
+# Install golang 1.18
+WORKDIR /usr/local
+ARG GOLANG_VERSION="1.18"
+RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
+ && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
+ && tar -xzf ${GO_TARBALL} \
+ && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+ && rm ${GO_TARBALL}
 
 ENV MAGMA_ROOT /magma
 


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In build-all the job `agw container build` is currently failing on master in the step `Run ghz docker compose` (inclusive retry). See, e.g., https://github.com/magma/magma/runs/6645140161?check_suite_focus=true.

**Analysis**
* ghz (https://github.com/bojand/ghz) was updated three days ago from v0.108.0 to v0.109.0. Looks like v0.109.0 needs go >= 1.14 if not even 1.17. Via apt go 1.13 was installed.
* Using go 1.18 (as in other magma builds) seems to fix the build. Approach here.

**Open**
* I do not know if this is compatible with follow up steps, where the image might be used - @reviewers: ideas?
* Alternatively ghz can be pinned to `--branch v0.108.0`.
 
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->


* CI
* manually in `magma/lte/gateway/docker/ghz$`:
  * `docker-compose --file docker-compose.yaml --file docker-compose.override.yaml build gateway_c`
  * `docker-compose --file docker-compose.yaml --file docker-compose.override.yaml build gateway_python`

## Additional Information
<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
