### PR TITLE
fix(ci): Work around unattended upgrades holding lock

### DIFF
--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -20,6 +20,10 @@
     name: "{{ packages }}"
     state: latest
     update_cache: yes
+  register: result
+  until: result is not failed
+  retries: 7
+  delay: 9
   vars:
     packages:
       - ca-certificates


### PR DESCRIPTION
## Summary

In the CI we sometimes see these failures when provisioning the magma VM:
```
TASK [pkgrepo : Ensure ca-certificates is up to date] **************************
Thursday 16 June 2022  16:41:06 +0000 (0:00:00.563)       0:00:04.214 ********* 
fatal: [magma]: FAILED! => {"cache_update_time": 1655397684, "cache_updated": true, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"       install 'ca-certificates'' failed: E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4076 (unattended-upgr)\nE: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?\n", "rc": 100, "stderr": "E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4076 (unattended-upgr)\nE: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?\n", "stderr_lines": ["E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4076 (unattended-upgr)", "E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?"], "stdout": "", "stdout_lines": []}
```

This is due to `unattended-upgrades` holding the `/var/lib/dpkg/lock-frontend`. This problem is described in [this issue](https://github.com/ansible/ansible/issues/51663), and we use a workaround from [a comment in that discussion](https://github.com/ansible/ansible/issues/51663#issuecomment-650562476).

## Test Plan

Verified that the VM provisions successfully once. Given that the described problem doesn't appear reproducably we cannot be certain that this PR fixes the issue, but it doesn't break anything and it's worth trying it out.

## Additional Information

- [ ] This change is backwards-breaking

In the past @LKreutzer fixed an issue with the same root cause in https://github.com/magma/magma/pull/12329
