### PR TITLE
chore(agw): 'nose' is replaced by 'pytest' for unittests

### DIFF
--- a/lte/gateway/pytest.ini
+++ b/lte/gateway/pytest.ini
@@ -1,0 +1,20 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[pytest]
+python_files = 
+    *_test.py 
+    *_tests.py
+    test_*.py
+python_classes = 
+    *Test
+    *Tests
+python_functions = test*

--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -15,15 +15,15 @@ buildenv: setupenv protos swagger $(BUILD_LIST) py_patches
 $(BUILD_LIST): %_build:
 	make -C $* install_egg
 
-test_all: buildenv $(BIN)/nosetests $(BIN)/coverage $(TEST_LIST)
+test_all: buildenv $(BIN)/pytest $(BIN)/pytest-cov $(TEST_LIST)
 $(TEST_LIST): %_test:
 	make -C $* .test
 
 define run_unit_tests
-    . $(PYTHON_BUILD)/bin/activate; cd $(2); $(PYTHON_BUILD)/bin/nosetests -s $(1) || exit 1
+    . $(PYTHON_BUILD)/bin/activate; cd $(2); $(PYTHON_BUILD)/bin/pytest -s $(1) || exit 1
 endef
 define run_sudo_unit_tests
-    . $(PYTHON_BUILD)/bin/activate; cd $(2); sudo $(PYTHON_BUILD)/bin/nosetests -s $(1) || exit 1
+    . $(PYTHON_BUILD)/bin/activate; cd $(2); sudo $(PYTHON_BUILD)/bin/pytest -s $(1) || exit 1
 endef
 
 # unit_tests (UT_PATH=unit_test_path|MAGMA_SERVICE=service_name)[DONT_BUILD_ENV=1]
@@ -42,7 +42,7 @@ else ifdef UT_PATH
 endif
 	@if [ ! -d "$(MAGMA_ROOT)/lte/gateway/python/$(TEST_PATH)" ]; then if [ ! -d "$(MAGMA_ROOT)/orc8r/gateway/python/$(TEST_PATH_ORC8R)" ]; then echo "no tests found" && exit 1; fi; fi
 ifndef DONT_BUILD_ENV
-	@$(MAKE) buildenv $(BIN)/nosetests
+	@$(MAKE) buildenv $(BIN)/pytest
 endif
 ifdef MAGMA_SERVICE
 	sudo service magma@$(MAGMA_SERVICE) stop
@@ -65,6 +65,12 @@ $(BIN)/nosetests: install_virtualenv
 
 $(BIN)/coverage: install_virtualenv
 	$(VIRT_ENV_PIP_INSTALL) "coverage>=6.1.2"
+
+$(BIN)/pytest: install_virtualenv
+	$(VIRT_ENV_PIP_INSTALL) pytest==7.1.2
+
+$(BIN)/pytest-cov: install_virtualenv
+	$(VIRT_ENV_PIP_INSTALL) pytest-cov==3.0.0
 
 $(BIN)/pylint: install_virtualenv
 	$(VIRT_ENV_PIP_INSTALL) pylint==2.14.0

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -142,6 +142,8 @@ setup(
             'coverage',
             'iperf3',
             'parameterized==0.8.1',
+            'pytest==7.1.2',
+            'pytest-cov==3.0.0',
         ],
     },
 )

--- a/orc8r/gateway/python/pytest.ini
+++ b/orc8r/gateway/python/pytest.ini
@@ -1,0 +1,20 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[pytest]
+python_files = 
+    *_test.py 
+    *_tests.py
+    test_*.py
+python_classes = 
+    *Test
+    *Tests
+python_functions = test*

--- a/orc8r/gateway/python/python.mk
+++ b/orc8r/gateway/python/python.mk
@@ -113,10 +113,10 @@ $(PROTO_LIST): %_protos:
 	@echo "Generating python code for $* .proto files"
 	@mkdir -p $(PYTHON_BUILD)/gen
 	@echo "$(PYTHON_BUILD)/gen" > $(SITE_PACKAGES_DIR)/magma_gen.pth
-	$(BIN)/python $(SRC)/protos/gen_protos.py $(SRC)/$*/protos/ $(MAGMA_ROOT),$(MAGMA_ROOT)/orc8r/protos/prometheus $(SRC) $(PYTHON_BUILD)/gen/
+	$(BIN)/python$(PYTHON_VERSION) $(SRC)/protos/gen_protos.py $(SRC)/$*/protos/ $(MAGMA_ROOT),$(MAGMA_ROOT)/orc8r/protos/prometheus $(SRC) $(PYTHON_BUILD)/gen/
 
 prometheus_proto:
-	$(BIN)/python $(SRC)/protos/gen_prometheus_proto.py $(MAGMA_ROOT) $(PYTHON_BUILD)/gen
+	$(BIN)/python$(PYTHON_VERSION) $(SRC)/protos/gen_prometheus_proto.py $(MAGMA_ROOT) $(PYTHON_BUILD)/gen
 
 # If you update the version here, you probably also want to update it in setup.py
 $(BIN)/grpcio-tools: install_virtualenv
@@ -130,21 +130,21 @@ CODECOV_DIR := /var/tmp/codecovs
 .tests:
 ifdef TESTS
 ifndef SKIP_NON_SUDO_TESTS
-	$(eval NAME ?= $(shell $(BIN)/python setup.py --name))
-	. $(PYTHON_BUILD)/bin/activate; $(BIN)/nosetests --with-xunit --xunit-file=$(RESULTS_DIR)/tests_$(NAME).xml --with-coverage --cover-erase --cover-branches --cover-package=magma --cover-xml --cover-xml-file=$(CODECOV_DIR)/cover_$(NAME).xml -s $(TESTS)
+	$(eval NAME ?= $(shell $(BIN)/python$(PYTHON_VERSION) setup.py --name))
+	. $(PYTHON_BUILD)/bin/activate; $(BIN)/pytest --junit-xml=$(RESULTS_DIR)/tests_$(NAME).xml --cov=magma --cov-branch --cov-report xml:$(CODECOV_DIR)/cover_$(NAME).xml $(TESTS)
 endif
 endif
 
 .sudo_tests:
 ifdef SUDO_TESTS
 ifndef SKIP_SUDO_TESTS
-	$(eval NAME ?= $(shell $(BIN)/python setup.py --name))
-	. $(PYTHON_BUILD)/bin/activate; sudo $(BIN)/nosetests --with-xunit --xunit-file=$(RESULTS_DIR)/sudo_$(NAME).xml --with-coverage --cover-branches --cover-package=magma --cover-xml --cover-xml-file=$(CODECOV_DIR)/cover_$(NAME).xml -s $(SUDO_TESTS)
+	$(eval NAME ?= $(shell $(BIN)/python$(PYTHON_VERSION) setup.py --name))
+	. $(PYTHON_BUILD)/bin/activate; sudo $(BIN)/pytest --junit-xml=$(RESULTS_DIR)/sudo_$(NAME).xml --cov=magma --cov-branch --cov-report xml:$(CODECOV_DIR)/cover_sudo_$(NAME).xml $(SUDO_TESTS)
 endif
 endif
 
 install_egg: install_virtualenv setup.py
-	$(eval NAME ?= $(shell $(BIN)/python setup.py --name))
+	$(eval NAME ?= $(shell $(BIN)/python$(PYTHON_VERSION) setup.py --name))
 	@echo "Installing egg link for $(NAME)"
 	$(VIRT_ENV_PIP_INSTALL) --no-build-isolation -e .[dev]
 


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

The `nose` package for testing is not maintained anymore and is replaced by `pytest`. In this PR, only the python unit tests for the AGW (https://docs.magmacore.org/docs/lte/dev_unit_testing) are migrated. The migration of the S1AP integration tests is tackled in a follow-up PR, #13060.

## Test Plan

```vagrant@magma-dev-focal:~/magma/lte/gateway$ make test_python```
```vagrant@magma-dev-focal:~/magma/lte/gateway$ make test_python_service MAGMA_SERVICE=<service_name>```
(the `UT_PATH` does need a bug fix, #13054)

Outputs:
```
------------------------ generated xml file: /var/tmp/test_results/tests_lte.xml ------------------------

----------- coverage: platform linux, python 3.8.5-final-0 -----------
Coverage XML written to file /var/tmp/codecovs/cover_lte.xml

======================== 434 passed, 4 skipped, 118 warnings in 99.23s (0:01:39) ========================
...
------------------------ generated xml file: /var/tmp/test_results/sudo_lte.xml -------------------------

----------- coverage: platform linux, python 3.8.5-final-0 -----------
Coverage XML written to file /var/tmp/codecovs/cover_sudo_lte.xml

======================== 154 passed, 3 skipped, 14 warnings in 527.74s (0:08:47) ========================
...
----------------------- generated xml file: /var/tmp/test_results/tests_orc8r.xml -----------------------

----------- coverage: platform linux, python 3.8.5-final-0 -----------
Coverage XML written to file /var/tmp/codecovs/cover_orc8r.xml

================================== 142 passed, 123 warnings in 54.91s ===================================
```
vs the existing:
```
Ran 438 tests in 87.672s
...
Ran 152 tests in 544.081s
...
Ran 142 tests in 49.833s
```
The `nose` output does not count the skipped tests separately.



## Additional Information

There are quite a lot of deprecation warnings popping up using `pytest`. These are out of scope here, but should be addressed in the future.

- [ ] This change is backwards-breaking