### PR TITLE
fix(ci): magma_test uses latest version of libgnutls30

### DIFF
--- a/lte/gateway/deploy/roles/magma_test_registry/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_test_registry/tasks/main.yml
@@ -23,6 +23,7 @@
   vars:
     packages:
       - ca-certificates
+      - libgnutls30
 
 - name: Copy gpg key from codebase
   copy:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

The latest version of libgnutls30 is needed in order for magma_test to use the magma artifactory.

## Test Plan

CI - manually trigger lte integ tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
