### PR TITLE
fix(ci): Remove failing publishing step from FeG integ workflow

### DIFF
--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -186,17 +186,6 @@ jobs:
         with:
           files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
-      - name: Publish results to Firebase
-        if: always() && github.event.workflow_run.event == 'push'
-        env:
-          FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
-          REPORT_FILENAME: "federated_integ_test_${{ env.SHA }}.html"
-        run: |
-          npm install -g xunit-viewer
-          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
-          [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
-          [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
-          python ci-scripts/firebase_publish_report.py -id ${{ env.SHA }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} lte --url $URL
       - name: Notify failure to slack
         if: failure() && github.event.workflow_run.event == 'push'
         env:


### PR DESCRIPTION
## Summary

The CI is failing due to the publishing step within the FeG integ test workflow, e.g. https://github.com/magma/magma/runs/7119165649?check_suite_focus=true. As this is not yet implemented in the CI dashboard, https://magma-ci.web.app/, this step is being removed for now. It should be added back in when implemented in the dashboard.

## Test Plan

- [x] Check it passes on branch
