### PR TITLE
fix(ci): Update the fabfile.py under magma/lte/gateway/ used during federated integ test

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -52,7 +52,7 @@ in `release/magma.lockfile`
 AGW_ROOT = "$MAGMA_ROOT/lte/gateway"
 AGW_PYTHON_ROOT = "$MAGMA_ROOT/lte/gateway/python"
 FEG_INTEG_TEST_ROOT = AGW_PYTHON_ROOT + "/integ_tests/federated_tests"
-FEG_INTEG_TEST_DOCKER_ROOT = FEG_INTEG_TEST_ROOT + "/Docker"
+FEG_INTEG_TEST_DOCKER_ROOT = FEG_INTEG_TEST_ROOT + "/docker"
 ORC8R_AGW_PYTHON_ROOT = "$MAGMA_ROOT/orc8r/gateway/python"
 AGW_INTEG_ROOT = "$MAGMA_ROOT/lte/gateway/python/integ_tests"
 DEFAULT_CERT = "$MAGMA_ROOT/.cache/test_certs/rootCA.pem"


### PR DESCRIPTION

* Error occured while running the command 'fab federated_integ_test:build_all=False,orc8r_on_vagrant=True' for running federated integ test
* Corrected the parameter where 'Docker' is used instead of 'docker' which was under /lte/gateway/python/integ_tests/federated_tests/docker

Signed-off-by: Nitin Rajput <nitinrajput706021@gmail.com>
