### PR TITLE
chore(dp): Make target with tests development POD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -51,6 +51,7 @@
 !orc8r/tools/ansible/roles/fluent_bit/files
 !orc8r/tools/docker/
 
+!dp/cloud/docker/python/test_runner/entrypoint.sh
 !dp/cloud/go/
 !dp/cloud/python/
 !dp/protos/

--- a/dp/Makefile
+++ b/dp/Makefile
@@ -34,6 +34,12 @@ orc8r_integration_tests: init_orc8r _ci_init cleanup_test_db
 	kubectl delete pods test-runner-orc8r --ignore-not-found=true
 	skaffold dev -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only --trigger=manual
 
+.PHONY: dev_integration_tests
+dev_integration_tests: init_orc8r _ci_init cleanup_test_db
+	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
+	kubectl delete pods test-runner-dev --ignore-not-found=true
+	skaffold dev -p orc8r-deployment,integration-tests-no-orc8,integration-tests-dev --trigger=manual
+
 .PHONY: orc8r
 orc8r: init_orc8r dev_orc8r
 

--- a/dp/cloud/docker/python/test_runner/Dockerfile
+++ b/dp/cloud/docker/python/test_runner/Dockerfile
@@ -32,8 +32,9 @@ COPY dp/cloud/python/magma/db_service /dp/cloud/python/magma/db_service/
 COPY dp/cloud/python/magma/mappings /dp/cloud/python/magma/mappings/
 COPY dp/cloud/python/magma/test_runner /dp/cloud/python/magma/test_runner/
 COPY dp/cloud/python/magma/fixtures /dp/cloud/python/magma/fixtures/
+COPY --chmod=755 dp/cloud/docker/python/test_runner/entrypoint.sh /entrypoint.sh
 COPY --from=protos-generator /magma/build/gen /magma/build/gen
 
 WORKDIR /dp/cloud/python/magma/test_runner
 ENV PYTHONPATH=/magma/build/gen:/dp/cloud/python
-ENTRYPOINT ["python"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dp/cloud/docker/python/test_runner/entrypoint.sh
+++ b/dp/cloud/docker/python/test_runner/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "$TESTS_DEV" = true ] ; then
+    sleep infinity
+else
+    python "$@"
+fi

--- a/dp/skaffold.yaml
+++ b/dp/skaffold.yaml
@@ -133,12 +133,13 @@ profiles:
         value:
           manifests:
             - "./tools/deployment/tests/test_runner_deployment_orc8r.yml"
-  - name: integration-tests-all
+  - name: integration-tests-dev
     patches:
       - op: add
         path: /deploy/kubectl
         value:
-          manifests: "./tools/deployment/tests/test_runner_*.yml"
+          manifests:
+            - "./tools/deployment/tests/test_runner_deployment_dev.yml"
 
   - name: remote
     deploy:

--- a/dp/tools/deployment/tests/test_runner_deployment.yml
+++ b/dp/tools/deployment/tests/test_runner_deployment.yml
@@ -11,12 +11,19 @@ spec:
   initContainers:
     - name: wait-for-elasticsearch
       image: curlimages/curl
-      command: ['sh', '-c', "until curl -sf http://elasticsearch:9200/_cluster/health; do echo \"waiting for elasticsearch...\"; sleep 0.2; done"]
+      command:
+        - sh
+        - -c
+        - |
+          until curl -sf http://elasticsearch:9200/_cluster/health; do
+            echo "Waiting for elasticsearch...";
+            sleep 0.2;
+          done
   containers:
     - image: test_runner_image
-      name: test-runner
+      name: test-runner-dev
       imagePullPolicy: IfNotPresent
-      command: ["python"]
+      command: ["/entrypoint.sh"]
       args: ["-m", "pytest", "-vvv", "-s", "-m", "local", "--junit-xml=/backend/test_runner/test-results/test_report.xml", "tests"]
       volumeMounts:
         - name: test-results

--- a/dp/tools/deployment/tests/test_runner_deployment_dev.yml
+++ b/dp/tools/deployment/tests/test_runner_deployment_dev.yml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-runner-orc8r
+  name: test-runner-dev
   labels:
-    name: test-runner-orc8r
+    name: test-runner
     type: integration-tests
 spec:
   restartPolicy: Never
@@ -21,16 +21,18 @@ spec:
           done
   containers:
     - image: test_runner_image
-      name: test-runner-orc8
+      name: test-runner
       imagePullPolicy: IfNotPresent
       command: ["/entrypoint.sh"]
-      args: ["-m", "pytest", "-vvv", "-s", "-m", "orc8r", "--junit-xml=/backend/test_runner/test-results/test_report.xml", "tests"]
       volumeMounts:
         - name: test-results
           mountPath: /backend/test_runner/test-results
         - name: certificates
           mountPath: /backend/test_runner/certs
           readOnly: true
+      env:
+        - name: TESTS_DEV
+          value: "true"
   volumes:
     - name: test-results
       hostPath:


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>


Add `make` target which will leave `test-runner` POD,
for local tests running/debugging.
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
