### PR TITLE
fix(nms): Fix settings link on host portal

### DIFF
--- a/nms/app/components/ProfileButton.js
+++ b/nms/app/components/ProfileButton.js
@@ -107,6 +107,11 @@ const ProfileButton = (props: Props) => {
 
   const hasAdministration = user.isSuperUser && !isOrganizations;
   const hasDocumentation = isFeatureEnabled('documents_site');
+  const settingsPath = isOrganizations
+    ? '/host/settings'
+    : networkId === null
+    ? '/settings'
+    : 'settings';
 
   return (
     <Popout
@@ -128,7 +133,7 @@ const ProfileButton = (props: Props) => {
               onClick={() => {
                 GeneralLogger.info(Events.SETTINGS_CLICKED);
                 props.setMenuOpen(false);
-                navigate(networkId === null ? '/settings' : 'settings');
+                navigate(settingsPath);
               }}
               component="a">
               <Text className={classes.profileItemText}>Account Settings</Text>


### PR DESCRIPTION
## Summary
The link to the account settings is broken on host portal.

## Test Plan
Check that account settings can be opened form:
- the host portal
- the nms portal with a network
- the nms portal **without** a network
![Screenshot 2022-06-20 at 12 57 31](https://user-images.githubusercontent.com/102796295/174587659-a227d6bd-9416-48d5-8b01-70d2fc0a58ac.png)

