### PR TITLE
docs: fix misstyped magmacore.org URLs

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.5.X/howtos/inbound_roaming.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/howtos/inbound_roaming.md
@@ -52,7 +52,7 @@ setup to handle your own/local subscribers. So before configuring Inbound
 Roaming you need:
 - Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
 - Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacoreorg/docs/lte/setup_deb).
+- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
 - Create a Federate Deployment (see [below](#Create a Federated Deployment)).
 - Make sure your setup is able to serve calls with your local subscribers
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/howtos/inbound_roaming.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/howtos/inbound_roaming.md
@@ -19,7 +19,7 @@ At the bottom of this document you have
 [configuration example](#configuration-example)
 
 TEID allocation is described on
-[Technical Reference](https://docs.magmacoreorg/docs/lte/dev_teid_allocation)
+[Technical Reference](https://docs.magmacore.org/docs/lte/dev_teid_allocation)
 section.
 
 ## Architecture
@@ -99,7 +99,7 @@ Roaming you need:
 
 - Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
 - Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacoreorg/docs/lte/setup_deb).
+- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
 - Create a Federate Deployment (see [below](#Create a Federated Deployment)).
 - Make sure your setup is able to serve calls with your local subscribers
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/integrated_5G_sa.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/integrated_5G_sa.md
@@ -29,7 +29,7 @@ Before starting to configure 5G SA setup, first you need to bring up a setup to 
 
 - Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
 - Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacoreorg/docs/lte/setup_deb).
+- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
 - Make sure your setup is able to serve calls with your local subscribers
 
 Once you are done you need to enable the 5G feature set from the orchestrator. Also need to ensure that this AGW serves the mapped PLMN.Once done we can connect Magma AGW with GNB and the 5G supported UE.

--- a/docs/readmes/howtos/inbound_roaming.md
+++ b/docs/readmes/howtos/inbound_roaming.md
@@ -18,7 +18,7 @@ At the bottom of this document you have
 [configuration example](#configuration-example)
 
 TEID allocation is described on
-[Technical Reference](https://docs.magmacoreorg/docs/lte/dev_teid_allocation)
+[Technical Reference](https://docs.magmacore.org/docs/lte/dev_teid_allocation)
 section.
 
 ## Architecture
@@ -98,7 +98,7 @@ Roaming you need:
 
 - Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
 - Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacoreorg/docs/lte/setup_deb).
+- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
 - Create a Federate Deployment (see [below](#Create a Federated Deployment)).
 - Make sure your setup is able to serve calls with your local subscribers
 

--- a/docs/readmes/lte/integrated_5G_sa.md
+++ b/docs/readmes/lte/integrated_5G_sa.md
@@ -28,7 +28,7 @@ Before starting to configure 5G SA setup, first you need to bring up a setup to 
 
 - Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
 - Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacoreorg/docs/lte/setup_deb).
+- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
 - Make sure your setup is able to serve calls with your local subscribers
 
 Once you are done you need to enable the 5G feature set from the orchestrator. Also need to ensure that this AGW serves the mapped PLMN.Once done we can connect Magma AGW with GNB and the 5G supported UE.


### PR DESCRIPTION
A few URLs along the documentation pointed to magmacoreorg, instead of
magmacore.org.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@i2cat.net>