### PR TITLE
fix(amf): Service-reject for request with invalid Session-id

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_asDefs.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_asDefs.h
@@ -85,11 +85,13 @@ class amf_as_data_t {
 #define AMF_AS_NAS_AMF_INFORMATION 0x05             // Amf information
 #define AMF_AS_NAS_DATA_DEREGISTRATION_ACCEPT 0x06  // DEREGISTRATION Accept
 #define AMF_AS_NAS_DL_NAS_TRANSPORT 0x09            // Downlink Nas Transport
+#define AMF_AS_NAS_INFO_SR_REJ 0x07
   uint8_t nas_info;     // Type of NAS information to transfer
   std::string nas_msg;  // NAS message to be transferred
   void amf_as_set_security_data(amf_as_security_data_t* data,
                                 const void* context, bool is_new,
                                 bool is_ciphered);
+  uint8_t amf_cause;
 };
 
 // Structure to handle UL/DL NAS message in AMF

--- a/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_fsm.cpp
@@ -161,6 +161,8 @@ void create_state_matrix() {
   Update_ue_state_matrix(REGISTERED_CONNECTED,
                          STATE_PDU_SESSION_RELEASE_COMPLETE, INACTIVE,
                          REGISTERED_CONNECTED, RELEASED, "PDU_Release");
+  Update_ue_state_matrix(REGISTERED_IDLE, STATE_PDU_SESSION_RELEASE_COMPLETE,
+                         INACTIVE, REGISTERED_IDLE, RELEASED, "PDU_Release");
   OAILOG_FUNC_OUT(LOG_AMF_APP);
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5gNasMessage.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5gNasMessage.h
@@ -86,4 +86,7 @@ namespace magma5g {
 #define IMSI_LENGTH 15
 #define NATIVE_SECURITY_CONTEXT 0
 #define MAPPED_SECURITY_CONTEXT 1
+#define SERVICE_REJ_T3346_LEN 1
+#define SERVICE_REJ_T3346_VALUE 60
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -1743,6 +1743,7 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
                                         NGAP_PDUSESSION_RESOURCE_SETUP_REQ,
                                         NGAP_UE_CONTEXT_RELEASE_COMMAND,
                                         AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_NAS_DL_DATA_REQ,
                                         NGAP_INITIAL_CONTEXT_SETUP_REQ,
                                         NGAP_PDUSESSIONRESOURCE_REL_REQ,
                                         NGAP_NAS_DL_DATA_REQ,


### PR DESCRIPTION
Fixing #12732 #12923 
Issue:
Added a flag to check if matching session id exist and handled reject if no matching session id found.
Signed-off-by: Sathyaj27 <sathya.jayadev@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested on abot .
Tested UT (ServiceRequestMTWithPDU).
<img width="920" alt="sathya_reject" src="https://user-images.githubusercontent.com/94469973/172304324-25a55b0f-4118-4499-947d-8ed20dd0cd21.PNG">


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is not backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
