### PR TITLE
fix: Document usage of Python 3.8 in Magma prerequisites.

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.7.0/basics/prerequisites.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/basics/prerequisites.md
@@ -123,11 +123,11 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
       exec "$SHELL"
       ```
 
-   5. Create python virtual environment version 3.7.3.
+   5. Create python virtual environment version 3.8.10.
 
       ```bash
-      pyenv install 3.7.3
-      pyenv global 3.7.3
+      pyenv install 3.8.10
+      pyenv global 3.8.10
       ```
 
 4. Install `pip3` and its dependencies.

--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -124,14 +124,14 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
       exec "$SHELL"
       ```
 
-   5. Create python virtual environment version 3.7.3.
+   5. Create python virtual environment version 3.8.10.
 
       ```bash
-      pyenv install 3.7.3
-      pyenv global 3.7.3
+      pyenv install 3.8.10
+      pyenv global 3.8.10
       ```
 
-        **Note**: The `pyenv` installation [might fail with a segmentation fault](https://github.com/pyenv/pyenv/issues/2046). Try using `CFLAGS="-O2" pyenv install 3.7.3` in that case.
+        **Note**: The `pyenv` installation [might fail with a segmentation fault](https://github.com/pyenv/pyenv/issues/2046). Try using `CFLAGS="-O2" pyenv install 3.8.10` in that case.
 
 4. Install `pip3` and its dependencies.
 


### PR DESCRIPTION
## Summary

Python 3.7 has not been used since release 1.7.0.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking