### PR TITLE
chore: Remove unnecessary usage of deadsnakes ppa

### DIFF
--- a/cwf/gateway/docker/python/Dockerfile
+++ b/cwf/gateway/docker/python/Dockerfile
@@ -19,8 +19,6 @@ RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1
   chmod -R a+Xr /usr/include/google && \
   rm -rf protoc3.zip protoc3
 
-# Install python3.8 since it's not native on focal
-RUN apt-add-repository "ppa:deadsnakes/ppa"
 RUN apt-get -y update && apt-get -y install python3.8
 
 ENV MAGMA_ROOT /magma
@@ -54,9 +52,6 @@ RUN apt-key add /tmp/jfrog.pub && \
     apt-add-repository "deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main" && \
     apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ focal-proposed restricted main multiverse universe"
 
- # Install python3.8 since it's not native on focal
-RUN apt-add-repository "ppa:deadsnakes/ppa"
-RUN apt-get -y update && apt-get -y install python3.8
 RUN apt-get -y update && apt-get -y install \
     curl \
     libc-ares2 \
@@ -72,6 +67,7 @@ RUN apt-get -y update && apt-get -y install \
     pkg-config \
     python-cffi \
     python3-pip \
+    python3.8 \
     python3.8-dev \
     redis-server \
     iptables \

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -19,8 +19,6 @@ RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1
   chmod -R a+Xr /usr/include/google && \
   rm -rf protoc3.zip protoc3
 
-# Install python3.8 since it's not native on focal
-RUN apt-add-repository "ppa:deadsnakes/ppa"
 RUN apt-get -y update && apt-get -y install python3.8
 
 ENV MAGMA_ROOT /magma
@@ -75,10 +73,6 @@ RUN curl -L http://packages.fluentbit.io/fluentbit.key > /tmp/fluentbit.key
 RUN apt-key add /tmp/fluentbit.key && \
     apt-add-repository "deb https://packages.fluentbit.io/ubuntu/focal focal main"
 
-# Install python3.8 since it's not native on focal
-RUN apt-add-repository "ppa:deadsnakes/ppa"
-RUN apt-get -y update && apt-get -y install python3.8
-
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install \
   iproute2 \
@@ -96,6 +90,7 @@ RUN apt-get -y update && apt-get -y install \
   pkg-config \
   python-cffi \
   python3-pip \
+  python3.8 \
   python3.8-dev \
   redis-server \
   git \

--- a/orc8r/gateway/docker/Dockerfile
+++ b/orc8r/gateway/docker/Dockerfile
@@ -15,8 +15,6 @@ RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1
   chmod -R a+Xr /usr/include/google && \
   rm -rf protoc3.zip protoc3
 
-# Install python3.8 since it's not native on focal
-RUN apt-add-repository "ppa:deadsnakes/ppa"
 RUN apt-get -y update && apt-get -y install python3.8
 
 ENV MAGMA_ROOT /magma
@@ -45,10 +43,6 @@ COPY cwf/gateway/deploy/roles/ovs/files/magma-preferences /etc/apt/preferences.d
 RUN apt-key add /tmp/jfrog.pub && \
     apt-add-repository "deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main"
 
-# Install python3.8 since it's not native on focal
-RUN apt-add-repository "ppa:deadsnakes/ppa"
-RUN apt-get -y update && apt-get -y install python3.8
-
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install \
   curl \
@@ -67,6 +61,7 @@ RUN apt-get -y update && apt-get -y install \
   pkg-config \
   python-cffi \
   python3-pip \
+  python3.8 \
   python3.8-dev \
   redis-server \
   network-manager


### PR DESCRIPTION
## Summary

Python 3.8 is the default version in Ubuntu focal, it's not necessary to get it from a ppa.

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking