### PR TITLE
chore: Upgrade pylint to 2.14.0

### DIFF
--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -68,7 +68,7 @@ $(BIN)/coverage: install_virtualenv
 	$(VIRT_ENV_PIP_INSTALL) "coverage>=6.1.2"
 
 $(BIN)/pylint: install_virtualenv
-	$(VIRT_ENV_PIP_INSTALL) pylint==2.12.2
+	$(VIRT_ENV_PIP_INSTALL) pylint==2.14.0
 
 $(BIN)/pep8: install_virtualenv
 	# pylint doesn't cover all the pep8 style guidelines. Specifically,

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops.py
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+# pylint: disable=unnecessary-ellipsis
 
 from __future__ import (
     absolute_import,

--- a/lte/gateway/python/magma/subscriberdb/protocols/diameter/avp.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/diameter/avp.py
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+# pylint: disable=too-many-function-args
 
 import abc
 import socket

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -168,7 +168,7 @@ class SqliteStore(BaseStore):
         try:
             with conn:
                 res = conn.execute(
-                    "SELECT data FROM subscriberdb WHERE " "subscriber_id = ?",
+                    "SELECT data FROM subscriberdb WHERE subscriber_id = ?",
                     (subscriber_id,),
                 )
                 row = res.fetchone()

--- a/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
+++ b/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
@@ -65,8 +65,8 @@ class SyncRPCClient(threading.Thread):
         will be attempted after RETRY_DELAY_SECS seconds.
         """
         while True:
+            start_time = time.time()
             try:
-                start_time = time.time()
                 chan = ServiceRegistry.get_rpc_channel(
                     'dispatcher',
                     ServiceRegistry.CLOUD,

--- a/orc8r/gateway/python/magma/magmad/upgrade/upgrader2.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/upgrader2.py
@@ -483,5 +483,5 @@ async def run_command(*args, **kwargs):
     stdout, stderr = await process.communicate()
     if check:
         if process.returncode != 0:
-            raise Exception("Command failed: %s" % args)
+            raise Exception(f"Command failed: {args}")
     return process.returncode, stdout, stderr

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -73,7 +73,7 @@ setup(
         'protobuf==3.19.0',
         'Jinja2>=2.8',
         'netifaces>=0.10.4',
-        'pylint>=1.7.1,<2.13.0',
+        'pylint>=1.7.1,<=2.14.0',
         'PyYAML>=3.12',
         'pytz>=2014.4',
         'prometheus_client==0.3.1',


### PR DESCRIPTION
## Summary

Upgrades pylint from 2.12.2 to the lastest version, 2.14.0. The version isn't pinned since the magma-test VM is using a version of Python that is inconsistent with pylint 2.14.0.

I have then addressed a few issues that were causing the pylint test in the CI to fail:
- The change in `tc_ops.py` is due to "Unnecessary ellipsis constant (unnecessary-ellipsis)" on lines 38, 46, 53 and 60
- The change in `avp.py` is due to "Too many positional arguments for method call (too-many-function-args)" on lines 264, 265, 269, 270, 275 and 276
- The change in `sqlite.py` is due to "Implicit string concatenation found in call (implicit-str-concat)"
- The change in `sync_rp_client.py` is due to "Using variable 'start_time' before assignment (used-before-assignment)"
- The change in `upgrader2.py` is due to "Not enough arguments for format string (too-few-format-args)"

## Test Plan

Running `pip3 install 'pylint>=1.7.1,<=2.14.0'` on the VMs leads to:
- magma:
```
vagrant@magma-dev-focal:~$ pip3 show pylint
Name: pylint
Version: 2.14.0
Summary: python code static checker
Home-page: None
Author: Python Code Quality Authority
Author-email: code-quality@python.org
License: GPL-2.0-or-later
Location: /home/vagrant/.local/lib/python3.8/site-packages
Requires: isort, dill, tomlkit, typing-extensions, tomli, mccabe, astroid, platformdirs
Required-by: 
```
- magma_test:
```
vagrant@magma-test:~$ pip3 show pylint
Name: pylint
Version: 2.6.2
Summary: python code static checker
Home-page: https://github.com/PyCQA/pylint
Author: Python Code Quality Authority
Author-email: code-quality@python.org
License: GPL
Location: /home/vagrant/.local/lib/python3.5/site-packages
Requires: isort, mccabe, astroid, toml
```
where the version on magma_test is the same as on master.