### PR TITLE
fix(orc8r): Add new table for reindexed subscriber state

### DIFF
--- a/lte/cloud/go/services/subscriberdb/storage/subscriber_state.go
+++ b/lte/cloud/go/services/subscriberdb/storage/subscriber_state.go
@@ -1,0 +1,197 @@
+/*
+ Copyright 2022 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package storage
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Masterminds/squirrel"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/services/state"
+	"magma/orc8r/cloud/go/sqorc"
+)
+
+type SubscriberStorage interface {
+	// Initialize the backing store.
+	Initialize() error
+
+	GetSubscribersForGateway(networkID string, gatewayID string) ([]SubscriberState, error)
+
+	DeleteSubscribersForGateway(networkID string, gatewayID string) error
+
+	SetAllSubscribersForGateway(networkID string, gatewayID string, subscriberStates []SubscriberState) error
+}
+
+const (
+	tableName = "gateway_subscriber_states"
+
+	nidColumn         = "network_id"
+	gwidColumn        = "gateway_id"
+	imsiColumn        = "imsi"
+	lastUpdatedColumn = "last_updated_at"
+	stateColumn       = "reported_state"
+)
+
+type subscriberStorage struct {
+	db      *sql.DB
+	builder sqorc.StatementBuilder
+}
+
+func NewSubscriberStorage(db *sql.DB, builder sqorc.StatementBuilder) SubscriberStorage {
+	return &subscriberStorage{
+		db:      db,
+		builder: builder,
+	}
+}
+
+func (ss *subscriberStorage) Initialize() error {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		_, err := ss.builder.CreateTable(tableName).
+			IfNotExists().
+			Column(nidColumn).Type(sqorc.ColumnTypeText).NotNull().EndColumn().
+			Column(gwidColumn).Type(sqorc.ColumnTypeText).NotNull().EndColumn().
+			Column(imsiColumn).Type(sqorc.ColumnTypeText).NotNull().EndColumn().
+			Column(lastUpdatedColumn).Type(sqorc.ColumnTypeBigInt).NotNull().EndColumn().
+			Column(stateColumn).Type(sqorc.ColumnTypeBytes).NotNull().EndColumn().
+			PrimaryKey(nidColumn, gwidColumn, imsiColumn).
+			RunWith(tx).
+			Exec()
+		if err != nil {
+			return nil, fmt.Errorf("initialize subscriber storage table: %w", err)
+		}
+		return nil, nil
+	}
+	_, err := sqorc.ExecInTx(ss.db, nil, nil, txFn)
+	return err
+}
+
+type SubscriberState struct {
+	Imsi  string
+	Value state.ArbitraryJSON
+}
+
+func (ss *subscriberStorage) GetSubscribersForGateway(networkID string, gatewayID string) ([]SubscriberState, error) {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		rows, err := ss.getSubscribers(tx, networkID, gatewayID)
+		if err != nil {
+			return nil, fmt.Errorf("Error getting subscribers for nid / gwid:  %v / %v", networkID, gatewayID)
+		}
+		defer sqorc.CloseRowsLogOnError(rows, "GetSubscribersForGateway")
+
+		var mappings []SubscriberState
+		for rows.Next() {
+			var rawState []byte
+			imsi := ""
+			err = rows.Scan(&imsi, &rawState)
+			if err != nil {
+				return nil, fmt.Errorf("GetSubscribersForGateway, SQL row scan error: %w", err)
+			}
+			reportedState := make(state.ArbitraryJSON)
+			err = json.Unmarshal(rawState, &reportedState)
+			if err != nil {
+				return nil, fmt.Errorf("GetSubscribersForGateway, error unmarshaling state: %w", err)
+			}
+			mappings = append(mappings, SubscriberState{Imsi: imsi, Value: reportedState})
+		}
+		err = rows.Err()
+		if err != nil {
+			return nil, fmt.Errorf("GetSubscribersForGateway, SQL rows error: %w", err)
+		}
+
+		return mappings, nil
+	}
+	txRet, err := sqorc.ExecInTx(ss.db, nil, nil, txFn)
+	if err != nil {
+		return nil, err
+	}
+	ret := txRet.([]SubscriberState)
+	return ret, nil
+
+}
+
+func (ss *subscriberStorage) SetAllSubscribersForGateway(networkID string, gatewayID string, subscriberStates []SubscriberState) error {
+	timeSec := clock.Now().Unix()
+
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		sc := squirrel.NewStmtCache(tx)
+		defer sqorc.ClearStatementCacheLogOnError(sc, "SetAllSubscribersForGateway")
+
+		err := ss.deleteAllSubscribers(sc, networkID, gatewayID)
+		if err != nil {
+			return nil, fmt.Errorf("error deleting subscribers before update: %w", err)
+		}
+
+		for _, blob := range subscriberStates {
+			value, err := blob.Value.MarshalBinary()
+			if err != nil {
+				return nil, fmt.Errorf("convert subscriber value %+v: %w", blob, err)
+			}
+
+			err = ss.insertSubscriber(sc, networkID, gatewayID, blob.Imsi, timeSec, value)
+			if err != nil {
+				return nil, fmt.Errorf("insert subscriber %+v: %w", blob, err)
+			}
+		}
+		return nil, nil
+	}
+
+	_, err := sqorc.ExecInTx(ss.db, nil, nil, txFn)
+	return err
+}
+
+func (ss *subscriberStorage) DeleteSubscribersForGateway(networkID string, gatewayID string) error {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		sc := squirrel.NewStmtCache(tx)
+		defer sqorc.ClearStatementCacheLogOnError(sc, "DeleteSubscribersForGateway")
+
+		err := ss.deleteAllSubscribers(sc, networkID, gatewayID)
+		if err != nil {
+			return nil, fmt.Errorf("delete subscribers from network %v, gateway %v: %w", networkID, gatewayID, err)
+		}
+		return nil, nil
+	}
+
+	_, err := sqorc.ExecInTx(ss.db, nil, nil, txFn)
+	return err
+}
+
+func (ss *subscriberStorage) getSubscribers(tx *sql.Tx, networkID string, gatewayID string) (*sql.Rows, error) {
+	rows, err := ss.builder.
+		Select(imsiColumn, stateColumn).
+		From(tableName).
+		Where(squirrel.Eq{nidColumn: networkID, gwidColumn: gatewayID}).
+		RunWith(tx).
+		Query()
+	return rows, err
+}
+
+func (ss *subscriberStorage) deleteAllSubscribers(sc *squirrel.StmtCache, networkID string, gatewayID string) error {
+	_, err := ss.builder.Delete(tableName).
+		Where(squirrel.Eq{nidColumn: networkID, gwidColumn: gatewayID}).
+		RunWith(sc).
+		Exec()
+	return err
+}
+
+func (ss *subscriberStorage) insertSubscriber(sc *squirrel.StmtCache, networkID string, gatewayID string, imsi string, timeSec int64, value []byte) error {
+	_, err := ss.builder.Insert(tableName).
+		Columns(nidColumn, gwidColumn, imsiColumn, lastUpdatedColumn, stateColumn).
+		Values(networkID, gatewayID, imsi, timeSec, value).
+		RunWith(sc).
+		Exec()
+	return err
+}

--- a/lte/cloud/go/services/subscriberdb/storage/subscriber_state_test.go
+++ b/lte/cloud/go/services/subscriberdb/storage/subscriber_state_test.go
@@ -1,0 +1,124 @@
+/*
+ Copyright 2022 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/cloud/go/sqorc"
+)
+
+const nid1 = "network_1"
+const nid2 = "network_2"
+
+const gwid1 = "snowflake_ID_1"
+const gwid2 = "snowflake_ID_2"
+
+func TestSubscriberStorage(t *testing.T) {
+	db, err := sqorc.Open("sqlite3", ":memory:")
+	assert.NoError(t, err)
+	s := NewSubscriberStorage(db, sqorc.GetSqlBuilder())
+	assert.NoError(t, s.Initialize())
+
+	t.Run("Test inserting, querying and deleting subscriber states for a gateway", func(t *testing.T) {
+		subscriberStates := []SubscriberState{subscriberState("IMSI001010000000123"), subscriberState("IMSI001010000000456")}
+		err = s.SetAllSubscribersForGateway(nid1, gwid1, subscriberStates)
+		assert.NoError(t, err)
+
+		foundStates, err := s.GetSubscribersForGateway(nid2, gwid1)
+		assert.NoError(t, err)
+		assert.Empty(t, foundStates)
+		foundStates, err = s.GetSubscribersForGateway(nid1, gwid2)
+		assert.NoError(t, err)
+		assert.Empty(t, foundStates)
+
+		foundStates, err = s.GetSubscribersForGateway(nid1, gwid1)
+		assert.NoError(t, err)
+		assert.True(t, cmp.Equal(foundStates, subscriberStates))
+
+		err = s.DeleteSubscribersForGateway(nid1, gwid1)
+		assert.NoError(t, err)
+		foundStates, err = s.GetSubscribersForGateway(nid1, gwid1)
+		assert.NoError(t, err)
+		assert.Empty(t, foundStates)
+	})
+
+	t.Run("Test updating subscriber states for a gateway", func(t *testing.T) {
+		oldSubscriberStatesGw1 := []SubscriberState{subscriberState("IMSI001010000000123"), subscriberState("IMSI001010000000456")}
+		subscriberStatesGw2 := []SubscriberState{subscriberState("IMSI001010000000789")}
+
+		err = s.SetAllSubscribersForGateway(nid1, gwid1, oldSubscriberStatesGw1)
+		assert.NoError(t, err)
+		err = s.SetAllSubscribersForGateway(nid1, gwid2, subscriberStatesGw2)
+		assert.NoError(t, err)
+
+		foundStates, err := s.GetSubscribersForGateway(nid1, gwid1)
+		assert.NoError(t, err)
+		assert.True(t, cmp.Equal(foundStates, oldSubscriberStatesGw1))
+
+		// Test updating states for gateway 1
+
+		newSubscriberStatesGw1 := []SubscriberState{subscriberState("IMSI001010000000012"), subscriberState("IMSI001010000000123")}
+		err = s.SetAllSubscribersForGateway(nid1, gwid1, newSubscriberStatesGw1)
+		assert.NoError(t, err)
+
+		foundStates, err = s.GetSubscribersForGateway(nid1, gwid1)
+		assert.NoError(t, err)
+		assert.True(t, cmp.Equal(foundStates, newSubscriberStatesGw1))
+
+		// Test emptying states for gateway 1
+
+		err = s.SetAllSubscribersForGateway(nid1, gwid1, []SubscriberState{})
+		assert.NoError(t, err)
+
+		foundStates, err = s.GetSubscribersForGateway(nid1, gwid1)
+		assert.NoError(t, err)
+		assert.Empty(t, foundStates)
+
+		// Gateway 2 should be unaffected
+
+		foundStates, err = s.GetSubscribersForGateway(nid1, gwid2)
+		assert.NoError(t, err)
+		assert.True(t, cmp.Equal(foundStates, subscriberStatesGw2))
+
+		err = s.DeleteSubscribersForGateway(nid1, gwid1)
+		assert.NoError(t, err)
+		err = s.DeleteSubscribersForGateway(nid1, gwid2)
+		assert.NoError(t, err)
+	})
+}
+
+func subscriberState(imsi string) SubscriberState {
+	return SubscriberState{
+		Imsi: imsi,
+		Value: map[string]interface{}{
+			"magma.ipv4": []interface{}{
+				map[string]interface{}{
+					"active_policy_rules": []interface{}{},
+					"active_duration_sec": 6.,
+					"lifecycle_state":     "SESSION_RELEASED",
+					"session_start_time":  1653484144.,
+					"apn":                 "magma.ipv4",
+					"ipv4":                "192.168.128.12",
+					"msisdn":              "",
+					"session_id":          fmt.Sprintf("%s-1234", imsi),
+				},
+			},
+		},
+	}
+}

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -69,6 +69,11 @@ func main() {
 		glog.Fatalf("Error initializing subscriber syncstore: %+v", err)
 	}
 
+	subscriberStateStore := subscriberdb_storage.NewSubscriberStorage(db, sqorc.GetSqlBuilder())
+	if err := subscriberStateStore.Initialize(); err != nil {
+		glog.Fatalf("Error initializing subscriber state storage : %+v", err)
+	}
+
 	var serviceConfig subscriberdb.Config
 	config.MustGetStructuredServiceConfig(lte.ModuleName, subscriberdb.ServiceName, &serviceConfig)
 	glog.Infof("Subscriberdb service config %+v", serviceConfig)


### PR DESCRIPTION
## Summary

Adds a new table to orc8r's subscriberdb that will contain subscriber state data from gateways after reindexing. The table has a combined primary key:

* network ID, gateway ID, imsi

The interface of the table is designed to allow updating all data for a certain gateway in order to remove stale subscriber entries. This implements step 2 of the plan outlined in https://github.com/magma/magma/issues/8621#issuecomment-1144762649. Follow-up PRs will add a reindexer that calls this interface every time a state update is received from a gateway.

## Test Plan

* Added unit tests for CRUD logic.
* Manual test of the new storage logic using PostgreSQL by calling the methods directly in subscriberdb.
![gateway_subscriber_states_dbeaver](https://user-images.githubusercontent.com/14236667/172847310-9206f3cd-6d3e-4299-a463-93689c06e477.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
