### PR TITLE
docs: Amendments to AGW installation instructions

### DIFF
--- a/docs/readmes/lte/deploy_install.md
+++ b/docs/readmes/lte/deploy_install.md
@@ -14,43 +14,44 @@ To set up a Magma Access Gateway, you will need a machine that
 satisfies the following requirements:
 
 - AGW_HOST: 64bit-X86 machine, baremetal strongly recommended
-  (not virtualized). You will need two ethernet ports. We use
-  `enp1s0` and `enp2s0` in this guide.
-    - `enp1s0`: Will carry any traffic that is not S1. So data plane traffic (SGi)
-    control plane traffic (Orc8r HTTP2), management (ssh)
+  (not virtualized). You will need two ethernet ports. In this guide,
+  `enp1s0` and `enp2s0` are used:
+    - `enp1s0`: Will carry any traffic that is not S1. That is, data plane traffic (SGi),
+    control plane traffic (Orc8r HTTP2) and management (ssh).
     - `enp2s0`: S1 interface.
 
-  *Note interface names might have different names on your hardware so just
-  replace `enp1s0` and `enp2s0` with your current interfaces name
-  in this guideline.
-
-  *Note that the `agw_install_ubuntu.sh` script will rename the `enp1s0`
-   interface to `eth0`.
-
-  *Note if you don't want all internet traffic to go through `enp1s0`
-  to separate control plane (Orc8r Http2 traffic) from user plane, you
-  may want to add another interface and configure proper routing.
+> NOTE:
+>
+> - Interface names might have different names on your hardware, so just
+>   replace `enp1s0` and `enp2s0` with your current interface names
+>   when following this guide.
+>
+> - The `agw_install_ubuntu.sh` script will rename the `enp1s0`
+>   interface to `eth0`.
+>
+> - If you do not want all internet traffic to go through `enp1s0`
+>  to separate control plane (Orc8r Http2 traffic) from user plane, you
+>  may want to add another interface and configure proper routing.
 
 ## Deployment
 
 ### 1. Create boot USB stick and install Ubuntu on your AGW host
 
-- Download the Ubuntu Server 20.04 LTS .iso image from the Ubuntu website
-- Create bootable usb using etcher [tutorial here](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos#0)
+- Download the Ubuntu Server 20.04 LTS `.iso` image from the Ubuntu website
+- Create a bootable USB using this [Etcher tutorial](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos#0)
 - Boot your AGW host from USB
-  (Press F11 to select boot sequence, :warning: This might be different for
-  your machine). If you see 2 options to boot from USB, select the non-UEFI
-  option.
-- Install and configure you access gateway according to your network defaults.
-    - Make sure to enable ssh server and utilities (untick every other)
+    - Press F11 to select boot sequence. WARNING: This might be different for your machine.
+    - If you see two options to boot from USB, select the non-UEFI option.
+- Install and configure your Access Gateway according to your network defaults.
+    - Make sure to enable ssh server and utilities (untick every other).
 - Connect your SGi interface to the internet and select this port during the
 installation process to get an IP using DHCP.
 
-### 2. Deploy magma on the  AGW_HOST
+### 2. Deploy magma on the AGW_HOST
 
 #### Run AGW installation
 
-To install on server with DHCP configured SGi interface.
+To install on a server with a DHCP-configured SGi interface
 
 ```bash
 su
@@ -58,8 +59,8 @@ wget https://raw.githubusercontent.com/magma/magma/v1.6/lte/gateway/deploy/agw_i
 bash agw_install_ubuntu.sh
 ```
 
-To Install on server with statically allocated SGi interface. Fow example:
-SGi has 1.1.1.1/24 IP and upstream router IP is 1.1.1.200
+To install on a server with statically-allocated SGi interface. For example,
+if SGi has an IP of 1.1.1.1/24 and the upstream router IP is 1.1.1.200
 
 ```bash
 su
@@ -67,9 +68,9 @@ wget https://raw.githubusercontent.com/magma/magma/v1.6/lte/gateway/deploy/agw_i
 bash agw_install_ubuntu.sh 1.1.1.1/24 1.1.1.200
 ```
 
-The script will run a pre-check script that will prompt you what will change
-on your machine. If you're okay with those changes reply `yes` and magma will
-be installed. If `no` is replied It will stop the installation.
+The script will run a pre-check script that will tell you what will change on your machine
+and prompt you for your approval. If you are okay with these changes, reply `yes` and magma will
+be installed. If you respond with `no`, the installation will be stopped.
 
 ```bash
   - Check if Ubuntu is installed
@@ -81,25 +82,25 @@ be installed. If `no` is replied It will stop the installation.
   eth0 will be set to dhcp and eth1 10.0.2.1
   Do you accept those modifications and want to proceed with magma installation?(y/n)
   Please answer yes or no.
-  ```
+```
 
-The machine will reboot but It's not finished yet, the script is still running in the background.
-You can follow the output there
+The machine will reboot but the installation is not finished yet; the script is still running in the background.
+You can follow the output using
 
 ```bash
 journalctl -fu agw_installation
 ```
 
-When you see "AGW installation is done." It means that your AGW installation is done, you can make sure magma is running by executing:
+When you see "AGW installation is done.", it means that your installation is complete. You can make sure magma is running by executing
 
 ```bash
 service magma@* status
 ```
 
-#### Post Install Check
+#### Post-install check
 
-Make sure you have `control_proxy.yml` file in directory /var/opt/magma/configs/
-before running post install script.
+Make sure you have the `control_proxy.yml` file in directory `/var/opt/magma/configs/`
+before running the post-install script
 
 ```bash
 bash /root/agw_post_install_ubuntu.sh


### PR DESCRIPTION
## Summary

Some minor changes to the [Install Access Gateway on Ubuntu (Bare Metal) page](https://magma.github.io/magma/docs/next/lte/deploy_install) that I made when reading through the instructions.

## Test Plan

- [x] `cd magma/docs && make precommit`