### PR TITLE
fix(agw): Pin Ansible version to fix installation

### DIFF
--- a/lte/gateway/deploy/agw_install_ubuntu.sh
+++ b/lte/gateway/deploy/agw_install_ubuntu.sh
@@ -185,7 +185,7 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   apt-get -y install curl make virtualenv zip rsync git software-properties-common python3-pip python-dev apt-transport-https
 
   alias python=python3
-  pip3 install ansible
+  pip3 install ansible==5.10.0
 
   git clone "${GIT_URL}" /home/$MAGMA_USER/magma
   cd /home/$MAGMA_USER/magma || exit


### PR DESCRIPTION
## Summary

At the moment, both releases v1.6 and v1.7 fail with a crashing pipelined after installation because of broken imports.

The reason is that Ansible is installed from PyPI as a part of the Magma installation, and it uses some of the same dependencies as Magma. This leads to incompatibilities with pipelined for Ansible version >= 6 because that version of Ansible requires an incompatible version of **Jinja2**.

This can be avoided by pinning the Ansible version to something < 6.

In the future, it would be better to keep the Ansible installation completely separate from Magma's Python dependencies. I created a [follow-up issue](https://github.com/magma/magma/issues/13160) for that. 

## Test Plan

- [x] Install release v1.6 with this change on a VM.
- [x] Install release v1.7 with this change on a VM.

## Additional Information

This change needs to be backported to all supported releases. 

- [ ] This change is backwards-breaking