### PR TITLE
chore(ci): Remove legacy support for docker.bazelrc import

### DIFF
--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -131,7 +131,4 @@ RUN ldconfig -v
 RUN ln -s /workspaces/magma/.bazel-cache /var/cache/bazel-cache
 RUN ln -s /workspaces/magma/.bazel-cache-repo /var/cache/bazel-cache-repo
 
-# TODO(@LKREUTZER): Remove unused link once new docker image has been generated and PRs have been rebased or merged.
-RUN ln -s /workspaces/magma/bazel/bazelrcs/docker.bazelrc /etc/bazelrc
-
 WORKDIR /workspaces/magma


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary
In the reconfiguration of the bazel cache mechanism (see https://github.com/magma/magma/pull/12987) the support for the old import was kept temporarily in order not to make all PRs fail that are not rebased on the change. This support is removed in this PR.

To be merged on/after 23. June.

## Test Plan
CI

## Additional Information

- [ ] This change is backwards-breaking

