### PR TITLE
refactor(nms): Replace useRefreshingContext with useInterval for FEGGatewayContext

### DIFF
--- a/nms/app/components/context/FEGGatewayContext.ts
+++ b/nms/app/components/context/FEGGatewayContext.ts
@@ -24,6 +24,7 @@ export type FEGGatewayContextType = {
     val?: MutableFederationGateway,
     newState?: Record<string, FederationGateway>,
   ) => Promise<void>;
+  refetch: (id?: GatewayId) => void;
   health: Record<GatewayId, FederationGatewayHealthStatus>;
   activeFegGatewayId: GatewayId;
 };

--- a/nms/app/components/feg/FEGContext.tsx
+++ b/nms/app/components/feg/FEGContext.tsx
@@ -26,12 +26,14 @@ import type {
 import type {FederationGatewayHealthStatus} from '../GatewayUtils';
 
 import MagmaAPI from '../../api/MagmaAPI';
-import {FetchFegSubscriberState} from '../../state/feg/SubscriberState';
-import {GatewayId, NetworkId, NetworkType} from '../../../shared/types/network';
 import {
+  FetchFegGateway,
+  FetchFegGateways,
   InitGatewayState,
   SetGatewayState,
 } from '../../state/feg/EquipmentState';
+import {FetchFegSubscriberState} from '../../state/feg/SubscriberState';
+import {GatewayId, NetworkId, NetworkType} from '../../../shared/types/network';
 import {UpdateNetworkState as UpdateFegNetworkState} from '../../state/feg/NetworkState';
 import {useCallback, useEffect, useState} from 'react';
 import {useEnqueueSnackbar} from '../../hooks/useSnackbar';
@@ -129,7 +131,7 @@ export function FEGGatewayContextProvider(props: Props) {
     <FEGGatewayContext.Provider
       value={{
         state: fegGateways,
-        setState: (key, value?, newState?) => {
+        setState: (key, value?) => {
           return SetGatewayState({
             networkId,
             fegGateways,
@@ -139,9 +141,36 @@ export function FEGGatewayContextProvider(props: Props) {
             setActiveFegGatewayId,
             key,
             value,
-            newState,
             enqueueSnackbar,
           });
+        },
+        refetch: (id?: GatewayId) => {
+          if (id) {
+            void FetchFegGateway({id, networkId, enqueueSnackbar}).then(
+              response => {
+                if (response) {
+                  setFegGateways(gateways => ({
+                    ...gateways,
+                    [id]: response.fegGateway,
+                  }));
+                  setFegGatewaysHealthStatus(healthStatus => ({
+                    ...healthStatus,
+                    [id]: response.healthStatus,
+                  }));
+                }
+              },
+            );
+          } else {
+            void FetchFegGateways({networkId, enqueueSnackbar}).then(
+              response => {
+                if (response) {
+                  setFegGateways(response.fegGateways);
+                  setFegGatewaysHealthStatus(response.fegGatewaysHealthStatus);
+                  setActiveFegGatewayId(response.activeFegGatewayId);
+                }
+              },
+            );
+          }
         },
         health: fegGatewaysHealthStatus,
         activeFegGatewayId,

--- a/nms/app/components/feg/FEGGateways.tsx
+++ b/nms/app/components/feg/FEGGateways.tsx
@@ -103,7 +103,7 @@ function EditDialog(props: {
   );
 }
 
-function CWFGateways(props: WithAlert) {
+function FEGGateways(props: WithAlert) {
   const ctx = useContext(FEGGatewayContext);
   const [gateways, setGateways] = useState<Array<FederationGateway>>(
     Object.keys(ctx.state).map(gatewayId => ctx.state[gatewayId]),
@@ -218,4 +218,4 @@ function GatewayRow(props: {
   );
 }
 
-export default withAlert(CWFGateways);
+export default withAlert(FEGGateways);

--- a/nms/app/hooks/useSnackbar.tsx
+++ b/nms/app/hooks/useSnackbar.tsx
@@ -22,6 +22,8 @@ type AllowedConfig = {
   variant?: VariantType;
 } & OptionsObject;
 
+export type EnqueueSnackbar = (msg: string, cfg: OptionsObject) => SnackbarKey;
+
 export default function useSnackbar(
   message: string,
   config: AllowedConfig,
@@ -64,7 +66,7 @@ export default function useSnackbar(
   /*eslint-enable react-hooks/exhaustive-deps*/
 }
 
-export function useEnqueueSnackbar() {
+export function useEnqueueSnackbar(): EnqueueSnackbar {
   const {enqueueSnackbar} = useNotistackSnackbar();
   return useCallback(
     (message: string, config: OptionsObject) =>

--- a/nms/app/views/equipment/__tests__/FEGGatewayConnectionStatusTest.tsx
+++ b/nms/app/views/equipment/__tests__/FEGGatewayConnectionStatusTest.tsx
@@ -89,6 +89,7 @@ describe('<FEGGatewayConnectionStatus />', () => {
             value={{
               state: fegGateways,
               setState: async () => {},
+              refetch: () => {},
               health: fegGatewaysHealth,
               activeFegGatewayId: mockGw0.id,
             }}>

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.tsx
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.tsx
@@ -175,6 +175,7 @@ describe('<FEGGatewayDetailConfig />', () => {
             value={{
               state: fegGateways,
               setState: async () => {},
+              refetch: () => {},
               health: fegGatewaysHealth,
               activeFegGatewayId: mockGw0.id,
             }}>
@@ -208,7 +209,7 @@ describe('<FEGGatewayDetailConfig />', () => {
             <FEGGatewayContext.Provider
               value={{
                 state: fegGateways,
-                setState: async (key, value?, newState?) => {
+                setState: async (key, value?) => {
                   return SetGatewayState({
                     networkId: 'mynetwork',
                     fegGateways,
@@ -218,10 +219,10 @@ describe('<FEGGatewayDetailConfig />', () => {
                     setActiveFegGatewayId,
                     key,
                     value,
-                    newState,
                     enqueueSnackbar,
                   });
                 },
+                refetch: () => {},
                 health: fegGatewaysHealthStatus,
                 activeFegGatewayId: activeFegGatewayId,
               }}>

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.tsx
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.tsx
@@ -11,7 +11,6 @@
  * limitations under the License.
  */
 
-import * as hooks from '../../../components/context/RefreshContext';
 import FEGGatewayContext from '../../../components/context/FEGGatewayContext';
 import FEGGatewayDetailStatus from '../FEGGatewayDetailStatus';
 import MagmaAPI from '../../../api/MagmaAPI';
@@ -118,13 +117,6 @@ const mockCPUUsage: PromqlReturnObject = {
 };
 
 describe('<FEGGatewayDetailStatus />', () => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-  jest.spyOn(hooks, 'useRefreshingContext').mockImplementation((() => ({
-    fegGateways: fegGateways,
-    health: fegGatewaysHealth,
-    activeFegGatewayId: mockGw0.id,
-  })) as any);
-
   beforeEach(() => {
     // called when getting the CPU Usage
     mockAPI(
@@ -146,6 +138,7 @@ describe('<FEGGatewayDetailStatus />', () => {
             value={{
               state: fegGateways,
               setState: async () => {},
+              refetch: () => {},
               health: fegGatewaysHealth,
               activeFegGatewayId: mockGw0.id,
             }}>

--- a/nms/app/views/equipment/__tests__/FEGGatewaySummaryTest.tsx
+++ b/nms/app/views/equipment/__tests__/FEGGatewaySummaryTest.tsx
@@ -106,6 +106,7 @@ describe('<FEGEquipmentGateway />', () => {
             value={{
               state: fegGateways,
               setState: async () => {},
+              refetch: () => {},
               health: fegGatewaysHealth,
               activeFegGatewayId: mockGw0.id,
             }}>


### PR DESCRIPTION
Replaces `useRefreshingContext` with a simpler `useInterval` solution and a `refetch` method on the context.
This prevents potential state inconsistencies and leads to a better separation of concerns. 

- Fixes: #13219

## Testplan

* Go to the Equipment page for a FEG network
* Open the Gateways page for the same network in another tab
* Add a new FEG gateway
* Make sure it appears on the equipment page. Note: the error for the heath status is expect because the gateways doesn't really exist.
![Screenshot 2022-07-07 at 13 19 24](https://user-images.githubusercontent.com/102796295/177762237-7d0146e3-91f7-4402-8155-40486ee1fd54.png)

 
