### PR TITLE
chore(ci): Make the GCC Warnings & Errors workflow run on master merges only

### DIFF
--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -13,14 +13,6 @@ on:
     branches:
       - master
       - 'v1.*'
-  pull_request:
-    branches:
-      - master
-      - 'v1.*'
-    types:
-      - opened
-      - reopened
-      - synchronize
 env:
   BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   CACHE_KEY: bazel-base-image
@@ -32,6 +24,7 @@ concurrency:
 # See [Example Sharing Container Between Jobs](https://github.com/docker/build-push-action/issues/225)
 jobs:
   path_filter:
+    if: github.repository_owner == 'magma'
     runs-on: ubuntu-latest
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

The GCC Warnings & Errors workflow is made to only run on merges to magma/master (and magma/v1.*).

## Test Plan

Tested on demo workflow, see runs:
- [Path filter is blocking run](https://github.com/LKreutzer/GH-actions-testing/actions/runs/2549436124)
- [Path filter is allowing run](https://github.com/LKreutzer/GH-actions-testing/actions/runs/2549429823)

## Additional Information

- [ ] This change is backwards-breaking
