### PR TITLE
chore(pipelined): selection of mypy errors are fixed

### DIFF
--- a/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
+++ b/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
@@ -106,7 +106,7 @@ def _get_ovsdb_dump_params(params: OVSDBDumpCommandParams) -> List[str]:
 
 
 def _parse_ovsdb_dump_output(
-    stdout: str, stderr: str,
+    stdout: bytes, stderr: str,
     _,
 ) -> OVSDBCommandResult:
     """

--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -15,7 +15,7 @@ import logging
 import threading
 import traceback
 from enum import Enum
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from lte.protos.policydb_pb2 import FlowMatch
 from magma.common.redis.client import get_default_client
@@ -107,13 +107,11 @@ class SubscriberState(object):
     def remove_session(self, ip_addr: str) -> None:
         del self.sessions[ip_addr]
 
-    def find_session_with_rule(self, rule_num: int) -> SubscriberSession:
-        session_with_rule = None
+    def find_session_with_rule(self, rule_num: int) -> Optional[SubscriberSession]:
         for session in self.sessions.values():
             if rule_num in session.rules:
-                session_with_rule = session
-                break
-        return session_with_rule
+                return session
+        return None
 
     def _update_rules_map(
         self, ip_addr: str, rule_num: int, d: FlowMatch.Direction,
@@ -148,9 +146,9 @@ class SubscriberState(object):
                 )
                 if get_key_json(k) in self._redis_store:
                     del self._redis_store[get_key_json(k)]
+            session_with_rule.rules.remove(rule_num)
 
         del self.rules[rule_num]
-        session_with_rule.rules.remove(rule_num)
 
     def find_rule(self, rule_num: int):
         return self.rules.get(rule_num)

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -15,7 +15,7 @@ import logging
 import os
 import queue
 from concurrent.futures import Future
-from typing import List, OrderedDict, Tuple
+from typing import List, OrderedDict
 
 import grpc
 from lte.protos import pipelined_pb2_grpc
@@ -1023,7 +1023,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
     def _ng_qer_update(
         self, request: SessionSet, pdr_entry: PDRRuleEntry,
-    ) -> Tuple[List[RuleModResult], List[RuleModResult]]:
+    ) -> List[RuleModResult]:
         enforcement_res = []
         failed_policy_rules_results: List = []
 

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -10,6 +10,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+# pylint: disable=unsubscriptable-object
+
+from __future__ import annotations
+
 import concurrent.futures
 import logging
 import os
@@ -156,7 +160,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             context.set_details('SetupDefaultController processing timed out')
             return SetupFlowsResult(result=SetupFlowsResult.FAILURE)
 
-    def _setup_default_controller(self, controller, fut: 'Future(SetupFlowsResult)'):
+    def _setup_default_controller(self, controller, fut: Future[SetupFlowsResult]):
         res = controller.handle_restart(None)
         fut.set_result(res)
 
@@ -196,7 +200,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
     def _setup_flows(
         self, request: SetupPolicyRequest,
-        fut: 'Future[List[SetupFlowsResult]]',
+        fut: Future[List[SetupFlowsResult]],
     ) -> SetupFlowsResult:
         gx_reqs = [
             req for req in request.requests
@@ -290,7 +294,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
     def _activate_flows(
         self, request: ActivateFlowsRequest,
-        fut: 'Future[ActivateFlowsResult]',
+        fut: Future[ActivateFlowsResult],
     ) -> None:
         """
         Activate flows for ipv4 / ipv6 or both
@@ -582,7 +586,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
                 cause_info=CauseIE(cause_ie=CauseIE.REQUEST_REJECTED_NO_REASON),
             )
 
-    def _setup_pg_tunnel_update(self, request: UESessionSet, fut: 'Future(UESessionContextResponse)'):
+    def _setup_pg_tunnel_update(self, request: UESessionSet, fut: Future[UESessionContextResponse]):
         res = self._classifier_app.process_mme_tunnel_request(request)
         fut.set_result(res)
 
@@ -696,7 +700,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
     def _setup_ue_mac(
         self, request: SetupUEMacRequest,
-        fut: 'Future(SetupFlowsResult)',
+        fut: Future[SetupFlowsResult],
     ) -> SetupFlowsResult:
         res = self._ue_mac_app.handle_restart(request.requests)
 
@@ -740,7 +744,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             context.set_details('AddUEMacFlow processing timed out')
             return FlowResponse()
 
-    def _add_ue_mac_flow(self, request, fut: 'Future(FlowResponse)'):
+    def _add_ue_mac_flow(self, request, fut: Future[FlowResponse]):
         res = self._ue_mac_app.add_ue_mac_flow(request.sid.id, request.mac_addr)
 
         fut.set_result(res)
@@ -832,7 +836,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
     def _setup_quota(
         self, request: SetupQuotaRequest,
-        fut: 'Future(SetupFlowsResult)',
+        fut: Future[SetupFlowsResult],
     ) -> SetupFlowsResult:
         res = self._check_quota_app.handle_restart(request.requests)
         fut.set_result(res)
@@ -933,7 +937,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
     def ng_update_session_flows(
         self, request: SessionSet,
-        fut: 'Future(UPFSessionContextState)',
+        fut: Future[UPFSessionContextState],
     ) -> UPFSessionContextState:
         """
         Install PDR, FAR and QER flows for the 5G Session send by SMF

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -18,7 +18,7 @@ import time
 import unittest
 import warnings
 from concurrent.futures import Future
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress, IPBlock
 from magma.pipelined.app import egress
@@ -46,7 +46,7 @@ def mocked_get_mobilityd_gw_info() -> List[GWInfo]:
     global gw_info_lock
 
     with gw_info_lock:
-        return gw_info_map.values()
+        return list(gw_info_map.values())
 
 
 def mocked_set_mobilityd_gw_info(ip: IPAddress, mac: str, vlan: str):
@@ -535,7 +535,7 @@ def mocked_setmacbyip6(ipv6_addr: str, mac: str):
         ipv6_mac_table[ipv6_addr] = mac
 
 
-def mocked_getmacbyip6(ipv6_addr: str) -> str:
+def mocked_getmacbyip6(ipv6_addr: str) -> Optional[str]:
     global ipv6_mac_table
     with gw_info_lock:
         return ipv6_mac_table.get(ipv6_addr)


### PR DESCRIPTION
## Summary

This is a follow-up to several mypy clean-ups, i.e. #12833, #12875, focusing on invalid type comments and incompatible return value types. After the PR, the number of mypy --ignore-missing-imports magma/lte/gateway/python/magma/pipelined errors is decreased by 12.

## Test Plan
on magma-dev: 

- `bazel test lte/gateway/python/magma/pipelined/...`
- `./bazel/scripts/run_sudo_tests.sh lte/gateway/python/magma/pipelined/`

## Additional Information

- [ ] This change is backwards-breaking