### PR TITLE
fix(enodebd): Fix Domain Proxy installation params for Sercomm

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
+++ b/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
@@ -83,6 +83,7 @@ DP_MODE_KEY = 'dp_mode'
 RADIO_MIN_POWER = 0
 RADIO_MAX_POWER = 24
 ANTENNA_GAIN_DBI = 5
+ANTENNA_HEIGHT = 0
 
 
 class SASParameters(object):
@@ -829,6 +830,8 @@ class FreedomFiOneTrDataModel(DataModel):
         # We don't set these parameters
         ParameterName.BAND_CAPABILITY: transform_for_magma.band_capability,
         ParameterName.DUPLEX_MODE_CAPABILITY: transform_for_magma.duplex_mode,
+        ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
+        ParameterName.GPS_LONG: transform_for_magma.gps_tr181,
     }
 
     @classmethod
@@ -1429,12 +1432,16 @@ class FreedomFiOneNotifyDPState(NotifyDPState):
         ff_one_update_desired_config_from_cbsd_state(
             state, self.acs.desired_cfg,
         )
+        # NOTE: Some params are not available in eNB Data Model, but still required by Domain Proxy
+        # antenna_gain: suggested by Sercomm to hardcode it
+        # antenna_height: need to provide any value, SAS should not care about the value for CBSD cat A indoor.
+        #                 Hardcode it.
         enodebd_update_cbsd_request = build_enodebd_update_cbsd_request(
             serial_number=self.acs.device_cfg.get_parameter(ParameterName.SERIAL_NUMBER),
             latitude_deg=self.acs.device_cfg.get_parameter(ParameterName.GPS_LAT),
             longitude_deg=self.acs.device_cfg.get_parameter(ParameterName.GPS_LONG),
             indoor_deployment=self.acs.device_cfg.get_parameter(SASParameters.SAS_LOCATION),
-            antenna_height=None,
+            antenna_height=str(ANTENNA_HEIGHT),
             antenna_height_type=self.acs.device_cfg.get_parameter(SASParameters.SAS_HEIGHT_TYPE),
             antenna_gain=str(ANTENNA_GAIN_DBI),
             cbsd_category=self.acs.device_cfg.get_parameter(SASParameters.SAS_CATEGORY),

--- a/lte/gateway/python/magma/enodebd/dp_client.py
+++ b/lte/gateway/python/magma/enodebd/dp_client.py
@@ -84,12 +84,13 @@ def build_enodebd_update_cbsd_request(
 
     indoor_deployment_bool = _indoortobool(indoor_deployment)
     antenna_gain_float = float(antenna_gain)
+    antenna_height_float = float(antenna_height)
 
     installation_param = InstallationParam(
         latitude_deg=DoubleValue(value=latitude_deg_float),
         longitude_deg=DoubleValue(value=longitude_deg_float),
         indoor_deployment=BoolValue(value=indoor_deployment_bool),
-        height_m=DoubleValue(value=float(antenna_height)) if antenna_height else None,
+        height_m=DoubleValue(value=antenna_height_float),
         height_type=StringValue(value=antenna_height_type),
         antenna_gain=DoubleValue(value=antenna_gain_float),
     )


### PR DESCRIPTION
* Transform GPS values from TR181 to float degrees
* Send hardocded antenna height value
* Made antenna height a required parameter for sending params to Domain
Proxy

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

Domain Proxy installation params from CBSD that are part of the `EnodebdUpdateCbsd` gRPC API are all required params.
Sercomm Englewood data model does not have an `antenna_height` param available, so we need to send something to Domain Proxy. Hardcoded the height value to `0` - SAS does not care for the value of this param for CBSD Cat A indoor eNBs.

Domain Proxy installation params `latitude` and `longitude` are supposed to be floats representing degrees. Added tr181 transforms for those params in freedomfi_one device.

As a result, Domain Proxy did not proceed with Single Step Registration since `height` param was missing (and is a required param for Single Step Registration).
Also, SAS rejected registration when `latitude` and `longitude` where integers in TR181 format.

## Test Plan

Tested modification using Sercomm Englewood indoor Cat A with latest Domain Proxy code (from Magma master) with Single Step enabled. Successfully executed Single Step Registration with applied fixes.

## Additional Information

- [ ] This change is backwards-breaking
