### PR TITLE
fix(agw): `make check` lintering is improved

### DIFF
--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -77,8 +77,10 @@ $(BIN)/pep8: install_virtualenv
 
 # Disable W0511: todo warnings
 # Disable R0903: Too few public methods
-CHECK_CMD_PYLINT := find . -name '*.py' -exec $(BIN)/pylint --disable=R0903,W0511 {} +;
-CHECK_CMD_PEP8 := find . -name '*.py' -exec $(BIN)/pep8 {} +;
+CHECK_CMD_PYLINT := -find . -name '*.py' -exec $(BIN)/pylint --disable=R0903,W0511 {} +;
+CHECK_CMD_PEP8 := -find . -name '*.py' -exec $(BIN)/pep8 {} +;
+# ’-’ ignores the exit 1 and the script is not terminated by a linter error,
+# see https://www.gnu.org/software/make/manual/make.html#Errors
 check: buildenv $(BIN)/pylint $(BIN)/pep8
 	$(CHECK_CMD_PEP8)
 	$(CHECK_CMD_PYLINT)

--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -70,19 +70,19 @@ $(BIN)/coverage: install_virtualenv
 $(BIN)/pylint: install_virtualenv
 	$(VIRT_ENV_PIP_INSTALL) pylint==2.14.0
 
-$(BIN)/pep8: install_virtualenv
+$(BIN)/pycodestyle: install_virtualenv
 	# pylint doesn't cover all the pep8 style guidelines. Specifically,
 	# E203, E301, E303, W203, W291, W292
-	$(VIRT_ENV_PIP_INSTALL) pep8==1.7.0
+	$(VIRT_ENV_PIP_INSTALL) pycodestyle==2.8.0
 
 # Disable W0511: todo warnings
 # Disable R0903: Too few public methods
 CHECK_CMD_PYLINT := -find . -name '*.py' -exec $(BIN)/pylint --disable=R0903,W0511 {} +;
-CHECK_CMD_PEP8 := -find . -name '*.py' -exec $(BIN)/pep8 {} +;
+CHECK_CMD_PYCODESTYLE := -find . -name '*.py' -exec $(BIN)/pycodestyle {} +;
 # ’-’ ignores the exit 1 and the script is not terminated by a linter error,
 # see https://www.gnu.org/software/make/manual/make.html#Errors
-check: buildenv $(BIN)/pylint $(BIN)/pep8
-	$(CHECK_CMD_PEP8)
+check: buildenv $(BIN)/pylint $(BIN)/pycodestyle
+	$(CHECK_CMD_PYCODESTYLE)
 	$(CHECK_CMD_PYLINT)
 
 clean: $(CLEAN_LIST)


### PR DESCRIPTION
## Summary

This PR introduces two improvements for the linter checks in 
`vagrant@magma-dev-focal:~/magma/lte/gateway/python$ make check`

1. Both used checks in lines 83 and 84 exit with 1 if any errors are found in the `.py` files. This stopps the script and the second linter check is never executed. A `-` is added at the beginning of each command for `exit 1` to be ignored and both of them are executed.
2. The `pep8` package was renamed to `pycodestyle` in 2016. Name and version number is adapted.

## Test Plan

```
vagrant@magma-dev-focal:~/magma/lte/gateway/python$ make check
...
make: [Makefile:83: check] Error 1 (ignored)
...
make: [Makefile:84: check] Error 1 (ignored)
```
After the `make check` and with `vagrant@magma-dev-focal:~/build/python$ source bin/activate`:
```
(python) vagrant@magma-dev-focal:~/build/python$ pip3 show pycodestyle
Name: pycodestyle
Version: 2.8.0
Summary: Python style guide checker
Home-page: https://pycodestyle.pycqa.org/
Author: Johann C. Rocholl
Author-email: johann@rocholl.net
License: Expat license
Location: /home/vagrant/build/python/lib/python3.8/site-packages
Requires: 
Required-by: 
(python) vagrant@magma-dev-focal:~/build/python$ pip3 show pylint
Name: pylint
Version: 2.14.0
Summary: python code static checker
Home-page: None
Author: Python Code Quality Authority
Author-email: code-quality@python.org
License: GPL-2.0-or-later
Location: /home/vagrant/build/python/lib/python3.8/site-packages
Requires: isort, platformdirs, tomlkit, mccabe, astroid, typing-extensions, tomli, dill
Required-by: orc8r
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
