### PR TITLE
chore(mme): static init is refactored

### DIFF
--- a/lte/gateway/c/core/oai/lib/s6a_proxy/S6aClient.hpp
+++ b/lte/gateway/c/core/oai/lib/s6a_proxy/S6aClient.hpp
@@ -78,6 +78,17 @@ class S6aClient : public GRPCReceiver {
  public:
   S6aClient(S6aClient const&) = delete;
   void operator=(S6aClient const&) = delete;
+  // There are 3 services which can handle authentication:
+  // 1) Local subscriberdb
+  // 2) Subscriberdb in the cloud (EPS Authentication)
+  // 3) S6a Proxy running in the FeG
+  // When relay_enabled is true, then auth requests are sent to the S6a Proxy.
+  // Otherwise, if cloud_subscriberdb_enabled is true, then auth requests are
+  // sent to the EPS Authentication service.
+  // If neither flag is true, then a local instance of subscriberdb receives the
+  // auth messages.
+  static bool get_s6a_relay_enabled();
+  static bool get_cloud_subscriberdb_enabled();
 
  private:
   S6aClient(bool enable_s6a_proxy_channel);
@@ -85,20 +96,10 @@ class S6aClient : public GRPCReceiver {
   static S6aClient& get_s6a_proxy_instance();
   static S6aClient& get_subscriberdb_instance();
   static S6aClient& get_client_based_on_fed_mode(const char* imsi);
+  static bool read_hss_relay_enabled();
+  static bool read_mme_cloud_subscriberdb_enabled();
   std::unique_ptr<feg::S6aProxy::Stub> stub_;
   static const uint32_t RESPONSE_TIMEOUT = 10;  // seconds
 };
-
-// There are 3 services which can handle authentication:
-// 1) Local subscriberdb
-// 2) Subscriberdb in the cloud (EPS Authentication)
-// 3) S6a Proxy running in the FeG
-// When relay_enabled is true, then auth requests are sent to the S6a Proxy.
-// Otherwise, if cloud_subscriberdb_enabled is true, then auth requests are
-// sent to the EPS Authentication service.
-// If neither flag is true, then a local instance of subscriberdb receives the
-// auth messages.
-bool get_s6a_relay_enabled(void);
-bool get_cloud_subscriberdb_enabled(void);
 
 }  // namespace magma

--- a/lte/gateway/c/core/oai/lib/s6a_proxy/s6a_client_api.cpp
+++ b/lte/gateway/c/core/oai/lib/s6a_proxy/s6a_client_api.cpp
@@ -42,7 +42,7 @@ bool s6a_purge_ue(const char* imsi) {
   if (imsi == nullptr) {
     return false;
   }
-  if (!get_s6a_relay_enabled()) {
+  if (!magma::S6aClient::get_s6a_relay_enabled()) {
     return true;
   }
   magma::S6aClient::purge_ue(imsi, [imsiStr = std::string(imsi)](


### PR DESCRIPTION
## Summary

This is a preparation for building mme oai with statically linked libraries. This is needed for building a hermetically-ish mme artifact with bazel.

**Problem (in a build with statically linked libraries)**
* In a make build `protobuf` and `glog` are linked dynamically.
* In `S6AClient` are static variables that are initialized by using `protobuf` functionality (json to message mapping). This does not work with statically linked libraries. Furthermore, in the error handling `glog` is used which then also fails with dynamic linking.

**Solution here**
* There are two variables that are initialized with `protobuf` calls.
* The variables are refactored to do the `protobuf` calls after the initialization phase when the result is actually needed (but the results are cached as before).

Best practice suggestions to solve this more elegant are appreciated.

Note: disregard the branch name, as in a first approach one of the variables was removed as dead code.

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
