### PR TITLE
chore(agw): `nose` package is dropped

### DIFF
--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -60,9 +60,6 @@ endif
 coverage: $(BIN)/coverage
 	$(BIN)/coverage report
 
-$(BIN)/nosetests: install_virtualenv
-	$(VIRT_ENV_PIP_INSTALL) -I nose==1.3.7
-
 $(BIN)/coverage: install_virtualenv
 	$(VIRT_ENV_PIP_INSTALL) "coverage>=6.1.2"
 

--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -61,7 +61,7 @@ coverage: $(BIN)/coverage
 	$(BIN)/coverage report
 
 $(BIN)/coverage: install_virtualenv
-	$(VIRT_ENV_PIP_INSTALL) "coverage>=6.1.2"
+	$(VIRT_ENV_PIP_INSTALL) coverage==6.4.1
 
 $(BIN)/pytest: install_virtualenv
 	$(VIRT_ENV_PIP_INSTALL) pytest==7.1.2

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -138,7 +138,7 @@ setup(
             # If you update this version here, you probably also want to
             # update it in lte/gateway/python/Makefile
             'grpcio-tools>=1.16.1',
-            'coverage',
+            'coverage==6.4.1',
             'iperf3',
             'parameterized==0.8.1',
             'pytest==7.1.2',

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -138,7 +138,6 @@ setup(
             # If you update this version here, you probably also want to
             # update it in lte/gateway/python/Makefile
             'grpcio-tools>=1.16.1',
-            'nose==1.3.7',
             'coverage',
             'iperf3',
             'parameterized==0.8.1',


### PR DESCRIPTION
## Summary

After merging #13052 and #13060, `nose` is dropped. Touching the files, the `coverage` version is bumped.

## Test Plan

Testing the `coverage` version with ```vagrant@magma-dev-focal:~/magma/lte/gateway/python$ make coverage```:
Before and after version bump:
```
---------------------------------------------------------------------------------------------------------
TOTAL                                                                   23271  21860   5293     19     6%
```


## Additional Information
The github actions won't be green until the two PRs mentioned above are merged. Rebase is necessary.

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
