### PR TITLE
docs: remove remarks about the future

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.7.0/nms/organizations.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/nms/organizations.md
@@ -17,8 +17,7 @@ organization name. For example, users of a `facebook` organization in the NMS
 would access the NMS using `facebook.nms.yourdomain.com`.
 
 Note that multitenacy is currently only supported through mechanisms living
-in the NMS, but not through the Orc8r API. This is planned to be unified with
-Magma v1.8.
+in the NMS, but not through the Orc8r API.
 
 ## First-time Setup
 

--- a/docs/readmes/nms/organizations.md
+++ b/docs/readmes/nms/organizations.md
@@ -16,8 +16,7 @@ organization name. For example, users of a `facebook` organization in the NMS
 would access the NMS using `facebook.nms.yourdomain.com`.
 
 Note that multitenacy is currently only supported through mechanisms living
-in the NMS, but not through the Orc8r API. This is planned to be unified with
-Magma v1.8.
+in the NMS, but not through the Orc8r API.
 
 ## First-time Setup
 


### PR DESCRIPTION
## Summary

- There should only be documentation and no remarks about a uncertain future in the documentation.