### PR TITLE
fix(agw): suppressed dual exception message

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -222,7 +222,7 @@ class S1ApUtil(object):
                     "Timeout ("
                     + str(timeout)
                     + " sec) occurred while waiting for response message",
-                )
+                ) from None
 
     def populate_pco(
         self,


### PR DESCRIPTION
## Title
fix(agw): suppressed dual exception message

## Summary
Some of the test cases were throwing unnecessary dual exceptions if timeout occurs while waiting for messages. This PR suppresses the dual exception messages by discarding exception chain


Example of unnecessary dual exception:
```
test_activate_deactivate_multiplededicated failed (2 runs remaining out of 3).Traceback (most recent call last):
          File "/home/vagrant/magma/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py", line 218, in get_response
            return self._msg.get(True, timeout)
          File "/usr/lib/python3.5/queue.py", line 172, in get
            raise Empty
        queue.Empty

        During handling of the above exception, another exception occurred:

        Traceback (most recent call last):
          File "/usr/lib/python3.5/unittest/case.py", line 59, in testPartExecutor
            yield
          File "/usr/lib/python3.5/unittest/case.py", line 601, in run
            testMethod()
          File "/home/vagrant/magma/lte/gateway/python/integ_tests/s1aptests/test_activate_deactivate_multiple_dedicated.py", line 114, in test_activate_deactivate_multiplededicated
            response = self._s1ap_wrapper.s1_util.get_response()
          File "/home/vagrant/magma/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py", line 224, in get_response
            + " sec) occurred while waiting for response message",
        AssertionError: Timeout (180 sec) occurred while waiting for response message
```

Suppressed excption:
```
test_activate_deactivate_multiplededicated failed (2 runs remaining out of 3).Traceback (most recent call last):
          File "/usr/lib/python3.5/unittest/case.py", line 59, in testPartExecutor
            yield
          File "/usr/lib/python3.5/unittest/case.py", line 601, in run
            testMethod()
          File "/home/vagrant/magma/lte/gateway/python/integ_tests/s1aptests/test_activate_deactivate_multiple_dedicated.py", line 114, in test_activate_deactivate_multiplededicated
            response = self._s1ap_wrapper.s1_util.get_response()
          File "/home/vagrant/magma/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py", line 225, in get_response
            ) from None

```

## Test plan
Verified with sanity

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>