### PR TITLE
fix(ci): Resolve the dpkg lock issue

### DIFF
--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -14,6 +14,27 @@
   become: yes
   ignore_errors: yes
 
+- name: Wait for APT Lock
+  shell: |
+    while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
+      sleep 1
+    done
+    while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 ; do
+      sleep 1
+    done
+    if [ -f /var/log/unattended-upgrades/unattended-upgrades.log ]; then
+      while sudo fuser /var/log/unattended-upgrades/unattended-upgrades.log >/dev/null 2>&1 ; do
+        sleep 1
+      done
+    fi
+
+- name: Remove unattended upgrades
+  apt:
+    state: absent
+    purge: yes
+    pkg:
+      - unattended-upgrades
+
 - name: Ensure ca-certificates is up to date
   become: yes
   apt:
@@ -22,8 +43,6 @@
     update_cache: yes
   register: result
   until: result is not failed
-  retries: 7
-  delay: 9
   vars:
     packages:
       - ca-certificates


### PR DESCRIPTION
## Summary

Upgrading the ca-certificates package sometimes fails because another process is holding the dpkg lock.

The workaround implemented in #13015 helped sometimes, but not always. So just copy a fix that we
use elsewhere: Wait for the lock and remove unattended upgrades before using apt.

## Test Plan

Build the magma dev VM in a custom workflow: https://github.com/jheidbrink/magma/runs/7020386324?check_suite_focus=true#step:10:130

## Additional Information

- [ ] This change is backwards-breaking