### PR TITLE
fix(feg): renamed shadowed function which kept the feg orc8r cleanup …

### DIFF
--- a/lte/gateway/python/integ_tests/federated_tests/fabfile.py
+++ b/lte/gateway/python/integ_tests/federated_tests/fabfile.py
@@ -62,7 +62,7 @@ def build_all(clear_orc8r='False', provision_vm='False'):
     build_agw(provision_vm=provision_vm)
 
     if clear_orc8r:
-        clear_orc8r()
+        clear_orc8r_db()
 
     # build other VMs
     build_test_vm(provision_vm=provision_vm)
@@ -120,7 +120,7 @@ def clear_gateways():
     subprocess.check_call('fab deregister_feg_gw', shell=True, cwd=feg_path)
 
 
-def clear_orc8r():
+def clear_orc8r_db():
     """
     Delete orc8r database. Requieres orc8r to be stopped
     """

--- a/lte/gateway/python/integ_tests/federated_tests/fabfile.py
+++ b/lte/gateway/python/integ_tests/federated_tests/fabfile.py
@@ -122,7 +122,7 @@ def clear_gateways():
 
 def clear_orc8r_db():
     """
-    Delete orc8r database. Requieres orc8r to be stopped
+    Delete orc8r database. Requires orc8r to be stopped
     """
     print('#### Clearing swagger database from Orc8r ####')
     subprocess.check_call(['./run.py --clear-db'], shell=True, cwd=orc8_docker_path)


### PR DESCRIPTION
## Summary

Fixes orc8r db reset

## Test Plan
After this a clean setup ran just fine:
`:lte/gateway/python/integ_tests# fab federated_integ_test:build_all=True,clear_orc8r=True,destroy_vm=True`
