### PR TITLE
fix(ci): Fix bazel remote cache config for bazel version 5

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,8 +24,6 @@ build:vm --define=folly_so=1
 build:vm --config=specify_vm_cc
 
 # MAGMA-BUILDER DOCKER CONTAINER CONFIGS
-build:docker --disk_cache=/workspaces/magma/.bazel-cache
-common:docker --repository_cache=/workspaces/magma/.bazel-cache-repo
 build:docker --define=folly_so=1
 
 # DEVCONTAINER CONFIGS

--- a/bazel/bazelrcs/docker.bazelrc
+++ b/bazel/bazelrcs/docker.bazelrc
@@ -1,1 +1,1 @@
-common --config=docker
+build --config=docker


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- In bazel 5 the disk and repository cache configs (in `config:docker`) clash with the remote cache config and the PUT requests to the remote cache are not processed properly.
  - The disk and repository cache configs are disabled for the bazel base container.

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking
