### PR TITLE
fix(orc8r): Add PKCS#8 support to ReadKey func

### DIFF
--- a/orc8r/lib/go/security/key/key.go
+++ b/orc8r/lib/go/security/key/key.go
@@ -94,6 +94,8 @@ func ReadKey(keyFile string) (priv interface{}, err error) {
 		priv, err = x509.ParsePKCS1PrivateKey(pemKey.Bytes)
 	case "EC PRIVATE KEY":
 		priv, err = x509.ParseECPrivateKey(pemKey.Bytes)
+	case "PRIVATE KEY":
+		priv, err = x509.ParsePKCS8PrivateKey(pemKey.Bytes)
 	default:
 		err = fmt.Errorf("Key type %s is not supported.", pemKey.Type)
 		priv = nil


### PR DESCRIPTION
Signed-off-by: Jarosław Jaszczuk <jaroslaw.jaszczuk@codilime.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
#### Problem
Magma scripts use `openssl genrsa -out {FILENAME} 2048` command to generate RSA keys. OpenSSL currently supports 1.1.1 and 3.0 versions. When generating RSA private keys OpenSSL 1.1.1 uses PKCS#1 by default, but OpenSSL 3.0 uses PKCS#8, which is not supported by Orc8r `ReadKey` function.

If key was generated using new OpenSSL it causes an error when starting the bootstrapper:
```
F0706 11:04:39.642362       1 main.go:66] error reading bootstrapper private key: Failed to parse key from file /var/opt/magma/certs/bootstrapper.key: Key type PRIVATE KEY is not supported.
```
#### Solution
`x509` used for parsing keys by Orc8r supports PKCS#8 private keys and indicates to use its `ParsePKCS8PrivateKey` function for PEM blocks of type `PRIVATE KEY`, so adding new case for this key type resloves the issue.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] bootstrapper starts successfully using key generated with OpenSSL 3.0.2
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
