### PR TITLE
feat(enodebd): BaiCells QRTB and FreedomFi One Carrier Aggregation

### DIFF
--- a/lte/gateway/python/magma/enodebd/dp_client.py
+++ b/lte/gateway/python/magma/enodebd/dp_client.py
@@ -19,6 +19,7 @@ from dp.protos.cbsd_pb2 import (
 from dp.protos.cbsd_pb2_grpc import CbsdManagementStub
 from dp.protos.enodebd_dp_pb2 import CBSDRequest, CBSDStateResult
 from dp.protos.enodebd_dp_pb2_grpc import DPServiceStub
+from google.protobuf.json_format import MessageToJson
 from google.protobuf.wrappers_pb2 import (  # pylint: disable=no-name-in-module
     BoolValue,
     DoubleValue,
@@ -48,7 +49,11 @@ def get_cbsd_state(request: CBSDRequest) -> CBSDStateResult:
         return CBSDStateResult(radio_enabled=False)
     client = DPServiceStub(chan)
     try:
+        msg_json = MessageToJson(request, including_default_value_fields=True, preserving_proto_field_name=True)
+        logger.debug(f"Sending GetCBSDState request: {msg_json}")
         res = client.GetCBSDState(request, DEFAULT_GRPC_TIMEOUT)
+        msg_json = MessageToJson(res, including_default_value_fields=True, preserving_proto_field_name=True)
+        logger.debug(f"Received GetCBSDState reply: {msg_json}")
     except grpc.RpcError as err:
         logger.warning(
             "GetCBSDState error: [%s] %s",
@@ -116,7 +121,11 @@ def enodebd_update_cbsd(request: EnodebdUpdateCbsdRequest) -> UpdateCbsdResponse
         return UpdateCbsdResponse()
     client = CbsdManagementStub(chan)
     try:
+        msg_json = MessageToJson(request, including_default_value_fields=True, preserving_proto_field_name=True)
+        logger.debug(f"Sending EnodebdUpdateCbsd request: {msg_json}")
         res = client.EnodebdUpdateCbsd(request, DEFAULT_GRPC_TIMEOUT)
+        msg_json = MessageToJson(res, including_default_value_fields=True, preserving_proto_field_name=True)
+        logger.debug(f"Received EnodebdUpdateCbsd reply: {msg_json}")
     except grpc.RpcError as err:
         logger.warning(
             "EnodebdUpdateCbsd error: [%s] %s",


### PR DESCRIPTION
Added support for setting and configuring Carrier Aggregation
on BaiCells QRTB and FreedomFi One based on state results received from
Domain Proxy:
* Added Carrier Aggregation TR parameter nodes
* Changed TX power parameters on FreedomFi one (necessary to utilize Carrier Aggregation configuraion)
* Tweaked postprocessing on FreedomFi one to remove some TX related parameters from device desired config (band and earfcn has to be removed from the configuration, since it may be set in the eNB RAN config in NMS/Orc8r and may initially overwrite domain proxy configuration before `enodebd` manages to ask for Domain Proxy state and acquire correct TX parameters)

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

Extended and modified BaiCells QRTB and FreedomFi One devices models in `enodebd` to support Carrier Aggregation configuration based on Domain Proxy responses.

Domain Proxy may obtain many LTE channel grants from SAS servers. As a result, `enodebd` device "drivers" will query Domain Proxy for CBSD state, and may receive a reply containing many LTE channels.
If Domain Proxy response contains 2 or more channels, and explicitly enables carrier aggregation, Carrier Aggregation will be attempted to be configured on the respective eNBs.

In case Domain Proxy responses do no allow setting Carrier Aggregation (only 1 channel, carrier aggregation explicitly disabled), `enodebd` will reconfigure the eNB to parameters derived from the available channel and set eNB to work in Single Carrier mode - this behavior was suggested by both BaiCells (for eNBs running QRTB firmware) and Sercomm (for FreedomFi One Englewood and HGO)

## Test Plan

Extended unit testing for all supported scenarios.
Tested `enodebd` code contained in this PR with 1 BaiCells unit (Software Version: QRTB 2.8.15) and Sercomm Englewood (Software Version: RC3925@2204201602). Testing included simulations of Domain Proxy responses (0 channel response, 1 channel response, 2 channel response with CA-incompatible channels, 2 channels with CA-compatible channels) and verified transmission on each case.

## Additional Information

Domain Proxy does not yet implement obtaining multiple SAS grants for CBSDs. However the `enodebd` gRPC API is already prepared as it returns a `LTEChannel` array in the state response - but for the time being, the array will now only contain 1 channel, so the code will be "unused".
Once Domain Proxy implementation finishes multiple grant support, the extra functionality in this PR will be fully utilized.

- [ ] This change is backwards-breaking