### PR TITLE
fix(agw): change regexp to accept flow and ip address

### DIFF
--- a/lte/gateway/python/magma/pipelined/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/BUILD.bazel
@@ -49,16 +49,25 @@ py_library(
     srcs = [
         "check_quota_server.py",
         "datapath_setup.py",
-        "gtp_stats_collector.py",
         "ifaces.py",
     ],
     deps = [
+        ":gtp_stats_collector",
         ":rpc_servicer",
         ":service_manager",
         "//lte/gateway/python/magma/pipelined/app:uplink_bridge",
-        "//orc8r/gateway/python/magma/magmad/check:subprocess_workflow",
         requirement("flask"),
         requirement("wsgiserver"),
+    ],
+)
+
+py_library(
+    name = "gtp_stats_collector",
+    srcs = ["gtp_stats_collector.py"],
+    deps = [
+        ":metrics",
+        "//orc8r/gateway/python/magma/common:job",
+        "//orc8r/gateway/python/magma/magmad/check:subprocess_workflow",
     ],
 )
 

--- a/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
+++ b/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
@@ -42,10 +42,10 @@ class OVSDBCommandResult(NamedTuple):
 
 
 interface_group = r"(?P<Interface>\w+)"
-remote_ip_group = r"(?P<remote_ip>.*)"
+remote_ip_group = r"[\"]?(?P<remote_ip>[^}\"]*)"
 rx_bytes_group = r"(?P<rx_bytes>\d+)"
 tx_bytes_group = r"(?P<tx_bytes>\d+)"
-stats_re_str = r'{}(.*)(remote_ip="{}")(.*)?rx_bytes={}.+tx_bytes={}'
+stats_re_str = r'{}(.*)(remote_ip={})(.*)?rx_bytes={}.+tx_bytes={}'
 
 interface_tx_rx_stats_re = re.compile(
     stats_re_str.format(
@@ -116,37 +116,13 @@ def _parse_ovsdb_dump_output(
         ValueError: If any errors are encountered while parsing output.
     """
 
-    def create_error_result(error_msg):
-        return OVSDBCommandResult(
-            out='',
-            err=error_msg,
-        )
-
-    def find_header_line_idx(lines):
-        line_re = re.compile('^---.+$')
-        for i, line in enumerate(lines):
-            if line_re.match(line):
-                return i
-        raise ValueError('Could not find header in ovsdb-client output')
-
-    def match_gtp_lines(lines):
-        line_matches = []
-        for line in lines:
-            line_remote_ip_match = interface_tx_rx_stats_re.match(line)
-            if line_remote_ip_match:
-                match_dict = line_remote_ip_match.groupdict()
-                if not 'remote_ip' in match_dict:
-                    match_dict['remote_ip'] = ""
-                line_matches.append(match_dict)
-        return line_matches
-
     if stderr:
-        return create_error_result(stderr)
+        return _create_error_result(stderr)
 
     try:
         stdout_lines = stdout.decode('ascii').split('\n')
-        header_line_idx = find_header_line_idx(stdout_lines)
-        gtp_matches = match_gtp_lines(stdout_lines[header_line_idx + 1:])
+        header_line_idx = _find_header_line_idx(stdout_lines)
+        gtp_matches = _match_gtp_lines(stdout_lines[header_line_idx + 1:])
 
         results = []
         for m in gtp_matches:
@@ -157,4 +133,31 @@ def _parse_ovsdb_dump_output(
             err=None,
         )
     except ValueError as e:
-        return create_error_result(str(e.args[0]))
+        return _create_error_result(str(e.args[0]))
+
+
+def _create_error_result(error_msg):
+    return OVSDBCommandResult(
+        out='',
+        err=error_msg,
+    )
+
+
+def _find_header_line_idx(lines):
+    line_re = re.compile('^---.+$')
+    for i, line in enumerate(lines):
+        if line_re.match(line):
+            return i
+    raise ValueError('Could not find header in ovsdb-client output')
+
+
+def _match_gtp_lines(lines):
+    line_matches = []
+    for line in lines:
+        line_remote_ip_match = interface_tx_rx_stats_re.match(line)
+        if line_remote_ip_match:
+            match_dict = line_remote_ip_match.groupdict()
+            if not 'remote_ip' in match_dict:
+                match_dict['remote_ip'] = ""
+            line_matches.append(match_dict)
+    return line_matches

--- a/lte/gateway/python/magma/pipelined/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/tests/BUILD.bazel
@@ -844,3 +844,14 @@ pytest_test(
         requirement("grpcio"),
     ],
 )
+
+pytest_test(
+    name = "test_gtp_stats_collector",
+    size = "small",
+    srcs = ["test_gtp_stats_collector.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    deps = ["//lte/gateway/python/magma/pipelined:gtp_stats_collector"],
+)

--- a/lte/gateway/python/magma/pipelined/tests/test_gtp_stats_collector.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_gtp_stats_collector.py
@@ -1,0 +1,51 @@
+"""
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+
+from magma.pipelined.gtp_stats_collector import _match_gtp_lines
+
+
+class GtpStatsCollecotrTest(unittest.TestCase):
+
+    def test_match_gtp_lines(self):
+        """
+        Verifies that correct lines are matched and groups are captured.
+        """
+
+        # test input taken from https://github.com/magma/magma/issues/8926
+        test_lines = [
+            "dhcp0        {}                                 {collisions=0, rx_bytes=2639990, rx_crc_err=0, rx_dropped=0, rx_errors=0, rx_frame_err=0, rx_missed_errors=0, rx_over_err=0, rx_packets=62842, tx_bytes=25926, tx_dropped=0, tx_errors=0, tx_packets=369}",
+            "eth1.1506    {}                                 {collisions=0, rx_bytes=586074454, rx_crc_err=0, rx_dropped=0, rx_errors=0, rx_frame_err=0, rx_missed_errors=0, rx_over_err=0, rx_packets=1123201, tx_bytes=1654735320, tx_dropped=0, tx_errors=0, tx_packets=1681111}",
+            "g_2509330a   {key=flow, remote_ip=\"10.51.9.37\"} {rx_bytes=737220973, rx_packets=552257, tx_bytes=16652981, tx_packets=277380}",
+            "gtp0         {key=flow, remote_ip=flow}         {rx_bytes=0, rx_packets=0, tx_bytes=0, tx_packets=0}",
+            "gtp_br0      {}                                 {collisions=0, rx_bytes=300, rx_crc_err=0, rx_dropped=5, rx_errors=0, rx_frame_err=0, rx_missed_errors=0, rx_over_err=0, rx_packets=4, tx_bytes=1076, tx_dropped=0, tx_errors=0, tx_packets=14}",
+            "ipfix0       {}                                 {collisions=0, rx_bytes=376, rx_crc_err=0, rx_dropped=0, rx_errors=0, rx_frame_err=0, rx_missed_errors=0, rx_over_err=0, rx_packets=5, tx_bytes=1076, tx_dropped=0, tx_errors=0, tx_packets=14}",
+            "li_port      {}                                 {collisions=0, rx_bytes=300, rx_crc_err=0, rx_dropped=0, rx_errors=0, rx_frame_err=0, rx_missed_errors=0, rx_over_err=0, rx_packets=4, tx_bytes=1076, tx_dropped=0, tx_errors=0, tx_packets=14}",
+            "mtr0         {}                                 {collisions=0, rx_bytes=600, rx_crc_err=0, rx_dropped=0, rx_errors=0, rx_frame_err=0, rx_missed_errors=0, rx_over_err=0, rx_packets=8, tx_bytes=1076, tx_dropped=0, tx_errors=0, tx_packets=14}",
+            "patch-agw    {peer=patch-up}                    {rx_bytes=1629631587, rx_packets=1620630, tx_bytes=601730199, tx_packets=1122219}",
+            "patch-up     {peer=patch-agw}                   {rx_bytes=16657013, rx_packets=277443, tx_bytes=737205499, tx_packets=551224}",
+            "proxy_port   {}                                 {collisions=0, rx_bytes=4540665, rx_crc_err=0, rx_dropped=0, rx_errors=0, rx_frame_err=0, rx_missed_errors=0, rx_over_err=0, rx_packets=54539, tx_bytes=1727478, tx_dropped=13, tx_errors=0, tx_packets=19937}",
+            "uplink_br0   {}                                 {collisions=0, rx_bytes=2639914, rx_crc_err=0, rx_dropped=1, rx_errors=0, rx_frame_err=0, rx_missed_errors=0, rx_over_err=0, rx_packets=62841, tx_bytes=2664422, tx_dropped=0, tx_errors=0, tx_packets=63191}",
+            "vlan_pop_in  {}                                 {collisions=0, rx_bytes=25996, rx_crc_err=0, rx_dropped=0, rx_errors=0, rx_frame_err=0, rx_missed_errors=0, rx_over_err=0, rx_packets=370, tx_bytes=25996, tx_dropped=0, tx_errors=0, tx_packets=370}",
+            "vlan_pop_out {}                                 {collisions=0, rx_bytes=25996, rx_crc_err=0, rx_dropped=0, rx_errors=0, rx_frame_err=0, rx_missed_errors=0, rx_over_err=0, rx_packets=370, tx_bytes=25996, tx_dropped=0, tx_errors=0, tx_packets=370}",
+        ]
+
+        result = _match_gtp_lines(test_lines)
+
+        expected = [
+            {'Interface': 'g_2509330a', 'remote_ip': '10.51.9.37', 'rx_bytes': '737220973', 'tx_bytes': '16652981'},
+            {'Interface': 'gtp0', 'remote_ip': 'flow', 'rx_bytes': '0', 'tx_bytes': '0'},
+        ]
+
+        self.assertEqual(expected, result)


### PR DESCRIPTION
Signed-off-by: Paulo Henrique Calaes Oliveira <paulo@radtonics.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Change regular expression to accept "flow" and "ip-address". It was causing a bug on NMS as showed on the picture below:

![bugfix](https://user-images.githubusercontent.com/3208178/177611406-95c2c2ef-db21-4083-af95-88c71234cfac.png)

After fix:

![Screenshot from 2022-07-07 15-35-00](https://user-images.githubusercontent.com/3208178/177844962-c1a2398e-c234-409e-822d-fc5e65caa212.png)


Files changed:
- lte/gateway/python/magma/pipelined/gtp_stats_collector.py

## Test Plan

1. Open Metrics page in Orc8r
2. Open Gateways dashboard
3. On Download Throughput chart, click to explore and check if the value is correct

