### PR TITLE
fix(amf): PDU-Session accept message coming with extra buffer causing failure of PDU-Session

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -680,10 +680,8 @@ void ngap_handle_conn_est_cnf(
       session_context->s_NSSAI.sST.buf = (uint8_t*)calloc(1, sizeof(uint8_t));
       session_context->s_NSSAI.sST.buf[0] = 0x11;
 
-      Ngap_PDUSessionResourceSetupRequestTransfer_t*
-          pduSessionResourceSetupRequestTransferIEs =
-              (Ngap_PDUSessionResourceSetupRequestTransfer_t*)calloc(
-                  1, sizeof(Ngap_PDUSessionResourceSetupRequestTransfer_t));
+      Ngap_PDUSessionResourceSetupRequestTransfer_t
+          pduSessionResourceSetupRequestTransferIEs = {0};
 
       // filling PDU TX Structure
       pdu_session_resource_setup_request_transfer_t*
@@ -692,14 +690,14 @@ void ngap_handle_conn_est_cnf(
 
       ngap_fill_pdu_session_resource_setup_request_transfer(
           amf_pdu_ses_setup_transfer_req,
-          pduSessionResourceSetupRequestTransferIEs);
+          &pduSessionResourceSetupRequestTransferIEs);
 
       uint32_t buffer_size = 1024;
       char* buffer = (char*)calloc(1, buffer_size);
 
       asn_enc_rval_t er = aper_encode_to_buffer(
           &asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer, NULL,
-          pduSessionResourceSetupRequestTransferIEs, buffer, buffer_size);
+          &pduSessionResourceSetupRequestTransferIEs, buffer, buffer_size);
 
       if (er.encoded <= 0) {
         OAILOG_ERROR(LOG_NGAP,
@@ -708,14 +706,15 @@ void ngap_handle_conn_est_cnf(
       }
 
       asn_fprint(stderr, &asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer,
-                 pduSessionResourceSetupRequestTransferIEs);
+                 &pduSessionResourceSetupRequestTransferIEs);
+      uint32_t encoded_bytes = NGAP_ASN_ENCODED_BYTES(er.encoded);
 
-      bstring transfer = blk2bstr(buffer, er.encoded);
+      bstring transfer = blk2bstr(buffer, encoded_bytes);
       session_context->pDUSessionResourceSetupRequestTransfer.buf =
-          (uint8_t*)calloc(er.encoded, sizeof(uint8_t));
+          (uint8_t*)calloc(encoded_bytes, sizeof(uint8_t));
 
       memcpy((void*)session_context->pDUSessionResourceSetupRequestTransfer.buf,
-             (void*)transfer->data, er.encoded);
+             (void*)transfer->data, blength(transfer));
 
       session_context->pDUSessionResourceSetupRequestTransfer.size =
           blength(transfer);
@@ -728,8 +727,7 @@ void ngap_handle_conn_est_cnf(
 
       ASN_STRUCT_FREE_CONTENTS_ONLY(
           asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer,
-          pduSessionResourceSetupRequestTransferIEs);
-      free(pduSessionResourceSetupRequestTransferIEs);
+          &pduSessionResourceSetupRequestTransferIEs);
 
     } /*for loop*/
   }
@@ -1231,13 +1229,14 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
 
     asn_fprint(stderr, &asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer,
                &pduSessionResourceSetupRequestTransferIEs);
+    uint32_t encoded_bytes = NGAP_ASN_ENCODED_BYTES(er.encoded);
 
     /* Aligned PER encoder of any ASN.1 type. aper_encode function returns the
     number of encoded bits in the .encoded field of the return value. Use the
     following formula to convert to bytes: bytes = ((.encoded + 7) / 8) */
-    bstring transfer = blk2bstr(buffer, ((er.encoded + 7) >> 3));
+    bstring transfer = blk2bstr(buffer, encoded_bytes);
     ngap_pdusession_setup_item_ies->pDUSessionResourceSetupRequestTransfer.buf =
-        (uint8_t*)calloc(((er.encoded + 7) >> 3), sizeof(uint8_t));
+        (uint8_t*)calloc(encoded_bytes, sizeof(uint8_t));
 
     memcpy((void*)ngap_pdusession_setup_item_ies
                ->pDUSessionResourceSetupRequestTransfer.buf,

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -1211,20 +1211,17 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
         &(session_item->PDU_Session_Resource_Setup_Request_Transfer);
 
     /*tx_out*/
-    Ngap_PDUSessionResourceSetupRequestTransfer_t*
-        pduSessionResourceSetupRequestTransferIEs =
-            (Ngap_PDUSessionResourceSetupRequestTransfer_t*)calloc(
-                1, sizeof(Ngap_PDUSessionResourceSetupRequestTransfer_t));
+    Ngap_PDUSessionResourceSetupRequestTransfer_t msg;
+    memset(&msg, 0, sizeof(Ngap_PDUSessionResourceSetupRequestTransfer_t));
 
     ngap_fill_pdu_session_resource_setup_request_transfer(
-        amf_pdu_ses_setup_transfer_req,
-        pduSessionResourceSetupRequestTransferIEs);
+        amf_pdu_ses_setup_transfer_req, &msg);
     uint32_t buffer_size = 1024;
     char* buffer = (char*)calloc(1, buffer_size);
 
     asn_enc_rval_t er = aper_encode_to_buffer(
-        &asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer, NULL,
-        pduSessionResourceSetupRequestTransferIEs, buffer, buffer_size);
+        &asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer, NULL, &msg,
+        buffer, buffer_size);
 
     if (er.encoded <= 0) {
       OAILOG_ERROR(LOG_NGAP, "PDU Session Resource Request IE encode error \n");
@@ -1232,15 +1229,15 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
     }
 
     asn_fprint(stderr, &asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer,
-               pduSessionResourceSetupRequestTransferIEs);
+               &msg);
 
-    bstring transfer = blk2bstr(buffer, er.encoded);
+    bstring transfer = blk2bstr(buffer, ((er.encoded + 7) >> 3));
     ngap_pdusession_setup_item_ies->pDUSessionResourceSetupRequestTransfer.buf =
-        (uint8_t*)calloc(er.encoded, sizeof(uint8_t));
+        (uint8_t*)calloc(((er.encoded + 7) >> 3), sizeof(uint8_t));
 
     memcpy((void*)ngap_pdusession_setup_item_ies
                ->pDUSessionResourceSetupRequestTransfer.buf,
-           (void*)transfer->data, er.encoded);
+           (void*)transfer->data, blength(transfer));
 
     ngap_pdusession_setup_item_ies->pDUSessionResourceSetupRequestTransfer
         .size = blength(transfer);
@@ -1252,9 +1249,7 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
     bdestroy(transfer);
 
     ASN_STRUCT_FREE_CONTENTS_ONLY(
-        asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer,
-        pduSessionResourceSetupRequestTransferIEs);
-    free(pduSessionResourceSetupRequestTransferIEs);
+        asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer, &msg);
 
   } /*for loop*/
 

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -1232,7 +1232,9 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
     asn_fprint(stderr, &asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer,
                &pduSessionResourceSetupRequestTransferIEs);
 
-    // trim unused buffer length
+    /* Aligned PER encoder of any ASN.1 type. aper_encode function returns the
+    number of encoded bits in the .encoded field of the return value. Use the
+    following formula to convert to bytes: bytes = ((.encoded + 7) / 8) */
     bstring transfer = blk2bstr(buffer, ((er.encoded + 7) >> 3));
     ngap_pdusession_setup_item_ies->pDUSessionResourceSetupRequestTransfer.buf =
         (uint8_t*)calloc(((er.encoded + 7) >> 3), sizeof(uint8_t));

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -1211,17 +1211,18 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
         &(session_item->PDU_Session_Resource_Setup_Request_Transfer);
 
     /*tx_out*/
-    Ngap_PDUSessionResourceSetupRequestTransfer_t msg;
-    memset(&msg, 0, sizeof(Ngap_PDUSessionResourceSetupRequestTransfer_t));
+    Ngap_PDUSessionResourceSetupRequestTransfer_t
+        pduSessionResourceSetupRequestTransferIEs = {0};
 
     ngap_fill_pdu_session_resource_setup_request_transfer(
-        amf_pdu_ses_setup_transfer_req, &msg);
+        amf_pdu_ses_setup_transfer_req,
+        &pduSessionResourceSetupRequestTransferIEs);
     uint32_t buffer_size = 1024;
     char* buffer = (char*)calloc(1, buffer_size);
 
     asn_enc_rval_t er = aper_encode_to_buffer(
-        &asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer, NULL, &msg,
-        buffer, buffer_size);
+        &asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer, NULL,
+        &pduSessionResourceSetupRequestTransferIEs, buffer, buffer_size);
 
     if (er.encoded <= 0) {
       OAILOG_ERROR(LOG_NGAP, "PDU Session Resource Request IE encode error \n");
@@ -1229,8 +1230,9 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
     }
 
     asn_fprint(stderr, &asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer,
-               &msg);
+               &pduSessionResourceSetupRequestTransferIEs);
 
+    // trim unused buffer length
     bstring transfer = blk2bstr(buffer, ((er.encoded + 7) >> 3));
     ngap_pdusession_setup_item_ies->pDUSessionResourceSetupRequestTransfer.buf =
         (uint8_t*)calloc(((er.encoded + 7) >> 3), sizeof(uint8_t));
@@ -1249,7 +1251,8 @@ int ngap_amf_nas_pdusession_resource_setup_stream(
     bdestroy(transfer);
 
     ASN_STRUCT_FREE_CONTENTS_ONLY(
-        asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer, &msg);
+        asn_DEF_Ngap_PDUSessionResourceSetupRequestTransfer,
+        &pduSessionResourceSetupRequestTransferIEs);
 
   } /*for loop*/
 

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_types.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_types.h
@@ -27,6 +27,7 @@
 
 #define NGAP_TIMER_INACTIVE_ID (-1)
 #define NGAP_UE_CONTEXT_REL_COMP_TIMER 1  // in seconds
+#define NGAP_ASN_ENCODED_BYTES(x) (x + 7) >> 3
 
 // Forward declarations
 struct gnb_description_s;


### PR DESCRIPTION
Signed-off-by: priya-wavelabs <priya.agrawal@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

PDU-Session accept message coming with extra buffer causing failure of PDU-Session . With other gnb simulators we are not seeing this issue.

## Test Plan

Verified with unit test:
![image](https://user-images.githubusercontent.com/102359835/176168809-1a89a8f3-88e1-43a3-8ce4-cc67a4f4accc.png)

Basic sanity with ueransim.
Pcap:
![image](https://user-images.githubusercontent.com/102359835/177695834-b4bf678e-75cd-499a-bf20-24c0c5c2b328.png)


MME Log:

[mme_july_6.log](https://github.com/magma/magma/files/9060557/mme_july_6.log)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
