### PR TITLE
docs: updated url for go installation

### DIFF
--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -66,7 +66,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    1. Download the tar file.
 
       ```bash
-      wget https://golang.org/dl/go1.18.linux-amd64.tar.gz
+      wget https://artifactory.magmacore.org/artifactory/generic/go1.18.linux-amd64.tar.gz
       ```
 
    2. Extract the archive you downloaded into `/usr/local`, creating a Go tree in `/usr/local/go`.


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

As introduced in #12605 , only the Go version from https://artifactory.magmacore.org/artifactory should be used.  The PR updates the installation guide.

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking
