### PR TITLE
fix(agw): Properly closes client_sd in SCTP Listener

### DIFF
--- a/lte/gateway/c/sctpd/src/sctp_connection.cpp
+++ b/lte/gateway/c/sctpd/src/sctp_connection.cpp
@@ -163,6 +163,8 @@ void SctpConnection::Listen() {
             MLOG_perror("epoll_ctl");
             std::terminate();
           }
+          shutdown(client_sd, SHUT_RDWR);
+          close(client_sd);
         }
 
         if (status == SctpStatus::NEW_ASSOC_NOTIF_FAILED) {


### PR DESCRIPTION
## Summary

Implements the solution in https://github.com/magma/magma/issues/12818

## Test Plan

- Run unit tests
- Reproduce errors on a local `magma_test` vagrant with the current state of the master branch. This worked, but I did not take a screenshot. The error occurs about once every hour after which the sctpd connection drops and restarts. The restart takes about 15 minutes.
- Run this branch manually on a local `magma_test` vagrant to see if the changes fix the described problem. Grepping for "Too many" to find the error message now yields now result.
![image](https://user-images.githubusercontent.com/8889531/172742832-79e2c6eb-cd54-4293-9cad-30aa659d2d1e.png)


## Additional Information

- [ ] This change is backwards-breaking
