### PR TITLE
chore(ci): excessive logging of asn1 builds is mitigated

### DIFF
--- a/bazel/asn1c.bzl
+++ b/bazel/asn1c.bzl
@@ -50,13 +50,17 @@ def _construct_asn1c_commands(ctx, dir_path):
     """Return a string of command that runs asn1c"""
     flags = ctx.attr.flags
     asn1_file = ctx.attr.asn1_file.files.to_list()[0].path
-    asn1c_command_template = "{asn1c} {flags} -D {dir} {input}"
+
+    # TODO: GH13021 this is a mitigation for excessive logging that should be handled more clean
+    output_filter = '2> >(grep -v "Parameterized type" | grep -v "Compiled " | grep -v "Copied " >&2)'
+    asn1c_command_template = "{asn1c} {flags} -D {dir} {input} {output_filter}"
     return [
         asn1c_command_template.format(
             asn1c = ctx.executable._asn1c.path,
             flags = flags,
             dir = dir_path,
             input = asn1_file,
+            output_filter = output_filter,
         ),
     ]
 

--- a/lte/gateway/c/core/oai/tasks/ngap/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/ngap/CMakeLists.txt
@@ -16,16 +16,24 @@ set(ngap_generate_code_done_flag ${GENERATED_FULL_DIR}/NGAP_GENERATE_CODE_DONE)
 file(MAKE_DIRECTORY ${GENERATED_FULL_DIR})
 set(ngap_generate_code_done_flag ${GENERATED_FULL_DIR}/NGAP_GENERATE_CODE_DONE)
 
+# TODO: GH13021 this is a mitigation for excessive logging that should be handled more clean
+set(ASN1_ERR_FILTER "2> >(grep -v \"Parameterized type\" | grep -v \"Compiled \" | grep -v \"Copied \" >&2)")
+
 if( ${ASN1_SOURCE_DIR} IS_NEWER_THAN ${ngap_generate_code_done_flag})
    file(REMOVE ${GENERATED_FULL_DIR}/${ASN1C_PREFIX}*.c ${GENERATED_FULL_DIR}/${ASN1C_PREFIX}*.h)
    file(MAKE_DIRECTORY ${GENERATED_FULL_DIR})
 
-#Create NGAP_PDU structure without pointer references
- execute_process(COMMAND asn1c -pdu=all -fcompound-names -fno-include-deps -gen-PER -D ${GENERATED_FULL_DIR} ${ASN1_SOURCE_DIR} RESULT_VARIABLE ret)
-   if (NOT ${ret} STREQUAL 0)
-      message(FATAL_ERROR "${ret}")
-   endif (NOT ${ret} STREQUAL 0)
-   execute_process(COMMAND bash "-c" "egrep -lRZ \"18446744073709551615\" ${GENERATED_FULL_DIR} | xargs -0 -l sed -i -e \"s/18446744073709551615/18446744073709551615u/g\"")
+    #Create NGAP_PDU structure without pointer references
+    execute_process(
+        COMMAND bash "-c" "asn1c -pdu=all -fcompound-names -fno-include-deps -gen-PER -D ${GENERATED_FULL_DIR} ${ASN1_SOURCE_DIR} ${ASN1_ERR_FILTER}"
+        RESULT_VARIABLE ret
+    )
+    if (NOT ${ret} STREQUAL 0)
+        message(FATAL_ERROR "${ret}")
+    endif (NOT ${ret} STREQUAL 0)
+    execute_process(
+        COMMAND bash "-c" "egrep -lRZ \"18446744073709551615\" ${GENERATED_FULL_DIR} | xargs -0 -l sed -i -e \"s/18446744073709551615/18446744073709551615u/g\""
+    )
 endif()
 # TOUCH not in cmake 3.10
 file(WRITE ${ngap_generate_code_done_flag})

--- a/lte/gateway/c/core/oai/tasks/s1ap/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/s1ap/CMakeLists.txt
@@ -25,13 +25,21 @@ set(ENV{ASN1C_PREFIX} "S1ap_")
 file(MAKE_DIRECTORY ${GENERATED_FULL_DIR})
 set(s1ap_generate_code_done_flag ${GENERATED_FULL_DIR}/S1AP_GENERATE_CODE_DONE)
 
+# TODO: GH13021 this is a mitigation for excessive logging that should be handled more clean
+set(ASN1_ERR_FILTER "2> >(grep -v \"Parameterized type\" | grep -v \"Compiled \" | grep -v \"Copied \" >&2)")
+
 if (${ASN1_SOURCE_DIR} IS_NEWER_THAN ${s1ap_generate_code_done_flag})
-  file(REMOVE ${GENERATED_FULL_DIR}/${ASN1C_PREFIX}*.c ${GENERATED_FULL_DIR}/${ASN1C_PREFIX}*.h)
-  execute_process(COMMAND asn1c -pdu=all -fcompound-names -gen-PER -no-gen-example -fno-include-deps -D ${GENERATED_FULL_DIR} ${ASN1_SOURCE_DIR} RESULT_VARIABLE ret)
-  if (NOT ${ret} STREQUAL 0)
-    message(FATAL_ERROR "${ret}")
-  endif (NOT ${ret} STREQUAL 0)
-  execute_process(COMMAND bash "-c" "egrep -lRZ \"18446744073709551615\" ${GENERATED_FULL_DIR} | xargs -0 -l sed -i -e \"s/18446744073709551615/18446744073709551615u/g\"")
+    file(REMOVE ${GENERATED_FULL_DIR}/${ASN1C_PREFIX}*.c ${GENERATED_FULL_DIR}/${ASN1C_PREFIX}*.h)
+    execute_process(
+        COMMAND bash "-c" "asn1c -pdu=all -fcompound-names -gen-PER -no-gen-example -fno-include-deps -D ${GENERATED_FULL_DIR} ${ASN1_SOURCE_DIR} ${ASN1_ERR_FILTER}"
+        RESULT_VARIABLE ret
+    )
+    if (NOT ${ret} STREQUAL 0)
+        message(FATAL_ERROR "${ret}")
+    endif (NOT ${ret} STREQUAL 0)
+    execute_process(
+        COMMAND bash "-c" "egrep -lRZ \"18446744073709551615\" ${GENERATED_FULL_DIR} | xargs -0 -l sed -i -e \"s/18446744073709551615/18446744073709551615u/g\""
+    )
 endif ()
 # TOUCH not in cmake 3.10
 file(WRITE ${s1ap_generate_code_done_flag})


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

See #13021. Mitigation to reduce logging of asn1 builds by filtering stream to stderr.

## Test Plan

CI
lte integ test run on fork:
* with this change https://github.com/nstng/magma/runs/6998212826?check_suite_focus=true
  * 27224 log lines in "Run the integ tests" job
  * 3h 44m 44s (of course not a relevant sample size - but fastest successful run for me on my fork yet)
* without this change https://github.com/nstng/magma/runs/6999671196?check_suite_focus=true
  * 40904 log lines in "Run the integ tests" job
  * 4h 9m 58s (again, not a relevant sample size)

<img src="https://user-images.githubusercontent.com/42540177/175025372-9e16dd0b-efb8-41aa-bb6f-1ae95b03a14f.jpg" width=50% height=50%>



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
