### PR TITLE
chore(agw): several warnings in the python unittests are …

### DIFF
--- a/lte/gateway/python/magma/enodebd/tests/enodeb_status_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/enodeb_status_tests.py
@@ -82,12 +82,12 @@ class EnodebStatusTests(TestCase):
         )
         manager.handle_tr069_message(ctx1, inform_msg)
         status = get_single_enb_status('120200002618AGP0001', manager)
-        self.assertEquals(
+        self.assertEqual(
             status.connected,
             SingleEnodebStatus.StatusProperty.Value('ON'),
             'Status should be connected.',
         )
-        self.assertEquals(
+        self.assertEqual(
             status.configured,
             SingleEnodebStatus.StatusProperty.Value('OFF'),
             'Status should be not configured.',
@@ -111,7 +111,7 @@ class EnodebStatusTests(TestCase):
         manager.handle_tr069_message(ctx1, inform_msg)
         enb_status_by_serial = get_all_enb_status(manager)
         enb_status = enb_status_by_serial.get('120200002618AGP0001')
-        self.assertEquals(
+        self.assertEqual(
             enb_status.enodeb_connected,
             SingleEnodebStatus.StatusProperty.Value('ON'),
             'Status should be connected.',

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 from concurrent.futures import Future
 from datetime import datetime
 from difflib import unified_diff
-from typing import List, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple
 from unittest import TestCase, mock
 from unittest.mock import MagicMock
 
@@ -42,6 +42,8 @@ from magma.pipelined.tests.app.exceptions import (
 )
 from magma.pipelined.tests.app.flow_query import RyuDirectFlowQuery
 from magma.pipelined.tests.app.start_pipelined import StartThread
+from magma.pipelined.tests.app.subscriber import RyuDirectSubscriberContext
+from magma.pipelined.tests.app.table_isolation import RyuDirectTableIsolator
 from ryu.lib import hub
 
 """
@@ -49,7 +51,6 @@ Pipelined test util functions can be used for testing pipelined, the usage of
 these functions can be seen in pipelined/tests/test_*.py files
 """
 
-SubTest = namedtuple('SubTest', ['context', 'isolator', 'flowtest_list'])
 PktsToSend = namedtuple('PktsToSend', ['pkt', 'num'])
 QueryMatch = namedtuple('QueryMatch', ['pkts', 'flow_count'])
 
@@ -59,10 +60,18 @@ SNAPSHOT_EXTENSION = '.snapshot'
 
 # Tuple for FlowVerifier, class wrapper needed becuse of optional flow_count
 class FlowTest(namedtuple('FlowTest', ['query', 'match_num', 'flow_count'])):
+    __test__ = False
     __slots__ = ()
 
     def __new__(cls, query, match_num, flow_count=None):
         return super(FlowTest, cls).__new__(cls, query, match_num, flow_count)
+
+
+class SubTest(NamedTuple):
+    __test__ = False
+    context: RyuDirectSubscriberContext
+    isolator: RyuDirectTableIsolator
+    flowtest_list: FlowTest
 
 
 class WaitTimeExceeded(Exception):

--- a/orc8r/gateway/python/magma/common/job.py
+++ b/orc8r/gateway/python/magma/common/job.py
@@ -47,7 +47,7 @@ class Job(abc.ABC):
         self._timeout = cast(Optional[float], None)
         # Condition variable used to control how long the job waits until
         # executing its task again.
-        self._cond = self._cond = asyncio.Condition(loop=self._loop)
+        self._cond = asyncio.Condition(loop=self._loop)
 
     @abc.abstractmethod
     async def _run(self):

--- a/orc8r/gateway/python/magma/common/service.py
+++ b/orc8r/gateway/python/magma/common/service.py
@@ -277,7 +277,7 @@ class MagmaService(Service303Servicer):
         self._state = ServiceInfo.STOPPING
         self._server.stop(0)
 
-        for pending_task in asyncio.Task.all_tasks(self._loop):
+        for pending_task in asyncio.all_tasks(self._loop):
             pending_task.cancel()
 
         self._state = ServiceInfo.STOPPED


### PR DESCRIPTION
…fixed

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

After migrating the python unittests from `nose` to `pytest` (#13052), several deprecation warning are displayed. This PR fixes the first warnings, focusing on

- deprecated `assertEquals`
- deprecated `asyncio.Task`
- classes named `*Test` do not contain tests 

## Test Plan

```vagrant@magma-dev-focal:~/magma/lte/gateway$ make test_python```

before: 
```
======================== 434 passed, 4 skipped, 118 warnings in 99.23s (0:01:39) ========================
======================== 154 passed, 3 skipped, 14 warnings in 527.74s (0:08:47) ========================
======================== 142 passed, 123 warnings in 54.91s ======================================== 
```
after:
```
======================= 434 passed, 4 skipped, 115 warnings in 111.66s (0:01:51) =======================
======================== 154 passed, 3 skipped, 5 warnings in 536.91s (0:08:56) =========================
======================== 142 passed, 122 warnings in 52.82s =========================================
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
