### PR TITLE
chore(ci): Login to vagrant cloud in CI

### DIFF
--- a/.github/workflows/bazel-cache-push.yml
+++ b/.github/workflows/bazel-cache-push.yml
@@ -30,11 +30,6 @@ jobs:
       - run: echo "::set-output name=date::$(date +'%m-%d-%Y--%H-%M-%S')"
         id: date
       - uses: actions/checkout@v2
-      - name: Cache magma-dev-box
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -59,6 +54,10 @@ jobs:
           sudo touch /etc/vbox/networks.conf
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
           sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
+      - name: Log in to vagrant cloud
+        run: |
+          echo "Logging in to vagrant cloud..."
+          vagrant cloud auth login --token "${{ secrets.VAGRANT_CLOUD_TOKEN }}"
       - name: Bring up the Magma VM
         run: |
           cd lte/gateway

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -108,11 +108,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Cache magma-dev-box
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@v8"
         with:
@@ -131,6 +126,10 @@ jobs:
           sudo touch /etc/vbox/networks.conf
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
           sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
+      - name: Log in to vagrant cloud
+        run: |
+          echo "Logging in to vagrant cloud..."
+          vagrant cloud auth login --token "${{ secrets.VAGRANT_CLOUD_TOKEN }}"
       - name: Build AGW
         run: |
           cd lte/gateway

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -65,11 +65,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.SHA }}
-      - name: Cache Vagrant Boxes
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes
-          key: vagrant-boxes-cwf
       - name: Setup Python env
         uses: "gabrielfalcao/pyenv-action@v8"
         with:
@@ -102,6 +97,10 @@ jobs:
           sudo touch /etc/vbox/networks.conf
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
           sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
+      - name: Log in to vagrant cloud
+        run: |
+          echo "Logging in to vagrant cloud..."
+          vagrant cloud auth login --token "${{ secrets.VAGRANT_CLOUD_TOKEN }}"
       - name: Run the integ test
         run: |
           cd cwf/gateway

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -100,21 +100,10 @@ jobs:
           sudo touch /etc/vbox/networks.conf
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
           sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
-      - name: Cache magma-dev-box
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev
-      - name: Cache magma-test-box
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test
-      - name: Cache magma-trfserver-box
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
-          key: vagrant-box-magma-trfserver
+      - name: Log in to vagrant cloud
+        run: |
+          echo "Logging in to vagrant cloud..."
+          vagrant cloud auth login --token "${{ secrets.VAGRANT_CLOUD_TOKEN }}"
       - name: Build test vms
         run: |
           cd ${{ env.AGW_ROOT }} && fab build_test_vms

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -23,21 +23,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.SHA }}
-      - name: Cache magma-dev-box
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev
-      - name: Cache magma-test-box
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test
-      - name: Cache magma-trfserver-box
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
-          key: vagrant-box-magma-trfserver
       - name: setup pyenv
         uses: "gabrielfalcao/pyenv-action@v8"
         with:
@@ -56,6 +41,10 @@ jobs:
           sudo touch /etc/vbox/networks.conf
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
           sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
+      - name: Log in to vagrant cloud
+        run: |
+          echo "Logging in to vagrant cloud..."
+          vagrant cloud auth login --token "${{ secrets.VAGRANT_CLOUD_TOKEN }}"
       - name: Run the integ test
         run: |
           cd lte/gateway


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Log in to the vagrant cloud to avoid rate limiting. See previous PRs:
  -  https://github.com/magma/magma/pull/13003
  - https://github.com/magma/magma/pull/13007
- Vagrant cloud API docs: https://www.vagrantup.com/docs/cli/login 
- The login persists across workflow steps.
  - This can be checked with: `vagrant login --check` 
  - See [testing run](https://github.com/LKreutzer/magma/actions/runs/2590155542) with [these changes](https://github.com/LKreutzer/magma/commit/8651a921cd06e1883656a483ca1a001f13919751) (aborted after successful log in steps and check).
  - Test run of the [cwf integ tests](https://github.com/LKreutzer/magma/actions/runs/2590554625).
- :warning:  REQUIREMENT :warning: : 
  - A vagrant cloud token needs to be configured as a GH actions secret `secrets.VAGRANT_CLOUD_TOKEN` on magma/magma. 

## Test Plan

- CI
- I tested the login when I previously saw consistent 429 HTTP errors on my magma fork and every run with the login succeeded.


## Additional Information

- [ ] This change is backwards-breaking