### PR TITLE
chore(ci): Bazel workflows send slack message

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -213,6 +213,17 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "C/C++ unit tests with Bazel"
+          SLACK_USERNAME: "agw-workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
 
   li_agent_test:
     needs: path_filter
@@ -369,6 +380,7 @@ jobs:
             cp $C_BUILD/coverage.info $MAGMA_ROOT
       - name: Run coverage with Bazel (COMMON / SESSIOND / SCTPD / LIAGENT / CONNECTIOND)
         if: always()
+        id: bazel-codecoverage
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
@@ -420,6 +432,17 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify Bazel failure to slack
+        if: steps.bazel-codecoverage.outcome=='failure' && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "C / C++ code coverage with Bazel"
+          SLACK_USERNAME: "agw-workflow"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
 
   lint-clang-format:
     needs: path_filter

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -82,6 +82,17 @@ jobs:
 
           aws s3 cp ${{ env.BAZEL_CACHE_MAGMA_VM_TAR }} ${{ env.S3_BUCKET_PATH }}/${{ env.BAZEL_CACHE_MAGMA_VM_TAR}}
           aws s3 cp ${{ env.BAZEL_CACHE_REPO_MAGMA_VM_TAR }} ${{ env.S3_BUCKET_PATH }}/${{ env.BAZEL_CACHE_REPO_MAGMA_VM_TAR}}
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "VM Caches"
+          SLACK_USERNAME: "Push Bazel Cache To S3"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
 
   bazel-build-devcontainer-and-push-cache:
     runs-on: ubuntu-latest
@@ -135,3 +146,15 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Devcontainer Caches"
+          SLACK_USERNAME: "Push Bazel Cache To S3"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -102,6 +102,17 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel Build Job `bazel build //...`"
+          SLACK_USERNAME: "Bazel Build & Test"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
 
   bazel_test:
     needs: path_filter
@@ -178,6 +189,17 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel Test Job `bazel test //...`"
+          SLACK_USERNAME: "Bazel Build & Test"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
 
   bazel_package:
     needs: path_filter
@@ -234,6 +256,17 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel Package Job"
+          SLACK_USERNAME: "Bazel Build & Test"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
 
   python_file_check:
     name: Check if there are not bazelified python files
@@ -245,6 +278,17 @@ jobs:
         shell: bash
         run: |
           ./bazel/scripts/check_py_bazel.sh
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel Python Check Job `./bazel/scripts/check_py_bazel.sh`"
+          SLACK_USERNAME: "Bazel Build & Test"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
 
   c_cpp_file_check:
     name: Check if there are non-bazelified c or c++ files
@@ -256,3 +300,14 @@ jobs:
         shell: bash
         run: |
           ./bazel/scripts/check_c_cpp_bazel.sh
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel C/C++ Check Job `./bazel/scripts/check_c_cpp_bazel.sh`"
+          SLACK_USERNAME: "Bazel Build & Test"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -134,3 +134,14 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Build all Bazelified C/C++ targets"
+          SLACK_USERNAME: "GCC Warnings & Errors"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Because more code gets bazelified more regression of bazel build files can happen. In order to react proactively, failures of bazel workflows are sent to #bazel-ci. This way the bazel team can react fast and provide support for bazel related workflows on master.

## Test Plan
Additional commit with intentional bazel failure was created. Messages were sent to #bazel-ci.

## Additional Information

The message is null if the workflow was manually triggered (workflow dispatch event), because the event does not have the property `commits`.

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
