### PR TITLE
chore: Publish bazel profile data in ci

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -186,7 +186,11 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
-            bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* --config=asan --test_output=errors --cache_test_results=no
+            bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* \
+              --config=asan \
+              --test_output=errors \
+              --cache_test_results=no \
+              --profile=Bazel_cpp_unit_tests_profile
             TEST_RESULT=$?
             # copy out test results
             echo "Copying out test result XMLs for testing with ASAN"
@@ -198,6 +202,12 @@ jobs:
         with:
           name: Unit Test Results
           path: c-cpp-test-results/
+      - name: Publish bazel profile
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Bazel cpp unit tests profile
+          path: Bazel_cpp_unit_tests_profile
       - name: Build space left after run
         shell: bash
         run: |
@@ -370,7 +380,9 @@ jobs:
             # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178
             # Omit OAI coverage until it is tested. We need to determine what the behavior is for doing both CMake and Bazel based coverage at the same time
             # TODO: GH11936
-            bazel coverage -- //orc8r/gateway/c/...:* //lte/gateway/c/...:* -//lte/gateway/c/core/...:*
+            bazel coverage \
+              --profile=Bazel_test_coverage_profile \
+              -- //orc8r/gateway/c/...:* //lte/gateway/c/...:* -//lte/gateway/c/core/...:*
             # copy out coverage information into magma so that it's accessible from the CI node
             cp bazel-out/_coverage/_coverage_report.dat $MAGMA_ROOT
       - name: Upload code coverage
@@ -379,6 +391,12 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           flags: c_cpp
+      - name: Publish bazel profile
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Bazel test coverage profile
+          path: Bazel_test_coverage_profile
       - name: Extract commit title
         # yamllint enable
         if: failure() && github.event_name == 'push'

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -89,7 +89,14 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
-            bazel build //...
+            bazel build //... \
+              --profile=Bazel_build_all_profile
+      - name: Publish bazel profile
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Bazel build all profile
+          path: Bazel_build_all_profile
       - name: Build space left after run
         shell: bash
         run: |
@@ -139,7 +146,14 @@ jobs:
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             bazel test //... \
               --cache_test_results=no \
-              --test_output=errors
+              --test_output=errors \
+              --profile=Bazel_test_all_profile
+      - name: Publish bazel profile
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Bazel test all profile
+          path: Bazel_test_all_profile
       - name: Run `bazel run //:check_starlark_format`
         uses: addnab/docker-run-action@v3
         with:
@@ -206,7 +220,15 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
-            bazel build lte/gateway/release:sctpd_deb_pkg --config=production
+            bazel build lte/gateway/release:sctpd_deb_pkg \
+              --config=production \
+              --profile=Bazel_build_package_profile
+      - name: Publish bazel profile
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Bazel build package profile
+          path: Bazel_build_package_profile
       - name: Build space left after run
         shell: bash
         run: |

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -96,6 +96,12 @@ jobs:
             cd /workspaces/magma
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             ./.github/workflows/generate-gcc-warnings.sh "${{ steps.changed_files.outputs.all }}"
+      - name: Publish bazel profile
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Bazel build gcc problems profile
+          path: Bazel_build_gcc_problems_profile
       - name: Load problem matcher
         # If needed https://github.com/microsoft/vscode-cpptools/issues/2266 for path fixups
         #

--- a/.github/workflows/generate-gcc-warnings.sh
+++ b/.github/workflows/generate-gcc-warnings.sh
@@ -8,7 +8,7 @@ FILES=$1
 bazel clean
 
 # shellcheck disable=SC2086
-bazel build --color=no //orc8r/gateway/c/... //lte/gateway/c/... --config=max_gcc_warnings 2>&1 | tee compile.log
+bazel build --color=no //orc8r/gateway/c/... //lte/gateway/c/... --config=max_gcc_warnings --profile=Bazel_build_gcc_problems_profile 2>&1 | tee compile.log
 
 rm -f filtered-compile.log
 echo "$FILES" | tr , '\n' | while read f


### PR DESCRIPTION
## Summary

- Bazel [profile data](https://bazel.build/rules/performance#performance-profiling) is published in the agw, gcc problems and bazel workflows for each bazel step.

## Test Plan

Check the workflow summary pages for the published profiles:
![Screenshot from 2022-06-02 16-35-53](https://user-images.githubusercontent.com/34488763/171654369-a3e1a0f1-cfa4-4413-b017-89c452d5ff09.png)


- [Test run of bazel workflow on fork](https://github.com/LKreutzer/magma/actions/runs/2428805387)
- CI 


## Additional Information

The bazel profile data can be viewed with a chromium or chrome browser, see [further infos here](https://bazel.build/rules/performance#performance-profiling).

- [ ] This change is backwards-breaking

