### PR TITLE
chore(agw): Determine Ubuntu AMI ID dynamically

### DIFF
--- a/.github/workflows/amis-workflow.yml
+++ b/.github/workflows/amis-workflow.yml
@@ -83,7 +83,6 @@ jobs:
             sed -i -e '/^stackDevOpsCloudstrapper: /s/:.*$/: publish-amis-to-marketplace-stack-devopscloustrapper/' ${{ env.VARS_DIR }}/defaults.yaml
             sed -i -e '/^stackCloudstrapper: /s/:.*$/: publish-amis-to-marketplace-stack-cloustrapper/' ${{ env.VARS_DIR }}/defaults.yaml
             sed -i -e '/^devOpsAmi: /s/:.*$/: cloudstrapper-'"$VERSION"'/' ${{ env.VARS_DIR }}/defaults.yaml
-            sed -i -e '/^buildUbuntuAmi: /s/:.*$/: ami-09e67e426f25ce0d7/' ${{ env.VARS_DIR }}/build.yaml
             sed -i -e '/^buildAgwVersion: /s/:.*$/: '"$GIT_REF"'/' ${{ env.VARS_DIR }}/build.yaml
             sed -i -e '/^buildAgwPackage: /s/:.*$/: '"$PACKAGE_VERSION"'/' ${{ env.VARS_DIR }}/build.yaml
             sed -i -e '/^taggedVersion: /s/:.*$/: '"$VERSION"'/' ${{ env.VARS_DIR }}/build.yaml

--- a/experimental/cloudstrapper/README.md
+++ b/experimental/cloudstrapper/README.md
@@ -79,8 +79,6 @@
      - devOpsCloudstrapper indicates the 'Name' tag used to identify the DevOps Cloudstrapper instance
      - primaryCloudstrapper indicates the 'Name' tag used to identify the Primary Cloudstrapper instance
      - devOpsAmi indicates the name of the AMI created for the Cloudstrapper base image
-   - build.yaml
-    - buildUbuntuAmi - AMI id of base Ubuntu image to be used, available in the region where Cloudstrapper is run
 
   Run the following commands
   - devops-provision: Setup instance using default security group, Bootkey and Ubuntu
@@ -133,7 +131,6 @@
 
       - buildAwsRegion indicates which region will host the build instance.
       - buildAwsAz indicates an Availability Zone within the region specified above
-      - buildUbuntuAmi reflects the base Ubuntu AMI available in the region described in buildAwsRegion
 
     All variables can be customized by making a change in the build.yaml file. Invocations
     using Dynamic Inventory would have to be changed to reflect the new labels.
@@ -250,7 +247,6 @@
   - Tunables (in roles/vars/):
 
     - build.yaml:
-      - buildUbuntuAmi: AMI ID of Base Ubuntu 20.04 image
       - buildAgwAmiName: Name of the AGW AMI created, used to label the AMI
       - buildGwTagName: Tag to be used for the AGW Devops instance, used to filter instance for configuration
       - buildAgwVersion: Version of AGW to be built

--- a/experimental/cloudstrapper/playbooks/roles/agw-infra/tasks/provision-instances.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/agw-infra/tasks/provision-instances.yaml
@@ -1,4 +1,14 @@
 ---
+- name: Find out Ubuntu 20.04 AMI ID
+  amazon.aws.ec2_ami_info:
+    filters:
+      name: "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220610"
+  register: ubuntuAmiSearchResult
+
+- name: Set Ubuntu AMI fact
+  set_fact:
+    factUbuntuAmi: "{{ ubuntuAmiSearchResult.images[0].image_id }}"
+
 - name: check if gateway name is defined
   assert:
     that:
@@ -79,7 +89,7 @@
     state: present
     template: "roles/cfn/cfnMagmaAgwPublicDual.json"
     template_parameters:
-      paramImageBase: "{{ buildUbuntuAmi }}"
+      paramImageBase: "{{ factUbuntuAmi }}"
       paramSubnetPublic: "{{ factBridgeSubnetId }}"
       paramSubnetPrivate: "{{ factSgiSubnetId }}"
       paramAzHome: "{{ awsAgwAz }}"

--- a/experimental/cloudstrapper/playbooks/roles/build-infra/tasks/agw-devops.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-infra/tasks/agw-devops.yaml
@@ -12,13 +12,23 @@
     factSecGroup: "{{ regSecGroup.security_groups[0].group_id }}"
   tags: infra-agw
 
+- name: Find out Ubuntu 20.04 AMI ID
+  amazon.aws.ec2_ami_info:
+    filters:
+      name: "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220610"
+  register: ubuntuAmiSearchResult
+
+- name: Set Ubuntu AMI fact
+  set_fact:
+    factUbuntuAmi: "{{ ubuntuAmiSearchResult.images[0].image_id }}"
+
 - name: launch AGW AMI devops node
   cloudformation:
     stack_name: "stackBuildUbuntuAgw"
     state: "present"
     template: "roles/cfn/cfnMagmaAgwAmiPublicDual.json"
     template_parameters:
-      paramImageBase: "{{ buildUbuntuAmi }}"
+      paramImageBase: "{{ factUbuntuAmi }}"
       paramSecGroup: "{{ factSecGroup }}"
       paramAvlZone: "{{ buildAwsAz }}"
       paramKeyHost: "{{ keyHost }}"

--- a/experimental/cloudstrapper/playbooks/roles/build-infra/tasks/orc8r-devops.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-infra/tasks/orc8r-devops.yaml
@@ -12,6 +12,16 @@
     factSecGroup: "{{ regSecGroup.security_groups[0].group_id }}" 
   tags: infra
 
+- name: Find out Ubuntu 20.04 AMI ID
+  ec2_ami_facts:
+    filters:
+      - name: "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220610"
+  register: ubuntuAmiSearchResult
+
+- name: Set Ubuntu AMI fact
+  set_fact:
+    factUbuntuAmi: "{{ ubuntuAmiSearchResult.images[0].image_id }}"
+
 - name: launch build node
   cloudformation:
     stack_name: "stackBuildOrc8r"
@@ -21,7 +31,7 @@
       paramSecGroup: "{{ factSecGroup }}"
       paramAvlZone: "{{ buildAwsAz }}"
       paramKeyHost: "{{ keyHost }}"
-      paramImageId: "{{ buildUbuntuAmi }}"
+      paramImageId: "{{ factUbuntuAmi }}"
       paramInstanceType: "{{ buildInstanceType }}"
       paramTagName: "{{ buildTagName }}"
   tags:

--- a/experimental/cloudstrapper/playbooks/roles/devops-infra/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/devops-infra/tasks/main.yaml
@@ -9,6 +9,16 @@
   set_fact:
     factSecgroup: "{{ reg_secgroup.security_groups[0].group_id }}"
 
+- name: Find out Ubuntu 20.04 AMI ID
+  amazon.aws.ec2_ami_info:
+    filters:
+      name: "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220610"
+  register: ubuntuAmiSearchResult
+
+- name: Set Ubuntu AMI fact
+  set_fact:
+    factUbuntuAmi: "{{ ubuntuAmiSearchResult.images[0].image_id }}"
+
 - name: instantiate ec2 instance using cloudformation
   cloudformation:
     stack_name: "{{ stackDevOpsCloudstrapper }}"
@@ -21,4 +31,4 @@
       paramSecGroup: "{{ factSecgroup }}"
       paramTagId: "Mantle"
       paramTagName: "{{ devOpsCloudstrapper }}"
-      paramImageId: "{{ buildUbuntuAmi }}"
+      paramImageId: "{{ factUbuntuAmi }}"

--- a/experimental/cloudstrapper/playbooks/roles/vars/build.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/vars/build.yaml
@@ -14,7 +14,6 @@ buildInstanceType: t2.xlarge
 buildGwInstanceType: t2.medium
 
 #AMI IDs are different across regions
-buildUbuntuAmi: ami-0df99b3a8349462c6
 buildGwTagName: buildAgw
 buildAgwAmi: ami-0aac5cd08e351ff0f
 buildAgwAmiName: imgMagmaAgw15Delta


### PR DESCRIPTION
## Summary

Currently one has to manually change the AMI ID when deploying to a different AWS region. This change uses the `amazon.aws.ec2_ami_info` Ansible module to dynamically determine the Ubuntu AMI ID during Ansible invocation, making it easier to deploy to a different region.

## Test Plan

Followed [experimental/cloudstrapper/README.md](https://github.com/magma/magma/blob/c82dcc560582bc293f4cb08d25b017ff906d8ac3/experimental/cloudstrapper/README.md) and bits of [lte/gateway/docker/readme.md
](https://github.com/magma/magma/blob/c82dcc560582bc293f4cb08d25b017ff906d8ac3/lte/gateway/docker/readme.md) and verified I could set up an AGW instance on AWS

## Additional Information

- [ ] This change is backwards-breaking
