### PR TITLE
chore(agw): 'nose' is replaced by 'pytest' for S1AP integration tests

### DIFF
--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -25,18 +25,18 @@ $(PYTHON_BUILD)/setupinteg_env:
 # TODO T21489739 - Don't sleep and don't stop after a failure
 RESULTS_DIR := /var/tmp/test_results
 ifdef enable-flaky-retry
-	FLAKY_CMD_ARGS := --with-flaky --force-flaky --no-flaky-report --max-runs=3 --min-passes=1
+	FLAKY_CMD_ARGS := --force-flaky --no-flaky-report --max-runs=3 --min-passes=1
 else
 	FLAKY_CMD_ARGS :=
 endif
 define execute_test
 	echo "Running test: $(1)"
-	timeout --foreground -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(PYTHON_BUILD)/bin/nosetests $(FLAKY_CMD_ARGS) --with-xunit --xunit-file=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x -s $(1) || (echo "fail" > $(MAGMA_ROOT)/test_status.txt && exit 1)
+	timeout --foreground -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(BIN)/pytest $(FLAKY_CMD_ARGS) --capture=tee-sys --junit-xml=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x $(1) || (echo "fail" > $(MAGMA_ROOT)/test_status.txt && exit 1)
 	sleep 1
 endef
 
 .PHONY: precommit
-precommit: $(PYTHON_BUILD)/setupinteg_env $(BIN)/nosetests
+precommit: $(PYTHON_BUILD)/setupinteg_env $(BIN)/pytest
 	. $(PYTHON_BUILD)/bin/activate
 ifdef TESTS
 	$(call execute_test,$(TESTS))
@@ -45,7 +45,7 @@ else
 endif
 
 .PHONY: integ_test
-integ_test: $(PYTHON_BUILD)/setupinteg_env $(BIN)/nosetests
+integ_test: $(PYTHON_BUILD)/setupinteg_env $(BIN)/pytest
 	. $(PYTHON_BUILD)/bin/activate
 ifdef TESTS
 	$(call execute_test,$(TESTS))
@@ -55,7 +55,7 @@ else
 endif
 
 .PHONY: nonsanity
-nonsanity: $(PYTHON_BUILD)/setupinteg_env $(BIN)/nosetests
+nonsanity: $(PYTHON_BUILD)/setupinteg_env $(BIN)/pytest
 	. $(PYTHON_BUILD)/bin/activate
 ifdef TESTS
 	$(call execute_test,$(TESTS))
@@ -66,4 +66,4 @@ endif
 local_integ_test:
 	# check if magma services are running
 	systemctl is-active --quiet magma@magmad || (echo "Local integ tests should be run on access gw with magma services running"; exit 1)
-	. $(PYTHON_BUILD)/bin/activate; sudo $(BIN)/nosetests -s $(LOCAL_INTEG_TESTS)
+	. $(PYTHON_BUILD)/bin/activate; sudo $(BIN)/pytest -s $(LOCAL_INTEG_TESTS)

--- a/lte/gateway/python/integ_tests/pytest.ini
+++ b/lte/gateway/python/integ_tests/pytest.ini
@@ -1,0 +1,22 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[pytest]
+python_files = 
+    *_test.py 
+    *_tests.py
+    test_*.py
+python_classes = 
+    *Test
+    *Tests
+    Test*
+python_functions = test*
+junit_logging = system-out

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete.py
@@ -15,7 +15,7 @@ import unittest
 
 import s1ap_types
 import s1ap_wrapper
-from python.integ_tests.common.service303_utils import (
+from integ_tests.common.service303_utils import (
     MetricValue,
     verify_gateway_metrics,
 )

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response.py
@@ -15,7 +15,7 @@ import unittest
 
 import s1ap_types
 import s1ap_wrapper
-from python.integ_tests.common.service303_utils import (
+from integ_tests.common.service303_utils import (
     MetricValue,
     verify_gateway_metrics,
 )

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_security_mode_complete.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_security_mode_complete.py
@@ -15,7 +15,7 @@ import unittest
 
 import s1ap_types
 import s1ap_wrapper
-from python.integ_tests.common.service303_utils import (
+from integ_tests.common.service303_utils import (
     MetricValue,
     verify_gateway_metrics,
 )


### PR DESCRIPTION
## Summary

Follow-up PR to #13052. The two PRs are independent to not break master by merge order. The duplicate code will be adapted before the second merge.
After that, there will be a cleanup PR for the remaining occurrences of `nose`/`nosetests` and the handling of `coverage`.
Additionally ...
... `pytest` did complain about some python imports --> adapted according to the other tests.
... `flaky` in `pytest` is enabled by default (https://github.com/box/flaky#activating-the-plugin) --> argument is removed

## Test Plan
With all three VMs for AGW testing:
```vagrant@magma-test:~/magma/lte/gateway/python/integ_test$ make integ_test``` 

LTE integ_test CI runs on my fork: 
https://github.com/mpfirrmann/magma/actions/runs/2548683727
https://github.com/mpfirrmann/magma/actions/runs/2550991806
A different unit test fails at both runs, but probably not due to the code change here.

## Additional Information

The test results are stored in `.xml` files. On this basis, CI html reports are created. The style of the result `.xml` changes slightly with the change from `XUnit XML` to `JUnit XML`.
For `s1aptests/test_attach_detatch.xml`:
current `XUnit XML`
```
<testsuite name="nosetests" tests="1" errors="0" failures="0" skip="0">
<testcase classname="test_attach_detach.TestAttachDetach" name="test_attach_detach" time="5.273">
<system-out>
<![CDATA[ Test Case Execution Count: 1 Start time 06:56:28 ************************* Enb tester config AGW is stateless APN Correction configured Health service is disabled Using subscriber IMSI IMSI001010000000001 Using IMEI 3805468432113171 Using subscriber IMSI IMSI001010000000002 Using IMEI 3805468432113172 ************************* UE device config for ue_id 1 ************************* UE device config for ue_id 2 ************************* Configuring IP block ************************* Waiting for IP changes to propagate ************************* S1 setup ************************* UE App config ************************* Running End to End attach for UE id 1 ************************* Running UE detach for UE id 1 ************************* Running End to End attach for UE id 2 ************************* Running UE detach for UE id 2 ************************* send SCTP SHUTDOWN Keys left in Redis (list should be empty)[ ] Entries in s1ap_imsi_map (should be zero): 0 Entries left in hashtables (should be zero): 0 Entries in mme_ueip_imsi_map (should be zero): 0 ]]>
</system-out>
</testcase>
</testsuite>
```
new `JUnit XML`
```
<testsuites>
<testsuite name="pytest" errors="0" failures="0" skipped="0" tests="1" time="5.188" timestamp="2022-07-06T07:36:02.476018" hostname="magma-test">
<testcase classname="s1aptests.test_attach_detach.TestAttachDetach" name="test_attach_detach" time="4.998">
<system-out>--------------------------------- Captured Out --------------------------------- Test Case Execution Count: 1 Start time 07:36:02 ************************* Enb tester config AGW is stateless APN Correction configured Health service is disabled Using subscriber IMSI IMSI001010000000001 Using IMEI 3805468432113171 Using subscriber IMSI IMSI001010000000002 Using IMEI 3805468432113172 ************************* UE device config for ue_id 1 ************************* UE device config for ue_id 2 ************************* Configuring IP block ************************* Waiting for IP changes to propagate ************************* S1 setup ************************* UE App config ************************* Running End to End attach for UE id 1 ************************* Running UE detach for UE id 1 ************************* Running End to End attach for UE id 2 ************************* Running UE detach for UE id 2 ************************* send SCTP SHUTDOWN Keys left in Redis (list should be empty)[ ] Entries in s1ap_imsi_map (should be zero): 0 Entries left in hashtables (should be zero): 0 Entries in mme_ueip_imsi_map (should be zero): 0 </system-out>
</testcase>
</testsuite>
</testsuites>
```

- [ ] This change is backwards-breaking

