### PR TITLE
fix(lte): Use last resort default subscriber profile in EPS UpdateLoation

### DIFF
--- a/lte/cloud/go/services/eps_authentication/servicers/ul.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ul.go
@@ -30,12 +30,20 @@ import (
 )
 
 const (
-	serviceSelection                  = "oai.ipv4"
+	serviceSelection                  = "magma.ipv4"
 	qosProfileClassID                 = 9
 	qosProfilePriorityLevel           = 15
 	qosProfilePreemptionCapability    = true
 	qosProfilePreemptionVulnerability = false
+
+	defaultMaxUlBitRate uint64 = 2000000000
+	defaultMaxDlBitRate uint64 = 4000000000
 )
+
+var defaultSubscriberProfile = models.NetworkEpcConfigsSubProfilesAnon{
+	MaxDlBitRate: defaultMaxUlBitRate,
+	MaxUlBitRate: defaultMaxDlBitRate,
+}
 
 func (srv *EPSAuthServer) UpdateLocation(
 	ctx context.Context, ulr *protos.UpdateLocationRequest) (*protos.UpdateLocationAnswer, error) {
@@ -104,7 +112,6 @@ func (srv *EPSAuthServer) UpdateLocation(
 
 // getSubProfile looks up the subscription profile to be used for a subscriber.
 func getSubProfile(profileName string, config *EpsAuthConfig) *models.NetworkEpcConfigsSubProfilesAnon {
-
 	profile, ok := config.SubProfiles[profileName]
 	if ok {
 		return &profile
@@ -113,11 +120,12 @@ func getSubProfile(profileName string, config *EpsAuthConfig) *models.NetworkEpc
 
 	profile, ok = config.SubProfiles["default"]
 	if ok {
-		glog.V(2).Infof("Subscriber profile '%s' not found, using default profile instead", profileName)
+		glog.V(2).Infof("Subscriber profile '%s' not found, using 'default' network profile instead", profileName)
 		return &profile
 	}
-
-	return nil
+	glog.V(2).Info("Network subscriber profile 'default' is not configured, using defaults")
+	profile = defaultSubscriberProfile
+	return &profile
 }
 
 // validateULR returns an error iff the ULR is invalid.

--- a/lte/cloud/go/services/eps_authentication/servicers/ul_test.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ul_test.go
@@ -85,7 +85,7 @@ func (suite *EpsAuthTestSuite) checkULA(ula *protos.UpdateLocationAnswer, maxUlB
 	apn := ula.Apn[0]
 	suite.Equal(maxDlBitRate, apn.GetAmbr().GetMaxBandwidthDl())
 	suite.Equal(maxUlBitRate, apn.GetAmbr().GetMaxBandwidthUl())
-	suite.Equal("oai.ipv4", apn.GetServiceSelection())
+	suite.Equal("magma.ipv4", apn.GetServiceSelection())
 	suite.Equal(protos.UpdateLocationAnswer_APNConfiguration_IPV4, apn.GetPdn())
 
 	qos := apn.GetQosProfile()


### PR DESCRIPTION
…

Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Use last resort, system wide default subscriber profile in EPS UpdateLoation similar to the logic of local subscriberdb

## Test Plan

unit tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
