### PR TITLE
fix(agw): Fix glog path to be compatible with arm builds

### DIFF
--- a/bazel/external/system_libraries.BUILD
+++ b/bazel/external/system_libraries.BUILD
@@ -97,7 +97,10 @@ cc_library(
 
 cc_library(
     name = "libglog",
-    srcs = ["usr/lib/x86_64-linux-gnu/libglog.so.0"],
+    srcs = glob(
+        ["usr/lib/*-linux-gnu/libglog.so.0"],
+        allow_empty = False,
+    ),
 )
 
 cc_library(


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Linking glog dynamically (#13006) broke the arm builds, because the path provided was x86 specific. See #13055.
This PR fixes this by providing an architecture independent path.

## Test Plan

On an arm machine:
`cd magma/lte/gateway/docker`
`docker-compose --file docker-compose.yaml --file docker-compose.override.yaml build --build-arg CPU_ARCH=aarch64 --build-arg DEB_PORT=arm64 gateway_c`
Should succeed.

On an x86 machine:
`cd magma`
`bazel build lte/gateway/c/core:oai_mme`
Should succeed.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
