### PR TITLE
fix(agw): Handle the absense of _IO_IN_BACKUP in newer glibc releases

### DIFF
--- a/third_party/build/bin/gnutls_build.sh
+++ b/third_party/build/bin/gnutls_build.sh
@@ -61,7 +61,7 @@ cd ${WORK_DIR}
 wget http://mirrors.dotsrc.org/gcrypt/gnutls/v3.1/gnutls-$PKGVERSION.tar.xz
 tar xf gnutls-$PKGVERSION.tar.xz
 cd gnutls-$PKGVERSION/
-patch -p1 < ${MAGMA_ROOT}/third_party/build/patches/gnutls/glibc-2.28.patch
+patch -p1 < "${MAGMA_ROOT}/third_party/build/patches/gnutls/glibc-2.28.patch"
 ./configure --prefix=/usr
 make -j`nproc`
 make install DESTDIR=${WORK_DIR}/install/

--- a/third_party/build/bin/gnutls_build.sh
+++ b/third_party/build/bin/gnutls_build.sh
@@ -61,6 +61,7 @@ cd ${WORK_DIR}
 wget http://mirrors.dotsrc.org/gcrypt/gnutls/v3.1/gnutls-$PKGVERSION.tar.xz
 tar xf gnutls-$PKGVERSION.tar.xz
 cd gnutls-$PKGVERSION/
+patch -p1 < ${MAGMA_ROOT}/third_party/build/patches/gnutls/glibc-2.28.patch
 ./configure --prefix=/usr
 make -j`nproc`
 make install DESTDIR=${WORK_DIR}/install/

--- a/third_party/build/patches/gnutls/glibc-2.28.patch
+++ b/third_party/build/patches/gnutls/glibc-2.28.patch
@@ -1,0 +1,33 @@
+Subject: Workaround change in glibc
+
+Temporary workaround to compile with glibc 2.28, which
+deprecated some constants
+
+Based on the workaround made for the tools/m4 package
+
+--- a/gl/stdio-impl.h
++++ b/gl/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 
+--- a/gl/fseterr.c
++++ b/gl/fseterr.c
+@@ -29,7 +29,7 @@
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+ #elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
+   fp_->_flags |= __SERR;


### PR DESCRIPTION
Signed-off-by: Gustavo Junior Alves <gustavo@radtonics.com>

## Summary

Handle the absense of _IO_IN_BACKUP in newer glibc releases

## Test Plan

If you try to compile GNUTLS using this script in newer Linux versions, like Ubuntu 20.04, it will fail with the following error:

`fseterr.c: In function 'fseterr':`
`fseterr.c:77:3: error: #error "Please port gnulib fseterr.c to your platform! Look at the definitions of ferror and clearerr on your system, then report this to bug-gnulib."`
`   77 |  #error "Please port gnulib fseterr.c to your platform! Look at the definitions of ferror and clearerr on your system, then report this to bug-gnulib."`
`      |   ^~~~~`
`make[4]: *** [Makefile:2050: fseterr.lo] Error 1`
`make[4]: *** Waiting for unfinished jobs....`
`make[4]: Leaving directory '/tmp/build-oai-gnutls/gnutls-3.1.23/gl'`
`make[3]: *** [Makefile:2072: all-recursive] Error 1`
`make[3]: Leaving directory '/tmp/build-oai-gnutls/gnutls-3.1.23/gl'`
`make[2]: *** [Makefile:1828: all] Error 2`
`make[2]: Leaving directory '/tmp/build-oai-gnutls/gnutls-3.1.23/gl'`
`make[1]: *** [Makefile:1716: all-recursive] Error 1`
`make[1]: Leaving directory '/tmp/build-oai-gnutls/gnutls-3.1.23'`
`make: *** [Makefile:1643: all] Error 2`

This patch allow the smoothly execution of this code.