### PR TITLE
fix(orc8r): Read from subscriber storage by IMSI

### DIFF
--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -79,7 +79,7 @@ func main() {
 	glog.Infof("Subscriberdb service config %+v", serviceConfig)
 
 	// Attach handlers
-	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers(subscriberStateStore))
 	protos.RegisterSubscriberLookupServer(srv.ProtectedGrpcServer, lookup_servicers.NewLookupServicer(fact, ipStore))
 	state_protos.RegisterIndexerServer(srv.ProtectedGrpcServer, lookup_servicers.NewIndexerServicer(subscriberStateStore))
 	lte_protos.RegisterSubscriberDBCloudServer(srv.GrpcServer, subscriberdbcloud_servicer.NewSubscriberdbServicer(serviceConfig, subscriberStore))

--- a/lte/cloud/go/services/subscriberdb/test_init/test_service_init.go
+++ b/lte/cloud/go/services/subscriberdb/test_init/test_service_init.go
@@ -40,7 +40,7 @@ func StartTestService(t *testing.T) storage.SubscriberStorage {
 	}
 	annotations := map[string]string{
 		orc8r.StateIndexerVersionAnnotation: "1",
-		orc8r.StateIndexerTypesAnnotation:   lte.MobilitydStateType,
+		orc8r.StateIndexerTypesAnnotation:   lte.MobilitydStateType + "," + lte.GatewaySubscriberStateType,
 	}
 	srv, lis, plis := test_utils.NewTestOrchestratorService(t, orc8r.ModuleName, subscriberdb.ServiceName, labels, annotations)
 


### PR DESCRIPTION
⚠️ Merge after #13212

## Summary

In this PR we enable NMS to read `subscriber_state` from the new `gateway_subscriber_states` table (#12949). It follows up on #13041 and implements step 4 from [#8621 - comment](https://github.com/magma/magma/issues/8621#issuecomment-1144762649).

We adapt the obsidian handlers of subscriberdb to read all states of type `lte.SubscriberStateType = 'subscriber_state'`
from the `gateway_subscriber_states` table instead of the `states` table. To that end we add a new method to the SubscriberStorage interface, which enables to read state by network ID and imsi (`GetSubscribersForIMSIs`). Accordingly we also add an index for network ID and imsi to the `gateway_subscriber_states` table.

The handlers that are getting `subscriber_state`, are now hard coded to always get it the new interface method by calling the `getSubscribersForIMSIs` function.

Tests are adapted accordingly.

## Test Plan

- [x] Check in postgres database that index was created.
- [x] run handlers_test.go
- [x] Test manually in NMS whether all relevant routes are loading state correctly
         - /magma/v1/lte/:network_id/subscribers (called in subscribers tab)
         - /magma/v1/lte/:network_id/subscribers/:subscriber_id (view of single subscriber)
         - /magma/v1/lte/:network_id/subscriber_state (called in subscribers tab)
         - /magma/v1/lte/:network_id/subscriber_state/:subscriber_id (called if autorefresh in single subscriber view is activated)
- [x] e2e test with simple integration test


## Additional Information

- Done in pairing with @sebathomas.

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
