### PR TITLE
feat(ci): create cleanup GH workflow

### DIFF
--- a/.github/workflows/cleanup-old-workflows.yml
+++ b/.github/workflows/cleanup-old-workflows.yml
@@ -1,0 +1,26 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Cleanup Github Workflows"
+
+on:
+  schedule:
+    - cron: '42 * * * *'
+
+jobs:
+  cleanup-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Mattraks/delete-workflow-runs@c1a2f0de3fa4134a2357de83c92acff6e298bb8a # pin@v2.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          retain_days: 90
+          keep_minimum_runs: 0


### PR DESCRIPTION
... to cleanup the mess in the Github actions tab.

Using [Delete Workflow Runs](https://github.com/marketplace/actions/delete-workflow-runs) Github Action.

`keep_minimum_runs` needs to be set to `0` to also clean up those workflow runs which were generated by some manual tests from forks or outdated workflows from old releases.

Fixes https://github.com/magma/magma/issues/13199.
