### PR TITLE
fix(ci): Use same configuration for markdown linters

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -152,6 +152,7 @@ jobs:
           filter_mode: added
           reporter: github-pr-review
           fail_on_error: false
+          markdownlint_flags: "--config ./docs/readmes/.markdownlint.yaml"
 
   misspell:
     name: misspell


### PR DESCRIPTION
## Summary

There are two markdown linters in the CI (https://github.com/magma/magma/actions/workflows/docs-workflow.yml and https://github.com/magma/magma/actions/workflows/reviewdog-workflow.yml), which currently use different configurations. In particular, the former uses this file https://github.com/magma/magma/blob/master/docs/readmes/.markdownlint.yaml, while the latter uses default settings. This was noticed via https://github.com/magma/magma/pull/13198, in which 'Markdown lint check' passes but the reviewdog version has many complaints.

This PR fixes this by using the  .markdownlint.yaml` configuration file in the reviewdog workflow.