### PR TITLE
chore(ci): clarify names of cache actions

### DIFF
--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -30,7 +30,7 @@ jobs:
       - run: echo "::set-output name=date::$(date +'%m-%d-%Y--%H-%M-%S')"
         id: date
       - uses: actions/checkout@v2
-      - name: Cache magma dev
+      - name: Cache magma-dev-box
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Cache magma dev
+      - name: Cache magma-dev-box
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -23,17 +23,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.SHA }}
-      - name: Cache magma dev
+      - name: Cache magma-dev-box
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
           key: vagrant-box-magma-dev
-      - name: Cache magma test
+      - name: Cache magma-test-box
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
           key: vagrant-box-magma-test
-      - name: Cache magma trfserver
+      - name: Cache magma-trfserver-box
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver


### PR DESCRIPTION
## Summary

The name `Cache magma test` looks a lot like caching test results, this
replaces it by `Cache magma-test-box` which should be a lot clearer.
