### PR TITLE
fix(amf): Fixed the syncing of ambr values in initial context setup request

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -1226,11 +1226,6 @@ int initial_context_setup_request(amf_ue_ngap_id_t ue_id,
   req->Security_Key = (unsigned char*)&amf_ctx->_security.kgnb;
   memcpy(&req->Ngap_guami, &amf_ctx->m5_guti.guamfi, sizeof(guamfi_t));
 
-  // Get the ambr values
-  amf_smf_context_ue_aggregate_max_bit_rate_get(
-      amf_ctx, &(req->ue_aggregate_max_bit_rate.dl),
-      &(req->ue_aggregate_max_bit_rate.ul));
-
   for (const auto& it : ue_context->amf_context.smf_ctxt_map) {
     pdusession_setup_item_t* item = nullptr;
     pdu_resource_transfer_ie = &req->PDU_Session_Resource_Setup_Transfer_List;


### PR DESCRIPTION
Signed-off-by: sreedharkumartn <sreedhar.kumar@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Issue :
Getting the extra Item UE Aggregrate Maximum Bit Rate in Initial context setup request due to which Initial context setup response is not coming from gnb.
Pcap Snap:
![image](https://user-images.githubusercontent.com/89978170/175304889-468eeab9-39a5-4c30-a295-a187cbd28704.png)

Fix :
Fixed the Syncing of ambr values in Initial context setup request message.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Tested on Spirent Setup.
Pcap Snap:
![image](https://user-images.githubusercontent.com/89978170/175305429-e925f0bc-94b5-400b-9484-2333100de193.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
