### PR TITLE
fix(ci): Add path to flags to get reviewdog markdownlint working

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -152,7 +152,7 @@ jobs:
           filter_mode: added
           reporter: github-pr-review
           fail_on_error: false
-          markdownlint_flags: "--config ./docs/readmes/.markdownlint.yaml"
+          markdownlint_flags: "--config ./docs/readmes/.markdownlint.yaml ."
 
   misspell:
     name: misspell


### PR DESCRIPTION
## Summary

Adds a missing path to fix the reviewdog markdownlint job (https://github.com/magma/magma/pull/13227).

## Test Plan

Tested on my fork, where errors are outputted to the PR as expected: https://github.com/voisey/magma/pull/4#discussion_r916594073
