### PR TITLE
fix(nms): Only show policy placeholder if all tabs are empty

### DIFF
--- a/nms/app/views/traffic/PolicyOverview.tsx
+++ b/nms/app/views/traffic/PolicyOverview.tsx
@@ -175,6 +175,12 @@ export default function PolicyOverview() {
     link: 'https://docs.magmacore.org/docs/nms/traffic#policy-configuration',
   };
 
+  const isEmpty =
+    Object.keys(ctx.state || {}).length === 0 &&
+    Object.keys(ctx.ratingGroups || {}).length === 0 &&
+    Object.keys(ctx.qosProfiles || {}).length === 0 &&
+    Object.keys(ctx.baseNames || {}).length === 0;
+
   return (
     <div className={classes.dashboardRoot}>
       <PolicyRuleEditDialog
@@ -182,7 +188,19 @@ export default function PolicyOverview() {
         onClose={() => setOpen(false)}
         rule={undefined}
       />
-      {Object.keys(ctx.state || {}).length > 0 ? (
+      {isEmpty ? (
+        <Grid container justify="space-between" spacing={3}>
+          <EmptyState
+            title={'Set up a Policy'}
+            instructions={
+              'Add a policy to the NMS by filling out the required fields.'
+            }
+            cardActions={cardActions}
+            overviewTitle={'Policy Overview'}
+            overviewDescription={EMPTY_STATE_OVERVIEW}
+          />
+        </Grid>
+      ) : (
         <>
           <MagmaTabs
             value={currTabIndex}
@@ -197,18 +215,6 @@ export default function PolicyOverview() {
           {currTabIndex === 2 && <ProfileTable />}
           {currTabIndex === 3 && <RatingGroupTable />}
         </>
-      ) : (
-        <Grid container justify="space-between" spacing={3}>
-          <EmptyState
-            title={'Set up a Policy'}
-            instructions={
-              'Add a policy to the NMS by filling out the required fields.'
-            }
-            cardActions={cardActions}
-            overviewTitle={'Policy Overview'}
-            overviewDescription={EMPTY_STATE_OVERVIEW}
-          />
-        </Grid>
       )}
     </div>
   );

--- a/nms/app/views/traffic/__tests__/PolicyAddEditTest.tsx
+++ b/nms/app/views/traffic/__tests__/PolicyAddEditTest.tsx
@@ -233,7 +233,6 @@ describe('<TrafficDashboard />', () => {
               networkId={'test'}
               networkType={networkType}>
               <PolicyProvider networkId={'test'} networkType={networkType}>
-                \
                 <Routes>
                   <Route
                     path="/nms/:networkId/traffic/policy/*"
@@ -247,6 +246,38 @@ describe('<TrafficDashboard />', () => {
       </MuiThemeProvider>
     </MemoryRouter>
   );
+
+  it('shows placeholder', async () => {
+    mockAPI(MagmaAPI.policies, 'networksNetworkIdPoliciesRulesviewfullGet', {});
+    const {findByText} = render(<PolicyWrapper networkType={LTE} />);
+
+    expect(
+      await findByText(
+        'Add a policy to the NMS by filling out the required fields.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show placeholder if there is some data', async () => {
+    mockAPI(MagmaAPI.policies, 'networksNetworkIdPoliciesRulesviewfullGet', {});
+    mockAPI(MagmaAPI.policies, 'lteNetworkIdPolicyQosProfilesGet', {
+      foo: {
+        class_id: 1,
+        id: 'foo',
+        max_req_bw_dl: 5,
+        max_req_bw_ul: 6,
+      },
+    });
+    const {queryByText} = render(<PolicyWrapper networkType={LTE} />);
+
+    await waitFor(() => {
+      expect(
+        queryByText(
+          'Add a policy to the NMS by filling out the required fields.',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
 
   // verify feg_lte network wide policy add
   // verify lte network wide policy add


### PR DESCRIPTION
## Summary

Show the Policy placeholder only if all tabs on the policy page are empty. 

- Fixes: #13257

## Test Plan

Follow the steps to reproduce in #13257. Make sure that the placeholder is only shown if nothing has been created.
Also verify that the placeholder reappears if all policy tabs become empty.  



