### PR TITLE
chore: Upgrade Go to version 1.18.3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,7 +77,7 @@ RUN echo "Install general purpose packages" && \
 
 # Install golang 1.18
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.18"
+ARG GOLANG_VERSION="1.18.3"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -98,7 +98,7 @@ jobs:
         if: always()
         id: gateway_test_init
         with:
-          go-version: '1.18'
+          go-version: '1.18.3'
       - name: Download dependencies
         if: always() && steps.gateway_test_init.outcome=='success'
         id: gateway_test_dep

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
-          go-version: '1.18'
+          go-version: '1.18.3'
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
-          go-version: '1.18'
+          go-version: '1.18.3'
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -145,8 +145,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version:
-          - 1.18.x
+        go-version: [1.18.3]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
       - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # pin@v3
         with:
-          go-version: '1.18'
+          go-version: '1.18.3'
       - run: go version
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh

--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -49,8 +49,8 @@ jobs:
     if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
-        go-version: [ 1.18.x ]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        go-version: [1.18.3]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
@@ -86,8 +86,8 @@ jobs:
     if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
-        go-version: [ 1.18.x ]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        go-version: [1.18.3]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
@@ -132,8 +132,8 @@ jobs:
     if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
-        go-version: [ 1.18.x ]
-        arch: [ 386, arm, arm64 ]
+        go-version: [1.18.3]
+        arch: [386, arm, arm64]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -183,7 +183,7 @@ jobs:
     if: ${{ needs.pre_job_src_go_determinator.outputs.should_not_skip == 'true' }}
     strategy:
       matrix:
-        go-version: [ 1.18.x ]
+        go-version: [1.18.3]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go

--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -39,8 +39,8 @@
     - role: ovs
     - role: golang
       vars:
-        golang_tar: go1.18.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f'
+        golang_tar: go1.18.3.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245'
     - role: cwag
 
   tasks:

--- a/cwf/gateway/deploy/cwag_dev_centos7.yml
+++ b/cwf/gateway/deploy/cwag_dev_centos7.yml
@@ -32,8 +32,8 @@
     - role: ovs
     - role: golang
       vars:
-        golang_tar: go1.18.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f'
+        golang_tar: go1.18.3.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245'
 #    - role: cwag
 
   tasks:

--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -30,8 +30,8 @@
         override_nameserver: 8.8.8.8
     - role: golang
       vars:
-        golang_tar: go1.18.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f'
+        golang_tar: go1.18.3.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245'
     - role: cwag_test
   tasks:
     - name: Set build environment variables

--- a/cwf/gateway/docker/go/Dockerfile
+++ b/cwf/gateway/docker/go/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y \
 
 # Golang 1.18
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.18"
+ARG GOLANG_VERSION="1.18.3"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/cwf/k8s/cwf_operator/docker/Dockerfile
+++ b/cwf/k8s/cwf_operator/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y bzr curl daemontools gcc
 
 # Install Golang 1.18
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.18"
+ARG GOLANG_VERSION="1.18.3"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y \
 
 # Golang 1.18
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.18"
+ARG GOLANG_VERSION="1.18.3"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -340,7 +340,7 @@
 - name: Download golang tar
   # TODO: make this preburn again
   get_url:
-    url: "https://storage.googleapis.com/golang/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
+    url: "https://artifactory.magmacore.org/artifactory/generic/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
     dest: "{{ all_vars.WORK_DIR }}"
     mode: 0440
   when: full_provision

--- a/lte/gateway/deploy/roles/magma/vars/all.yaml
+++ b/lte/gateway/deploy/roles/magma/vars/all.yaml
@@ -1,2 +1,2 @@
 WORK_DIR: "~/"
-GO_VERSION: "1.18"
+GO_VERSION: "1.18.3"

--- a/lte/gateway/docker/ghz/Dockerfile
+++ b/lte/gateway/docker/ghz/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install golang 1.18
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.18"
+ARG GOLANG_VERSION="1.18.3"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install golang 1.18
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.18"
+ARG GOLANG_VERSION="1.18.3"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform
     rm -rf /root/download/*
 
 # Install go if we are building testframework image
-ARG GOLANG_VERSION="1.18"
+ARG GOLANG_VERSION="1.18.3"
 RUN if [ "$ENV" = "testframework" ]; \
     then \
         GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \

--- a/orc8r/cloud/deploy/roles/golang/defaults/main.yml
+++ b/orc8r/cloud/deploy/roles/golang/defaults/main.yml
@@ -10,8 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-golang_tar: go1.18.linux-amd64.tar.gz
-golang_tar_checksum: 'sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f'
+golang_tar: go1.18.3.linux-amd64.tar.gz
+golang_tar_checksum: 'sha256:956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245'
 go_install_path: /usr/local
 gopath: '/home/{{ user }}/go'
 gobin: '/home/{{ user }}/go/bin'

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 
 # Golang 1.18
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.18"
+ARG GOLANG_VERSION="1.18.3"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/orc8r/tools/ansible/roles/golang/defaults/main.yml
+++ b/orc8r/tools/ansible/roles/golang/defaults/main.yml
@@ -10,8 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-golang_tar: go1.18.linux-amd64.tar.gz
-golang_tar_checksum: 'sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f'
+golang_tar: go1.18.3.linux-amd64.tar.gz
+golang_tar_checksum: 'sha256:956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245'
 go_install_path: /usr/local
 gopath: '/home/{{ user }}/go'
 gobin: '/home/{{ user }}/go/bin'


### PR DESCRIPTION
## Summary

Use the most recent version of Go in all containers and virtual machines except openwrt (that one is still stuck on Go 1.13).

This is sort of a test run to see how easy it is to upgrade Go and to document the process. The plan is to follow all future major version upgrades as they appear to avoid ending up in the situation again where we have an unmaintained version of Go that is very hard to upgrade.

## Test Plan

- [x] CI
- [x] Test connection between AGW and Orc8r locally
- [x] Federated inegration tests
- [x] CWF integration tests
- [x] CWF precommit test

## Additional Information

- [ ] This change is backwards-breaking
