### PR TITLE
fix(ci): Fix Bazel failure Slack message in agw-workflow

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -433,7 +433,7 @@ jobs:
           echo "Available storage:"
           df -h
       - name: Notify Bazel failure to slack
-        if: steps.bazel-codecoverage.outcome=='failure' && github.event_name == 'push'
+        if: failure() && steps.bazel-codecoverage.conclusion == 'failure' && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The failure reporting step was not triggered on failure. We have to still include failure() to override the default status check of success() that is automatically applied to if conditions that don't contain a status check function.

## Test Plan

CI.
Also tested on fork: https://github.com/vktng/magma/runs/6917739513?check_suite_focus=true

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
