### PR TITLE
chore: Link glog library dynamically in Bazel builds

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -24,13 +24,6 @@ def cpp_repositories():
     )
 
     http_archive(
-        name = "com_github_google_glog",
-        strip_prefix = "glog-0.4.0",
-        sha256 = "f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c",
-        urls = ["https://github.com/google/glog/archive/v0.4.0.tar.gz"],
-    )
-
-    http_archive(
         name = "yaml-cpp",
         strip_prefix = "yaml-cpp-yaml-cpp-0.7.0",
         sha256 = "43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3",

--- a/bazel/external/system_libraries.BUILD
+++ b/bazel/external/system_libraries.BUILD
@@ -96,6 +96,11 @@ cc_library(
 )
 
 cc_library(
+    name = "libglog",
+    srcs = ["usr/lib/x86_64-linux-gnu/libglog.so.0"],
+)
+
+cc_library(
     name = "libgnutls",
     srcs = ["usr/lib/libgnutls.so"],
     linkopts = ["-lgnutls"],

--- a/cwf/gateway/docker/c/Dockerfile
+++ b/cwf/gateway/docker/c/Dockerfile
@@ -22,17 +22,17 @@ FROM $OS_DIST:$OS_RELEASE AS builder
 ARG OS_DIST OS_RELEASE EXTRA_REPO
 
 RUN apt-get update && \
-    # Setup necessary tools for adding the Magma repository
-    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg wget && \
-    # Download Bazel
-    wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
-    chmod +x /usr/sbin/bazelisk-linux-amd64 && \
-    ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
+  # Setup necessary tools for adding the Magma repository
+  apt-get install -y apt-utils software-properties-common apt-transport-https gnupg wget && \
+  # Download Bazel
+  wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
+  chmod +x /usr/sbin/bazelisk-linux-amd64 && \
+  ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
 
 # Add the magma apt repo
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
 RUN apt-key add /tmp/jfrog.pub && \
-    apt-add-repository "deb ${EXTRA_REPO} focal-ci main"
+  apt-add-repository "deb ${EXTRA_REPO} focal-ci main"
 
 # Install dependencies required for building
 RUN apt-get -y update && apt-get -y install \
@@ -69,7 +69,6 @@ COPY bazel/ ${MAGMA_ROOT}/bazel
 # Build external dependencies first. This will help not rebuilt all dependencies triggered by Magma changes.
 RUN bazel build \
   @com_github_grpc_grpc//:grpc++ \
-  @com_github_google_glog//:glog \
   @com_google_protobuf//:protobuf \
   @prometheus_cpp//:prometheus-cpp \
   @yaml-cpp//:yaml-cpp \

--- a/lte/gateway/c/core/oai/common/glogwrapper/BUILD.bazel
+++ b/lte/gateway/c/core/oai/common/glogwrapper/BUILD.bazel
@@ -17,5 +17,5 @@ cc_library(
     name = "glog_logging",
     srcs = ["glog_logging.cpp"],
     hdrs = ["glog_logging.hpp"],
-    deps = ["@com_github_google_glog//:glog"],
+    deps = ["@system_libraries//:libglog"],
 )

--- a/lte/gateway/c/li_agent/src/test/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/test/BUILD.bazel
@@ -24,8 +24,8 @@ cc_test(
         "//lte/gateway/c/li_agent/src:pdu_generator",
         "//lte/gateway/c/li_agent/src:utilities",
         "@com_github_gflags_gflags//:gflags",
-        "@com_github_google_glog//:glog",
         "@com_google_googletest//:gtest_main",
+        "@system_libraries//:libglog",
     ],
 )
 

--- a/lte/gateway/c/sctpd/src/test/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/test/BUILD.bazel
@@ -18,8 +18,8 @@ cc_test(
     deps = [
         "//lte/gateway/c/sctpd/src:sctpd_event_handler",
         "//lte/protos:sctpd_cpp_grpc",
-        "@com_github_google_glog//:glog",
         "@com_google_googletest//:gtest_main",
+        "@system_libraries//:libglog",
     ],
 )
 
@@ -30,7 +30,7 @@ cc_test(
     deps = [
         "//lte/gateway/c/sctpd/src:sctp_assoc",
         "//lte/gateway/c/sctpd/src:sctp_desc",
-        "@com_github_google_glog//:glog",
         "@com_google_googletest//:gtest_main",
+        "@system_libraries//:libglog",
     ],
 )

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -25,8 +25,8 @@ cc_library(
     hdrs = ["GrpcMagmaUtils.hpp"],
     deps = [
         "//orc8r/gateway/c/common/logging",
-        "@com_github_google_glog//:glog",
         "@com_google_protobuf//:protobuf",
+        "@system_libraries//:libglog",
     ],
 )
 
@@ -89,8 +89,8 @@ cc_library(
         "//orc8r/gateway/c/common/config:service_config_loader",
         "//orc8r/gateway/c/common/logging",
         "//orc8r/protos:redis_cpp_proto",
-        "@com_github_google_glog//:glog",
         "@cpp_redis",
+        "@system_libraries//:libglog",
         "@yaml-cpp//:yaml-cpp",
     ],
 )
@@ -104,8 +104,8 @@ cc_library(
         "//lte/protos:session_manager_cpp_grpc",
         "//orc8r/gateway/c/common/async_grpc:async_grpc_receiver",
         "//orc8r/gateway/c/common/service_registry",
-        "@com_github_google_glog//:glog",
         "@system_libraries//:folly",
+        "@system_libraries//:libglog",
     ],
 )
 
@@ -119,8 +119,8 @@ cc_library(
         "//lte/protos:pipelined_cpp_grpc",
         "//lte/protos:session_manager_cpp_grpc",
         "//orc8r/gateway/c/common/logging",
-        "@com_github_google_glog//:glog",
         "@system_libraries//:folly",
+        "@system_libraries//:libglog",
     ],
 )
 
@@ -133,7 +133,7 @@ cc_library(
         "//lte/protos:pipelined_cpp_grpc",
         "//orc8r/gateway/c/common/async_grpc:async_grpc_receiver",
         "//orc8r/gateway/c/common/service_registry",
-        "@com_github_google_glog//:glog",
+        "@system_libraries//:libglog",
     ],
 )
 
@@ -211,8 +211,8 @@ cc_library(
         ":metering_reporter",
         ":session_state",
         "//orc8r/gateway/c/common/logging",
-        "@com_github_google_glog//:glog",
         "@cpp_redis",
+        "@system_libraries//:libglog",
     ],
 )
 
@@ -273,7 +273,7 @@ cc_library(
         "//orc8r/gateway/c/common/async_grpc:async_grpc_receiver",
         "//orc8r/gateway/c/common/logging",
         "//orc8r/gateway/c/common/service_registry",
-        "@com_github_google_glog//:glog",
+        "@system_libraries//:libglog",
     ],
 )
 
@@ -286,8 +286,8 @@ cc_library(
         "//lte/protos:session_manager_cpp_grpc",
         "//orc8r/gateway/c/common/async_grpc:async_grpc_receiver",
         "//orc8r/gateway/c/common/service_registry",
-        "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",
+        "@system_libraries//:libglog",
     ],
 )
 

--- a/lte/gateway/c/session_manager/test/BUILD.bazel
+++ b/lte/gateway/c/session_manager/test/BUILD.bazel
@@ -64,8 +64,8 @@ cc_test(
         "//lte/gateway/c/session_manager:session_store",
         "//orc8r/gateway/c/common/logging",
         "//orc8r/gateway/c/common/service303",
-        "@com_github_google_glog//:glog",
         "@com_google_googletest//:gtest_main",
+        "@system_libraries//:libglog",
     ],
 )
 

--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -40,12 +40,12 @@ ENV MAGMA_DEV_MODE 0
 ENV XDG_CACHE_HOME ${MAGMA_ROOT}/.cache
 
 RUN apt-get update && \
-    # Setup necessary tools for adding the Magma repository
-    apt-get install -y apt-utils software-properties-common apt-transport-https gnupg wget && \
-    # Download Bazel
-    wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-"${DEB_PORT}" && \
-    chmod +x /usr/sbin/bazelisk-linux-"${DEB_PORT}" && \
-    ln -s /usr/sbin/bazelisk-linux-"${DEB_PORT}" /usr/sbin/bazel
+  # Setup necessary tools for adding the Magma repository
+  apt-get install -y apt-utils software-properties-common apt-transport-https gnupg wget && \
+  # Download Bazel
+  wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-"${DEB_PORT}" && \
+  chmod +x /usr/sbin/bazelisk-linux-"${DEB_PORT}" && \
+  ln -s /usr/sbin/bazelisk-linux-"${DEB_PORT}" /usr/sbin/bazel
 
 # Install dependencies required for building
 RUN apt-get update && apt-get install -y \
@@ -116,7 +116,6 @@ COPY bazel/ ${MAGMA_ROOT}/bazel
 # Build external dependencies first. This will help not rebuilt all dependencies triggered by Magma changes.
 RUN bazel build \
   @com_github_grpc_grpc//:grpc++ \
-  @com_github_google_glog//:glog \
   @com_google_protobuf//:protobuf \
   @prometheus_cpp//:prometheus-cpp \
   @yaml-cpp//:yaml-cpp \

--- a/orc8r/gateway/c/common/logging/BUILD.bazel
+++ b/orc8r/gateway/c/common/logging/BUILD.bazel
@@ -19,5 +19,5 @@ cc_library(
         "magma_logging.hpp",
         "magma_logging_init.hpp",
     ],
-    deps = ["@com_github_google_glog//:glog"],
+    deps = ["@system_libraries//:libglog"],
 )


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The glog library is not working correctly when it is statically linked. (Sometimes log files or links to them are not created.)
By linking it dynamically we avoid this problem.

## Test Plan

CI.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
