### PR TITLE
fix(ci): fix dependency issues in agw build

### DIFF
--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -1041,7 +1041,7 @@ def main(args):
 
         required_distributions = {}
         to_traverse = [pip_distributions[k] for k in [req.key for req in input_root_requirements]
-                       if k not in repo_installable]
+                       if k not in [inst.key for inst in repo_installable]]
         while to_traverse:
             dist = to_traverse.pop()
             required_distributions[dist.key] = dist
@@ -1058,8 +1058,9 @@ def main(args):
 
     dep_source = gen_dep_sources(dep_set, pypi_only=args.force_pypi, py2=args.use_py2)
 
-    root_versions = {req.key: {'version': pip_distributions[req.key].version}
-                     for req in input_root_requirements}
+    root_versions = {req.key: {'version': pip_distributions[k].version}
+                     for k in [req.key for req in input_root_requirements]
+                     if k not in [inst.key for inst in repo_installable]}
 
     log.debug(root_versions)
 

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -73,7 +73,7 @@ setup(
         'protobuf==3.19.0',
         'Jinja2>=2.8',
         'netifaces>=0.10.4',
-        'pylint==2.14.0',
+        'pylint>=1.7.1,<=2.14.0',
         'PyYAML>=3.12',
         'pytz>=2014.4',
         'prometheus_client==0.3.1',


### PR DESCRIPTION
## Summary

Three changes happen(ed) in this context:
* fix dependency build process in `lte/gateway/release/pydep finddep` in agw build (for manual run, see below)
  * this should fix [1]
  * unclear how this could ever work before (?)
* downgrade pylint (reverts #12955)
  * `pydep` uses the version that is currently in the magma core artifactory- this was pylint 2.14.0 after the upgrade (uploaded with merge run of #12955)
  * pylint 2.14.0 needs typing-extensions in a newer version - python3-typing-extensions  was **not** generated and uploaded because the new version does not use a setup.py (but project.toml) and could not be build with fpm (!)
  * -> also removed manually respective python3-pylint package from magma artifactory
* the third change only happened manually on the magma artifactory
  * added the following packes from the fb artifactory to the magma artifactory as they are needed for the magma installation. These are currently not re-created by pydept because lower versions are already in the artifactory.
    * python3-aioh2_0.2.3-1_all.deb
    * python3-click_7.1.2_all.deb
    * sentry-native_0.4.8-1_amd64.deb
  * python3-websocket-client_1.3.2_all.deb was created manually in VM and uploaded (this would have been done by agw build, but I wanted to test the magma install)

In pairing with @sebathomas.

Note: from the findings here a couple of follow-up tasks should be created

[1]
```
[vagrant@127.0.0.1:2222] out:   File "./release/pydep", line 1043, in <listcomp>
[vagrant@127.0.0.1:2222] out:     to_traverse = [pip_distributions[k] for k in [req.key for req in input_root_requirements]
[vagrant@127.0.0.1:2222] out: KeyError: 'aiodns'
```

## Test Plan

In a fresh VM
* all here happens in `lte/gateway`
* `./release/pydep finddep --install-from-repo -b --build-output ~/magma-deps -l ./release/magma.lockfile.ubuntu python/setup.py $MAGMA_ROOT/orc8r/gateway/python/setup.py`
  * generates `python3-<dep>.deb` packages in `~/magma-deps` - these are uploaded to the magmacore artifactory in the agw build
  * check that script runs through **and** does not have issues creating .deb packages (this is not causing an exit!)
* build magma deb: `./release/build-magma.sh -h 123 --commit-count 23 -t RelWithDebInfo --cert $MAGMA_ROOT/.cache/test_certs/rootCA.pem --proxy $MAGMA_ROOT/lte/gateway/configs/control_proxy.yml --os ubuntu`
  * install: `sudo apt install ./magma_1.8.0-1655271992-123_amd64.deb`
  * check if there are dependency issues during install
  * note: I was not able to install magma on the magma vm because of an existing hard link on `/etc/magma/sessiond.yml_prod` - I will assume here that this because of the magma vm provisioning and will not happen on, e.g., ubuntu based VMs

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
