### PR TITLE
feat(ci): add reviewdog for markdownlint

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -136,6 +136,24 @@ jobs:
           reporter: github-pr-review
           workdir: 'nms/'
 
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code.
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+      - name: markdownlint
+        uses: reviewdog/action-markdownlint@v0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          filter_mode: added
+          reporter: github-pr-review
+          fail_on_error: false
+
   misspell:
     name: misspell
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

... to visualise the markdown errors in Github

## Test Plan

- CI:
  - :heavy_check_mark: [run](https://github.com/Neudrino/magma/actions/runs/2596962967) with [annotation of an error](https://github.com/Neudrino/magma/pull/5#discussion_r911967707)
  - :heavy_check_mark: [run](https://github.com/Neudrino/magma/actions/runs/2596986036) without annotation in diff