### PR TITLE
chore(agw): Add NET_ADMIN capability to enodebd container

### DIFF
--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -89,6 +89,8 @@ services:
       test: ["CMD", "nc", "-zv", "localhost", "60055"]
       timeout: "4s"
       retries: 3
+    cap_add:
+      - NET_ADMIN  # The container is invoking iptables and needs NET_ADMIN for that
     command: /usr/bin/env python3 -m magma.enodebd.main
 
   state:


### PR DESCRIPTION
## Summary

`enodebd` invokes `iptables`, so that the enodebd container needs the `NET_ADMIN` capability. This PR grants that capability

## Test Plan

Verified that the logs show no errors of enodebd invoking iptables

## Additional Information

- [ ] This change is backwards-breaking