### PR TITLE
chore(agw): deprecated 'assert_()' is no longer used

### DIFF
--- a/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
@@ -223,7 +223,7 @@ class DhcpClient(unittest.TestCase):
     def _validate_state_as_current(self, mac: MacAddress, vlan: int):
         with self.dhcp_wait:
             dhcp1 = self.dhcp_store.get(mac.as_redis_key(vlan))
-            self.assert_(
+            self.assertTrue(
                 dhcp1.state == DHCPState.OFFER or dhcp1.state == DHCPState.ACK,
             )
 
@@ -261,7 +261,7 @@ class DhcpClient(unittest.TestCase):
             dhcp1 = self.dhcp_store.get(mac.as_redis_key(vlan))
             self.assertEqual(dhcp1.subnet, str(exptected_subnet))
             self.assertEqual(dhcp1.router_ip, exptected_router_ip)
-            self.assert_(ipaddress.ip_address(dhcp1.ip) in exptected_subnet)
+            self.assertTrue(ipaddress.ip_address(dhcp1.ip) in exptected_subnet)
 
     def _release_ip(self, mac: MacAddress, vlan: int):
         self._dhcp_client.release_ip_address(mac, vlan)


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

Replaces the deprecated `assert_()` with `assertTrue()`.

## Test Plan
Tested with the bugfix in #12979.

```
./bazel/scripts/run_sudo_tests.sh lte/gateway/python/magma/mobilityd/
...
lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py::DhcpClient::test_dhcp_lease1 PASSED [ 33%]
lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py::DhcpClient::test_dhcp_vlan PASSED  [ 66%]
lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py::DhcpClient::test_dhcp_vlan_multi SKIPPED [100%]

======================================= short test summary info ========================================
SKIPPED [1] lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py:103: needs more investigation.
==================================== 2 passed, 1 skipped in 33.18s =====================================
SUMMARY: 2/2 tests were successful.
  //lte/gateway/python/magma/mobilityd/tests:test_dhcp_client: PASSED
  //lte/gateway/python/magma/mobilityd/tests:ip_alloc_dhcp_test: PASSED

```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
