### PR TITLE
chore(dp): Use magma artifactory in DP helm chart

### DIFF
--- a/dp/cloud/docker/fluentd/Dockerfile
+++ b/dp/cloud/docker/fluentd/Dockerfile
@@ -1,4 +1,0 @@
-FROM fluent/fluentd:v1.7-1
-USER root
-RUN ["fluent-gem", "install", "fluent-plugin-multi-format-parser:1.0.0"]
-USER fluent

--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/minikube_values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/minikube_values.yaml
@@ -217,11 +217,6 @@ dp:
       name: ""
 
   fluentd:
-    image:
-      repository: fluentd
-      tag: ""
-      pullPolicy: IfNotPresent
-
     env:
       output_host: orc8r-fluentd-forward
       output_flush_interval: 1s

--- a/dp/cloud/helm/dp/charts/domain-proxy/values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/values.yaml
@@ -29,9 +29,9 @@ dp:
     name: configuration-controller  # Domain proxy component name.
 
     image:
-      repository: configuration-controller  # Docker image repository.
+      repository: docker.artifactory.magmacore.org/configuration-controller  # Docker image repository.
       pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
-      tag: ""  # Overrides the image tag whose default is the chart appVersion.
+      tag: "1.7.0"
 
     replicaCount: 1  # How many replicas of particular component should be created.
 
@@ -156,8 +156,8 @@ dp:
     name: radio-controller  # Domain proxy component name.
 
     image:
-      repository: radio-controller  # Docker image repository.
-      tag: ""  # Overrides the image tag whose default is the chart appVersion.
+      repository: docker.artifactory.magmacore.org/radio-controller  # Docker image repository.
+      tag: "1.7.0"
       pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
 
     replicaCount: 1  # How many replicas of particular component should be created.
@@ -235,8 +235,8 @@ dp:
     name: active-mode-controller  # Domain proxy component name.
 
     image:
-      repository: active-mode-controller  # Docker image repository.
-      tag: ""  # Overrides the image tag whose default is the chart appVersion.
+      repository: docker.artifactory.magmacore.org/active-mode-controller  # Docker image repository.
+      tag: "1.7.0"
       pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
 
     replicaCount: 1  # How many replicas of particular component should be created.
@@ -325,9 +325,9 @@ dp:
     name: db-service  # Domain proxy component name.
 
     image:
-      repository: db-service  # Docker image repository.
+      repository: docker.artifactory.magmacore.org/db-service  # Docker image repository.
       pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
-      tag: ""  # Overrides the image tag whose default is the chart appVersion.
+      tag: "1.7.0"
 
     imagePullSecrets: []  # Name of the secret that contains container image registry keys
 
@@ -343,9 +343,9 @@ dp:
     name: fluentd  # Domain proxy component name.
 
     image:
-      repository: fluentd  # Docker image repository.
+      repository: fluent/fluentd  # Docker image repository.
       pullPolicy: IfNotPresent  # Default the pull policy of all containers in that pod.
-      tag: ""  # Overrides the image tag whose default is the chart appVersion.
+      tag: "v1.7-1"
 
     imagePullSecrets: []  # Name of the secret that contains container image registry keys
 

--- a/dp/skaffold.yaml
+++ b/dp/skaffold.yaml
@@ -31,10 +31,6 @@ build:
       context: tools/fake_sas
       docker:
         dockerfile: Dockerfile
-    - image: fluentd
-      context: ..
-      docker:
-        dockerfile: dp/cloud/docker/fluentd/Dockerfile
     - image: fluentd_forward
       context: ..
       docker:
@@ -82,8 +78,6 @@ deploy:
             image: radio-controller
           dp.db_service:
             image: db-service
-          dp.fluentd:
-            image: fluentd
         imageStrategy:
           helm: {}
   kubectl:
@@ -310,4 +304,6 @@ profiles:
       - op: remove
         path: /build/artifacts/4  # remove fake sas image
       - op: remove
-        path: /build/artifacts/6  # remove postgresql image
+        path: /build/artifacts/4  # remove fluentd-forward image
+      - op: remove
+        path: /build/artifacts/4  # remove postgresql image


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Currently, the Domain-proxy helm chart doesn't point to any external registry, so it will be not possible to install it, if images are not available locally. Rather than the Magma artifactory should be used here

<!-- Enumerate changes you made and why you made them -->
## Test plan
- [x] Take care to put images in Magma artifactory
- [x] Try to install the domain-proxy helm chart