### PR TITLE
feat(ci): exclude yarn.lock from misspell

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -130,6 +130,8 @@ jobs:
           filter_mode: added
           reporter: github-pr-review
           locale: "US"
+          exclude: |
+            nms/yarn.lock
 
   mypy:
     needs: files_changed


### PR DESCRIPTION
... as it contains packages in British English
