### PR TITLE
chore(ci): Run the LTE integ tests on bazel-built services

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -1,0 +1,85 @@
+---
+name: LTE integ test bazel
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - build-all
+    branches:
+      - master
+      - 'v1.*'
+    types:
+      - completed
+
+jobs:
+  lte-integ-test-bazel:
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-10.15
+    env:
+      SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.SHA }}
+      - name: setup pyenv
+        uses: "gabrielfalcao/pyenv-action@v8"
+        with:
+          default: 3.8.5
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.5'
+      - name: Install pre requisites
+        run: |
+          pip3 install --upgrade pip
+          pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
+          vagrant plugin install vagrant-vbguest vagrant-disksize
+      - name: Open up network interfaces for VM
+        run: |
+          sudo mkdir -p /etc/vbox/
+          sudo touch /etc/vbox/networks.conf
+          sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
+      - name: Configure bazel remote cache
+        run: |
+          bazel/scripts/remote_cache_bazelrc_setup.sh "magma-vm-lte-integ" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+      - name: Run the integ test
+        run: |
+          cd lte/gateway
+          export MAGMA_DEV_CPUS=3
+          export MAGMA_DEV_MEMORY_MB=8192
+          fab integ_test:bazel_build="True"
+      - name: Upload bazel profile
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Bazel profile lte integ tests
+          path: bazel_profile_lte_integ_tests
+      - name: Get test results
+        if: always()
+        run: |
+          cd lte/gateway
+          fab get_test_summaries:dst_path="test-results"
+          ls -R
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-results
+          path: lte/gateway/test-results/**/*.xml
+      - name: Get test logs
+        if: failure()
+        run: |
+          cd lte/gateway
+          fab get_test_logs:dst_path=./logs.tar.gz
+      - name: Upload test logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-logs
+          path: lte/gateway/logs.tar.gz
+      - name: Publish Unit Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        with:
+          files: lte/gateway/test-results/**/*.xml
+          check_run_annotations: all tests

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@connectiond.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@connectiond.service
@@ -1,0 +1,35 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma connection tracking service
+PartOf=magma@mme.service
+Before=magma@mme.service
+After=magma@pipelined.service
+After=openvswitch-switch.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/connection_tracker/src/connectiond
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py connectiond
+MemoryAccounting=yes
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=connectiond
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@ctraced.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@ctraced.service
@@ -1,0 +1,29 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma ctraced service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/ctraced/ctraced
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py ctraced
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=ctraced
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@directoryd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@directoryd.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma directoryd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/directoryd/directoryd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py directoryd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=directoryd
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@enodebd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@enodebd.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma enodebd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/enodebd/enodebd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py enodebd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=enodebd
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@eventd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@eventd.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma eventd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStartPre=/usr/sbin/ntpdate pool.ntp.org
+ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/eventd/eventd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py eventd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=eventd
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@health.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@health.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma health service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/health/health
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py health
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=health
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@kernsnoopd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@kernsnoopd.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma kernsnoopd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/kernsnoopd/kernsnoopd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py kernsnoopd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=kernsnoopd
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@liagentd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@liagentd.service
@@ -1,0 +1,33 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma li agent service
+PartOf=magma@pipelined.service
+After=magma@pipelined.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/li_agent/src/liagentd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py liagentd
+MemoryAccounting=yes
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=liagentd
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@magmad.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@magmad.service
@@ -1,0 +1,31 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma magmad service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/magmad/magmad
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py magmad
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=magmad
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+KillMode=process
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mme.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mme.service
@@ -1,0 +1,43 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma OAI MME service
+PartOf=magma@mobilityd.service
+After=magma@mobilityd.service
+PartOf=magma@pipelined.service
+After=magma@pipelined.service
+PartOf=magma@sessiond.service
+After=magma@sessiond.service
+Requires=sctpd.service
+After=sctpd.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/core/oai_mme -c /var/opt/magma/tmp/mme.conf -s /var/opt/magma/tmp/spgw.conf
+MemoryAccounting=yes
+MemoryLimit=13%
+MemoryMin=512M
+ExecStartPre=/usr/bin/env python3 /usr/local/bin/generate_oai_config.py
+ExecStartPre=/usr/bin/env python3 /usr/local/bin/config_stateless_agw.py reset_sctpd_for_stateful
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py mme
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=mme
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mobilityd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mobilityd.service
@@ -1,0 +1,35 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma mobilityd service
+PartOf=magma@mme.service
+Before=magma@mme.service
+After=magma@subscriberdb.service
+Wants=magma@subscriberdb.service
+After=openvswitch-switch.service
+Wants=openvswitch-switch.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/mobilityd/mobilityd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py mobilityd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=mobilityd
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@monitord.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@monitord.service
@@ -1,0 +1,31 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma monitord service
+PartOf=magma@mme.service
+Before=magma@mme.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/monitord/monitord
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py monitord
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=monitord
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@pipelined.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@pipelined.service
@@ -1,0 +1,47 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma pipelined service
+PartOf=magma@mme.service
+Before=magma@mme.service
+PartOf=magma@mobilityd.service
+After=magma@mobilityd.service
+PartOf=openvswitch-switch.service
+After=openvswitch-switch.service
+Wants=openvswitch-switch.service
+
+[Service]
+Type=simple
+PermissionsStartOnly=true
+LimitNOFILE=65536
+LimitNPROC=65536
+LimitSIGPENDING=65536
+EnvironmentFile=/etc/environment
+ExecStartPre=/usr/bin/ovs-vsctl --all destroy Flow_Sample_Collector_Set
+ExecStartPre=/usr/bin/ovs-vsctl set bridge gtp_br0 protocols=OpenFlow10,OpenFlow13,OpenFlow14 other-config:disable-in-band=true
+ExecStartPre=/usr/bin/ovs-vsctl set-controller gtp_br0 tcp:127.0.0.1:6633 tcp:127.0.0.1:6654
+ExecStartPre=/usr/bin/ovs-vsctl set-fail-mode gtp_br0 secure
+ExecStartPre=/bin/bash -c 'for id in `sudo /usr/bin/ovsdb-client dump Controller _uuid|tail -n +4` ; do  sudo /usr/bin/ovs-vsctl set Controller $id inactivity_probe=300  ; done'
+ExecStartPre=/usr/bin/ovs-vsctl set-manager ptcp:6640
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/pipelined/pipelined
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py pipelined
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=pipelined
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=13%
+MemoryMin=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@policydb.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@policydb.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma policydb service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/policydb/policydb
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py policydb
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=policydb
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@redirectd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@redirectd.service
@@ -1,0 +1,29 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma redirectd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/redirectd/redirectd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=redirectd
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@sessiond.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@sessiond.service
@@ -1,0 +1,34 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma session manager service
+PartOf=magma@mme.service
+Before=magma@mme.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/session_manager/sessiond
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py sessiond
+MemoryAccounting=yes
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sessiond
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+MemoryLimit=8%
+MemoryMin=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@smsd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@smsd.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma smsd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/smsd/smsd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py smsd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=smsd
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@state.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@state.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma state service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/state/state
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py state
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=state
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@subscriberdb.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@subscriberdb.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma subscriberdb service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/subscriberdb/subscriberdb
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py subscriberdb
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=subscriberdb
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/sctpd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/sctpd.service
@@ -1,0 +1,37 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma sctpd service
+Before=magma@mme.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStartPre=-/bin/cp -f /usr/local/share/sctpd/version /var/run/sctpd.version
+ExecStartPre=/usr/bin/env python3 /usr/local/bin/config_stateless_agw.py sctpd_pre
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/sctpd/src/sctpd
+ExecStartPost=/usr/bin/env python3 /usr/local/bin/config_stateless_agw.py sctpd_post
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py sctpd
+ExecStopPost=-/bin/rm -f /var/run/sctpd.version
+MemoryAccounting=yes
+MemoryLimit=512M
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sctpd
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Create LTE integ test workflow that runs the integ tests on the bazel-built services.
  - Create service files for all services that start the bazel-built executables.
    - This is done by copying the standard service files and changing the ExecStart command.
    - The services that use the template service file get new service files derived from the template. 
  - Service files are copied at runtime into the `/etc/systemd/system/` folder.

## Test Plan

Manually run the workflow.
- [#1 Run on fork, with log level "warning".](https://github.com/LKreutzer/magma/actions/runs/2475783198)
- [#2 Run on fork, with log level "warning".](https://github.com/LKreutzer/magma/actions/runs/2475079087)
- [#3 Run on fork, with log level "warning".](https://github.com/LKreutzer/magma/actions/runs/2488809869)
- [#4 Run on fork, with log level "warning".](https://github.com/LKreutzer/magma/actions/runs/2488821759)
- ( [Run on fork, with log level "fatal".](https://github.com/LKreutzer/magma/actions/runs/2475079087))

## Additional Information

- Note: The log level of bazel needs to be limited in order to not block the SSH connection of fabric. Here this is done with `--ui_event_filters=warning` (see https://github.com/bazelbuild/bazel/issues/4867).
  - Higher log levels lead to much longer run times of the workflow.
  - A better solution to this issue will be investigated. This will also benefit the other parts of the workflow and possibly the standard LTE workflow. E.g.:
    - Do not use fabric
    - Suppress all bazel logging and upload `/tmp/bazel/command.log` afterwards
    - Reconfigure fabric to allow more traffic through SSH if possible (?)
    - ...
- Note: We do not use a GH matrix workflow here in order to keep the complexity low, to not disrupt the result reporting from the standard LTE integ test workflow and because we expect further modifications of this workflow that may be incompatible with the standard workflow.
- Note: The `/etc/gai.conf` file is temporarily - for the bazel build - modified in order to prefer IPv4 connections which speeds up the bazel build.


- [ ] This change is backwards-breaking