### PR TITLE
fix(agw): trim hardware id string

### DIFF
--- a/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
+++ b/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <regex>
 
 #include "lte/gateway/c/session_manager/EnumToString.hpp"
 #include "lte/gateway/c/session_manager/SessionState.hpp"
@@ -111,7 +112,10 @@ std::string get_gateway_hw_id() {
   std::ifstream input_file(SNOWFLAKE_PATH, std::ifstream::in);
   std::stringstream buffer;
   buffer << input_file.rdbuf();
-  return buffer.str();
+  std::string hw_id = buffer.str();
+  hw_id = std::regex_replace(hw_id, std::regex("\\s+$"),
+                             std::string(""));  // trim right
+  return hw_id;
 }
 
 }  // namespace magma


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

The snowflake file might end with a newline.
![image](https://user-images.githubusercontent.com/6066106/176160016-327ffb8a-0028-466b-bb8f-cdb96d97ba27.png)

## Test Plan

- connect the AGW to an Orc8r
- gateway subscriber state including the hardware id is dumped into the Orc8r Postgres DB 

## Additional Information

- [ ] This change is backwards-breaking
