### PR TITLE
chore(enodebd): fix type errors to make mypy green

### DIFF
--- a/lte/gateway/python/magma/enodebd/data_models/data_model.py
+++ b/lte/gateway/python/magma/enodebd/data_models/data_model.py
@@ -102,7 +102,8 @@ class DataModel(ABC):
     def get_names_of_optional_params(cls) -> List[ParameterName]:
         all_optional_params = []
         for name in cls.get_parameter_names():
-            if cls.get_parameter(name).is_optional:
+            parameter = cls.get_parameter(name)
+            if parameter and parameter.is_optional:
                 all_optional_params.append(name)
         return all_optional_params
 

--- a/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
+++ b/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import textwrap
-from typing import Optional, Union
+from typing import Optional, Union, no_type_check
 
 from magma.enodebd.exceptions import ConfigurationError
 from magma.enodebd.logger import EnodebdLogger as logger
@@ -58,6 +58,7 @@ def gps_tr181(value: str) -> str:
         return value
 
 
+@no_type_check
 def bandwidth(bandwidth_rbs: Union[str, int, float]) -> float:
     """
     Map bandwidth in number of RBs to MHz
@@ -65,7 +66,7 @@ def bandwidth(bandwidth_rbs: Union[str, int, float]) -> float:
     BaiCells eNodeB uses 'n6'. Need to resolve this.
 
     Args:
-        bandwidth_rbs (str): Bandwidth in number of RBs
+        bandwidth_rbs (str, int, float): Bandwidth in number of RBs
     Returns:
         str: Bandwidth in MHz
     """

--- a/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
@@ -13,7 +13,7 @@ limitations under the License.
 
 import json
 from collections import namedtuple
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Dict, List
 
 from lte.protos.mconfig import mconfigs_pb2
 from magma.common.misc_utils import get_ip_from_if
@@ -140,7 +140,7 @@ def _get_enb_yang_config(
     Returns:
         None or a SingleEnodebConfig from YANG with matching serial number
     """
-    enb = []
+    enb: List[Dict[Any, Any]] = []
     mme_list = []
     mme_address = None
     mme_port = None
@@ -428,10 +428,10 @@ def _set_plmnids_tac(
     Input 'plmnids' is comma-separated list of PLMNIDs
     """
     # Convert int PLMNID to string
-    if type(plmnids) == int:
+    if isinstance(plmnids, int):
         plmnid_str = str(plmnids)
     else:
-        config_assert(type(plmnids) == str, 'PLMNID must be string')
+        config_assert(isinstance(plmnids, str), 'PLMNID must be string')
         plmnid_str = plmnids
 
     # Multiple PLMNIDs will be supported using comma-separated list.

--- a/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
@@ -13,7 +13,7 @@ limitations under the License.
 
 import json
 from collections import namedtuple
-from typing import Any, Optional, Union, Dict, List
+from typing import Any, Dict, List, Optional, Union
 
 from lte.protos.mconfig import mconfigs_pb2
 from magma.common.misc_utils import get_ip_from_if
@@ -85,7 +85,7 @@ def build_desired_config(
 
     # Attempt to load device configuration from YANG before service mconfig
     enb_config = _get_enb_yang_config(device_config) or \
-                 _get_enb_config(mconfig, device_config)
+        _get_enb_config(mconfig, device_config)
 
     _set_earfcn_freq_band_mode(
         device_config, cfg_desired, data_model,

--- a/lte/gateway/python/magma/enodebd/device_config/enodeb_configuration.py
+++ b/lte/gateway/python/magma/enodebd/device_config/enodeb_configuration.py
@@ -12,7 +12,7 @@ limitations under the License.
 """
 
 import json
-from typing import Any, List
+from typing import Any, Dict, List
 
 from magma.enodebd.data_models.data_model import DataModel
 from magma.enodebd.data_models.data_model_parameters import ParameterName
@@ -43,10 +43,10 @@ class EnodebConfiguration():
         self._data_model = data_model
 
         # Dict[ParameterName, Any]
-        self._param_to_value = {}
+        self._param_to_value: Dict[ParameterName, Any] = {}
 
         # Dict[ParameterName, Dict[ParameterName, Any]]
-        self._numbered_objects = {}
+        self._numbered_objects: Dict[ParameterName, Dict[ParameterName, Any]] = {}
         # If adding a PLMN object, then you would set something like
         # self._numbered_objects['PLMN_1'] = {'PLMN_1_ENABLED': True}
 

--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -55,7 +55,7 @@ class BaicellsHandler(BasicEnodebAcsStateMachine):
         self,
         service: MagmaService,
     ) -> None:
-        self._state_map = {}
+        self._state_map: Dict[str, Any] = {}
         super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -55,7 +55,7 @@ class BaicellsOldHandler(BasicEnodebAcsStateMachine):
             self,
             service: MagmaService,
     ) -> None:
-        self._state_map = {}
+        self._state_map: Dict[str, Any] = {}
         super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafa.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafa.py
@@ -55,7 +55,7 @@ class BaicellsQAFAHandler(BasicEnodebAcsStateMachine):
         self,
         service: MagmaService,
     ) -> None:
-        self._state_map = {}
+        self._state_map: Dict[str, Any] = {}
         super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
@@ -64,7 +64,7 @@ class BaicellsQAFBHandler(BasicEnodebAcsStateMachine):
             self,
             service: MagmaService,
     ) -> None:
-        self._state_map = {}
+        self._state_map: Dict[str, Any] = {}
         super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:
@@ -139,7 +139,7 @@ def _get_object_params_to_get(
     if device_cfg.has_object(ParameterName.PLMN_N % 1):
         return []
 
-    names = []
+    names: List[ParameterName] = []
     num_plmns = data_model.get_num_plmns()
     obj_to_params = data_model.get_numbered_param_names()
     for i in range(1, num_plmns + 1):

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qrtb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qrtb.py
@@ -374,6 +374,7 @@ class BaicellsQRTBQueuedEventsWaitState(EnodebAcsState):
         return 'Waiting for eNB REM to run for %d more seconds before ' \
                'resuming with configuration.' % remaining
 
+
 class BaicellsQRTBWaitInformRebootState(WaitInformMRebootState):
     """
     BaicellsQRTB WaitInformRebootState implementation

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qrtb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qrtb.py
@@ -85,7 +85,7 @@ class BaicellsQRTBHandler(BasicEnodebAcsStateMachine):
             self,
             service: MagmaService,
     ) -> None:
-        self._state_map = {}
+        self._state_map: Dict[str, Any] = {}
         super().__init__(service, use_param_key=False)
 
     def reboot_asap(self) -> None:
@@ -343,6 +343,10 @@ class BaicellsQRTBQueuedEventsWaitState(EnodebAcsState):
         Returns:
             AcsMsgAndTransition
         """
+        if not self.wait_timer:
+            logger.error('wait_timer is None.')
+            raise ValueError('wait_timer is None.')
+
         if self.wait_timer.is_done():
             return AcsMsgAndTransition(
                 msg=models.DummyInput(),
@@ -362,10 +366,13 @@ class BaicellsQRTBQueuedEventsWaitState(EnodebAcsState):
         Returns:
             str
         """
+        if not self.wait_timer:
+            logger.error('wait_timer is None.')
+            raise ValueError('wait_timer is None.')
+
         remaining = self.wait_timer.seconds_remaining()
         return 'Waiting for eNB REM to run for %d more seconds before ' \
                'resuming with configuration.' % remaining
-
 
 class BaicellsQRTBWaitInformRebootState(WaitInformMRebootState):
     """

--- a/lte/gateway/python/magma/enodebd/devices/baicells_rts.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_rts.py
@@ -54,7 +54,7 @@ class BaicellsRTSHandler(BasicEnodebAcsStateMachine):
             self,
             service: MagmaService,
     ) -> None:
-        self._state_map = {}
+        self._state_map: Dict[str, Any] = {}
         super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:

--- a/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
@@ -201,13 +201,13 @@ class CaviumDisableAdminEnableState(EnodebAcsState):
         param_name = ParameterName.ADMIN_STATE
         # if we want the cell to be down don't force it up
         desired_admin_value = \
-                self.acs.desired_cfg.get_parameter(param_name) \
-                and self.admin_value
+            self.acs.desired_cfg.get_parameter(param_name) \
+            and self.admin_value
         admin_value = \
-                self.acs.data_model.transform_for_enb(
-                    param_name,
-                    desired_admin_value,
-                )
+            self.acs.data_model.transform_for_enb(
+                param_name,
+                desired_admin_value,
+            )
         admin_path = self.acs.data_model.get_parameter(param_name).path
         param_values = {admin_path: admin_value}
 
@@ -267,13 +267,13 @@ class CaviumWaitDisableAdminEnableState(EnodebAcsState):
             )
         param_name = ParameterName.ADMIN_STATE
         desired_admin_value = \
-                self.acs.desired_cfg.get_parameter(param_name) \
-                and self.admin_value
+            self.acs.desired_cfg.get_parameter(param_name) \
+            and self.admin_value
         magma_value = \
-                self.acs.data_model.transform_for_magma(
-                    param_name,
-                    desired_admin_value,
-                )
+            self.acs.data_model.transform_for_magma(
+                param_name,
+                desired_admin_value,
+            )
         self.acs.device_cfg.set_parameter(param_name, magma_value)
 
         if len(

--- a/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
@@ -63,7 +63,7 @@ class CaviumHandler(BasicEnodebAcsStateMachine):
             self,
             service: MagmaService,
     ) -> None:
-        self._state_map = {}
+        self._state_map: Dict[str, Any] = {}
         super().__init__(service=service, use_param_key=False)
 
     def reboot_asap(self) -> None:

--- a/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
+++ b/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
@@ -12,7 +12,7 @@ limitations under the License.
 """
 import logging
 from math import log10
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from dp.protos.enodebd_dp_pb2 import CBSDRequest, CBSDStateResult
 from magma.enodebd.data_models import transform_for_magma
@@ -472,7 +472,7 @@ class FreedomFiOneHandler(BasicEnodebAcsStateMachine):
             self,
             service,
     ) -> None:
-        self._state_map = {}
+        self._state_map: Dict[str, Any] = {}
         super().__init__(service=service, use_param_key=True)
 
     def reboot_asap(self) -> None:
@@ -790,7 +790,7 @@ class FreedomFiOneTrDataModel(DataModel):
             is_optional=False,
         ),
     }
-    TRANSFORMS_FOR_ENB = {}
+    TRANSFORMS_FOR_ENB: Dict[ParameterName, Callable[[Any], Any]] = {}
     NUM_PLMNS_IN_CONFIG = 1
     for i in range(1, NUM_PLMNS_IN_CONFIG + 1):  # noqa: WPS604
         PARAMETERS[ParameterName.PLMN_N % i] = TrParam(
@@ -918,7 +918,7 @@ class FreedomFiOneTrDataModel(DataModel):
         return names
 
     @classmethod
-    def get_sas_param_names(cls) -> List[ParameterName]:
+    def get_sas_param_names(cls) -> Iterable[ParameterName]:
         """
         Retrieve names of SAS parameters
 

--- a/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
+++ b/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
@@ -53,8 +53,7 @@ def does_iface_config_match_expected(ip: str, netmask: str) -> bool:
 
 
 def _get_prerouting_rules(output: str) -> List[str]:
-    prerouting_rules = output.split('\n\n')[0]
-    prerouting_rules = prerouting_rules.split('\n')
+    prerouting_rules = output.split('\n\n')[0].split('\n')
     # Skipping the first two lines since it contains only column names
     prerouting_rules = prerouting_rules[2:]
     return prerouting_rules

--- a/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
@@ -280,7 +280,7 @@ def get_obj_param_values_to_set(
     data_model: DataModel,
 ) -> Dict[ParameterName, Dict[ParameterName, Any]]:
     """ Returns a map from object name to (a map of param name to value) """
-    param_values = {}
+    param_values: Dict[ParameterName, Dict[ParameterName, Any]] = {}
     objs = desired_cfg.get_object_names()
     for obj_name in objs:
         param_values[obj_name] = {}

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs.py
@@ -13,7 +13,7 @@ limitations under the License.
 from abc import ABC, abstractmethod
 from asyncio import BaseEventLoop
 from time import time
-from typing import Any, Type
+from typing import Any, Type, Optional
 
 from magma.common.service import MagmaService
 from magma.enodebd.data_models.data_model import DataModel
@@ -49,7 +49,7 @@ class EnodebAcsStateMachine(ABC):
         self._are_invasive_changes_applied = True
         # Flag to preseve backwards compatibility
         self._use_param_key = use_param_key
-        self._param_version_key = None
+        self._param_version_key: Optional[int] = None
 
     def has_parameter(self, param: ParameterName) -> bool:
         """
@@ -130,16 +130,25 @@ class EnodebAcsStateMachine(ABC):
         self._service = service
 
     @property
-    def event_loop(self) -> BaseEventLoop:
-        return self._service.loop
+    def event_loop(self) -> Optional[BaseEventLoop]:
+        if self._service:
+            return self._service.loop
+        else:
+            return None
 
     @property
     def mconfig(self) -> Any:
-        return self._service.mconfig
+        if self._service:
+            return self._service.mconfig
+        else:
+            return None
 
     @property
     def service_config(self) -> Any:
-        return self._service.config
+        if self._service:
+            return self._service.config
+        else:
+            return None
 
     @property
     def desired_cfg(self) -> EnodebConfiguration:
@@ -163,23 +172,23 @@ class EnodebAcsStateMachine(ABC):
     def data_model(self) -> DataModel:
         return self._data_model
 
+    @data_model.setter
+    def data_model(self, data_model) -> None:
+        self._data_model = data_model
+
     @property
     def has_version_key(self) -> bool:
         """ Return if the ACS supports param version key """
         return self._use_param_key
 
     @property
-    def parameter_version_key(self) -> int:
+    def parameter_version_key(self) -> Optional[int]:
         """ Return the param version key """
         return self._param_version_key
 
     def parameter_version_inc(self):
         """ Set the internal version key to the timestamp """
         self._param_version_key = time()
-
-    @data_model.setter
-    def data_model(self, data_model) -> None:
-        self._data_model = data_model
 
     @property
     def are_invasive_changes_applied(self) -> bool:

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs.py
@@ -13,7 +13,7 @@ limitations under the License.
 from abc import ABC, abstractmethod
 from asyncio import BaseEventLoop
 from time import time
-from typing import Any, Type, Optional
+from typing import Any, Optional, Type
 
 from magma.common.service import MagmaService
 from magma.enodebd.data_models.data_model import DataModel

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
@@ -70,7 +70,7 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
             use_param_key: bool,
     ) -> None:
         super().__init__(use_param_key=use_param_key)
-        self.state = None
+        self.state: EnodebAcsState
         self.timeout_handler = None
         self.mme_timeout_handler = None
         self.mme_timer = None
@@ -226,9 +226,9 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
         """
         if isinstance(message, models.Inform):
             logger.debug(
-                'ACS in (%s) state. Received an Inform message',
-                self.state.state_description(),
-            )
+                    'ACS in (%s) state. Received an Inform message',
+                    self.state.state_description(),
+                )
             self._reset_state_machine(self.service)
         elif isinstance(message, models.Fault):
             logger.debug(

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
@@ -226,9 +226,9 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
         """
         if isinstance(message, models.Inform):
             logger.debug(
-                    'ACS in (%s) state. Received an Inform message',
-                    self.state.state_description(),
-                )
+                'ACS in (%s) state. Received an Inform message',
+                self.state.state_description(),
+            )
             self._reset_state_machine(self.service)
         elif isinstance(message, models.Fault):
             logger.debug(

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_manager.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_manager.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from magma.common.service import MagmaService
 from magma.enodebd.device_config.configuration_util import is_enb_registered
@@ -40,7 +40,7 @@ class StateMachineManager:
     ):
         self._ip_serial_mapping = IpToSerialMapping()
         self._service = service
-        self._state_machine_by_ip = {}
+        self._state_machine_by_ip: Dict[str, Optional[EnodebAcsStateMachine]] = {}
 
     def handle_tr069_message(
         self,
@@ -166,7 +166,7 @@ class StateMachineManager:
     def _parse_msg_for_serial(tr069_message: models.Inform) -> Optional[str]:
         """ Return the eNodeB serial ID if it's found in the message """
         if not isinstance(tr069_message, models.Inform):
-            return
+            return None
 
         # Mikrotik Intercell does not return serial in ParameterList
         if hasattr(tr069_message, 'DeviceId') and \
@@ -213,8 +213,8 @@ class IpToSerialMapping:
     """ Bidirectional map between <eNodeB IP> and <eNodeB serial ID> """
 
     def __init__(self) -> None:
-        self.ip_by_enb_serial = {}
-        self.enb_serial_by_ip = {}
+        self.ip_by_enb_serial: Dict[str, str] = {}
+        self.enb_serial_by_ip: Dict[str, str] = {}
 
     def del_ip(self, ip: str) -> None:
         if ip not in self.enb_serial_by_ip:

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -413,6 +413,7 @@ class BaicellsRemWaitState(EnodebAcsState):
                    'resuming with configuration.' % remaining
         return 'rem_timer is None'
 
+
 class WaitEmptyMessageState(EnodebAcsState):
     def __init__(
         self,

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -282,7 +282,7 @@ class WaitForFirmwareUpgradeDownloadResponse(EnodebAcsState):
     This state reacts to a reply from the eNB after a Download request has been sent.
 
     When a DownloadReponse object is received, that means the Download request was accepted
-    and a firmware download is in progress. 
+    and a firmware download is in progress.
     However, if there is already a download requested pending on the eNB, issuing a Download request
     may cause the eNB to return a Fault code 9017. It is a generic download failure code that
     seemed to indicate on FreedomFi One/Sercomm eNBs that a download of the same CommandKey is already
@@ -399,7 +399,7 @@ class BaicellsRemWaitState(EnodebAcsState):
         return AcsReadMsgResult(True, None)
 
     def get_msg(self, message: Any) -> AcsMsgAndTransition:
-        if self.rem_timer.is_done():
+        if self.rem_timer and self.rem_timer.is_done():
             return AcsMsgAndTransition(
                 models.DummyInput(),
                 self.done_transition,
@@ -407,10 +407,11 @@ class BaicellsRemWaitState(EnodebAcsState):
         return AcsMsgAndTransition(models.DummyInput(), None)
 
     def state_description(self) -> str:
-        remaining = self.rem_timer.seconds_remaining()
-        return 'Waiting for eNB REM to run for %d more seconds before ' \
-               'resuming with configuration.' % remaining
-
+        if self.rem_timer:
+            remaining = self.rem_timer.seconds_remaining()
+            return 'Waiting for eNB REM to run for %d more seconds before ' \
+                   'resuming with configuration.' % remaining
+        return 'rem_timer is None'
 
 class WaitEmptyMessageState(EnodebAcsState):
     def __init__(
@@ -445,7 +446,7 @@ class WaitEmptyMessageState(EnodebAcsState):
             next_state=self.done_transition,
         )
 
-    def get_msg(self, message: Any) -> AcsReadMsgResult:
+    def get_msg(self, message: Any) -> AcsMsgAndTransition:
         """
         Return a dummy message waiting for the empty message from CPE
         """
@@ -1351,7 +1352,7 @@ class WaitInformMRebootState(EnodebAcsState):
         self.timeout_timer = StateMachineTimer(self.REBOOT_TIMEOUT)
 
         def check_timer() -> None:
-            if self.timeout_timer.is_done():
+            if self.timeout_timer and self.timeout_timer.is_done():
                 self.acs.transition(self.timeout_transition)
                 raise Tr069Error(
                     'Did not receive Inform response after '
@@ -1407,7 +1408,7 @@ class WaitRebootDelayState(EnodebAcsState):
         self.config_timer = StateMachineTimer(self.SHORT_CONFIG_DELAY)
 
         def check_timer() -> None:
-            if self.config_timer.is_done():
+            if self.config_timer and self.config_timer.is_done():
                 self.acs.transition(self.done_transition)
 
         self.timer_handle = \

--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 
 import asyncio
+from typing import Optional
 from xml.etree import ElementTree
 
 from aiohttp import web
@@ -72,7 +73,7 @@ class StatsManager:
         self.enb_manager = enb_acs_manager
         self.loop = asyncio.get_event_loop()
         self._prev_rf_tx = False
-        self.mme_timeout_handler = None
+        self.mme_timeout_handler: Optional[asyncio.TimerHandle] = None
 
     def run(self) -> None:
         """ Create and start HTTP server """

--- a/lte/gateway/python/magma/enodebd/tests/baicells_old_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_old_tests.py
@@ -35,7 +35,7 @@ class BaicellsOldHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
 
         # Send an Inform message
         inform_msg = \
@@ -61,7 +61,7 @@ class BaicellsOldHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
 
         # User uses the CLI tool to get eNodeB to reboot
         acs_state_machine.reboot_asap()
@@ -105,7 +105,7 @@ class BaicellsOldHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = \
@@ -160,7 +160,7 @@ class BaicellsOldHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = \
@@ -479,7 +479,7 @@ class BaicellsOldHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = \

--- a/lte/gateway/python/magma/enodebd/tests/baicells_qafb_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_qafb_tests.py
@@ -32,7 +32,7 @@ class BaicellsQAFBHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS_QAFB)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS_QAFB)
 
         # User uses the CLI tool to get eNodeB to reboot
         acs_state_machine.reboot_asap()
@@ -76,7 +76,7 @@ class BaicellsQAFBHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS_QAFB)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS_QAFB)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = \
@@ -195,7 +195,7 @@ class BaicellsQAFBHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder\
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS_QAFB)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS_QAFB)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = \

--- a/lte/gateway/python/magma/enodebd/tests/baicells_qrtb_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_qrtb_tests.py
@@ -15,6 +15,7 @@ limitations under the License.
 import logging
 from copy import deepcopy
 from time import sleep
+from typing import Any, Dict
 from unittest import TestCase, mock
 
 from dp.protos.cbsd_pb2 import UpdateCbsdResponse
@@ -801,7 +802,7 @@ class BaicellsQRTBFirmwareUpgradeDownloadTests(EnodebHandlerTestCase):
     }
 
     # configs which should not lead to firmware upgrade download flow
-    config_empty = {'firmwares': {}, 'enbs': {}, 'models': {}}
+    config_empty: Dict[str, Dict[Any, Any]] = {'firmwares': {}, 'enbs': {}, 'models': {}}
 
     config_just_firmwares = deepcopy(config_empty)
     config_just_firmwares['firmwares'] = _firmwares

--- a/lte/gateway/python/magma/enodebd/tests/baicells_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_tests.py
@@ -36,7 +36,7 @@ class BaicellsHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
 
         # Send an Inform message
         inform_msg = Tr069MessageBuilder.get_inform(
@@ -62,7 +62,7 @@ class BaicellsHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
 
         # User uses the CLI tool to get eNodeB to reboot
         acs_state_machine.reboot_asap()
@@ -99,7 +99,7 @@ class BaicellsHandlerTests(EnodebHandlerTestCase):
         """ Check GPS coordinates are processed and stored correctly """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = Tr069MessageBuilder.get_inform(
@@ -183,7 +183,7 @@ class BaicellsHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = Tr069MessageBuilder.get_inform(
@@ -234,7 +234,7 @@ class BaicellsHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = Tr069MessageBuilder.get_inform()
@@ -316,7 +316,7 @@ class BaicellsHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_multi_enb_acs_state_machine(EnodebDeviceName.BAICELLS)
+            .build_multi_enb_acs_state_machine(EnodebDeviceName.BAICELLS)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = Tr069MessageBuilder.get_inform()
@@ -414,7 +414,7 @@ class BaicellsHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = Tr069MessageBuilder.get_inform()
@@ -695,7 +695,7 @@ class BaicellsHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = Tr069MessageBuilder.get_inform(

--- a/lte/gateway/python/magma/enodebd/tests/cavium_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/cavium_tests.py
@@ -35,7 +35,7 @@ class CaviumHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.CAVIUM)
+            .build_acs_state_machine(EnodebDeviceName.CAVIUM)
 
         # Send an Inform message
         inform_msg = Tr069MessageBuilder.get_inform(
@@ -79,7 +79,7 @@ class CaviumHandlerTests(EnodebHandlerTestCase):
 
         # Send back some object parameters with TWO plmns
         req = Tr069MessageBuilder.get_cavium_object_param_values_response(
-                num_plmns=2,
+            num_plmns=2,
         )
         resp = acs_state_machine.handle_tr069_message(req)
 
@@ -93,8 +93,8 @@ class CaviumHandlerTests(EnodebHandlerTestCase):
 
         # Number of PLMNs should reflect object count
         num_plmns_cur = \
-                acs_state_machine \
-                .device_cfg.get_parameter(ParameterName.NUM_PLMNS)
+            acs_state_machine \
+            .device_cfg.get_parameter(ParameterName.NUM_PLMNS)
         self.assertEqual(num_plmns_cur, 2)
 
     def test_count_plmns_more_defined(self) -> None:
@@ -106,7 +106,7 @@ class CaviumHandlerTests(EnodebHandlerTestCase):
         """
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
-                .build_acs_state_machine(EnodebDeviceName.CAVIUM)
+            .build_acs_state_machine(EnodebDeviceName.CAVIUM)
 
         # Send an Inform message
         inform_msg = Tr069MessageBuilder.get_inform(
@@ -140,7 +140,7 @@ class CaviumHandlerTests(EnodebHandlerTestCase):
 
         # Send back regular parameters, and some absurd number of PLMNS
         req = Tr069MessageBuilder.get_cavium_param_values_response(
-                num_plmns=100,
+            num_plmns=100,
         )
         resp = acs_state_machine.handle_tr069_message(req)
 
@@ -152,7 +152,7 @@ class CaviumHandlerTests(EnodebHandlerTestCase):
 
         # Send back some object parameters with an absurd number of PLMNs
         req = Tr069MessageBuilder.get_cavium_object_param_values_response(
-                num_plmns=100,
+            num_plmns=100,
         )
         resp = acs_state_machine.handle_tr069_message(req)
 
@@ -166,6 +166,6 @@ class CaviumHandlerTests(EnodebHandlerTestCase):
 
         # Number of PLMNs should reflect data model
         num_plmns_cur = \
-                acs_state_machine \
-                .device_cfg.get_parameter(ParameterName.NUM_PLMNS)
+            acs_state_machine \
+            .device_cfg.get_parameter(ParameterName.NUM_PLMNS)
         self.assertEqual(num_plmns_cur, 6)

--- a/lte/gateway/python/magma/enodebd/tests/enodeb_acs_states_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/enodeb_acs_states_tests.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Dict, Any
+from typing import Any, Dict
 from unittest import TestCase
 from unittest.mock import patch
 

--- a/lte/gateway/python/magma/enodebd/tests/enodeb_acs_states_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/enodeb_acs_states_tests.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Dict
+from typing import Dict, Any
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -70,7 +70,7 @@ class DummyHandler(BasicEnodebAcsStateMachine):
             self,
             service: MagmaService,
     ) -> None:
-        self._state_map = {}
+        self._state_map: Dict[str, Any] = {}
         super().__init__(service=service, use_param_key=False)
 
     def are_invasive_changes_applied(self) -> bool:

--- a/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/freedomfi_one_tests.py
@@ -13,6 +13,7 @@ limitations under the License.
 import logging
 import os
 from copy import deepcopy
+from typing import Any, Dict
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -54,10 +55,12 @@ from magma.enodebd.tests.test_utils.tr069_msg_builder import Tr069MessageBuilder
 from magma.enodebd.tr069 import models
 from parameterized import parameterized
 
-SRC_CONFIG_DIR = os.path.join(
-    os.environ.get('MAGMA_ROOT'),
-    'lte/gateway/configs',
-)
+magma_root = os.environ.get('MAGMA_ROOT')
+if magma_root:
+    SRC_CONFIG_DIR = os.path.join(
+        magma_root,
+        'lte/gateway/configs',
+    )
 
 MOCK_CBSD_STATE = CBSDStateResult(
     radio_enabled=True,
@@ -1072,7 +1075,7 @@ class FreedomFiOneFirmwareUpgradeDownloadTests(EnodebHandlerTestCase):
     }
 
     # configs which should not lead to firmware upgrade download flow
-    config_empty = {'firmwares': {}, 'enbs': {}, 'models': {}}
+    config_empty: Dict[str, Dict[Any, Any]] = {'firmwares': {}, 'enbs': {}, 'models': {}}
 
     config_just_firmwares = deepcopy(config_empty)
     config_just_firmwares['firmwares'] = _firmwares

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/config_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/config_builder.py
@@ -68,15 +68,15 @@ class EnodebConfigBuilder:
         id1 = '120200002618AGP0003'
         #enb_conf_1 = mconfigs_pb2.EnodebD.EnodebConfig()
         mconfig.enb_configs_by_serial[id1]\
-                .earfcndl = 39151
+            .earfcndl = 39151
         mconfig.enb_configs_by_serial[id1]\
-                .subframe_assignment = 2
+            .subframe_assignment = 2
         mconfig.enb_configs_by_serial[id1]\
-                .special_subframe_pattern = 7
+            .special_subframe_pattern = 7
         mconfig.enb_configs_by_serial[id1]\
-                .pci = 259
+            .pci = 259
         mconfig.enb_configs_by_serial[id1]\
-                .bandwidth_mhz = 20
+            .bandwidth_mhz = 20
         mconfig.enb_configs_by_serial[id1] \
             .tac = 1
         mconfig.enb_configs_by_serial[id1] \
@@ -89,13 +89,13 @@ class EnodebConfigBuilder:
         id2 = '120200002618AGP0004'
         #enb_conf_2 = mconfigs_pb2.EnodebD.EnodebConfig()
         mconfig.enb_configs_by_serial[id2]\
-                .earfcndl = 39151
+            .earfcndl = 39151
         mconfig.enb_configs_by_serial[id2]\
-                .subframe_assignment = 2
+            .subframe_assignment = 2
         mconfig.enb_configs_by_serial[id2]\
-                .special_subframe_pattern = 7
+            .special_subframe_pattern = 7
         mconfig.enb_configs_by_serial[id2]\
-                .pci = 261
+            .pci = 261
         mconfig.enb_configs_by_serial[id2] \
             .bandwidth_mhz = 20
         mconfig.enb_configs_by_serial[id2] \
@@ -103,9 +103,9 @@ class EnodebConfigBuilder:
         mconfig.enb_configs_by_serial[id2] \
             .cell_id = 0
         mconfig.enb_configs_by_serial[id2]\
-                .transmit_enabled = True
+            .transmit_enabled = True
         mconfig.enb_configs_by_serial[id2]\
-                .device_class = 'Baicells Band 40'
+            .device_class = 'Baicells Band 40'
 
         return mconfig
 

--- a/lte/gateway/python/magma/enodebd/tests/transform_for_magma_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/transform_for_magma_tests.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 
 # pylint: disable=protected-access
+from typing import Union
 from unittest import TestCase
 
 from magma.enodebd.data_models.transform_for_magma import bandwidth, gps_tr181
@@ -37,7 +38,7 @@ class TransformForMagmaTests(TestCase):
         self.assertEqual(out, expected, 'Should leave zero as zero')
 
     def test_bandwidth(self) -> None:
-        inp = 'n6'
+        inp: Union[str, float, int] = 'n6'
         out = bandwidth(inp)
         expected = 1.4
         self.assertEqual(out, expected, 'Should convert RBs')

--- a/lte/gateway/python/magma/enodebd/tr069/models.py
+++ b/lte/gateway/python/magma/enodebd/tr069/models.py
@@ -194,11 +194,11 @@ class ParameterAttributeList(Tr069ComplexModel):
     _type_info["arrayType"] = XmlAttribute(String, ns=SOAP_ENC)
 
 
-class CommandKeyType(String.customize(max_length=32)):
+class CommandKeyType(String.customize(max_length=32)): #type: ignore[misc]
     pass
 
 
-class ObjectNameType(String.customize(max_length=256)):
+class ObjectNameType(String.customize(max_length=256)): #type: ignore[misc]
     pass
 
 

--- a/lte/gateway/python/magma/enodebd/tr069/models.py
+++ b/lte/gateway/python/magma/enodebd/tr069/models.py
@@ -194,11 +194,11 @@ class ParameterAttributeList(Tr069ComplexModel):
     _type_info["arrayType"] = XmlAttribute(String, ns=SOAP_ENC)
 
 
-class CommandKeyType(String.customize(max_length=32)): #type: ignore[misc]
+class CommandKeyType(String.customize(max_length=32)):  # type: ignore[misc]
     pass
 
 
-class ObjectNameType(String.customize(max_length=256)): #type: ignore[misc]
+class ObjectNameType(String.customize(max_length=256)):  # type: ignore[misc]
     pass
 
 


### PR DESCRIPTION
## Summary

Fixes type errors in enodebd.

Some details:
- mypy has issues with property setters that are not defined right next to the getters (see https://github.com/python/mypy/issues/1465). Thus, in lte/gateway/python/magma/enodebd/state_machines/enb_acs.py the setter was moved accordingly.
- python/magma/enodebd/tr069/models.py:197 and below: mypy error ignored (Unsupported dynamic base class "String.customize")
- ran mypy with `--install-types --non-interactive` flags due to `Library stubs not installed for X` errors. (https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports)

## Test Plan

Run mypy 
```
mypy --ignore-missing-imports --install-types --non-interactive python/magma/enodebd
```
```
output: Success: no issues found in 73 source files
```
and python unit tests
```
vagrant@magma-dev-focal:~/magma$ bazel test lte/gateway/python/magma/...
```
```
output: Executed 60 out of 60 tests: 60 tests pass.
```


## Additional Information

- Ran `lte/gateway/python $ ./precommit.py --format -p lte/gateway/python/magma/enodebd` for format changes.
