### PR TITLE
chore(ci): Change the remote cache download behaviour to minimize traffic

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,13 +33,19 @@ common:disk_cache --repository_cache=/var/cache/bazel-cache-repo
 # REMOTE CACHING READ AND WRITE CONFIGS
 # The file bazel/bazelrcs/remote_caching_rw.bazelrc is templated in CI
 # The full config is then written to bazel/bazelrcs/cache.bazelrc
-build:remote_caching_rw --remote_download_toplevel
+build:remote_caching_rw --remote_download_minimal
+# --remote_download_toplevel instead of --remote_download_minimal is
+# needed for 'bazel run' due to https://github.com/bazelbuild/bazel/issues/11920
+run:remote_caching_rw --remote_download_toplevel
 
 # REMOTE CACHING READ-ONLY CONFIGS
 # The file bazel/bazelrcs/remote_caching_ro.bazelrc is templated in CI
 # The full config is then written to bazel/bazelrcs/cache.bazelrc
-build:remote_caching_ro --remote_download_toplevel
 build:remote_caching_ro --remote_upload_local_results=false 
+build:remote_caching_ro --remote_download_minimal
+# --remote_download_toplevel instead of --remote_download_minimal is
+# needed for 'bazel run' due to https://github.com/bazelbuild/bazel/issues/11920
+run:remote_caching_ro --remote_download_toplevel
 
 # Import the bazel caching config, with default disk cache,
 # which in CI gets overwritten by the remote caching config. 

--- a/bazel/scripts/test_python_service_imports.sh
+++ b/bazel/scripts/test_python_service_imports.sh
@@ -80,7 +80,10 @@ collect_services
 for SERVICE in "${SERVICES[@]}"
 do
     echo "Building service: ${SERVICE}"
-    bazel build "${SERVICE}"
+    bazel build --remote_download_toplevel "${SERVICE}"
+# 'bazel build' needs the --remote_download_toplevel option here in order to have
+# the same options as the 'bazel run' below. For 'bazel run' the option is set
+# in the bazelrc, due to https://github.com/bazelbuild/bazel/issues/11920
     echo "Testing service: ${SERVICE}"
     if timeout --preserve-status 5 bazel run "${SERVICE}" 2>&1  | tee "${LOGGING_FILE}";
     then


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- The remote cache download behaviour is modified to minimize download volume from the bazel remote cache.
- Expected change in build times is moderate, see analysis https://github.com/magma/magma/issues/12458#issuecomment-1105096885
- It seems that there are some issues with `--remote_download_minimal` and `bazel run`, which is relevant for the starlark check and the ModuleNotFound check which runs all python services:
  - https://github.com/bazelbuild/bazel/issues/11920
  - https://github.com/bazelbuild/bazel/issues/12665
  - https://github.com/bazelbuild/buildtools/issues/899
  -  https://github.com/bazelbuild/bazel/issues/9386
- To mitigate this, both checks keep using `--remote_download_toplevel`, which is configured via the `.bazelrc`
## Test Plan

- CI

## Additional Information

- [ ] This change is backwards-breaking