### PR TITLE
ci(dp): Change domain-proxy workflow trigger

### DIFF
--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -6,7 +6,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - 'v1.*'
-  pull_request:
+  pull_request_target:
     branches:
       - master
       - 'v1.*'


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

As we are using Github secrets in our workflow, we should use pull_request_target as trigger to have them passed to PR from  forked repository.

This was suggested by @Neudrino in https://github.com/magma/magma/issues/12855#issuecomment-1149883837

## Test Plan
- Check CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
