### PR TITLE
fix(amf): Service-accept for request without uplink data status

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -86,7 +86,7 @@ int amf_handle_service_request(
       amf_app_stop_timer(paging_ctx->m5_paging_response_timer.id);
       paging_ctx->m5_paging_response_timer.id = NAS5G_TIMER_INACTIVE_ID;
       paging_ctx->paging_retx_count = 0;
-      // Fill the itti msg based on context info produced in amf core
+      // Fill the itti msg based on context info produced in amf core.
       OAILOG_DEBUG(LOG_AMF_APP, "T3513: After stopping PAGING Timer\n");
     }
 
@@ -108,37 +108,25 @@ int amf_handle_service_request(
                 SERVICE_TYPE_HIGH_PRIORITY_ACCESS) ||
                (msg->service_type.service_type_value ==
                 SERVICE_TYPE_MOBILE_TERMINATED_SERVICES)) {
-      if (((msg->service_type.service_type_value == SERVICE_TYPE_DATA) ||
-           (msg->service_type.service_type_value ==
-            SERVICE_TYPE_MOBILE_TERMINATED_SERVICES)) &&
-          !(msg->uplink_data_status.uplinkDataStatus)) {
-        // prepare and send reject message.
-        OAILOG_INFO(
-            LOG_NAS_AMF,
-            "Sending service reject with cuase condtional IE missing\n");
-        amf_sap.primitive = AMFAS_ESTABLISH_REJ;
+      if (msg->service_type.service_type_value == SERVICE_TYPE_DATA) {
+        OAILOG_DEBUG(LOG_NAS_AMF, "Service request type is Data \n");
+      } else if (msg->service_type.service_type_value ==
+                 SERVICE_TYPE_MOBILE_TERMINATED_SERVICES) {
+        OAILOG_DEBUG(LOG_NAS_AMF,
+                     "Service request type is Mobile Terminated Services \n");
+      } else {
+        OAILOG_DEBUG(LOG_NAS_AMF,
+                     "Service request type is High Priority Access \n");
+      }
+
+      if (ue_context->cm_state == M5GCM_CONNECTED) {
+        amf_sap.primitive = AMFAS_ESTABLISH_CNF;
         amf_sap.u.amf_as.u.establish.ue_id = ue_id;
         amf_sap.u.amf_as.u.establish.nas_info = AMF_AS_NAS_INFO_SR;
-        if (msg->pdu_session_status.iei) {
-          amf_sap.u.amf_as.u.establish.pdu_session_status_ie =
-              AMF_AS_PDU_SESSION_STATUS;
-          amf_sap.u.amf_as.u.establish.pdu_session_status =
-              msg->pdu_session_status.pduSessionStatus;
-        }
-        amf_sap.u.amf_as.u.establish.amf_cause =
-            AMF_CAUSE_CONDITIONAL_IE_MISSING;
-        rc = amf_sap_send(&amf_sap);
-      } else {
-        OAILOG_DEBUG(LOG_NAS_AMF, "Service request type is %s \n",
-                     (msg->service_type.service_type_value == SERVICE_TYPE_DATA)
-                         ? "Data"
-                         : "Mobile Terminated Services");
 
-        if (ue_context->cm_state == M5GCM_CONNECTED) {
-          amf_sap.primitive = AMFAS_ESTABLISH_CNF;
-          amf_sap.u.amf_as.u.establish.ue_id = ue_id;
-          amf_sap.u.amf_as.u.establish.nas_info = AMF_AS_NAS_INFO_SR;
-
+        if (!msg->uplink_data_status.uplinkDataStatus) {
+          rc = amf_sap_send(&amf_sap);
+        } else {
           for (const auto& it : ue_context->amf_context.smf_ctxt_map) {
             std::shared_ptr<smf_context_t> smf_ctxt = it.second;
             if (smf_ctxt) {
@@ -157,26 +145,24 @@ int amf_handle_service_request(
           amf_sap.u.amf_as.u.establish.pdu_session_status = pdu_session_status;
           amf_sap.u.amf_as.u.establish.guti = ue_context->amf_context.m5_guti;
           rc = amf_sap_send(&amf_sap);
-        } else {
-          ue_context->pending_service_response = true;
-
-          IMSI64_TO_STRING(ue_context->amf_context.imsi64, imsi, 15);
-          for (const auto& it : ue_context->amf_context.smf_ctxt_map) {
-            std::shared_ptr<smf_context_t> smf_ctxt = it.second;
-            if (smf_ctxt) {
-              if (msg->uplink_data_status.uplinkDataStatus &
-                  (1 << smf_ctxt->smf_proc_data.pdu_session_id)) {
-                OAILOG_DEBUG(
-                    LOG_NAS_AMF,
-                    "Sending session request to SMF on service request for"
-                    "imsi %s sessionid %u \n",
-                    imsi, smf_ctxt->smf_proc_data.pdu_session_id);
-                notify_ue_event_type = UE_SERVICE_REQUEST_ON_PAGING;
-                // construct the proto structure and send message to SMF
-                amf_smf_notification_send(
-                    ue_id, ue_context, notify_ue_event_type,
-                    smf_ctxt->smf_proc_data.pdu_session_id);
-              }
+        }
+      } else {
+        ue_context->pending_service_response = true;
+        IMSI64_TO_STRING(ue_context->amf_context.imsi64, imsi, 15);
+        for (const auto& it : ue_context->amf_context.smf_ctxt_map) {
+          std::shared_ptr<smf_context_t> smf_ctxt = it.second;
+          if (smf_ctxt) {
+            if (msg->uplink_data_status.uplinkDataStatus &
+                (1 << smf_ctxt->smf_proc_data.pdu_session_id)) {
+              OAILOG_DEBUG(
+                  LOG_NAS_AMF,
+                  "Sending session request to SMF on service request for"
+                  "imsi %s sessionid %u \n",
+                  imsi, smf_ctxt->smf_proc_data.pdu_session_id);
+              notify_ue_event_type = UE_SERVICE_REQUEST_ON_PAGING;
+              // construct the proto structure and send message to SMF
+              amf_smf_notification_send(ue_id, ue_context, notify_ue_event_type,
+                                        smf_ctxt->smf_proc_data.pdu_session_id);
             }
           }
         }
@@ -459,8 +445,7 @@ int amf_handle_registration_request(
         std::string empheral_public_key = reinterpret_cast<char*>(
             msg->m5gs_mobile_identity.mobile_identity.imsi.empheral_public_key);
         std::string ciphertext = reinterpret_cast<char*>(
-            msg->m5gs_mobile_identity.mobile_identity.imsi.ciphertext->data);
-        bdestroy(msg->m5gs_mobile_identity.mobile_identity.imsi.ciphertext);
+            msg->m5gs_mobile_identity.mobile_identity.imsi.ciphertext);
         std::string mac_tag = reinterpret_cast<char*>(
             msg->m5gs_mobile_identity.mobile_identity.imsi.mac_tag);
 

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -81,20 +81,15 @@ class AMFAppProcedureTest : public ::testing::Test {
                  .mnc_digit2 = 5,
                  .mnc_digit1 = 4};
 
-  itti_amf_decrypted_msin_info_ans_t decrypted_msin = {
-      .msin = {'9', '7', '6', '5', '4', '5', '6', '6', '0'},
-      .msin_length = 10,
-      .result = 1,
-      .ue_id = 1};
+  itti_amf_decrypted_imsi_info_ans_t decrypted_imsi;
 
-  std::string decrypted_imsi = "222456976545660";
-  const uint8_t intital_ue_message_suci_ext_hexbuf[67] = {
-      0x7e, 0x00, 0x41, 0x79, 0x00, 0x39, 0x01, 0x22, 0x62, 0x54, 0xf0, 0xff,
-      0x01, 0x05, 0x25, 0xb6, 0xb6, 0xdf, 0x89, 0xaf, 0x58, 0xb0, 0xe7, 0x07,
-      0x87, 0xfe, 0x52, 0x77, 0xa6, 0x31, 0x7c, 0x2c, 0xc4, 0x7d, 0x76, 0x4a,
-      0x81, 0xaa, 0x3e, 0xcc, 0xbe, 0xa3, 0x7b, 0xd0, 0x57, 0x40, 0xae, 0xe0,
-      0xd5, 0x54, 0x70, 0xbf, 0xf4, 0x7c, 0x08, 0xe3, 0x1d, 0xf9, 0xb8, 0x55,
-      0x99, 0x12, 0x48, 0x2e, 0x02, 0xf0, 0xf0};
+  const uint8_t intital_ue_message_suci_ext_hexbuf[65] = {
+      0x7e, 0x00, 0x41, 0x79, 0x00, 0x35, 0x01, 0x22, 0x62, 0x54, 0x00,
+      0x00, 0x01, 0x04, 0xc8, 0xfc, 0x0c, 0xe5, 0x47, 0x9a, 0x51, 0x5d,
+      0xab, 0xf2, 0xf3, 0x45, 0xae, 0xb4, 0x66, 0x92, 0xd6, 0xff, 0x7a,
+      0x5f, 0x4f, 0x57, 0x2a, 0x47, 0x99, 0xf2, 0x33, 0x69, 0x35, 0x16,
+      0x40, 0x31, 0xbd, 0x3f, 0x84, 0x41, 0x26, 0xdf, 0x5b, 0x47, 0x06,
+      0x41, 0xe2, 0xa9, 0x57, 0x2e, 0x04, 0xf0, 0xf0, 0xf0, 0xf0};
 
   const uint8_t initial_ue_message_hexbuf[29] = {
       0x7e, 0x00, 0x41, 0x79, 0x00, 0x0d, 0x01, 0x22, 0x62, 0x54,
@@ -233,6 +228,13 @@ class AMFAppProcedureTest : public ::testing::Test {
       0x00, 0x00, 0x07, 0xf4, 0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b,
       0x71, 0x00, 0x11, 0x7e, 0x00, 0x4c, 0x00, 0x00, 0x07, 0xf4,
       0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b, 0x50, 0x02, 0x20, 0x00};
+
+  const uint8_t
+      initial_ue_msg_service_request_mobile_trminated_no_UL_data_status[40] = {
+          0x7e, 0x01, 0x30, 0x6f, 0xf2, 0xae, 0x03, 0x7e, 0x00, 0x4c,
+          0x20, 0x00, 0x07, 0xf4, 0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b,
+          0x71, 0x00, 0x11, 0x7e, 0x00, 0x4c, 0x00, 0x00, 0x07, 0xf4,
+          0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b, 0x50, 0x02, 0x20, 0x00};
 
   const uint8_t service_req_wrong_tmsi[44] = {
       0x7e, 0x01, 0xca, 0x3f, 0x92, 0xbe, 0x03, 0x7e, 0x00, 0x4c, 0x10,
@@ -1422,20 +1424,26 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
       amf_app_desc_p, 36, 1, 1, 0, plmn, intital_ue_message_suci_ext_hexbuf,
       sizeof(intital_ue_message_suci_ext_hexbuf));
 
-  rc = amf_decrypt_msin_info_answer(&decrypted_msin);
-  EXPECT_TRUE(rc == RETURNok);
+  char imsi_h[] = {"\x00\x00\x00\x00\x10"};
+  memset(&decrypted_imsi.imsi, 0, sizeof(decrypted_imsi.imsi));
+  memcpy(&decrypted_imsi.imsi, &imsi_h, sizeof(imsi_h));
+  decrypted_imsi.imsi_length = sizeof(imsi_h) + 1;
+  decrypted_imsi.result = 1;
+  decrypted_imsi.ue_id = 1;
 
-  ue_m5gmm_context_s* context_encrypted_imsi =
-      amf_get_ue_context_from_imsi((char*)decrypted_imsi.c_str());
+  imsi64 = amf_decrypt_imsi_info_answer(&decrypted_imsi);
+  EXPECT_EQ(imsi64, 222456000000001);
+
+  char imsi[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, imsi, 15);
 
   // Check if UE Context is created with correct imsi
   bool res = false;
-  res = get_ue_id_from_imsi(amf_app_desc_p,
-                            context_encrypted_imsi->amf_context.imsi64, &ue_id);
+  res = get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id);
   EXPECT_TRUE(res == true);
 
   // Send the authentication response message from subscriberdb
-  rc = send_proc_authentication_info_answer(decrypted_imsi, ue_id, true);
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
   EXPECT_TRUE(rc == RETURNok);
 
   // Validate if authentication procedure is initialized as expected
@@ -1458,7 +1466,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
                                                sizeof(ue_smc_response_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(decrypted_imsi);
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
   rc = amf_handle_s6a_update_location_ans(&ula_ans);
   EXPECT_EQ(rc, RETURNok);
 
@@ -1468,14 +1476,7 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcSUCIExt) {
       sizeof(ue_registration_complete_hexbuf));
   EXPECT_TRUE(rc == RETURNok);
 
-  /* Send uplink nas message for deregistration complete response from UE */
-  rc = send_uplink_nas_ue_deregistration_request(
-      amf_app_desc_p, ue_id, plmn, ue_initiated_dereg_hexbuf,
-      sizeof(ue_initiated_dereg_hexbuf));
-
-  EXPECT_TRUE(rc == RETURNok);
-
-  send_ue_context_release_complete_message(amf_app_desc_p, 1, 1, ue_id);
+  amf_app_handle_deregistration_req(ue_id);
 }
 
 TEST_F(AMFAppProcedureTest, TestAuthFailureFromSubscribeDb) {
@@ -1869,6 +1870,95 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
   EXPECT_TRUE(rc == RETURNok);
 
   send_ue_context_release_complete_message(amf_app_desc_p, 1, 1, ue_id);
+
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
+TEST_F(AMFAppProcedureTest, ServiceRequestMTWithoutUplinkDataStatus) {
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND,
+                                        AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND};
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn,
+                                           initial_ue_message_hexbuf,
+                                           sizeof(initial_ue_message_hexbuf));
+  /* Check if UE Context is created with correct imsi */
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send UE context release request to move to idle mode */
+  send_ue_context_release_request_message(amf_app_desc_p, 1, 1, ue_id);
+
+  send_ue_context_release_complete_message(amf_app_desc_p, 1, 1, ue_id);
+
+  ue_m5gmm_context_s* ue_context = nullptr;
+  ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  EXPECT_EQ(REGISTERED_IDLE, ue_context->mm_state);
+
+  /*Send initial UE message Service Request with PDU*/
+  amf_ue_ngap_id_t updated_ue_id = 0;
+  imsi64 = 0;
+  imsi64 = send_initial_ue_message_service_request(
+      amf_app_desc_p, 36, 1, 2, ue_id, plmn,
+      initial_ue_msg_service_request_mobile_trminated_no_UL_data_status,
+      sizeof(initial_ue_msg_service_request_mobile_trminated_no_UL_data_status),
+      4);
+
+  // Check if UE Context is created with correct imsi
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &updated_ue_id));
+
+  EXPECT_EQ(REGISTERED_CONNECTED, ue_context->mm_state);
+
+  // Ue id will be freshly generated
+  EXPECT_NE(ue_context->amf_ue_ngap_id, ue_id);
+
+  send_initial_context_response(amf_app_desc_p, updated_ue_id);
+
+  // Send uplink nas message for deregistration complete response from UE */
+  rc = send_uplink_nas_ue_deregistration_request(
+      amf_app_desc_p, updated_ue_id, plmn, ue_initiated_dereg_hexbuf,
+      sizeof(ue_initiated_dereg_hexbuf));
+
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_ue_context_release_complete_message(amf_app_desc_p, 1, 2, updated_ue_id);
 
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
 }


### PR DESCRIPTION
Signed-off-by: Akshayp77 <aksahy.patidar@wavelabs.ai>

 

## Summary
Fix #12628 
Service-accept for request without uplink data status.
In case of service request without having uplink data status, service request should not be reject.

## Test Plan
-Tested With UT
-Further testing is in progress
![UT_snapshot](https://user-images.githubusercontent.com/87304387/174582201-ece7a32f-ea35-47ed-aa33-bcdbccab8a8a.png)
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
