### PR TITLE
fix(ci): full path required for misspell excludes

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -172,7 +172,7 @@ jobs:
           reporter: github-pr-review
           locale: "US"
           exclude: |
-            nms/yarn.lock
+            ./nms/yarn.lock
 
   mypy:
     needs: files_changed


### PR DESCRIPTION
It seems, as if excludes for misspell need fully qualified path names.
The documentation does not specify this explicitly, but [the examples also seem to indicate it](https://github.com/reviewdog/action-misspell#exclude).

![Log from job](https://user-images.githubusercontent.com/13189449/177329112-84d76cef-0281-45c1-9e2f-28692ec9bbfd.png)

