### PR TITLE
refactor(nms): Replace useRefreshingContext with FEGSubscriberContext.refetch()

### DIFF
--- a/nms/app/components/context/FEGSubscriberContext.ts
+++ b/nms/app/components/context/FEGSubscriberContext.ts
@@ -16,6 +16,7 @@ import {NetworkId, SubscriberId} from '../../../shared/types/network';
 import {SubscriberState} from '../../../generated';
 
 export type FEGSubscriberContextType = {
+  refetch: () => void;
   sessionState: Record<NetworkId, Record<SubscriberId, SubscriberState>>;
   setSessionState: (
     newSessionState: Record<NetworkId, Record<SubscriberId, SubscriberState>>,

--- a/nms/app/components/context/RefreshContext.ts
+++ b/nms/app/components/context/RefreshContext.ts
@@ -11,11 +11,7 @@
  * limitations under the License.
  */
 
-import FEGSubscriberContext, {
-  FEGSubscriberContextType,
-} from './FEGSubscriberContext';
 import SubscriberContext, {SubscriberContextType} from './SubscriberContext';
-import {FetchFegSubscriberState} from '../../state/feg/SubscriberState';
 import {FetchSubscriberState} from '../../state/lte/SubscriberState';
 import {useContext, useEffect, useRef, useState} from 'react';
 import type {OptionsObject} from 'notistack';
@@ -29,15 +25,11 @@ export const RefreshTypeEnum = {
 
 type ContextMap = {
   [RefreshTypeEnum.SUBSCRIBER]: typeof SubscriberContext;
-  [RefreshTypeEnum.FEG_SUBSCRIBER]: typeof FEGSubscriberContext;
 };
 
 type StateMap = {
   [RefreshTypeEnum.SUBSCRIBER]: {
     sessionState: SubscriberContextType['sessionState'];
-  };
-  [RefreshTypeEnum.FEG_SUBSCRIBER]: {
-    sessionState: FEGSubscriberContextType['sessionState'];
   };
 };
 
@@ -65,10 +57,7 @@ export function useRefreshingContext<T extends keyof ContextMap>(
 ): StateMap[T] {
   const ctx: any = useContext(props.context as any);
   const initState = () => {
-    if (
-      props.type === RefreshTypeEnum.SUBSCRIBER ||
-      props.type === RefreshTypeEnum.FEG_SUBSCRIBER
-    ) {
+    if (props.type === RefreshTypeEnum.SUBSCRIBER) {
       return {sessionState: ctx.sessionState};
     }
     return ctx.state;
@@ -108,8 +97,6 @@ export function useRefreshingContext<T extends keyof ContextMap>(
               }
             : {},
         };
-      } else if (props.type === RefreshTypeEnum.FEG_SUBSCRIBER) {
-        newState = {...ctx.sessionState};
       } else {
         newState = {...ctx.state, [id]: state?.[id]};
       }
@@ -117,8 +104,6 @@ export function useRefreshingContext<T extends keyof ContextMap>(
     if (props.type === 'subscriber') {
       // update subscriber session state
       return ctx.setState(null, null, null, newState);
-    } else if (props.type === RefreshTypeEnum.FEG_SUBSCRIBER) {
-      return ctx.setSessionState(newState);
     }
     return ctx.setState(null, null, newState);
   }
@@ -187,12 +172,6 @@ async function fetchRefreshState(props: FetchProps) {
         sessionState: {[id]: sessions || {}},
       };
     }
-    return {sessionState: sessions};
-  } else if (type === RefreshTypeEnum.FEG_SUBSCRIBER) {
-    const sessions = await FetchFegSubscriberState({
-      networkId,
-      enqueueSnackbar,
-    });
     return {sessionState: sessions};
   }
 }

--- a/nms/app/components/feg/FEGContext.tsx
+++ b/nms/app/components/feg/FEGContext.tsx
@@ -81,6 +81,13 @@ export function FEGSubscriberContextProvider(props: Props) {
   return (
     <FEGSubscriberContext.Provider
       value={{
+        refetch: () => {
+          void FetchFegSubscriberState({networkId}).then(fegSubscriberState => {
+            setSessionState(fegSubscriberState);
+            if (fegSubscriberState) {
+            }
+          });
+        },
         sessionState: sessionState,
         setSessionState: newSessionState => {
           return setSessionState(newSessionState);

--- a/nms/app/views/equipment/FEGGatewayDetailSubscribers.tsx
+++ b/nms/app/views/equipment/FEGGatewayDetailSubscribers.tsx
@@ -16,15 +16,11 @@ import FEGSubscriberContext from '../../components/context/FEGSubscriberContext'
 import Link from '@material-ui/core/Link';
 import LoadingFiller from '../../components/LoadingFiller';
 import React from 'react';
-import nullthrows from '../../../shared/util/nullthrows';
 import {FetchSubscribers} from '../../state/lte/SubscriberState';
-import {
-  REFRESH_INTERVAL,
-  RefreshTypeEnum,
-  useRefreshingContext,
-} from '../../components/context/RefreshContext';
-import {useEffect, useState} from 'react';
-import {useNavigate, useParams, useResolvedPath} from 'react-router-dom';
+import {REFRESH_INTERVAL} from '../../components/context/RefreshContext';
+import {useContext, useEffect, useState} from 'react';
+import {useInterval} from '../../hooks';
+import {useNavigate, useResolvedPath} from 'react-router-dom';
 import type {FederationGateway, Subscriber} from '../../../generated';
 
 /**
@@ -55,20 +51,14 @@ type SubscriberRowType = {
 export default function GatewayDetailSubscribers(props: FEGGatewayDetailType) {
   const resolvedPath = useResolvedPath('');
   const navigate = useNavigate();
-  const params = useParams();
-  const networkId: string = nullthrows(params.networkId);
   const [subscriberRows, setSubscriberRows] = useState<
     Array<SubscriberRowType>
   >([]);
+  const ctx = useContext(FEGSubscriberContext);
   const [isLoading, setIsLoading] = useState(true);
   // Auto refresh every REFRESH_INTERVAL seconds
-  const ctx = useRefreshingContext({
-    context: FEGSubscriberContext,
-    networkId: networkId,
-    type: RefreshTypeEnum.FEG_SUBSCRIBER,
-    interval: REFRESH_INTERVAL,
-    refresh: props.refresh,
-  });
+  useInterval(() => ctx.refetch(), props.refresh ? REFRESH_INTERVAL : null);
+
   const sessionState = ctx?.sessionState || {};
   const subscriberToNetworkIdMap: Record<string, string> = {};
 

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailSubscribersTest.tsx
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailSubscribersTest.tsx
@@ -142,6 +142,7 @@ describe('<FEGGatewayDetailSubscribers />', () => {
         <MuiStylesThemeProvider theme={defaultTheme}>
           <FEGSubscriberContext.Provider
             value={{
+              refetch: () => {},
               sessionState: {
                 feg_lte_network1: mockSubscriberSessionState0,
                 feg_lte_network2: mockSubscriberSessionState1,


### PR DESCRIPTION
Signed-off-by: HannaFar <hannafarag159@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Replace useRefreshingContext with FEGSubscriberContext.refetch() and remove useRefreshingContext
Closes #13220  


## Test Plan

go to feg gateway detail page
enable autorefresh checkbox (default disabled)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
