### PR TITLE
fix(agw): Pin Ansible version to fix installation [v1.7 backport]

### DIFF
--- a/lte/gateway/deploy/agw_install_ubuntu.sh
+++ b/lte/gateway/deploy/agw_install_ubuntu.sh
@@ -185,7 +185,7 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   apt-get -y install curl make virtualenv zip rsync git software-properties-common python3-pip python-dev apt-transport-https
 
   alias python=python3
-  pip3 install ansible
+  pip3 install ansible==5.10.0
 
   git clone "${GIT_URL}" /home/$MAGMA_USER/magma
   cd /home/$MAGMA_USER/magma || exit


### PR DESCRIPTION
## Summary

Backporting code from #13158 to v1.7 branch. See #13164 for the backport to v1.6.

## Test Plan

Release v1.7 was successfully installed with these changes as part of #13158.

## Additional Information

- [ ] This change is backwards-breaking
