### PR TITLE
chore(agw): deprecation warnings in the python integration tests are …

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_ded_bearer_deact.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_ded_bearer_deact.py
@@ -228,7 +228,7 @@ class TestEpsBearerContextStatusDedBearerDeact(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEquals(
+        self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
         )
         tau_acc = response.cast(s1ap_types.ueTauAccept_t)

--- a/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_def_bearer_deact.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_def_bearer_deact.py
@@ -197,7 +197,7 @@ class TestEpsBearerContextStatusDefBearerDeact(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEquals(
+        self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
         )
         tau_acc = response.cast(s1ap_types.ueTauAccept_t)

--- a/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_multiple_ded_bearer_deact.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_multiple_ded_bearer_deact.py
@@ -253,7 +253,7 @@ class TestEpsBearerCxtStsMulDedBearerDeact(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEquals(
+        self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
         )
         tau_acc = response.cast(s1ap_types.ueTauAccept_t)

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_mixed_partial_lists.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_mixed_partial_lists.py
@@ -102,7 +102,7 @@ class TestTauMixedPartialLists(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEquals(
+            self.assertEqual(
                 response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
             )
             tau_acc = response.cast(s1ap_types.ueTauAccept_t)

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_active.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_active.py
@@ -93,7 +93,7 @@ class TestTauPeriodicActive(unittest.TestCase):
             response = self._s1ap_wrapper.s1_util.get_response()
             if s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value == response.msg_type:
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEquals(
+                self.assertEqual(
                     response.msg_type,
                     s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
                 )
@@ -115,7 +115,7 @@ class TestTauPeriodicActive(unittest.TestCase):
                 )
 
             else:
-                self.assertEquals(
+                self.assertEqual(
                     response.msg_type,
                     s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value,
                 )

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating.py
@@ -102,7 +102,7 @@ class TestTauTaUpdating(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEquals(
+        self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
         )
         tau_acc = response.cast(s1ap_types.ueTauAccept_t)
@@ -129,7 +129,7 @@ class TestTauTaUpdating(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEquals(
+        self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
         )
         tau_acc = response.cast(s1ap_types.ueTauAccept_t)

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating_connected_mode.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating_connected_mode.py
@@ -77,7 +77,7 @@ class TestTauTaUpdatingConnectedMode(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEquals(
+            self.assertEqual(
                 response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
             )
             tau_acc = response.cast(s1ap_types.ueTauAccept_t)

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating_reject.py
@@ -101,7 +101,7 @@ class TestTauTaUpdatingReject(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEquals(
+        self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value,
         )
         tau_rej = response.cast(s1ap_types.ueTauRejInd_t)


### PR DESCRIPTION
…fixed

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

After migrating the python S1AP integration tests from `nose` to `pytest` (#13060), several deprecation warnings are displayed. 
All warning concern `unittest`'s deprecated `assertEquals()` method (https://docs.python.org/3/library/unittest.html#deprecated-aliases).

### Test Plan

With all three VMs for AGW testing:
```vagrant@magma-test:~/magma/lte/gateway/python/integ_test$ make -i integ_test``` 

--> all 15 warnings are fixed.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
