### PR TITLE
chore: Modify bazel cache configuration setup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,34 +16,34 @@ build --compilation_mode=dbg
 test --test_output=errors
 test --flaky_test_attempts=5
 
+# Use dynamically linked folly library
+build --define=folly_so=1
+
 # MAGMA VM CONFIGS
 build:specify_vm_cc --action_env=CC=/usr/bin/gcc
-build:vm --disk_cache=/home/vagrant/magma/.bazel-cache
-common:vm --repository_cache=/home/vagrant/magma/.bazel-cache-repo
-build:vm --define=folly_so=1
 build:vm --config=specify_vm_cc
 
-# MAGMA-BUILDER DOCKER CONTAINER CONFIGS
-build:docker --define=folly_so=1
-
-# DEVCONTAINER CONFIGS
-build:devcontainer --disk_cache=/workspaces/magma/.bazel-cache
-common:devcontainer --repository_cache=/workspaces/magma/.bazel-cache-repo
-build:devcontainer --define=folly_so=1
+# DISK CACHE CONFIGS
+# The locations of the disk_cache/repository_cache are symlinks in the
+# docker containers/magma-vm. They point to the correct cache locations
+# $MAGMA/.bazel-cache and $MAGMA/.bazel-cache-repo inside the magma repository.
+build:disk_cache --disk_cache=/var/cache/bazel-cache
+common:disk_cache --repository_cache=/var/cache/bazel-cache-repo
 
 # REMOTE CACHING READ AND WRITE CONFIGS
 # The file bazel/bazelrcs/remote_caching_rw.bazelrc is templated in CI
-# The full config is then written to remote-cache.bazelrc
+# The full config is then written to bazel/bazelrcs/cache.bazelrc
 build:remote_caching_rw --remote_download_toplevel
 
 # REMOTE CACHING READ-ONLY CONFIGS
 # The file bazel/bazelrcs/remote_caching_ro.bazelrc is templated in CI
-# The full config is then written to remote-cache.bazelrc
+# The full config is then written to bazel/bazelrcs/cache.bazelrc
 build:remote_caching_ro --remote_download_toplevel
 build:remote_caching_ro --remote_upload_local_results=false 
 
-# Try importing the bazel remote caching config (relevant in CI)
-try-import remote-cache.bazelrc
+# Import the bazel caching config, with default disk cache,
+# which in CI gets overwritten by the remote caching config. 
+import bazel/bazelrcs/cache.bazelrc
 
 # TEST CONFIGS
 # Bazel test runtime default: PATH=/bin:/usr/bin:/usr/local/bin

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -278,6 +278,4 @@ RUN for SWAGGER_SRC in lte orc8r; \
     rm -r ${PYTHON_VENV}/${GEN_DIR}/${SWAGGER_SRC}/swagger/test; \
     done
 
-RUN ln -fs $MAGMA_ROOT/bazel/bazelrcs/devcontainer.bazelrc /etc/bazelrc
-
 WORKDIR $MAGMA_ROOT

--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -128,6 +128,7 @@ RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/dow
 # Update shared library configuration
 RUN ldconfig -v
 
-RUN ln -s /workspaces/magma/bazel/bazelrcs/docker.bazelrc /etc/bazelrc
+RUN ln -s /workspaces/magma/.bazel-cache /var/cache/bazel-cache
+RUN ln -s /workspaces/magma/.bazel-cache-repo /var/cache/bazel-cache-repo
 
 WORKDIR /workspaces/magma

--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -131,4 +131,7 @@ RUN ldconfig -v
 RUN ln -s /workspaces/magma/.bazel-cache /var/cache/bazel-cache
 RUN ln -s /workspaces/magma/.bazel-cache-repo /var/cache/bazel-cache-repo
 
+# TODO(@LKREUTZER): Remove unused link once new docker image has been generated and PRs have been rebased or merged.
+RUN ln -s /workspaces/magma/bazel/bazelrcs/docker.bazelrc /etc/bazelrc
+
 WORKDIR /workspaces/magma

--- a/bazel/bazelrcs/cache.bazelrc
+++ b/bazel/bazelrcs/cache.bazelrc
@@ -1,0 +1,3 @@
+# In CI this file is overwritten by bazel/scripts/remote_cache_bazelrc_setup.sh
+# in order to configure the remote cache.
+common --config=disk_cache

--- a/bazel/bazelrcs/devcontainer.bazelrc
+++ b/bazel/bazelrcs/devcontainer.bazelrc
@@ -1,1 +1,0 @@
-common --config=devcontainer

--- a/bazel/bazelrcs/docker.bazelrc
+++ b/bazel/bazelrcs/docker.bazelrc
@@ -1,1 +1,0 @@
-build --config=docker

--- a/bazel/bazelrcs/remote_caching_ro.bazelrc
+++ b/bazel/bazelrcs/remote_caching_ro.bazelrc
@@ -1,4 +1,4 @@
 # This file is templated in CI (see e.g. .github/workflows/bazel.yml)
-# The full config is then written to remote-cache.bazelrc which is imported in the .bazelrc
+# The full config is then written to bazel/bazelrcs/cache.bazelrc which is imported in the .bazelrc
 build --config=remote_caching_ro
 build:remote_caching_ro --remote_cache="https://bazel-remote-cache.magmacore-ci.org:9090/~~CACHE_KEY~~"

--- a/bazel/bazelrcs/remote_caching_rw.bazelrc
+++ b/bazel/bazelrcs/remote_caching_rw.bazelrc
@@ -1,4 +1,4 @@
 # This file is templated in CI (see e.g. .github/workflows/bazel.yml)
-# The full config is then written to remote-cache.bazelrc which is imported in the .bazelrc
+# The full config is then written to bazel/bazelrcs/cache.bazelrc which is imported in the .bazelrc
 build --config=remote_caching_rw
 build:remote_caching_rw --remote_cache="https://bazelbuild:~~BAZEL_REMOTE_PASSWORD~~@bazel-remote-cache.magmacore-ci.org:9090/~~CACHE_KEY~~"

--- a/bazel/bazelrcs/vm.bazelrc
+++ b/bazel/bazelrcs/vm.bazelrc
@@ -1,1 +1,1 @@
-common --config=vm
+build --config=vm

--- a/bazel/scripts/remote_cache_bazelrc_setup.sh
+++ b/bazel/scripts/remote_cache_bazelrc_setup.sh
@@ -53,6 +53,7 @@ create_config_for_rw_remote_cache () {
     -e s/~~CACHE_KEY~~/"$cache_key"/ \
     -e s/~~BAZEL_REMOTE_PASSWORD~~/"$bazel_remote_password"/ \
     bazel/bazelrcs/remote_caching_rw.bazelrc
+  echo "Configured bazel for read and write access to the remote cache with cache key: $cache_key" 1>&2
 }
 
 create_config_for_ro_remote_cache () {
@@ -60,6 +61,7 @@ create_config_for_ro_remote_cache () {
   sed \
     -e s/~~CACHE_KEY~~/"$cache_key"/ \
     bazel/bazelrcs/remote_caching_ro.bazelrc
+  echo "Configured bazel for read-only access to the remote cache with cache key: $cache_key" 1>&2
 }
 
 ###############################################################################

--- a/bazel/scripts/remote_cache_bazelrc_setup.sh
+++ b/bazel/scripts/remote_cache_bazelrc_setup.sh
@@ -66,4 +66,4 @@ create_config_for_ro_remote_cache () {
 # SCRIPT SECTION
 ###############################################################################
 
-create_config "$CACHE_KEY" "$BAZEL_REMOTE_PASSWORD" > remote-cache.bazelrc
+create_config "$CACHE_KEY" "$BAZEL_REMOTE_PASSWORD" > bazel/bazelrcs/cache.bazelrc

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -488,6 +488,20 @@
     state: link
     force: yes
 
+- name: Symlink bazel disk cache configuration into the VM
+  file:
+    src: '/home/vagrant/magma/.bazel-cache'
+    path: '/var/cache/bazel-cache'
+    state: link
+    force: yes
+
+- name: Symlink bazel disk repository cache configuration into the VM
+  file:
+    src: '/home/vagrant/magma/.bazel-cache-repo'
+    path: '/var/cache/bazel-cache-repo'
+    state: link
+    force: yes
+
 # TODO: Fix magma-dev VM box and remove this step.
 - name: Install Magma dependencies
   retries: 5


### PR DESCRIPTION
## Summary

- The bazel cache configuration setup is modified to avoid clashing with the remote cache in bazel 5 and some options are simplified.
- Caching is now controlled by the `bazel/bazelrcs/cache.bazelrc` file.
  - The default configuration for the docker images/magma-vm is the disk cache. This is enabled via a symlink that is written in the images.
  - In the CI the `bazel/bazelrcs/cache.bazelrc` file is overwritten with the remote cache config.
- `--define=folly_so=1` is always used and can thus be moved into the general `build` config.
- The `docker.bazelrc` link is kept in the bazel-base container docker file in order to not make the CI fail on PRs that are not rebased. This link will be removed in a future clean up PR.

## Test Plan

- Building the dev-/bazel-base container locally and provisioning the VM locally leads to the correct cache configs.
- CI

## Additional Information

- [ ] This change is backwards-breaking
