### PR TITLE
chore(agw): Make publish.sh executable

### DIFF
--- a/lte/gateway/docker/publish.sh
+++ b/lte/gateway/docker/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the


### PR DESCRIPTION
## Summary

Adapt the shebang for systems that don't have `/bin` and set the executable bit.
