### PR TITLE
chore(ci): Cache the test results for bazel unit test runs if there are no changes

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -192,7 +192,6 @@ jobs:
             bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* \
               --config=asan \
               --test_output=errors \
-              --cache_test_results=no \
               --profile=Bazel_cpp_unit_tests_profile
             TEST_RESULT=$?
             # copy out test results

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -105,7 +105,6 @@ jobs:
             printf '\r%s\r' 'Executing bazel test //...' 1>&2 &&
             printf '\r%s\r' '###############################' 1>&2 &&
             bazel test //... \
-              --cache_test_results=no \
               --test_output=errors \
               --profile=Bazel_test_all_profile &&
 


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The unit test results are cached by bazel in CI
  - This is the **default** behaviour 
  - If there have been no changes to the relevant code the cached test result is displayed (if the test was successful)
- Benefits: much faster workflow
  - Typical time for executing all unit tests with bazel **`233.835s`** without caching test results
  -  Time for running all unit tests with cached test results on this PR: **`23.436s`** (most results were cached)
  
 

## Test Plan

- CI

## Additional Information

Extract from the [bazel docs](https://bazel.build/reference/command-line-reference):
![Screenshot from 2022-07-12 17-57-43](https://user-images.githubusercontent.com/34488763/178538077-e712a04b-e124-4b61-8929-05e2cbfe97ff.png)


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
