### PR TITLE
fix(orc8r): add reindexing of gateway subscriber state to subscriberdb indexer

### DIFF
--- a/lte/cloud/configs/service_registry.yml
+++ b/lte/cloud/configs/service_registry.yml
@@ -53,7 +53,7 @@ services:
       orc8r.io/state_indexer: "true"
       orc8r.io/swagger_spec: "true"
     annotations:
-      orc8r.io/state_indexer_types: "mobilityd_ipdesc_record"
+      orc8r.io/state_indexer_types: "mobilityd_ipdesc_record,gateway_subscriber_state"
       orc8r.io/state_indexer_version: "1"
       orc8r.io/obsidian_handlers_path_prefixes: >
         /magma/v1/lte/:network_id/msisdns,

--- a/lte/cloud/go/lte/const.go
+++ b/lte/cloud/go/lte/const.go
@@ -86,13 +86,14 @@ const (
 	SubscriberStreamName       = "subscriberdb"
 
 	// EnodebStateType etc. denote types of state replicated from AGWs.
-	EnodebStateType     = "single_enodeb"
-	ICMPStateType       = "icmp_monitoring"
-	MMEStateType        = "MME"
-	MobilitydStateType  = "mobilityd_ipdesc_record"
-	S1APStateType       = "S1AP"
-	SPGWStateType       = "SPGW"
-	SubscriberStateType = "subscriber_state"
+	EnodebStateType            = "single_enodeb"
+	ICMPStateType              = "icmp_monitoring"
+	MMEStateType               = "MME"
+	MobilitydStateType         = "mobilityd_ipdesc_record"
+	S1APStateType              = "S1AP"
+	SPGWStateType              = "SPGW"
+	SubscriberStateType        = "subscriber_state"
+	GatewaySubscriberStateType = "gateway_subscriber_state"
 
 	// MSISDNBlobstoreType etc. denote blob types stored in blobstore tables.
 	MSISDNBlobstoreType = "msisdn"

--- a/lte/cloud/go/serdes/serdes.go
+++ b/lte/cloud/go/serdes/serdes.go
@@ -19,6 +19,7 @@ import (
 	nprobe_models "magma/lte/cloud/go/services/nprobe/obsidian/models"
 	policydb_models "magma/lte/cloud/go/services/policydb/obsidian/models"
 	subscriberdb_models "magma/lte/cloud/go/services/subscriberdb/obsidian/models"
+	subscriberdb_storage "magma/lte/cloud/go/services/subscriberdb/storage"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/state"
@@ -49,6 +50,7 @@ var (
 		state.NewStateSerde(lte.S1APStateType, &state.ArbitraryJSON{}),
 		state.NewStateSerde(lte.SPGWStateType, &state.ArbitraryJSON{}),
 		state.NewStateSerde(lte.SubscriberStateType, &state.ArbitraryJSON{}),
+		state.NewStateSerde(lte.GatewaySubscriberStateType, &subscriberdb_storage.GatewaySubscriberState{}),
 	))
 	// Device contains the full set of device serdes used in the LTE module
 	Device = serdes.Device

--- a/lte/cloud/go/services/subscriberdb/servicers/protected/indexer_servicer_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/protected/indexer_servicer_test.go
@@ -19,11 +19,13 @@ import (
 	"net"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/serdes"
 	"magma/lte/cloud/go/services/subscriberdb"
+	"magma/lte/cloud/go/services/subscriberdb/storage"
 	subscriberdb_test_init "magma/lte/cloud/go/services/subscriberdb/test_init"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/state"
@@ -56,10 +58,10 @@ func TestIndexerIP(t *testing.T) {
 	//   "ip": {"address": "wKiArg=="}
 	//  }
 	states := state_types.SerializedStatesByID{
-		id00: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}})},
-		id01: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}})},
-		id10: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}})},
-		id11: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.2")}})},
+		id00: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}}, lte.MobilitydStateType)},
+		id01: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}}, lte.MobilitydStateType)},
+		id10: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}}, lte.MobilitydStateType)},
+		id11: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.2")}}, lte.MobilitydStateType)},
 	}
 
 	// Index the imsi0->sid0 state, result is sid0->imsi0 reverse mapping
@@ -75,8 +77,8 @@ func TestIndexerIP(t *testing.T) {
 
 	// Correctly handle per-state errs
 	states = state_types.SerializedStatesByID{
-		id00: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.3")}})},
-		id2:  {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": "deadbeef"}})},
+		id00: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.3")}}, lte.MobilitydStateType)},
+		id2:  {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": "deadbeef"}}, lte.MobilitydStateType)},
 	}
 	errs, err = idx.Index("nid0", states)
 	assert.NoError(t, err)
@@ -86,8 +88,8 @@ func TestIndexerIP(t *testing.T) {
 	assert.Equal(t, []string{"IMSI0"}, gotC)
 }
 
-func serialize(t *testing.T, mobilitydState *state.ArbitraryJSON) []byte {
-	bytes, err := serde.Serialize(mobilitydState, lte.MobilitydStateType, serdes.State)
+func serialize(t *testing.T, state serde.ValidateableBinaryConvertible, stateType string) []byte {
+	bytes, err := serde.Serialize(state, stateType, serdes.State)
 	assert.NoError(t, err)
 	return bytes
 }
@@ -95,4 +97,144 @@ func serialize(t *testing.T, mobilitydState *state.ArbitraryJSON) []byte {
 func encodeIP(ip string) string {
 	ipBytes := net.ParseIP(ip)[12:16] // get just the IPv4 bytes
 	return base64.StdEncoding.EncodeToString(ipBytes)
+}
+
+const gwid1 = "snowflake_ID_1"
+const gwid2 = "snowflake_ID_2"
+
+func TestIndexerSubscriber(t *testing.T) {
+	const (
+		version indexer.Version = 1 // copied from indexer_servicer.go
+	)
+
+	var (
+		types = []string{lte.GatewaySubscriberStateType}
+	)
+
+	subscriberStorage := subscriberdb_test_init.StartTestService(t)
+	idx := indexer.NewRemoteIndexer(subscriberdb.ServiceName, version, types...)
+
+	// define IDs
+	id0 := state_types.ID{Type: lte.GatewaySubscriberStateType, DeviceID: gwid1}
+	id1 := state_types.ID{Type: lte.GatewaySubscriberStateType, DeviceID: gwid2}
+	// define gateway states
+	gatewayState0 := storage.CreateTestGatewaySubscriberState("IMSI001010000000123", "IMSI001010000000456", "IMSI001010000000789", "IMSI001010000001011")
+	gatewayState1 := storage.CreateTestGatewaySubscriberState("IMSI002020000000123", "IMSI002020000000456", "IMSI002020000000789")
+
+	// empty gateway state
+	emptyState := storage.GatewaySubscriberState{Subscribers: map[string]state.ArbitraryJSON{}}
+	emptySerializedState := state_types.SerializedStatesByID{
+		id0: {SerializedReportedState: serialize(t, &emptyState, lte.GatewaySubscriberStateType)},
+	}
+	errs, err := idx.Index("nid0", emptySerializedState)
+	assert.NoError(t, err)
+	assert.Empty(t, errs)
+	foundStates, err := subscriberStorage.GetSubscribersForGateway("nid0", gwid1)
+	assert.NoError(t, err)
+	assert.True(t, cmp.Equal(*foundStates, emptyState))
+
+	// one gateway
+	serializedGatewayState := state_types.SerializedStatesByID{
+		id0: {SerializedReportedState: serialize(t, &gatewayState0, lte.GatewaySubscriberStateType)},
+	}
+	errs, err = idx.Index("nid0", serializedGatewayState)
+	assert.NoError(t, err)
+	assert.Empty(t, errs)
+	foundStates, err = subscriberStorage.GetSubscribersForGateway("nid0", gwid1)
+	assert.NoError(t, err)
+	assert.True(t, cmp.Equal(*foundStates, gatewayState0))
+
+	// two gatewayIDs
+	serializedGatewayState = state_types.SerializedStatesByID{
+		id0: {SerializedReportedState: serialize(t, &gatewayState1, lte.GatewaySubscriberStateType)},
+		id1: {SerializedReportedState: serialize(t, &gatewayState0, lte.GatewaySubscriberStateType)},
+	}
+	errs, err = idx.Index("nid0", serializedGatewayState)
+	assert.NoError(t, err)
+	assert.Empty(t, errs)
+	foundStates, err = subscriberStorage.GetSubscribersForGateway("nid0", gwid1)
+	assert.NoError(t, err)
+	assert.True(t, cmp.Equal(*foundStates, gatewayState1))
+	foundStates, err = subscriberStorage.GetSubscribersForGateway("nid0", gwid2)
+	assert.NoError(t, err)
+	assert.True(t, cmp.Equal(*foundStates, gatewayState0))
+
+	// empty gateways
+	emptySerializedState = state_types.SerializedStatesByID{
+		id0: {SerializedReportedState: serialize(t, &emptyState, lte.GatewaySubscriberStateType)},
+		id1: {SerializedReportedState: serialize(t, &emptyState, lte.GatewaySubscriberStateType)},
+	}
+	errs, err = idx.Index("nid0", emptySerializedState)
+	assert.NoError(t, err)
+	assert.Empty(t, errs)
+	foundStates, err = subscriberStorage.GetSubscribersForGateway("nid0", gwid1)
+	assert.NoError(t, err)
+	assert.True(t, cmp.Equal(*foundStates, emptyState))
+	foundStates, err = subscriberStorage.GetSubscribersForGateway("nid0", gwid2)
+	assert.NoError(t, err)
+	assert.True(t, cmp.Equal(*foundStates, emptyState))
+}
+
+func TestIndexerSubscriberAndIP(t *testing.T) {
+	const (
+		version indexer.Version = 1 // copied from indexer_servicer.go
+	)
+
+	var (
+		types = []string{lte.GatewaySubscriberStateType, lte.MobilitydStateType}
+	)
+
+	subscriberStorage := subscriberdb_test_init.StartTestService(t)
+	idx := indexer.NewRemoteIndexer(subscriberdb.ServiceName, version, types...)
+
+	// define IDs
+	id0 := state_types.ID{Type: lte.GatewaySubscriberStateType, DeviceID: gwid1}
+	id1 := state_types.ID{Type: lte.GatewaySubscriberStateType, DeviceID: gwid2}
+	// define gateway states
+	gatewayState0 := storage.CreateTestGatewaySubscriberState("IMSI001010000000123", "IMSI001010000000456", "IMSI001010000000789", "IMSI001010000001011")
+	gatewayState1 := storage.CreateTestGatewaySubscriberState("IMSI002020000000123", "IMSI002020000000456", "IMSI002020000000789")
+
+	// define mobilityd state ids
+	idm0 := state_types.ID{Type: lte.MobilitydStateType, DeviceID: "IMSI0.apn0"}
+	idm1 := state_types.ID{Type: lte.MobilitydStateType, DeviceID: "IMSI0.apn1"}
+
+	// mixed state
+	states := state_types.SerializedStatesByID{
+		id0:  {SerializedReportedState: serialize(t, &gatewayState0, lte.GatewaySubscriberStateType)},
+		idm0: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}}, lte.MobilitydStateType)},
+		idm1: {SerializedReportedState: serialize(t, &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}}, lte.MobilitydStateType)},
+		id1:  {SerializedReportedState: serialize(t, &gatewayState1, lte.GatewaySubscriberStateType)},
+	}
+	errs, err := idx.Index("nid0", states)
+	assert.NoError(t, err)
+	assert.Empty(t, errs)
+	foundStates, err := subscriberStorage.GetSubscribersForGateway("nid0", gwid1)
+	assert.NoError(t, err)
+	assert.True(t, cmp.Equal(*foundStates, gatewayState0))
+	foundStates, err = subscriberStorage.GetSubscribersForGateway("nid0", gwid2)
+	assert.NoError(t, err)
+	assert.True(t, cmp.Equal(*foundStates, gatewayState1))
+	foundIPs, err := subscriberdb.GetIMSIsForIP(context.Background(), "nid0", "127.0.0.1")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"IMSI0"}, foundIPs)
+
+	// create empty gateway states
+	emptyState := storage.GatewaySubscriberState{Subscribers: map[string]state.ArbitraryJSON{}}
+	emptySerializedState := state_types.SerializedStatesByID{
+		id0: {SerializedReportedState: serialize(t, &emptyState, lte.GatewaySubscriberStateType)},
+		id1: {SerializedReportedState: serialize(t, &emptyState, lte.GatewaySubscriberStateType)},
+	}
+	// empty gateway states
+	errs, err = idx.Index("nid0", emptySerializedState)
+	assert.NoError(t, err)
+	assert.Empty(t, errs)
+	foundStates, err = subscriberStorage.GetSubscribersForGateway("nid0", gwid1)
+	assert.NoError(t, err)
+	assert.True(t, cmp.Equal(*foundStates, emptyState))
+	foundStates, err = subscriberStorage.GetSubscribersForGateway("nid0", gwid2)
+	assert.NoError(t, err)
+	assert.True(t, cmp.Equal(*foundStates, emptyState))
+	foundIPs, err = subscriberdb.GetIMSIsForIP(context.Background(), "nid0", "127.0.0.1")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"IMSI0"}, foundIPs)
 }

--- a/lte/cloud/go/services/subscriberdb/storage/subscriber_state_test.go
+++ b/lte/cloud/go/services/subscriberdb/storage/subscriber_state_test.go
@@ -14,12 +14,12 @@
 package storage
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
+	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/sqorc"
 )
 
@@ -36,89 +36,69 @@ func TestSubscriberStorage(t *testing.T) {
 	assert.NoError(t, s.Initialize())
 
 	t.Run("Test inserting, querying and deleting subscriber states for a gateway", func(t *testing.T) {
-		subscriberStates := []SubscriberState{subscriberState("IMSI001010000000123"), subscriberState("IMSI001010000000456")}
-		err = s.SetAllSubscribersForGateway(nid1, gwid1, subscriberStates)
+		subscriberStates := CreateTestGatewaySubscriberState("IMSI001010000000123", "IMSI001010000000456")
+		err = s.SetAllSubscribersForGateway(nid1, gwid1, &subscriberStates)
 		assert.NoError(t, err)
 
 		foundStates, err := s.GetSubscribersForGateway(nid2, gwid1)
 		assert.NoError(t, err)
-		assert.Empty(t, foundStates)
+		assert.Empty(t, foundStates.Subscribers)
 		foundStates, err = s.GetSubscribersForGateway(nid1, gwid2)
 		assert.NoError(t, err)
-		assert.Empty(t, foundStates)
+		assert.Empty(t, foundStates.Subscribers)
 
 		foundStates, err = s.GetSubscribersForGateway(nid1, gwid1)
 		assert.NoError(t, err)
-		assert.True(t, cmp.Equal(foundStates, subscriberStates))
+		assert.True(t, cmp.Equal(*foundStates, subscriberStates))
 
 		err = s.DeleteSubscribersForGateway(nid1, gwid1)
 		assert.NoError(t, err)
 		foundStates, err = s.GetSubscribersForGateway(nid1, gwid1)
 		assert.NoError(t, err)
-		assert.Empty(t, foundStates)
+		assert.Empty(t, foundStates.Subscribers)
 	})
 
 	t.Run("Test updating subscriber states for a gateway", func(t *testing.T) {
-		oldSubscriberStatesGw1 := []SubscriberState{subscriberState("IMSI001010000000123"), subscriberState("IMSI001010000000456")}
-		subscriberStatesGw2 := []SubscriberState{subscriberState("IMSI001010000000789")}
+		oldSubscriberStatesGw1 := CreateTestGatewaySubscriberState("IMSI001010000000123", "IMSI001010000000456")
+		subscriberStatesGw2 := CreateTestGatewaySubscriberState("IMSI001010000000789")
 
-		err = s.SetAllSubscribersForGateway(nid1, gwid1, oldSubscriberStatesGw1)
+		err = s.SetAllSubscribersForGateway(nid1, gwid1, &oldSubscriberStatesGw1)
 		assert.NoError(t, err)
-		err = s.SetAllSubscribersForGateway(nid1, gwid2, subscriberStatesGw2)
+		err = s.SetAllSubscribersForGateway(nid1, gwid2, &subscriberStatesGw2)
 		assert.NoError(t, err)
 
 		foundStates, err := s.GetSubscribersForGateway(nid1, gwid1)
 		assert.NoError(t, err)
-		assert.True(t, cmp.Equal(foundStates, oldSubscriberStatesGw1))
+		assert.True(t, cmp.Equal(*foundStates, oldSubscriberStatesGw1))
 
 		// Test updating states for gateway 1
 
-		newSubscriberStatesGw1 := []SubscriberState{subscriberState("IMSI001010000000012"), subscriberState("IMSI001010000000123")}
-		err = s.SetAllSubscribersForGateway(nid1, gwid1, newSubscriberStatesGw1)
+		newSubscriberStatesGw1 := CreateTestGatewaySubscriberState("IMSI001010000000012", "IMSI001010000000123")
+		err = s.SetAllSubscribersForGateway(nid1, gwid1, &newSubscriberStatesGw1)
 		assert.NoError(t, err)
 
 		foundStates, err = s.GetSubscribersForGateway(nid1, gwid1)
 		assert.NoError(t, err)
-		assert.True(t, cmp.Equal(foundStates, newSubscriberStatesGw1))
+		assert.True(t, cmp.Equal(*foundStates, newSubscriberStatesGw1))
 
 		// Test emptying states for gateway 1
 
-		err = s.SetAllSubscribersForGateway(nid1, gwid1, []SubscriberState{})
+		err = s.SetAllSubscribersForGateway(nid1, gwid1, &GatewaySubscriberState{Subscribers: map[string]state.ArbitraryJSON{}})
 		assert.NoError(t, err)
 
 		foundStates, err = s.GetSubscribersForGateway(nid1, gwid1)
 		assert.NoError(t, err)
-		assert.Empty(t, foundStates)
+		assert.Empty(t, foundStates.Subscribers)
 
 		// Gateway 2 should be unaffected
 
 		foundStates, err = s.GetSubscribersForGateway(nid1, gwid2)
 		assert.NoError(t, err)
-		assert.True(t, cmp.Equal(foundStates, subscriberStatesGw2))
+		assert.True(t, cmp.Equal(*foundStates, subscriberStatesGw2))
 
 		err = s.DeleteSubscribersForGateway(nid1, gwid1)
 		assert.NoError(t, err)
 		err = s.DeleteSubscribersForGateway(nid1, gwid2)
 		assert.NoError(t, err)
 	})
-}
-
-func subscriberState(imsi string) SubscriberState {
-	return SubscriberState{
-		Imsi: imsi,
-		Value: map[string]interface{}{
-			"magma.ipv4": []interface{}{
-				map[string]interface{}{
-					"active_policy_rules": []interface{}{},
-					"active_duration_sec": 6.,
-					"lifecycle_state":     "SESSION_RELEASED",
-					"session_start_time":  1653484144.,
-					"apn":                 "magma.ipv4",
-					"ipv4":                "192.168.128.12",
-					"msisdn":              "",
-					"session_id":          fmt.Sprintf("%s-1234", imsi),
-				},
-			},
-		},
-	}
 }

--- a/lte/cloud/go/services/subscriberdb/storage/test_utils.go
+++ b/lte/cloud/go/services/subscriberdb/storage/test_utils.go
@@ -1,0 +1,41 @@
+/*
+ Copyright 2022 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+
+	"magma/orc8r/cloud/go/services/state"
+)
+
+func CreateTestGatewaySubscriberState(imsis ...string) GatewaySubscriberState {
+	states := GatewaySubscriberState{Subscribers: map[string]state.ArbitraryJSON{}}
+	for i, imsi := range imsis {
+		states.Subscribers[imsi] = map[string]interface{}{
+			"magma.ipv4": []interface{}{
+				map[string]interface{}{
+					"active_policy_rules": []interface{}{},
+					"active_duration_sec": float64(i),
+					"lifecycle_state":     "SESSION_RELEASED",
+					"session_start_time":  1653484144.,
+					"apn":                 "magma.ipv4",
+					"ipv4":                "192.168.128.12",
+					"msisdn":              "",
+					"session_id":          fmt.Sprintf("%s-1234", imsi),
+				},
+			},
+		}
+	}
+	return states
+}

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -81,7 +81,7 @@ func main() {
 	// Attach handlers
 	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	protos.RegisterSubscriberLookupServer(srv.ProtectedGrpcServer, lookup_servicers.NewLookupServicer(fact, ipStore))
-	state_protos.RegisterIndexerServer(srv.ProtectedGrpcServer, lookup_servicers.NewIndexerServicer())
+	state_protos.RegisterIndexerServer(srv.ProtectedGrpcServer, lookup_servicers.NewIndexerServicer(subscriberStateStore))
 	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, subscriberdbcloud_servicer.NewSubscriberdbServicer(serviceConfig, subscriberStore))
 
 	swagger_protos.RegisterSwaggerSpecServer(srv.ProtectedGrpcServer, swagger_servicers.NewSpecServicerFromFile(subscriberdb.ServiceName))


### PR DESCRIPTION
## Summary

This PR adds capabilities to subscriberdb indexer to write state of type `gateway_subscriber_state` into the `gateway_subscriber_states` table created in #12949. The logic implemented there splits up the state into its entries and renews the entire state with every indexing run (old entries are deleted and new entries are written into `gateway_subscriber_states` table).

The second commit adds annotations such that the indexer is triggered for this type as well in docker and k8s deployments. 

This is the follow up PR to #12949 and implements step 3 of the plan outlined in [#8621 - comment](https://github.com/magma/magma/issues/8621#issuecomment-1144762649).


## Test Plan

- [x] Unit tests of subscriberdb: indexer and subscriber storage
- [x] manual test of orc8r deployed locally with docker compose

Manual testing is done with grpcurl and the following commands.

1) Send gateway state with three IMSIs.

```
grpcurl -vv \
    -insecure \
    -key /tmp/magma_protos/gateway.key \
    -cert /tmp/magma_protos/gateway.crt \
    -authority state-controller.magma.test \
    -protoset /tmp/magma_protos/out.protoset \
    -d '{"states": [{"type": "gateway_subscriber_state",
"deviceID": "d02a138b-04d3-4710-95aa-d810efc61fc1", "value":"eyJzdWJzY3JpYmVycyI6eyJJTVNJMDAyMDIwMDAwMDAwMTIzIjp7Im1hZ21hLmlwdjQiOlt7ImFjdGl2ZV9kdXJhdGlvbl9zZWMiOjAsImFjdGl2ZV9wb2xpY3lfcnVsZXMiOltdLCJhcG4iOiJtYWdtYS5pcHY0IiwiaXB2NCI6IjE5Mi4xNjguMTI4LjEyIiwibGlmZWN5Y2xlX3N0YXRlIjoiU0VTU0lPTl9SRUxFQVNFRCIsIm1zaXNkbiI6IiIsInNlc3Npb25faWQiOiJJTVNJMDAyMDIwMDAwMDAwMTIzLTEyMzQiLCJzZXNzaW9uX3N0YXJ0X3RpbWUiOjE2NTM0ODQxNDR9XX0sIklNU0kwMDIwMjAwMDAwMDA0NTYiOnsibWFnbWEuaXB2NCI6W3siYWN0aXZlX2R1cmF0aW9uX3NlYyI6MSwiYWN0aXZlX3BvbGljeV9ydWxlcyI6W10sImFwbiI6Im1hZ21hLmlwdjQiLCJpcHY0IjoiMTkyLjE2OC4xMjguMTIiLCJsaWZlY3ljbGVfc3RhdGUiOiJTRVNTSU9OX1JFTEVBU0VEIiwibXNpc2RuIjoiIiwic2Vzc2lvbl9pZCI6IklNU0kwMDIwMjAwMDAwMDA0NTYtMTIzNCIsInNlc3Npb25fc3RhcnRfdGltZSI6MTY1MzQ4NDE0NH1dfSwiSU1TSTAwMjAyMDAwMDAwMDc4OSI6eyJtYWdtYS5pcHY0IjpbeyJhY3RpdmVfZHVyYXRpb25fc2VjIjoyLCJhY3RpdmVfcG9saWN5X3J1bGVzIjpbXSwiYXBuIjoibWFnbWEuaXB2NCIsImlwdjQiOiIxOTIuMTY4LjEyOC4xMiIsImxpZmVjeWNsZV9zdGF0ZSI6IlNFU1NJT05fUkVMRUFTRUQiLCJtc2lzZG4iOiIiLCJzZXNzaW9uX2lkIjoiSU1TSTAwMjAyMDAwMDAwMDc4OS0xMjM0Iiwic2Vzc2lvbl9zdGFydF90aW1lIjoxNjUzNDg0MTQ0fV19fX0=", "version":"0"}]}' \
    localhost:7443 \
    magma.orc8r.StateService/ReportStates
```

The state is written to `states` table and the indexer writes its entries to the `gateway_subscriber_states` table. 

![Screenshot 2022-06-21 at 20 11 09](https://user-images.githubusercontent.com/82914459/174871189-d76aef4b-c784-45d3-bb03-13d8d9d10826.png)

2) After sending an empty state

```
grpcurl -vv \
    -insecure \
    -key /tmp/magma_protos/gateway.key \
    -cert /tmp/magma_protos/gateway.crt \
    -authority state-controller.magma.test \
    -protoset /tmp/magma_protos/out.protoset \
    -d '{"states": [{"type": "gateway_subscriber_state",
"deviceID": "d02a138b-04d3-4710-95aa-d810efc61fc1", "value":"eyJzdWJzY3JpYmVycyI6e319", "version":"0"}]}' \
    localhost:7443 \
    magma.orc8r.StateService/ReportStates
```
the `gateway_subscriber_states` table is indeed empty.

3) Sending mixed states like

```
'{"states": [{"type": "gateway_subscriber_state",
"deviceID": "d02a138b-04d3-4710-95aa-d810efc61fc1", "value":"eyJzdWJzY3JpYmVycyI6eyJJTVNJMDAyMDIwMDAwMDAwMTIzIjp7Im1hZ21hLmlwdjQiOlt7ImFjdGl2ZV9kdXJhdGlvbl9zZWMiOjAsImFjdGl2ZV9wb2xpY3lfcnVsZXMiOltdLCJhcG4iOiJtYWdtYS5pcHY0IiwiaXB2NCI6IjE5Mi4xNjguMTI4LjEyIiwibGlmZWN5Y2xlX3N0YXRlIjoiU0VTU0lPTl9SRUxFQVNFRCIsIm1zaXNkbiI6IiIsInNlc3Npb25faWQiOiJJTVNJMDAyMDIwMDAwMDAwMTIzLTEyMzQiLCJzZXNzaW9uX3N0YXJ0X3RpbWUiOjE2NTM0ODQxNDR9XX0sIklNU0kwMDIwMjAwMDAwMDA0NTYiOnsibWFnbWEuaXB2NCI6W3siYWN0aXZlX2R1cmF0aW9uX3NlYyI6MSwiYWN0aXZlX3BvbGljeV9ydWxlcyI6W10sImFwbiI6Im1hZ21hLmlwdjQiLCJpcHY0IjoiMTkyLjE2OC4xMjguMTIiLCJsaWZlY3ljbGVfc3RhdGUiOiJTRVNTSU9OX1JFTEVBU0VEIiwibXNpc2RuIjoiIiwic2Vzc2lvbl9pZCI6IklNU0kwMDIwMjAwMDAwMDA0NTYtMTIzNCIsInNlc3Npb25fc3RhcnRfdGltZSI6MTY1MzQ4NDE0NH1dfSwiSU1TSTAwMjAyMDAwMDAwMDc4OSI6eyJtYWdtYS5pcHY0IjpbeyJhY3RpdmVfZHVyYXRpb25fc2VjIjoyLCJhY3RpdmVfcG9saWN5X3J1bGVzIjpbXSwiYXBuIjoibWFnbWEuaXB2NCIsImlwdjQiOiIxOTIuMTY4LjEyOC4xMiIsImxpZmVjeWNsZV9zdGF0ZSI6IlNFU1NJT05fUkVMRUFTRUQiLCJtc2lzZG4iOiIiLCJzZXNzaW9uX2lkIjoiSU1TSTAwMjAyMDAwMDAwMDc4OS0xMjM0Iiwic2Vzc2lvbl9zdGFydF90aW1lIjoxNjUzNDg0MTQ0fV19fX0=", "version":"0"},
{"type": "mobilityd_ipdesc_record",
"deviceID": "IMSI001010000333333.magma.ipv4,ipv4",
"value":"eyJpcCI6IHsiYWRkcmVzcyI6ICJ3S2lBSVE9PSJ9LCAiaXBCbG9jayI6IHsibmV0QWRkcmVzcyI6ICJ3S2lBQUE9PSIsICJwcmVmaXhMZW4iOiAyNH0sICJzdGF0ZSI6ICJBTExPQ0FURUQiLCAic2lkIjogeyJpZCI6ICJJTVNJMDAxMDEwMDAwMzMzMzMzLm1hZ21hLmlwdjQsaXB2NCJ9LCAidHlwZSI6ICJJUF9QT09MIn0=", "version":"0"}
]}'
```

also works. The respective states get written into the `gateway_subscriber_states` table as above and `subscriberdb_ip_to_imsi`.





## Additional Information

- Done in pairing with @sebathomas.
- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
