### PR TITLE
fix(amf): Service-accept for request without uplink data status

### DIFF
--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -239,6 +239,13 @@ class AMFAppProcedureTest : public ::testing::Test {
       0x71, 0x00, 0x11, 0x7e, 0x00, 0x4c, 0x00, 0x00, 0x07, 0xf4,
       0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b, 0x50, 0x02, 0x20, 0x00};
 
+  const uint8_t
+      initial_ue_msg_service_request_mobile_trminated_no_UL_data_status[40] = {
+          0x7e, 0x01, 0x30, 0x6f, 0xf2, 0xae, 0x03, 0x7e, 0x00, 0x4c,
+          0x20, 0x00, 0x07, 0xf4, 0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b,
+          0x71, 0x00, 0x11, 0x7e, 0x00, 0x4c, 0x00, 0x00, 0x07, 0xf4,
+          0x00, 0x40, 0xd9, 0x58, 0xf8, 0x3b, 0x50, 0x02, 0x20, 0x00};
+
   const uint8_t service_req_wrong_tmsi[44] = {
       0x7e, 0x01, 0xca, 0x3f, 0x92, 0xbe, 0x03, 0x7e, 0x00, 0x4c, 0x10,
       0x00, 0x07, 0xf4, 0x00, 0x40, 0xff, 0xff, 0xff, 0xff, 0x71, 0x00,
@@ -1883,6 +1890,95 @@ TEST_F(AMFAppProcedureTest, ServiceRequestMTWithPDU) {
   EXPECT_TRUE(rc == RETURNok);
 
   send_ue_context_release_complete_message(amf_app_desc_p, 1, 1, ue_id);
+
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
+TEST_F(AMFAppProcedureTest, ServiceRequestMTWithoutUplinkDataStatus) {
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND,
+                                        AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND};
+
+  /* Send the initial UE message */
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn,
+                                           initial_ue_message_hexbuf,
+                                           sizeof(initial_ue_message_hexbuf));
+  /* Check if UE Context is created with correct imsi */
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &ue_id));
+
+  /* Send the authentication response message from subscriberdb */
+  rc = send_proc_authentication_info_answer(imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for auth response from UE */
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for security mode complete response from UE */
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, ue_id);
+
+  /* Send uplink nas message for registration complete response from UE */
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /*Send UE context release request to move to idle mode*/
+  send_ue_context_release_request_message(amf_app_desc_p, 1, 1, ue_id);
+
+  send_ue_context_release_complete_message(amf_app_desc_p, 1, 1, ue_id);
+
+  ue_m5gmm_context_s* ue_context = nullptr;
+  ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  EXPECT_EQ(REGISTERED_IDLE, ue_context->mm_state);
+
+  /*Send initial UE message Service Request with PDU*/
+  amf_ue_ngap_id_t updated_ue_id = 0;
+  imsi64 = 0;
+  imsi64 = send_initial_ue_message_service_request(
+      amf_app_desc_p, 36, 1, 2, ue_id, plmn,
+      initial_ue_msg_service_request_mobile_trminated_no_UL_data_status,
+      sizeof(initial_ue_msg_service_request_mobile_trminated_no_UL_data_status),
+      4);
+
+  // Check if UE Context is created with correct imsi
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &updated_ue_id));
+
+  EXPECT_EQ(REGISTERED_CONNECTED, ue_context->mm_state);
+
+  // Ue id will be freshly generated
+  EXPECT_NE(ue_context->amf_ue_ngap_id, ue_id);
+
+  send_initial_context_response(amf_app_desc_p, updated_ue_id);
+
+  // Send uplink nas message for deregistration complete response from UE */
+  rc = send_uplink_nas_ue_deregistration_request(
+      amf_app_desc_p, updated_ue_id, plmn, ue_initiated_dereg_hexbuf,
+      sizeof(ue_initiated_dereg_hexbuf));
+
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_ue_context_release_complete_message(amf_app_desc_p, 1, 2, updated_ue_id);
 
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
 }


### PR DESCRIPTION
Signed-off-by: Akshayp77 <aksahy.patidar@wavelabs.ai>


## Summary

Fix https://github.com/magma/magma/issues/12628
Service-accept for request without uplink data status.
In case of service request without having uplink data status, service request should not be reject.

## Test Plan
-Tested with Spirent
[Logs.zip](https://github.com/magma/magma/files/9179388/Logs.zip)
-Tested with UT
![UT_snapshot](https://user-images.githubusercontent.com/87304387/174625370-59735d11-4150-4d10-87b1-d049ed8a2996.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
