### PR TITLE
chore(ci): Add check that all Go versions are consistent

### DIFF
--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -19,6 +19,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_go_version:
+    runs-on: ubuntu-latest
+    env:
+      MAGMA_ROOT: "${{ github.workspace }}"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run golang_check_version.sh script
+        run: ./.github/workflows/scripts/golang_check_version.sh
+
   pre_job_src_go_determinator:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/scripts/golang_check_version.sh
+++ b/.github/workflows/scripts/golang_check_version.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+expected_version="1.18.3"
+all_versions_good=true
+
+while IFS= read -r -d '' file
+do
+  while read -r line;
+  do
+    version=$(echo "$line" | awk -F '[]["'"'"']' '{print $2}')
+    if [[ -n $version && $version != "$expected_version" ]]
+    then
+      echo "Found unexpected Go version $version in file $(realpath --relative-to="$MAGMA_ROOT" "$file"):"
+      echo "$line"
+      all_versions_good=false
+    fi
+  done < <(grep -i 'go[-_]version:' "$file" )
+
+  while read -r line;
+  do
+    version=$(echo "$line" | awk '{ print $NF }')
+    if [[ -n $version && $version != "go$expected_version.linux-amd64.tar.gz" ]]
+    then
+      echo "Found unexpected Go version $version in file $(realpath --relative-to="$MAGMA_ROOT" "$file"):"
+      echo "$line"
+      all_versions_good=false
+    fi
+  done < <(grep -i 'golang_tar:' "$file" )
+done < <(find "$MAGMA_ROOT" -regex '.*\.ya?ml' -print0)
+
+while IFS= read -r -d '' file
+do
+  while read -r line;
+  do
+    version=$(echo "$line" | awk -F '"' '{print $2}')
+    if [[ -n $version && $version != "$expected_version" ]]
+    then
+      echo "Found unexpected Go version $version in file $(realpath --relative-to="$MAGMA_ROOT" "$file"):"
+      echo "$line"
+      all_versions_good=false
+    fi
+  done < <(grep -i '^ARG GOLANG_VERSION' "$file" )
+done < <(find "$MAGMA_ROOT" -name Dockerfile -print0)
+
+while IFS= read -r -d '' file
+do
+  while read -r version;
+  do
+    if [[ -n $version && $version != "go$expected_version" ]]
+    then
+      echo "Found unexpected Go version $version in file $(realpath --relative-to="$MAGMA_ROOT" "$file"):"
+      all_versions_good=false
+    fi
+  done < <(grep -o -P 'go[\d\.]+\d' "$file" )
+done < <(find "$MAGMA_ROOT/docs/readmes/basics/" -regex '.*\.md' -print0)
+
+if [ $all_versions_good = true ]
+then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

Adds a workflow step to grep yml files and Dockerfiles for Go
versions that are installed, and to make sure they are all set
to the expected version

## Test Plan

- [x] Run the script locally
- [x] Run the new step in the CI
  - Failed run: https://github.com/magma/magma/runs/7043019811?check_suite_focus=true
  - Successful run: https://github.com/magma/magma/runs/7235650661?check_suite_focus=true

## Additional Information

- [ ] This change is backwards-breaking
