### PR TITLE
fix(orc8r): add k8s annotations to trigger subscriberdb for gateway_subscriber_state

### DIFF
--- a/lte/cloud/helm/lte-orc8r/examples/minikube.values.yaml
+++ b/lte/cloud/helm/lte-orc8r/examples/minikube.values.yaml
@@ -111,7 +111,7 @@ subscriberdb:
       orc8r.io/state_indexer: "true"
       orc8r.io/swagger_spec: "true"
     annotations:
-      orc8r.io/state_indexer_types: "mobilityd_ipdesc_record"
+      orc8r.io/state_indexer_types: "mobilityd_ipdesc_record,gateway_subscriber_state"
       orc8r.io/state_indexer_version: "1"
       orc8r.io/obsidian_handlers_path_prefixes: >
         /magma/v1/lte/:network_id/msisdns,

--- a/lte/cloud/helm/lte-orc8r/values.yaml
+++ b/lte/cloud/helm/lte-orc8r/values.yaml
@@ -125,7 +125,7 @@ subscriberdb:
       orc8r.io/state_indexer: "true"
       orc8r.io/swagger_spec: "true"
     annotations:
-      orc8r.io/state_indexer_types: "mobilityd_ipdesc_record"
+      orc8r.io/state_indexer_types: "mobilityd_ipdesc_record,gateway_subscriber_state"
       orc8r.io/state_indexer_version: "1"
       orc8r.io/obsidian_handlers_path_prefixes: >
         /magma/v1/lte/:network_id/msisdns,


### PR DESCRIPTION
## Summary

This PR adds the necessary annotations to trigger subscriberdb indexer for `gateway_subscriber_state` in k8s deployments. This is a follow-up task from #13041.

## Test Plan

- [x] manual test with orc8r deployed locally on minikube (orc8r and lte-orc8r module)

Manual testing is done with grpcurl and the following commands.

1) Send gateway state with three IMSIs.

```
grpcurl -vv \
    -insecure \
    -key /tmp/magma_protos/gateway.key \
    -cert /tmp/magma_protos/gateway.crt \
    -authority state-controller.magma.test \
    -protoset /tmp/magma_protos/out.protoset \
    -d '{"states": [{"type": "gateway_subscriber_state",
"deviceID": "d02a138b-04d3-4710-95aa-d810efc61fc1", "value":"eyJzdWJzY3JpYmVycyI6eyJJTVNJMDAyMDIwMDAwMDAwMTIzIjp7Im1hZ21hLmlwdjQiOlt7ImFjdGl2ZV9kdXJhdGlvbl9zZWMiOjAsImFjdGl2ZV9wb2xpY3lfcnVsZXMiOltdLCJhcG4iOiJtYWdtYS5pcHY0IiwiaXB2NCI6IjE5Mi4xNjguMTI4LjEyIiwibGlmZWN5Y2xlX3N0YXRlIjoiU0VTU0lPTl9SRUxFQVNFRCIsIm1zaXNkbiI6IiIsInNlc3Npb25faWQiOiJJTVNJMDAyMDIwMDAwMDAwMTIzLTEyMzQiLCJzZXNzaW9uX3N0YXJ0X3RpbWUiOjE2NTM0ODQxNDR9XX0sIklNU0kwMDIwMjAwMDAwMDA0NTYiOnsibWFnbWEuaXB2NCI6W3siYWN0aXZlX2R1cmF0aW9uX3NlYyI6MSwiYWN0aXZlX3BvbGljeV9ydWxlcyI6W10sImFwbiI6Im1hZ21hLmlwdjQiLCJpcHY0IjoiMTkyLjE2OC4xMjguMTIiLCJsaWZlY3ljbGVfc3RhdGUiOiJTRVNTSU9OX1JFTEVBU0VEIiwibXNpc2RuIjoiIiwic2Vzc2lvbl9pZCI6IklNU0kwMDIwMjAwMDAwMDA0NTYtMTIzNCIsInNlc3Npb25fc3RhcnRfdGltZSI6MTY1MzQ4NDE0NH1dfSwiSU1TSTAwMjAyMDAwMDAwMDc4OSI6eyJtYWdtYS5pcHY0IjpbeyJhY3RpdmVfZHVyYXRpb25fc2VjIjoyLCJhY3RpdmVfcG9saWN5X3J1bGVzIjpbXSwiYXBuIjoibWFnbWEuaXB2NCIsImlwdjQiOiIxOTIuMTY4LjEyOC4xMiIsImxpZmVjeWNsZV9zdGF0ZSI6IlNFU1NJT05fUkVMRUFTRUQiLCJtc2lzZG4iOiIiLCJzZXNzaW9uX2lkIjoiSU1TSTAwMjAyMDAwMDAwMDc4OS0xMjM0Iiwic2Vzc2lvbl9zdGFydF90aW1lIjoxNjUzNDg0MTQ0fV19fX0=", "version":"0"}]}' \
    localhost:7443 \
    magma.orc8r.StateService/ReportStates
```

The state is written to `states` table and the indexer writes its entries to the `gateway_subscriber_states` table. 

![Screenshot 2022-06-23 at 20 02 25](https://user-images.githubusercontent.com/82914459/175904463-cbb10af6-9b86-4cc8-b93b-b1bc27d891d1.png)


2) After sending an empty state

```
grpcurl -vv \
    -insecure \
    -key /tmp/magma_protos/gateway.key \
    -cert /tmp/magma_protos/gateway.crt \
    -authority state-controller.magma.test \
    -protoset /tmp/magma_protos/out.protoset \
    -d '{"states": [{"type": "gateway_subscriber_state",
"deviceID": "d02a138b-04d3-4710-95aa-d810efc61fc1", "value":"eyJzdWJzY3JpYmVycyI6e319", "version":"0"}]}' \
    localhost:7443 \
    magma.orc8r.StateService/ReportStates
```
the `gateway_subscriber_states` table is indeed empty.

3) Sending mixed states like

```
'{"states": [{"type": "gateway_subscriber_state",
"deviceID": "d02a138b-04d3-4710-95aa-d810efc61fc1", "value":"eyJzdWJzY3JpYmVycyI6eyJJTVNJMDAyMDIwMDAwMDAwMTIzIjp7Im1hZ21hLmlwdjQiOlt7ImFjdGl2ZV9kdXJhdGlvbl9zZWMiOjAsImFjdGl2ZV9wb2xpY3lfcnVsZXMiOltdLCJhcG4iOiJtYWdtYS5pcHY0IiwiaXB2NCI6IjE5Mi4xNjguMTI4LjEyIiwibGlmZWN5Y2xlX3N0YXRlIjoiU0VTU0lPTl9SRUxFQVNFRCIsIm1zaXNkbiI6IiIsInNlc3Npb25faWQiOiJJTVNJMDAyMDIwMDAwMDAwMTIzLTEyMzQiLCJzZXNzaW9uX3N0YXJ0X3RpbWUiOjE2NTM0ODQxNDR9XX0sIklNU0kwMDIwMjAwMDAwMDA0NTYiOnsibWFnbWEuaXB2NCI6W3siYWN0aXZlX2R1cmF0aW9uX3NlYyI6MSwiYWN0aXZlX3BvbGljeV9ydWxlcyI6W10sImFwbiI6Im1hZ21hLmlwdjQiLCJpcHY0IjoiMTkyLjE2OC4xMjguMTIiLCJsaWZlY3ljbGVfc3RhdGUiOiJTRVNTSU9OX1JFTEVBU0VEIiwibXNpc2RuIjoiIiwic2Vzc2lvbl9pZCI6IklNU0kwMDIwMjAwMDAwMDA0NTYtMTIzNCIsInNlc3Npb25fc3RhcnRfdGltZSI6MTY1MzQ4NDE0NH1dfSwiSU1TSTAwMjAyMDAwMDAwMDc4OSI6eyJtYWdtYS5pcHY0IjpbeyJhY3RpdmVfZHVyYXRpb25fc2VjIjoyLCJhY3RpdmVfcG9saWN5X3J1bGVzIjpbXSwiYXBuIjoibWFnbWEuaXB2NCIsImlwdjQiOiIxOTIuMTY4LjEyOC4xMiIsImxpZmVjeWNsZV9zdGF0ZSI6IlNFU1NJT05fUkVMRUFTRUQiLCJtc2lzZG4iOiIiLCJzZXNzaW9uX2lkIjoiSU1TSTAwMjAyMDAwMDAwMDc4OS0xMjM0Iiwic2Vzc2lvbl9zdGFydF90aW1lIjoxNjUzNDg0MTQ0fV19fX0=", "version":"0"},
{"type": "mobilityd_ipdesc_record",
"deviceID": "IMSI001010000333333.magma.ipv4,ipv4",
"value":"eyJpcCI6IHsiYWRkcmVzcyI6ICJ3S2lBSVE9PSJ9LCAiaXBCbG9jayI6IHsibmV0QWRkcmVzcyI6ICJ3S2lBQUE9PSIsICJwcmVmaXhMZW4iOiAyNH0sICJzdGF0ZSI6ICJBTExPQ0FURUQiLCAic2lkIjogeyJpZCI6ICJJTVNJMDAxMDEwMDAwMzMzMzMzLm1hZ21hLmlwdjQsaXB2NCJ9LCAidHlwZSI6ICJJUF9QT09MIn0=", "version":"0"}
]}'
```

also works. The respective states get written into the `gateway_subscriber_states` table as above and `subscriberdb_ip_to_imsi`.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
