### PR TITLE
chore: Pin pylint to 2.14.0

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -73,7 +73,7 @@ setup(
         'protobuf==3.19.0',
         'Jinja2>=2.8',
         'netifaces>=0.10.4',
-        'pylint>=1.7.1,<=2.14.0',
+        'pylint==2.14.0',
         'PyYAML>=3.12',
         'pytz>=2014.4',
         'prometheus_client==0.3.1',


### PR DESCRIPTION
## Summary

Now that the [test VM is running Ubuntu](https://github.com/magma/magma/pull/12934) and so its Python version has been updated, we can pin the version of pylint.

## Test Plan

Running `pip3 install 'pylint==2.14.0'` on the magma_test VM leads to:
```
vagrant@magma-test:~$ pip3 show pylint
Name: pylint
Version: 2.14.0
Summary: python code static checker
Home-page: None
Author: Python Code Quality Authority
Author-email: code-quality@python.org
License: GPL-2.0-or-later
Location: /home/vagrant/.local/lib/python3.8/site-packages
Requires: dill, platformdirs, tomlkit, typing-extensions, mccabe, isort, astroid, tomli
Required-by:
```
Previously the version was 2.6.2: https://github.com/magma/magma/pull/12895.