### PR TITLE
refactor(nms): remove refreshingContext for EnodebContext

### DIFF
--- a/nms/app/components/__tests__/KPI-test.tsx
+++ b/nms/app/components/__tests__/KPI-test.tsx
@@ -203,6 +203,7 @@ describe('<EnodebKPIs />', () => {
   const enodebCtx: EnodebContextType = {
     state: {enbInfo},
     setState: async () => {},
+    refetch: () => {},
   };
 
   const Wrapper = () => {

--- a/nms/app/components/context/EnodebContext.ts
+++ b/nms/app/components/context/EnodebContext.ts
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import type {EnodebInfo} from '../lte/EnodebUtils';
 import type {NetworkRanConfigs} from '../../../generated';
 
@@ -22,11 +23,8 @@ export type EnodebState = {
 export type EnodebContextType = {
   state: EnodebState;
   lteRanConfigs?: NetworkRanConfigs;
-  setState: (
-    key: string,
-    val?: EnodebInfo,
-    newState?: EnodebState,
-  ) => Promise<void>;
+  setState: (key: string, val?: EnodebInfo) => Promise<void>;
+  refetch: (id?: string) => void;
 };
 
 export default React.createContext<EnodebContextType>({} as EnodebContextType);

--- a/nms/app/components/context/RefreshContext.ts
+++ b/nms/app/components/context/RefreshContext.ts
@@ -11,12 +11,10 @@
  * limitations under the License.
  */
 
-import EnodebContext, {EnodebContextType} from './EnodebContext';
 import FEGSubscriberContext, {
   FEGSubscriberContextType,
 } from './FEGSubscriberContext';
 import SubscriberContext, {SubscriberContextType} from './SubscriberContext';
-import {FetchEnodebs} from '../../state/lte/EquipmentState';
 import {FetchFegSubscriberState} from '../../state/feg/SubscriberState';
 import {FetchSubscriberState} from '../../state/lte/SubscriberState';
 import {useContext, useEffect, useRef, useState} from 'react';
@@ -27,13 +25,11 @@ export const REFRESH_INTERVAL = 30000;
 export const RefreshTypeEnum = {
   SUBSCRIBER: 'subscriber',
   FEG_SUBSCRIBER: 'feg_subscriber',
-  ENODEB: 'enodeb',
 } as const;
 
 type ContextMap = {
   [RefreshTypeEnum.SUBSCRIBER]: typeof SubscriberContext;
   [RefreshTypeEnum.FEG_SUBSCRIBER]: typeof FEGSubscriberContext;
-  [RefreshTypeEnum.ENODEB]: typeof EnodebContext;
 };
 
 type StateMap = {
@@ -43,7 +39,6 @@ type StateMap = {
   [RefreshTypeEnum.FEG_SUBSCRIBER]: {
     sessionState: FEGSubscriberContextType['sessionState'];
   };
-  [RefreshTypeEnum.ENODEB]: EnodebContextType['state'];
 };
 
 type RefreshType = keyof ContextMap;
@@ -113,8 +108,6 @@ export function useRefreshingContext<T extends keyof ContextMap>(
               }
             : {},
         };
-      } else if (props.type === 'enodeb') {
-        newState = {...ctx.state, [id]: state.enbInfo?.[id]};
       } else if (props.type === RefreshTypeEnum.FEG_SUBSCRIBER) {
         newState = {...ctx.sessionState};
       } else {
@@ -201,13 +194,5 @@ async function fetchRefreshState(props: FetchProps) {
       enqueueSnackbar,
     });
     return {sessionState: sessions};
-  } else {
-    const enodebs = await FetchEnodebs({
-      id: id,
-      networkId,
-      enqueueSnackbar,
-    });
-
-    return {enbInfo: enodebs};
   }
 }

--- a/nms/app/components/lte/LteContext.tsx
+++ b/nms/app/components/lte/LteContext.tsx
@@ -44,7 +44,6 @@ import type {
   Tier,
 } from '../../../generated';
 import type {EnodebInfo} from './EnodebUtils';
-import type {EnodebState} from '../context/EnodebContext';
 import type {gatewayPoolsStateType} from '../context/GatewayPoolsContext';
 
 import * as cbsdState from '../../state/lte/CbsdState';
@@ -56,6 +55,7 @@ import {
   SubscriberId,
 } from '../../../shared/types/network';
 import {
+  FetchEnodebs,
   FetchGateways,
   InitEnodeState,
   InitGatewayPoolState,
@@ -329,14 +329,26 @@ export function EnodebContextProvider(props: Props) {
       value={{
         state: {enbInfo},
         lteRanConfigs: lteRanConfigs,
-        setState: (key: string, value?, newState?: EnodebState) => {
+        setState: (key: string, value?) => {
           return SetEnodebState({
             enbInfo,
             setEnbInfo,
             networkId,
             key,
             value,
-            newState,
+          });
+        },
+        refetch: id => {
+          void FetchEnodebs({
+            id: id,
+            networkId,
+            enqueueSnackbar,
+          }).then(enodebs => {
+            if (enodebs) {
+              setEnbInfo(enodebState =>
+                id ? {...enodebState, ...enodebs} : enodebs,
+              );
+            }
           });
         },
       }}>

--- a/nms/app/state/lte/EquipmentState.ts
+++ b/nms/app/state/lte/EquipmentState.ts
@@ -33,7 +33,6 @@ import type {
   GatewayPoolId,
   NetworkId,
 } from '../../../shared/types/network';
-import type {EnodebState} from '../../components/context/EnodebContext';
 import type {
   GatewayPoolRecordsType,
   gatewayPoolsStateType,
@@ -244,16 +243,10 @@ type EnodebStateProps = {
   setEnbInfo: (enodebInfo: Record<string, EnodebInfo>) => void;
   key: string;
   value?: EnodebInfo;
-  newState?: EnodebState;
 };
 
 export async function SetEnodebState(props: EnodebStateProps) {
-  const {networkId, enbInfo, setEnbInfo, key, value, newState} = props;
-
-  if (newState) {
-    setEnbInfo(newState.enbInfo);
-    return;
-  }
+  const {networkId, enbInfo, setEnbInfo, key, value} = props;
 
   if (value != null) {
     // remove attached gateway id read only property

--- a/nms/app/views/equipment/EnodebDetailSummaryStatus.tsx
+++ b/nms/app/views/equipment/EnodebDetailSummaryStatus.tsx
@@ -17,13 +17,10 @@ import EnodebContext from '../../components/context/EnodebContext';
 import React from 'react';
 import SettingsInputAntennaIcon from '@material-ui/icons/SettingsInputAntenna';
 import nullthrows from '../../../shared/util/nullthrows';
-import {
-  REFRESH_INTERVAL,
-  useRefreshingContext,
-} from '../../components/context/RefreshContext';
+import {REFRESH_INTERVAL} from '../../components/context/RefreshContext';
 import {isEnodebHealthy} from '../../components/lte/EnodebUtils';
 import {useContext} from 'react';
-import {useEnqueueSnackbar} from '../../hooks/useSnackbar';
+import {useInterval} from '../../hooks';
 import {useParams} from 'react-router-dom';
 import type {DataRows} from '../../components/DataGrid';
 
@@ -51,21 +48,14 @@ export function EnodebSummary() {
 export function EnodebStatus({refresh}: {refresh: boolean}) {
   const params = useParams();
   const enodebSerial: string = nullthrows(params.enodebSerial);
-  const networkId: string = nullthrows(params.networkId);
-  const enqueueSnackbar = useEnqueueSnackbar();
+  const enodebContext = useContext(EnodebContext);
 
-  // Auto refresh enodeb every 30 seconds
-  const state = useRefreshingContext({
-    context: EnodebContext,
-    networkId: networkId,
-    type: 'enodeb',
-    interval: REFRESH_INTERVAL,
-    id: enodebSerial,
-    enqueueSnackbar,
-    refresh: refresh,
-  });
+  useInterval(
+    () => enodebContext.refetch(enodebSerial),
+    refresh ? REFRESH_INTERVAL : null,
+  );
 
-  const enbInfo = state.enbInfo?.[enodebSerial];
+  const enbInfo = enodebContext.state.enbInfo?.[enodebSerial];
   const isEnbHealthy = enbInfo ? isEnodebHealthy(enbInfo) : false;
   const isEnbManaged = enbInfo?.enb?.enodeb_config?.config_type === 'MANAGED';
 

--- a/nms/app/views/equipment/__tests__/EnodebConfigTest.tsx
+++ b/nms/app/views/equipment/__tests__/EnodebConfigTest.tsx
@@ -122,6 +122,7 @@ describe('<AddEditEnodeButton />', () => {
                     key: key,
                     value: value,
                   }),
+                refetch: () => {},
               }}>
               <Routes>
                 <Route
@@ -162,6 +163,7 @@ describe('<AddEditEnodeButton />', () => {
                     key: key,
                     value: value,
                   }),
+                refetch: () => {},
               }}>
               <Routes>
                 <Route
@@ -247,6 +249,7 @@ describe('<AddEditEnodeButton />', () => {
                     enbInfo: enbInf,
                   },
                   setState: async () => {},
+                  refetch: () => {},
                 }}>
                 <Routes>
                   <Route

--- a/nms/app/views/equipment/__tests__/EnodebDetailMainTest.tsx
+++ b/nms/app/views/equipment/__tests__/EnodebDetailMainTest.tsx
@@ -12,15 +12,13 @@
  */
 import type {PromqlReturnObject} from '../../../../generated';
 
-import * as hooks from '../../../components/context/RefreshContext';
 import EnodebContext from '../../../components/context/EnodebContext';
 import EnodebDetail from '../EnodebDetailMain';
+import MagmaAPI from '../../../api/MagmaAPI';
 import MomentUtils from '@date-io/moment';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
 import defaultTheme from '../../../theme/default';
-
-import MagmaAPI from '../../../api/MagmaAPI';
 import {EnodebInfo} from '../../../components/lte/EnodebUtils';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiPickersUtilsProvider} from '@material-ui/pickers';
@@ -140,9 +138,6 @@ describe('<Enodeb />', () => {
   };
 
   it('managed eNodeB', async () => {
-    jest.spyOn(hooks, 'useRefreshingContext').mockImplementation(() => ({
-      enbInfo: {testEnodebSerial0: enbInfo['testEnodebSerial0']},
-    }));
     const Wrapper = () => (
       <MemoryRouter
         initialEntries={['/nms/mynetwork/enodeb/testEnodebSerial0/overview']}
@@ -154,6 +149,7 @@ describe('<Enodeb />', () => {
                 value={{
                   state: {enbInfo: enbInfo},
                   setState: async () => {},
+                  refetch: () => {},
                 }}>
                 <Routes>
                   <Route
@@ -181,9 +177,6 @@ describe('<Enodeb />', () => {
   });
 
   it('unManaged eNodeB', async () => {
-    jest.spyOn(hooks, 'useRefreshingContext').mockImplementation(() => ({
-      enbInfo: {testEnodebSerial1: enbInfo['testEnodebSerial1']},
-    }));
     const Wrapper = () => (
       <MemoryRouter
         initialEntries={['/nms/mynetwork/enodeb/testEnodebSerial1/overview']}
@@ -195,6 +188,7 @@ describe('<Enodeb />', () => {
                 value={{
                   state: {enbInfo: enbInfo},
                   setState: async () => {},
+                  refetch: () => {},
                 }}>
                 <Routes>
                   <Route

--- a/nms/app/views/equipment/__tests__/EquipmentEnodebTest.tsx
+++ b/nms/app/views/equipment/__tests__/EquipmentEnodebTest.tsx
@@ -14,18 +14,15 @@ import type {PromqlReturnObject} from '../../../../generated';
 
 import Enodeb from '../EquipmentEnodeb';
 import EnodebContext from '../../../components/context/EnodebContext';
+import MagmaAPI from '../../../api/MagmaAPI';
 import MomentUtils from '@date-io/moment';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
 import defaultTheme from '../../../theme/default';
-
-import * as hooks from '../../../components/context/RefreshContext';
-import MagmaAPI from '../../../api/MagmaAPI';
+import {EnodebInfo} from '../../../components/lte/EnodebUtils';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MuiPickersUtilsProvider} from '@material-ui/pickers';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-
-import {EnodebInfo} from '../../../components/lte/EnodebUtils';
 import {PaginatedEnodebs} from '../../../../generated';
 import {mockAPI} from '../../../util/TestUtils';
 import {render, wait, waitFor} from '@testing-library/react';
@@ -129,11 +126,8 @@ describe('<Enodeb />', () => {
   const enbCtx = {
     state: {enbInfo: enbInfo},
     setState: async () => {},
+    refetch: () => {},
   };
-
-  jest
-    .spyOn(hooks, 'useRefreshingContext')
-    .mockImplementation(() => enbCtx.state);
 
   const Wrapper = () => (
     <MemoryRouter initialEntries={['/nms/mynetwork/enodeb']} initialIndex={0}>

--- a/nms/app/views/network/__tests__/NetworkTest.tsx
+++ b/nms/app/views/network/__tests__/NetworkTest.tsx
@@ -297,6 +297,7 @@ describe('<NetworkDashboard />', () => {
     const enodebCtx = {
       state: {enbInfo},
       setState: async () => {},
+      refetch: () => {},
     } as EnodebContextType;
 
     const gatewayCtx = {


### PR DESCRIPTION
## Summary

- Fixes #13218 

## Test Plan

- CI
- Manual testing, that the requests to refetch are executed in **three** different panels in the UI
