### PR TITLE
fix(agw): Adapt nonsanity tests for Python 3.8

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py
@@ -101,7 +101,7 @@ class TestAttachAndMmeRestartLoopDetachAndMmeRestartLoopMultiUe(
 
         for ue in ue_ids:
             # Now detach the UE
-            random.seed(time.clock())
+            random.seed(time.time())
             index = random.randint(0, 1)
             print(
                 "************************* Running UE detach for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_mme_restart_detach_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_mme_restart_detach_multi_ue.py
@@ -75,7 +75,7 @@ class TestAttachMmeRestartDetachMultiUe(unittest.TestCase):
 
         for ue in ue_ids:
             # Now detach the UE
-            random.seed(time.clock())
+            random.seed(time.time())
             index = random.randint(0, 1)
             print(
                 "************************* Running UE detach for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue.py
@@ -57,9 +57,9 @@ class TestEnbPartialResetMultiUe(unittest.TestCase):
         time.sleep(0.5)
 
         # Set the reset UEs list
-        random.seed(time.clock())
+        random.seed(time.time())
         reset_ue_count = random.randint(1, num_ues)
-        random.seed(time.clock())
+        random.seed(time.time())
         reset_ue_list = random.sample(range(num_ues), reset_ue_count)
 
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
@@ -62,9 +62,9 @@ class TestEnbPartialResetMultiUeWithMmeRestart(unittest.TestCase):
         time.sleep(0.5)
 
         # Set the reset UEs list
-        random.seed(time.clock())
+        random.seed(time.time())
         reset_ue_count = random.randint(1, num_ues)
-        random.seed(time.clock())
+        random.seed(time.time())
         reset_ue_list = random.sample(range(num_ues), reset_ue_count)
 
         print(


### PR DESCRIPTION
## Summary

`time.clock()` is no longer supported.

## Test Plan

```
make nonsanity
```

## Additional Information

- [ ] This change is backwards-breaking