### PR TITLE
fix(ci): the latest package version coincides with the version apt would choose

### DIFF
--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -394,18 +394,14 @@ def get_latest_apt_pkg_version(pkgname: str, py2: bool = False) -> Optional[str]
     """
     cache = apt.Cache()
     sys_pkgname = gen_sys_package_name(pkgname, py2)
+
     try:
-        avail_versions = cache[sys_pkgname].versions
+        package = cache[sys_pkgname]
     except KeyError:
         # package isn't available
         return None
 
-    latest = None
-    for v in avail_versions:
-        if not latest or v.version > latest:
-            latest = v.version
-
-    return latest
+    return package.candidate.version
 
 
 def gen_fpm_dep_string_from_lockfile(lockfile_str: str) -> str:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In pydep at one point for a package `python3-<NAME>` it is checked, what is the latest version that could be installed via apt. The latest version is calculated manually via "<"-comparison. This fails e.g., for `python3-webcolors` when it is available in versions `1.5-2.1` and `1.11.1`. The algorithm returns `1.5-2.1` while apt would install `1.11.1` as the latest version.

Here: do not calculate the latest version manually, but use the existing apt.package.candidate.version mechanics (candidate ^= the candidate of a package that would be installed by apt).

## Test Plan

CI - build-all/agw-build/Build AGW
But to be honest, this is hard to reproduce because this relies on certain repository states.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
