### PR TITLE
chore(dp): Add SERVICE_HOSTAME variable to domain-proxy containers deployment

### DIFF
--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/active_mode_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/active_mode_controller/deployment.yaml
@@ -52,6 +52,10 @@ spec:
             - name: {{ $key }}
               value: {{ $value }}
             {{- end }}
+            - name: SERVICE_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           envFrom:
           - configMapRef:
               name: {{ include "domain-proxy.configuration_controller.fullname" . }}-common

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/configuration_controller/deployment.yaml
@@ -37,6 +37,10 @@ spec:
             - name: {{ $key }}
               value: {{ $value }}
             {{- end }}
+            - name: SERVICE_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           {{- if .Values.dp.configuration_controller.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.dp.configuration_controller.livenessProbe | nindent 12 }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/fluentd/deployment.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/fluentd/deployment.yaml
@@ -53,6 +53,10 @@ spec:
               value: {{.Values.dp.fluentd.env.output_port | quote }}
             - name: FLUENTD_OUTPUT_FLUSH_INTERVAL
               value: {{.Values.dp.fluentd.env.output_flush_interval | quote }}
+            - name: SERVICE_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           volumeMounts:
             - name: config-volume
               mountPath: /fluentd/etc

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/deployment.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/radio_controller/deployment.yaml
@@ -52,6 +52,10 @@ spec:
             - name: {{ $key }}
               value: {{ $value }}
             {{- end }}
+            - name: SERVICE_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           {{- if .Values.dp.radio_controller.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.dp.radio_controller.livenessProbe | nindent 12 }}


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Add SERVICE_HOSTNAME variable to all domain proxy containers

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- deploy apps with `make`
- connect to POD container and check if env variable  exists
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
