### PR TITLE
docs: typo in Security Debugging docs

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.5.X/orc8r/dev_security.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/orc8r/dev_security.md
@@ -242,7 +242,7 @@ openssl verify \
     gateway.crt  # copied from target gateway
 
 # Consolidate Magma and its imported protos, copying to /tmp/magma_protos/
-${MAGMA_ROOT}/orc8r/tools/scripts/consolidate_protos.sh
+${MAGMA_ROOT}/orc8r/tools/scripts/consolidate_protos.bash
 
 # Generate compiled proto definitions
 cd /tmp/magma_protos/ && \

--- a/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/dev_security.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/dev_security.md
@@ -244,7 +244,7 @@ openssl verify \
     gateway.crt  # copied from target gateway
 
 # Consolidate Magma and its imported protos, copying to /tmp/magma_protos/
-${MAGMA_ROOT}/orc8r/tools/scripts/consolidate_protos.sh
+${MAGMA_ROOT}/orc8r/tools/scripts/consolidate_protos.bash
 
 # Generate compiled proto definitions
 cd /tmp/magma_protos/ && \

--- a/docs/readmes/orc8r/dev_security.md
+++ b/docs/readmes/orc8r/dev_security.md
@@ -243,7 +243,7 @@ openssl verify \
     gateway.crt  # copied from target gateway
 
 # Consolidate Magma and its imported protos, copying to /tmp/magma_protos/
-${MAGMA_ROOT}/orc8r/tools/scripts/consolidate_protos.sh
+${MAGMA_ROOT}/orc8r/tools/scripts/consolidate_protos.bash
 
 # Generate compiled proto definitions
 cd /tmp/magma_protos/ && \


### PR DESCRIPTION
## Summary

Replace `.sh` with `.bash` to make command work properly.
