### PR TITLE
chore(feg): integ test vms are pulled from cache in order to prevent vagrant rate limit aka 429

### DIFF
--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -100,6 +100,21 @@ jobs:
           sudo touch /etc/vbox/networks.conf
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
           sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
+      - name: Cache magma-dev-box
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
+          key: vagrant-box-magma-dev
+      - name: Cache magma-test-box
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
+          key: vagrant-box-magma-test
+      - name: Cache magma-trfserver-box
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
+          key: vagrant-box-magma-trfserver
       - name: Build test vms
         run: |
           cd ${{ env.AGW_ROOT }} && fab build_test_vms


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

See e.g., https://github.com/magma/magma/runs/7110286254?check_suite_focus=true
```
[localhost] local: vagrant status magma_trfserver
The requested URL returned error: 429
```
See e.g., `.github/workflows/lte-integ-test.yml` for caching in lte integ tests.

## Test Plan

CI on master

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
