### PR TITLE
docs: Update references to Go version from 1.18 to 1.18.3

### DIFF
--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -66,13 +66,13 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    1. Download the tar file.
 
       ```bash
-      wget https://artifactory.magmacore.org/artifactory/generic/go1.18.linux-amd64.tar.gz
+      wget https://artifactory.magmacore.org/artifactory/generic/go1.18.3.linux-amd64.tar.gz
       ```
 
    2. Extract the archive you downloaded into `/usr/local`, creating a Go tree in `/usr/local/go`.
 
       ```bash
-      sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
+      sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz
       ```
 
    3. Add `/usr/local/go/bin` to the PATH environment variable.
@@ -90,7 +90,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
       You should expect something like this
 
       ```bash
-      go version go1.18 linux/amd64
+      go version go1.18.3 linux/amd64
       ```
 
 3. Install `pyenv`.


### PR DESCRIPTION
## Summary

**Note:** To merge alongside https://github.com/magma/magma/pull/13046

Updates the Prerequisites page so that users download the correct Go version.

## Test Plan

- [x] `cd magma/docs && make precommit`
