### PR TITLE
chore: pin github action

### DIFF
--- a/.github/workflows/agw-docker-load-test.yaml
+++ b/.github/workflows/agw-docker-load-test.yaml
@@ -1,7 +1,7 @@
 ---
 name: AGW docker load test
 
-on:  # yamllint disable-line rule:truthy
+on:
   workflow_run:
     workflows:
       - build-all
@@ -25,14 +25,14 @@ jobs:
       WORK_DIR: "${{ github.workspace }}/experimental/cloudstrapper/playbooks"
       AGW_DOCKER_AMI: "ami-0150e153a94c122b5"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run apt
         run: sudo apt-get update && sudo apt -y upgrade
       - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@v8"
+        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
           default: 3.7.0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - name: Install Dependencies

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -1,7 +1,7 @@
 ---
 name: agw-workflow
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - 'v1.*'
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -28,9 +28,9 @@ jobs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -46,7 +46,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo -n ${{ steps.changes.outputs.filesChanged == 'false' }} > ./pr/skipped
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr
@@ -67,55 +67,55 @@ jobs:
       MAGMA_DEV_MODE: 1
       SKIP_SUDO_TESTS: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@v8"
+        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
           default: 3.8.5
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.5'
       - name: Run apt-focal-install-aioeventlet
         run: |
-            cd nms
-            # Install python3-aioeventlet from the magma apt repo
-            cat ${{ env.MAGMA_ROOT }}/orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub | sudo -E apt-key add -
-            echo "deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main" | sudo -E tee /etc/apt/sources.list.d/fbc.list
-            sudo apt-get update -y
-            sudo apt-get install -y python3-aioeventlet
-            sudo rm -rf /var/lib/apt/lists/*
+          cd nms
+          # Install python3-aioeventlet from the magma apt repo
+          cat ${{ env.MAGMA_ROOT }}/orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub | sudo -E apt-key add -
+          echo "deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main" | sudo -E tee /etc/apt/sources.list.d/fbc.list
+          sudo apt-get update -y
+          sudo apt-get install -y python3-aioeventlet
+          sudo rm -rf /var/lib/apt/lists/*
       - name: Install libraries and dependecies
         run: |
-            mkdir -p /var/tmp/test_results
-            mkdir -p /var/tmp/codecovs
-            sudo -E apt-get update -y
-            sudo -E apt-get install -y libsystemd-dev pkg-config curl zip unzip net-tools
-            sudo -E apt-get install -y virtualenv python-babel python-dev build-essential autogen autoconf libtool python3-apt python3-requests python3-pip python-protobuf
+          mkdir -p /var/tmp/test_results
+          mkdir -p /var/tmp/codecovs
+          sudo -E apt-get update -y
+          sudo -E apt-get install -y libsystemd-dev pkg-config curl zip unzip net-tools
+          sudo -E apt-get install -y virtualenv python-babel python-dev build-essential autogen autoconf libtool python3-apt python3-requests python3-pip python-protobuf
       - name: Setup protoc3
         run: |
-            pip3 install protobuf
-            pip3 install setuptools==49.6.0
-            curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip
-            unzip protoc3.zip -d protoc3
-            sudo -E mv protoc3/bin/protoc /bin/protoc
-            sudo -E chmod a+rx /bin/protoc
-            # Workaround: the include files need to be found
-            mv ./protoc3/include/google .
-            sudo -E rm -rf protoc3.zip protoc3
+          pip3 install protobuf
+          pip3 install setuptools==49.6.0
+          curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip
+          unzip protoc3.zip -d protoc3
+          sudo -E mv protoc3/bin/protoc /bin/protoc
+          sudo -E chmod a+rx /bin/protoc
+          # Workaround: the include files need to be found
+          mv ./protoc3/include/google .
+          sudo -E rm -rf protoc3.zip protoc3
       - name: Setup Swagger
         run: |
-            mkdir ${{ env.CODEGEN_ROOT }}
-            wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O ${{ env.SWAGGER_CODEGEN_JAR }}
+          mkdir ${{ env.CODEGEN_ROOT }}
+          wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O ${{ env.SWAGGER_CODEGEN_JAR }}
       - name: Execute test_all
         run: |
-            make -C ${{ env.MAGMA_ROOT }}/lte/gateway/python test_all
+          make -C ${{ env.MAGMA_ROOT }}/lte/gateway/python test_all
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: Unit Test Results
           path: /var/tmp/test_results
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
         with:
           files: /var/tmp/codecovs/cover_lte.xml,/var/tmp/codecovs/cover_orc8r.xml
           flags: lte-test
@@ -123,11 +123,11 @@ jobs:
         if: failure() && github.event_name == 'push'
         id: commit
         run: |
-            str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
-            echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action lte-test update failed"
@@ -159,9 +159,9 @@ jobs:
           df -h
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           options: --pull always
@@ -169,7 +169,7 @@ jobs:
           run: |
             echo "Pulled the devontainer image!"
       - name: Create a directory to store XML test results
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           shell: bash
           image: ${{ env.BAZEL_BASE_IMAGE }}
@@ -180,7 +180,7 @@ jobs:
             mkdir -p c-cpp-test-results/
             echo "created c-cpp-test-results/ directory"
       - name: Run `bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* --config=asan`
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           shell: bash
           image: ${{ env.BAZEL_BASE_IMAGE }}
@@ -201,12 +201,12 @@ jobs:
             exit $TEST_RESULT
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: Unit Test Results
           path: c-cpp-test-results/
       - name: Publish bazel profile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: Bazel cpp unit tests profile
@@ -236,10 +236,10 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run li agent tests
         timeout-minutes: 5
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -252,11 +252,11 @@ jobs:
         if: failure() && github.event_name == 'push'
         id: commit
         run: |
-            str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
-            echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action li_agent_test failed"
@@ -274,9 +274,9 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run sctpd tests with Debug build type
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -285,7 +285,7 @@ jobs:
             cd /workspaces/magma/lte/gateway
             make test_sctpd BUILD_TYPE=Debug
       - name: Run sctpd tests with RelWithDebInfo build type
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -294,7 +294,7 @@ jobs:
             cd /workspaces/magma/lte/gateway
             make test_sctpd BUILD_TYPE=RelWithDebInfo
       - name: Run mme tests with Debug build type
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -303,7 +303,7 @@ jobs:
             cd /workspaces/magma/lte/gateway
             make test_oai BUILD_TYPE=Debug;
       - name: Run mme tests with RelWithDebInfo build type
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -316,11 +316,11 @@ jobs:
         if: failure() && github.event_name == 'push'
         id: commit
         run: |
-            str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
-            echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action mme_test failed"
@@ -353,16 +353,16 @@ jobs:
           df -h
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Setup Devcontainer Image
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the devontainer image!"
       - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           options: --pull always
@@ -372,7 +372,7 @@ jobs:
             bazel # pull down bazel, if bazel download fails we can fail before we do all the lengthy work below
       - name: Run codecov with CMake (MME)
         if: always()
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -382,12 +382,9 @@ jobs:
             make coverage
             cp $C_BUILD/coverage.info $MAGMA_ROOT
       - name: Run coverage with Bazel (COMMON / SESSIOND / SCTPD / LIAGENT / CONNECTIOND)
-        if: |
-          always() &&
-          github.repository_owner == 'magma' &&
-          github.ref_name == 'master'
+        if: always()
         id: bazel-codecoverage
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -407,11 +404,11 @@ jobs:
       - name: Upload code coverage
         if: always()
         id: c-cpp-codecov-upload
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
         with:
           flags: c_cpp
       - name: Publish bazel profile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: |
           always() &&
           github.repository_owner == 'magma' &&
@@ -424,11 +421,11 @@ jobs:
         if: failure() && github.event_name == 'push'
         id: commit
         run: |
-            str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
-            echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
         if: steps.c-cpp-codecov-upload.outcome=='failure' && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action c-cpp-codecov-upload failed"
@@ -459,9 +456,9 @@ jobs:
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Check clang-format for orc8r/gateway/c
-        uses: DoozyX/clang-format-lint-action@v0.13
+        uses: DoozyX/clang-format-lint-action@9ea72631b74e61ce337d0839a90e76180e997283 # pin@v0.13
         with:
           source: 'orc8r/gateway/c'
           extensions: 'h,hpp,c,cpp'
@@ -469,7 +466,7 @@ jobs:
           # taken from .clang-format
           style: file
       - name: Check clang-format for lte/gateway
-        uses: DoozyX/clang-format-lint-action@v0.13
+        uses: DoozyX/clang-format-lint-action@9ea72631b74e61ce337d0839a90e76180e997283 # pin@v0.13
         with:
           source: 'lte/gateway/c lte/gateway/python'
           extensions: 'h,hpp,c,cpp'
@@ -485,10 +482,10 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run session_manager tests
         timeout-minutes: 20
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -501,11 +498,11 @@ jobs:
         if: failure() && github.event_name == 'push'
         id: commit
         run: |
-            str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
-            echo ::set-output name=title::${str%%\\n*} | tr -d '"'
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action session_manager_test failed"
@@ -519,7 +516,7 @@ jobs:
     name: jsonlint-mconfig
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/amis-workflow.yml
+++ b/.github/workflows/amis-workflow.yml
@@ -1,8 +1,8 @@
 ---
 name: amis-workflow
 
-on:  # yamllint disable-line rule:truthy
-  workflow_dispatch:
+on:
+  workflow_dispatch: null
   schedule:
     - cron: "0 2 * * 0"
 
@@ -19,90 +19,91 @@ jobs:
       VARS_DIR: "${{ github.workspace }}/experimental/cloudstrapper/playbooks/roles/vars"
       WORK_DIR: "${{ github.workspace }}/experimental/cloudstrapper/playbooks"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run apt
         run: sudo apt-get update && sudo apt -y upgrade
       - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@v8"
+        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
           default: 3.7.0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - name: Install Dependencies
         run: |
-            pip install ansible awscli boto3
-            sudo apt-get update
+          pip install ansible awscli boto3
+          sudo apt-get update
       - name: Determine AWS credentials to use
         run: |
-            if ${{ github.event_name == 'workflow_dispatch' }}; then
-              echo AWS_ACCOUNT="LF" >> $GITHUB_ENV
-              echo BASE_REFERENCE=${{ github.base_ref }} >> $GITHUB_ENV
-            elif ${{ github.event_name == 'schedule' }}; then
-              echo AWS_ACCOUNT="FB" >> $GITHUB_ENV
-              echo BASE_REFERENCE="master" >> $GITHUB_ENV
-            fi
+          if ${{ github.event_name == 'workflow_dispatch' }}; then
+            echo AWS_ACCOUNT="LF" >> $GITHUB_ENV
+            echo BASE_REFERENCE=${{ github.base_ref }} >> $GITHUB_ENV
+          elif ${{ github.event_name == 'schedule' }}; then
+            echo AWS_ACCOUNT="FB" >> $GITHUB_ENV
+            echo BASE_REFERENCE="master" >> $GITHUB_ENV
+          fi
       - name: Propagate AWS credentials to ansible and create version
         run: |
-            if [ "${{ env.AWS_ACCOUNT }}" = "FB" ]; then
-              sed -i -e "s@awsAccessKey:@& ${{ secrets.FB_AWS_ACCESS_KEY }}@1"  ${{ env.VARS_DIR }}/secrets.yaml
-              sed -i -e "s@awsSecretKey:@& ${{ secrets.FB_AWS_SECRET_ACCESS_KEY }}@1"  ${{ env.VARS_DIR }}/secrets.yaml
-              echo VERSION="${{ env.MAGMA_VERSION }}-${{ github.sha }}" >> $GITHUB_ENV
-              echo PACKAGE_VERSION="${{ env.MAGMA_VERSION }}" >> $GITHUB_ENV
-              # When focal-ci is clean we will be able to dynamically fetch latest ci debian packages
-            elif  [ "${{ env.AWS_ACCOUNT }}" = "LF" ]; then
-              sed -i -e "s@awsAccessKey:@& ${{ secrets.LF_AWS_ACCESS_KEY }}@1"  ${{ env.VARS_DIR }}/secrets.yaml
-              sed -i -e "s@awsSecretKey:@& ${{ secrets.LF_AWS_SECRET_ACCESS_KEY }}@1"  ${{ env.VARS_DIR }}/secrets.yaml
-              GIT_BRANCH_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-              echo PACKAGE_VERSION="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
-              echo VERSION="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
-            fi
-            echo PACKAGE_REPO_HOST="artifactory.magmacore.org\\\/artifactory\\\/debian" >> $GITHUB_ENV
-            echo GIT_REF="${{ github.sha }}" >> $GITHUB_ENV
+          if [ "${{ env.AWS_ACCOUNT }}" = "FB" ]; then
+            sed -i -e "s@awsAccessKey:@& ${{ secrets.FB_AWS_ACCESS_KEY }}@1"  ${{ env.VARS_DIR }}/secrets.yaml
+            sed -i -e "s@awsSecretKey:@& ${{ secrets.FB_AWS_SECRET_ACCESS_KEY }}@1"  ${{ env.VARS_DIR }}/secrets.yaml
+            echo VERSION="${{ env.MAGMA_VERSION }}-${{ github.sha }}" >> $GITHUB_ENV
+            echo PACKAGE_VERSION="${{ env.MAGMA_VERSION }}" >> $GITHUB_ENV
+            # When focal-ci is clean we will be able to dynamically fetch latest ci debian packages
+          elif  [ "${{ env.AWS_ACCOUNT }}" = "LF" ]; then
+            sed -i -e "s@awsAccessKey:@& ${{ secrets.LF_AWS_ACCESS_KEY }}@1"  ${{ env.VARS_DIR }}/secrets.yaml
+            sed -i -e "s@awsSecretKey:@& ${{ secrets.LF_AWS_SECRET_ACCESS_KEY }}@1"  ${{ env.VARS_DIR }}/secrets.yaml
+            GIT_BRANCH_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
+            echo PACKAGE_VERSION="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
+            echo VERSION="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
+          fi
+          echo PACKAGE_REPO_HOST="artifactory.magmacore.org\\\/artifactory\\\/debian" >> $GITHUB_ENV
+          echo GIT_REF="${{ github.sha }}" >> $GITHUB_ENV
       - name: Propagate AWS region information
         run: |
-            sed -i -e '/^awsAgwRegion: /s/:.*$/: us-east-1/' ${{ env.VARS_DIR }}/cluster.yaml
-            sed -i -e '/^awsOrc8rRegion: /s/:.*$/: us-east-1/' ${{ env.VARS_DIR }}/cluster.yaml
-            sed -i -e '/^awsAgwAz: /s/:.*$/: us-east-1b/' ${{ env.VARS_DIR }}/cluster.yaml
-            sed -i -e '/^buildAwsRegion: /s/:.*$/: us-east-1/' ${{ env.VARS_DIR }}/build.yaml
-            sed -i -e '/^buildAwsAz: /s/:.*$/: us-east-1b/' ${{ env.VARS_DIR }}/build.yaml
+          sed -i -e '/^awsAgwRegion: /s/:.*$/: us-east-1/' ${{ env.VARS_DIR }}/cluster.yaml
+          sed -i -e '/^awsOrc8rRegion: /s/:.*$/: us-east-1/' ${{ env.VARS_DIR }}/cluster.yaml
+          sed -i -e '/^awsAgwAz: /s/:.*$/: us-east-1b/' ${{ env.VARS_DIR }}/cluster.yaml
+          sed -i -e '/^buildAwsRegion: /s/:.*$/: us-east-1/' ${{ env.VARS_DIR }}/build.yaml
+          sed -i -e '/^buildAwsAz: /s/:.*$/: us-east-1b/' ${{ env.VARS_DIR }}/build.yaml
       - name: Propagate names for AWS essential components
         run: |
-            sed -i -e '/^secgroupDefault: /s/:.*$/: publish-amis-to-marketplace-secgroup/' ${{ env.VARS_DIR }}/defaults.yaml
-            sed -i -e '/^bucketDefault: /s/:.*$/: publish-amis-to-marketplace-bucket2/' ${{ env.VARS_DIR }}/defaults.yaml
-            sed -i -e '/^stackEssentialsDefault: /s/:.*$/: publish-amis-to-marketplace-stack/' ${{ env.VARS_DIR }}/defaults.yaml
-            sed -i -e '/^keyBoot: /s/:.*$/: publish-amis-to-marketplace-keyboot/' ${{ env.VARS_DIR }}/defaults.yaml
-            sed -i -e '/^keyHost: /s/:.*$/: publish-amis-to-marketplace-keyhost/' ${{ env.VARS_DIR }}/defaults.yaml
+          sed -i -e '/^secgroupDefault: /s/:.*$/: publish-amis-to-marketplace-secgroup/' ${{ env.VARS_DIR }}/defaults.yaml
+          sed -i -e '/^bucketDefault: /s/:.*$/: publish-amis-to-marketplace-bucket2/' ${{ env.VARS_DIR }}/defaults.yaml
+          sed -i -e '/^stackEssentialsDefault: /s/:.*$/: publish-amis-to-marketplace-stack/' ${{ env.VARS_DIR }}/defaults.yaml
+          sed -i -e '/^keyBoot: /s/:.*$/: publish-amis-to-marketplace-keyboot/' ${{ env.VARS_DIR }}/defaults.yaml
+          sed -i -e '/^keyHost: /s/:.*$/: publish-amis-to-marketplace-keyhost/' ${{ env.VARS_DIR }}/defaults.yaml
       - name: Setup AWS essentials components
         run: |
-            ansible-playbook ${{ env.WORK_DIR }}/aws-prerequisites.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}" --tags keyCreate,essentialsCreate
+          ansible-playbook ${{ env.WORK_DIR }}/aws-prerequisites.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}" --tags keyCreate,essentialsCreate
       - name: Propagate Tags for Cloudstrapper instances
         run: |
-            sed -i -e '/^devOpsCloudstrapper: /s/:.*$/: publishAmisToMarketplaceDevopsCloudstrapper/' ${{ env.VARS_DIR }}/defaults.yaml
-            sed -i -e '/^primaryCloudstrapper: /s/:.*$/: publishAmisToMarketplacePrimaryCloudstrapper/' ${{ env.VARS_DIR }}/defaults.yaml
-            sed -i -e '/^stackDevOpsCloudstrapper: /s/:.*$/: publish-amis-to-marketplace-stack-devopscloustrapper/' ${{ env.VARS_DIR }}/defaults.yaml
-            sed -i -e '/^stackCloudstrapper: /s/:.*$/: publish-amis-to-marketplace-stack-cloustrapper/' ${{ env.VARS_DIR }}/defaults.yaml
-            sed -i -e '/^devOpsAmi: /s/:.*$/: cloudstrapper-'"$VERSION"'/' ${{ env.VARS_DIR }}/defaults.yaml
-            sed -i -e '/^buildAgwVersion: /s/:.*$/: '"$GIT_REF"'/' ${{ env.VARS_DIR }}/build.yaml
-            sed -i -e '/^buildAgwPackage: /s/:.*$/: '"$PACKAGE_VERSION"'/' ${{ env.VARS_DIR }}/build.yaml
-            sed -i -e '/^taggedVersion: /s/:.*$/: '"$VERSION"'/' ${{ env.VARS_DIR }}/build.yaml
+          sed -i -e '/^devOpsCloudstrapper: /s/:.*$/: publishAmisToMarketplaceDevopsCloudstrapper/' ${{ env.VARS_DIR }}/defaults.yaml
+          sed -i -e '/^primaryCloudstrapper: /s/:.*$/: publishAmisToMarketplacePrimaryCloudstrapper/' ${{ env.VARS_DIR }}/defaults.yaml
+          sed -i -e '/^stackDevOpsCloudstrapper: /s/:.*$/: publish-amis-to-marketplace-stack-devopscloustrapper/' ${{ env.VARS_DIR }}/defaults.yaml
+          sed -i -e '/^stackCloudstrapper: /s/:.*$/: publish-amis-to-marketplace-stack-cloustrapper/' ${{ env.VARS_DIR }}/defaults.yaml
+          sed -i -e '/^devOpsAmi: /s/:.*$/: cloudstrapper-'"$VERSION"'/' ${{ env.VARS_DIR }}/defaults.yaml
+          sed -i -e '/^buildUbuntuAmi: /s/:.*$/: ami-09e67e426f25ce0d7/' ${{ env.VARS_DIR }}/build.yaml
+          sed -i -e '/^buildAgwVersion: /s/:.*$/: '"$GIT_REF"'/' ${{ env.VARS_DIR }}/build.yaml
+          sed -i -e '/^buildAgwPackage: /s/:.*$/: '"$PACKAGE_VERSION"'/' ${{ env.VARS_DIR }}/build.yaml
+          sed -i -e '/^taggedVersion: /s/:.*$/: '"$VERSION"'/' ${{ env.VARS_DIR }}/build.yaml
       - name: Generate Cloudstrapper AMI
         timeout-minutes: 120
         run: |
-            echo "DEFAULTS"
-            cat ${{ env.VARS_DIR }}/defaults.yaml
-            echo "BUILD"
-            cat ${{ env.VARS_DIR }}/build.yaml
-            echo "CLUSTER"
-            cat ${{ env.VARS_DIR }}/cluster.yaml
-            ansible-playbook ${{ env.WORK_DIR }}/devops-provision.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}"
-            echo "Waiting one minute for the instance to boot up."
-            sleep 60
-            ansible-playbook ${{ env.WORK_DIR }}/devops-configure.yaml -e "devops=tag_Name_publishAmisToMarketplaceDevopsCloudstrapper" -e "dirLocalInventory=${{ env.VARS_DIR }}" -i ${{ env.VARS_DIR }}/common_instance_aws_ec2.yaml -u ubuntu --skip-tags usingGitSshKey,buildMagma,pubMagma,helm,pubHelm
-            ansible-playbook ${{ env.WORK_DIR }}/devops-init.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}"
+          echo "DEFAULTS"
+          cat ${{ env.VARS_DIR }}/defaults.yaml
+          echo "BUILD"
+          cat ${{ env.VARS_DIR }}/build.yaml
+          echo "CLUSTER"
+          cat ${{ env.VARS_DIR }}/cluster.yaml
+          ansible-playbook ${{ env.WORK_DIR }}/devops-provision.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}"
+          echo "Waiting one minute for the instance to boot up."
+          sleep 60
+          ansible-playbook ${{ env.WORK_DIR }}/devops-configure.yaml -e "devops=tag_Name_publishAmisToMarketplaceDevopsCloudstrapper" -e "dirLocalInventory=${{ env.VARS_DIR }}" -i ${{ env.VARS_DIR }}/common_instance_aws_ec2.yaml -u ubuntu --skip-tags usingGitSshKey,buildMagma,pubMagma,helm,pubHelm
+          ansible-playbook ${{ env.WORK_DIR }}/devops-init.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}"
       - name: Notify success to Slack
         if: success() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
@@ -114,33 +115,33 @@ jobs:
           SLACK_FOOTER: ' '
       - name: Propagate variables for AGW AMI build
         run: |
-            sed -i -e '/^buildAgwAmiName: /s/:.*$/: agw-ami-'"$VERSION"'/' ${{ env.VARS_DIR }}/build.yaml
-            sed -i -e '/^buildGwTagName: /s/:.*$/: publishAmisToMarketplaceAgw/' ${{ env.VARS_DIR }}/build.yaml
-            sed -i -e '/^packageRepoHost: /s/:.*$/: '"${{ env.PACKAGE_REPO_HOST }}"'/' ${{ env.VARS_DIR }}/build.yaml
-            sed -i -e '/^awsAgwAmi: /s/:.*$/: ami-09e67e426f25ce0d7/' ${{ env.VARS_DIR }}/cluster.yaml
-            # TODO Overwriting the previous buildAgwVersion to the current branch
-            sed -i -e '/^buildAgwVersion: /s/:.*$/: '"refs\/heads\/${{ env.BASE_REFERENCE }}"'/' ${{ env.VARS_DIR }}/build.yaml
+          sed -i -e '/^buildAgwAmiName: /s/:.*$/: agw-ami-'"$VERSION"'/' ${{ env.VARS_DIR }}/build.yaml
+          sed -i -e '/^buildGwTagName: /s/:.*$/: publishAmisToMarketplaceAgw/' ${{ env.VARS_DIR }}/build.yaml
+          sed -i -e '/^packageRepoHost: /s/:.*$/: '"${{ env.PACKAGE_REPO_HOST }}"'/' ${{ env.VARS_DIR }}/build.yaml
+          sed -i -e '/^awsAgwAmi: /s/:.*$/: ami-09e67e426f25ce0d7/' ${{ env.VARS_DIR }}/cluster.yaml
+          # TODO Overwriting the previous buildAgwVersion to the current branch
+          sed -i -e '/^buildAgwVersion: /s/:.*$/: '"refs\/heads\/${{ env.BASE_REFERENCE }}"'/' ${{ env.VARS_DIR }}/build.yaml
       - name: Generate AGW AMI
         timeout-minutes: 30
         run: |
-            ansible-playbook ${{ env.WORK_DIR }}/agw-provision.yaml -e "idSite=DevOps" -e "idGw=publishAmisToMarketplaceAgw" -e "dirLocalInventory=${{ env.VARS_DIR }}" --tags infra,inventory  -e "agwDevops=1" --skip-tags createBridge,cleanupBridge,cleanupNet
-            echo "Waiting one minute for the instance to boot up."
-            sleep 60
-            ansible-playbook ${{ env.WORK_DIR }}/ami-configure.yaml -i "${{ env.VARS_DIR }}/common_instance_aws_ec2.yaml" -e "dirLocalInventory=${{ env.VARS_DIR }}" -e "aminode=tag_Name_publishAmisToMarketplaceAgw" -e "ansible_python_interpreter=/usr/bin/python3" -u ubuntu
-            ansible-playbook ${{ env.WORK_DIR }}/ami-init.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}"
+          ansible-playbook ${{ env.WORK_DIR }}/agw-provision.yaml -e "idSite=DevOps" -e "idGw=publishAmisToMarketplaceAgw" -e "dirLocalInventory=${{ env.VARS_DIR }}" --tags infra,inventory  -e "agwDevops=1" --skip-tags createBridge,cleanupBridge,cleanupNet
+          echo "Waiting one minute for the instance to boot up."
+          sleep 60
+          ansible-playbook ${{ env.WORK_DIR }}/ami-configure.yaml -i "${{ env.VARS_DIR }}/common_instance_aws_ec2.yaml" -e "dirLocalInventory=${{ env.VARS_DIR }}" -e "aminode=tag_Name_publishAmisToMarketplaceAgw" -e "ansible_python_interpreter=/usr/bin/python3" -u ubuntu
+          ansible-playbook ${{ env.WORK_DIR }}/ami-init.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}"
       - name: Export qcow2 image for fb aws account in s3
         timeout-minutes: 30
         run: |
-            if [ "${{ env.AWS_ACCOUNT }}" = "FB" ]; then
-              ansible-playbook ${{ env.WORK_DIR }}/devops-convert-to-qcow2.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}" -e "agwAmiName=agw-ami-$VERSION"
-            fi
+          if [ "${{ env.AWS_ACCOUNT }}" = "FB" ]; then
+            ansible-playbook ${{ env.WORK_DIR }}/devops-convert-to-qcow2.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}" -e "agwAmiName=agw-ami-$VERSION"
+          fi
       - name: Clean AWS resources
         if: always()
         run: |
-            ansible-playbook ${{ env.WORK_DIR }}/cleanup.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}" --tags agw,subnet,secgroup,vpc,keys --skip-tags orc8r  -e "{"deleteStacks": [stackDevOpspublishAmisToMarketplaceAgw, publish-amis-to-marketplace-stack-devopscloustrapper, publish-amis-to-marketplace-stack, stackDevOpsNetwork]}"
+          ansible-playbook ${{ env.WORK_DIR }}/cleanup.yaml -e "dirLocalInventory=${{ env.VARS_DIR }}" --tags agw,subnet,secgroup,vpc,keys --skip-tags orc8r  -e "{"deleteStacks": [stackDevOpspublishAmisToMarketplaceAgw, publish-amis-to-marketplace-stack-devopscloustrapper, publish-amis-to-marketplace-stack, stackDevOpsNetwork]}"
       - name: Notify success to Slack
         if: success() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
@@ -161,14 +162,14 @@ jobs:
       WORK_DIR: "${{ github.workspace }}/experimental/cloudstrapper/playbooks"
       SHA: "${{ github.sha }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run apt
         run: sudo apt-get update && sudo apt -y upgrade
       - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@v8"
+        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
           default: 3.7.0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - name: Install Dependencies

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -1,10 +1,10 @@
 ---
 name: AutoLabel PR
-on:  # yamllint disable-line rule:truthy
+on:
   # Use pull_request_target to gain write permissions.
   # Ref: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
     paths:
       - '.github/**'
       - 'ci-scripts/**'
@@ -34,10 +34,9 @@ jobs:
   AutoLabelPR:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
-
             let newCompLbls = new Set(); // Set of new label strings
 
             // Fetch files modified in the PR

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,7 @@
 ---
 name: backport
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -13,18 +13,18 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - run: |
-            mkdir ~/.magma
-            echo ${{ secrets.GITHUB_TOKEN }} > ~/.magma/github_access_token
+          mkdir ~/.magma
+          echo ${{ secrets.GITHUB_TOKEN }} > ~/.magma/github_access_token
       - name: Install python prerequisites
         run: pip3 install fabric3 jsonpickle requests PyYAML PyGithub
       - run: |
-            cd ${MAGMA_ROOT}/.github/workflows/scripts
-            fab find_release_commits
+          cd ${MAGMA_ROOT}/.github/workflows/scripts
+          fab find_release_commits
       - name: Extract commit title
         if: failure()
         id: commit
@@ -33,7 +33,7 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
         if: failure()
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Failure of backport on master"

--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -1,6 +1,6 @@
 ---
 name: Push Bazel Cache To S3
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -29,23 +29,23 @@ jobs:
     steps:
       - run: echo "::set-output name=date::$(date +'%m-%d-%Y--%H-%M-%S')"
         id: date
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Cache magma-dev-box
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
           key: vagrant-box-magma-dev
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # pin@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_AMI_BAZEL_CACHE_S3 }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_AMI_BAZEL_CACHE_S3 }}
           aws-region: us-east-1
       - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@v8"
+        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
           default: 3.8.5
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.5'
       - name: Install pre requisites
@@ -114,15 +114,15 @@ jobs:
           sudo rm -rf /opt/ghc
           echo "Available storage after:"
           df -h
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # pin@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_AMI_BAZEL_CACHE_S3 }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_AMI_BAZEL_CACHE_S3 }}
           aws-region: us-east-1
       - name: Build all `bazel build //...`
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -131,7 +131,7 @@ jobs:
             cd /workspaces/magma
             bazel build //...
       - name: Test all  `bazel test //...`
-        uses: addnab/docker-run-action@v2
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.DEVCONTAINER_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,6 +1,7 @@
 ---
 name: "Bazel Build & Test"
-on:  # yamllint disable-line rule:truthy
+on:
+  # yamllint disable-line rule:truthy
   workflow_dispatch:
   pull_request:
     types:
@@ -19,7 +20,6 @@ env:
   BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   CACHE_KEY: bazel-base-image
 
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -31,7 +31,7 @@ jobs:
       files_changed: ${{ steps.changes.outputs.files_changed }}
     steps:
       # Need to get git on push event
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         if: github.event_name == 'pull_request'
         id: changes
         with:
@@ -71,9 +71,9 @@ jobs:
           df -h
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           options: --pull always
@@ -81,7 +81,7 @@ jobs:
           run: |
             echo "Pulled the bazel base image!"
       - name: Run bazel build, test, starlark format check & python import check
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -119,13 +119,13 @@ jobs:
             printf '\r%s\r' '###############################' 1>&2 &&
             bazel/scripts/test_python_service_imports.sh
       - name: Publish bazel build profile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: Bazel build all profile
           path: Bazel_build_all_profile
       - name: Publish bazel test profile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: Bazel test all profile
@@ -137,7 +137,7 @@ jobs:
           df -h
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
           SLACK_TITLE: "Bazel Build & Test Job `bazel build //...; bazel test //...`"
@@ -170,9 +170,9 @@ jobs:
           df -h
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           options: --pull always
@@ -180,7 +180,7 @@ jobs:
           run: |
             echo "Pulled the bazel base image!"
       - name: Build .deb Packages
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -192,7 +192,7 @@ jobs:
               --config=production \
               --profile=Bazel_build_package_profile
       - name: Publish bazel profile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: Bazel build package profile
@@ -204,7 +204,7 @@ jobs:
           df -h
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
           SLACK_TITLE: "Bazel Package Job"
@@ -219,14 +219,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Execute check
         shell: bash
         run: |
           ./bazel/scripts/check_py_bazel.sh
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
           SLACK_TITLE: "Bazel Python Check Job `./bazel/scripts/check_py_bazel.sh`"
@@ -241,14 +241,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Execute check
         shell: bash
         run: |
           ./bazel/scripts/check_c_cpp_bazel.sh
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
           SLACK_TITLE: "Bazel C/C++ Check Job `./bazel/scripts/check_c_cpp_bazel.sh`"

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -1,7 +1,7 @@
 ---
 name: build-all
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - 'v1.*'
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   build_publish_helm_charts:
@@ -25,7 +25,7 @@ jobs:
       ISSUE_NUMBER: "${{ github.event.number }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       # Version is github job run number when running on master
       # Or is branch name when on release branch
       - name: Set Helm chart version
@@ -46,7 +46,7 @@ jobs:
             orc8r/tools/helm/package.sh --deployment-type all
           fi
       - name: Upload charts as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: github.event_name == 'pull_request'
         with:
           name: helm-charts
@@ -58,7 +58,7 @@ jobs:
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/pr_number
           echo "false" > ./pr/skipped
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: pr
           path: pr/
@@ -72,7 +72,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action Push helm charts to artifactory failed"
@@ -84,7 +84,7 @@ jobs:
       # Notify ci channel when push succeeds
       - name: Notify success to Slack
         if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
@@ -105,7 +105,7 @@ jobs:
     outputs:
       artifacts: ${{ steps.publish_packages.outputs.artifacts }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           fetch-depth: 0
       - name: Cache magma-dev-box
@@ -114,10 +114,10 @@ jobs:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
           key: vagrant-box-magma-dev
       - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@v8"
+        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
           default: 3.8.5
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.5'
       - name: Install pre requisites
@@ -168,12 +168,12 @@ jobs:
             ARTIFACTS=$(echo $ARTIFACTS | jq '. += {"valid":true}')
           fi
           echo "::set-output name=artifacts::$(echo $ARTIFACTS)"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: github.event_name == 'pull_request'
         with:
           name: magma-packages
           path: lte/gateway/magma-packages/*.deb
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         name: Export sentry executables
         if: github.event_name == 'push'
         with:
@@ -192,7 +192,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: "Github action agw build failed"
           SLACK_AVATAR: ":boom:"
-        uses: Ilshidur/action-slack@2.1.0
+        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         with:
           args: "AGW  build failed on [${{github.sha}}](${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}): ${{ steps.commit.outputs.title}}"
       # Notify ci channel when push succeeds
@@ -202,12 +202,12 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
           SLACK_USERNAME: "Github action agw build got published"
-        uses: Ilshidur/action-slack@2.1.0
+        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         with:
           args: "AGW  build succeeded on [${{github.sha}}](${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}): ${{ steps.commit.outputs.title}}"
   sentry_release:
     if: always() && github.event_name == 'push'
-    needs: [agw-build]
+    needs: [ agw-build ]
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
       SENTRY_ENVIRONMENT: "staging"
@@ -216,13 +216,13 @@ jobs:
       MAGMA_VERSION: ${{ needs.agw-build.outputs.magma_version }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # pin@v2
         with:
           name: sentry-exec
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # pin@v1
         with:
           name: sentry-exec
       - run: ls -R
@@ -261,10 +261,10 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
         run: |
-           COMMIT_HASH_WITH_VERSION="magma@1.7.0.$(git rev-list --count HEAD)-${GITHUB_SHA:0:8}"
-           sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native -p magma-staging-native ${COMMIT_HASH_WITH_VERSION}
-           sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${COMMIT_HASH_WITH_VERSION}
-           sentry-cli --log-level=info releases finalize ${COMMIT_HASH_WITH_VERSION}
+          COMMIT_HASH_WITH_VERSION="magma@1.7.0.$(git rev-list --count HEAD)-${GITHUB_SHA:0:8}"
+          sentry-cli --log-level=info releases new -p lab-agws-python -p lab-agws-native -p magma-staging-native ${COMMIT_HASH_WITH_VERSION}
+          sentry-cli --log-level=info releases set-commits --auto --ignore-missing ${COMMIT_HASH_WITH_VERSION}
+          sentry-cli --log-level=info releases finalize ${COMMIT_HASH_WITH_VERSION}
   orc8r-build:
     if: github.repository_owner == 'magma'
     name: orc8r build job
@@ -274,10 +274,10 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run apt-get update
         run: sudo apt-get update
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - name: Run build.py
@@ -291,7 +291,7 @@ jobs:
           cd images
           docker save orc8r_nginx | gzip > nginx.tar.gz
           docker save orc8r_controller  | gzip > controller.tar.gz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: github.event_name == 'pull_request'
         with:
           name: docker-images-orc8r
@@ -324,7 +324,7 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         # yamllint enable
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -337,7 +337,7 @@ jobs:
       # Notify ci channel when push succeeds
       - name: Notify success to Slack
         if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
@@ -355,7 +355,7 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
       DOCKER_BUILDKIT: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run agw docker compose
         id: agw-docker-compose
         continue-on-error: true
@@ -412,7 +412,7 @@ jobs:
           docker save ghz_gateway_c | gzip > ghz_gateway_c.tar.gz
           docker save ghz_gateway_python | gzip > ghz_gateway_python.tar.gz
       - name: Upload docker images as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: github.event_name == 'pull_request'
         with:
           name: docker-images-agw
@@ -423,7 +423,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: pr
           path: pr/
@@ -450,7 +450,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository_owner == 'magma'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Install SwaggerHub CLI
         run: npm install --global swaggerhub-cli
       - name: Publish SwaggerHub API
@@ -468,7 +468,7 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action cloud-upload failed"
@@ -480,7 +480,7 @@ jobs:
       # Notify ci channel when push succeeds
       - name: Notify success to Slack
         if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
@@ -499,7 +499,7 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run docker compose
         id: cwag-docker-compose
         continue-on-error: true
@@ -551,7 +551,7 @@ jobs:
           docker save goradius | gzip > goradius.tar.gz
           docker save xwfm-integ-tests | gzip > xwfm-integ-tests.tar.gz
       - name: Upload docker images as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: github.event_name == 'pull_request'
         with:
           name: docker-images-cwag
@@ -562,7 +562,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/pr_number
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: pr
           path: pr/
@@ -615,7 +615,7 @@ jobs:
       # yamllint enable
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "CWAG/xwfm-deploy failed"
@@ -627,7 +627,7 @@ jobs:
       # Notify ci channel when push succeeds
       - name: Notify success to slack
         if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
@@ -644,7 +644,7 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run docker compose build
         env:
           DOCKER_REGISTRY: cwf_
@@ -658,7 +658,7 @@ jobs:
           cd images
           docker save cwf_operator | gzip > operator.tar.gz
       - name: Upload docker images as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: github.event_name == 'pull_request'
         with:
           name: docker-images-cwf
@@ -669,7 +669,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/pr_number
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: pr
           path: pr/
@@ -702,7 +702,7 @@ jobs:
       # yamllint enable
       - name: Notify failure to slack
         if: failure() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "CWF-operator-build failed"
@@ -714,7 +714,7 @@ jobs:
       # Notify ci channel when push succeeds
       - name: Notify success to slack
         if: success() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
@@ -733,8 +733,8 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - name: generate test certs and snowflake
@@ -768,7 +768,7 @@ jobs:
           docker save feg_gateway_go | gzip > feg_gateway_go.tar.gz
           docker save feg_gateway_python | gzip > feg_gateway_python.tar.gz
       - name: Upload docker images as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: github.event_name == 'pull_request'
         with:
           name: docker-images-feg
@@ -803,7 +803,7 @@ jobs:
       # yamllint enable
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "FeG-precommit tests failed"
@@ -815,7 +815,7 @@ jobs:
       # Notify ci channel when push succeeds
       - name: Notify success to slack
         if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
@@ -835,7 +835,7 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
       NMS_ROOT: "${{ github.workspace }}/nms"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run docker compose
         id: nms-docker-compose
         # yamllint disable rule:line-length
@@ -849,7 +849,7 @@ jobs:
           cd images
           docker save magmalte_magmalte | gzip > magmalte.tar.gz
       - name: Upload docker images as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: github.event_name == 'pull_request'
         with:
           name: docker-images-nms
@@ -885,7 +885,7 @@ jobs:
       # yamllint enable
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_TITLE: "Github action nms-build failed"
@@ -897,7 +897,7 @@ jobs:
       # Notify ci channel when push succeeds
       - name: Notify success to slack
         if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
@@ -911,18 +911,27 @@ jobs:
     name: Publish to firebase
     if: always() && github.event_name == 'push' && github.repository_owner == 'magma'
     runs-on: ubuntu-latest
-    needs: [agw-build, feg-build, orc8r-build, cwag-deploy, nms-build]
+    needs:
+      [
+        agw-build,
+        feg-build,
+        orc8r-build,
+        cwag-deploy,
+        nms-build
+      ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - name: Publish to
         env:
           FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
-          WORKERS: "wl_lab_5g"  # all workers for post-merge pipeline. Comma separated
+          WORKERS: "wl_lab_5g" # all workers for post-merge pipeline. Comma separated
           BUILD_ID: "${{ github.sha }}"
-          BUILD_METADATA: '{"github:workflow": "${{ github.workflow }}", "github:run_id": "${{ github.run_id }}", "github:actor": "${{ github.actor }}", "github:repository": "${{ github.repository }}", "github:event_name": "${{ github.event_name }}", "github:sha": "${{ github.sha }}", "github:sha:url": "${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}", "github:ref": "${{ github.ref }}"}'
+          BUILD_METADATA: '{"github:workflow": "${{ github.workflow }}", "github:run_id": "${{ github.run_id }}", "github:actor": "${{ github.actor }}", "github:repository": "${{ github.repository }}",
+            "github:event_name": "${{ github.event_name }}", "github:sha": "${{ github.sha }}", "github:sha:url": "${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}",
+            "github:ref": "${{ github.ref }}"}'
           AGW_ARTIFACTS: ${{ needs.agw-build.outputs.artifacts }}
           FEG_ARTIFACTS: ${{ needs.feg-build.outputs.artifacts }}
           ORC8R_ARTIFACTS: ${{ needs.orc8r-build.outputs.artifacts }}
@@ -941,7 +950,7 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Prepare tools
         working-directory: "${{ github.workspace }}/dp"
         run: |
@@ -973,7 +982,7 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         # yamllint enable
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -986,7 +995,7 @@ jobs:
       # Notify ci channel when push succeeds
       - name: Notify success to Slack
         if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}

--- a/.github/workflows/check-rebase.yml
+++ b/.github/workflows/check-rebase.yml
@@ -1,7 +1,7 @@
 ---
 name: "Check Rebase"
 
-on:  # yamllint disable-line rule:truthy
+on:
   pull_request:
     branches:
       - master
@@ -17,12 +17,12 @@ jobs:
       BASE_SHA: "${{ github.event.pull_request.base.sha }}"
     steps:
       - name: Checkout Head
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           repository: "${{env.HEAD_FULL_NAME}}"
           fetch-depth: 0
       - name: Checkout Base
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           repository: "${{env.BASE_FULL_NAME}}"
           fetch-depth: 0

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -1,7 +1,7 @@
 ---
 name: cloud-workflow
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - 'v1.*'
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -23,9 +23,9 @@ jobs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo -n ${{ steps.changes.outputs.filesChanged == 'false' }} > ./pr/skipped
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr
@@ -52,8 +52,8 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
       GO111MODULE: 'on'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - name: deploy-sync-checkin
@@ -74,7 +74,7 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/orc8r/cloud/docker
           python3 build.py --coverage
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
         if: always() && steps.cloud-lint-cov.outcome=='success'
         id: cloud-lint-codecov
         with:
@@ -90,11 +90,11 @@ jobs:
         timeout-minutes: 15
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: Unit Test Results
           path: "${{ env.MAGMA_ROOT}}/orc8r/cloud/test-results/*"
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         if: always()
         id: gateway_test_init
         with:
@@ -120,7 +120,7 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack for deploy-sync-checkin
         if: steps.deploy-sync-checkin.outcome=='failure' && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action insync-checkin failed"
@@ -131,7 +131,7 @@ jobs:
           SLACK_FOOTER: ' '
       - name: Notify failure to Slack for cloud-test
         if: steps.cloud-test.outcome=='failure' && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action cloud-test failed"
@@ -142,7 +142,7 @@ jobs:
           SLACK_FOOTER: ' '
       - name: Notify failure to Slack for cloud-lint
         if: ( steps.cloud-lint.outcome=='failure' || steps.cloud-lint-codecov.outcome=='failure' || steps.cloud-lint-cov.outcome=='failure' ) && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action cloud-test failed"
@@ -153,7 +153,7 @@ jobs:
           SLACK_FOOTER: ' '
       - name: Notify failure to Slack for orc8r-gateway-test
         if: ( steps.gateway_test_init.outcome=='failure' || steps.gateway_test_dep.outcome=='failure' || steps.gateway_test.outcome=='failure' ) && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action orc8r-gateway-test failed"

--- a/.github/workflows/codeowners-syntax.yml
+++ b/.github/workflows/codeowners-syntax.yml
@@ -1,7 +1,7 @@
 ---
 name: "Codeowners Validator"
 
-on:  # yamllint disable-line rule:truthy
+on:
   pull_request:
     types:
       - opened
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository, which is validated in the next step
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: GitHub CODEOWNERS Validator
-        uses: mszostok/codeowners-validator@v0.6.0
+        uses: mszostok/codeowners-validator@2f6e3bb39aa6837d7dcf8eff2de5d6c046d0c9a9 # pin@v0.6.0
         with:
           checks: "syntax,files,duppatterns"
           # TODO: enable owner check

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
+---
 name: "CodeQL"
 
 on:
@@ -39,58 +40,54 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@a6611b86918424d4588efe7d6dbe18fe52d42518 # pin@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+          # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+          # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@a6611b86918424d4588efe7d6dbe18fe52d42518 # pin@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
+      #   - run: |
+      #   make bootstrap
+      #   make release
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@a6611b86918424d4588efe7d6dbe18fe52d42518 # pin@v1
+        env:
+          NODE_OPTIONS: --max-old-space-size=5120
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      - name: Extract commit title
+        if: failure() && github.ref == 'refs/heads/master'
+        id: commit
+        run: |
+          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
+          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
 
-    #- run: |
-    #   make bootstrap
-    #   make release
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
-      env:
-        NODE_OPTIONS: --max-old-space-size=5120
-
-    - name: Extract commit title
-      if: failure() && github.ref == 'refs/heads/master'
-      id: commit
-      run: |
-        str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
-        echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-
-    # Notify ci-info channel when failing
-    # Plugin info: https://github.com/marketplace/actions/slack-notify
-
-    - name: Notify failure to slack
-      if: failure() && github.ref == 'refs/heads/master'
-      uses: rtCamp/action-slack-notify@v2.2.0
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-        SLACK_TITLE: "Github action CodeQL-analysis ${{ matrix.language }} failed"
-        SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-        SLACK_USERNAME: "CodeQL-analysis ${{ matrix.language }} "
-        SLACK_ICON_EMOJI: ":boom:"
-        SLACK_COLOR: "#FF0000"
-        SLACK_FOOTER: ' '
+      # Notify ci-info channel when failing
+      # Plugin info: https://github.com/marketplace/actions/slack-notify
+      - name: Notify failure to slack
+        if: failure() && github.ref == 'refs/heads/master'
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
+          SLACK_TITLE: "Github action CodeQL-analysis ${{ matrix.language }} failed"
+          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
+          SLACK_USERNAME: "CodeQL-analysis ${{ matrix.language }} "
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -1,6 +1,6 @@
 ---
 name: Update PR on check failure
-on:  # yamllint disable-line rule:truthy
+on:
   workflow_run:
     workflows:
       - DCO check
@@ -23,7 +23,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -45,7 +45,7 @@ jobs:
       - run: unzip pr.zip
       - name: Check if the workflow is skipped
         id: skip_check
-        uses: actions/github-script@v3
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
             var fs = require('fs');
@@ -71,7 +71,7 @@ jobs:
     steps:
       # Retrieve PR number from triggering workflow artifacts
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -124,7 +124,7 @@ jobs:
           - [Instructions on formatting your Markdown changes](https://magma.github.io/magma/docs/next/docs/docs_overview#precommit)
           - $CHECK_GUIDELINE" >> $GITHUB_WORKSPACE/msg
       - name: Comment on PR
-        uses: actions/github-script@v3
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
             var fs = require('fs');

--- a/.github/workflows/config/yamllint_config.yml
+++ b/.github/workflows/config/yamllint_config.yml
@@ -12,18 +12,23 @@ ignore: |
   **/templates/**/*.yaml
 
 rules:
-  braces: enable
-  brackets: enable
+  braces: 
+    max-spaces-inside: 1
+    min-spaces-inside: 1
+  brackets:
+    max-spaces-inside: 1
   colons: enable
   commas: enable
   comments:
     level: warning
+    min-spaces-from-content: 1
   comments-indentation:
     level: warning
   document-end: disable
   document-start:
     level: warning
-  empty-lines: enable
+  empty-lines: 
+    max: 3
   empty-values: disable
   hyphens: enable
   indentation: enable
@@ -35,5 +40,4 @@ rules:
   octal-values: disable
   quoted-strings: disable
   trailing-spaces: enable
-  truthy:
-    level: warning
+  truthy: disable

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -1,7 +1,7 @@
 ---
 name: cwag-workflow
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - 'v1.*'
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -24,9 +24,9 @@ jobs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -38,31 +38,31 @@ jobs:
     name: cwag pre-commit job
     runs-on: ubuntu-latest
     env:
-      GO111MODULE: on  # yamllint disable-line rule:truthy
+      GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
           go-version: '1.18'
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@e88a9994b039653512d697de1bce46b00bfe11b5 # pin@v2
         with:
           command: cd ${MAGMA_ROOT}/cwf/gateway && go mod download
           timeout_minutes: 10
       - name: Run precommit
         run: |
-            make -C ${MAGMA_ROOT}/cwf/gateway precommit
-            make -C ${MAGMA_ROOT}/cwf/gateway/integ_tests precommit
+          make -C ${MAGMA_ROOT}/cwf/gateway precommit
+          make -C ${MAGMA_ROOT}/cwf/gateway/integ_tests precommit
       - name: Check precommit has not generated formatting changes
         run: |
-            echo "Checking for changes caused by 'make -C \${MAGMA_ROOT}/cwf/gateway precommit' and 'make -C \${MAGMA_ROOT}/cwf/gateway/integ_tests precommit'."\
-                 "Run these commands locally to see the respective changes."
-            cd ${MAGMA_ROOT}
-            git status
-            git diff-index --quiet HEAD
+          echo "Checking for changes caused by 'make -C \${MAGMA_ROOT}/cwf/gateway precommit' and 'make -C \${MAGMA_ROOT}/cwf/gateway/integ_tests precommit'."\
+               "Run these commands locally to see the respective changes."
+          cd ${MAGMA_ROOT}
+          git status
+          git diff-index --quiet HEAD
       - name: Extract commit title
         if: failure() && github.event_name == 'push'
         id: commit
@@ -73,7 +73,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "CWAG-precommit tests failed"

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -2,8 +2,8 @@
 
 name: CWF integ test
 
-on:  # yamllint disable-line rule:truthy
-  workflow_dispatch:
+on:
+  workflow_dispatch: null
   workflow_run:
     workflows:
       - build-all
@@ -20,7 +20,7 @@ jobs:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ env.SHA }}
       - name: Run docker compose
@@ -37,7 +37,7 @@ jobs:
           docker save cwf_cwag_go:latest  | gzip > cwf_cwag_go.tar.gz
           docker save cwf_gateway_go:latest | gzip > cwf_gateway_go.tar.gz
           docker save cwf_gateway_pipelined:latest | gzip > cwf_gateway_pipelined.tar.gz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: docker-images
           path: images
@@ -54,7 +54,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: "CWF integ test"
           SLACK_AVATAR: ":boom:"
-        uses: Ilshidur/action-slack@2.1.0
+        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         with:
           args: 'CWF integration test: docker build step failed on [${{ env.SHA }}](${{github.event.repository.owner.html_url}}/magma/commits/${{ env.SHA }}): ${{ steps.commit.outputs.title}}'
   cwf-integ-test:
@@ -62,7 +62,7 @@ jobs:
     runs-on: macos-10.15
     needs: docker-build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ env.SHA }}
       - name: Cache Vagrant Boxes
@@ -71,10 +71,10 @@ jobs:
           path: ~/.vagrant.d/boxes
           key: vagrant-boxes-cwf
       - name: Setup Python env
-        uses: "gabrielfalcao/pyenv-action@v8"
+        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
           default: 3.8.5
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.5'
       - name: Install pre requisites
@@ -82,10 +82,10 @@ jobs:
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
           vagrant plugin install vagrant-vbguest vagrant-disksize
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # pin@v2
         with:
           name: docker-images
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # pin@v1
         with:
           name: docker-images
       - name: Copy docker images into /tmp/cwf-images
@@ -108,13 +108,13 @@ jobs:
           fab integ_test:destroy_vm=True,transfer_images=True,test_result_xml=tests.xml,rerun_fails=3,skip_docker_load=True,tar_path="/tmp/cwf-images"
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: test-results
           path: cwf/gateway/tests.xml
       - name: Publish Unit Test Results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        uses: EnricoMi/publish-unit-test-result-action/composite@7377632048da85434c30810c38353542d3162dc4 # pin@v1
         with:
           check_run_annotations: all tests
           files: cwf/gateway/tests.xml
@@ -127,7 +127,7 @@ jobs:
           cp *.log logs/
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: test-logs
           path: cwf/gateway/logs
@@ -148,6 +148,6 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: "CWF integ test"
           SLACK_AVATAR: ":boom:"
-        uses: Ilshidur/action-slack@2.1.0
+        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         with:
           args: 'CWF integration test: tests failed on [${{ env.SHA }}](${{github.event.repository.owner.html_url}}/magma/commits/${{ env.SHA }}): ${{ steps.commit.outputs.title}}'

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -1,7 +1,7 @@
 ---
 name: cwf-operator
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - master
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -23,9 +23,9 @@ jobs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -37,24 +37,24 @@ jobs:
     name: cwf operator pre-commit job
     runs-on: ubuntu-latest
     env:
-      GO111MODULE: on  # yamllint disable-line rule:truthy
+      GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
           go-version: '1.18'
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@e88a9994b039653512d697de1bce46b00bfe11b5 # pin@v2
         with:
           command: cd ${MAGMA_ROOT}/cwf/k8s/cwf_operator && go mod download
           timeout_minutes: 10
       - name: Run precommit
         run: |
-            cd ${MAGMA_ROOT}/cwf/k8s/cwf_operator
-            make -C ${MAGMA_ROOT}/cwf/k8s/cwf_operator precommit
+          cd ${MAGMA_ROOT}/cwf/k8s/cwf_operator
+          make -C ${MAGMA_ROOT}/cwf/k8s/cwf_operator precommit
       - name: Extract commit title
         id: commit
         run: |
@@ -64,7 +64,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
         if: failure() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "CWF-operator-precommit tests failed"

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,8 +1,8 @@
 ---
 name: DCO check
-on:  # yamllint disable-line rule:truthy
+on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Check if PR is a Reverted PR
         id: reverted_pr_check
-        uses: actions/github-script@v3
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
             if( process.env.PR_TITLE.startsWith('Revert') ) {
@@ -35,7 +35,7 @@ jobs:
           mkdir -p ./pr
           echo -n ${{ steps.reverted_pr_check.outputs.is_reverted_pr }} > ./pr/is_reverted_pr
           echo -n "false" > ./pr/skipped
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr
@@ -47,23 +47,23 @@ jobs:
     name: DCO Check
     runs-on: ubuntu-latest
     steps:
-    - name: Get PR Commits
-      id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - name: DCO Check
-      uses: tim-actions/dco@master
-      with:
-        commits: ${{ steps.get-pr-commits.outputs.commits }}
-    # Need to save PR number as Github action does not propagate it with workflow_run event
-    - name: Save PR number
-      if: always()
-      run: |
-        mkdir -p ./pr
-        echo -n ${{ github.event.number }} > ./pr/pr_number
-    - uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        name: pr
-        path: pr/
+      - name: Get PR Commits
+        id: 'get-pr-commits'
+        uses: tim-actions/get-pr-commits@c64db31d359214d244884dd68f971a110b29ab83 # pin@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: DCO Check
+        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21 # pin@master
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+      # Need to save PR number as Github action does not propagate it with workflow_run event
+      - name: Save PR number
+        if: always()
+        run: |
+          mkdir -p ./pr
+          echo -n ${{ github.event.number }} > ./pr/pr_number
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: pr
+          path: pr/

--- a/.github/workflows/deploy-build-from-pr.yml
+++ b/.github/workflows/deploy-build-from-pr.yml
@@ -1,7 +1,7 @@
 ---
 
 name: Deploy PR build
-on:  # yamllint disable-line rule:truthy
+on:
   workflow_run:
     workflows:
       - build-all
@@ -17,13 +17,13 @@ jobs:
       WORKFLOW_NAME: "${{ github.event.workflow.name }}"
       WORKFLOW_STATUS: "${{ github.event.workflow_run.conclusion }}"
     steps:
-      - uses: hmarr/debug-action@v2
+      - uses: hmarr/debug-action@1201a20fc9d278ddddd5f0f46922d06513892491 # pin@v2
       # Could be improved, only need the tag push docker and helm rotation script here
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       # Retrieve Generated artifacts and delete them to keep cache usage low
       - name: Download builds
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -63,7 +63,7 @@ jobs:
           done
       - name: Save metadata
         id: save_metadata
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
             var fs = require('fs');

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -1,6 +1,6 @@
 ---
 name: "Build Docker image for Bazel Base and DevContainer"
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -34,7 +34,7 @@ jobs:
   build_dockerfile_bazel_base:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: ./.github/workflows/composite/docker-builder
         with:
           REGISTRY: ${{ env.REGISTRY }}
@@ -46,7 +46,7 @@ jobs:
     needs: build_dockerfile_bazel_base
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: ./.github/workflows/composite/docker-builder
         with:
           REGISTRY: ${{ env.REGISTRY }}

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -1,6 +1,6 @@
 ---
 name: "Build Docker image for Python Precommit"
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -30,7 +30,7 @@ jobs:
   build_dockerfile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: ./.github/workflows/composite/docker-builder
         with:
           REGISTRY: ${{ env.REGISTRY }}

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -1,14 +1,14 @@
 ---
 name: Markdown lint check
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
   pull_request:
     branches:
       - master
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -21,9 +21,9 @@ jobs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -37,7 +37,7 @@ jobs:
           echo -n ${{ github.event.number }} > ./pr/pr_number
           echo -n ${{ steps.changes.outputs.filesChanged == 'false' }} > ./pr/skipped
           echo -n "false" > ./pr/is_reverted_pr
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr
@@ -52,14 +52,14 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - name: Run docs precommit
         run: |
-            cd ${MAGMA_ROOT}/docs
-            make precommit
+          cd ${MAGMA_ROOT}/docs
+          make precommit
 
   markdown-insync:
     needs: path_filter
@@ -69,14 +69,14 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - name: Run docs `make`
         run: |
-            cd ${MAGMA_ROOT}/docs
-            make
+          cd ${MAGMA_ROOT}/docs
+          make
       - name: Check all generated files are checked in after running `make -C $MAGMA_ROOT/docs`
         run: |
           git status

--- a/.github/workflows/docusaurus-workflow.yml
+++ b/.github/workflows/docusaurus-workflow.yml
@@ -1,7 +1,7 @@
 ---
 name: docusaurus-workflow
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -9,26 +9,26 @@ jobs:
   docusaurus-build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Export vars
         run: |
-            echo "DOCUSAURUS_URL=https://magma.github.io" >> $GITHUB_ENV
-            echo "DOCUSAURUS_BASE_URL=/magma/" >> $GITHUB_ENV
+          echo "DOCUSAURUS_URL=https://magma.github.io" >> $GITHUB_ENV
+          echo "DOCUSAURUS_BASE_URL=/magma/" >> $GITHUB_ENV
       - name: Setup docusaurus expected directory structure
         run: |
-            mv docs/docusaurus website/
-            mv docs/readmes readmes/
-            rm -rf docs/
-            mv readmes/ docs/
+          mv docs/docusaurus website/
+          mv docs/readmes readmes/
+          rm -rf docs/
+          mv readmes/ docs/
       - name: Deploying to GitHub Pages
         # yamllint disable rule:line-length
         run: |
-            git config --global user.email "magma-docusaurus-bot@users.noreply.github.com"
-            git config --global user.name "magma-docusaurus-bot"
-            echo "machine github.com login magma-docusaurus-bot password ${{ secrets.DOCUSAURUS_GITHUB_TOKEN }}" > ~/.netrc
-            cd website && yarn install
-            CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" GIT_USER=magma-docusaurus-bot yarn run publish-gh-pages
-            # yamllint enable
+          git config --global user.email "magma-docusaurus-bot@users.noreply.github.com"
+          git config --global user.name "magma-docusaurus-bot"
+          echo "machine github.com login magma-docusaurus-bot password ${{ secrets.DOCUSAURUS_GITHUB_TOKEN }}" > ~/.netrc
+          cd website && yarn install
+          CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" GIT_USER=magma-docusaurus-bot yarn run publish-gh-pages
+          # yamllint enable
       - name: Extract commit title
         id: commit
         if: failure() && github.ref == 'refs/heads/master'
@@ -39,7 +39,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
         if: failure() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action Docusaurus update failed"

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -1,7 +1,7 @@
 ---
 name: dp-workflow
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - 'v1.*'
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -27,9 +27,9 @@ jobs:
       helm: ${{ steps.filter.outputs.helm }}
       integration_tests: ${{ steps.filter.outputs.integration_tests }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: filter
         with:
           filters: |
@@ -77,7 +77,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo -n ${{ steps.filter.outputs.integration_tests  == 'false' }} > ./pr/skipped
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr
@@ -96,12 +96,12 @@ jobs:
         working-directory: dp/cloud/python/magma/configuration_controller
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [ 3.8 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -126,7 +126,7 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
         with:
           flags: unittests,configuration-controller
           name: codecov-configuration-controller
@@ -150,15 +150,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Run Go linter
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # pin@v2
         with:
           version: v1.45.0
           working-directory: dp/cloud/go/active_mode_controller
@@ -169,13 +169,12 @@ jobs:
           go test ./... -v -race -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
         with:
           flags: unittests,active-mode-controller
           name: codecov-active-mode-controller
           fail_ci_if_error: false
           verbose: true
-
 
   radio_controller_unit_tests:
     needs: path_filter
@@ -194,13 +193,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [ 3.8 ]
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -251,7 +250,7 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
         with:
           flags: unittests,radio-controller
           name: codecov-radio-controller
@@ -272,7 +271,7 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}/dp/cloud/python
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [ 3.8 ]
     services:
       postgres:
         image: postgres:13.3
@@ -283,10 +282,10 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -321,13 +320,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [ 3.8 ]
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -352,7 +351,7 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
         with:
           flags: unittests,db-service
           name: codecov-db-service
@@ -377,12 +376,12 @@ jobs:
           - _ci_integration_tests_orc8r
           - _ci_integration_tests_no_orc8r
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Set env
         run: |
           echo "MINIKUBE_DP_MAX_MEMORY=$(grep MemTotal /proc/meminfo | awk '{printf "%dm",$2/1024 - 1}')" >> $GITHUB_ENV
       - name: Install Minikube
-        uses: manusa/actions-setup-minikube@v2.4.1
+        uses: manusa/actions-setup-minikube@cdef63c020a1c7b3d4787f30b3787ca1095ed9a7 # pin@v2.4.1
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.20.7'
@@ -408,21 +407,17 @@ jobs:
       - name: Collect Pods logs
         if: always()
         run: >-
-          mkdir ${TEST_DIR}/k8s-pods-logs;
-          for pod in $(kubectl get pods -o custom-columns=NAME:.metadata.name --no-headers);
-          do
+          mkdir ${TEST_DIR}/k8s-pods-logs; for pod in $(kubectl get pods -o custom-columns=NAME:.metadata.name --no-headers); do
             kubectl logs --timestamps=true $pod > ${TEST_DIR}/k8s-pods-logs/${pod}.log;
           done
       - name: Collect Elasticsearch data
         if: always()
         run: >
-          kubectl exec
-          $(kubectl get pods -o custom-columns=NAME:.metadata.name | grep elasticsearch)
-          -- curl localhost:9200/dp-*/_search?size=200 > ${TEST_DIR}/elasticsearch-data.json
+          kubectl exec $(kubectl get pods -o custom-columns=NAME:.metadata.name | grep elasticsearch) -- curl localhost:9200/dp-*/_search?size=200 > ${TEST_DIR}/elasticsearch-data.json
 
       - name: Upload integration test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: ${{ matrix.test_type }}-results
           path: ${{ env.TEST_DIR }}
@@ -436,12 +431,12 @@ jobs:
       run:
         working-directory: dp
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Set env
         run: |
           echo "MINIKUBE_DP_MAX_MEMORY=$(grep MemTotal /proc/meminfo | awk '{printf "%dm",$2/1024 - 1}')" >> $GITHUB_ENV
       - name: Install Minikube
-        uses: manusa/actions-setup-minikube@v2.4.1
+        uses: manusa/actions-setup-minikube@cdef63c020a1c7b3d4787f30b3787ca1095ed9a7 # pin@v2.4.1
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.20.7'

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -1,7 +1,6 @@
 ---
 name: feg-workflow
 
-# yamllint disable-line rule:truthy
 on:
   push:
     branches:
@@ -11,7 +10,7 @@ on:
     branches:
       - master
       - 'v1.*'
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -24,9 +23,9 @@ jobs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -37,7 +36,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo -n ${{ steps.changes.outputs.filesChanged == 'false' }} > ./pr/skipped
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr
@@ -49,18 +48,18 @@ jobs:
     name: feg lint and precommit
     runs-on: ubuntu-latest
     env:
-      GO111MODULE: on  # yamllint disable-line rule:truthy
+      GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
           go-version: '1.18'
       - run: go version
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@e88a9994b039653512d697de1bce46b00bfe11b5 # pin@v2
         if: always()
         id: feg-lint-init
         with:
@@ -70,15 +69,15 @@ jobs:
         if: always() && steps.feg-lint-init.outcome=='success'
         id: feg-lint
         run: |
-              cd ${MAGMA_ROOT}/feg/gateway
-              make -C ${MAGMA_ROOT}/feg/gateway lint
+          cd ${MAGMA_ROOT}/feg/gateway
+          make -C ${MAGMA_ROOT}/feg/gateway lint
       - name: Generate test coverage
         if: always() && steps.feg-lint.outcome=='success'
         id: feg-lint-cov
         run: |
-              cd ${MAGMA_ROOT}/feg/gateway
-              make -C ${MAGMA_ROOT}/feg/gateway cover
-      - uses: codecov/codecov-action@v2
+          cd ${MAGMA_ROOT}/feg/gateway
+          make -C ${MAGMA_ROOT}/feg/gateway cover
+      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
         if: always()
         id: feg-lint-codecov
         with:
@@ -94,7 +93,7 @@ jobs:
       - name: Upload Test Results
         id: feg-precommit-upload
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: Unit Test Results
           path: "/tmp/test-results"
@@ -107,8 +106,9 @@ jobs:
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
-        if: ( steps.feg-lint-init.outcome=='failure' || steps.feg-lint.outcome=='failure' || steps.feg-lint-cov.outcome=='failure' || steps.feg-lint-codecov.outcome=='failure'  ) && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        if: ( steps.feg-lint-init.outcome=='failure' || steps.feg-lint.outcome=='failure' || steps.feg-lint-cov.outcome=='failure' || steps.feg-lint-codecov.outcome=='failure'  ) && github.event_name ==
+          'push'
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
@@ -121,7 +121,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
         if: ( steps.feg-precommit.outcome=='failure' || steps.feg-precommit-upload.outcome=='failure' ) && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "FeG-precommit tests failed"

--- a/.github/workflows/fossa-workflow.yml
+++ b/.github/workflows/fossa-workflow.yml
@@ -1,7 +1,7 @@
 ---
 name: fossa-workflow
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -21,22 +21,22 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Download fossa analyze script
         # yamllint disable rule:line-length
         run: |
-            echo "Downloading CLI"
-            mkdir -p /tmp/magma && cd /tmp/magma
-            wget https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz
-            bash -c 'sha256sum fossa-cli_1.0.11_linux_amd64.tar.gz | grep -q 0e20286630a9bc5a17408c81e6ba9003f91a14fdd680b96ca4def400693e028e'
-            rm -f /tmp/magma/fossa
-            tar xzf fossa-cli_1.0.11_linux_amd64.tar.gz
-            sudo cp /tmp/magma/fossa /usr/local/bin/
+          echo "Downloading CLI"
+          mkdir -p /tmp/magma && cd /tmp/magma
+          wget https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz
+          bash -c 'sha256sum fossa-cli_1.0.11_linux_amd64.tar.gz | grep -q 0e20286630a9bc5a17408c81e6ba9003f91a14fdd680b96ca4def400693e028e'
+          rm -f /tmp/magma/fossa
+          tar xzf fossa-cli_1.0.11_linux_amd64.tar.gz
+          sudo cp /tmp/magma/fossa /usr/local/bin/
         # yamllint enable
       - name: Run fossa analyze script
         run: |
-            echo "Running fossa-analyze-go.sh"
-            sudo ${MAGMA_ROOT}/.github/workflows/scripts/fossa-analyze-go.sh
+          echo "Running fossa-analyze-go.sh"
+          sudo ${MAGMA_ROOT}/.github/workflows/scripts/fossa-analyze-go.sh
       - name: Extract commit title
         id: commit
         if: failure() && github.event_name == 'push'
@@ -47,7 +47,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action fossa-analyze update failed"

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -7,6 +7,7 @@
 #   - Option: by use of Workflow Templates per gcc-build-target (need to move docker build to another workflow and requires container repo)
 #   - Option: by improving our build system and enabling faster build-all-targets
 #######
+---
 name: "GCC Warnings & Errors"
 on:
   push:
@@ -30,9 +31,9 @@ jobs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -62,9 +63,9 @@ jobs:
           df -h
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           options: --pull always
@@ -76,11 +77,11 @@ jobs:
         #   Rationale: our workflow (merge branch into upstream master) is incompatible
         #   See long list of GH Issues on https://github.com/jitterbit/get-changed-files w.r.t. head ahead of base
         id: changed_files
-        uses: mmagician/get-changed-files@v2
+        uses: mmagician/get-changed-files@1028587c8596c55a9d03d813a48aa1377f60b087 # pin@v2
         with:
           format: 'csv'
       - name: Build and Apply GCC Problem Matcher
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
@@ -90,7 +91,7 @@ jobs:
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             ./.github/workflows/generate-gcc-warnings.sh "${{ steps.changed_files.outputs.all }}"
       - name: Publish bazel profile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: Bazel build gcc problems profile
@@ -104,21 +105,21 @@ jobs:
         #
         # Paths emitted on warnings must be relative to the repository (e.g. lte/gateway/...),
         # Therefore below I use `xo` to fixup our path emissions on gcc warnings.
-        uses: electronjoe/gcc-problem-matcher@v1
+        uses: electronjoe/gcc-problem-matcher@654cb8a3a64f6e3c9a24a96eae3baab3c00a5f66 # pin@v1
       - name: Cat compilation log (filtered by file names)
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
           # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
           options: -v ${{ github.workspace }}:/workspaces/magma
           run: cat /workspaces/magma/filtered-compile.log
       - name: Store build_logs_c_full_log Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: build_logs_c_full_log
           path: ${{ github.workspace }}/compile.log
       - name: Store build_logs_c_filtered_log Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: build_logs_c_filtered_log
           path: ${{ github.workspace }}/filtered-compile.log

--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -1,6 +1,6 @@
 ---
 name: Golang Build & Test
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -25,9 +25,9 @@ jobs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo -n ${{ steps.changes.outputs.filesChanged == 'false' }} > ./pr/skipped
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr
@@ -49,16 +49,16 @@ jobs:
     if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
-        go-version: [1.18.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [ 1.18.x ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Test
         run: |
           cd src/go/
@@ -71,7 +71,7 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "build_src_go tests failed"
@@ -86,26 +86,26 @@ jobs:
     if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
-        go-version: [1.18.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [ 1.18.x ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Setup gotestsum
-        uses: autero1/action-gotestsum@v1.0.0
+        uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # pin@v1.0.0
         with:
           gotestsum_version: 1.7.0
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Test
         run: |
           cd src/go/
           gotestsum --format=testname --junitfile test_src_go.xml -- -race ./...
       - name: Upload Test Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: Unit Test Results
           path: "${{ github.workspace }}/src/go/test_src_go.xml"
@@ -117,7 +117,7 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "test_src_go tests failed"
@@ -132,31 +132,31 @@ jobs:
     if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
-        go-version: [1.18.x]
-        arch: [386, arm, arm64]
+        go-version: [ 1.18.x ]
+        arch: [ 386, arm, arm64 ]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # pin@v1
       - name: Setup gotestsum
-        uses: autero1/action-gotestsum@v1.0.0
+        uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # pin@v1.0.0
         with:
           gotestsum_version: 1.7.0
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Run tests via qemu/binfmt
         run: |
           cd src/go/
           gotestsum --format=testname --junitfile test_src_go.xml -- ./...
         env:
           GOARCH: ${{ matrix.arch }}
-        # TODO: Upload this test result as a comment on PR
+          # TODO: Upload this test result as a comment on PR
       - name: Upload Test Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: Unit Test Results arm64
           path: "${{ github.workspace }}/src/go/test_src_go.xml"
@@ -168,7 +168,7 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "test_src_go_qemu tests failed"
@@ -178,27 +178,26 @@ jobs:
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
 
-
   codecov_src_go:
     needs: pre_job_src_go_determinator
     if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [ 1.18.x ]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Test
         run: |
           cd src/go/
           go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Codecov.io Upload
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
         with:
           flags: src_go
           fail_ci_if_error: true
@@ -211,7 +210,7 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "codecov_src_go tests failed"

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -2,7 +2,7 @@
 
 name: "Check dependencies of helm charts"
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -14,7 +14,7 @@ on:  # yamllint disable-line rule:truthy
     types:
       - opened
       - reopened
-      - synchronize  # yamllint disable-line rule:truthy
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check dependency of helm chart ${{ matrix.charts[0] }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Check Orc8r
         run: |
           echo "DIGEST=$(cat $MAGMA_ROOT/orc8r/cloud/helm/orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
@@ -71,7 +71,7 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "check_helm_chart_dependencies tests failed"

--- a/.github/workflows/helm-deploy-on-demand.yml
+++ b/.github/workflows/helm-deploy-on-demand.yml
@@ -2,8 +2,8 @@
 name: helm-build-on-demand
 
 # Temporary on demand Job until we refactor helm build job in build-all
-on:  # yamllint disable-line rule:truthy
-  workflow_dispatch:
+on:
+  ? workflow_dispatch
 jobs:
   build_publish_helm_charts_on_demand:
     env:
@@ -16,7 +16,7 @@ jobs:
       ISSUE_NUMBER: "${{ github.event.number }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Launch build and publish script
         run: |
-            orc8r/tools/helm/package.sh --deployment-type all
+          orc8r/tools/helm/package.sh --deployment-type all

--- a/.github/workflows/insync-checkin.yml
+++ b/.github/workflows/insync-checkin.yml
@@ -1,7 +1,7 @@
 ---
 name: insync-check
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - 'v1.*'
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -23,8 +23,8 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.7'
       - name: Run build.py
@@ -44,12 +44,20 @@ jobs:
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to Slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "Github action insync-checkin failed"
           SLACK_USERNAME: "Cloud workflow"
-          SLACK_MESSAGE: "COMMIT TITLE:\n ${{steps.commit.outputs.title}}\n\n\n GIT STATUS OUTPUT:\n ${{env.GIT_STATUS}}"
+          SLACK_MESSAGE: "COMMIT TITLE:
+
+            \ ${{steps.commit.outputs.title}}
+
+
+
+            \ GIT STATUS OUTPUT:
+
+            \ ${{env.GIT_STATUS}}"
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -2,8 +2,8 @@
 
 name: LTE integ test
 
-on:  # yamllint disable-line rule:truthy
-  workflow_dispatch:
+on:
+  workflow_dispatch: null
   workflow_run:
     workflows:
       - build-all
@@ -20,7 +20,7 @@ jobs:
     env:
       SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ env.SHA }}
       - name: Cache magma-dev-box
@@ -39,10 +39,10 @@ jobs:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver
       - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@v8"
+        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
           default: 3.8.5
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.5'
       - name: Install pre requisites
@@ -69,7 +69,7 @@ jobs:
           fab get_test_summaries:dst_path="test-results"
           ls -R
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: test-results
@@ -80,14 +80,14 @@ jobs:
           cd lte/gateway
           fab get_test_logs:dst_path=./logs.tar.gz
       - name: Upload test logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: failure()
         with:
           name: test-logs
           path: lte/gateway/logs.tar.gz
       - name: Publish Unit Test Results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        uses: EnricoMi/publish-unit-test-result-action/composite@7377632048da85434c30810c38353542d3162dc4 # pin@v1
         with:
           files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
@@ -108,6 +108,6 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: "LTE integ test"
           SLACK_AVATAR: ":boom:"
-        uses: Ilshidur/action-slack@2.1.0
+        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         with:
           args: "LTE integration test test failed on [${{ env.SHA }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ env.SHA }}): ${{ steps.commit.outputs.title}}"

--- a/.github/workflows/nms-workflow.yml
+++ b/.github/workflows/nms-workflow.yml
@@ -1,7 +1,7 @@
 ---
 name: nms-workflow
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -26,9 +26,9 @@ jobs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -39,7 +39,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo -n ${{ steps.changes.outputs.filesChanged == 'false' }} > ./pr/skipped
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr
@@ -53,19 +53,19 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: install flow
         run: |
-            cd ${MAGMA_ROOT}/nms
-            # Extract the specified flow version from the .flowconfig
-            yarn add --dev -W flow-bin@$(x=$(grep "\[version\]" .flowconfig -A 1 | tail -n 1); echo ${x:1})
-      - uses: borales/actions-yarn@v3.0.0
+          cd ${MAGMA_ROOT}/nms
+          # Extract the specified flow version from the .flowconfig
+          yarn add --dev -W flow-bin@$(x=$(grep "\[version\]" .flowconfig -A 1 | tail -n 1); echo ${x:1})
+      - uses: borales/actions-yarn@d8ce577a6f5d99a459fc7fdf2a86844617e353e4 # pin@v3.0.0
         with:
-          cmd: install  # will run `yarn install` command
+          cmd: install # will run `yarn install` command
       - name: flow typecheck
         run: |
-            cd ${MAGMA_ROOT}/nms
-            yarn run flow
+          cd ${MAGMA_ROOT}/nms
+          yarn run flow
       - name: Extract commit title
         id: commit
         if: failure() && github.event_name == 'push'
@@ -76,7 +76,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "NMS flow tests failed"
@@ -131,8 +131,8 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # pin@v2
         with:
           node-version: 16
       - name: apt install yarn
@@ -161,7 +161,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "NMS eslint tests failed"
@@ -178,10 +178,10 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: borales/actions-yarn@v3.0.0
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+      - uses: borales/actions-yarn@d8ce577a6f5d99a459fc7fdf2a86844617e353e4 # pin@v3.0.0
         with:
-          cmd: install  # will run `yarn install` command
+          cmd: install # will run `yarn install` command
       - name: run yarn test
         run: |
           cd ${MAGMA_ROOT}/nms
@@ -197,7 +197,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "NMS yarn tests failed"
@@ -217,39 +217,39 @@ jobs:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
       PUPPETEER_EXECUTABLE_PATH: "/usr/bin/google-chrome-stable"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: apt install yarn
         run: |
-            cd ${MAGMA_ROOT}/nms
-            sudo apt-get install -y apt-transport-https
-            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-            sudo apt-get update -y
-            sudo apt-get install -y yarn
-            yarn add jest@^26.4.2 -W --dev
+          cd ${MAGMA_ROOT}/nms
+          sudo apt-get install -y apt-transport-https
+          curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+          echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+          sudo apt-get update -y
+          sudo apt-get install -y yarn
+          yarn add jest@^26.4.2 -W --dev
       - name: apt install chrome
         run: |
-            cd ${MAGMA_ROOT}/nms
-            # Install latest chrome dev package
-            # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
-            # installs, work.
-            curl -sS https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-            echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google.list
-            sudo apt-get update -y
-            sudo apt-get install -y google-chrome-stable libxss1 --no-install-recommends
-            sudo rm -rf /var/lib/apt/lists/*
-      - uses: borales/actions-yarn@v3.0.0
+          cd ${MAGMA_ROOT}/nms
+          # Install latest chrome dev package
+          # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+          # installs, work.
+          curl -sS https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google.list
+          sudo apt-get update -y
+          sudo apt-get install -y google-chrome-stable libxss1 --no-install-recommends
+          sudo rm -rf /var/lib/apt/lists/*
+      - uses: borales/actions-yarn@d8ce577a6f5d99a459fc7fdf2a86844617e353e4 # pin@v3.0.0
         with:
-          cmd: install  # will run `yarn install` command
+          cmd: install # will run `yarn install` command
       - name: run e2e_test_setup.sh
         run: |
-            source $NVM_DIR/nvm.sh
-            nvm install stable
-            cd ${MAGMA_ROOT}/nms
-            ./e2e_test_setup.sh
+          source $NVM_DIR/nvm.sh
+          nvm install stable
+          cd ${MAGMA_ROOT}/nms
+          ./e2e_test_setup.sh
       - name: Publish Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: NMS Test Results
           path: "/tmp/nms_artifacts/*"
@@ -263,7 +263,7 @@ jobs:
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
           SLACK_TITLE: "NMS e2e tests failed"

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -1,17 +1,17 @@
 ---
 name: PR Hello
-on:  # yamllint disable-line rule:truthy
+on:
   # Use pull_request_target to gain write permissions.
   # Ref: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
   pull_request_target:
-    types: [opened]
+    types: [ opened ]
 
 jobs:
   # This job is a manual approximation of https://github.com/peter-evans/create-or-update-comment
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -1,6 +1,6 @@
 ---
 name: Python Format Check
-on:  # yamllint disable-line rule:truthy
+on:
   push:
     branches:
       - master
@@ -26,9 +26,9 @@ jobs:
       files_changed: ${{ steps.changes.outputs.filesChanged_files }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -43,7 +43,7 @@ jobs:
           echo -n ${{ github.event.number }} > ./pr/pr_number
           echo -n ${{ steps.changes.outputs.filesChanged == 'false' }} > ./pr/skipped
           echo -n "false" > ./pr/is_reverted_pr
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr
@@ -55,18 +55,18 @@ jobs:
     name: Python Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           fetch-depth: 0
       - name: Build the python-precommit Docker base image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # pin@v2
         with:
           context: .
           file: ./lte/gateway/docker/python-precommit/Dockerfile
           push: false
           tags: magma/py-lint:latest
       - name: Format and check for leftover changes
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: magma/py-lint:latest
           options: -u 0 -v ${{ github.workspace }}:/code
@@ -89,7 +89,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/pr_number
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,8 +1,8 @@
 ---
 name: Automatic Rebase
-on:  # yamllint disable-line rule:truthy
+on:
   issue_comment:
-    types: [created]
+    types: [ created ]
 jobs:
   # This job is based on https://github.com/marketplace/actions/automatic-rebase
   rebase:
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0  # otherwise, you will fail to push refs to dest repo
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.4
+        uses: cirrus-actions/rebase@7cea12ac34ab078fa37e87798d8986185afa7bf2 # pin@1.4
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -1,6 +1,6 @@
 ---
 name: reviewdog-workflow
-on:  # yamllint disable-line rule:truthy
+on:
   pull_request_target:
     types:
       - opened
@@ -14,7 +14,6 @@ concurrency:
 # See Reviewdog doc provided at https://github.com/reviewdog/reviewdog
 # github-pr-check: Adds lint as annotations in the PR that can be toggled by pressing 'a'
 # github-pr-review: Adds lint as GitHub comments
-
 jobs:
   files_changed:
     runs-on: ubuntu-latest
@@ -26,9 +25,9 @@ jobs:
       changed_terraform: ${{ steps.changes.outputs.terraform }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2
         id: changes
         with:
           filters: |
@@ -60,7 +59,7 @@ jobs:
     ##
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -85,13 +84,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
+        uses: reviewdog/action-golangci-lint@1530051a4d9af7e1c94afb2ea38fe7ba13e180ee # pin@v2
         with:
           golangci_lint_flags: '--config=../../.golangci.yml'
           reporter: github-pr-review
@@ -102,13 +101,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: hadolint
-        uses: reviewdog/action-hadolint@v1
+        uses: reviewdog/action-hadolint@55be5d2c4b0b80d439247b128a9ded3747f92a29 # pin@v1
         with:
           github_token: ${{ secrets.github_token }}
           filter_mode: added
@@ -159,13 +158,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: misspell
-        uses: reviewdog/action-misspell@v1
+        uses: reviewdog/action-misspell@811b1e15f531430be3a5784e3d591bd657df18b0 # pin@v1
         with:
           github_token: ${{ secrets.github_token }}
           filter_mode: added
@@ -181,13 +180,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: Run mypy with reviewdog
-        uses: tsuyoshicho/action-mypy@v3.6.0
+        uses: tsuyoshicho/action-mypy@631cb44fa199efd4ed132c5005d4f5b08d7ac1e6 # pin@v3.6.0
         with:
           github_token: ${{ secrets.github_token }}
           filter_mode: added
@@ -197,13 +196,13 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: shellcheck
-        uses: reviewdog/action-shellcheck@v1
+        uses: reviewdog/action-shellcheck@66c9a47bf02255b250284a82251cb4cadf5043f5 # pin@v1
         with:
           github_token: ${{ secrets.github_token }}
           filter_mode: added
@@ -216,13 +215,13 @@ jobs:
     name: tflint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: Run tflint with reviewdog
-        uses: reviewdog/action-tflint@v1.16.2
+        uses: reviewdog/action-tflint@86b1913cb664b079cb435014ad64835acf66c639 # pin@v1.16.2
         with:
           github_token: ${{ secrets.github_token }}
           filter_mode: added
@@ -236,13 +235,13 @@ jobs:
     name: wemake-python-styleguide
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: wemake-python-styleguide
-        uses: wemake-services/wemake-python-styleguide@0.15.2
+        uses: wemake-services/wemake-python-styleguide@b8260e79fcbc2feeae2dd4aae2b59ed86aafbf9d # pin@0.15.2
         with:
           reporter: github-pr-review
           path: ${{ steps.py-changes.outputs.py }}
@@ -253,13 +252,13 @@ jobs:
     name: yamllint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: yamllint
-        uses: reviewdog/action-yamllint@v1
+        uses: reviewdog/action-yamllint@8c429dfe4fc47b1ce1fa99a64e94693880d5dc30 # pin@v1
         with:
           github_token: ${{ secrets.github_token }}
           filter_mode: added

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,7 +1,7 @@
 ---
 name: "Semantic PR"
 
-on:  # yamllint disable-line rule:truthy
+on:
   # Semantic PR module only works with pull_request_target
   pull_request_target:
     types:
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Check if PR is a Reverted PR
         id: reverted_pr_check
-        uses: actions/github-script@v3
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
             if( process.env.PR_TITLE.startsWith('Revert') ) {
@@ -40,7 +40,7 @@ jobs:
           mkdir -p ./pr
           echo -n ${{ steps.reverted_pr_check.outputs.is_reverted_pr }} > ./pr/is_reverted_pr
           echo -n "false" > ./pr/skipped
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr
@@ -53,7 +53,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v3.4.0
+      - uses: amannn/action-semantic-pull-request@db6e259b93f286e3416eef27aaae88935d16cf2e # pin@v3.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -142,7 +142,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo -n ${{ github.event.number }} > ./pr/pr_number
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
           name: pr

--- a/.github/workflows/testim-workflow.yml
+++ b/.github/workflows/testim-workflow.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-  workflow_dispatch:
+  workflow_dispatch: null
 
 jobs:
   testim_check_job:
@@ -13,18 +13,18 @@ jobs:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - name: Setup Node v12
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # pin@v2
         with:
           node-version: '12'
       - name: Install Testim CLI
         run: npm install -g @testim/testim-cli
       - name: Setup pyenv
-        uses: "gabrielfalcao/pyenv-action@v8"
+        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
         with:
           default: 3.8.5
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.5'
       - name: Install Python Dependencies

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -1,6 +1,6 @@
 ---
 name: Cloud Unit Test Results
-on:  # yamllint disable-line rule:truthy
+on:
   workflow_run:
     workflows:
       - cloud-workflow
@@ -20,7 +20,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -42,7 +42,7 @@ jobs:
       - run: unzip pr.zip
       - name: Check if the workflow is skipped
         id: skip_check
-        uses: actions/github-script@v3
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
         with:
           script: |
             var fs = require('fs');
@@ -67,16 +67,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-           mkdir -p artifacts && cd artifacts
-           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
-           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
-           do
-             IFS=$'\t' read name url <<< "$artifact"
-             gh api $url > "$name.zip"
-             unzip -d "$name" "$name.zip"
-           done
+          mkdir -p artifacts && cd artifacts
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@7377632048da85434c30810c38353542d3162dc4 # pin@v1
         with:
           check_name: ${{ github.event.workflow.name }}
           commit: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
Fixes https://github.com/magma/security/issues/97

Version numbers were converted to hashes using https://github.com/mheap/pin-github-action/. We'll need to periodically re-run this in the future, and might want a monthly action.

I had to modify `/magma/.github/workflows/config/yamllint_config.yml` to accept the YAML output formatting from that script, as follows:

```
15,20c15,16
<   braces: 
<     max-spaces-inside: 1
<     min-spaces-inside: 1
<   brackets:
<     min-spaces-inside: 0
<     max-spaces-inside: 1
---
>   braces: enable
>   brackets: enable
25d20
<     min-spaces-from-content: 1
31,32c26
<   empty-lines: 
<     max: 3
---
>   empty-lines: enable
43c37
<   trailing-spaces: disable
---
>   trailing-spaces: enable
```


<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
