### PR TITLE
fix(ci): base box caching is refactored

### DIFF
--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -30,11 +30,11 @@ jobs:
       - run: echo "::set-output name=date::$(date +'%m-%d-%Y--%H-%M-%S')"
         id: date
       - uses: actions/checkout@v2
-      - name: Cache Vagrant Boxes
+      - name: Cache magma dev
         uses: actions/cache@v3
         with:
-          path: ~/.vagrant.d/boxes
-          key: vagrant-boxes-lte
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
+          key: vagrant-box-magma-dev
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -108,11 +108,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Cache Vagrant Boxes
+      - name: Cache magma dev
         uses: actions/cache@v3
         with:
-          path: ~/.vagrant.d/boxes
-          key: vagrant-boxes-lte
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
+          key: vagrant-box-magma-dev
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@v8"
         with:

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -23,11 +23,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.SHA }}
-      - name: Cache Vagrant Boxes
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes
-          key: vagrant-boxes-cwf
       - name: Run docker compose
         run: |
           cd cwf/gateway/docker
@@ -70,6 +65,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.SHA }}
+      - name: Cache Vagrant Boxes
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes
+          key: vagrant-boxes-cwf
       - name: Setup Python env
         uses: "gabrielfalcao/pyenv-action@v8"
         with:

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -23,11 +23,21 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.SHA }}
-      - name: Cache Vagrant Boxes
+      - name: Cache magma dev
         uses: actions/cache@v3
         with:
-          path: ~/.vagrant.d/boxes
-          key: vagrant-boxes-lte
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
+          key: vagrant-box-magma-dev
+      - name: Cache magma test
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
+          key: vagrant-box-magma-test
+      - name: Cache magma trfserver
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
+          key: vagrant-box-magma-trfserver
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@v8"
         with:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

* Small correction for #13003. The caching directive was placed  in the wrong job.
* lte box caching is split up - github caches are never updated, this is e.g., build-all caches magma dev, but not test and trf server, then the lte integ test will not get test and trf server. This could be handled via cache keys with sha and restore keys, but this would take to much space in the cache (10gb restriction).

## Test Plan

CI on master - already works for lte integ tests and other VM based workflows.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
