### PR TITLE
chore(agw): python syntax is adapted

### DIFF
--- a/lte/gateway/python/integ_tests/common/service303_utils.py
+++ b/lte/gateway/python/integ_tests/common/service303_utils.py
@@ -21,13 +21,13 @@ from orc8r.protos.common_pb2 import Void
 from orc8r.protos.service303_pb2 import ServiceInfo
 from orc8r.protos.service303_pb2_grpc import Service303Stub
 
+
 # Container for storing metric values
-MetricValue = NamedTuple(
-    'MetricValue', [
-        ('service', str), ('name', str),
-        ('labels', List), ('value', Any),
-    ],
-)
+class MetricValue(NamedTuple):
+    service: str
+    name: str
+    labels: List
+    value: Any
 
 
 class MetricNotFoundException(Exception):
@@ -144,8 +144,7 @@ class Service303Util(object):
                 return default
             else:
                 raise MetricNotFoundException(
-                    "No {metric_name} metric found."
-                    .format(metric_name=metric_name),
+                    f"No {metric_name} metric found.",
                 )
         metric_type = metric.type
         if not self._is_metric_type_supported(metric_type):
@@ -162,9 +161,8 @@ class Service303Util(object):
             return default
         else:
             raise MetricNotFoundException(
-                "No metric under {metric_name} "
-                "has all  of the label_values specified"
-                .format(metric_name=metric_name),
+                f"No metric under {metric_name} "
+                "has all of the label_values specified",
             )
 
     def get_start_time(self):
@@ -247,11 +245,11 @@ class Service303Util(object):
                 if self._service_started_after(started_after_time):
                     return True
                 else:
-                    print("%s hasn't restarted yet" % (self._service_name))
+                    print(f"{self._service_name} hasn't restarted yet")
             else:
-                print("%s not healthy, waiting..." % (self._service_name))
+                print(f"{self._service_name} not healthy, waiting...")
             time.sleep(self.SLEEP_TIME)
-        print("max iterations hit, %s not healthy" % (self._service_name))
+        print(f"max iterations hit, {self._service_name} not healthy")
         return False
 
 
@@ -329,11 +327,9 @@ def _verify_metric_differences(
         diff = final_vals[i].value - initial_vals[i].value
         expected = expected_vals[i].value
         logging.debug(
-            'Metric %s %s increased by %d, expected %d',
-            expected_vals[i].name,
-            str(expected_vals[i].labels),
-            diff,
-            expected,
+            f'Metric {expected_vals[i].name} '
+            f'{str(expected_vals[i].labels)} increased by {diff}, '
+            f'expected {expected}',
         )
         test_class.assertEqual(diff, expected)
     return

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
@@ -66,12 +66,10 @@ class TrafficServerInstance(object):
 
     def __repr__(self):
         ''' String representation of this test server instance '''
-        return ' '.join((
-            '%s:' % type(self).__name__,
-            '%s:%d' % (self.ip.exploded, self.port),
-            'on device',
-            self.mac,
-        ))
+        return (
+            f'{type(self).__name__}: {self.ip.exploded}:{self.port} '
+            f'on device {self.mac}'
+        )
 
 
 class TrafficTestInstance(object):
@@ -96,15 +94,13 @@ class TrafficTestInstance(object):
 
     def __repr__(self):
         ''' String representation of this test instance '''
-        return ' '.join((
-            '%s:' % type(self).__name__,
-            'UPLINK' if self.is_uplink else 'DOWNLINK',
-            'UDP' if self.is_udp else 'TCP',
-            'test,',
-            '%d seconds' % self.duration,
-            'for test device at',
-            '%s:%d' % (self.ip.exploded, self.port),
-        ))
+        return (
+            f'{type(self).__name__}: '
+            f'{"UPLINK" if self.is_uplink else "DOWNLINK"} '
+            f'{"UDP" if self.is_udp else "TCP"} test, '
+            f'{self.duration} seconds '
+            f'for test device at {self.ip.exploded}:{self.port}'
+        )
 
 
 class TrafficMessage(object):
@@ -126,12 +122,10 @@ class TrafficMessage(object):
 
     def __repr__(self):
         ''' String representation of this message '''
-        payload_str = repr(self.payload)
-        return ' '.join((
-            '%s' % type(self).__name__,
-            '(%s, id %s):' % (self.message.name, str(self.id)),
-            payload_str,
-        ))
+        return (
+            f'{type(self).__name__} ({self.message.name}, '
+            f'id {self.id}): {repr(self.payload)}'
+        )
 
     @staticmethod
     def recv(stream):


### PR DESCRIPTION
## Summary
Some changes in the Python syntax after upgrading to 3.8 on `magma_test`. 
This PR is also related to #12435 and #12673.

## Test Plan

S1AP integ tests were executed together with the VM upgrade.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
