### PR TITLE
fix(amf): Implicit deregistration for re-registration

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.hpp
@@ -29,6 +29,22 @@ namespace magma5g {
 
 #define M5GSMobileIdentityMsg_GUTI_LENGTH 11
 
+// Checks PLMNs equality
+#define PLMN_ARE_EQUAL(p1, p2) \
+  ((MCCS_ARE_EQUAL((p1), (p2))) && (MNCS_ARE_EQUAL((p1), (p2))))
+
+// Checks MCC equality
+#define MCCS_ARE_EQUAL(n1, n2)             \
+  (((n1).mcc_digit1 == (n2).mcc_digit1) && \
+   ((n1).mcc_digit2 == (n2).mcc_digit2) && \
+   ((n1).mcc_digit3 == (n2).mcc_digit3))
+
+// Checks Mobile Network Code equality
+#define MNCS_ARE_EQUAL(n1, n2)             \
+  (((n1).mnc_digit1 == (n2).mnc_digit1) && \
+   ((n1).mnc_digit2 == (n2).mnc_digit2) && \
+   ((n1).mnc_digit3 == (n2).mnc_digit3))
+
 // AMF_AS Service Access point primitive
 status_code_e amf_as_send(amf_as_t* msg);
 

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.cpp
@@ -48,6 +48,43 @@ imsi64_t send_initial_ue_message_no_tmsi(
   return imsi64;
 }
 
+// Create initial ue message without TMSI and replace tmsi in hexbuf
+imsi64_t send_initial_ue_message_no_tmsi_replace_mtmsi(
+    amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,
+    uint32_t gnb_id, gnb_ue_ngap_id_t gnb_ue_ngap_id,
+    amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, const uint8_t* nas_msg,
+    uint8_t nas_msg_length, amf_ue_ngap_id_t ue_id, uint8_t tmsi_offset) {
+  itti_ngap_initial_ue_message_t initial_ue_message = {};
+
+  initial_ue_message.sctp_assoc_id = sctp_assoc_id;
+  initial_ue_message.gnb_id = gnb_id;
+  initial_ue_message.gnb_ue_ngap_id = gnb_ue_ngap_id;
+  initial_ue_message.amf_ue_ngap_id = amf_ue_ngap_id;
+
+  initial_ue_message.nas = blk2bstr(nas_msg, nas_msg_length);
+
+  initial_ue_message.tai.plmn = plmn;
+  initial_ue_message.tai.tac = 1;
+  initial_ue_message.ecgi.plmn = plmn;
+  initial_ue_message.ecgi.cell_identity = {0, 0, 0};
+  initial_ue_message.m5g_rrc_establishment_cause = M5G_MO_SIGNALING;
+  initial_ue_message.ue_context_request = M5G_UEContextRequest_requested;
+  initial_ue_message.is_s_tmsi_valid = false;
+  tmsi_t ue_tmsi = amf_lookup_guti_by_ueid(ue_id);
+
+  ue_tmsi = htonl(ue_tmsi);
+  memcpy(&(initial_ue_message.nas
+               ->data[nas_msg_length - sizeof(tmsi_t) - tmsi_offset]),
+         &(ue_tmsi), sizeof(tmsi_t));
+
+  imsi64_t imsi64 = 0;
+
+  imsi64 =
+      amf_app_handle_initial_ue_message(amf_app_desc_p, &initial_ue_message);
+
+  return imsi64;
+}
+
 /* Create initial ue message without TMSI no context*/
 imsi64_t send_initial_ue_message_no_tmsi_no_ctx_req(
     amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,

--- a/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
+++ b/lte/gateway/c/core/oai/test/amf/amf_app_test_util.h
@@ -38,6 +38,12 @@ imsi64_t send_initial_ue_message_no_tmsi(
     amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, const uint8_t* nas_msg,
     uint8_t nas_msg_length);
 
+imsi64_t send_initial_ue_message_no_tmsi_replace_mtmsi(
+    amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,
+    uint32_t gnb_id, gnb_ue_ngap_id_t gnb_ue_ngap_id,
+    amf_ue_ngap_id_t amf_ue_ngap_id, const plmn_t& plmn, const uint8_t* nas_msg,
+    uint8_t nas_msg_length, amf_ue_ngap_id_t ue_id, uint8_t tmsi_offset);
+
 /* API for creating initial UE message without TMSI */
 imsi64_t send_initial_ue_message_no_tmsi_no_ctx_req(
     amf_app_desc_t* amf_app_desc_p, sctp_assoc_id_t sctp_assoc_id,

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -117,6 +117,11 @@ class AMFAppProcedureTest : public ::testing::Test {
       0x1c, 0x30, 0x18, 0x01, 0x00, 0x74, 0x00, 0x0a, 0x09, 0x08, 0x69,
       0x6e, 0x74, 0x65, 0x72, 0x6e, 0x65, 0x74, 0x53, 0x01, 0x01};
 
+  const uint8_t guti_initial_ue_reregister_message_hexbuf[36] = {
+      0x7e, 0x00, 0x41, 0x01, 0x00, 0x0b, 0xf2, 0x22, 0x62, 0x54, 0x01, 0x00,
+      0x40, 0xd9, 0x8a, 0x4a, 0x7d, 0x10, 0x01, 0x00, 0x2e, 0x02, 0xc0, 0xc0,
+      0x2f, 0x02, 0x01, 0x02, 0x17, 0x02, 0xc0, 0xc0, 0xb0, 0x2b, 0x01, 0x00};
+
   /* Mobile Termination as the initial ue message */
   const uint8_t mu_initial_ue_message_hexbuf[93] = {
       0x7e, 0x01, 0xa3, 0xcf, 0x4c, 0x7e, 0xd1, 0x7e, 0x00, 0x41, 0x02, 0x00,
@@ -2479,6 +2484,117 @@ TEST_F(AMFAppProcedureTest, PeriodicRegistraionNoTmsi) {
   EXPECT_TRUE(rc == RETURNok);
 
   amf_app_handle_deregistration_req(init_ue_id);
+  EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
+TEST_F(AMFAppProcedureTest, ReRegistraion) {
+  int rc = RETURNerror;
+  amf_ue_ngap_id_t init_ue_id = 0;
+  std::vector<MessagesIds> expected_Ids{AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_NAS_DL_DATA_REQ,
+                                        NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND};
+
+  // Send the initial UE message
+  imsi64_t imsi64 = 0;
+  imsi64 = send_initial_ue_message_no_tmsi(amf_app_desc_p, 36, 1, 1, 0, plmn,
+                                           initial_ue_message_hexbuf,
+                                           sizeof(initial_ue_message_hexbuf));
+
+  // Check if UE Context is created with correct imsi
+  EXPECT_TRUE(get_ue_id_from_imsi(amf_app_desc_p, imsi64, &init_ue_id));
+
+  // Send the authentication response message from subscriberdb
+  rc = send_proc_authentication_info_answer(imsi, init_ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+  // Send uplink nas message for auth response from UE
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, init_ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+  // Send uplink nas message for security mode complete response from UE
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, init_ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, init_ue_id);
+
+  // Send uplink nas message for registration complete response from UE
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, init_ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_initial_context_response(amf_app_desc_p, init_ue_id);
+
+  amf_ue_ngap_id_t updated_ue_id = 0;
+  imsi64 = 0;
+
+  // Replace the tmsi with tmsi generated during first registration
+
+  imsi64 = send_initial_ue_message_no_tmsi_replace_mtmsi(
+      amf_app_desc_p, 36, 1, 2, 0, plmn,
+      guti_initial_ue_reregister_message_hexbuf,
+      sizeof(guti_initial_ue_reregister_message_hexbuf), init_ue_id, 19);
+
+  EXPECT_TRUE(validate_identification_procedure(0, &updated_ue_id));
+
+  rc = send_uplink_nas_identity_response_message(amf_app_desc_p, updated_ue_id,
+                                                 plmn, identity_response,
+                                                 sizeof(identity_response));
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(updated_ue_id);
+  ASSERT_NE(ue_context_p, nullptr);
+  EXPECT_TRUE(ue_context_p->amf_context.imsi64 == stoul(imsi));
+
+  // Send the authentication response message from subscriberdb
+  rc = send_proc_authentication_info_answer(imsi, updated_ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  // Validate if authentication procedure is initialized as expected
+  EXPECT_TRUE(validate_auth_procedure(updated_ue_id, 0));
+
+  // Send uplink nas message for auth response from UE
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, updated_ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  // Check whether security mode procedure is initiated
+  EXPECT_TRUE(validate_smc_procedure(updated_ue_id, 0));
+
+  // Send uplink nas message for security mode complete response from UE
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, updated_ue_id,
+                                               plmn, ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  ula_ans = util_amf_send_s6a_ula(imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
+
+  // Send uplink nas message for registration complete response from UE
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, updated_ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+  amf_app_handle_deregistration_req(updated_ue_id);
+  ue_context_p = amf_ue_context_exists_amf_ue_ngap_id(init_ue_id);
+  delete ue_context_p;
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
 }
 TEST_F(AMFAppProcedureTest, SctpShutWithServiceRequest) {


### PR DESCRIPTION
Signed-off-by: Sathyaj27 <sathya.jayadev@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- During Guti based registration, if context with same TMSi exist then implicit
   deregistration of existing context should be triggered before going for fresh registration.
- If Different TMSI is used in GUTI registration then it should be considered a fresh registration
   and no implicit deregistration has to be triggered. 

fixing #12930 


<!-- Enumerate changes you made and why you made them -->

## Test Plan
Test case 1:
1) Initiate a SUCI based registration
2) Once registration is complete trigger a GUTI registration with same TMSI.
3) Then a release complete message from AMF should be sent for initial context.
4) Identity procedure for new registration
Tested With abot
<img width="887" alt="Re-register" src="https://user-images.githubusercontent.com/94469973/177610861-a41b3e6e-0b94-4e5d-9161-b4d189101dd2.PNG">


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is not backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
