### PR TITLE
chore(mme): Link the MME binaries statically

### DIFF
--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1181,7 +1181,7 @@ cc_binary(
     name = "agw_of",
     srcs = ["oai/oai_mme/oai_mme.c"],
     copts = ["-DEMBEDDED_SGW=1"],
-    linkstatic = False,
+    linkstatic = True,
     deps = [":lib_agw_of"],
 )
 
@@ -1189,7 +1189,7 @@ cc_binary(
     name = "mme_oai",
     srcs = ["oai/oai_mme/oai_mme.c"],
     copts = ["-DEMBEDDED_SGW=0"],
-    linkstatic = False,
+    linkstatic = True,
     deps = [":lib_mme_oai"],
 )
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

After the glog fix #13006 and the splitting of MME binary #13058 the new binaries can be linked statically. With this change the Bazel build will resemble more closely what the Make build does.
Needs #13058 to be merged first.

## Test Plan

CI.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
