### PR TITLE
fix(agw): Formatted config to remove residue after sanity

### DIFF
--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -137,10 +137,10 @@
       "sentry_config": {
         "dsn_native": "",
         "dsn_python": "",
-        "sample_rate": 1.0,
-        "upload_mme_log": false,
+        "exclusion_patterns": [],
         "number_of_lines_in_log": 0,
-        "exclusion_patterns": []
+        "sample_rate": 1.0,
+        "upload_mme_log": false
       }
     },
     "state": {


### PR DESCRIPTION
## Title
fix(agw): Formatted config to remove residue after sanity

## Summary
The test scenario s1aptests/test_attach_detach_non_nat_dp_ul_tcp.py is modifying the configuration file which leaves residue after execution during sanity. This PR uploads the modified configuration in sorted order to prevent residue after test case execution.

## Test plan
Verified with sanity

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>