### PR TITLE
chore(feg): The s8_proxy expects ips for the local_address and pgw_ad…

### DIFF
--- a/feg/cloud/go/services/feg/obsidian/models/s8_swaggergen.go
+++ b/feg/cloud/go/services/feg/obsidian/models/s8_swaggergen.go
@@ -25,12 +25,12 @@ type S8 struct {
 	ApnOperatorSuffix string `json:"apn_operator_suffix,omitempty"`
 
 	// local address
-	// Example: foo.bar.com:5555
+	// Example: 0.0.0.0:0
 	// Pattern: [^\:]+(:[0-9]{1,5})?
 	LocalAddress string `json:"local_address,omitempty"`
 
 	// pgw address
-	// Example: foo.bar.com:5555
+	// Example: 0.0.0.0:0
 	// Pattern: [^\:]+(:[0-9]{1,5})?
 	PgwAddress string `json:"pgw_address,omitempty"`
 }

--- a/feg/cloud/go/services/feg/obsidian/models/swagger.v1.yml
+++ b/feg/cloud/go/services/feg/obsidian/models/swagger.v1.yml
@@ -872,12 +872,12 @@ definitions:
       local_address:
         type: string
         pattern: '[^\:]+(:[0-9]{1,5})?'
-        example: "foo.bar.com:5555"
+        example: "0.0.0.0:0"
         x-nullable: false
       pgw_address:
         type: string
         pattern: '[^\:]+(:[0-9]{1,5})?'
-        example: "foo.bar.com:5555"
+        example: "0.0.0.0:0"
         x-nullable: false
       apn_operator_suffix:
         type: string

--- a/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/obsidian/swagger/v1/swagger.yml
@@ -10975,12 +10975,12 @@ definitions:
         type: string
         x-nullable: false
       local_address:
-        example: foo.bar.com:5555
+        example: 0.0.0.0:0
         pattern: '[^\:]+(:[0-9]{1,5})?'
         type: string
         x-nullable: false
       pgw_address:
-        example: foo.bar.com:5555
+        example: 0.0.0.0:0
         pattern: '[^\:]+(:[0-9]{1,5})?'
         type: string
         x-nullable: false


### PR DESCRIPTION
The s8_proxy expects ips for the local_address and pgw_address parameters. If hostnames are provided the s8_proxy crashes on startup.

This pr replaces the previous hostnames with ips.
