### PR TITLE
chore(mobilityd): Make mypy green

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -16,7 +16,7 @@ import datetime
 import logging
 import threading
 import time
-from ipaddress import IPv4Network, ip_address
+from ipaddress import IPv4Network
 from threading import Condition
 from typing import MutableMapping, Optional
 
@@ -278,7 +278,7 @@ class DHCPClient:
 
                 dhcp_router_opt = self._get_option(packet, "router")
                 if dhcp_router_opt is not None:
-                    router_ip_addr = ip_address(dhcp_router_opt)
+                    router_ip_addr = dhcp_router_opt
                 else:
                     # use DHCP as upstream router in case of missing Open 3.
                     router_ip_addr = dhcp_server_ip

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -132,7 +132,7 @@ class IPAllocatorDHCP(IPAllocator):
         if not dhcp_desc or not dhcp_allocated_ip(dhcp_desc):
             dhcp_desc = self._alloc_ip_address_from_dhcp(mac, vlan_id)
 
-        if dhcp_desc and dhcp_allocated_ip(dhcp_desc):
+        if dhcp_desc and dhcp_desc.subnet and dhcp_allocated_ip(dhcp_desc):
             ip_block = ip_network(dhcp_desc.subnet)
             ip_desc = IPDesc(
                 ip=ip_address(dhcp_desc.ip),
@@ -146,9 +146,7 @@ class IPAllocatorDHCP(IPAllocator):
 
             return ip_desc
         else:
-            msg = "No available IP addresses From DHCP for SID: {} MAC {}".format(
-                sid, mac,
-            )
+            msg = f"No available IP addresses From DHCP for SID: {sid} MAC {mac}"
             raise NoAvailableIPError(msg)
 
     def release_ip(self, ip_desc: IPDesc):

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -28,7 +28,7 @@ class NetworkInfo:
     ):
         gw_ip_parsed = None
         try:
-            gw_ip_parsed = ipaddress.ip_address(gw_ip)
+            gw_ip_parsed = ipaddress.ip_address(gw_ip)  # type: ignore
         except ValueError:
             logging.debug("invalid internet gw ip: %s", gw_ip)
 
@@ -37,11 +37,7 @@ class NetworkInfo:
         self.vlan = vlan
 
     def __str__(self):
-        return "GW-IP: {} GW-MAC: {} VLAN: {}".format(
-            self.gw_ip,
-            self.gw_mac,
-            self.vlan,
-        )
+        return f"GW-IP: {self.gw_ip} GW-MAC: {self.gw_mac} VLAN: {self.vlan}"
 
 
 class StaticIPInfo:
@@ -60,10 +56,11 @@ class StaticIPInfo:
         self.ip = None
         if ip:
             self.ip = ipaddress.ip_address(ip)
+
         self.net_info = NetworkInfo(gw_ip, gw_mac, vlan)
 
     def __str__(self):
-        return "IP: {} NETWORK: {}".format(self.ip, self.net_info)
+        return f"IP: {self.ip} NETWORK: {self.net_info}"
 
 
 class SubscriberDbClient:
@@ -142,7 +139,7 @@ class SubscriberDbClient:
     # use same API to retrieve IP address and related config.
     def _find_ip_and_apn_config(
             self, sid: str,
-    ) -> (Optional[APNConfiguration]):
+    ) -> Optional[APNConfiguration]:
         if '.' in sid:
             imsi, apn_name_part = sid.split('.', maxsplit=1)
             apn_name, _ = apn_name_part.split(',', maxsplit=1)

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -57,10 +57,9 @@ class StaticIPInfo:
         gw_mac: Optional[str],
         vlan: int,
     ):
+        self.ip = None
         if ip:
             self.ip = ipaddress.ip_address(ip)
-        else:
-            self.ip = None
         self.net_info = NetworkInfo(gw_ip, gw_mac, vlan)
 
     def __str__(self):

--- a/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
@@ -255,8 +255,8 @@ class DhcpClient(unittest.TestCase):
         # vlan is configured with subnet : 10.200.x.1
         # router IP is 10.200.x.211
         # x is vlan id
-        exptected_subnet = ipaddress.ip_network("10.200.%s.0/24" % vlan)
-        exptected_router_ip = ipaddress.ip_address("10.200.%s.211" % vlan)
+        exptected_subnet = ipaddress.ip_network(f"10.200.{vlan}.0/24")
+        exptected_router_ip = ipaddress.ip_address(f"10.200.{vlan}.211")
         with self.dhcp_wait:
             dhcp1 = self.dhcp_store.get(mac.as_redis_key(vlan))
             self.assertEqual(dhcp1.subnet, str(exptected_subnet))

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -132,7 +132,7 @@ class UplinkGatewayInfo:
             vlan_id: vlan of the GW, None in case of no vlan used.
         """
         try:
-            ip_addr = ipaddress.ip_address(ip)
+            ip_addr = ipaddress.ip_address(ip)  # type: ignore
         except ValueError:
             logging.debug("could not parse GW IP: %s", ip)
             return
@@ -177,7 +177,7 @@ class UplinkGatewayInfo:
             mac: mac address of the GW.
         """
         try:
-            ip_addr = ipaddress.ip_address(ip)
+            ip_addr = ipaddress.ip_address(ip)  # type: ignore
         except ValueError:
             logging.debug("could not parse GW IP: %s", ip)
             return


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fix mypy issues for mobilityd.

- Argument has incompatible type
- Incompatible types in assigment

## Test Plan
tested with mypy 0.960

```
cd $MAGMA_ROOT/lte/gateway
mypy --ignore-missing-imports python/magma/mobilityd/
```
```
Success: no issues found in 31 source files
```
Unit tests: 
```
vagrant@magma-dev-focal:~/magma$ bazel test lte/gateway/python/magma/...
```
```
Executed 60 out of 60 tests: 60 tests pass.
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
