### PR TITLE
ci(dp): Fix paths in job path_filter

### DIFF
--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -35,7 +35,7 @@ jobs:
           filters: |
             cc:
               - '.github/workflows/dp-workflow.yml'
-              - 'dp/cloud/python/configuration_controller/**'
+              - 'dp/cloud/python/magma/configuration_controller/**'
               - 'dp/cloud/docker/python/configuration_controller/**'
               - 'dp/cloud/python/magma/db_service/**'
               - 'dp/cloud/python/magma/fluentd_client/**'
@@ -52,7 +52,7 @@ jobs:
               - 'dp/cloud/go/active_mode_controller/protos'
             rc:
               - '.github/workflows/dp-workflow.yml'
-              - 'dp/cloud/python/radio_controller/**'
+              - 'dp/cloud/python/magma/radio_controller/**'
               - 'dp/cloud/docker/python/radio_controller/**'
               - 'dp/cloud/python/magma/db_service/**'
               - 'dp/cloud/python/magma/fluentd_client/**'


### PR DESCRIPTION
* Corrected mistake in paths used as filters for job selection, which
caused Domain Proxy unit tests be skipped when application code for
Configuration Controller and Radio Controller was modified.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

We noticed that Domain Proxy workflow was skipping unit tests for Domain Proxy components when changes where made just for python application code. For example PR #13145 did not run unit tests for Radio Controller, effectively leading to a false-positive CI report which then in turn got merged and broke the code, as the PR had a mistake.

This PR corrects the dp-workflow job path_filter paths to Domain Proxy python code.

## Additional Information

- [ ] This change is backwards-breaking