### PR TITLE
fix(agw): Remove unused patch reference on liblfds packet generation

### DIFF
--- a/third_party/build/bin/liblfds_build.sh
+++ b/third_party/build/bin/liblfds_build.sh
@@ -51,10 +51,6 @@ git clone https://github.com/liblfds/liblfds.git
 # maybe want to edit a persistent copy...
 # rsync -ravP --delete "${SCRIPT_DIR}/liblfds/" liblfds/
 
-pushd liblfds
-git apply --verbose "${PATCH_DIR}"/*.patch
-popd
-
 cd liblfds/liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake
 make so_vanilla
 LIB_DIR=/usr/local/lib


### PR DESCRIPTION
Signed-off-by: Gustavo Junior Alves <gustavo@radtonics.com>

## Summary

Remove unused patch reference on liblfds packet generation.

## Test Plan

Without this patch, trying to build liblfds with liblfds_build.sh script fails to build.
