### PR TITLE
chore(agw): Update ec2_elb_info module

### DIFF
--- a/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-elb.yaml
+++ b/experimental/cloudstrapper/playbooks/roles/aws-cleanup/tasks/orc8r-elb.yaml
@@ -1,7 +1,7 @@
 ---
 
 - name: collect all elb info
-  ec2_elb_info:
+  community.aws.elb_classic_lb_info:
   register: valElb
 
 - name: delete all elbs, because this is a clean deployment


### PR DESCRIPTION
## Summary

Update from the deprecated `ec2_elb_info` module to the `elb_classic_lb_info` module

`ec2_elb_info` has a dependency on `boto` which prevents us from using
`Python >= 3.9`. The new module depends on `boto3` which is available for
current Python versions.


## Test Plan

Verified that Ansible works with the new module.

## Additional Information

- [ ] This change is backwards-breaking
