### PR TITLE
chore(dp): allow rc enodebd_client to send EnodebdUpdateCbsd request

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -172,7 +172,7 @@ jobs:
           reporter: github-pr-review
           locale: "US"
           exclude: |
-            nms/yarn.lock
+            ./nms/yarn.lock
 
   mypy:
     needs: files_changed

--- a/dp/cloud/python/magma/radio_controller/enodebd_client.py
+++ b/dp/cloud/python/magma/radio_controller/enodebd_client.py
@@ -15,10 +15,38 @@ import argparse
 import json
 import logging
 import sys
+from collections import namedtuple
+from typing import Optional, Type, Union
 
 import grpc
-from dp.protos import enodebd_dp_pb2 as enodebd_msgs
-from dp.protos import enodebd_dp_pb2_grpc as enodebd_services
+from dp.protos.cbsd_pb2 import EnodebdUpdateCbsdRequest
+from dp.protos.cbsd_pb2_grpc import CbsdManagementStub
+from dp.protos.enodebd_dp_pb2 import CBSDRequest
+from dp.protos.enodebd_dp_pb2_grpc import DPServiceStub
+from google.protobuf import json_format
+
+SERVICES_ADDRESSES = {
+    DPServiceStub: 'localhost:50053',
+    CbsdManagementStub: 'orc8r-dp:9180',
+}
+MAGMA_CERTS = (
+    'x-magma-client-cert-serial',
+    '7ZZXAF7CAETF241KL22B8YRR7B5UF401',
+)
+
+CommandConfig = namedtuple("CommandConfig", 'service_cls method_name message_cls request_kwargs')
+COMMANDS_CONFIG = {
+    'state': CommandConfig(DPServiceStub, 'GetCBSDState', CBSDRequest, {}),
+    'register': CommandConfig(DPServiceStub, 'CBSDRegister', CBSDRequest, {}),
+    'deregister': CommandConfig(DPServiceStub, 'CBSDDeregister', CBSDRequest, {}),
+    'relinquish': CommandConfig(DPServiceStub, 'CBSDRelinquish', CBSDRequest, {}),
+    'update': CommandConfig(
+        CbsdManagementStub, 'EnodebdUpdateCbsd', EnodebdUpdateCbsdRequest, {'metadata': (MAGMA_CERTS,)},
+    ),
+}
+
+ServiceType = Union[DPServiceStub, CbsdManagementStub]
+MessageType = Union[CBSDRequest, EnodebdUpdateCbsdRequest]
 
 default_cbsd_dict = {
     "serial_number": "enodebd_client_serial_number",
@@ -29,8 +57,18 @@ default_cbsd_dict = {
     "antenna_gain": 15,
     "number_of_ports": 2,
 }
-
-DP_RC_SERVICE_ADDR = 'localhost:50053'
+default_cbsd_update_dict = {
+    "serial_number": "enodebd_client_serial_number",
+    "installation_param": {
+        "antenna_gain": 15,
+        "latitude_deg": 10.6,
+        "longitude_deg": 11.6,
+        "indoor_deployment": True,
+        "height_type": "agl",
+        "height_m": 12.5,
+    },
+    "cbsd_category": "a",
+}
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -39,17 +77,35 @@ logging.basicConfig(
 )
 
 
-def create_rc_service_channel(addr: str):
+def _create_service(
+        service_cls: Type[ServiceType], address: Optional[str] = None,
+) -> ServiceType:
     """
-    Create Radio Controller service gRPC channel
+    Create gRPC service.
 
     Parameters:
-        addr: Radio Controller gRPC service URL
+        service_cls: protobuf class of gRPC service
+        address: gRPC service URL
+
+    Returns:
+        gRPC service instance
+    """
+    service_address = address or SERVICES_ADDRESSES[service_cls]
+    channel = _create_service_channel(address=service_address)
+    return service_cls(channel)
+
+
+def _create_service_channel(address: str) -> grpc.Channel:
+    """
+    Create gRPC channel for the gRPC service
+
+    Parameters:
+        address: Radio Controller gRPC service URL
 
     Returns:
         gRPC channel
     """
-    channel = grpc.insecure_channel(addr)
+    channel = grpc.insecure_channel(address)
     try:
         grpc.channel_ready_future(channel).result(timeout=10)
     except grpc.FutureTimeoutError:
@@ -58,102 +114,115 @@ def create_rc_service_channel(addr: str):
         return channel
 
 
-def create_grpc_dp_service(channel):
+def _create_message(
+        message_cls: Type[MessageType], json_file: Optional[str] = None,
+) -> MessageType:
     """
-    Create Radio Controller gRPC service
+    Create gRPC message
 
     Parameters:
-        channel: Radio Controller gRPC service channel
+        message_cls: protobuf class of the gRPC message
+        json_file: path to json file containing message content
 
     Returns:
-        DPServiceStub
+        gRPC message instance
     """
-    stub = enodebd_services.DPServiceStub(channel)
-    return stub
+    if json_file:
+        data = _load_json(path=json_file)
+    else:
+        data = _get_default_cbsd_message(message_cls=message_cls)
+
+    return json_format.ParseDict(js_dict=data, message=message_cls())
 
 
-def create_rc_grpc_cbsd_request(**kwargs):
+def _load_json(path: str) -> dict:
     """
-    Construct a CBSDRequest gRPC message
+    Read json file content
 
     Parameters:
-        kwargs: dict where keys are CBSDRequest fields, and values are the values
+        path: path to json file
 
     Returns:
-        CBSDRequest message
+        unmarshalled json
     """
-    msg = enodebd_msgs.CBSDRequest(**kwargs)
-    return msg
-
-
-def send_request(service, rpc, msg):
-    """
-    Send a CBSDRequest gRPC message to gRPC endpoint
-
-    Parameters:
-        service: DBService
-        rpc: the gRPC method of the service
-        msg: CBSDRequest message
-
-    Returns:
-        CBSDStateResult
-    """
-    resp = rpc(msg)
-    return resp
-
-
-def _get_cbsd_dict(json_file_path: str) -> dict:
-    if not json_file_path:
-        return default_cbsd_dict
     try:
-        with open(json_file_path, 'r') as f:
+        with open(path, 'r') as f:
             return json.load(f)
-    except (ValueError, OSError) as err:
-        logging.warning(
-            f"Failed to read or parse CBSD file {json_file_path}. {err}",
-        )
-        raise
+    except (ValueError, OSError) as e:
+        raise ValueError(f"Failed to read the json file {path}: {e}")
 
 
-def _create_argparse(dp_service: enodebd_services.DPServiceStub):
+def _get_default_cbsd_message(message_cls: Type[MessageType]) -> dict:
+    """
+    Get default message content corresponding to given message class
+
+    Parameters:
+        message_cls: protobuf class of the gRPC message
+
+    Returns:
+        default content for message class
+    """
+    if message_cls == EnodebdUpdateCbsdRequest:
+        return default_cbsd_update_dict
+    return default_cbsd_dict
+
+
+def _create_argparse() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
+
+    commands_group = parser.add_argument_group('commands')
+    commands = commands_group.add_mutually_exclusive_group()
+    commands.add_argument(
+        '-s', '--state', dest='command', action='store_const',
+        default='state', const='state', help='RPC get CBSD state [default]',
+    )
+    commands.add_argument(
+        '-r', '--register', dest='command', action='store_const',
+        const='register', help='RPC register CBSD [deprecated]',
+    )
+    commands.add_argument(
+        '-d', '--deregister', dest='command', action='store_const',
+        const='deregister', help='RPC deregister CBSD [deprecated]',
+    )
+    commands.add_argument(
+        '-e', '--relinquish', dest='command', action='store_const',
+        const='relinquish', help='RPC relinquish CBSD',
+    )
+    commands.add_argument(
+        '-u', '--update', dest='command', action='store_const',
+        const='update', help='RPC update CBSD params',
+    )
+
     parser.add_argument(
-        '-s', '--state', dest='rpc', action='store_const',
-        default=dp_service.GetCBSDState, const=dp_service.GetCBSDState, help='CBSD Get State RPC',
+        '-a', '--address', dest='address', action='store', type=str,
+        default=None, help='RPC call destination, if different than default',
     )
     parser.add_argument(
-        '-r', '--register', dest='rpc', action='store_const',
-        const=dp_service.CBSDRegister, help='CBSD Register RPC',
-    )
-    parser.add_argument(
-        '-d', '--deregister', dest='rpc', action='store_const',
-        const=dp_service.CBSDDeregister, help='CBSD Deregister RPC',
-    )
-    parser.add_argument(
-        '-e', '--relinquish', dest='rpc', action='store_const',
-        const=dp_service.CBSDRelinquish, help='CBSD Register RPC',
-    )
-    parser.add_argument(
-        '-c', '--cbsd', dest='cbsd_json_file', action='store', type=str,
-        default=None, help='Path to JSON file with CBSD config params',
+        '-c', '--cbsd', dest='json_file', action='store', type=str,
+        default=None, help='Path to JSON file with CBSD config, if different than default',
     )
     return parser
 
 
-def main():
-    """
-    Top level function of the module
-    """
-    channel = create_rc_service_channel(DP_RC_SERVICE_ADDR)
-    dp_service = create_grpc_dp_service(channel)
-    parser = _create_argparse(dp_service=dp_service)
+def main() -> None:
+    parser = _create_argparse()
     args = parser.parse_args()
-    cbsd = _get_cbsd_dict(args.cbsd_json_file)
-    msg = create_rc_grpc_cbsd_request(**cbsd)
-    rpc_method_name = str(args.rpc._method)
-    logging.info(f'Sending gRPC {rpc_method_name} request:\n{msg}')
-    resp = send_request(dp_service, args.rpc, msg)
-    logging.info(f'Received gRPC response:\n{resp}')
+
+    command_config = COMMANDS_CONFIG[args.command]
+    message = _create_message(
+        message_cls=command_config.message_cls, json_file=args.json_file,
+    )
+    service = _create_service(
+        service_cls=command_config.service_cls, address=args.address,
+    )
+    method = getattr(service, command_config.method_name)
+
+    logging.info(
+        f'Sending gRPC {command_config.method_name} '
+        f'request:\n{message}',
+    )
+    response = method(message, **command_config.request_kwargs)
+    logging.info(f'Received gRPC response:\n{response}\n')
 
 
 if __name__ == '__main__':

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.c
@@ -242,6 +242,20 @@ void mme_app_ue_context_free_content(ue_mm_context_t* const ue_context_p) {
   }
   ue_context_p->ue_context_rel_cause = S1AP_INVALID_CAUSE;
 
+  // Delete pending dedicated bearer request
+  for (uint8_t idx = 0; idx < BEARERS_PER_UE; idx++) {
+    if (ue_context_p->pending_ded_ber_req[idx]) {
+      if (ue_context_p->pending_ded_ber_req[idx]->tft) {
+        free_traffic_flow_template(
+            &ue_context_p->pending_ded_ber_req[idx]->tft);
+      }
+      if (ue_context_p->pending_ded_ber_req[idx]->pco) {
+        free_protocol_configuration_options(
+            &ue_context_p->pending_ded_ber_req[idx]->pco);
+      }
+      free_wrapper((void**)&ue_context_p->pending_ded_ber_req[idx]);
+    }
+  }
   ue_context_p->send_ue_purge_request = false;
   ue_context_p->hss_initiated_detach = false;
   for (int i = 0; i < MAX_APN_PER_UE; i++) {

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -391,6 +391,7 @@ class TestWrapper(object):
         Raises:
             ValueError: If no valid IP is found
         """
+        time.sleep(1)
         # Configure downlink route in TRF server
         assert self._trf_util.update_dl_route(self.TEST_IP_BLOCK)
 
@@ -425,6 +426,7 @@ class TestWrapper(object):
         Raises:
             ValueError: If no valid IP is found
         """
+        time.sleep(1)
         ips = self._getAddresses(*ues)
         for ip, ue in zip(ips, ues):
             if not ip:

--- a/nms/app/state/lte/SubscriberState.ts
+++ b/nms/app/state/lte/SubscriberState.ts
@@ -369,7 +369,7 @@ export async function handleSubscriberQuery(
       const metrics = subscriberMetrics?.[`${search}`];
       if (searchedSubscriber) {
         subscriberSearch = {
-          name: searchedSubscriber.id,
+          name: searchedSubscriber.name || '',
           imsi: searchedSubscriber.id,
           service: searchedSubscriber.lte?.state || '',
           currentUsage: metrics?.currentUsage ?? '0',

--- a/nms/app/views/alarms/components/alertmanager/Receivers/Receivers.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/Receivers.tsx
@@ -44,6 +44,21 @@ const useStyles = makeStyles<Theme>(theme => ({
   },
 }));
 
+const receiverColumns = [
+  {
+    title: 'Name',
+    field: 'name',
+  },
+  {
+    title: 'Notifications',
+    field: 'labels',
+    render: (row: AlertReceiver) => {
+      const labels = getNotificationsSummary(row);
+      return <LabelsCell value={labels} />;
+    },
+  },
+];
+
 export default function Receivers() {
   const {apiUtil, alertManagerGlobalConfigEnabled} = useAlarmContext();
   const [isAddEditReceiver, setIsAddEditReceiver] = React.useState(false);
@@ -159,20 +174,7 @@ export default function Receivers() {
         <>
           <SimpleTable
             onRowClick={row => setSelectedRow(row)}
-            columnStruct={[
-              {
-                title: 'Name',
-                field: 'name',
-              },
-              {
-                title: 'Notifications',
-                field: 'labels',
-                render: row => {
-                  const labels = getNotificationsSummary(row);
-                  return <LabelsCell value={labels} />;
-                },
-              },
-            ]}
+            columnStruct={receiverColumns}
             tableData={receiversData}
             dataTestId="receiver"
             menuItems={[

--- a/nms/app/views/equipment/GatewayPoolConfigEdit.tsx
+++ b/nms/app/views/equipment/GatewayPoolConfigEdit.tsx
@@ -95,7 +95,7 @@ export default function ConfigEdit(props: GatewayPoolEditProps) {
               placeholder="Ex: pool1"
               fullWidth={true}
               value={gwPool.gateway_pool_id}
-              readOnly={Object.keys(props.gwPool).length > 0 ? false : true}
+              disabled={!!props.gwPool.gateway_pool_id}
               onChange={({target}) =>
                 setGwPool({...gwPool, gateway_pool_id: target.value})
               }

--- a/nms/app/views/equipment/__tests__/EquipmentGatewayPoolTest.tsx
+++ b/nms/app/views/equipment/__tests__/EquipmentGatewayPoolTest.tsx
@@ -28,7 +28,7 @@ import {
   SetGatewayPoolsState,
   UpdateGatewayPoolRecords,
 } from '../../../state/lte/EquipmentState';
-import {fireEvent, render, wait} from '@testing-library/react';
+import {fireEvent, render, wait, waitFor} from '@testing-library/react';
 import {mockAPI} from '../../../util/TestUtils';
 import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 import {useState} from 'react';
@@ -237,6 +237,53 @@ describe('<GatewayPools />', () => {
       gatewayPoolId: 'pool3',
     });
   });
+
+  it('verify gateway pool edit', async () => {
+    mockAPI(MagmaAPI.lteNetworks, 'lteNetworkIdGatewayPoolsGatewayPoolIdPut');
+
+    const {
+      queryByTestId,
+      getByTestId,
+      getByText,
+      findAllByTitle,
+      findByTestId,
+    } = render(<Wrapper />);
+
+    const actionList = await findAllByTitle('Actions');
+    fireEvent.click(actionList[2]);
+    await findByTestId('actions-menu');
+    fireEvent.click(getByText('Edit'));
+
+    // check if only first tab (config) is active
+    expect(queryByTestId('configEdit')).not.toBeNull();
+    expect(queryByTestId('PrimaryEdit')).toBeNull();
+    expect(queryByTestId('SecondaryEdit')).toBeNull();
+
+    const name = getByTestId('name').firstChild as HTMLInputElement;
+    const poolId = getByTestId('poolId').firstChild as HTMLInputElement;
+    const mmeGroupId = getByTestId('mmeGroupId').firstChild as HTMLInputElement;
+
+    expect(poolId).toBeDisabled();
+
+    fireEvent.change(name, {target: {value: 'foo'}});
+    fireEvent.change(mmeGroupId, {target: {value: '4'}});
+
+    fireEvent.click(getByText('Save And Continue'));
+
+    await waitFor(() => {
+      expect(
+        MagmaAPI.lteNetworks.lteNetworkIdGatewayPoolsGatewayPoolIdPut,
+      ).toHaveBeenCalledWith({
+        networkId,
+        gatewayPoolId: 'pool3',
+        hAGatewayPool: {
+          config: {mme_group_id: 4},
+          gateway_pool_id: 'pool3',
+          gateway_pool_name: 'foo',
+        },
+      });
+    });
+  });
 });
 
 describe('<AddEditGatewayPoolButton />', () => {
@@ -334,21 +381,13 @@ describe('<AddEditGatewayPoolButton />', () => {
     expect(queryByTestId('PrimaryEdit')).toBeNull();
     expect(queryByTestId('SecondaryEdit')).toBeNull();
 
-    const name = getByTestId('name').firstChild;
-    const poolId = getByTestId('poolId').firstChild;
-    const mmeGroupId = getByTestId('mmeGroupId').firstChild;
+    const name = getByTestId('name').firstChild as HTMLInputElement;
+    const poolId = getByTestId('poolId').firstChild as HTMLInputElement;
+    const mmeGroupId = getByTestId('mmeGroupId').firstChild as HTMLInputElement;
 
-    if (
-      name instanceof HTMLInputElement &&
-      poolId instanceof HTMLInputElement &&
-      mmeGroupId instanceof HTMLInputElement
-    ) {
-      fireEvent.change(name, {target: {value: 'pool_4'}});
-      fireEvent.change(poolId, {target: {value: 'pool4'}});
-      fireEvent.change(mmeGroupId, {target: {value: '4'}});
-    } else {
-      throw 'invalid type';
-    }
+    fireEvent.change(name, {target: {value: 'pool_4'}});
+    fireEvent.change(poolId, {target: {value: 'pool4'}});
+    fireEvent.change(mmeGroupId, {target: {value: '4'}});
 
     fireEvent.click(getByText('Save And Continue'));
     await wait();
@@ -383,20 +422,14 @@ describe('<AddEditGatewayPoolButton />', () => {
     expect(queryByTestId('PrimaryEdit')).not.toBeNull();
     expect(queryByTestId('SecondaryEdit')).toBeNull();
 
-    const mmeCode = getByTestId('mmeCode').firstChild;
-    const PrimaryId = getByTestId('gwIdPrimary').firstChild;
+    const mmeCode = getByTestId('mmeCode').firstChild as HTMLInputElement;
+    const PrimaryId = getByTestId('gwIdPrimary').firstChild as HTMLElement;
 
-    if (
-      mmeCode instanceof HTMLInputElement &&
-      PrimaryId instanceof HTMLElement
-    ) {
-      fireEvent.mouseDown(PrimaryId);
-      await wait();
-      fireEvent.click(getByText('testGatewayId0'));
-      fireEvent.change(mmeCode, {target: {value: '4'}});
-    } else {
-      throw 'invalid type';
-    }
+    fireEvent.mouseDown(PrimaryId);
+    await wait();
+    fireEvent.click(getByText('testGatewayId0'));
+    fireEvent.change(mmeCode, {target: {value: '4'}});
+
     fireEvent.click(getByText('Save And Continue'));
     await wait();
 
@@ -430,20 +463,15 @@ describe('<AddEditGatewayPoolButton />', () => {
     expect(queryByTestId('PrimaryEdit')).toBeNull();
     expect(queryByTestId('SecondaryEdit')).not.toBeNull();
 
-    const mmeCodeSecondary = getByTestId('mmeCode').firstChild;
-    const secondaryId = getByTestId('gwIdSecondary').firstChild;
+    const mmeCodeSecondary = getByTestId('mmeCode')
+      .firstChild as HTMLInputElement;
+    const secondaryId = getByTestId('gwIdSecondary').firstChild as HTMLElement;
 
-    if (
-      mmeCodeSecondary instanceof HTMLInputElement &&
-      secondaryId instanceof HTMLElement
-    ) {
-      fireEvent.mouseDown(secondaryId);
-      await wait();
-      fireEvent.click(getByText('testGatewayId1'));
-      fireEvent.change(mmeCodeSecondary, {target: {value: '5'}});
-    } else {
-      throw 'invalid type';
-    }
+    fireEvent.mouseDown(secondaryId);
+    await wait();
+    fireEvent.click(getByText('testGatewayId1'));
+    fireEvent.change(mmeCodeSecondary, {target: {value: '5'}});
+
     fireEvent.click(getByText('Save'));
     await wait();
 

--- a/nms/app/views/subscriber/SubscriberDetailConfig.tsx
+++ b/nms/app/views/subscriber/SubscriberDetailConfig.tsx
@@ -204,10 +204,6 @@ function SubscriberConfigTrafficPolicy({
 }
 
 function SubscriberInfoConfig({subscriberInfo}: {subscriberInfo: Subscriber}) {
-  const [authKey] = useState(subscriberInfo.lte.auth_key);
-  const [authOPC] = useState(subscriberInfo.lte.auth_opc);
-  const [dataPlan] = useState(subscriberInfo.lte.sub_profile);
-
   function CollapseItems(props: {
     key: SubscriberForbiddenNetworkTypesEnum;
     data: SubscriberForbiddenNetworkTypesEnum;
@@ -242,23 +238,23 @@ function SubscriberInfoConfig({subscriberInfo}: {subscriberInfo: Subscriber}) {
     [
       {
         category: 'Data plan',
-        value: dataPlan,
+        value: subscriberInfo.lte.sub_profile,
       },
     ],
     [
       {
         category: 'Auth Key',
-        value: authKey,
+        value: subscriberInfo.lte.auth_key,
         obscure: true,
       },
     ],
   ];
 
-  if (authOPC) {
+  if (subscriberInfo.lte.auth_opc) {
     kpiData.push([
       {
         category: 'Auth OPC',
-        value: authOPC,
+        value: subscriberInfo.lte.auth_opc,
       },
     ]);
   }

--- a/nms/app/views/subscriber/SubscriberTable.tsx
+++ b/nms/app/views/subscriber/SubscriberTable.tsx
@@ -497,7 +497,7 @@ function SubscribersTable(props: WithAlert) {
               filter={() => (
                 <Grid
                   container
-                  justify="flex-end"
+                  justifyContent="flex-end"
                   alignItems="center"
                   spacing={2}>
                   <Grid item>
@@ -593,6 +593,8 @@ function SubscribersTable(props: WithAlert) {
                 },
               ]}
               options={{
+                idSynonym: 'imsi',
+                sorting: false,
                 actionsColumnIndex: -1,
                 pageSize: DEFAULT_PAGE_SIZE,
                 pageSizeOptions: [],
@@ -601,7 +603,7 @@ function SubscribersTable(props: WithAlert) {
             />
           </>
         ) : (
-          <Grid container justify="space-between" spacing={3}>
+          <Grid container justifyContent="space-between" spacing={3}>
             <SubscriberActionsMenu
               addDialog={addDialog}
               hideButton={true}

--- a/nms/app/views/subscriber/__tests__/SubscriberTest.tsx
+++ b/nms/app/views/subscriber/__tests__/SubscriberTest.tsx
@@ -155,4 +155,36 @@ describe('<SubscriberDashboard />', () => {
       expect(getByTestId('actions-menu')).toBeVisible();
     });
   });
+
+  it('subscribers can be searched by IMSI', async () => {
+    const geSubscribersBySubscriberId = mockAPI(
+      MagmaAPI.subscribers,
+      'lteNetworkIdSubscribersSubscriberIdGet',
+      subscribers['IMSI0000000001'],
+    );
+
+    const {findByPlaceholderText, findAllByRole} = render(<Wrapper />);
+
+    const searchInput = await findByPlaceholderText(
+      'Search IMSI001011234560000',
+    );
+
+    fireEvent.change(searchInput, {
+      target: {value: 'IMSI0000000001'},
+    });
+
+    await waitFor(() =>
+      expect(geSubscribersBySubscriberId).toBeCalledWith({
+        networkId: 'test',
+        subscriberId: 'IMSI0000000001',
+      }),
+    );
+
+    const rowItems = await findAllByRole('row');
+
+    expect(rowItems[1]).toHaveTextContent('subscriber1');
+    expect(rowItems[1]).toHaveTextContent('IMSI0000000001');
+    expect(rowItems[1]).toHaveTextContent('INACTIVE');
+    expect(rowItems[1]).toHaveTextContent('0');
+  });
 });

--- a/nms/app/views/traffic/ApnOverview.tsx
+++ b/nms/app/views/traffic/ApnOverview.tsx
@@ -111,7 +111,7 @@ const useStyles = makeStyles<Theme>(theme => ({
 }));
 
 type ApnRowType = {
-  apnID: string;
+  id: string;
   classID: number;
   arpPriorityLevel: number;
   maxReqdULBw: number;
@@ -133,7 +133,7 @@ function ApnOverview(props: WithAlert) {
     ? Object.keys(apns).map((apn: string) => {
         const cfg = apns[apn].apn_configuration;
         return {
-          apnID: apn,
+          id: apn,
           classID: cfg?.qos_profile.class_id ?? 0,
           arpPriorityLevel: cfg?.qos_profile.priority_level ?? 0,
           maxReqdULBw: cfg?.ambr.max_bandwidth_ul ?? 0,
@@ -158,7 +158,7 @@ function ApnOverview(props: WithAlert) {
         <ApnEditDialog
           open={open}
           onClose={() => setOpen(false)}
-          apn={Object.keys(currRow).length ? apns[currRow.apnID] : undefined}
+          apn={Object.keys(currRow).length ? apns[currRow.id] : undefined}
         />
         {Object.keys(ctx.state).length > 0 ? (
           <>
@@ -168,7 +168,7 @@ function ApnOverview(props: WithAlert) {
               columns={[
                 {
                   title: 'Apn ID',
-                  field: 'apnID',
+                  field: 'id',
                   render: currRow => (
                     <Link
                       variant="body2"
@@ -177,7 +177,7 @@ function ApnOverview(props: WithAlert) {
                         setCurrRow(currRow);
                         setOpen(true);
                       }}>
-                      {currRow.apnID}
+                      {currRow.id}
                     </Link>
                   ),
                 },
@@ -215,7 +215,7 @@ function ApnOverview(props: WithAlert) {
                 {
                   name: 'Edit JSON',
                   handleFunc: () => {
-                    navigate(currRow.apnID + '/json');
+                    navigate(currRow.id + '/json');
                   },
                 },
                 {name: 'Deactivate'},
@@ -223,9 +223,7 @@ function ApnOverview(props: WithAlert) {
                   name: 'Remove',
                   handleFunc: () => {
                     void props
-                      .confirm(
-                        `Are you sure you want to delete ${currRow.apnID}?`,
-                      )
+                      .confirm(`Are you sure you want to delete ${currRow.id}?`)
                       .then(async confirmed => {
                         if (!confirmed) {
                           return;
@@ -233,14 +231,11 @@ function ApnOverview(props: WithAlert) {
 
                         try {
                           // trigger deletion
-                          await ctx.setState(currRow.apnID);
+                          await ctx.setState(currRow.id);
                         } catch (e) {
-                          enqueueSnackbar(
-                            'failed deleting APN ' + currRow.apnID,
-                            {
-                              variant: 'error',
-                            },
-                          );
+                          enqueueSnackbar('failed deleting APN ' + currRow.id, {
+                            variant: 'error',
+                          });
                         }
                       });
                   },

--- a/nms/app/views/traffic/DataPlanOverview.tsx
+++ b/nms/app/views/traffic/DataPlanOverview.tsx
@@ -42,14 +42,14 @@ const useStyles = makeStyles<Theme>(theme => ({
 /**
  * Stores info for a single row of the data plan table.
  *
- * @property {string} dataPlanID
+ * @property {string} id
  * @property {string} maxUploadBitRate
  *    - bit rate specified in Mbps
  * @property {string} maxDownloadBitRate
  *    - bit rate specified in Mbps
  */
 type DataPlanRowType = {
-  dataPlanID: string;
+  id: string;
   maxUploadBitRate: string;
   maxDownloadBitRate: string;
 };
@@ -79,7 +79,7 @@ function DataPlanOverview(props: WithAlert) {
     ? Object.keys(dataPlans || {}).map((id: string) => {
         const profile = nullthrows(dataPlans)[id];
         return {
-          dataPlanID: id,
+          id: id,
           maxUploadBitRate:
             profile.max_dl_bit_rate ===
             DATA_PLAN_UNLIMITED_RATES.max_dl_bit_rate
@@ -126,14 +126,14 @@ function DataPlanOverview(props: WithAlert) {
         <DataPlanEditDialog
           open={open}
           onClose={() => setOpen(false)}
-          dataPlanId={currRow.dataPlanID}
+          dataPlanId={currRow.id}
         />
         <ActionTable
           data={dataPlanRows}
           columns={[
             {
               title: 'Data Plan ID',
-              field: 'dataPlanID',
+              field: 'id',
               render: currRow => (
                 <Link
                   variant="body2"
@@ -142,7 +142,7 @@ function DataPlanOverview(props: WithAlert) {
                     setCurrRow(currRow);
                     setOpen(true);
                   }}>
-                  {currRow.dataPlanID}
+                  {currRow.id}
                 </Link>
               ),
             },
@@ -170,7 +170,7 @@ function DataPlanOverview(props: WithAlert) {
               handleFunc: () => {
                 void props
                   .confirm(
-                    `Are you sure you want to delete data plan ${currRow.dataPlanID}?`,
+                    `Are you sure you want to delete data plan ${currRow.id}?`,
                   )
                   .then(async confirmed => {
                     if (!confirmed) {
@@ -178,10 +178,10 @@ function DataPlanOverview(props: WithAlert) {
                     }
 
                     try {
-                      await onDelete(currRow.dataPlanID);
+                      await onDelete(currRow.id);
                     } catch (e) {
                       enqueueSnackbar(
-                        'failed deleting data plan ' + currRow.dataPlanID,
+                        'failed deleting data plan ' + currRow.id,
                         {
                           variant: 'error',
                         },

--- a/nms/app/views/traffic/PolicyOverview.tsx
+++ b/nms/app/views/traffic/PolicyOverview.tsx
@@ -111,7 +111,7 @@ const useStyles = makeStyles<Theme>(theme => ({
 }));
 
 type PolicyRowType = {
-  policyID: string;
+  id: string;
   numFlows: number;
   priority: number;
   numSubscribers: number;
@@ -122,20 +122,20 @@ type PolicyRowType = {
 };
 
 type BaseNameRowType = {
-  baseNameID: string;
+  id: string;
   ruleNames: Array<string>;
   numSubscribers: number;
 };
 
 type ProfileRowType = {
   classID: QosClassId;
-  profileID: string;
+  id: string;
   uplinkBandwidth: number;
   downlinkBandwidth: number;
 };
 
 type RatingGroupRowType = {
-  ratingGroupID: string;
+  id: string;
   limitType: string;
 };
 
@@ -236,7 +236,7 @@ export function PolicyTableRaw(props: WithAlert) {
     ? Object.keys(policies).map((policyID: string) => {
         const policyRule = policies[policyID];
         return {
-          policyID: policyRule.id,
+          id: policyRule.id,
           numFlows: policyRule.flow_list?.length ?? 0,
           priority: policyRule.priority,
           numSubscribers: policyRule.assigned_subscribers?.length ?? 0,
@@ -253,16 +253,14 @@ export function PolicyTableRaw(props: WithAlert) {
       <PolicyRuleEditDialog
         open={open}
         onClose={() => setOpen(false)}
-        rule={
-          Object.keys(currRow).length ? policies[currRow.policyID] : undefined
-        }
+        rule={Object.keys(currRow).length ? policies[currRow.id] : undefined}
       />
       <ActionTable
         data={policyRows}
         columns={[
           {
             title: 'Policy ID',
-            field: 'policyID',
+            field: 'id',
             render: currRow => (
               <Link
                 variant="body2"
@@ -271,7 +269,7 @@ export function PolicyTableRaw(props: WithAlert) {
                   setCurrRow(currRow);
                   setOpen(true);
                 }}>
-                {currRow.policyID}
+                {currRow.id}
               </Link>
             ),
           },
@@ -309,7 +307,7 @@ export function PolicyTableRaw(props: WithAlert) {
           {
             name: 'Edit JSON',
             handleFunc: () => {
-              navigate(currRow.policyID + '/json');
+              navigate(currRow.id + '/json');
             },
           },
           {name: 'Deactivate'},
@@ -317,7 +315,7 @@ export function PolicyTableRaw(props: WithAlert) {
             name: 'Remove',
             handleFunc: () => {
               void props
-                .confirm(`Are you sure you want to delete ${currRow.policyID}?`)
+                .confirm(`Are you sure you want to delete ${currRow.id}?`)
                 .then(async confirmed => {
                   if (!confirmed) {
                     return;
@@ -325,14 +323,11 @@ export function PolicyTableRaw(props: WithAlert) {
 
                   try {
                     // trigger deletion
-                    await ctx.setState(currRow.policyID);
+                    await ctx.setState(currRow.id);
                   } catch (e) {
-                    enqueueSnackbar(
-                      'failed deleting policy ' + currRow.policyID,
-                      {
-                        variant: 'error',
-                      },
-                    );
+                    enqueueSnackbar('failed deleting policy ' + currRow.id, {
+                      variant: 'error',
+                    });
                   }
                 });
             },
@@ -359,7 +354,7 @@ export function BaseNameTableRaw(props: WithAlert) {
     ? Object.keys(baseNames).map((baseNameID: string) => {
         const baseNameRecord = baseNames[baseNameID];
         return {
-          baseNameID: baseNameID,
+          id: baseNameID,
           ruleNames: baseNameRecord.rule_names,
           numSubscribers: baseNameRecord?.assigned_subscribers?.length || 0,
         };
@@ -371,14 +366,14 @@ export function BaseNameTableRaw(props: WithAlert) {
       <BaseNameEditDialog
         open={open}
         onClose={() => setOpen(false)}
-        baseNameId={currRow?.baseNameID}
+        baseNameId={currRow?.id}
       />
       <ActionTable
         data={baseNameRows}
         columns={[
           {
             title: 'Base Name ID',
-            field: 'baseNameID',
+            field: 'id',
             render: currRow => (
               <Link
                 variant="body2"
@@ -387,7 +382,7 @@ export function BaseNameTableRaw(props: WithAlert) {
                   setCurrRow(currRow);
                   setOpen(true);
                 }}>
-                {currRow.baseNameID}
+                {currRow.id}
               </Link>
             ),
           },
@@ -424,9 +419,7 @@ export function BaseNameTableRaw(props: WithAlert) {
             name: 'Remove',
             handleFunc: () => {
               void props
-                .confirm(
-                  `Are you sure you want to delete ${currRow.baseNameID}?`,
-                )
+                .confirm(`Are you sure you want to delete ${currRow.id}?`)
                 .then(async confirmed => {
                   if (!confirmed) {
                     return;
@@ -434,14 +427,11 @@ export function BaseNameTableRaw(props: WithAlert) {
 
                   try {
                     // trigger deletion
-                    await ctx.setBaseNames(currRow.baseNameID);
+                    await ctx.setBaseNames(currRow.id);
                   } catch (e) {
-                    enqueueSnackbar(
-                      'failed deleting base name ' + currRow.baseNameID,
-                      {
-                        variant: 'error',
-                      },
-                    );
+                    enqueueSnackbar('failed deleting base name ' + currRow.id, {
+                      variant: 'error',
+                    });
                   }
                 });
             },
@@ -466,7 +456,7 @@ export function ProfileTableRaw(props: WithAlert) {
     ? Object.keys(profiles).map((profileID: string) => {
         const profile = profiles[profileID];
         return {
-          profileID: profile.id,
+          id: profile.id,
           classID: profile.class_id,
           uplinkBandwidth: profile.max_req_bw_ul,
           downlinkBandwidth: profile.max_req_bw_dl,
@@ -479,16 +469,14 @@ export function ProfileTableRaw(props: WithAlert) {
       <ProfileEditDialog
         open={open}
         onClose={() => setOpen(false)}
-        profile={
-          Object.keys(currRow).length ? profiles[currRow.profileID] : undefined
-        }
+        profile={Object.keys(currRow).length ? profiles[currRow.id] : undefined}
       />
       <ActionTable
         data={profileRows}
         columns={[
           {
             title: 'Profile ID',
-            field: 'profileID',
+            field: 'id',
             render: currRow => (
               <Link
                 variant="body2"
@@ -497,7 +485,7 @@ export function ProfileTableRaw(props: WithAlert) {
                   setCurrRow(currRow);
                   setOpen(true);
                 }}>
-                {currRow.profileID}
+                {currRow.id}
               </Link>
             ),
           },
@@ -525,9 +513,7 @@ export function ProfileTableRaw(props: WithAlert) {
             name: 'Remove',
             handleFunc: () => {
               void props
-                .confirm(
-                  `Are you sure you want to delete ${currRow.profileID}?`,
-                )
+                .confirm(`Are you sure you want to delete ${currRow.id}?`)
                 .then(async confirmed => {
                   if (!confirmed) {
                     return;
@@ -535,14 +521,11 @@ export function ProfileTableRaw(props: WithAlert) {
 
                   try {
                     // trigger deletion
-                    await ctx.setQosProfiles(currRow.profileID);
+                    await ctx.setQosProfiles(currRow.id);
                   } catch (e) {
-                    enqueueSnackbar(
-                      'failed deleting profile ' + currRow.profileID,
-                      {
-                        variant: 'error',
-                      },
-                    );
+                    enqueueSnackbar('failed deleting profile ' + currRow.id, {
+                      variant: 'error',
+                    });
                   }
                 });
             },
@@ -569,7 +552,7 @@ export function RatingGroupTableRaw(props: WithAlert) {
     ? Object.keys(ratingGroups).map((ratingGroupID: string) => {
         const ratingGroup = ratingGroups[ratingGroupID];
         return {
-          ratingGroupID: ratingGroup.id.toString(),
+          id: ratingGroup.id.toString(),
           limitType: ratingGroup.limit_type,
         };
       })
@@ -580,9 +563,7 @@ export function RatingGroupTableRaw(props: WithAlert) {
         open={open}
         onClose={() => setOpen(false)}
         ratingGroup={
-          Object.keys(currRow).length
-            ? ratingGroups[currRow.ratingGroupID]
-            : undefined
+          Object.keys(currRow).length ? ratingGroups[currRow.id] : undefined
         }
       />
       <ActionTable
@@ -590,7 +571,7 @@ export function RatingGroupTableRaw(props: WithAlert) {
         columns={[
           {
             title: 'Rating Group ID',
-            field: 'ratingGroupID',
+            field: 'id',
             render: currRow => (
               <Link
                 variant="body2"
@@ -599,7 +580,7 @@ export function RatingGroupTableRaw(props: WithAlert) {
                   setCurrRow(currRow);
                   setOpen(true);
                 }}>
-                {currRow.ratingGroupID}
+                {currRow.id}
               </Link>
             ),
           },
@@ -618,7 +599,7 @@ export function RatingGroupTableRaw(props: WithAlert) {
             handleFunc: () => {
               void props
                 .confirm(
-                  `Are you sure you want to delete Rating Group ${currRow.ratingGroupID}?`,
+                  `Are you sure you want to delete Rating Group ${currRow.id}?`,
                 )
                 .then(async confirmed => {
                   if (!confirmed) {
@@ -626,10 +607,10 @@ export function RatingGroupTableRaw(props: WithAlert) {
                   }
 
                   try {
-                    await ctx.setRatingGroups(currRow.ratingGroupID.toString());
+                    await ctx.setRatingGroups(currRow.id.toString());
                   } catch (e) {
                     enqueueSnackbar(
-                      'failed deleting rating group ' + currRow.ratingGroupID,
+                      'failed deleting rating group ' + currRow.id,
                       {
                         variant: 'error',
                       },


### PR DESCRIPTION
Signed-off-by: Jarosław Jaszczuk <jaroslaw.jaszczuk@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
- allow to send `EnodebdUpdateCbsdRequest` to dp
- refactor `enodedb_client.py` to enable use of new gRPC service and new request type
<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] `enodebd_client.py` sends valid `EnodebdUpdateCbsdRequest` request that is properly interpreted by dp
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
