### PR TITLE
chore(agw): Make core file appear outside of the sessiond container.

### DIFF
--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -250,9 +250,11 @@ services:
       test: ["CMD", "nc", "-zv", "localhost", "50065"]
       timeout: "4s"
       retries: 3
+    cap_drop:
+      - ALL
     command: >
-      sh -c "mkdir -p /var/opt/magma/cores &&
-        sysctl -w kernel.core_pattern=/var/opt/magma/cores/core.%e.%t &&
+      sh -c "mkdir -p /var/opt/magma/docker/cores &&
+        sysctl -w kernel.core_pattern=/var/opt/magma/docker/cores/core.%e.%t &&
         /usr/local/bin/sessiond"
 
   mobilityd:


### PR DESCRIPTION
## Summary

Enable outside access to sessiond core files.

## Test Plan

Started the container and looked for errors.

## Additional Information

Unfortunately the container needs to be privileged in order to execute
the sysctl command. There is no linux capability that enables write
access for sysctl.

