### PR TITLE
fix(nms): Fix context menu postion in some action tables

### DIFF
--- a/nms/app/views/alarms/components/alertmanager/Receivers/Receivers.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/Receivers.tsx
@@ -44,6 +44,21 @@ const useStyles = makeStyles<Theme>(theme => ({
   },
 }));
 
+const receiverColumns = [
+  {
+    title: 'Name',
+    field: 'name',
+  },
+  {
+    title: 'Notifications',
+    field: 'labels',
+    render: (row: AlertReceiver) => {
+      const labels = getNotificationsSummary(row);
+      return <LabelsCell value={labels} />;
+    },
+  },
+];
+
 export default function Receivers() {
   const {apiUtil, alertManagerGlobalConfigEnabled} = useAlarmContext();
   const [isAddEditReceiver, setIsAddEditReceiver] = React.useState(false);
@@ -159,20 +174,7 @@ export default function Receivers() {
         <>
           <SimpleTable
             onRowClick={row => setSelectedRow(row)}
-            columnStruct={[
-              {
-                title: 'Name',
-                field: 'name',
-              },
-              {
-                title: 'Notifications',
-                field: 'labels',
-                render: row => {
-                  const labels = getNotificationsSummary(row);
-                  return <LabelsCell value={labels} />;
-                },
-              },
-            ]}
+            columnStruct={receiverColumns}
             tableData={receiversData}
             dataTestId="receiver"
             menuItems={[

--- a/nms/app/views/traffic/ApnOverview.tsx
+++ b/nms/app/views/traffic/ApnOverview.tsx
@@ -111,7 +111,7 @@ const useStyles = makeStyles<Theme>(theme => ({
 }));
 
 type ApnRowType = {
-  apnID: string;
+  id: string;
   classID: number;
   arpPriorityLevel: number;
   maxReqdULBw: number;
@@ -133,7 +133,7 @@ function ApnOverview(props: WithAlert) {
     ? Object.keys(apns).map((apn: string) => {
         const cfg = apns[apn].apn_configuration;
         return {
-          apnID: apn,
+          id: apn,
           classID: cfg?.qos_profile.class_id ?? 0,
           arpPriorityLevel: cfg?.qos_profile.priority_level ?? 0,
           maxReqdULBw: cfg?.ambr.max_bandwidth_ul ?? 0,
@@ -158,7 +158,7 @@ function ApnOverview(props: WithAlert) {
         <ApnEditDialog
           open={open}
           onClose={() => setOpen(false)}
-          apn={Object.keys(currRow).length ? apns[currRow.apnID] : undefined}
+          apn={Object.keys(currRow).length ? apns[currRow.id] : undefined}
         />
         {Object.keys(ctx.state).length > 0 ? (
           <>
@@ -168,7 +168,7 @@ function ApnOverview(props: WithAlert) {
               columns={[
                 {
                   title: 'Apn ID',
-                  field: 'apnID',
+                  field: 'id',
                   render: currRow => (
                     <Link
                       variant="body2"
@@ -177,7 +177,7 @@ function ApnOverview(props: WithAlert) {
                         setCurrRow(currRow);
                         setOpen(true);
                       }}>
-                      {currRow.apnID}
+                      {currRow.id}
                     </Link>
                   ),
                 },
@@ -215,7 +215,7 @@ function ApnOverview(props: WithAlert) {
                 {
                   name: 'Edit JSON',
                   handleFunc: () => {
-                    navigate(currRow.apnID + '/json');
+                    navigate(currRow.id + '/json');
                   },
                 },
                 {name: 'Deactivate'},
@@ -223,9 +223,7 @@ function ApnOverview(props: WithAlert) {
                   name: 'Remove',
                   handleFunc: () => {
                     void props
-                      .confirm(
-                        `Are you sure you want to delete ${currRow.apnID}?`,
-                      )
+                      .confirm(`Are you sure you want to delete ${currRow.id}?`)
                       .then(async confirmed => {
                         if (!confirmed) {
                           return;
@@ -233,14 +231,11 @@ function ApnOverview(props: WithAlert) {
 
                         try {
                           // trigger deletion
-                          await ctx.setState(currRow.apnID);
+                          await ctx.setState(currRow.id);
                         } catch (e) {
-                          enqueueSnackbar(
-                            'failed deleting APN ' + currRow.apnID,
-                            {
-                              variant: 'error',
-                            },
-                          );
+                          enqueueSnackbar('failed deleting APN ' + currRow.id, {
+                            variant: 'error',
+                          });
                         }
                       });
                   },

--- a/nms/app/views/traffic/DataPlanOverview.tsx
+++ b/nms/app/views/traffic/DataPlanOverview.tsx
@@ -42,14 +42,14 @@ const useStyles = makeStyles<Theme>(theme => ({
 /**
  * Stores info for a single row of the data plan table.
  *
- * @property {string} dataPlanID
+ * @property {string} id
  * @property {string} maxUploadBitRate
  *    - bit rate specified in Mbps
  * @property {string} maxDownloadBitRate
  *    - bit rate specified in Mbps
  */
 type DataPlanRowType = {
-  dataPlanID: string;
+  id: string;
   maxUploadBitRate: string;
   maxDownloadBitRate: string;
 };
@@ -79,7 +79,7 @@ function DataPlanOverview(props: WithAlert) {
     ? Object.keys(dataPlans || {}).map((id: string) => {
         const profile = nullthrows(dataPlans)[id];
         return {
-          dataPlanID: id,
+          id: id,
           maxUploadBitRate:
             profile.max_dl_bit_rate ===
             DATA_PLAN_UNLIMITED_RATES.max_dl_bit_rate
@@ -126,14 +126,14 @@ function DataPlanOverview(props: WithAlert) {
         <DataPlanEditDialog
           open={open}
           onClose={() => setOpen(false)}
-          dataPlanId={currRow.dataPlanID}
+          dataPlanId={currRow.id}
         />
         <ActionTable
           data={dataPlanRows}
           columns={[
             {
               title: 'Data Plan ID',
-              field: 'dataPlanID',
+              field: 'id',
               render: currRow => (
                 <Link
                   variant="body2"
@@ -142,7 +142,7 @@ function DataPlanOverview(props: WithAlert) {
                     setCurrRow(currRow);
                     setOpen(true);
                   }}>
-                  {currRow.dataPlanID}
+                  {currRow.id}
                 </Link>
               ),
             },
@@ -170,7 +170,7 @@ function DataPlanOverview(props: WithAlert) {
               handleFunc: () => {
                 void props
                   .confirm(
-                    `Are you sure you want to delete data plan ${currRow.dataPlanID}?`,
+                    `Are you sure you want to delete data plan ${currRow.id}?`,
                   )
                   .then(async confirmed => {
                     if (!confirmed) {
@@ -178,10 +178,10 @@ function DataPlanOverview(props: WithAlert) {
                     }
 
                     try {
-                      await onDelete(currRow.dataPlanID);
+                      await onDelete(currRow.id);
                     } catch (e) {
                       enqueueSnackbar(
-                        'failed deleting data plan ' + currRow.dataPlanID,
+                        'failed deleting data plan ' + currRow.id,
                         {
                           variant: 'error',
                         },

--- a/nms/app/views/traffic/PolicyOverview.tsx
+++ b/nms/app/views/traffic/PolicyOverview.tsx
@@ -111,7 +111,7 @@ const useStyles = makeStyles<Theme>(theme => ({
 }));
 
 type PolicyRowType = {
-  policyID: string;
+  id: string;
   numFlows: number;
   priority: number;
   numSubscribers: number;
@@ -122,20 +122,20 @@ type PolicyRowType = {
 };
 
 type BaseNameRowType = {
-  baseNameID: string;
+  id: string;
   ruleNames: Array<string>;
   numSubscribers: number;
 };
 
 type ProfileRowType = {
   classID: QosClassId;
-  profileID: string;
+  id: string;
   uplinkBandwidth: number;
   downlinkBandwidth: number;
 };
 
 type RatingGroupRowType = {
-  ratingGroupID: string;
+  id: string;
   limitType: string;
 };
 
@@ -236,7 +236,7 @@ export function PolicyTableRaw(props: WithAlert) {
     ? Object.keys(policies).map((policyID: string) => {
         const policyRule = policies[policyID];
         return {
-          policyID: policyRule.id,
+          id: policyRule.id,
           numFlows: policyRule.flow_list?.length ?? 0,
           priority: policyRule.priority,
           numSubscribers: policyRule.assigned_subscribers?.length ?? 0,
@@ -253,16 +253,14 @@ export function PolicyTableRaw(props: WithAlert) {
       <PolicyRuleEditDialog
         open={open}
         onClose={() => setOpen(false)}
-        rule={
-          Object.keys(currRow).length ? policies[currRow.policyID] : undefined
-        }
+        rule={Object.keys(currRow).length ? policies[currRow.id] : undefined}
       />
       <ActionTable
         data={policyRows}
         columns={[
           {
             title: 'Policy ID',
-            field: 'policyID',
+            field: 'id',
             render: currRow => (
               <Link
                 variant="body2"
@@ -271,7 +269,7 @@ export function PolicyTableRaw(props: WithAlert) {
                   setCurrRow(currRow);
                   setOpen(true);
                 }}>
-                {currRow.policyID}
+                {currRow.id}
               </Link>
             ),
           },
@@ -309,7 +307,7 @@ export function PolicyTableRaw(props: WithAlert) {
           {
             name: 'Edit JSON',
             handleFunc: () => {
-              navigate(currRow.policyID + '/json');
+              navigate(currRow.id + '/json');
             },
           },
           {name: 'Deactivate'},
@@ -317,7 +315,7 @@ export function PolicyTableRaw(props: WithAlert) {
             name: 'Remove',
             handleFunc: () => {
               void props
-                .confirm(`Are you sure you want to delete ${currRow.policyID}?`)
+                .confirm(`Are you sure you want to delete ${currRow.id}?`)
                 .then(async confirmed => {
                   if (!confirmed) {
                     return;
@@ -325,14 +323,11 @@ export function PolicyTableRaw(props: WithAlert) {
 
                   try {
                     // trigger deletion
-                    await ctx.setState(currRow.policyID);
+                    await ctx.setState(currRow.id);
                   } catch (e) {
-                    enqueueSnackbar(
-                      'failed deleting policy ' + currRow.policyID,
-                      {
-                        variant: 'error',
-                      },
-                    );
+                    enqueueSnackbar('failed deleting policy ' + currRow.id, {
+                      variant: 'error',
+                    });
                   }
                 });
             },
@@ -359,7 +354,7 @@ export function BaseNameTableRaw(props: WithAlert) {
     ? Object.keys(baseNames).map((baseNameID: string) => {
         const baseNameRecord = baseNames[baseNameID];
         return {
-          baseNameID: baseNameID,
+          id: baseNameID,
           ruleNames: baseNameRecord.rule_names,
           numSubscribers: baseNameRecord?.assigned_subscribers?.length || 0,
         };
@@ -371,14 +366,14 @@ export function BaseNameTableRaw(props: WithAlert) {
       <BaseNameEditDialog
         open={open}
         onClose={() => setOpen(false)}
-        baseNameId={currRow?.baseNameID}
+        baseNameId={currRow?.id}
       />
       <ActionTable
         data={baseNameRows}
         columns={[
           {
             title: 'Base Name ID',
-            field: 'baseNameID',
+            field: 'id',
             render: currRow => (
               <Link
                 variant="body2"
@@ -387,7 +382,7 @@ export function BaseNameTableRaw(props: WithAlert) {
                   setCurrRow(currRow);
                   setOpen(true);
                 }}>
-                {currRow.baseNameID}
+                {currRow.id}
               </Link>
             ),
           },
@@ -424,9 +419,7 @@ export function BaseNameTableRaw(props: WithAlert) {
             name: 'Remove',
             handleFunc: () => {
               void props
-                .confirm(
-                  `Are you sure you want to delete ${currRow.baseNameID}?`,
-                )
+                .confirm(`Are you sure you want to delete ${currRow.id}?`)
                 .then(async confirmed => {
                   if (!confirmed) {
                     return;
@@ -434,14 +427,11 @@ export function BaseNameTableRaw(props: WithAlert) {
 
                   try {
                     // trigger deletion
-                    await ctx.setBaseNames(currRow.baseNameID);
+                    await ctx.setBaseNames(currRow.id);
                   } catch (e) {
-                    enqueueSnackbar(
-                      'failed deleting base name ' + currRow.baseNameID,
-                      {
-                        variant: 'error',
-                      },
-                    );
+                    enqueueSnackbar('failed deleting base name ' + currRow.id, {
+                      variant: 'error',
+                    });
                   }
                 });
             },
@@ -466,7 +456,7 @@ export function ProfileTableRaw(props: WithAlert) {
     ? Object.keys(profiles).map((profileID: string) => {
         const profile = profiles[profileID];
         return {
-          profileID: profile.id,
+          id: profile.id,
           classID: profile.class_id,
           uplinkBandwidth: profile.max_req_bw_ul,
           downlinkBandwidth: profile.max_req_bw_dl,
@@ -479,16 +469,14 @@ export function ProfileTableRaw(props: WithAlert) {
       <ProfileEditDialog
         open={open}
         onClose={() => setOpen(false)}
-        profile={
-          Object.keys(currRow).length ? profiles[currRow.profileID] : undefined
-        }
+        profile={Object.keys(currRow).length ? profiles[currRow.id] : undefined}
       />
       <ActionTable
         data={profileRows}
         columns={[
           {
             title: 'Profile ID',
-            field: 'profileID',
+            field: 'id',
             render: currRow => (
               <Link
                 variant="body2"
@@ -497,7 +485,7 @@ export function ProfileTableRaw(props: WithAlert) {
                   setCurrRow(currRow);
                   setOpen(true);
                 }}>
-                {currRow.profileID}
+                {currRow.id}
               </Link>
             ),
           },
@@ -525,9 +513,7 @@ export function ProfileTableRaw(props: WithAlert) {
             name: 'Remove',
             handleFunc: () => {
               void props
-                .confirm(
-                  `Are you sure you want to delete ${currRow.profileID}?`,
-                )
+                .confirm(`Are you sure you want to delete ${currRow.id}?`)
                 .then(async confirmed => {
                   if (!confirmed) {
                     return;
@@ -535,14 +521,11 @@ export function ProfileTableRaw(props: WithAlert) {
 
                   try {
                     // trigger deletion
-                    await ctx.setQosProfiles(currRow.profileID);
+                    await ctx.setQosProfiles(currRow.id);
                   } catch (e) {
-                    enqueueSnackbar(
-                      'failed deleting profile ' + currRow.profileID,
-                      {
-                        variant: 'error',
-                      },
-                    );
+                    enqueueSnackbar('failed deleting profile ' + currRow.id, {
+                      variant: 'error',
+                    });
                   }
                 });
             },
@@ -569,7 +552,7 @@ export function RatingGroupTableRaw(props: WithAlert) {
     ? Object.keys(ratingGroups).map((ratingGroupID: string) => {
         const ratingGroup = ratingGroups[ratingGroupID];
         return {
-          ratingGroupID: ratingGroup.id.toString(),
+          id: ratingGroup.id.toString(),
           limitType: ratingGroup.limit_type,
         };
       })
@@ -580,9 +563,7 @@ export function RatingGroupTableRaw(props: WithAlert) {
         open={open}
         onClose={() => setOpen(false)}
         ratingGroup={
-          Object.keys(currRow).length
-            ? ratingGroups[currRow.ratingGroupID]
-            : undefined
+          Object.keys(currRow).length ? ratingGroups[currRow.id] : undefined
         }
       />
       <ActionTable
@@ -590,7 +571,7 @@ export function RatingGroupTableRaw(props: WithAlert) {
         columns={[
           {
             title: 'Rating Group ID',
-            field: 'ratingGroupID',
+            field: 'id',
             render: currRow => (
               <Link
                 variant="body2"
@@ -599,7 +580,7 @@ export function RatingGroupTableRaw(props: WithAlert) {
                   setCurrRow(currRow);
                   setOpen(true);
                 }}>
-                {currRow.ratingGroupID}
+                {currRow.id}
               </Link>
             ),
           },
@@ -618,7 +599,7 @@ export function RatingGroupTableRaw(props: WithAlert) {
             handleFunc: () => {
               void props
                 .confirm(
-                  `Are you sure you want to delete Rating Group ${currRow.ratingGroupID}?`,
+                  `Are you sure you want to delete Rating Group ${currRow.id}?`,
                 )
                 .then(async confirmed => {
                   if (!confirmed) {
@@ -626,10 +607,10 @@ export function RatingGroupTableRaw(props: WithAlert) {
                   }
 
                   try {
-                    await ctx.setRatingGroups(currRow.ratingGroupID.toString());
+                    await ctx.setRatingGroups(currRow.id.toString());
                   } catch (e) {
                     enqueueSnackbar(
-                      'failed deleting rating group ' + currRow.ratingGroupID,
+                      'failed deleting rating group ' + currRow.id,
                       {
                         variant: 'error',
                       },


### PR DESCRIPTION
## Summary

The context menu of several action tables was placed incorrect because the anchor element for the menu was unmounted and remounted during the positioning.  

- Fixes: #13184

## Test Plan

Make sure that context menu in the tables of all policy tabs, the APNs page, Data Plans page and the Alert Receivers page open in the correct place.   
![Screenshot 2022-07-13 at 13 47 50](https://user-images.githubusercontent.com/102796295/178726626-89110b9d-df4e-4b43-b066-bc758bf51cd7.png)


