### PR TITLE
fix(agw): mobilityd sudo tests are green again

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -16,7 +16,7 @@ import datetime
 import logging
 import threading
 import time
-from ipaddress import IPv4Network
+from ipaddress import IPv4Network, ip_address
 from threading import Condition
 from typing import MutableMapping, Optional
 
@@ -272,7 +272,7 @@ class DHCPClient:
                         ip_offered + "/" + "32", strict=False,
                     )
 
-                dhcp_server_ip = None
+                dhcp_server_ip: Optional[str] = None
                 if IP in packet:
                     dhcp_server_ip = packet[IP].src
 
@@ -292,8 +292,8 @@ class DHCPClient:
                     vlan=vlan,
                     state_requested=state_requested,
                     subnet=str(ip_subnet),
-                    server_ip=dhcp_server_ip,
-                    router_ip=router_ip_addr,
+                    server_ip=ip_address(dhcp_server_ip) if dhcp_server_ip else None,
+                    router_ip=ip_address(router_ip_addr) if router_ip_addr else None,
                     lease_expiration_time=lease_expiration_time,
                     xid=packet[BOOTP].xid,
                 )

--- a/lte/gateway/python/magma/mobilityd/dhcp_desc.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_desc.py
@@ -15,6 +15,7 @@ from enum import IntEnum
 from typing import Optional
 
 from .mac import MacAddress
+from .utils import IPAddress
 
 
 # map the enum to actual protocol values.
@@ -38,9 +39,9 @@ class DHCPDescriptor:
         self, mac: MacAddress, ip: str,
         state_requested: DHCPState, vlan: int,
         state: DHCPState = DHCPState.UNKNOWN,
-        subnet: str = None, server_ip: str = None,
-        router_ip: str = None, lease_expiration_time: int = 0,
-        xid: str = None,
+        subnet: Optional[str] = None, server_ip: Optional[IPAddress] = None,
+        router_ip: Optional[IPAddress] = None, lease_expiration_time: int = 0,
+        xid: Optional[str] = None,
     ):
         """
         DHCP descriptor. This object maintains all information for


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

This PR aims to fix a bug introduced with #12956, which fails the mobilityd sudo tests.
The parsed IPs to `DHCPDescriptor` need to be cast via `ip_address()` and not be `str`. This PR also changes the type annotation for the class parameters.

## Test Plan

```
 bazel test lte/gateway/python/magma/...
...
Executed 60 out of 60 tests: 60 tests pass.
```
```
./bazel/scripts/run_sudo_tests.sh lte/gateway/python/magma/mobilityd/
...
SUMMARY: 2/2 tests were successful.
  //lte/gateway/python/magma/mobilityd/tests:test_dhcp_client: PASSED
  //lte/gateway/python/magma/mobilityd/tests:ip_alloc_dhcp_test: PASSED
```
```
mypy --ignore-missing-imports magma/mobilityd
Success: no issues found in 31 source files
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
