### PR TITLE
fix(agw): Add Iptables rule for enodebd when other rules exist

### DIFF
--- a/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
+++ b/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
@@ -81,7 +81,17 @@ async def check_and_apply_iptables_rules(
         )
     else:
         # Checks each rule in PREROUTING Chain
-        check_rules(prerouting_rules, port, enodebd_public_ip, enodebd_ip)
+        expected_rules_present = check_rules(prerouting_rules, port, enodebd_public_ip, enodebd_ip)
+        if not expected_rules_present:
+            logger.info('Configuring Iptables rule')
+            await run(
+                get_iptables_rule(
+                    port,
+                    enodebd_public_ip,
+                    enodebd_ip,
+                    add=True,
+                ),
+            )
 
 
 def check_rules(
@@ -91,19 +101,23 @@ def check_rules(
     private_ip: str,
 ) -> None:
     unexpected_rules = []
+    expected_rules_present = False
     pattern = r'DNAT\s+tcp\s+--\s+anywhere\s+{pub_ip}\s+tcp\s+dpt:{dport} to:{ip}'.format(
-                pub_ip=enodebd_public_ip,
-                dport=port,
-                ip=private_ip,
+        pub_ip=enodebd_public_ip,
+        dport=port,
+        ip=private_ip,
     )
     for rule in prerouting_rules:
         match = re.search(pattern, rule)
         if not match:
             unexpected_rules.append(rule)
+        else:
+            expected_rules_present = True
     if unexpected_rules:
         logger.warning('The following Prerouting rule(s) are unexpected')
         for rule in unexpected_rules:
             logger.warning(rule)
+    return expected_rules_present
 
 
 async def run(cmd):


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Enodebd was not adding the iptables rule to redirect eNB queries destined for 192.88.99.142 to 192.168.60.142, since there was an unexpected rule for Docker. 
This change adds a check to add the missing iptables rule if no matching rule exists.

## Test Plan

1. Before this change:

```
vagrant@magma-dev-focal:~/magma/lte/gateway$ tail -f /var/log/enodebd.log
2022-06-17 19:41:36,247 INFO Starting TR-069 server on 192.168.60.142:48080
2022-06-17 19:41:36,269 WARNING The following Prerouting rule(s) are unexpected
2022-06-17 19:41:36,269 WARNING DOCKER     all  --  anywhere             anywhere             ADDRTYPE match dst-type LOCAL
^C
vagrant@magma-dev-focal:~/magma/lte/gateway$ sudo iptables -t nat -L
Chain PREROUTING (policy ACCEPT)
target     prot opt source               destination
DOCKER     all  --  anywhere             anywhere             ADDRTYPE match dst-type LOCAL
```

2. After the change: Note the "Configuring Iptables rule" log
```
vagrant@magma-dev-focal:~$ tail -f /var/log/enodebd.log
2022-06-17 21:55:31,886 INFO Starting TR-069 server on 192.168.60.142:48080
2022-06-17 21:55:31,949 WARNING The following Prerouting rule(s) are unexpected
2022-06-17 21:55:31,949 WARNING DOCKER     all  --  anywhere             anywhere             ADDRTYPE match dst-type LOCAL
2022-06-17 21:55:31,949 INFO Configuring Iptables rule
^C
vagrant@magma-dev-focal:~$ sudo iptables -t nat -L
Chain PREROUTING (policy ACCEPT)
target     prot opt source               destination
DOCKER     all  --  anywhere             anywhere             ADDRTYPE match dst-type LOCAL
DNAT       tcp  --  anywhere             192.88.99.142        tcp dpt:48080 to:192.168.60.142
```

3. Restarting the service does not re-add the rule if it exists: Note that there is no "Configuring Iptables rule" log
```
vagrant@magma-dev-focal:~$ tail -f /var/log/enodebd.log
2022-06-17 22:11:02,608 INFO Starting TR-069 server on 192.168.60.142:48080
2022-06-17 22:11:02,694 WARNING The following Prerouting rule(s) are unexpected
2022-06-17 22:11:02,694 WARNING DOCKER     all  --  anywhere             anywhere             ADDRTYPE match dst-type LOCAL
^C
vagrant@magma-dev-focal:~$ sudo iptables -t nat -L
Chain PREROUTING (policy ACCEPT)
target     prot opt source               destination
DOCKER     all  --  anywhere             anywhere             ADDRTYPE match dst-type LOCAL
DNAT       tcp  --  anywhere             192.88.99.142        tcp dpt:48080 to:192.168.60.142
```