### PR TITLE
chore(ci): Reuse the bazel build artifacts for the bazel tests

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -48,14 +48,14 @@ jobs:
               - '**/*.bazel'
               - '**/*.bzl'
 
-  bazel_build:
+  bazel_build_and_test:
     needs: path_filter
     # Only run workflow if this is a scheduled run on master branch,
     # or a pull_request that skip-duplicate-action wants to run again.
     if: |
       (github.event_name == `schedule` && github.ref == 'refs/heads/master')
         || ${{ needs.path_filter.outputs.files_changed == 'true' }}
-    name: Bazel Build Job `bazel build //...`
+    name: Bazel Build & Test Job
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
@@ -80,74 +80,7 @@ jobs:
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the bazel base image!"
-      - name: Run `bazel build //...`
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.BAZEL_BASE_IMAGE }}
-          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/
-          run: |
-            cd /workspaces/magma
-            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
-            bazel build //... \
-              --config=mme_unit_test \
-              --profile=Bazel_build_all_profile
-      - name: Publish bazel profile
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: Bazel build all profile
-          path: Bazel_build_all_profile
-      - name: Build space left after run
-        shell: bash
-        run: |
-          echo "Available storage:"
-          df -h
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
-          SLACK_TITLE: "Bazel Build Job `bazel build //...`"
-          SLACK_USERNAME: "Bazel Build & Test"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
-
-  bazel_test:
-    needs: path_filter
-    # Only run workflow if this is a scheduled run on master branch,
-    # or a pull_request that skip-duplicate-action wants to run again.
-    if: |
-      (github.event_name == `schedule` && github.ref == 'refs/heads/master')
-        || ${{ needs.path_filter.outputs.files_changed == 'true' }}
-    name: Bazel Test Job `bazel test //...`
-    runs-on: ubuntu-latest
-    steps:
-      - name: Maximize build space
-        shell: bash
-        run: |
-          echo "Available storage before:"
-          df -h
-          echo "Removing /usr/share/dotnet, /usr/local/lib/android, /opt/ghc"
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          echo "Available storage after:"
-          df -h
-      - name: Check Out Repo
-        # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@v2
-      - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.BAZEL_BASE_IMAGE }}
-          options: --pull always
-          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
-          run: |
-            echo "Pulled the bazel base image!"
-      - name: Run `bazel test //...`
+      - name: Run bazel build, test, starlark format check & python import check
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
@@ -155,36 +88,48 @@ jobs:
           options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
             cd /workspaces/magma
+
+            printf '\r%s\r' '###############################' 1>&2
+            printf '\r%s\r' 'Configuring bazel remote cache.' 1>&2
+            printf '\r%s\r\r' '###############################' 1>&2
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+
+            printf '\r%s\r' '###############################' 1>&2
+            printf '\r%s\r' 'Executing bazel build //...' 1>&2
+            printf '\r%s\r' '###############################' 1>&2
+            bazel build //... \
+              --config=mme_unit_test \
+              --profile=Bazel_build_all_profile &&
+
+            printf '\r%s\r' '###############################' 1>&2 &&
+            printf '\r%s\r' 'Executing bazel test //...' 1>&2 &&
+            printf '\r%s\r' '###############################' 1>&2 &&
             bazel test //... \
               --cache_test_results=no \
               --test_output=errors \
-              --profile=Bazel_test_all_profile
-      - name: Publish bazel profile
+              --profile=Bazel_test_all_profile &&
+
+            printf '\r%s\r' '###############################' 1>&2 &&
+            printf '\r%s\r' 'Executing starlark format check.' 1>&2 &&
+            printf '\r%s\r' '###############################' 1>&2 &&
+            bazel run //:check_starlark_format &&
+
+            printf '\r%s\r' '###############################' 1>&2 &&
+            printf '\r%s\r' 'Executing python import bazelification check.' 1>&2 &&
+            printf '\r%s\r' '###############################' 1>&2 &&
+            bazel/scripts/test_python_service_imports.sh
+      - name: Publish bazel build profile
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Bazel build all profile
+          path: Bazel_build_all_profile
+      - name: Publish bazel test profile
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: Bazel test all profile
           path: Bazel_test_all_profile
-      - name: Run `bazel run //:check_starlark_format`
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.BAZEL_BASE_IMAGE }}
-          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/
-          run: |
-            cd /workspaces/magma
-            bazel run //:check_starlark_format
-      - name: Test python services for missing modules
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.BAZEL_BASE_IMAGE }}
-          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/
-          run: |
-            cd /workspaces/magma
-            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
-            bazel/scripts/test_python_service_imports.sh
       - name: Build space left after run
         shell: bash
         run: |
@@ -195,7 +140,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
-          SLACK_TITLE: "Bazel Test Job `bazel test //...`"
+          SLACK_TITLE: "Bazel Build & Test Job `bazel build //...; bazel test //...`"
           SLACK_USERNAME: "Bazel Build & Test"
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- To maximize the reuse of build outputs in the bazel workflow the `bazel build ...`, `bazel test ...`, starlark format check and python module import checks are all done in the same step. See https://github.com/magma/magma/issues/13131 for an analysis of the expected impact and comparison to other approaches.
- The relevant commands in this workflow step are chained by `&&` to give the correct exit value for the action.
  - Run with test failure (on purpose): [action run URL](https://github.com/LKreutzer/magma/runs/7128581017?check_suite_focus=true)
  - If a command fails the logging persists and ends with the exit of the failing command.
- One of the drawbacks of this approach is that the logging becomes somewhat difficult to read.
  - To mitigate this some `printf` statements are added to separate the command outputs.
  - Because much of the bazel logging is to `stderr` the `printf` statements are redirected to `stderr` to keep them in the right position.
  - The newline character `\n` does not work in this situation and `\r` has to be used.
  - Note: There seems to be a bug in the GH actions which prints most logging three times while it is running and when the workflow finishes it only appears once. This behaviour does not originate from the changes made here and I have observe this behaviour also on the current master runs.



## Test Plan

- CI

## Additional Information

- [ ] This change is backwards-breaking