### PR TITLE
fix(nms): Disable sorting of subscribers table

### DIFF
--- a/nms/app/views/subscriber/SubscriberTable.tsx
+++ b/nms/app/views/subscriber/SubscriberTable.tsx
@@ -497,7 +497,7 @@ function SubscribersTable(props: WithAlert) {
               filter={() => (
                 <Grid
                   container
-                  justify="flex-end"
+                  justifyContent="flex-end"
                   alignItems="center"
                   spacing={2}>
                   <Grid item>
@@ -593,6 +593,8 @@ function SubscribersTable(props: WithAlert) {
                 },
               ]}
               options={{
+                idSynonym: 'imsi',
+                sorting: false,
                 actionsColumnIndex: -1,
                 pageSize: DEFAULT_PAGE_SIZE,
                 pageSizeOptions: [],
@@ -601,7 +603,7 @@ function SubscribersTable(props: WithAlert) {
             />
           </>
         ) : (
-          <Grid container justify="space-between" spacing={3}>
+          <Grid container justifyContent="space-between" spacing={3}>
             <SubscriberActionsMenu
               addDialog={addDialog}
               hideButton={true}


### PR DESCRIPTION
## Summary

The subscribers are fetched paginated therefore the sorting has to be done in the orchestrator and is just not implemented at the moment. As quick "fix" we are disabling sorting on the table for now.

- fixes #8951

## Test Plan

Make sure that no sort indicators are shown on the subscribers table.


