### PR TITLE
chore: Consolidate the bazel build and test options

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,9 +12,9 @@ build --cxxopt=-std=c++14
 build --experimental_strict_action_env
 build --compilation_mode=dbg
 
-# Default test configuration
+# DEFAULT TEST CONFIGURATION
+# Please read the GH issue #13073 before adding "test" options.
 test --test_output=errors
-test --flaky_test_attempts=5
 
 # Use dynamically linked folly library
 build --define=folly_so=1
@@ -55,7 +55,8 @@ build --test_env=MAGMA_ROOT
 
 # MME specific compile time defines
 # Compile mme libraries with unit test flag
-test --per_file_copt=^lte/gateway/c/core/.*$@-DMME_UNIT_TEST
+test --per_file_copt=^lte/gateway/c/core/.*$@-DMME_UNIT_TEST  # See GH issue #13073
+build:mme_unit_test --per_file_copt=^lte/gateway/c/core/.*$@-DMME_UNIT_TEST  # See GH issue #13073
 # TODO: deprecate these flags used for logging if possible
 build --per_file_copt=^lte/gateway/c/core/.*$@-DPACKAGE_BUGREPORT=\"TBD\"
 build --per_file_copt=^lte/gateway/c/core/.*$@-DPACKAGE_VERSION=\"0.1\"

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -90,6 +90,7 @@ jobs:
             cd /workspaces/magma
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             bazel build //... \
+              --config=mme_unit_test \
               --profile=Bazel_build_all_profile
       - name: Publish bazel profile
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- See detailed explanation of the motivation in the issue https://github.com/magma/magma/issues/13073
- The `bazel test` options are consolidated with the `bazel build` options in order to address the same cache entries.
  - This is only required for the `test` options that are marked as `affects_outputs` in [the bazel command line docs](https://bazel.build/reference/command-line-reference#test-options)
- The `--config=mme_unit_test` option is only used in CI if this config should be used during a build step. The default is that `MME_UNIT_TEST` is only set for `bazel test`.
- The `--flaky_test_attempts=5` flag is removed as it is not needed.


## Test Plan
- Check that the same artifacts are generated by `build` and `test`, if `--config=mme_unit_test` is set.
- Check that the commands that inherit from build are compatible with the consolidated options. See:
![Screenshot from 2022-06-24 09-37-23](https://user-images.githubusercontent.com/34488763/175490246-14899afd-6af8-4a1a-9b9b-bfa18ef804da.png)

- CI


## Additional Information

- [ ] This change is backwards-breaking
