### PR TITLE
fix(agw): Fixed SCTP abort issue by setting finite timeout in sctp_sendmsg

### DIFF
--- a/lte/gateway/c/sctpd/src/sctp_connection.cpp
+++ b/lte/gateway/c/sctpd/src/sctp_connection.cpp
@@ -86,7 +86,7 @@ void SctpConnection::Send(uint32_t assoc_id, uint32_t stream,
   auto buf = msg.c_str();
   auto n = msg.size();
   auto rc = sctp_sendmsg(assoc.sd, buf, n, NULL, 0, htonl(assoc.ppid), 0,
-                         stream, 0, 0);
+                         stream, 100, 0);
 
   if (rc < 0) {
     MLOG_perror("sctp_sendmsg");

--- a/lte/gateway/c/sctpd/src/sctp_connection.cpp
+++ b/lte/gateway/c/sctpd/src/sctp_connection.cpp
@@ -85,6 +85,7 @@ void SctpConnection::Send(uint32_t assoc_id, uint32_t stream,
 
   auto buf = msg.c_str();
   auto n = msg.size();
+  // 100 indicates a timetolive of 100 ms
   auto rc = sctp_sendmsg(assoc.sd, buf, n, NULL, 0, htonl(assoc.ppid), 0,
                          stream, 100, 0);
 


### PR DESCRIPTION
Signed-off-by: bhuvaneshne <bhuvaneshne@highway9networks.com>

## Summary

See bug description (https://github.com/magma/magma/issues/13115) for description, RCA and proposal of fix.

## Test Plan

Reproduce the issue using the bundled simulator (See: https://github.com/magma/magma/issues/13115)
Replace the sctpd executable
Restart sctp daemon (systemctl restart sctpd)
Wait for sctpd to get ready (See syslog)
Rerun the simulator and see that the issue is not reproducible again

## Additional Information

- [ ] This change is backwards-breaking
