### PR TITLE
docs(agw): fixing instructions to connect enodeb to gateway VM

### DIFF
--- a/docs/readmes/lte/dev_notes.md
+++ b/docs/readmes/lte/dev_notes.md
@@ -68,14 +68,15 @@ testing to physical UE and eNodeB.
 To connect a physical eNodeB to the gateway VM:
 
 1. Connect the eNodeB to a port on the host machine, say it is interface `en9`.
-1. From the VirtualBox GUI, switch the Adapter 1 (for `eth1` interface) from
+1. From the VirtualBox GUI, switch the Adapter 2 (for `eth1` interface) from
 `Host-only` to `Bridged` mode and bridge it to interface `en9` from above.
 1. In gateway VM, modify the `nat_iface` in `/etc/magma/pipelined.yml` from
 `eth2` to `eth0`. Restart all services.
 1. In the gateway VM, follow the steps in [EnodeB
 Configuration](enodebd#basic-troubleshooting). Make sure the `earfcn` set in the
 enodebd section of `gateway.mconfig` is the one that is supported by the eNodeB
-under consideration.
+under consideration. Use this [calculator](https://www.sqimway.com/lte_band.php) to
+get the `earfcn` corresponding to the frequency range listed on the eNodeB.
 
 To connect a physical UE to the gateway VM,
 
@@ -285,7 +286,7 @@ num_enbs: 1
 
 ## Combining XML Unit test reports
 
-At the moment of writing, running the unit test targets does not generate the aggregated XML report file by default. To get the report of all unit tests, you have two options.  
+At the moment of writing, running the unit test targets does not generate the aggregated XML report file by default. To get the report of all unit tests, you have two options.
 
 ### Option 1: Running unit test target
 
@@ -332,7 +333,7 @@ For example, when you generated all the `.xml` report files at `${MAGMA_ROOT}/lo
 
 ```bash
 python3 python/scripts/runtime_report.py -i .+\\.xml$$ -w ${MAGMA_ROOT}/logs/
-```  
+```
 
 By default, the XML output file will be generated at `${MAGMA_ROOT}/report/merged_report/report_all_tests.xml`.
 You can overwrite this by using the `-o` option of `runtime_report.py`. Let's reuse the example above:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The docs currently state that on the VirtualBox GUI we must switch the Adapter 1 (for eth1 interface) from Host-only to Bridged mode but we should actually be doing this for Adapter 2 (eth2) and leave Adapter 1 for the NAT interface. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

I was able to connect an enodeb to my VM with the updated  settings 
<img width="677" alt="Screen Shot 2022-06-17 at 12 45 34 PM" src="https://user-images.githubusercontent.com/105877840/174391801-4469ac17-064f-485a-a50a-4668c111340b.png">


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
