### PR TITLE
chore(ci): Run the bazel workflow only in the magma repository or if dispatched manually

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       files_changed: ${{ steps.changes.outputs.files_changed }}
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     steps:
       # Need to get git on push event
       - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # pin@v2


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- The main part of the bazel workflow will only run in the actions of `magma/magma` (and not on the forks).
  - This saves remote caching costs and avoids unnecessary and unintentional triggers.
  - The workflow can be run manually with the workflow dispatch trigger anywhere, including forks.
  - The bash script jobs are unaffected (they do not execute bazel) as they are not behind the path filter. 

## Test Plan

- Tested on [demo workflow](https://github.com/LKreutzer/GH-actions-testing/blob/main/.github/workflows/test_if_conditions_for_path_filter.yml)
  - See [action runs](https://github.com/LKreutzer/GH-actions-testing/actions/workflows/test_if_conditions_for_path_filter.yml) where the repository owner name has been modified and the workflow dispatch has been tested.
  - CI

## Additional Information

- [ ] This change is backwards-breaking
