### PR TITLE
chore(agw): activate mypy code scanning for lte integ tests

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -14,7 +14,9 @@ limitations under the License.
 import ctypes
 import inspect
 import os
+import re
 import time
+from typing import List
 
 import s1ap_types
 from integ_tests.common.magmad_client import MagmadServiceGrpc
@@ -54,7 +56,7 @@ class TestWrapper(object):
     TEST_IP_BLOCK = "192.168.128.0/24"
     MSX_S1_RETRY = 2
     TEST_CASE_EXECUTION_COUNT = 0
-    TEST_ERROR_TRACEBACKS = []
+    TEST_ERROR_TRACEBACKS: List[str] = []
 
     def __init__(
         self,
@@ -490,7 +492,7 @@ class TestWrapper(object):
     def is_test_successful(cls, test) -> bool:
         """Get current test case execution status"""
         if test is None:
-            test = inspect.currentframe().f_back.f_back.f_locals["self"]
+            test = inspect.currentframe().f_back.f_back.f_locals["self"]  # type: ignore
         if test is not None and hasattr(test, "_outcome"):
             result = test.defaultTestResult()
             test._feedErrorsToResult(result, test._outcome.errors)
@@ -511,6 +513,7 @@ class TestWrapper(object):
                     else result.errors[0][1],
                 )
             return not (test_contains_error or test_contains_failure)
+        return False
 
     def cleanup(self, test=None):
         """Cleanup test setup after testcase execution"""

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_non_nat_dp_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_non_nat_dp_ul_tcp.py
@@ -22,9 +22,9 @@ from s1ap_utils import MagmadUtil
 class TestAttachDetachNonNatDpUlTcp(unittest.TestCase):
     """Integration Test: TestAttachDetachNonNatDpUlTcp"""
 
-    def __init__(self, method_name: str = ...) -> None:
+    def __init__(self) -> None:
         """Initialize unittest class"""
-        super().__init__(methodName=method_name)
+        super().__init__()
         self.magma_utils = MagmadUtil(None)
 
     def setUp(self):

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_messages.py
@@ -166,12 +166,12 @@ class TrafficMessage(object):
         stream.flush()
 
 
-# Enumerated type for TrafficRequest; module-level for pickling purposes
-TrafficRequestType = enum.unique(
-    enum.Enum(
-        'TrafficRequestType', 'EXIT SHUTDOWN START TEST',
-    ),
-)
+@enum.unique
+class TrafficRequestType(enum.Enum):
+    EXIT = 1
+    SHUTDOWN = 2
+    START = 3
+    TEST = 4
 
 
 class TrafficRequest(TrafficMessage):
@@ -191,12 +191,12 @@ class TrafficRequest(TrafficMessage):
         super(TrafficRequest, self).__init__(message, identifier, payload)
 
 
-# Enumerated type for TrafficResponse; module-level for pickling purposes
-TrafficResponseType = enum.unique(
-    enum.Enum(
-        'TrafficResponseType', 'INFO RESULTS SERVER STARTED',
-    ),
-)
+@enum.unique
+class TrafficResponseType(enum.Enum):
+    INFO = 1
+    RESULTS = 2
+    SERVER = 3
+    STARTED = 4
 
 
 class TrafficResponse(TrafficMessage):

--- a/lte/gateway/python/magma/pipelined/pg_set_session_msg.py
+++ b/lte/gateway/python/magma/pipelined/pg_set_session_msg.py
@@ -32,7 +32,7 @@ class CreateMMESessionUtils(ABC):
         vlan: int,
         in_teid: int,
         out_teid: int,
-        ue_state: int,
+        ue_state: str,
         flow_dl: str,
     ):
         """Do create the MME Sessions


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

The PR activates MyPy scanning for ` integ_tests` in lte and fixes all MyPy related errors.
MyPy version  0.971 is used.

## Test Plan

```
vagrant@magma$ cd $MAGMA_ROOT/lte/gateway
vagrant@magma$ mypy --ignore-missing-imports python/magma/
```

```
vagrant@magma$ bazel test //lte/gateway/python:all
```

- [x] Verified S1AP Integration Tests
Integ tests run successfully https://github.com/ajahl/magma/runs/7496395475?check_suite_focus=true
