### PR TITLE
chore(ci): Consolidate Python versions

### DIFF
--- a/.github/workflows/agw-docker-load-test.yaml
+++ b/.github/workflows/agw-docker-load-test.yaml
@@ -31,10 +31,10 @@ jobs:
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
-          default: 3.7.0
+          default: 3.8.10
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - name: Install Dependencies
         run: |
           pip install ansible awscli boto3 boto

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -71,10 +71,10 @@ jobs:
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
-          default: 3.8.5
+          default: 3.8.10
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.8.5'
+          python-version: '3.8.10'
       - name: Run apt-focal-install-aioeventlet
         run: |
           cd nms

--- a/.github/workflows/amis-workflow.yml
+++ b/.github/workflows/amis-workflow.yml
@@ -25,10 +25,10 @@ jobs:
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
-          default: 3.7.0
+          default: 3.8.10
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - name: Install Dependencies
         run: |
           pip install ansible awscli boto3
@@ -168,10 +168,10 @@ jobs:
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
-          default: 3.7.0
+          default: 3.8.10
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - name: Install Dependencies
         run: |
           pip install ansible awscli boto3 boto

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - run: |
           mkdir ~/.magma
           echo ${{ secrets.GITHUB_TOKEN }} > ~/.magma/github_access_token

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -47,7 +47,7 @@ jobs:
           default: 3.8.5
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.8.5'
+          python-version: '3.8.10'
       - name: Install pre requisites
         run: |
           pip3 install --upgrade pip

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -119,7 +119,7 @@ jobs:
           default: 3.8.5
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.8.5'
+          python-version: '3.8.10'
       - name: Install pre requisites
         run: |
           pip3 install --upgrade pip
@@ -279,7 +279,7 @@ jobs:
         run: sudo apt-get update
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - name: Run build.py
         run: |
           cd ${MAGMA_ROOT}/orc8r/cloud/docker
@@ -736,7 +736,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - name: generate test certs and snowflake
         run: |
           # TODO add rootCA.pem and snowflake files in the ubuntu-1604:201903-01 image
@@ -923,7 +923,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - name: Publish to
         env:
           FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - name: deploy-sync-checkin
         if: always()
         id: deploy-sync-checkin

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -76,7 +76,7 @@ jobs:
           default: 3.8.5
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.8.5'
+          python-version: '3.8.10'
       - name: Install pre requisites
         run: |
           pip3 install --upgrade pip

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - name: Run docs precommit
         run: |
           cd ${MAGMA_ROOT}/docs
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - name: Run docs `make`
         run: |
           cd ${MAGMA_ROOT}/docs

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -96,7 +96,7 @@ jobs:
         working-directory: dp/cloud/python/magma/configuration_controller
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ 3.8.10 ]
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
 
@@ -193,7 +193,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ 3.8.10 ]
     steps:
 
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
@@ -271,7 +271,7 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}/dp/cloud/python
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ 3.8.10 ]
     services:
       postgres:
         image: postgres:13.3
@@ -320,7 +320,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ 3.8.10 ]
     steps:
 
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2

--- a/.github/workflows/insync-checkin.yml
+++ b/.github/workflows/insync-checkin.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8.10'
       - name: Run build.py
         run: |
           cd ${MAGMA_ROOT}/orc8r/cloud/docker

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -44,7 +44,7 @@ jobs:
           default: 3.8.5
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.8.5'
+          python-version: '3.8.10'
       - name: Install pre requisites
         run: |
           pip3 install --upgrade pip

--- a/.github/workflows/testim-workflow.yml
+++ b/.github/workflows/testim-workflow.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Setup pyenv
         uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
-          default: 3.8.5
+          default: 3.8.10
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
-          python-version: '3.8.5'
+          python-version: '3.8.10'
       - name: Install Python Dependencies
         run: |
           python3 -m pip install junit2html requests xmltodict


### PR DESCRIPTION
## Summary

Makes the Python versions in the GitHub workflows consistent and the same as the version installed in the magma test VM.

## Test Plan

- [x] CI