### PR TITLE
refactor(nms): Use networkIds from AppContext consistently

### DIFF
--- a/nms/app/components/NetworkSelector.tsx
+++ b/nms/app/components/NetworkSelector.tsx
@@ -12,18 +12,15 @@
  */
 import AppContext from '../components/context/AppContext';
 import Divider from '@material-ui/core/Divider';
-import MagmaAPI from '../api/MagmaAPI';
 import MenuButton from './MenuButton';
 import MenuItem from '@material-ui/core/MenuItem';
 import NetworkContext from './context/NetworkContext';
-import React, {useCallback, useContext, useEffect, useState} from 'react';
+import React, {useContext, useState} from 'react';
 import Text from '../theme/design-system/Text';
-import useMagmaAPI from '../api/useMagmaAPI';
-import {LTE, coalesceNetworkType} from '../../shared/types/network';
+import {LTE} from '../../shared/types/network';
 import {NetworkEditDialog} from '../views/network/NetworkEdit';
 import {makeStyles} from '@material-ui/styles';
 import {useNavigate} from 'react-router-dom';
-import type {NetworkType} from '../../shared/types/network';
 
 const useStyles = makeStyles({
   button: {
@@ -36,41 +33,16 @@ const useStyles = makeStyles({
 const NetworkSelector = () => {
   const classes = useStyles();
   const navigate = useNavigate();
-  const appContext = useContext(AppContext);
-  const [networkIds, setNetworkIds] = useState<Array<string>>([]);
-  const [networkType, setNetworkType] = useState<NetworkType | null>(null);
-  const [lastRefreshTime, setLastRefreshTime] = useState(new Date().getTime());
+  const {networkIds, user} = useContext(AppContext);
   const [isNetworkAddOpen, setNetworkAddOpen] = useState(false);
-  const {networkId: selectedNetworkId} = useContext(NetworkContext);
-
-  useMagmaAPI(
-    MagmaAPI.networks.networksGet,
-    {},
-    useCallback((resp: Array<string>) => setNetworkIds(resp), []),
-    lastRefreshTime,
+  const {networkId: selectedNetworkId, networkType} = useContext(
+    NetworkContext,
   );
-
-  useEffect(() => {
-    const fetchNetworkType = async () => {
-      if (selectedNetworkId) {
-        const networkType = (
-          await MagmaAPI.networks.networksNetworkIdTypeGet({
-            networkId: selectedNetworkId,
-          })
-        ).data;
-        setNetworkType(coalesceNetworkType(selectedNetworkId, networkType));
-      }
-    };
-
-    void fetchNetworkType();
-  }, [selectedNetworkId]);
-
   if (!selectedNetworkId) {
     return null;
   }
-  const {isSuperUser} = appContext.user;
 
-  if (!isSuperUser && networkIds.length < 2) {
+  if (!user.isSuperUser && networkIds.length < 2) {
     return <Text variant="body2">{`Network: ${selectedNetworkId}`}</Text>;
   }
 
@@ -80,19 +52,18 @@ const NetworkSelector = () => {
         open={isNetworkAddOpen}
         onClose={() => {
           setNetworkAddOpen(false);
-          setLastRefreshTime(new Date().getTime());
         }}
       />
       <MenuButton
         data-testid="networkSelector"
         className={classes.button}
         label={`Network: ${selectedNetworkId}`}>
-        {isSuperUser && networkType === LTE && (
+        {user.isSuperUser && networkType === LTE && (
           <MenuItem onClick={() => setNetworkAddOpen(true)}>
             <Text variant="body2">Create Network</Text>
           </MenuItem>
         )}
-        {isSuperUser && (
+        {user.isSuperUser && (
           <MenuItem
             component="a"
             onClick={() => {
@@ -101,7 +72,9 @@ const NetworkSelector = () => {
             <Text variant="body2">Manage Networks</Text>
           </MenuItem>
         )}
-        {isSuperUser && networkIds.length > 0 && <Divider variant="middle" />}
+        {user.isSuperUser && networkIds.length > 0 && (
+          <Divider variant="middle" />
+        )}
         {networkIds.map(id => (
           <MenuItem key={id} component="a" href={`/nms/${id}`}>
             <Text variant="body2">{id}</Text>

--- a/nms/app/components/admin/AddNetworkDialog.tsx
+++ b/nms/app/components/admin/AddNetworkDialog.tsx
@@ -22,11 +22,12 @@ import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
 import ListItemText from '@material-ui/core/ListItemText';
 import MenuItem from '@material-ui/core/MenuItem';
-import React from 'react';
+import React, {useContext} from 'react';
 import Select from '@material-ui/core/Select';
 import TextField from '@material-ui/core/TextField';
 import axios from 'axios';
 
+import AppContext from '../context/AppContext';
 import nullthrows from '../../../shared/util/nullthrows';
 import {
   AllNetworkTypes,
@@ -76,6 +77,7 @@ export default function NetworkDialog(props: Props) {
   const [fegNetworkID, setFegNetworkID] = useState('');
   const [servedNetworkIDs, setServedNetworkIDs] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const appContext = useContext(AppContext);
 
   const onSave = () => {
     const payload = {
@@ -93,6 +95,7 @@ export default function NetworkDialog(props: Props) {
       .then(response => {
         if (response.data.success) {
           props.onSave(nullthrows(networkID));
+          appContext.addNetworkId(networkID);
           if (payload.data.networkType === XWFM) {
             void triggerAlertSync(networkID, enqueueSnackbar);
           }

--- a/nms/app/components/context/AppContext.tsx
+++ b/nms/app/components/context/AppContext.tsx
@@ -13,7 +13,9 @@
 'use strict';
 
 import * as React from 'react';
-import {noop} from 'lodash';
+import {NetworkId} from '../../../shared/types/network';
+import {noop, sortBy} from 'lodash';
+import {useState} from 'react';
 import type {EmbeddedData, User} from '../../../shared/types/embeddedData';
 import type {FeatureID} from '../../../shared/types/features';
 import type {SSOSelectedType} from '../../../shared/types/auth';
@@ -22,6 +24,8 @@ export type AppContextType = {
   csrfToken: string | null | undefined;
   version: string | null | undefined;
   networkIds: Array<string>;
+  addNetworkId: (id: string) => void;
+  removeNetworkId: (id: NetworkId) => void;
   user: User;
   showExpandButton: () => void;
   hideExpandButton: () => void;
@@ -36,6 +40,8 @@ const appContextDefaults: AppContextType = {
   csrfToken: null,
   version: null,
   networkIds: [],
+  addNetworkId: () => {},
+  removeNetworkId: () => {},
   user: {
     tenant: '',
     email: '',
@@ -62,6 +68,8 @@ export function AppContextProvider(props: Props) {
   const config: {
     appData: EmbeddedData;
   } = window.CONFIG;
+
+  const [networkIds, setNetworkIds] = useState(props.networkIDs || []);
   const {appData} = config;
   const value = {
     ...appContextDefaults,
@@ -69,7 +77,15 @@ export function AppContextProvider(props: Props) {
     hasAccountSettings: !appData.ssoEnabled,
     // is organizations management aka. the host site
     isOrganizations: !!props.isOrganizations,
-    networkIds: props.networkIDs || [],
+    networkIds,
+    addNetworkId: (id: NetworkId) => {
+      setNetworkIds(currentIds =>
+        sortBy([...currentIds, id], [n => n.toLowerCase()]),
+      );
+    },
+    removeNetworkId: (idToRemove: NetworkId) => {
+      setNetworkIds(currentIds => currentIds.filter(id => id !== idToRemove));
+    },
     isFeatureEnabled: (featureID: FeatureID): boolean => {
       return appData.enabledFeatures.indexOf(featureID) !== -1;
     },

--- a/nms/app/views/network/NetworkInfo.tsx
+++ b/nms/app/views/network/NetworkInfo.tsx
@@ -25,6 +25,7 @@ import OutlinedInput from '@material-ui/core/OutlinedInput';
 import React from 'react';
 import axios from 'axios';
 
+import AppContext from '../../components/context/AppContext';
 import {AltFormField} from '../../components/FormField';
 import {FEG_LTE, LTE} from '../../../shared/types/network';
 import {getErrorMessage} from '../../util/ErrorUtils';
@@ -94,6 +95,7 @@ export function NetworkInfoEdit(props: EditProps) {
   const [error, setError] = useState('');
   const enqueueSnackbar = useEnqueueSnackbar();
   const ctx = useContext(LteNetworkContext);
+  const appContext = useContext(AppContext);
   const [lteNetwork, setLteNetwork] = useState<
     Partial<LteNetwork & FegLteNetwork>
   >(props.lteNetwork);
@@ -132,6 +134,7 @@ export function NetworkInfoEdit(props: EditProps) {
           payload,
         );
         if (response.data.success) {
+          appContext.addNetworkId(lteNetwork.id!);
           enqueueSnackbar(`Network ${lteNetwork.name!} successfully created`, {
             variant: 'success',
           });


### PR DESCRIPTION
## Summary

Use networks ids from AppContext instead of duplicating the state three times.

## Test Plan

- Open the manage networks view.
- Add a network 
- Make sure the network is shown in the manage network table and in the dropdown in the top bar
- Remove a network
- Make sure the network is  no longer shown in the manage network table and in the dropdown
- Add a network through the "Create Network" entry in the dropdown
- Make sure the network is shown in both places

![Screenshot 2022-07-11 at 09 01 01](https://user-images.githubusercontent.com/102796295/178206957-7ad41473-1eca-4d67-8e5e-bf50d04e9190.png)

