### PR TITLE
chore(ci): cache Vagrant boxes with Github Actions Cache

### DIFF
--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -30,6 +30,11 @@ jobs:
       - run: echo "::set-output name=date::$(date +'%m-%d-%Y--%H-%M-%S')"
         id: date
       - uses: actions/checkout@v2
+      - name: Cache Vagrant Boxes
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes
+          key: vagrant-boxes-lte
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -108,6 +108,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Cache Vagrant Boxes
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes
+          key: vagrant-boxes-lte
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@v8"
         with:

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -23,6 +23,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.SHA }}
+      - name: Cache Vagrant Boxes
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes
+          key: vagrant-boxes-cwf
       - name: Run docker compose
         run: |
           cd cwf/gateway/docker

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -23,6 +23,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.SHA }}
+      - name: Cache Vagrant Boxes
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes
+          key: vagrant-boxes-lte
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@v8"
         with:


### PR DESCRIPTION
## Summary

The Github Actions workflows see a lot of HTTP 429 when downloading Vagrant boxes from the Vagrant Cloud.

As a quick fix, simply cache the `~/.vagrant.d/boxes` directory using the `actions/cache` action.

## Test Plan

Spin up the `magma_dev`, `magma_test` and `magma_trfserver` VMs and verify the cache is used: https://github.com/jheidbrink/magma/actions/runs/2507266285

## Additional Information

- [ ] This change is backwards-breaking

All our boxes (lte, cwf) currently use around 8 GiB of disk space. That is close to the cache size limit of 10GiB. Given that we don't use the Github Actions caches elsewhere and don't regularly update the boxes, this should be ok for now. Once the boxes receive more regular upgrades, we need to find a more elaborate solution.
