### PR TITLE
chore(ci): Run the LTE integ tests on bazel-built services in new workflow

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -109,3 +109,14 @@ jobs:
         with:
           files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
+      - name: Notify failure to slack
+        if: failure() && github.repository_owner == 'magma'
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel LTE integ tests"
+          SLACK_USERNAME: "Bazel LTE integ tests"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -1,0 +1,111 @@
+---
+
+name: LTE integ test bazel
+
+on:
+  workflow_dispatch: null
+  workflow_run:
+    workflows:
+      - build-all
+    branches:
+      - master
+      - 'v1.*'
+    types:
+      - completed
+
+jobs:
+  lte-integ-test-bazel:
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-10.15
+    env:
+      SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
+    steps:
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
+        with:
+          ref: ${{ env.SHA }}
+      - name: Cache magma-dev-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
+          key: vagrant-box-magma-dev
+      - name: Cache magma-test-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
+          key: vagrant-box-magma-test
+      - name: Cache magma-trfserver-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
+          key: vagrant-box-magma-trfserver
+      - name: setup pyenv
+        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
+        with:
+          default: 3.8.5
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
+        with:
+          python-version: '3.8.10'
+      - name: Install pre requisites
+        run: |
+          pip3 install --upgrade pip
+          pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
+          vagrant plugin install vagrant-vbguest vagrant-disksize
+      - name: Open up network interfaces for VM
+        run: |
+          sudo mkdir -p /etc/vbox/
+          sudo touch /etc/vbox/networks.conf
+          sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
+          sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
+      - name: Prepare the integ test
+        run: |
+          cd lte/gateway
+          export MAGMA_DEV_CPUS=3
+          export MAGMA_DEV_MEMORY_MB=9216
+          fab bazel_integ_test_pre_build
+      - name: Build all services with bazel
+        run: |
+          cd lte/gateway
+          vagrant ssh -c 'sudo sed -i "s@#precedence ::ffff:0:0/96  100@precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
+          vagrant ssh -c 'cd ~/magma; bazel build --profile=bazel_profile_lte_integ_tests `bazel query "kind(.*_binary, //orc8r/... union //lte/...)"`;' magma
+          vagrant ssh -c 'sudo sed -i "s@precedence ::ffff:0:0/96  100@#precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
+      - name: Run the integ test
+        run: |
+          cd lte/gateway
+          export MAGMA_DEV_CPUS=3
+          export MAGMA_DEV_MEMORY_MB=9216
+          fab bazel_integ_test_post_build
+      - name: Publish bazel profile
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: Bazel profile lte integ tests
+          path: bazel_profile_lte_integ_tests
+      - name: Get test results
+        if: always()
+        run: |
+          cd lte/gateway
+          fab get_test_summaries:dst_path="test-results"
+          ls -R
+      - name: Upload test results
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: test-results
+          path: lte/gateway/test-results/**/*.xml
+      - name: Get test logs
+        if: failure()
+        run: |
+          cd lte/gateway
+          fab get_test_logs:dst_path=./logs.tar.gz
+      - name: Upload test logs
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: failure()
+        with:
+          name: test-logs
+          path: lte/gateway/logs.tar.gz
+      - name: Publish Unit Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@7377632048da85434c30810c38353542d3162dc4 # pin@v1
+        with:
+          files: lte/gateway/test-results/**/*.xml
+          check_run_annotations: all tests

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@connectiond.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@connectiond.service
@@ -1,0 +1,35 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma connection tracking service
+PartOf=magma@mme.service
+Before=magma@mme.service
+After=magma@pipelined.service
+After=openvswitch-switch.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/connection_tracker/src/connectiond
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py connectiond
+MemoryAccounting=yes
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=connectiond
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@ctraced.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@ctraced.service
@@ -1,0 +1,29 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma ctraced service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/ctraced/ctraced
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py ctraced
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=ctraced
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@directoryd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@directoryd.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma directoryd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/directoryd/directoryd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py directoryd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=directoryd
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@enodebd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@enodebd.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma enodebd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/enodebd/enodebd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py enodebd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=enodebd
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@eventd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@eventd.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma eventd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStartPre=/usr/sbin/ntpdate pool.ntp.org
+ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/eventd/eventd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py eventd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=eventd
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@health.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@health.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma health service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/health/health
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py health
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=health
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@kernsnoopd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@kernsnoopd.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma kernsnoopd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/kernsnoopd/kernsnoopd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py kernsnoopd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=kernsnoopd
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@liagentd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@liagentd.service
@@ -1,0 +1,33 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma li agent service
+PartOf=magma@pipelined.service
+After=magma@pipelined.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/li_agent/src/liagentd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py liagentd
+MemoryAccounting=yes
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=liagentd
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@magmad.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@magmad.service
@@ -1,0 +1,31 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma magmad service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/magmad/magmad
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py magmad
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=magmad
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+KillMode=process
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mme.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mme.service
@@ -1,0 +1,43 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma OAI MME service
+PartOf=magma@mobilityd.service
+After=magma@mobilityd.service
+PartOf=magma@pipelined.service
+After=magma@pipelined.service
+PartOf=magma@sessiond.service
+After=magma@sessiond.service
+Requires=sctpd.service
+After=sctpd.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/core/agw_of -c /var/opt/magma/tmp/mme.conf -s /var/opt/magma/tmp/spgw.conf
+MemoryAccounting=yes
+MemoryLimit=13%
+MemoryMin=512M
+ExecStartPre=/usr/bin/env python3 /usr/local/bin/generate_oai_config.py
+ExecStartPre=/usr/bin/env python3 /usr/local/bin/config_stateless_agw.py reset_sctpd_for_stateful
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py mme
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=mme
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mobilityd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mobilityd.service
@@ -1,0 +1,35 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma mobilityd service
+PartOf=magma@mme.service
+Before=magma@mme.service
+After=magma@subscriberdb.service
+Wants=magma@subscriberdb.service
+After=openvswitch-switch.service
+Wants=openvswitch-switch.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/mobilityd/mobilityd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py mobilityd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=mobilityd
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@monitord.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@monitord.service
@@ -1,0 +1,31 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma monitord service
+PartOf=magma@mme.service
+Before=magma@mme.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/monitord/monitord
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py monitord
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=monitord
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@pipelined.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@pipelined.service
@@ -1,0 +1,47 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma pipelined service
+PartOf=magma@mme.service
+Before=magma@mme.service
+PartOf=magma@mobilityd.service
+After=magma@mobilityd.service
+PartOf=openvswitch-switch.service
+After=openvswitch-switch.service
+Wants=openvswitch-switch.service
+
+[Service]
+Type=simple
+PermissionsStartOnly=true
+LimitNOFILE=65536
+LimitNPROC=65536
+LimitSIGPENDING=65536
+EnvironmentFile=/etc/environment
+ExecStartPre=/usr/bin/ovs-vsctl --all destroy Flow_Sample_Collector_Set
+ExecStartPre=/usr/bin/ovs-vsctl set bridge gtp_br0 protocols=OpenFlow10,OpenFlow13,OpenFlow14 other-config:disable-in-band=true
+ExecStartPre=/usr/bin/ovs-vsctl set-controller gtp_br0 tcp:127.0.0.1:6633 tcp:127.0.0.1:6654
+ExecStartPre=/usr/bin/ovs-vsctl set-fail-mode gtp_br0 secure
+ExecStartPre=/bin/bash -c 'for id in `sudo /usr/bin/ovsdb-client dump Controller _uuid|tail -n +4` ; do  sudo /usr/bin/ovs-vsctl set Controller $id inactivity_probe=300  ; done'
+ExecStartPre=/usr/bin/ovs-vsctl set-manager ptcp:6640
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/pipelined/pipelined
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py pipelined
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=pipelined
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=13%
+MemoryMin=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@policydb.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@policydb.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma policydb service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/policydb/policydb
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py policydb
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=policydb
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@redirectd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@redirectd.service
@@ -1,0 +1,29 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma redirectd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/redirectd/redirectd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=redirectd
+User=root
+Restart=always
+RestartSec=5
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@sessiond.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@sessiond.service
@@ -1,0 +1,34 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma session manager service
+PartOf=magma@mme.service
+Before=magma@mme.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/session_manager/sessiond
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py sessiond
+MemoryAccounting=yes
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sessiond
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+MemoryLimit=8%
+MemoryMin=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@smsd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@smsd.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma smsd service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/smsd/smsd
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py smsd
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=smsd
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@state.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@state.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma state service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/state/state
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py state
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=state
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@subscriberdb.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@subscriberdb.service
@@ -1,0 +1,30 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma subscriberdb service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/subscriberdb/subscriberdb
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py subscriberdb
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=subscriberdb
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/sctpd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/sctpd.service
@@ -1,0 +1,37 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma sctpd service
+Before=magma@mme.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStartPre=-/bin/cp -f /usr/local/share/sctpd/version /var/run/sctpd.version
+ExecStartPre=/usr/bin/env python3 /usr/local/bin/config_stateless_agw.py sctpd_pre
+ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/sctpd/src/sctpd
+ExecStartPost=/usr/bin/env python3 /usr/local/bin/config_stateless_agw.py sctpd_post
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py sctpd
+ExecStopPost=-/bin/rm -f /var/run/sctpd.version
+MemoryAccounting=yes
+MemoryLimit=512M
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sctpd
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -306,6 +306,118 @@ def federated_integ_test(
     execute(run_integ_tests, "federated_tests/s1aptests/test_attach_detach.py")
 
 
+def _modify_for_bazel_services():
+    """ Modify the service definitions to use the bazel-built executables """
+    run(r"sudo cp $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/systemd_bazel/* /etc/systemd/system/")
+    run("sudo systemctl daemon-reload")
+
+
+def bazel_integ_test_pre_build(
+    gateway_host=None, test_host=None, trf_host=None,
+    destroy_vm='True', provision_vm='True',
+):
+    """
+    Prepare to run the integration tests on the bazel build services.
+    This defaults to running on local vagrant machines, but can also be
+    pointed to an arbitrary host (e.g. amazon) by passing "address:port"
+    as arguments
+
+    gateway_host: The ssh address string of the machine to run the gateway
+        services on. Formatted as "host:port". If not specified, defaults to
+        the `magma` vagrant box.
+
+    test_host: The ssh address string of the machine to run the tests on
+        on. Formatted as "host:port". If not specified, defaults to the
+        `magma_test` vagrant box.
+
+    trf_host: The ssh address string of the machine to run the TrafficServer
+        on. Formatted as "host:port". If not specified, defaults to the
+        `magma_trfserver` vagrant box.
+    """
+    destroy_vm = bool(strtobool(destroy_vm))
+    provision_vm = bool(strtobool(provision_vm))
+
+    # Setup the gateway: use the provided gateway if given, else default to the
+    # vagrant machine
+    gateway_ip = '192.168.60.142'
+
+    if not gateway_host:
+        gateway_host = vagrant_setup(
+            'magma', destroy_vm, force_provision=provision_vm,
+        )
+    else:
+        ansible_setup(gateway_host, "dev", "magma_dev.yml")
+        gateway_ip = gateway_host.split('@')[1].split(':')[0]
+
+    execute(_dist_upgrade)
+    execute(_modify_for_bazel_services)
+
+
+def bazel_integ_test_post_build(
+    gateway_host=None, test_host=None, trf_host=None,
+    destroy_vm='True', provision_vm='True',
+):
+    """
+    Run the integration tests on the bazel build services. This defaults to
+    running on local vagrant machines, but can also be pointed to an
+    arbitrary host (e.g. amazon) by passing "address:port" as arguments
+
+    gateway_host: The ssh address string of the machine to run the gateway
+        services on. Formatted as "host:port". If not specified, defaults to
+        the `magma` vagrant box.
+
+    test_host: The ssh address string of the machine to run the tests on
+        on. Formatted as "host:port". If not specified, defaults to the
+        `magma_test` vagrant box.
+
+    trf_host: The ssh address string of the machine to run the TrafficServer
+        on. Formatted as "host:port". If not specified, defaults to the
+        `magma_trfserver` vagrant box.
+    """
+    destroy_vm = bool(strtobool(destroy_vm))
+    provision_vm = bool(strtobool(provision_vm))
+
+    gateway_ip = '192.168.60.142'
+
+    if not gateway_host:
+        gateway_host = vagrant_setup(
+            'magma', False, force_provision=False,
+        )
+    else:
+        ansible_setup(gateway_host, "dev", "magma_dev.yml")
+        gateway_ip = gateway_host.split('@')[1].split(':')[0]
+
+    execute(_run_sudo_python_unit_tests)
+    execute(_restart_gateway)
+
+    # Setup the trfserver: use the provided trfserver if given, else default to the
+    # vagrant machine
+    if not trf_host:
+        trf_host = vagrant_setup(
+            'magma_trfserver', destroy_vm, force_provision=provision_vm,
+        )
+    else:
+        ansible_setup(trf_host, "trfserver", "magma_trfserver.yml")
+    execute(_start_trfserver)
+
+    # Run the tests: use the provided test machine if given, else default to
+    # the vagrant machine
+    if not test_host:
+        test_host = vagrant_setup(
+            'magma_test', destroy_vm, force_provision=provision_vm,
+        )
+    else:
+        ansible_setup(test_host, "test", "magma_test.yml")
+
+    execute(_make_integ_tests)
+    execute(_run_integ_tests, gateway_ip)
+
+    if not gateway_host:
+        setup_env_vagrant()
+    else:
+        env.hosts = [gateway_host]
+
+
 def integ_test(
     gateway_host=None, test_host=None, trf_host=None,
     destroy_vm='True', provision_vm='True',
@@ -664,6 +776,13 @@ def _start_gateway():
 
     with cd(AGW_ROOT):
         run('make run')
+
+
+def _restart_gateway():
+    """ Restart the gateway """
+
+    with cd(AGW_ROOT):
+        run('make restart')
 
 
 def _set_service_config_var(service, var_name, value):


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Create LTE integ test workflow that runs the LTE integ tests on the bazel-built services.
  - Create service files for all services that start the bazel-built executables.
  - Service files are copied at runtime into the `/etc/systemd/system/` folder.
- The `.yml` workflow file is kept as close as possible to the Make LTE integ tests to make sure that the environment is the same.
  - The code duplication is temporary until the bazel switchover happens.
  - Adapting the workflow to both build systems adds too much complexity. 
- New fabric functions for running the integ tests are created 
  - This was necessary in order to be able to run the bazel build with `vagrant ssh` directly from the runner which avoids going through fabric
  - Fabric leads to a massive slowdown of the bazel build due to logging piling up
  - See also #12963 
- Note: The `/etc/gai.conf` file is temporarily - for the bazel build - modified in order to prefer IPv4 connections which speeds up the bazel build.
- During the (re-)start of the AGW usually another `make build` is executed, to avoid this a new fabric function that only does a `make restart` is created.
- Resolves https://github.com/magma/magma/issues/12057

## Test Plan

Manually run the workflow.
1. [Run on fork](https://github.com/LKreutzer/magma/actions/runs/2690050327)
2. [Run on fork](https://github.com/LKreutzer/magma/actions/runs/2696194463)
3. [Run on fork](https://github.com/LKreutzer/magma/actions/runs/2696193874)
4. [Run on fork](https://github.com/LKreutzer/magma/actions/runs/2703791422)
5. [Run on fork](https://github.com/LKreutzer/magma/actions/runs/2703793455)

## Additional Information
- Currently the bazel remote cache is not used in this workflow
  - This saves remote caching costs
  - Currently there is an issue when building inside the VM on a MacOs runner with the remote cache that leads to IO errors and failing builds 
- Note: We do not use a GH matrix workflow here in order to keep the complexity low, to not disrupt the result reporting from the standard LTE integ test workflow and because we expect further modifications of this workflow that may be incompatible with the standard workflow.
- See also https://github.com/magma/magma/issues/13353



- [ ] This change is backwards-breaking