### PR TITLE
feat(orc8r): Protect Service 303 endpoints

### DIFF
--- a/cwf/gateway/services/gateway_health/gateway_health/main.go
+++ b/cwf/gateway/services/gateway_health/gateway_health/main.go
@@ -45,7 +45,7 @@ const (
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.GatewayHealth, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.GatewayHealth)
 	if err != nil {
 		glog.Fatalf("Error creating %s service: %s", registry.GatewayHealth, err)
 	}

--- a/cwf/gateway/services/gateway_health/gateway_health/main.go
+++ b/cwf/gateway/services/gateway_health/gateway_health/main.go
@@ -45,7 +45,7 @@ const (
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.GatewayHealth)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.GatewayHealth, false)
 	if err != nil {
 		glog.Fatalf("Error creating %s service: %s", registry.GatewayHealth, err)
 	}

--- a/cwf/gateway/services/uesim/uesim/main.go
+++ b/cwf/gateway/services/uesim/uesim/main.go
@@ -48,7 +48,7 @@ func main() {
 	flag.Parse()
 	glog.Info("Starting UESim service")
 
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.UeSim)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.UeSim, false)
 	if err != nil {
 		glog.Fatalf("Error creating UeSim service: %s", err)
 	}

--- a/cwf/gateway/services/uesim/uesim/main.go
+++ b/cwf/gateway/services/uesim/uesim/main.go
@@ -48,7 +48,7 @@ func main() {
 	flag.Parse()
 	glog.Info("Starting UESim service")
 
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.UeSim, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.UeSim)
 	if err != nil {
 		glog.Fatalf("Error creating UeSim service: %s", err)
 	}

--- a/feg/gateway/services/aaa/aaa_server/main.go
+++ b/feg/gateway/services/aaa/aaa_server/main.go
@@ -50,7 +50,7 @@ func main() {
 	sessions := store.NewMemorySessionTable()
 
 	// Create the EAP AKA Provider service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.AAA_SERVER)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.AAA_SERVER, false)
 	if err != nil {
 		glog.Fatalf("Error creating AAA service: %s", err)
 	}

--- a/feg/gateway/services/aaa/aaa_server/main.go
+++ b/feg/gateway/services/aaa/aaa_server/main.go
@@ -50,7 +50,7 @@ func main() {
 	sessions := store.NewMemorySessionTable()
 
 	// Create the EAP AKA Provider service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.AAA_SERVER, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.AAA_SERVER)
 	if err != nil {
 		glog.Fatalf("Error creating AAA service: %s", err)
 	}

--- a/feg/gateway/services/aaa/test/pipelined/main.go
+++ b/feg/gateway/services/aaa/test/pipelined/main.go
@@ -93,7 +93,7 @@ func main() {
 	flag.Parse() // for glog
 
 	// Dummy Pipelined service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.PIPELINED, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.PIPELINED)
 	if err != nil {
 		glog.Fatalf("Error creating %s service: %v", registry.PIPELINED, err)
 	}

--- a/feg/gateway/services/aaa/test/pipelined/main.go
+++ b/feg/gateway/services/aaa/test/pipelined/main.go
@@ -93,7 +93,7 @@ func main() {
 	flag.Parse() // for glog
 
 	// Dummy Pipelined service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.PIPELINED)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.PIPELINED, false)
 	if err != nil {
 		glog.Fatalf("Error creating %s service: %v", registry.PIPELINED, err)
 	}

--- a/feg/gateway/services/csfb/csfb/main.go
+++ b/feg/gateway/services/csfb/csfb/main.go
@@ -37,7 +37,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.CSFB)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.CSFB, false)
 	if err != nil {
 		glog.Fatalf("Error creating CSFB service: %s", err)
 	}

--- a/feg/gateway/services/csfb/csfb/main.go
+++ b/feg/gateway/services/csfb/csfb/main.go
@@ -37,7 +37,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.CSFB, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.CSFB)
 	if err != nil {
 		glog.Fatalf("Error creating CSFB service: %s", err)
 	}

--- a/feg/gateway/services/eap/eap_router/main.go
+++ b/feg/gateway/services/eap/eap_router/main.go
@@ -31,7 +31,7 @@ type eapRouter struct {
 
 func main() {
 	// Create the EAP AKA Provider service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.EAP)
 	if err != nil {
 		glog.Fatalf("Error creating EAP Router service: %s", err)
 	}

--- a/feg/gateway/services/eap/eap_router/main.go
+++ b/feg/gateway/services/eap/eap_router/main.go
@@ -31,7 +31,7 @@ type eapRouter struct {
 
 func main() {
 	// Create the EAP AKA Provider service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP, false)
 	if err != nil {
 		glog.Fatalf("Error creating EAP Router service: %s", err)
 	}

--- a/feg/gateway/services/eap/providers/aka/eap_aka/main.go
+++ b/feg/gateway/services/eap/providers/aka/eap_aka/main.go
@@ -35,7 +35,7 @@ func init() {
 
 func main() {
 	// Create the EAP AKA Provider service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP_AKA)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP_AKA, false)
 	if err != nil {
 		glog.Fatalf("Error creating EAP AKA service: %s", err)
 	}

--- a/feg/gateway/services/eap/providers/aka/eap_aka/main.go
+++ b/feg/gateway/services/eap/providers/aka/eap_aka/main.go
@@ -35,7 +35,7 @@ func init() {
 
 func main() {
 	// Create the EAP AKA Provider service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP_AKA, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.EAP_AKA)
 	if err != nil {
 		glog.Fatalf("Error creating EAP AKA service: %s", err)
 	}

--- a/feg/gateway/services/eap/providers/sim/eap_sim/main.go
+++ b/feg/gateway/services/eap/providers/sim/eap_sim/main.go
@@ -35,7 +35,7 @@ func init() {
 
 func main() {
 	// Create the EAP SIM Provider service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP_SIM)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP_SIM, false)
 	if err != nil {
 		glog.Fatalf("Error creating EAP SIM service: %s", err)
 	}

--- a/feg/gateway/services/eap/providers/sim/eap_sim/main.go
+++ b/feg/gateway/services/eap/providers/sim/eap_sim/main.go
@@ -35,7 +35,7 @@ func init() {
 
 func main() {
 	// Create the EAP SIM Provider service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP_SIM, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.EAP_SIM)
 	if err != nil {
 		glog.Fatalf("Error creating EAP SIM service: %s", err)
 	}

--- a/feg/gateway/services/envoy_controller/main.go
+++ b/feg/gateway/services/envoy_controller/main.go
@@ -69,7 +69,7 @@ func init() {
 func main() {
 	// Create the service
 	glog.Infof("Creating '%s' Service", registry.ENVOY_CONTROLLER)
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.ENVOY_CONTROLLER, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.ENVOY_CONTROLLER)
 	if err != nil {
 		glog.Fatalf("Error creating Envoy Controller service: %s", err)
 	}

--- a/feg/gateway/services/envoy_controller/main.go
+++ b/feg/gateway/services/envoy_controller/main.go
@@ -69,7 +69,7 @@ func init() {
 func main() {
 	// Create the service
 	glog.Infof("Creating '%s' Service", registry.ENVOY_CONTROLLER)
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.ENVOY_CONTROLLER)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.ENVOY_CONTROLLER, false)
 	if err != nil {
 		glog.Fatalf("Error creating Envoy Controller service: %s", err)
 	}

--- a/feg/gateway/services/feg_hello/main.go
+++ b/feg/gateway/services/feg_hello/main.go
@@ -30,7 +30,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.FEG_HELLO)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.FEG_HELLO, false)
 	if err != nil {
 		glog.Fatalf("Error creating FEG_HELLO service: %s", err)
 	}

--- a/feg/gateway/services/feg_hello/main.go
+++ b/feg/gateway/services/feg_hello/main.go
@@ -30,7 +30,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.FEG_HELLO, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.FEG_HELLO)
 	if err != nil {
 		glog.Fatalf("Error creating FEG_HELLO service: %s", err)
 	}

--- a/feg/gateway/services/gateway_health/gateway_health/main.go
+++ b/feg/gateway/services/gateway_health/gateway_health/main.go
@@ -30,7 +30,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.HEALTH)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.HEALTH, false)
 	if err != nil {
 		glog.Fatalf("Error creating HEALTH service: %s", err)
 	}

--- a/feg/gateway/services/gateway_health/gateway_health/main.go
+++ b/feg/gateway/services/gateway_health/gateway_health/main.go
@@ -30,7 +30,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.HEALTH, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.HEALTH)
 	if err != nil {
 		glog.Fatalf("Error creating HEALTH service: %s", err)
 	}

--- a/feg/gateway/services/n7_n40_proxy/n7_n40_proxy/main.go
+++ b/feg/gateway/services/n7_n40_proxy/n7_n40_proxy/main.go
@@ -33,7 +33,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.N7_N40_PROXY)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.N7_N40_PROXY, false)
 	if err != nil {
 		glog.Fatalf("Error creating N7_N40 Proxy service: %s", err)
 	}

--- a/feg/gateway/services/n7_n40_proxy/n7_n40_proxy/main.go
+++ b/feg/gateway/services/n7_n40_proxy/n7_n40_proxy/main.go
@@ -33,7 +33,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.N7_N40_PROXY, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.N7_N40_PROXY)
 	if err != nil {
 		glog.Fatalf("Error creating N7_N40 Proxy service: %s", err)
 	}

--- a/feg/gateway/services/radiusd/radiusd/main.go
+++ b/feg/gateway/services/radiusd/radiusd/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.RADIUSD, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.RADIUSD)
 	if err != nil {
 		glog.Fatalf("Error creating RADIUSD service: %s", err)
 	}

--- a/feg/gateway/services/radiusd/radiusd/main.go
+++ b/feg/gateway/services/radiusd/radiusd/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.RADIUSD)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.RADIUSD, false)
 	if err != nil {
 		glog.Fatalf("Error creating RADIUSD service: %s", err)
 	}

--- a/feg/gateway/services/s6a_proxy/s6a_proxy/main.go
+++ b/feg/gateway/services/s6a_proxy/s6a_proxy/main.go
@@ -32,7 +32,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.S6A_PROXY, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.S6A_PROXY)
 	if err != nil {
 		log.Fatalf("Error creating S6a Proxy service: %s", err)
 	}

--- a/feg/gateway/services/s6a_proxy/s6a_proxy/main.go
+++ b/feg/gateway/services/s6a_proxy/s6a_proxy/main.go
@@ -32,7 +32,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.S6A_PROXY)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.S6A_PROXY, false)
 	if err != nil {
 		log.Fatalf("Error creating S6a Proxy service: %s", err)
 	}

--- a/feg/gateway/services/s8_proxy/s8_proxy/main.go
+++ b/feg/gateway/services/s8_proxy/s8_proxy/main.go
@@ -30,7 +30,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.S8_PROXY)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.S8_PROXY, false)
 	if err != nil {
 		glog.Fatalf("Error creating S8 Proxy service: %s", err)
 	}

--- a/feg/gateway/services/s8_proxy/s8_proxy/main.go
+++ b/feg/gateway/services/s8_proxy/s8_proxy/main.go
@@ -30,7 +30,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.S8_PROXY, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.S8_PROXY)
 	if err != nil {
 		glog.Fatalf("Error creating S8 Proxy service: %s", err)
 	}

--- a/feg/gateway/services/session_proxy/session_proxy/main.go
+++ b/feg/gateway/services/session_proxy/session_proxy/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.SESSION_PROXY)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.SESSION_PROXY, false)
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}

--- a/feg/gateway/services/session_proxy/session_proxy/main.go
+++ b/feg/gateway/services/session_proxy/session_proxy/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.SESSION_PROXY, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.SESSION_PROXY)
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}

--- a/feg/gateway/services/swx_proxy/swx_proxy/main.go
+++ b/feg/gateway/services/swx_proxy/swx_proxy/main.go
@@ -31,7 +31,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.SWX_PROXY, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.SWX_PROXY)
 	if err != nil {
 		glog.Fatalf("Error creating Swx Proxy service: %s", err)
 	}

--- a/feg/gateway/services/swx_proxy/swx_proxy/main.go
+++ b/feg/gateway/services/swx_proxy/swx_proxy/main.go
@@ -31,7 +31,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.SWX_PROXY)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.SWX_PROXY, false)
 	if err != nil {
 		glog.Fatalf("Error creating Swx Proxy service: %s", err)
 	}

--- a/feg/gateway/services/testcore/hss/hss/main.go
+++ b/feg/gateway/services/testcore/hss/hss/main.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	flag.Parse()
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_HSS)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_HSS, false)
 	if err != nil {
 		log.Fatalf("Error creating hss service: %s", err)
 	}

--- a/feg/gateway/services/testcore/hss/hss/main.go
+++ b/feg/gateway/services/testcore/hss/hss/main.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	flag.Parse()
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_HSS, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.MOCK_HSS)
 	if err != nil {
 		log.Fatalf("Error creating hss service: %s", err)
 	}

--- a/feg/gateway/services/testcore/ocs/main.go
+++ b/feg/gateway/services/testcore/ocs/main.go
@@ -76,7 +76,7 @@ func main() {
 		},
 	)
 
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, serviceName)
 	if err != nil {
 		log.Fatalf("Error creating mock %s service: %s", serviceName, err)
 	}

--- a/feg/gateway/services/testcore/ocs/main.go
+++ b/feg/gateway/services/testcore/ocs/main.go
@@ -76,7 +76,7 @@ func main() {
 		},
 	)
 
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName, false)
 	if err != nil {
 		log.Fatalf("Error creating mock %s service: %s", serviceName, err)
 	}

--- a/feg/gateway/services/testcore/pcf/pcf/main.go
+++ b/feg/gateway/services/testcore/pcf/pcf/main.go
@@ -28,7 +28,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error reading N7 config: %s", err)
 	}
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_PCF)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_PCF, false)
 	if err != nil {
 		log.Fatalf("Error creating mock %s service: %s", registry.MOCK_PCF, err)
 	}

--- a/feg/gateway/services/testcore/pcf/pcf/main.go
+++ b/feg/gateway/services/testcore/pcf/pcf/main.go
@@ -28,7 +28,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error reading N7 config: %s", err)
 	}
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_PCF, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.MOCK_PCF)
 	if err != nil {
 		log.Fatalf("Error creating mock %s service: %s", registry.MOCK_PCF, err)
 	}

--- a/feg/gateway/services/testcore/pcrf/main.go
+++ b/feg/gateway/services/testcore/pcrf/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	pcrfServer := mock_pcrf.NewPCRFServer(gxCliConf, gxServConf)
 
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName, false)
+	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, serviceName)
 	if err != nil {
 		log.Fatalf("Error creating mock %s service: %s", serviceName, err)
 	}

--- a/feg/gateway/services/testcore/pcrf/main.go
+++ b/feg/gateway/services/testcore/pcrf/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	pcrfServer := mock_pcrf.NewPCRFServer(gxCliConf, gxServConf)
 
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName, false)
 	if err != nil {
 		log.Fatalf("Error creating mock %s service: %s", serviceName, err)
 	}

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -25,6 +25,7 @@ services:
   analytics:
     host: "localhost"
     port: 9200
+    protected_port: 9300
     proxy_type: "clientcert"
 
   dp_service:
@@ -60,6 +61,7 @@ services:
   streamer:
     host: "localhost"
     port: 9082
+    protected_port: 9182
     proxy_type: "clientcert"
 
   metricsd:
@@ -96,6 +98,7 @@ services:
   bootstrapper:
     host: "localhost"
     port: 9088
+    protected_port: 9188
     proxy_type: "open"
 
   accessd:
@@ -121,11 +124,13 @@ services:
   obsidian:
     host: "localhost"
     port: 9093
+    protected_port: 9193
     proxy_type: "obsidian"
 
   dispatcher:
     host: "localhost"
     port: 9096
+    protected_port: 9196
     proxy_type: "clientcert"
 
   directoryd:
@@ -143,6 +148,7 @@ services:
   orc8r_worker:
     host: "localhost"
     port: 9122
+    protected_port: 9222
     proxy_type: "clientcert"
 
   device:

--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -90,7 +90,7 @@ func NewOrchestratorService(moduleName string, serviceName string, serverOptions
 	grpc_prometheus.EnableHandlingTimeHistogram()
 	serverOptions = append(serverOptions, unary.GetInterceptorOpt())
 
-	platformService, err := platform_service.NewServiceWithOptions(moduleName, serviceName, serverOptions...)
+	platformService, err := platform_service.NewServiceWithOptions(moduleName, serviceName, true, serverOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -64,7 +64,7 @@ type OrchestratorService struct {
 // implementing service303. If configured, it will also initialize an HTTP echo
 // server as a part of the service. This service will implement a middleware
 // interceptor to perform identity check. If your service does not or can not
-// perform identity checks, (e.g., federation), use NewServiceWithOptions.
+// perform identity checks, (e.g., federation), use NewGatewayServiceWithOptions.
 func NewOrchestratorService(moduleName string, serviceName string, serverOptions ...grpc.ServerOption) (*OrchestratorService, error) {
 	flag.Parse()
 
@@ -90,7 +90,7 @@ func NewOrchestratorService(moduleName string, serviceName string, serverOptions
 	grpc_prometheus.EnableHandlingTimeHistogram()
 	serverOptions = append(serverOptions, unary.GetInterceptorOpt())
 
-	platformService, err := platform_service.NewServiceWithOptions(moduleName, serviceName, true, serverOptions...)
+	platformService, err := platform_service.NewOrc8rServiceWithOptions(moduleName, serviceName, serverOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/go/service/service_test.go
+++ b/orc8r/cloud/go/service/service_test.go
@@ -40,13 +40,13 @@ func TestServiceRun(t *testing.T) {
 	serviceName := state.ServiceName
 
 	// Create the service
-	srv, lis, _ := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, serviceName, nil, nil)
+	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, serviceName, nil, nil)
 	assert.Equal(t, protos.ServiceInfo_STARTING, srv.State)
 	assert.Equal(t, protos.ServiceInfo_APP_UNHEALTHY, srv.Health)
 	assert.NotNil(t, srv.EchoServer)
 
 	// Start the service
-	go srv.RunTest(lis, nil)
+	go srv.RunTest(lis, plis)
 
 	// Wait for the service to be started and check its state and health
 	time.Sleep(time.Second)

--- a/orc8r/cloud/go/service/service_test.go
+++ b/orc8r/cloud/go/service/service_test.go
@@ -54,7 +54,7 @@ func TestServiceRun(t *testing.T) {
 	assert.Equal(t, protos.ServiceInfo_APP_HEALTHY, srv.Health)
 
 	// Create a rpc stub and query the Service303 interface
-	conn, err := registry.GetConnection(serviceName, protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(serviceName, protos.ServiceType_PROTECTED)
 	assert.NoError(t, err, "err in getting connection to service")
 	client := protos.NewService303Client(conn)
 

--- a/orc8r/cloud/go/service/test_utils.go
+++ b/orc8r/cloud/go/service/test_utils.go
@@ -27,7 +27,7 @@ func NewTestService(t *testing.T, moduleName string, serviceType string) (*platf
 	if t == nil {
 		panic("for tests only")
 	}
-	return platform_service.NewServiceWithOptions(moduleName, serviceType, true, unary.GetInterceptorOpt())
+	return platform_service.NewOrc8rServiceWithOptions(moduleName, serviceType, unary.GetInterceptorOpt())
 }
 
 // NewTestOrchestratorService returns a new gRPC orchestrator service without
@@ -37,7 +37,7 @@ func NewTestOrchestratorService(t *testing.T, moduleName string, serviceType str
 	if t == nil {
 		panic("for tests only")
 	}
-	platformService, err := platform_service.NewServiceWithOptions(moduleName, serviceType, true, unary.GetInterceptorOpt())
+	platformService, err := platform_service.NewOrc8rServiceWithOptions(moduleName, serviceType, unary.GetInterceptorOpt())
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/go/service/test_utils.go
+++ b/orc8r/cloud/go/service/test_utils.go
@@ -27,7 +27,7 @@ func NewTestService(t *testing.T, moduleName string, serviceType string) (*platf
 	if t == nil {
 		panic("for tests only")
 	}
-	return platform_service.NewServiceWithOptions(moduleName, serviceType, unary.GetInterceptorOpt())
+	return platform_service.NewServiceWithOptions(moduleName, serviceType, true, unary.GetInterceptorOpt())
 }
 
 // NewTestOrchestratorService returns a new gRPC orchestrator service without
@@ -37,7 +37,7 @@ func NewTestOrchestratorService(t *testing.T, moduleName string, serviceType str
 	if t == nil {
 		panic("for tests only")
 	}
-	platformService, err := platform_service.NewServiceWithOptions(moduleName, serviceType, unary.GetInterceptorOpt())
+	platformService, err := platform_service.NewServiceWithOptions(moduleName, serviceType, true, unary.GetInterceptorOpt())
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/helm/orc8r/templates/analytics.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/analytics.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/analytics", "-logtostderr=tr
 ports:
   - name: grpc
     containerPort: 9200
+  - name: grpc-internal
+    containerPort: 9300
 livenessProbe:
   tcpSocket:
     port: 9200

--- a/orc8r/cloud/helm/orc8r/templates/analytics.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/analytics.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9200
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9300
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/bootstrapper.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/bootstrapper.deployment.yaml
@@ -40,6 +40,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/bootstrapper", "-cak=/var/op
 ports:
   - name: grpc
     containerPort: 9088
+  - name: grpc-internal
+    containerPort: 9188
 livenessProbe:
   tcpSocket:
     port: 9088

--- a/orc8r/cloud/helm/orc8r/templates/bootstrapper.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/bootstrapper.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9088
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9188
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/dispatcher.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dispatcher.deployment.yaml
@@ -38,6 +38,8 @@ ports:
     containerPort: 9096
   - name: http
     containerPort: 9080
+  - name: grpc-internal
+    containerPort: 9196
 livenessProbe:
   tcpSocket:
     port: 9096

--- a/orc8r/cloud/helm/orc8r/templates/dispatcher.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dispatcher.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9096
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9196
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/obsidian.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/obsidian.deployment.yaml
@@ -38,6 +38,8 @@ ports:
     containerPort: 9093
   - name: http
     containerPort: 9081
+  - name: grpc-internal
+    containerPort: 9193
 livenessProbe:
   tcpSocket:
     port: 9081

--- a/orc8r/cloud/helm/orc8r/templates/obsidian.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/obsidian.service.yaml
@@ -33,4 +33,7 @@ spec:
     - name: http
       port: 8080
       targetPort: 9081
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9193
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/orc8r_worker.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/orc8r_worker.deployment.yaml
@@ -37,6 +37,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/orc8r_worker", "-logtostderr
 ports:
   - name: grpc
     containerPort: 9122
+  - name: grpc-internal
+    containerPort: 9222
 livenessProbe:
   tcpSocket:
     port: 9122

--- a/orc8r/cloud/helm/orc8r/templates/orc8r_worker.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/orc8r_worker.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9122
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9222
   {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/streamer.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/streamer.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/streamer", "-logtostderr=tru
 ports:
   - name: grpc
     containerPort: 9082
+  - name: grpc-internal
+    containerPort: 9182
 livenessProbe:
   tcpSocket:
     port: 9082

--- a/orc8r/cloud/helm/orc8r/templates/streamer.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/streamer.service.yaml
@@ -30,4 +30,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9082
+    - name: grpc-internal
+      port: 9190
+      targetPort: 9182
 {{- end -}}

--- a/orc8r/gateway/go/services/magmad/service/magmad.go
+++ b/orc8r/gateway/go/services/magmad/service/magmad.go
@@ -226,7 +226,7 @@ func NewMagmadService() protos.MagmadServer {
 // StartMagmadServer runs instance of the magmad grpc service
 // StartMagmadServer only returns on error and has to be run in its own Go routine or main thread
 func StartMagmadServer() error {
-	srv, err := service.NewServiceWithOptions("", strings.ToUpper(definitions.MagmadServiceName))
+	srv, err := service.NewServiceWithOptions("", strings.ToUpper(definitions.MagmadServiceName), true)
 	if err != nil {
 		return fmt.Errorf("error creating '%s' service: %v", definitions.MagmadServiceName, err)
 	}

--- a/orc8r/gateway/go/services/magmad/service/magmad.go
+++ b/orc8r/gateway/go/services/magmad/service/magmad.go
@@ -226,7 +226,7 @@ func NewMagmadService() protos.MagmadServer {
 // StartMagmadServer runs instance of the magmad grpc service
 // StartMagmadServer only returns on error and has to be run in its own Go routine or main thread
 func StartMagmadServer() error {
-	srv, err := service.NewServiceWithOptions("", strings.ToUpper(definitions.MagmadServiceName), false)
+	srv, err := service.NewGatewayServiceWithOptions("", strings.ToUpper(definitions.MagmadServiceName))
 	if err != nil {
 		return fmt.Errorf("error creating '%s' service: %v", definitions.MagmadServiceName, err)
 	}

--- a/orc8r/gateway/go/services/magmad/service/magmad.go
+++ b/orc8r/gateway/go/services/magmad/service/magmad.go
@@ -226,7 +226,7 @@ func NewMagmadService() protos.MagmadServer {
 // StartMagmadServer runs instance of the magmad grpc service
 // StartMagmadServer only returns on error and has to be run in its own Go routine or main thread
 func StartMagmadServer() error {
-	srv, err := service.NewServiceWithOptions("", strings.ToUpper(definitions.MagmadServiceName), true)
+	srv, err := service.NewServiceWithOptions("", strings.ToUpper(definitions.MagmadServiceName), false)
 	if err != nil {
 		return fmt.Errorf("error creating '%s' service: %v", definitions.MagmadServiceName, err)
 	}

--- a/orc8r/gateway/go/services/magmad/status/poller.go
+++ b/orc8r/gateway/go/services/magmad/status/poller.go
@@ -39,7 +39,7 @@ var (
 )
 
 func startServiceQuery(service string, queryMetrics bool, maxMetricsQueueSz int) error {
-	conn, err := service_registry.Get().GetConnection(strings.ToUpper(service), protos.ServiceType_PROTECTED)
+	conn, err := service_registry.Get().GetConnection(strings.ToUpper(service), protos.ServiceType_SOUTHBOUND)
 	if err != nil {
 		return err
 	}

--- a/orc8r/gateway/go/services/magmad/status/poller.go
+++ b/orc8r/gateway/go/services/magmad/status/poller.go
@@ -39,7 +39,7 @@ var (
 )
 
 func startServiceQuery(service string, queryMetrics bool, maxMetricsQueueSz int) error {
-	conn, err := service_registry.Get().GetConnection(strings.ToUpper(service), protos.ServiceType_SOUTHBOUND)
+	conn, err := service_registry.Get().GetConnection(strings.ToUpper(service), protos.ServiceType_PROTECTED)
 	if err != nil {
 		return err
 	}

--- a/orc8r/lib/go/service/client/client_api.go
+++ b/orc8r/lib/go/service/client/client_api.go
@@ -24,7 +24,7 @@ import (
 )
 
 func getClient(service string) (protos.Service303Client, error) {
-	conn, err := registry.GetConnection(service, protos.ServiceType_SOUTHBOUND)
+	conn, err := registry.GetConnection(service, protos.ServiceType_PROTECTED)
 	if err != nil {
 		initErr := merrors.NewInitError(err, "SERVICE303")
 		glog.Error(initErr)

--- a/orc8r/lib/go/service/service.go
+++ b/orc8r/lib/go/service/service.go
@@ -88,10 +88,22 @@ type Service struct {
 	Config *config.Map
 }
 
-// NewServiceWithOptions returns a new GRPC orchestrator service implementing
+// NewGatewayServiceWithOptions calls newServiceWithOptions and specifies the
+// service type to be not protected.
+func NewGatewayServiceWithOptions(moduleName string, serviceName string, serverOptions ...grpc.ServerOption) (*Service, error) {
+	return newServiceWithOptions(moduleName, serviceName, false, serverOptions...)
+}
+
+// NewOrc8rServiceWithOptions calls newServiceWithOptions and specifies the
+// service type to be protected.
+func NewOrc8rServiceWithOptions(moduleName string, serviceName string, serverOptions ...grpc.ServerOption) (*Service, error) {
+	return newServiceWithOptions(moduleName, serviceName, true, serverOptions...)
+}
+
+// newServiceWithOptions returns a new GRPC orchestrator service implementing
 // service303 with the specified grpc server options.
 // It will not instantiate the service with the identity checking middleware.
-func NewServiceWithOptions(moduleName string, serviceName string, protected303Server bool, serverOptions ...grpc.ServerOption) (*Service, error) {
+func newServiceWithOptions(moduleName string, serviceName string, protected303Server bool, serverOptions ...grpc.ServerOption) (*Service, error) {
 	// Load config, in case it does not exist, log
 	configMap, err := config.GetServiceConfig(moduleName, serviceName)
 	if err != nil {

--- a/orc8r/lib/go/service/service.go
+++ b/orc8r/lib/go/service/service.go
@@ -91,7 +91,7 @@ type Service struct {
 // NewServiceWithOptions returns a new GRPC orchestrator service implementing
 // service303 with the specified grpc server options.
 // It will not instantiate the service with the identity checking middleware.
-func NewServiceWithOptions(moduleName string, serviceName string, serverOptions ...grpc.ServerOption) (*Service, error) {
+func NewServiceWithOptions(moduleName string, serviceName string, protected303Server bool, serverOptions ...grpc.ServerOption) (*Service, error) {
 	// Load config, in case it does not exist, log
 	configMap, err := config.GetServiceConfig(moduleName, serviceName)
 	if err != nil {
@@ -119,7 +119,11 @@ func NewServiceWithOptions(moduleName string, serviceName string, serverOptions 
 		StartTimeSecs:       uint64(time.Now().Unix()),
 		Config:              configMap,
 	}
-	protos.RegisterService303Server(service.ProtectedGrpcServer, service)
+	if protected303Server {
+		protos.RegisterService303Server(service.ProtectedGrpcServer, service)
+	} else {
+		protos.RegisterService303Server(service.GrpcServer, service)
+	}
 
 	// Store into global for future access
 	currentlyRunningServicesMu.Lock()

--- a/orc8r/lib/go/service/service.go
+++ b/orc8r/lib/go/service/service.go
@@ -119,7 +119,7 @@ func NewServiceWithOptions(moduleName string, serviceName string, serverOptions 
 		StartTimeSecs:       uint64(time.Now().Unix()),
 		Config:              configMap,
 	}
-	protos.RegisterService303Server(service.GrpcServer, service)
+	protos.RegisterService303Server(service.ProtectedGrpcServer, service)
 
 	// Store into global for future access
 	currentlyRunningServicesMu.Lock()


### PR DESCRIPTION
Fixes #12608 

## Summary

- Added protected ports to analytics, bootstrapper, dispatcher, obsidian, orc8r_worker, and streamer services
- Added protected listener to `srv.RunTest` call 
- Changed `ServiceType_SOUTHBOUND` to `ServiceType_PROTECTED` where appropriate.
- Added boolean `protected303Server` argument to `NewServiceWithOptions` in `orc8r/lib/go/service/service.go` to distinguish internal orc8rservers from external cwf/feg
-  Set appropriate `protected303Server` option in `main.go` files when they call `NewServiceWithOptions`.

## Test Plan

- Run unit tests
- Also made sure the correct ports are used, similar to #12564 (sorry for the weird string formatting)
![Screenshot from 2022-06-15 11-26-40](https://user-images.githubusercontent.com/8889531/173763327-6d03a0ca-ceaf-42f5-9d29-ee45b50aaa40.png)
![Screenshot from 2022-06-15 11-27-05](https://user-images.githubusercontent.com/8889531/173763341-a4485ce5-97c6-4938-9a67-e8212399aef2.png)


## Additional Information

- [ ] This change is backwards-breaking
