### PR TITLE
chore(agw): remove docker container privileges in agw

### DIFF
--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -1,4 +1,3 @@
----
 version: "3.7"
 
 # Standard logging for each service
@@ -122,8 +121,6 @@ services:
       test: ["CMD", "nc", "-zv", "localhost", "50080"]
       timeout: "4s"
       retries: 3
-    # Needed in order to enable/disable ICMP
-    privileged: true
     command: /usr/bin/env python3 -m magma.health.main
 
   monitord:
@@ -133,6 +130,8 @@ services:
       test: ["CMD", "nc", "-zv", "localhost", "50076"]
       timeout: "4s"
       retries: 3
+    cap_add:
+      - NET_RAW
     command: /usr/bin/env python3 -m magma.monitord.main
 
   redirectd:
@@ -177,7 +176,6 @@ services:
   sctpd:
     <<: *ltecservice
     container_name: sctpd
-    privileged: true
     ulimits:
       core: -1
     security_opt:
@@ -240,7 +238,6 @@ services:
       core: -1
     security_opt:
       - seccomp:unconfined
-    privileged: true
     environment:
       MAGMA_PRINT_GRPC_PAYLOAD: 0
     depends_on:
@@ -295,7 +292,8 @@ services:
       test: ["CMD", "nc", "-zv", "localhost", "50082"]
       timeout: "4s"
       retries: 3
-    privileged: true
+    cap_add:
+      - NET_ADMIN
     command: /usr/local/bin/connectiond
 
   liagentd:
@@ -305,6 +303,5 @@ services:
       test: ["CMD", "nc", "-zv", "localhost", "50065"]
       timeout: "4s"
       retries: 3
-    privileged: true
     command: /usr/local/bin/liagentd
     restart: "no"


### PR DESCRIPTION
Signed-off-by: Christian Krämer <christian.kraemer@tngtech.com>

## Summary

Removed priviliges for all running agw containers.

## Test Plan

I made sure that a least the health check for the container works.

## Additional Information

For pipelined and mme I was unable to test the changes at all so I skipped removing the privileges  there. Added required icmp capabilities to monitord as all monitord does is monitoring subscribers via icmp. 

Is there a way to run the integration tests against these containers? -> Answer: No. See seperate PR.