### PR TITLE
fix(agw): clash of installed pip packages and to be installed apt packages is resolved

### DIFF
--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -1026,6 +1026,12 @@ def main(args):
     repo_pkgs = [gen_sys_package_name(p.key, args.use_py2) for p in repo_installable]
     if args.install_from_repo:
         try:
+            # If apt packages are installed over existing pip packages
+            # then side effects can occur - see GH13075.
+            # Approach: remove existing pip packages before apt install
+            pip_packages = [req.key for req in repo_installable]
+            subprocess.call(shlex.split('sudo pip3 uninstall -y '
+                                        + ' '.join(pip_packages)))
             subprocess.call(shlex.split('sudo apt install -y '
                                         + ' '.join(repo_pkgs)))
         except Exception:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

See #13075. Approach here: remove all pip packages that will be installed as apt packages so that installations will not clash.

## Test Plan

* spin up a fresh magma vm (snapshotting is recommended)
* `lte/gateway$ ./release/pydep finddep --install-from-repo -b --build-output ~/magma-deps -l ./release/magma.lockfile.ubuntu python/setup.py $MAGMA_ROOT/orc8r/gateway/python/setup.py`
* `~/magma/orc8r/gateway/python$ make protos`
  * runs through without errors
* instead of `make protos` the magma.deb can be created and checked via `dpkg -c magma.deb | grep protos`
  * `./release/build-magma.sh -h 123 --commit-count 23 -t RelWithDebInfo --cert $MAGMA_ROOT/.cache/test_certs/rootCA.pem --proxy $MAGMA_ROOT/lte/gateway/configs/control_proxy.yml --os ubuntu`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
