### PR TITLE
fix(ci): bazel coverage failures are mitigated by several flags (see #13026)

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -390,10 +390,11 @@ jobs:
             cd $MAGMA_ROOT
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178
-            # Omit OAI coverage until it is tested. We need to determine what the behavior is for doing both CMake and Bazel based coverage at the same time
-            # TODO: GH11936
+            # Coverage in bazel is flaky for remote caches - the flags below are helping. See GH13026 for details.
+            # TODO: GH11936 Omit OAI coverage until it is tested. We need to determine what the behavior is for doing both CMake and Bazel based coverage at the same time
             bazel coverage \
               --profile=Bazel_test_coverage_profile \
+              --experimental_split_coverage_postprocessing --experimental_fetch_all_coverage_outputs --remote_download_outputs=all \
               -- //orc8r/gateway/c/...:* //lte/gateway/c/...:* -//lte/gateway/c/core/...:*
             # copy out coverage information into magma so that it's accessible from the CI node
             cp bazel-out/_coverage/_coverage_report.dat $MAGMA_ROOT


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

see #13026

## Test Plan

* setup remote caching with rw locally
* execute `bazel coverage lte/gateway/c/session_manager/test/...`
  * see that `bazel-out/_coverage/_coverage_report.dat` is (ok) or is not (failure) generated
  * do `bazel clean` between runs
  * you may need multiple runs to see that coverage is not generated
* execute `bazel coverage --experimental_split_coverage_postprocessing --experimental_fetch_all_coverage_outputs --remote_download_outputs=all lte/gateway/c/session_manager/test/...`
  * see that coverage is always generated

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
