### PR TITLE
fix(agw): Fixed root_versions

### DIFF
--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -1032,7 +1032,7 @@ def main(args):
 
     dep_source = gen_dep_sources(dep_set, pypi_only=args.force_pypi, py2=args.use_py2)
 
-    root_versions = {req.key: {'version': pip_distributions[k].version}
+    root_versions = {k: {'version': pip_distributions[k].version}
                      for k in [req.key for req in input_root_requirements]
                      if k not in [inst.key for inst in repo_installable]}
 


### PR DESCRIPTION
`root_versions` used `req.key` instead of `k` as the key

Signed-off-by: Moritz Huebner <moritz.huebner@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Logging out `root_versions` entry-by-entry before this change.

```
2022-07-05 06:01:00,121 [INFO ] __main__:main:1165 Listing root_versions:
2022-07-05 06:01:00,121 [INFO ] __main__:main:1167 websocket-client	{'version': '1.25.3'}
2022-07-05 06:01:00,121 [INFO ] __main__:main:1168 Stop listing root_versions:
```
Logging out `root_versions` entry-by-entry before after change.

```
2022-07-05 06:11:16,130 [INFO ] __main__:main:1159 Listing root_versions:
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 pyyaml	{'version': '5.3.1'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 aioeventlet	{'version': '0.5.1'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 chardet	{'version': '3.0.4'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 cryptography	{'version': '2.8'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 docker	{'version': '4.0.2'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 idna	{'version': '2.8'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 jsonpointer	{'version': '2.0'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 jsonschema	{'version': '3.1.0'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 netifaces	{'version': '0.10.4'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 pycares	{'version': '3.1.1'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 requests	{'version': '2.22.0'}
2022-07-05 06:11:16,130 [INFO ] __main__:main:1161 setuptools	{'version': '49.6.0'}
2022-07-05 06:11:16,131 [INFO ] __main__:main:1161 systemd-python	{'version': '234'}
2022-07-05 06:11:16,131 [INFO ] __main__:main:1161 urllib3	{'version': '1.25.3'}
2022-07-05 06:11:16,131 [INFO ] __main__:main:1162 Stop listing root_versions:
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan

Run unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
