### PR TITLE
chore(dp): Add grafana templates to dp helm chart

### DIFF
--- a/dp/Makefile
+++ b/dp/Makefile
@@ -19,6 +19,10 @@ else
 .DEFAULT_GOAL=local
 endif
 
+ifdef DP_METRICS
+APPEND_METRICS_PROFILE = ,metrics
+endif
+
 .PHONY: local
 local: init dev
 
@@ -32,13 +36,13 @@ integration_tests: init _ci_init cleanup_test_db
 orc8r_integration_tests: init_orc8r _ci_init cleanup_test_db
 	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
 	kubectl delete pods test-runner-orc8r --ignore-not-found=true
-	skaffold dev -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only --trigger=manual
+	skaffold dev -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only$(APPEND_METRICS_PROFILE) --trigger=manual
 
 .PHONY: dev_integration_tests
 dev_integration_tests: init_orc8r _ci_init cleanup_test_db
 	kubectl delete jobs -l jobName=domain-proxy-db-setup --ignore-not-found=true
 	kubectl delete pods test-runner-dev --ignore-not-found=true
-	skaffold dev -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only,integration-tests-dev --trigger=manual
+	skaffold dev -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only,integration-tests-dev$(APPEND_METRICS_PROFILE) --trigger=manual
 
 .PHONY: orc8r
 orc8r: init_orc8r dev_orc8r
@@ -81,7 +85,7 @@ clean:
 
 .PHONY: dev_orc8r
 dev_orc8r:
-	skaffold dev -p orc8r-deployment --trigger=manual
+	skaffold dev -p orc8r-deployment$(APPEND_METRICS_PROFILE) --trigger=manual
 
 .PHONY: dev
 dev:
@@ -161,7 +165,7 @@ _ci_integration_tests_no_orc8r: _install_skaffold_ci
 
 .PHONY: _ci_integration_tests_orc8r
 _ci_integration_tests_orc8r: _install_skaffold_ci
-	skaffold run -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only
+	skaffold run -p orc8r-deployment,integration-tests-no-orc8,integration-tests-orc8r-only,$(APPEND_METRICS_PROFILE)
 	kubectl logs test-runner-orc8r --timestamps=true -f | tee /tmp/integration-tests-results/$@.txt
 	@set -e;\
 	sleep 2;\

--- a/dp/README.md
+++ b/dp/README.md
@@ -32,3 +32,13 @@ make integration_tests
 ```
 make orc8r_integration_tests
 ```
+
+## Enabling metrics
+
+Make targets `orc8r` and `orc8r_integration_tests` can be run with metrics.
+In this case prometheus and grafana PODS will be included in deployment.
+To enable it evironment variable `DP_METRICS` have to be set e.g:
+
+```bash
+DP_METRICS=true make orc8r
+```

--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/metrics_overrides.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/metrics_overrides.yaml
@@ -1,0 +1,14 @@
+---
+# dp chart
+dp:
+  grafana:
+    enabled: true
+    persistdata:
+      enabled: true
+      volumeSpec:
+        hostPath:
+          path: /var/lib/dp-grafana
+          type: DirectoryOrCreate
+# orc8r metrics subchart
+metrics:
+  enabled: true

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/_helpers.tpl
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/_helpers.tpl
@@ -1,4 +1,17 @@
 {{/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "domain-proxy.name" -}}
@@ -99,6 +112,22 @@ fluentd labels
 */}}
 {{- define "domain-proxy.fluentd.labels" -}}
 {{ include "domain-proxy.fluentd.matchLabels" . }}
+{{ include "domain-proxy.common.metaLabels" . }}
+{{- end -}}
+
+{{/*
+grafana match labels
+*/}}
+{{- define "domain-proxy.grafana.matchLabels" -}}
+component: {{ .Values.dp.grafana.name | quote }}
+{{ include "domain-proxy.common.matchLabels" . }}
+{{- end -}}
+
+{{/*
+grafana labels
+*/}}
+{{- define "domain-proxy.grafana.labels" -}}
+{{ include "domain-proxy.grafana.matchLabels" . }}
 {{ include "domain-proxy.common.metaLabels" . }}
 {{- end -}}
 
@@ -212,6 +241,24 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a fully qualified grafana name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "domain-proxy.grafana.fullname" -}}
+{{- if .Values.dp.grafana.fullnameOverride -}}
+{{- .Values.dp.grafana.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.dp.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.dp.grafana.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.dp.grafana.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "domain-proxy.deployment.apiVersion" -}}
@@ -298,6 +345,17 @@ Create the name of the service account to use for fluentd
 {{- default (include "domain-proxy.fullname" .) .Values.dp.fluentd.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.dp.fluentd.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for grafana
+*/}}
+{{- define "domain-proxy.grafana.serviceAccountName" -}}
+{{- if .Values.dp.grafana.serviceAccount.create }}
+{{- default (include "domain-proxy.fullname" .) .Values.dp.grafana.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.dp.grafana.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/grafana/configmap.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/grafana/configmap.yaml
@@ -1,0 +1,25 @@
+{{/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{- if and .Values.dp.create .Values.dp.grafana.enabled -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    {{-  include "domain-proxy.grafana.labels" . | nindent 4 }}
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: {{ include "domain-proxy.grafana.fullname" . }}
+{{ include "domain-proxy.namespace" . | indent 2 }}
+data:
+  datasources: |
+    {{- toYaml .Values.dp.grafana.datasources | nindent 4 }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/grafana/deployment.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/grafana/deployment.yaml
@@ -1,0 +1,116 @@
+{{/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.dp.create .Values.dp.grafana.enabled -}}
+apiVersion:  {{ template "domain-proxy.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "domain-proxy.grafana.fullname" . }}
+  labels:
+    {{- include "domain-proxy.grafana.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "domain-proxy.grafana.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.dp.grafana.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "domain-proxy.grafana.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.dp.grafana.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "domain-proxy.grafana.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.dp.grafana.podSecurityContext | nindent 8 }}
+      {{- if .Values.dp.grafana.persistdata.enabled }}
+      initContainers:
+        - name: grafana-init-chown
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "grafana:root", "/var/lib/grafana"]
+          image: {{ .Values.dp.grafana.image.repository -}}:{{- .Values.dp.grafana.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.dp.grafana.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.dp.grafana.service.port }}
+          volumeMounts:
+            - name: storage
+              mountPath: /var/lib/grafana
+      {{- end }}
+      containers:
+        - name: {{ .Values.dp.grafana.name }}
+          securityContext:
+            {{- toYaml .Values.dp.grafana.securityContext | nindent 12 }}
+          image: {{ .Values.dp.grafana.image.repository -}}:{{- .Values.dp.grafana.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.dp.grafana.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.dp.grafana.service.port }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/grafana/provisioning/datasources/automatic.yml
+              subPath: datasources
+            {{- if .Values.dp.grafana.persistdata.enabled }}
+            - name: storage
+              mountPath: /var/lib/grafana
+            {{- end }}
+          env:
+            {{- range $key, $value := .Values.dp.grafana.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+            {{- if and (not .Values.dp.grafana.env.GF_SECURITY_ADMIN_USER) (not .Values.dp.grafana.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "domain-proxy.grafana.fullname" . }}
+                  key: admin-user
+            {{- end }}
+            {{- if and (not .Values.dp.grafana.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.dp.grafana.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.dp.grafana.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{  include "domain-proxy.grafana.fullname" . }}
+                  key: admin-password
+            {{- end }}
+      {{- with .Values.dp.grafana.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dp.grafana.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dp.grafana.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "domain-proxy.grafana.fullname" . }}
+      {{- if .Values.dp.grafana.persistdata.enabled }}
+        - name: storage
+        {{- if .Values.dp.grafana.persistdata.volumeSpec }}
+          {{- toYaml .Values.dp.grafana.persistdata.volumeSpec | nindent 10 }}
+        {{- else }}
+          persistentVolumeClaim:
+            claimName: {{  include "domain-proxy.grafana.fullname" . }}
+      {{- end }}
+      {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/grafana/secrets.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/grafana/secrets.yaml
@@ -1,0 +1,26 @@
+{{/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{- if and .Values.dp.create .Values.dp.grafana.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "domain-proxy.grafana.fullname" . }}
+  labels:
+    {{- include "domain-proxy.grafana.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if and (not .Values.dp.grafana.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) (not .Values.dp.grafana.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.dp.grafana.env.GF_SECURITY_ADMIN_PASSWORD) }}
+  admin-user: {{ .Values.dp.grafana.adminUser | b64enc | quote }}
+  admin-password: {{ .Values.dp.grafana.adminPassword | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/templates/grafana/service.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/templates/grafana/service.yaml
@@ -1,0 +1,27 @@
+{{/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{- if and .Values.dp.create .Values.dp.grafana.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "domain-proxy.grafana.fullname" . }}
+  labels:
+    {{- include "domain-proxy.grafana.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: {{ .Values.dp.grafana.service.port }}
+      targetPort: {{ .Values.dp.grafana.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "domain-proxy.grafana.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/dp/cloud/helm/dp/charts/domain-proxy/values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/values.yaml
@@ -386,3 +386,53 @@ dp:
       create: false  # Specifies whether a service account should be created.
       annotations: {}  # Annotations to add to the service account.
       name: ""  # The name of the service account to use,If not set and create is true, a name is generated using the fullname template.
+
+  grafana:
+    enabled: false
+    nameOverride: ""
+    fullnameOverride: ""
+    name: grafana
+
+    adminUser: admin
+    adminPassword: admin
+
+    image:
+      repository: grafana/grafana
+      pullPolicy: IfNotPresent
+      tag: 8.5.5
+
+    imagePullSecrets: []
+
+    service:
+      port: 3000
+
+    serviceAccount:
+      create: false
+      annotations: {}
+      name: ""
+
+    podSecurityContext: {}
+
+    persistdata:
+      enabled: false
+
+    env: {}
+
+    datasources:
+      apiVersion: 1
+      datasources:
+        - id: 1
+          orgId: 1
+          name: Prometheus
+          type: prometheus
+          typeName: Prometheus
+          access: proxy
+          url: http://orc8r-prometheus:9090
+          password: ''
+          user: ''
+          database: ''
+          basicAuth: false
+          isDefault: true
+          jsonData:
+            httpMethod: POST
+          readOnly: false

--- a/dp/skaffold.yaml
+++ b/dp/skaffold.yaml
@@ -42,7 +42,7 @@ build:
     - image: dp-postgres
       context: ../dp/cloud/docker/postgresql
       docker:
-        dockerfile: ../dp/cloud/docker/postgresql/Dockerfile
+        dockerfile: Dockerfile
 
 deploy:
   kubeContext: minikube
@@ -281,6 +281,14 @@ profiles:
                 - "/var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator || exit 0"
       - op: remove
         path: /deploy/helm/hooks/before/6
+  - name: metrics
+    patches:
+      - op: add
+        path: /deploy/helm/releases/0/valuesFiles/-
+        value: ./cloud/helm/dp/charts/domain-proxy/examples/metrics_overrides.yaml
+      - op: add
+        path: /deploy/helm/releases/2/valuesFiles/-
+        value: ./cloud/helm/dp/charts/domain-proxy/examples/metrics_overrides.yaml
   - name: remote-push
     patches:
       - op: remove


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Add Grafana to the domain-proxy chart as an optional component.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- run `DP_METRICS make orc8r`
- check if  Grafana POD was deployed and if is possible to login to it
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
