### PR TITLE
docs: fix broken community link

### DIFF
--- a/docs/docusaurus/siteConfig.js
+++ b/docs/docusaurus/siteConfig.js
@@ -35,7 +35,7 @@ const siteConfig = {
     {label: ' | '},
     {href: 'https://github.com/magma', label: 'Code'},
     {label: ' | '},
-    {href: 'https://magmacore.org/community', label: 'Community'},
+    {href: 'https://magmacore.org/join-the-open-source-community', label: 'Community'},
   ],
 
   // Path to images for header/footer


### PR DESCRIPTION
## Summary

Fixes https://github.com/magma/magma/issues/13163.

## Test Plan

- `magma/docs $ make dev` + manually tested link