### PR TITLE
fix(agw): upgrade go to fix an build error caused by an old go version

### DIFF
--- a/lte/gateway/docker/ghz/Dockerfile
+++ b/lte/gateway/docker/ghz/Dockerfile
@@ -9,8 +9,16 @@ ARG GHZ_REPO=https://github.com/bojand/ghz
 
 RUN apt-get update && apt-get install -y \
   git \
-  golang \
+  curl \
   build-essential
+
+WORKDIR /usr/local
+ARG GOLANG_VERSION="1.18"
+RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
+ && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
+ && tar -xzf ${GO_TARBALL} \
+ && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+  && rm ${GO_TARBALL} 
 
 WORKDIR ${MAGMA_ROOT}
 
@@ -26,8 +34,16 @@ ARG GHZ_REPO=https://github.com/bojand/ghz
 
 RUN apt-get update && apt-get install -y \
   git \
-  golang \
+  curl \
   build-essential
+
+WORKDIR /usr/local
+ARG GOLANG_VERSION="1.18"
+RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
+ && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
+ && tar -xzf ${GO_TARBALL} \
+ && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+  && rm ${GO_TARBALL} 
 
 ENV MAGMA_ROOT /magma
 


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

This PR fixes an error in `AGW Container Build` action caused by an old go version.
It replaces `apt install golang` by downloading and extracting go from https://artifactory.magmacore.org/artifactory.

## Test Plan
 ```
   cd ${MAGMA_ROOT}/lte/gateway/docker/ghz
   docker-compose --file docker-compose.yaml --file docker-compose.override.yaml build --parallel
```

## Additional Information

- [ ] This change is backwards-breaking
