### PR TITLE
fix(amf): AMF is processing the Auth-Response send after Identity-Req

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_authentication.cpp
@@ -560,6 +560,25 @@ int amf_proc_authentication_complete(amf_ue_ngap_id_t ue_id,
 
   amf_ctx = &ue_mm_context->amf_context;
 
+  nas_amf_ident_proc_t* ident_proc =
+      get_5g_nas_common_procedure_identification(amf_ctx);
+  if (ident_proc == NULL) {
+    OAILOG_ERROR(LOG_AMF_APP,
+                 "Failed to start identity procedure for "
+                 "ue_id " AMF_UE_NGAP_ID_FMT "\n",
+                 ue_id);
+  } else {
+    if (ident_proc->T3570.id != NAS5G_TIMER_INACTIVE_ID) {
+      OAILOG_WARNING(
+          LOG_NAS_AMF,
+          "AMF-PROC - Failed because identity request in progress \n");
+      amf_cause = AMF_UE_ILLEGAL;
+      rc = amf_proc_registration_reject(ue_id, amf_cause);
+      OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
+    }
+    OAILOG_WARNING(LOG_NAS_AMF, "AMF-PROC - no identity procedure ongoing \n");
+  }
+
   registration_proc = get_nas_specific_procedure_registration(amf_ctx);
   auth_proc = get_nas5g_common_procedure_authentication(amf_ctx);
 

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -239,6 +239,10 @@ class AMFAppProcedureTest : public ::testing::Test {
       0x00, 0x07, 0xf4, 0x00, 0x40, 0xff, 0xff, 0xff, 0xff, 0x71, 0x00,
       0x15, 0x7e, 0x00, 0x4c, 0x10, 0x00, 0x07, 0xf4, 0x00, 0x40, 0xff,
       0xff, 0xff, 0xff, 0x40, 0x02, 0x20, 0x00, 0x50, 0x02, 0x20, 0x00};
+  const uint8_t initial_ue_periodic_reg[36] = {
+      0x7e, 0x00, 0x41, 0x03, 0x00, 0x0b, 0xf2, 0x22, 0xf2, 0x07, 0x01, 0x00,
+      0x40, 0x42, 0xdb, 0x2a, 0x42, 0x10, 0x01, 0x00, 0x2e, 0x02, 0x00, 0x00,
+      0x2f, 0x02, 0x01, 0x02, 0x17, 0x02, 0xc0, 0xc0, 0xb0, 0x2b, 0x01, 0x00};
 
   const uint8_t initial_ue_msg_service_request[20] = {
       0x7e, 0x01, 0xca, 0x3f, 0x92, 0xbe, 0x03, 0x7e, 0x00, 0x4c,
@@ -2402,6 +2406,77 @@ TEST_F(AMFAppProcedureTest, ServiceRequestSignalWithPDU) {
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
 }
 
+TEST_F(AMFAppProcedureTest, PeriodicRegistraionNoTmsi) {
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t init_ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND,
+                                        AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND};
+  // Send the initial UE message
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn,
+                                           initial_ue_message_hexbuf,
+                                           sizeof(initial_ue_message_hexbuf));
+
+  // Check if UE Context is created with correct imsi
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &init_ue_id));
+
+  // Send the authentication response message from subscriberdb
+  rc = send_proc_authentication_info_answer(imsi, init_ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+  // Send uplink nas message for auth response from UE
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, init_ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+  // Send uplink nas message for security mode complete response from UE
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, init_ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, init_ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, init_ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, init_ue_id);
+
+  send_ue_context_release_request_message(amf_app_desc_p, 1, 1, init_ue_id);
+
+  send_ue_context_release_complete_message(amf_app_desc_p, 1, 1, init_ue_id);
+  ue_m5gmm_context_s* ue_context_p = nullptr;
+  ue_context_p = amf_ue_context_exists_amf_ue_ngap_id(init_ue_id);
+  delete ue_context_p;
+  uint32_t m_tmsi = 0x42db2a42;
+  send_initial_ue_message_with_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn, m_tmsi,
+                                    initial_ue_periodic_reg,
+                                    sizeof(initial_ue_periodic_reg));
+
+  EXPECT_TRUE(validate_identification_procedure(0, &init_ue_id));
+
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, init_ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  amf_app_handle_deregistration_req(init_ue_id);
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
 TEST_F(AMFAppProcedureTest, SctpShutWithServiceRequest) {
   int rc = RETURNerror;
   amf_ue_ngap_id_t ue_id = 0;


### PR DESCRIPTION
Signed-off-by: Sathyaj27 <sathya.jayadev@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
Addressed #12858 


## Summary
Used timer to check if identity request is going on.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested on abot
Implemented and tested using UT
<img width="839" alt="identity" src="https://user-images.githubusercontent.com/94469973/174590285-332c2436-74ba-4626-8ed7-3e2444dc194a.PNG">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is not backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
