### PR TITLE
chore(agw): Replace deprecated include with include_task

### DIFF
--- a/experimental/cloudstrapper/playbooks/roles/add-aws-ssh-key/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/add-aws-ssh-key/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 
-- include: kms-key.yaml
+- include_tasks: kms-key.yaml
   when: KMSKeyID is defined
 
-- include: ssh-key.yaml
+- include_tasks: ssh-key.yaml
   when: sshKey is defined

--- a/experimental/cloudstrapper/playbooks/roles/agw-infra/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/agw-infra/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
-- include: provision-networks.yaml
+- include_tasks: provision-networks.yaml
   tags: createNet
-- include: provision-bridge.yaml
+- include_tasks: provision-bridge.yaml
   tags: createBridge
-- include: provision-instances.yaml
+- include_tasks: provision-instances.yaml
   tags: createGw
-- include: cleanup-bridge.yaml
+- include_tasks: cleanup-bridge.yaml
   tags: cleanupBridge
-- include: cleanup-networks.yaml
+- include_tasks: cleanup-networks.yaml
   tags: cleanupNet

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/gw.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/gw.yaml
@@ -1,6 +1,6 @@
 ---
 
-- include: agw-stacks.yaml
+- include_tasks: agw-stacks.yaml
   tags: agw
   environment:
     AWS_REGION: "{{ awsAgwRegion }}"

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/main.yaml
@@ -1,13 +1,13 @@
 ---
 
-- include: gw.yaml
+- include_tasks: gw.yaml
   environment:
     AWS_DEFAULT_REGION: "{{ awsAgwRegion }}"
-- include: orc8r.yaml
+- include_tasks: orc8r.yaml
   environment:
     AWS_DEFAULT_REGION: "{{ awsOrc8rRegion }}"
   tags: orc8r
-- include: keys.yaml
+- include_tasks: keys.yaml
   environment:
     AWS_DEFAULT_REGION: "{{ awsAgwRegion }}"
   tags: [keys, never]

--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r.yaml
@@ -1,47 +1,47 @@
 ---
 
-- include: orc8r-es.yaml
+- include_tasks: orc8r-es.yaml
   tags: es
 
-- include: orc8r-eks.yaml
+- include_tasks: orc8r-eks.yaml
   tags: eks
 
-- include: orc8r-ec2-asg.yaml
+- include_tasks: orc8r-ec2-asg.yaml
   tags: asg
 
-- include: orc8r-elb.yaml
+- include_tasks: orc8r-elb.yaml
   tags: elb
 
-- include: orc8r-rds.yaml
+- include_tasks: orc8r-rds.yaml
   tags: rds
 
     #There may be no snapshots
-- include: orc8r-rds-snapshots.yaml
+- include_tasks: orc8r-rds-snapshots.yaml
   tags: [ never, ndssnap ]
 
-- include: orc8r-efs.yaml
+- include_tasks: orc8r-efs.yaml
   tags: efs
 
-- include: orc8r-secrets.yaml
+- include_tasks: orc8r-secrets.yaml
   tags: secrets
 
-- include: orc8r-cloudwatch.yaml
+- include_tasks: orc8r-cloudwatch.yaml
   tags: cloudwatch
 
-- include: orc8r-natgw.yaml
+- include_tasks: orc8r-natgw.yaml
   tags: natgw
 
-- include: orc8r-igw.yaml
+- include_tasks: orc8r-igw.yaml
   tags: igw
 
-- include: orc8r-eni-subnet-route.yaml
+- include_tasks: orc8r-eni-subnet-route.yaml
   tags: subnet
 
-- include: orc8r-secgroup.yaml
+- include_tasks: orc8r-secgroup.yaml
   tags: secgroup
 
-- include: orc8r-vpc.yaml
+- include_tasks: orc8r-vpc.yaml
   tags: vpc
 
-- include: orc8r-sns.yaml
+- include_tasks: orc8r-sns.yaml
   tags: sns

--- a/experimental/cloudstrapper/playbooks/roles/build-infra/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-infra/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 
-- include: orc8r-devops.yaml
+- include_tasks: orc8r-devops.yaml
   tags: devopsOrc8r
 
-- include: agw-devops.yaml
+- include_tasks: agw-devops.yaml
   tags: devopsAgw

--- a/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/build-platform/tasks/main.yaml
@@ -1,14 +1,14 @@
 ---
 
-- include: py-packages.yaml
+- include_tasks: py-packages.yaml
   tags: py
-- include: build-tools-packages.yaml
+- include_tasks: build-tools-packages.yaml
   tags: tools
-- include: magma-repo.yaml
+- include_tasks: magma-repo.yaml
   tags: setupMagma
-- include: build-magma.yaml
+- include_tasks: build-magma.yaml
   tags: buildMagma
-- include: publish-magma.yaml
+- include_tasks: publish-magma.yaml
   tags: pubMagma
-- include: publish-helm.yaml
+- include_tasks: publish-helm.yaml
   tags: pubHelm

--- a/experimental/cloudstrapper/playbooks/roles/control/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/control/tasks/main.yaml
@@ -1,8 +1,8 @@
 ---
-- include: configure-certs.yaml
+- include_tasks: configure-certs.yaml
   tags: config-certs
-- include: configure-terraform.yaml
+- include_tasks: configure-terraform.yaml
   tags: config-tf
   ignore_errors: true
-- include: deploy-orc8r.yaml
+- include_tasks: deploy-orc8r.yaml
   tags: deploy-orc8r

--- a/experimental/cloudstrapper/playbooks/roles/docker-infra/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/docker-infra/tasks/main.yaml
@@ -1,4 +1,4 @@
 ---
 
-- include: key.yaml
-- include: provision-instance.yaml
+- include_tasks: key.yaml
+- include_tasks: provision-instance.yaml

--- a/experimental/cloudstrapper/playbooks/roles/docker-platform/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/docker-platform/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
 
-- include: magma-repo.yaml
-- include: install-root-ca.yaml
-- include: init-docker.yaml
+- include_tasks: magma-repo.yaml
+- include_tasks: install-root-ca.yaml
+- include_tasks: init-docker.yaml

--- a/experimental/cloudstrapper/playbooks/roles/ghz-platform/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/ghz-platform/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- include: setup-tests.yaml
+- include_tasks: setup-tests.yaml
   tags: setupTests
-- include: run-tests.yaml
+- include_tasks: run-tests.yaml
   tags: runTests

--- a/experimental/cloudstrapper/playbooks/roles/magma-agw/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/magma-agw/tasks/main.yaml
@@ -1,17 +1,27 @@
 ---
 
-- include: ansible-setup.yaml
-  become: yes
-  tags: setupPackages
-- include: resolver-setup.yaml
-  become: yes
-  tags: setupResolver
-- include: magma-setup.yaml
-  become: yes
-  tags: setupMagma
-- include: agw-setup.yaml
-  become: yes
-  tags: setupAgw
-- include: magma-cleanup.yaml
-  become: yes
-  tags: cleanupMagmaAgw
+- include_tasks:
+    file: ansible-setup.yaml
+    apply:
+      become: yes
+      tags: [setupPackages]
+- include_tasks:
+    file: resolver-setup.yaml
+    apply:
+      become: yes
+      tags: [setupResolver]
+- include_tasks:
+    file: magma-setup.yaml
+    apply:
+      become: yes
+      tags: [setupMagma]
+- include_tasks:
+    file: agw-setup.yaml
+    apply:
+      become: yes
+      tags: [setupAgw]
+- include_tasks:
+    file: magma-cleanup.yaml
+    apply:
+      become: yes
+      tags: [cleanupMagmaAgw]

--- a/experimental/cloudstrapper/playbooks/roles/test-framework/tasks/main.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/test-framework/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
-- include: cleanup-gateway-instance.yaml
+- include_tasks: cleanup-gateway-instance.yaml
   tags: clusterGatewayCleanup
-- include: provision-test-instances.yaml
+- include_tasks: provision-test-instances.yaml
   tags: clusterStart
-- include: configure-test-instances.yaml
+- include_tasks: configure-test-instances.yaml
   tags: clusterConfigure
-- include: cleanup-test-instances.yaml
+- include_tasks: cleanup-test-instances.yaml
   tags: clusterCleanup
-- include: configure-ssh-forwarding.yaml
+- include_tasks: configure-ssh-forwarding.yaml
   tags: clusterJump


### PR DESCRIPTION
## Summary

Replace `include` with `include_tasks` in order to fix an Ansible deprecation warning

## Test Plan

I provisioned an Ubuntu EC2 instance configured to host the containerized AGW using the existing playbooks after making this change.

## Additional Information

- [ ] This change is backwards-breaking
