### PR TITLE
fix(subscriberdb): Handle nil check correctly

### DIFF
--- a/lte/cloud/go/services/subscriberdb/load.go
+++ b/lte/cloud/go/services/subscriberdb/load.go
@@ -238,12 +238,12 @@ func LoadSuciProtos(ctx context.Context, networkID string) ([]*lte_protos.SuciPr
 	}
 
 	ngcModel := &lte_models.NetworkNgcConfigs{}
-	ngcConfig := ngcModel.GetFromNetwork(network)
+	ngcConfig := ngcModel.GetFromNetwork(network).(*lte_models.NetworkNgcConfigs)
 	if ngcConfig == nil {
 		return nil, fmt.Errorf("ngcConfig is nil: %w", err)
 	}
 
-	suciProfiles := ngcConfig.(*lte_models.NetworkNgcConfigs).SuciProfiles
+	suciProfiles := ngcConfig.SuciProfiles
 	suciProtos := []*lte_protos.SuciProfile{}
 	for _, suciProfile := range suciProfiles {
 		suciProtos = append(suciProtos, ngcModel.ConvertSuciEntsToProtos(suciProfile))


### PR DESCRIPTION
## Summary

The type conversion needs to happen before the nil check, it does not trigger otherwise.

This is related to #13036 but does not fix the issue. It will return an error instead of panicking.

## Test Plan

Periodic SUCI profile load before the change:
```
orc8r-controller-1  | 2022-06-23T13:15:33.694818379Z subscriberdb stderr | E0623 13:15:33.694184      79 interceptors.go:74] [ERROR /magma.lte.SubscriberDBCloud/ListSuciProfiles]: rpc error: code = Unknown desc = handler panic: runtime error: invalid memory address or nil pointer dereference; stack trace: goroutine 55 [running]:
orc8r-controller-1  | 2022-06-23T13:15:33.694821726Z subscriberdb stderr | runtime/debug.Stack()
orc8r-controller-1  | 2022-06-23T13:15:33.694824371Z subscriberdb stderr |      /usr/local/go/src/runtime/debug/stack.go:24 +0x65
orc8r-controller-1  | 2022-06-23T13:15:33.694833408Z subscriberdb stderr | magma/orc8r/cloud/go/service/middleware/unary.recoveryInterceptor.func1()
orc8r-controller-1  | 2022-06-23T13:15:33.694836153Z subscriberdb stderr |      /src/magma/orc8r/cloud/go/service/middleware/unary/interceptors.go:61 +0x6b
orc8r-controller-1  | 2022-06-23T13:15:33.694839168Z subscriberdb stderr | panic({0xe33500, 0x1904460})
orc8r-controller-1  | 2022-06-23T13:15:33.694841613Z subscriberdb stderr |      /usr/local/go/src/runtime/panic.go:838 +0x207
orc8r-controller-1  | 2022-06-23T13:15:33.694844188Z subscriberdb stderr | magma/lte/cloud/go/services/subscriberdb.LoadSuciProtos({0x10e0c98, 0xc000541e00}, {0xc00043b298, 0x4})
orc8r-controller-1  | 2022-06-23T13:15:33.694846773Z subscriberdb stderr |      /src/magma/lte/cloud/go/services/subscriberdb/load.go:250 +0x35f
orc8r-controller-1  | 2022-06-23T13:15:33.694851101Z subscriberdb stderr | magma/lte/cloud/go/services/subscriberdb/servicers/southbound.(*subscriberdbServicer).ListSuciProfiles(0x0?, {0x10e0c98, 0xc000541e00}, 0xc2b7c0?)
orc8r-controller-1  | 2022-06-23T13:15:33.694856751Z subscriberdb stderr |      /src/magma/lte/cloud/go/services/subscriberdb/servicers/southbound/subscriberdb_servicer.go:221 +0x8d
orc8r-controller-1  | 2022-06-23T13:15:33.694859637Z subscriberdb stderr | magma/lte/cloud/go/protos._SubscriberDBCloud_ListSuciProfiles_Handler.func1({0x10e0c98, 0xc000541e00}, {0xe8eba0?, 0xc000564570})
orc8r-controller-1  | 2022-06-23T13:15:33.694862312Z subscriberdb stderr |      /src/magma/lte/cloud/go/protos/subscriberdb.pb.go:2912 +0x78
orc8r-controller-1  | 2022-06-23T13:15:33.694865789Z subscriberdb stderr | magma/orc8r/cloud/go/service/middleware/unary.makeInterceptorFromTemplate.func1({0x10e0c98, 0xc000541e00}, {0xe8eba0, 0xc000564570}, 0xef8a80?, 0xc000526108)
orc8r-controller-1  | 2022-06-23T13:15:33.694868423Z subscriberdb stderr |      /src/magma/orc8r/cloud/go/service/middleware/unary/interceptors.go:90 +0x8b
orc8r-controller-1  | 2022-06-23T13:15:33.694873764Z subscriberdb stderr | google.golang.org/grpc.chainUnaryInterceptors.func1.1({0x10e0c98?, 0xc000541e00?}, {0xe8eba0?, 0xc000564570?})
orc8r-controller-1  | 2022-06-23T13:15:33.694878172Z subscriberdb stderr |      /go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1116 +0x5b
orc8r-controller-1  | 2022-06-23T13:15:33.694880677Z subscriberdb stderr | magma/orc8r/cloud/go/service/middleware/unary.makeInterceptorFromTemplate.func1({0x10e0c98, 0xc000564540}, {0xe8eba0, 0xc000564570}, 0x3?, 0xc00059c0c0)
orc8r-controller-1  | 2022-06-23T13:15:33.694883291Z subscriberdb stderr |      /src/magma/orc8r/cloud/go/service/middleware/unary/interceptors.go:90 +0x8b
orc8r-controller-1  | 2022-06-23T13:15:33.694885716Z subscriberdb stderr | google.golang.org/grpc.chainUnaryInterceptors.func1.1({0x10e0c98?, 0xc000564540?}, {0xe8eba0?, 0xc000564570?})
orc8r-controller-1  | 2022-06-23T13:15:33.694888201Z subscriberdb stderr |      /go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1119 +0x83
orc8r-controller-1  | 2022-06-23T13:15:33.694890685Z subscriberdb stderr | github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1({0x10e0c98, 0xc000564540}, {0xe8eba0, 0xc000564570}, 0x83274f?, 0xc00059c0c0)
orc8r-controller-1  | 2022-06-23T13:15:33.694893260Z subscriberdb stderr |      /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0x87
orc8r-controller-1  | 2022-06-23T13:15:33.694895815Z subscriberdb stderr | google.golang.org/grpc.chainUnaryInterceptors.func1.1({0x10e0c98?, 0xc000564540?}, {0xe8eba0?, 0xc000564570?})
orc8r-controller-1  | 2022-06-23T13:15:33.694898450Z subscriberdb stderr |      /go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1119 +0x83
orc8r-controller-1  | 2022-06-23T13:15:33.694904191Z subscriberdb stderr | magma/orc8r/cloud/go/service/middleware/unary.recoveryInterceptor({0x10e0c98?, 0xc000564540?}, {0xe8eba0?, 0xc000564570?}, 0xc00059c0c0?, 0x8?)
orc8r-controller-1  | 2022-06-23T13:15:33.694906856Z subscriberdb stderr |      /src/magma/orc8r/cloud/go/service/middleware/unary/interceptors.go:65 +0xa2
orc8r-controller-1  | 2022-06-23T13:15:33.694909381Z subscriberdb stderr | google.golang.org/grpc.chainUnaryInterceptors.func1.1({0x10e0c98?, 0xc000564540?}, {0xe8eba0?, 0xc000564570?})
orc8r-controller-1  | 2022-06-23T13:15:33.694915763Z subscriberdb stderr |      /go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1119 +0x83
orc8r-controller-1  | 2022-06-23T13:15:40.616933071Z subscriberdb stderr | magma/orc8r/cloud/go/service/middleware/unary.errlogInterceptor({0x10e0c98?, 0xc000564540?}, {0xe8eba0?, 0xc000564570?}, 0xc00007e0e0, 0x7f7ff52b4501?)
orc8r-controller-1  | 2022-06-23T13:15:40.616965021Z subscriberdb stderr |      /src/magma/orc8r/cloud/go/service/middleware/unary/interceptors.go:72 +0x49
orc8r-controller-1  | 2022-06-23T13:15:40.616973567Z subscriberdb stderr | google.golang.org/grpc.chainUnaryInterceptors.func1.1({0x10e0c98?, 0xc000564540?}, {0xe8eba0?, 0xc000564570?})
orc8r-controller-1  | 2022-06-23T13:15:40.616980160Z subscriberdb stderr |      /go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1119 +0x83
orc8r-controller-1  | 2022-06-23T13:15:40.616986492Z subscriberdb stderr | google.golang.org/grpc.chainUnaryInterceptors.func1({0x10e0c98, 0xc000564540}, {0xe8eba0, 0xc000564570}, 0xc00007e0e0, 0xc000526108)
orc8r-controller-1  | 2022-06-23T13:15:40.616993234Z subscriberdb stderr |      /go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1121 +0x12b
orc8r-controller-1  | 2022-06-23T13:15:40.617000618Z subscriberdb stderr | magma/lte/cloud/go/protos._SubscriberDBCloud_ListSuciProfiles_Handler({0xefb480?, 0xc0002e8660}, {0x10e0c98, 0xc000564540}, 0xc0000aa840, 0xc00053f040)
orc8r-controller-1  | 2022-06-23T13:15:40.617007601Z subscriberdb stderr |      /src/magma/lte/cloud/go/protos/subscriberdb.pb.go:2914 +0x138
orc8r-controller-1  | 2022-06-23T13:15:40.617015496Z subscriberdb stderr | google.golang.org/grpc.(*Server).processUnaryRPC(0xc00053ca80, {0x10e3800, 0xc0002fcb60}, 0xc0001a2120, 0xc0002e86f0, 0x1910fc8, 0x0)
orc8r-controller-1  | 2022-06-23T13:15:40.617022169Z subscriberdb stderr |      /go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1282 +0xccf
orc8r-controller-1  | 2022-06-23T13:15:40.617028270Z subscriberdb stderr | google.golang.org/grpc.(*Server).handleStream(0xc00053ca80, {0x10e3800, 0xc0002fcb60}, 0xc0001a2120, 0x0)
orc8r-controller-1  | 2022-06-23T13:15:40.617034552Z subscriberdb stderr |      /go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1616 +0xa1b
orc8r-controller-1  | 2022-06-23T13:15:40.617040574Z subscriberdb stderr | google.golang.org/grpc.(*Server).serveStreams.func1.2()
orc8r-controller-1  | 2022-06-23T13:15:40.617046455Z subscriberdb stderr |      /go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:921 +0x98
orc8r-controller-1  | 2022-06-23T13:15:40.617052286Z subscriberdb stderr | created by google.golang.org/grpc.(*Server).serveStreams.func1
orc8r-controller-1  | 2022-06-23T13:15:40.617069197Z subscriberdb stderr |      /go/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:919 +0x28a
```

After the change:
```
orc8r-controller-1  | 2022-06-23T13:38:37.695056933Z subscriberdb stderr | E0623 13:38:29.767564      72 interceptors.go:74] [ERROR /magma.lte.SubscriberDBCloud/ListSuciProfiles]: loading suciProfiles in network failed test: ngcConfig is nil: %!w(<nil>)
```

## Additional Information

- [ ] This change is backwards-breaking