### PR TITLE
chore(agw): activate mypy code scanning in lte except integ_tests

### DIFF
--- a/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
+++ b/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
@@ -98,7 +98,7 @@ def check_rules(
     port: str,
     enodebd_public_ip: str,
     private_ip: str,
-) -> None:
+) -> bool:
     unexpected_rules = []
     expected_rules_present = False
     pattern = r'DNAT\s+tcp\s+--\s+anywhere\s+{pub_ip}\s+tcp\s+dpt:{dport} to:{ip}'.format(

--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -153,11 +153,10 @@ class StatsManager:
             logger.error("Couldn't find serial for ip", ip)
         return label
 
-    @asyncio.coroutine
-    def _post_and_put_handler(self, request) -> web.Response:
+    async def _post_and_put_handler(self, request) -> web.Response:
         """ HTTP POST handler """
         # Read request body and convert to XML tree
-        body = yield from request.read()
+        body = await request.read()
 
         root = ElementTree.fromstring(body)
         label = self._get_enb_label_from_request(request)

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -22,7 +22,7 @@ from concurrent.futures import Future
 from typing import List, OrderedDict
 
 import grpc
-from lte.protos import pipelined_pb2_grpc
+from lte.protos import pipelined_pb2_grpc  # type: ignore[attr-defined]
 from lte.protos.apn_pb2 import AggregatedMaximumBitrate
 from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.pipelined_pb2 import (

--- a/lte/gateway/python/magma/subscriberdb/protocols/m5g_auth_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/m5g_auth_servicer.py
@@ -14,7 +14,7 @@ limitations under the License.
 import logging
 
 from grpc import StatusCode
-from lte.protos import (
+from lte.protos import (  # type: ignore[attr-defined]
     diam_errors_pb2,
     subscriberauth_pb2,
     subscriberauth_pb2_grpc,

--- a/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
@@ -15,7 +15,11 @@ import logging
 from typing import NamedTuple
 
 import grpc
-from lte.protos import apn_pb2, subscriberdb_pb2, subscriberdb_pb2_grpc
+from lte.protos import (  # type: ignore[attr-defined]
+    apn_pb2,
+    subscriberdb_pb2,
+    subscriberdb_pb2_grpc,
+)
 from magma.common.rpc_utils import print_grpc, return_void
 from magma.subscriberdb.sid import SIDUtils
 from magma.subscriberdb.store.base import (

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -251,7 +251,7 @@ def _get_congestion_control_config(service_mconfig):
     return True
 
 
-def _get_converged_core_config(service_mconfig: object) -> bool:
+def _get_converged_core_config(service_mconfig: MME) -> bool:
     """Retrieve enable5g_features config value. If it does not exist it defaults to False. It gives precedence to the service_mconfig file.
 
     Args:
@@ -273,7 +273,7 @@ def _get_converged_core_config(service_mconfig: object) -> bool:
     return False
 
 
-def _get_default_slice_service_type_config(service_mconfig: object) -> str:
+def _get_default_slice_service_type_config(service_mconfig: MME) -> str:
     """Retrieve default_slice_service_type config value. If it does not exist, it defaults to DEFAULT_NGAP_S_NSSAI_SST.
 
     Args:
@@ -294,7 +294,7 @@ def _get_default_slice_service_type_config(service_mconfig: object) -> str:
     return service_mconfig.amf_default_slice_service_type or DEFAULT_NGAP_S_NSSAI_SST
 
 
-def _get_default_slice_differentiator_type_config(service_mconfig: object) -> str:
+def _get_default_slice_differentiator_type_config(service_mconfig: MME) -> str:
     """Retrieve default_slice_differentiator config value. If it does not exist it defaults to DEFAULT_NGAP_S_NSSAI_SD.
 
     Args:
@@ -313,7 +313,7 @@ def _get_default_slice_differentiator_type_config(service_mconfig: object) -> st
     return service_mconfig.amf_default_slice_differentiator or DEFAULT_NGAP_S_NSSAI_SD
 
 
-def _get_amf_name_config(service_mconfig: object) -> str:
+def _get_amf_name_config(service_mconfig: MME) -> str:
     """Retrieve amf_name config value. If it does not exist, it defaults to DEFAULT_NGAP_AMF_NAME.
 
     Args:
@@ -360,7 +360,7 @@ def _get_default_auth_timer_expire_msec() -> str:
     )
 
 
-def _get_default_dnn_config(service_mconfig: object) -> str:
+def _get_default_dnn_config(service_mconfig: MME) -> str:
     """Retrieve default_dnn config value. If it does not exist, it defaults to DEFAULT_DEFAULT_DNN.
 
     Args:
@@ -379,7 +379,7 @@ def _get_default_dnn_config(service_mconfig: object) -> str:
     return DEFAULT_DEFAULT_DNN
 
 
-def _get_amf_region_id(service_mconfig: object) -> str:
+def _get_amf_region_id(service_mconfig: MME) -> str:
     """Retrieve amf_region_id config value. If it does not exist it defaults to DEFAULT_NGAP_AMF_REGION_ID.
 
     Args:
@@ -398,7 +398,7 @@ def _get_amf_region_id(service_mconfig: object) -> str:
     return service_mconfig.amf_region_id or DEFAULT_NGAP_AMF_REGION_ID
 
 
-def _get_amf_set_id(service_mconfig: object) -> str:
+def _get_amf_set_id(service_mconfig: MME) -> str:
     """Retrieve amf_set_id config value. If it does not exist it defaults to DEFAULT_NGAP_SET_ID.
 
     Args:
@@ -417,7 +417,7 @@ def _get_amf_set_id(service_mconfig: object) -> str:
     return service_mconfig.amf_set_id or DEFAULT_NGAP_SET_ID
 
 
-def _get_amf_pointer(service_mconfig: object) -> str:
+def _get_amf_pointer(service_mconfig: MME) -> str:
     """Retrieve amf_pointer config value. If it does not exist it defaults to DEFAULT_NGAP_AMF_POINTER.
 
     Args:

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,8 +9,4 @@ install_types = True
 non_interactive = True
 exclude = (?x)(
           ^lte/gateway/python/integ_tests/ |
-          ^lte/gateway/python/magma/pipelined/ |
-          ^lte/gateway/python/magma/enodebd/ |
-          ^lte/gateway/python/magma/subscriberdb/protocols/m5g_auth_servicer.py$ |
-          ^lte/gateway/python/scripts/generate_oai_config.py$
           )


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

Active MyPy scanning for all Python code in `lte` except `integ_tests` (is part of a separate PR) and fix all MyPy related errors.

## Test Plan

```
vagrant@magma$ cd $MAGMA_ROOT/lte/gateway
vagrant@magma$ mypy --ignore-missing-imports python/magma/
```

```
vagrant@magma$ bazel test //lte/gateway/python:all
```

- [x] Verified S1AP Integration Tests

## Additional Information

This change is not backwards-breaking

