### PR TITLE
refactor(nms): Remove useRefreshingContext for gatewayContext

### DIFF
--- a/nms/app/components/__tests__/KPI-test.tsx
+++ b/nms/app/components/__tests__/KPI-test.tsx
@@ -133,6 +133,7 @@ describe('<GatewaysKPIs />', () => {
       },
       setState: async () => {},
       updateGateway: async () => {},
+      refetch: () => {},
     };
 
     return (

--- a/nms/app/components/context/GatewayContext.ts
+++ b/nms/app/components/context/GatewayContext.ts
@@ -18,12 +18,9 @@ import React from 'react';
 
 export type GatewayContextType = {
   state: Record<string, LteGateway>;
-  setState: (
-    key: GatewayId,
-    val?: MutableLteGateway,
-    newState?: Record<string, LteGateway>,
-  ) => Promise<void>;
+  setState: (key: GatewayId, val?: MutableLteGateway) => Promise<void>;
   updateGateway: (props: Partial<UpdateGatewayProps>) => Promise<void>;
+  refetch: (id?: string) => void;
 };
 
 export default React.createContext<GatewayContextType>(

--- a/nms/app/components/context/RefreshContext.ts
+++ b/nms/app/components/context/RefreshContext.ts
@@ -10,13 +10,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import EnodebContext, {EnodebContextType} from './EnodebContext';
 import FEGSubscriberContext, {
   FEGSubscriberContextType,
 } from './FEGSubscriberContext';
-import GatewayContext, {GatewayContextType} from './GatewayContext';
 import SubscriberContext, {SubscriberContextType} from './SubscriberContext';
-import {FetchEnodebs, FetchGateways} from '../../state/lte/EquipmentState';
+import {FetchEnodebs} from '../../state/lte/EquipmentState';
 import {FetchFegSubscriberState} from '../../state/feg/SubscriberState';
 import {FetchSubscriberState} from '../../state/lte/SubscriberState';
 import {useContext, useEffect, useRef, useState} from 'react';
@@ -26,14 +26,12 @@ export const REFRESH_INTERVAL = 30000;
 
 export const RefreshTypeEnum = {
   SUBSCRIBER: 'subscriber',
-  GATEWAY: 'gateway',
   FEG_SUBSCRIBER: 'feg_subscriber',
   ENODEB: 'enodeb',
 } as const;
 
 type ContextMap = {
   [RefreshTypeEnum.SUBSCRIBER]: typeof SubscriberContext;
-  [RefreshTypeEnum.GATEWAY]: typeof GatewayContext;
   [RefreshTypeEnum.FEG_SUBSCRIBER]: typeof FEGSubscriberContext;
   [RefreshTypeEnum.ENODEB]: typeof EnodebContext;
 };
@@ -42,7 +40,6 @@ type StateMap = {
   [RefreshTypeEnum.SUBSCRIBER]: {
     sessionState: SubscriberContextType['sessionState'];
   };
-  [RefreshTypeEnum.GATEWAY]: GatewayContextType['state'];
   [RefreshTypeEnum.FEG_SUBSCRIBER]: {
     sessionState: FEGSubscriberContextType['sessionState'];
   };
@@ -198,14 +195,6 @@ async function fetchRefreshState(props: FetchProps) {
       };
     }
     return {sessionState: sessions};
-  } else if (type === 'gateway') {
-    const gateways = await FetchGateways({
-      id: id,
-      networkId,
-      enqueueSnackbar,
-    });
-
-    return gateways;
   } else if (type === RefreshTypeEnum.FEG_SUBSCRIBER) {
     const sessions = await FetchFegSubscriberState({
       networkId,

--- a/nms/app/components/lte/LteContext.tsx
+++ b/nms/app/components/lte/LteContext.tsx
@@ -56,6 +56,7 @@ import {
   SubscriberId,
 } from '../../../shared/types/network';
 import {
+  FetchGateways,
   InitEnodeState,
   InitGatewayPoolState,
   InitTierState,
@@ -126,14 +127,13 @@ export function GatewayContextProvider(props: Props) {
     <GatewayContext.Provider
       value={{
         state: lteGateways,
-        setState: (key, value?, newState?) => {
+        setState: (key, value?) => {
           return SetGatewayState({
             lteGateways,
             setLteGateways,
             networkId,
             key,
             value,
-            newState,
           });
         },
         updateGateway: props =>
@@ -142,6 +142,19 @@ export function GatewayContextProvider(props: Props) {
             setLteGateways,
             ...props,
           } as UpdateGatewayProps),
+        refetch: id => {
+          void FetchGateways({
+            id: id,
+            networkId,
+            enqueueSnackbar,
+          }).then(gateways => {
+            if (gateways) {
+              setLteGateways(gatewayState =>
+                id ? {...gatewayState, ...gateways} : gateways,
+              );
+            }
+          });
+        },
       }}>
       {props.children}
     </GatewayContext.Provider>

--- a/nms/app/state/lte/EquipmentState.ts
+++ b/nms/app/state/lte/EquipmentState.ts
@@ -337,15 +337,11 @@ type GatewayStateProps = {
   setLteGateways: (lteGateways: Record<string, LteGateway>) => void;
   key: GatewayId;
   value?: MutableLteGateway;
-  newState?: Record<string, LteGateway>;
 };
 
 export async function SetGatewayState(props: GatewayStateProps) {
-  const {networkId, lteGateways, setLteGateways, key, value, newState} = props;
-  if (newState) {
-    setLteGateways(newState);
-    return;
-  }
+  const {networkId, lteGateways, setLteGateways, key, value} = props;
+
   if (value != null) {
     if (!(key in lteGateways)) {
       await MagmaAPI.lteGateways.lteNetworkIdGatewaysPost({

--- a/nms/app/views/equipment/GatewayDetailStatus.tsx
+++ b/nms/app/views/equipment/GatewayDetailStatus.tsx
@@ -10,36 +10,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import type {DataRows} from '../../components/DataGrid';
 
 import DataGrid from '../../components/DataGrid';
 import GatewayContext from '../../components/context/GatewayContext';
 import LoadingFiller from '../../components/LoadingFiller';
 import MagmaAPI from '../../api/MagmaAPI';
-import React from 'react';
+import React, {useContext} from 'react';
 import nullthrows from '../../../shared/util/nullthrows';
 import useMagmaAPI from '../../api/useMagmaAPI';
 import {DynamicServices} from '../../components/GatewayUtils';
-import {
-  REFRESH_INTERVAL,
-  useRefreshingContext,
-} from '../../components/context/RefreshContext';
+import {REFRESH_INTERVAL} from '../../components/context/RefreshContext';
+import {useInterval} from '../../hooks';
 import {useParams} from 'react-router-dom';
 
 export default function GatewayDetailStatus({refresh}: {refresh: boolean}) {
   const params = useParams();
   const networkId: string = nullthrows(params.networkId);
   const gatewayId: string = nullthrows(params.gatewayId);
-  // Auto refresh gateways every 30 seconds
-  const state = useRefreshingContext({
-    context: GatewayContext,
-    networkId: networkId,
-    type: 'gateway',
-    interval: REFRESH_INTERVAL,
-    id: gatewayId,
-    refresh: refresh,
-  });
-  const gwInfo = state[gatewayId];
+  const gatewayContext = useContext(GatewayContext);
+
+  useInterval(
+    () => gatewayContext.refetch(gatewayId),
+    refresh ? REFRESH_INTERVAL : null,
+  );
+
+  const gwInfo = gatewayContext.state[gatewayId];
   let checkInTime;
   if (
     gwInfo.status &&

--- a/nms/app/views/equipment/__tests__/EquipmentGatewayPoolTest.tsx
+++ b/nms/app/views/equipment/__tests__/EquipmentGatewayPoolTest.tsx
@@ -273,6 +273,7 @@ describe('<AddEditGatewayPoolButton />', () => {
                 state: lteGateways,
                 setState: async () => {},
                 updateGateway: async () => {},
+                refetch: () => {},
               }}>
               <GatewayPoolsContext.Provider
                 value={{

--- a/nms/app/views/equipment/__tests__/EquipmentGatewayTest.tsx
+++ b/nms/app/views/equipment/__tests__/EquipmentGatewayTest.tsx
@@ -141,6 +141,7 @@ describe('<Gateway />', () => {
               state: lteGateways,
               setState: async () => {},
               updateGateway: async () => {},
+              refetch: () => {},
             }}>
             <Routes>
               <Route path="/nms/:networkId/gateway/" element={<Gateway />} />

--- a/nms/app/views/equipment/__tests__/GatewayConfigTest.tsx
+++ b/nms/app/views/equipment/__tests__/GatewayConfigTest.tsx
@@ -216,6 +216,7 @@ describe('<AddEditGatewayButton />', () => {
                         setLteGateways,
                         ...props,
                       } as UpdateGatewayProps),
+                    refetch: () => {},
                   }}>
                   <Routes>
                     <Route
@@ -257,6 +258,7 @@ describe('<AddEditGatewayButton />', () => {
                     setLteGateways: setLteGateways,
                     ...props,
                   } as UpdateGatewayProps),
+                refetch: () => {},
               }}>
               <Routes>
                 <Route

--- a/nms/app/views/network/__tests__/NetworkTest.tsx
+++ b/nms/app/views/network/__tests__/NetworkTest.tsx
@@ -303,6 +303,7 @@ describe('<NetworkDashboard />', () => {
       state: gateways,
       setState: async () => {},
       updateGateway: async () => {},
+      refetch: () => {},
     } as GatewayContextType;
 
     const subscriberCtx = {


### PR DESCRIPTION
## Summary

- Fixes #13217


## Test Plan

- CI
- Manual testing, that the requests to refetch are executed in **two** different panels in the UI
  - Added gateway via swagger UI