### PR TITLE
fix(amf): Supporting the Implicit deregistration timer, fixing the TAC Value in Registration Accept message.

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -620,6 +620,8 @@ int amf_send_registration_accept(amf_context_t* amf_context) {
     ue_m5gmm_context_s* ue_m5gmm_context_p =
         PARENT_STRUCT(amf_context, ue_m5gmm_context_s, amf_context);
     amf_ue_ngap_id_t ue_id = ue_m5gmm_context_p->amf_ue_ngap_id;
+    amf_sap.u.amf_as.u.establish.tai.tac = amf_context->originating_tai.tac;
+    amf_sap.u.amf_as.u.data.tai.tac = amf_sap.u.amf_as.u.establish.tai.tac;
 
     if (registration_proc) {
       registration_proc->T3550.id = NAS5G_TIMER_INACTIVE_ID;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -733,11 +733,26 @@ static int amf_app_handle_mobile_reachability_timer_expiry(zloop_t* loop,
 
   ue_context_p->m5_mobile_reachability_timer.id = AMF_APP_TIMER_INACTIVE_ID;
 
-  // Start Implicit Deregister timer
-  ue_context_p->m5_implicit_deregistration_timer.id = amf_app_start_timer(
-      ue_context_p->m5_implicit_deregistration_timer.sec * 1000,
-      TIMER_REPEAT_ONCE, amf_app_handle_implicit_deregistration_timer_expiry,
-      ue_id);
+  // Start Implicit Deregister timer only if it is not running
+  if ((ue_context_p->m5_implicit_deregistration_timer.id = amf_app_start_timer(
+           ue_context_p->m5_implicit_deregistration_timer.sec * 1000,
+           TIMER_REPEAT_ONCE,
+           amf_app_handle_implicit_deregistration_timer_expiry, ue_id)) == -1) {
+    OAILOG_ERROR_UE(LOG_AMF_APP, ue_context_p->amf_context.imsi64,
+                    "Failed to start Implicit Deregistration timer for UE "
+                    "id: " AMF_UE_NGAP_ID_FMT "\n",
+                    ue_context_p->amf_ue_ngap_id);
+    ue_context_p->m5_implicit_deregistration_timer.id =
+        AMF_APP_TIMER_INACTIVE_ID;
+  } else {
+    OAILOG_DEBUG_UE(
+        LOG_AMF_APP, ue_context_p->amf_context.imsi64,
+        "Started Implicit Deregistration timer for UE id: " AMF_UE_NGAP_ID_FMT
+        ", Timer Id: %ld, Timer Val: %u (ms) ",
+        ue_context_p->amf_ue_ngap_id,
+        ue_context_p->m5_implicit_deregistration_timer.id,
+        ue_context_p->m5_implicit_deregistration_timer.sec);
+  }
 
   ue_context_p->ppf = false;
   OAILOG_FUNC_RETURN(LOG_AMF_APP, RETURNok);
@@ -785,13 +800,29 @@ void amf_ue_context_update_ue_sig_connection_state(
             AMF_APP_TIMER_INACTIVE_ID) {
       ue_context_p->m5_mobile_reachability_timer.sec =
           (amf_config.nas_config.t3512_min + 4 * 60);
+      ue_context_p->m5_implicit_deregistration_timer.sec =
+          ue_context_p->m5_mobile_reachability_timer.sec;
 
-      if (ue_context_p->m5_mobile_reachability_timer.sec ==
-          AMF_APP_TIMER_INACTIVE_ID) {
-        ue_context_p->m5_mobile_reachability_timer.id = amf_app_start_timer(
-            ue_context_p->m5_mobile_reachability_timer.sec * 1000,
-            TIMER_REPEAT_ONCE, amf_app_handle_mobile_reachability_timer_expiry,
-            ue_context_p->amf_ue_ngap_id);
+      // Start Mobile Reachability timer only if it is not running
+      if ((ue_context_p->m5_mobile_reachability_timer.id = amf_app_start_timer(
+               ue_context_p->m5_mobile_reachability_timer.sec * 1000,
+               TIMER_REPEAT_ONCE,
+               amf_app_handle_mobile_reachability_timer_expiry,
+               ue_context_p->amf_ue_ngap_id)) == -1) {
+        OAILOG_ERROR_UE(LOG_AMF_APP, ue_context_p->amf_context.imsi64,
+                        "Failed to start Mobile Reachability timer for UE id "
+                        " " AMF_UE_NGAP_ID_FMT "\n",
+                        ue_context_p->amf_ue_ngap_id);
+        ue_context_p->m5_mobile_reachability_timer.id =
+            AMF_APP_TIMER_INACTIVE_ID;
+      } else {
+        OAILOG_DEBUG_UE(
+            LOG_AMF_APP, ue_context_p->amf_context.imsi64,
+            "Started Mobile Reachability timer for UE id " AMF_UE_NGAP_ID_FMT
+            ", Timer Id: %ld, Timer Val: %u (s) ",
+            ue_context_p->amf_ue_ngap_id,
+            ue_context_p->m5_mobile_reachability_timer.id,
+            ue_context_p->m5_mobile_reachability_timer.sec);
       }
     }
 

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -737,7 +737,8 @@ static int amf_app_handle_mobile_reachability_timer_expiry(zloop_t* loop,
   if ((ue_context_p->m5_implicit_deregistration_timer.id = amf_app_start_timer(
            ue_context_p->m5_implicit_deregistration_timer.sec * 1000,
            TIMER_REPEAT_ONCE,
-           amf_app_handle_implicit_deregistration_timer_expiry, ue_id)) == -1) {
+           amf_app_handle_implicit_deregistration_timer_expiry, ue_id)) ==
+      RETURNerror) {
     OAILOG_ERROR_UE(LOG_AMF_APP, ue_context_p->amf_context.imsi64,
                     "Failed to start Implicit Deregistration timer for UE "
                     "id: " AMF_UE_NGAP_ID_FMT "\n",
@@ -799,7 +800,7 @@ void amf_ue_context_update_ue_sig_connection_state(
         ue_context_p->m5_mobile_reachability_timer.id ==
             AMF_APP_TIMER_INACTIVE_ID) {
       ue_context_p->m5_mobile_reachability_timer.sec =
-          (amf_config.nas_config.t3512_min + 4 * 60);
+          (amf_config.nas_config.t3512_min + (4 * 60));
       ue_context_p->m5_implicit_deregistration_timer.sec =
           ue_context_p->m5_mobile_reachability_timer.sec;
 
@@ -808,7 +809,7 @@ void amf_ue_context_update_ue_sig_connection_state(
                ue_context_p->m5_mobile_reachability_timer.sec * 1000,
                TIMER_REPEAT_ONCE,
                amf_app_handle_mobile_reachability_timer_expiry,
-               ue_context_p->amf_ue_ngap_id)) == -1) {
+               ue_context_p->amf_ue_ngap_id)) == RETURNerror) {
         OAILOG_ERROR_UE(LOG_AMF_APP, ue_context_p->amf_context.imsi64,
                         "Failed to start Mobile Reachability timer for UE id "
                         " " AMF_UE_NGAP_ID_FMT "\n",

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -387,7 +387,8 @@ static int amf_as_encode(bstring* info, amf_nas_message_t* msg, size_t length,
  **              Others:        None                                       **
  **                                                                        **
  ***************************************************************************/
-int amf_reg_acceptmsg(const guti_m5_t* guti, amf_nas_message_t* nas_msg) {
+int amf_reg_acceptmsg(const guti_m5_t* guti, const tai_t* tai,
+                      amf_nas_message_t* nas_msg) {
   OAILOG_FUNC_IN(LOG_NAS_AMF);
   int size = REGISTRATION_ACCEPT_MINIMUM_LENGTH;
   nas_msg->security_protected.plain.amf.header.message_type =
@@ -476,9 +477,9 @@ int amf_reg_acceptmsg(const guti_m5_t* guti, amf_nas_message_t* nas_msg) {
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg.tai_list
       .tac[0] = 0x00;
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg.tai_list
-      .tac[1] = 0x00;
+      .tac[1] = (tai->tac) >> 8;
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg.tai_list
-      .tac[2] = 0x01;
+      .tac[2] = tai->tac;
 
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg.allowed_nssai
       .iei = ALLOWED_NSSAI;
@@ -687,7 +688,7 @@ uint16_t amf_as_data_req(const amf_as_data_t* msg,
   if (amf_msg) {
     switch (msg->nas_info) {
       case AMF_AS_NAS_DATA_REGISTRATION_ACCEPT:
-        size = amf_reg_acceptmsg(msg->guti, &nas_msg);
+        size = amf_reg_acceptmsg(msg->guti, &(msg->tai), &nas_msg);
 
         if (msg->guti) {
           delete (msg->guti);
@@ -1347,7 +1348,7 @@ uint16_t amf_as_establish_cnf(const amf_as_establish_t* msg,
   amf_as_set_header(&nas_msg, &msg->sctx);
   switch (msg->nas_info) {
     case AMF_AS_NAS_INFO_REGISTERED:
-      size = amf_reg_acceptmsg(&(msg->guti), &nas_msg);
+      size = amf_reg_acceptmsg(&(msg->guti), &(msg->tai), &nas_msg);
       nas_msg.header.security_header_type =
           SECURITY_HEADER_TYPE_INTEGRITY_PROTECTED_CYPHERED;
       /* TODO amf_as_set_header() is incorrectly setting the security header

--- a/lte/gateway/c/core/oai/tasks/amf/amf_asDefs.h
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_asDefs.h
@@ -81,6 +81,7 @@ class amf_as_data_t {
   amf_ue_ngap_id_t ue_id;       // UE lower layer identifier
   guti_m5_t* guti;              // GUTI temporary mobile identity
   amf_as_security_data_t sctx;  // M5G NAS security context
+  tai_t tai;                    // The first tracking area the UE is registered
 #define AMF_AS_NAS_DATA_REGISTRATION_ACCEPT 0x04    // REGISTRATION Accept
 #define AMF_AS_NAS_AMF_INFORMATION 0x05             // Amf information
 #define AMF_AS_NAS_DATA_DEREGISTRATION_ACCEPT 0x06  // DEREGISTRATION Accept


### PR DESCRIPTION
Signed-off-by: sreedharkumartn <sreedhar.kumar@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
### Issues Resolved:
**Issue - 1:** Implicit deregistration timer is not getting triggered.
**Fix - 1:** Fixed the part of fetching Implicit deregistration timer value.

**Issue - 2:** TAC value is different in Registration Accept from the one we are getting in Initial UE Message.
![image](https://user-images.githubusercontent.com/89978170/178508833-8b6efe25-4352-44a7-a263-5420f34d4718.png)
![image](https://user-images.githubusercontent.com/89978170/178508925-0380a605-ae7c-4eec-9f35-0e7852644c29.png)
**Fix - 2:** Fixed the TAC value in Registration Accept message now.
![image](https://user-images.githubusercontent.com/89978170/178509118-a5e63d7a-e72c-4501-bd61-02e417429d7c.png)
![image](https://user-images.githubusercontent.com/89978170/178509160-ae0b4041-ddc4-413f-8ada-38a93c63c96b.png)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
### Testing Scenarios:

**Test 1:** Tested below case using UERANSIM. 
**Case :** As per spec _3GPP TS 24.501 version 15.1.0 Release 15_ now, if UE is gone to IDLE mode then mobile reachable timer triggers. After mobile reachable timer got expires, implicit deregistration timer triggers. After Implicit deregistration timer expires, then Implicit deregistration is happened.
- mme log.
[mme_12july_2.log](https://github.com/magma/magma/files/9093782/mme_12july_2.log)

**Test 2:** Tested TAC value using UERANSIM.
- PCAP snap shot.
![image](https://user-images.githubusercontent.com/89978170/178512076-fcec70d7-6984-4e52-877f-dbe089b6b8f3.png)
[mme_tac_fix.log](https://github.com/magma/magma/files/9093808/mme_tac_fix.log)
- mme log.
[mme_tac_fix.log](https://github.com/magma/magma/files/9093898/mme_tac_fix.log)


**Test 3:** Tested basic sanity using UERANSIM.
- PCAP snap shot.
![image](https://user-images.githubusercontent.com/89978170/178512835-c9b2bffc-b756-4146-abff-2c6bcbc983e5.png)
![image](https://user-images.githubusercontent.com/89978170/178512969-232f01aa-5c57-4b97-a6aa-e0e1739474c4.png)
- mme log.
[mme_basic_sanity.log](https://github.com/magma/magma/files/9093888/mme_basic_sanity.log)


**Test 4:** Tested Service Request with traffic using UERANSIM.
- PCAP snap shot.
![image](https://user-images.githubusercontent.com/89978170/178513753-ec8a515a-2a17-4437-8b28-a9ec4d5550dd.png)
- mme log.
[mme_service_request.log](https://github.com/magma/magma/files/9093924/mme_service_request.log)

**Test 5:** Tested UT.
![UT](https://user-images.githubusercontent.com/89978170/178513953-8a337cdb-dadd-4b19-9c51-b8fcfa9645db.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
