### PR TITLE
docs: Changed admin_cert.* to admin_operator.* in onboarding docs

### DIFF
--- a/docs/readmes/basics/quick_start_guide.md
+++ b/docs/readmes/basics/quick_start_guide.md
@@ -143,15 +143,15 @@ admin_operator.pem      certifier.key           controller.csr          rootCA.p
 admin_operator.pfx      certifier.pem           controller.key          rootCA.srl
 ```
 
-The owner and group of `admin_cert.key.pem` and `admin_cert.pfx` in `/magma/.cache/test_certs/` are `root`.
+The owner and group of `admin_operator.key.pem` and `admin_operator.pfx` in `/magma/.cache/test_certs/` are `root`.
 You need to change ownership of these files to your user with `chown`, e.g.
 
 ```bash
-HOST [magma/orc8r/cloud/docker] sudo chown username:username ../../../.cache/test_certs/admin_cert.key.pem
-HOST [magma/orc8r/cloud/docker] sudo chown username:username ../../../.cache/test_certs/admin_cert.pfx
+HOST [magma/orc8r/cloud/docker] sudo chown ${USER}:${USER} ../../../.cache/test_certs/admin_operator.key.pem
+HOST [magma/orc8r/cloud/docker] sudo chown ${USER}:${USER} ../../../.cache/test_certs/admin_operator.pfx
 ```
 
-Replace `username` with your username, then:
+then:
 
 ```bash
 HOST [magma/orc8r/cloud/docker]$ open ../../../.cache/test_certs


### PR DESCRIPTION
These files were named incorrectly in the last PR.

Signed-off-by: Moritz Huebner <moritz.huebner@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- I named some files incorrectly in the previous onboarding changes: #12800, those are now fixed. 
- This change also instructs the use of the ${USER} variable instead of telling the reader to replace a placeholder manually.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

Run unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
