### PR TITLE
fix(ci): obsolete project radtonics_lab_native is removed from sentry…

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -256,7 +256,7 @@ jobs:
           SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
         run: |
            COMMIT_HASH_WITH_VERSION="magma@1.7.0.$(git rev-list --count HEAD)-${GITHUB_SHA:0:8}"
-           sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native -p radtonics_lab_native -p magma-staging-native ${COMMIT_HASH_WITH_VERSION}
+           sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native -p magma-staging-native ${COMMIT_HASH_WITH_VERSION}
            sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${COMMIT_HASH_WITH_VERSION}
            sentry-cli --log-level=info releases finalize ${COMMIT_HASH_WITH_VERSION}
   orc8r-build:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

build_all sentry_release fails with
```
INFO    2022-06-02 11:44:11.384943362 +00:00 sentry-cli was invoked with the following command line: "sentry-cli" "--log-level=info" "releases" "new" "-p" "lab-agws-python" "-p" "lab-agws-native" "-p" "radtonics_lab_native" "-p" "magma-staging-native" "magma@1.7.0.10909-da4855ce"
error: API request failed
  caused by: sentry reported an error: request failure (http status: 400)
  Object({"projects": Array([String("Invalid project slugs")])})
```
Its not completely obvious, but it looks like the project `radtonics_lab_native` was removed from sentry.io.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
