### PR TITLE
docs: fluentd for orc8r minikube deployment documentation

### DIFF
--- a/docs/readmes/orc8r/dev_build.md
+++ b/docs/readmes/orc8r/dev_build.md
@@ -68,7 +68,16 @@ Build and publish Orchestrator images
 ```bash
 cd ${MAGMA_ROOT}/orc8r/cloud/docker
 ./build.py --all
-for image in controller nginx ; do ${PUBLISH} -r ${REGISTRY} -i ${image} -v ${MAGMA_TAG} ; done
+for image in controller nginx ; do ${PUBLISH} -r ${REGISTRY} -i ${image} -v ${MAGMA_TAG} -u '' -p '' ; done
+```
+
+Optionally, to build fluentd images for the Orchestrator, uncomment the line `docker-compose.logging.yaml` in `build.py`.
+Build and publish fluentd images
+
+```bash
+cd ${MAGMA_ROOT}/orc8r/cloud/docker
+./build.py --all
+for image in fluentd-forward fluentd-daemon ; do ${PUBLISH} -r ${REGISTRY} -i ${image} -v ${MAGMA_TAG} -u '' -p '' ; done
 ```
 
 Build and publish NMS images


### PR DESCRIPTION
## Summary

Documentation for using fluentd, elasticsearch, and kibana for the Orchestrator minikube deployment.
