### PR TITLE
fix(nms): Add test network to magma-test in dev setup

### DIFF
--- a/docs/readmes/basics/quick_start_guide.md
+++ b/docs/readmes/basics/quick_start_guide.md
@@ -223,12 +223,11 @@ After this, you will be able to access the UI by visiting
 [https://magma-test.localhost](https://magma-test.localhost), and using the email `admin@magma.test`
 and password `password1234`. We recommend Firefox or Chrome. If you see Gateway Error 502, don't worry, the
 NMS can take upto 60 seconds to finish starting up.
+Note that you will only see a network if you connected your local LTE gateway as described above.
 
-You will probably want to enable this organization (magma-test) to access all networks,
-so go to [host.localhost](https://host.localhost) and login with the same credentials.
-Once there, you can click on the "Organizations" tab on the left sidebar, choose
-`magma-test` (the three dots on the right) &rarr; View &rarr; Edit &rarr; Advanced Settings
-and then check "Enable all networks" in the subsequent pop-up window.
+`magma-test` is the default organization.
+Organizations are managed at [host.localhost](https://host.localhost)
+where you can log in with the same credentials.
 
 **Note**: If you want to test the access gateway VM with a physical eNB and UE,
 refer to

--- a/nms/scripts/dev_setup.sh
+++ b/nms/scripts/dev_setup.sh
@@ -17,6 +17,8 @@ set -e
 docker-compose exec magmalte yarn migrate
 docker-compose exec magmalte yarn setAdminPassword magma-test admin@magma.test password1234
 docker-compose exec magmalte yarn setAdminPassword host admin@magma.test password1234
+# Make sure that magma-test has access to the test network
+docker-compose exec magmalte yarn createOrganization magma-test test
 
 # Docker run in a Linux host doesn't resolve host.docker.internal to the host IP.
 # See https://github.com/docker/for-linux/issues/264


### PR DESCRIPTION
## Summary

The `test` network is now added to the `magma-test`  organization in dev setup script. Fixes #12195

## Test Plan

* Drop the orc8r and NMS  DB volumes 
* Setup connect the AGW using `dev_tools.py register_vm`
* Setup the initial state with `nms/scripts/dev_setup.sh`
* Make sure that the `magma-test` organization has access to the `test` network without manually adding it. 