### PR TITLE
chore(agw): adapt gateway_subscriber_state format

### DIFF
--- a/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
+++ b/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
@@ -47,7 +47,6 @@ OpState get_operational_states(magma::lte::SessionStore* session_store) {
     std::map<std::string, std::string> state;
     state[TYPE] = SUBSCRIBER_STATE_TYPE;
     state[DEVICE_ID] = it.first;
-    subscribers[state[DEVICE_ID]] = nlohmann::json::array();
     nlohmann::json sessions_by_apn = nlohmann::json::object();
 
     for (auto& session : it.second) {
@@ -59,7 +58,7 @@ OpState get_operational_states(magma::lte::SessionStore* session_store) {
     }
     state[VALUE] = sessions_by_apn.dump();
     states.push_back(state);
-    subscribers[state[DEVICE_ID]].push_back(sessions_by_apn);
+    subscribers[state[DEVICE_ID]] = sessions_by_apn;
   }
   std::map<std::string, std::string> gateway_subscriber_state;
   gateway_subscriber_state[TYPE] = GATEWAY_SUBSCRIBER_STATE_TYPE;

--- a/lte/gateway/c/session_manager/test/test_operational_states_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_operational_states_handler.cpp
@@ -85,22 +85,25 @@ TEST_F(OperationalStatesHandlerTest, test_get_operational_states) {
       EXPECT_FALSE(subscriber_state_it == subscriber_state.end());
       json_value = nlohmann::json::parse(subscriber_state_it->second);
       nlohmann::json gateway_subscribers = json_value[SUBSCRIBERS];
-      nlohmann::json content = gateway_subscribers[IMSI1];
-      content = content[0][APN1];
-      EXPECT_EQ(content[0]["lifecycle_state"],
+      nlohmann::json content = gateway_subscribers[IMSI1][APN1];
+      EXPECT_EQ(content.size(), 1);
+      content = content[0];
+      EXPECT_EQ(content["lifecycle_state"],
                 session_fsm_state_to_str(SESSION_ACTIVE));
-      EXPECT_EQ(content[0]["session_start_time"], SESSION_START_TIME_1);
-      EXPECT_EQ(content[0]["apn"], APN1);
-      EXPECT_EQ(content[0]["ipv4"], IP1);
-      EXPECT_EQ(content[0]["session_id"], SESSION_ID_1);
-      content = gateway_subscribers[IMSI2];
-      content = content[0][APN1];
-      EXPECT_EQ(content[0]["lifecycle_state"],
+      EXPECT_EQ(content["session_start_time"], SESSION_START_TIME_1);
+      EXPECT_EQ(content["apn"], APN1);
+      EXPECT_EQ(content["ipv4"], IP1);
+      EXPECT_EQ(content["session_id"], SESSION_ID_1);
+
+      content = gateway_subscribers[IMSI2][APN1];
+      EXPECT_EQ(content.size(), 1);
+      content = content[0];
+      EXPECT_EQ(content["lifecycle_state"],
                 session_fsm_state_to_str(SESSION_ACTIVE));
-      EXPECT_EQ(content[0]["session_start_time"], SESSION_START_TIME_2);
-      EXPECT_EQ(content[0]["apn"], APN1);
-      EXPECT_EQ(content[0]["ipv4"], IP2);
-      EXPECT_EQ(content[0]["session_id"], SESSION_ID_2);
+      EXPECT_EQ(content["session_start_time"], SESSION_START_TIME_2);
+      EXPECT_EQ(content["apn"], APN1);
+      EXPECT_EQ(content["ipv4"], IP2);
+      EXPECT_EQ(content["session_id"], SESSION_ID_2);
       break;
     }
   }


### PR DESCRIPTION
## Summary

To fix a deserializing error that occurred in an [e2e test ](https://github.com/magma/magma/pull/13151)with agw integ tests, the outer array in the gateway_subscriber_state is removed. 

## Test Plan

Going back to the example from the [original implementation](https://github.com/magma/magma/pull/12952), we basically change the following to make sure the entries for each IMSI exactly match the previous split `subscriber_state`:

```diff
{
    "subscribers": {
-        "IMSI001010000000002": [
+        "IMSI001010000000002": {
            {
                "magma.ipv4": [
                    {
                        "active_policy_rules": [
                            "{\"id\":\"allowlist_sid-IMSI001010000000002-magma.ipv4\",\"priority\":2,\"flowList\":[{\"match\":{}},{\"match\":{\"direction\":\"DOWNLINK\"}}],\"trackingType\":\"NO_TRACKING\"}"
                        ],
                        "active_duration_sec": 129,
                        "lifecycle_state": "SESSION_ACTIVE",
                        "session_start_time": 1654872554,
                        "apn": "magma.ipv4",
                        "ipv4": "192.168.128.13",
                        "msisdn": "",
                        "session_id": "IMSI001010000000002-320023"
                    }
                ]
            }
-        ],
-        "IMSI001010000000001": [
+        },
+        "IMSI001010000000001": {
            {
                "magma.ipv4": [
                    {
                        "active_policy_rules": [
                            "{\"id\":\"allowlist_sid-IMSI001010000000001-magma.ipv4\",\"priority\":2,\"flowList\":[{\"match\":{}},{\"match\":{\"direction\":\"DOWNLINK\"}}],\"trackingType\":\"NO_TRACKING\"}"
                        ],
                        "active_duration_sec": 129,
                        "lifecycle_state": "SESSION_ACTIVE",
                        "session_start_time": 1654872554,
                        "apn": "magma.ipv4",
                        "ipv4": "192.168.128.12",
                        "msisdn": "",
                        "session_id": "IMSI001010000000001-612699"
                    }
                ]
            }
-        ]
+        }
    }
}
```

## Additional Information

- Done in pairing with @sebathomas.

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
