### PR TITLE
feat(subscriberdb): Handle NW NGC config nil check correctly

### DIFF
--- a/lte/cloud/go/services/subscriberdb/load.go
+++ b/lte/cloud/go/services/subscriberdb/load.go
@@ -237,16 +237,19 @@ func LoadSuciProtos(ctx context.Context, networkID string) ([]*lte_protos.SuciPr
 		return nil, fmt.Errorf("network loading failed: %w", err)
 	}
 
+	suciProtos := []*lte_protos.SuciProfile{}
+
 	ngcModel := &lte_models.NetworkNgcConfigs{}
-	ngcConfig := ngcModel.GetFromNetwork(network).(*lte_models.NetworkNgcConfigs)
+	ngcConfig := ngcModel.GetFromNetwork(network)
 	if ngcConfig == nil {
-		return nil, fmt.Errorf("ngcConfig is nil: %w", err)
+		return suciProtos, fmt.Errorf("ngcConfig is nil: %w", err)
 	}
 
-	suciProfiles := ngcConfig.SuciProfiles
-	suciProtos := []*lte_protos.SuciProfile{}
-	for _, suciProfile := range suciProfiles {
-		suciProtos = append(suciProtos, ngcModel.ConvertSuciEntsToProtos(suciProfile))
+	if ngcConfig.(*lte_models.NetworkNgcConfigs) != nil {
+		suciProfiles := ngcConfig.(*lte_models.NetworkNgcConfigs).SuciProfiles
+		for _, suciProfile := range suciProfiles {
+			suciProtos = append(suciProtos, ngcModel.ConvertSuciEntsToProtos(suciProfile))
+		}
 	}
 
 	return suciProtos, nil

--- a/lte/gateway/python/magma/subscriberdb/client.py
+++ b/lte/gateway/python/magma/subscriberdb/client.py
@@ -109,26 +109,17 @@ class SubscriberDBCloudClient(SDWatchdogTask):
 
     async def _run(self) -> None:
 
-        suciprofiles_info = await self._list_suciprofiles()
-        if suciprofiles_info is None:
-            return
-
         in_sync = await self._check_subscribers_in_sync()
-        if in_sync:
-            return
-
-        resync = await self._sync_subscribers()
-        if not resync:
-            return
-
-        subscribers_info = await self._get_all_subscribers()
-        if subscribers_info is None:
-            return
-
-        # failure between the calls
-        self._process_subscribers(subscribers_info.subscribers)
-        self._update_root_digest(subscribers_info.root_digest)
-        self._update_leaf_digests(subscribers_info.leaf_digests)
+        if not in_sync:
+            resync = await self._sync_subscribers()
+            if resync:
+                subscribers_info = await self._get_all_subscribers()
+                if subscribers_info:
+                    # failure between the calls
+                    self._process_subscribers(subscribers_info.subscribers)
+                    self._update_root_digest(subscribers_info.root_digest)
+                    self._update_leaf_digests(subscribers_info.leaf_digests)
+        await self._list_suciprofiles()
 
     async def _check_subscribers_in_sync(self) -> bool:
         """


### PR DESCRIPTION
Signed-off-by: Moinuddin Khan <moinuddin.khan@wavelabs.ai>

feat(subscriberdb): Handle NW NGC config nil check correctly

## Summary
Done the following as part of the PR:
- Dereference the NetworkNgcConfigs only if it is not nil and populate the SUCI profiles relevant entries.

## Test Plan
Tested in local VM using docker based Orc8r and AGW. 

## Additional Information
#13036 
