### PR TITLE
chore: remove experimental_strict_action_env option from bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,7 +9,6 @@ build:production --config=lsan --strip=never --copt=-O3
 
 # C/C++ CONFIGS
 build --cxxopt=-std=c++14
-build --experimental_strict_action_env
 build --compilation_mode=dbg
 
 # DEFAULT TEST CONFIGURATION


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The bazel option `--experimental_strict_action_env` is removed from the `.bazelrc`
 - This option was introduced in https://github.com/magma/magma/pull/10642 to wrap some bazel commands in Make targets
   - The Make targets do not seem to be used in CI but may be convenient for local development

## Test Plan

- CI
- Run the Make targets `build_c`, `test_c` and `build_oai_clang`.
  - The Make calls need to happen in `magma/lte/gateway`, however there is currently a bug (see issue https://github.com/magma/magma/issues/13102) which requires a slight modification of the `.bazelrc` for testing.
  - The line `import bazel/bazelrcs/cache.bazelrc` needs to be replaced by `import /home/vagrant/magma/bazel/bazelrcs/cache.bazelrc` for testing inside the magma-vm.
  - Builds are successful and no change in behaviour is observed compared to the run with the flag.

## Additional Information
- The initial run of the bazel workflow is very slow on this PR because the removal of the flag prevents most cache hits. ~~Once the cache is filled on master the build time should be unaffected.~~ 
   - I filled the cache from the fork and now the workflow has a normal runtime. 
- The option has been renamed to `incompatible_strict_action_env` (see https://github.com/bazelbuild/bazel/issues/6648)
- The option has the following description in the current [docs](https://bazel.build/reference/command-line-reference):
![Screenshot from 2022-07-05 16-35-06](https://user-images.githubusercontent.com/34488763/177353184-5841630e-c481-4cf9-88f2-770fae050f6b.png)
  - Since we have a relatively reproducible build environment in CI it should not affect the cache hits once they are generated without this flag.
  - :warning: It might be good to monitor the remote cache hits in the weeks following a potential merge of this PR.
- We specify `build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always` in the current `.bazelrc`

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
