### PR TITLE
fix(agw): increase stability of ul dl integ tests

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -391,6 +391,7 @@ class TestWrapper(object):
         Raises:
             ValueError: If no valid IP is found
         """
+        time.sleep(1)
         # Configure downlink route in TRF server
         assert self._trf_util.update_dl_route(self.TEST_IP_BLOCK)
 
@@ -425,6 +426,7 @@ class TestWrapper(object):
         Raises:
             ValueError: If no valid IP is found
         """
+        time.sleep(1)
         ips = self._getAddresses(*ues)
         for ip, ue in zip(ips, ues):
             if not ip:


### PR DESCRIPTION
Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>

## Summary

Adding sleep timers for the uplink and downlink integration tests gives some time for the settings to propagate, which makes the tests much less flaky.

## Test Plan

During testing, the uplink and downlink integ tests were green on some machines, and on others they were red (the downlink tests were just really flaky). Introducing the sleep timer made the tests green on all machines.

Varying the sleep time showed the following behavior:
- 0.01: dl tests are flaky, ul tests fail
- 0.1: dl tests are stable, ul tests are flaky (~50% fail rate)
- 0.5 and more: ul and dl tests are stable

Since some tests are still very flaky for 0.5s sleep time and it seems to depend on the hardware (how quickly changes propagate vs how quickly the test runs through), to be on the save side we change use a sleep time about an order of magnitude larger than were the tests are still flaky, i.e. 1s.

## Additional Information

- [ ] This change is backwards-breaking

