### PR TITLE
feat(dp): Unsetting frequency for failed grant

### DIFF
--- a/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
+++ b/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
@@ -132,6 +132,7 @@ def _create_channels(response: DBResponse, session: Session):
     cbsd_id = response.request.payload["cbsdId"]
     cbsd = session.query(DBCbsd).filter(DBCbsd.cbsd_id == cbsd_id).scalar()
     available_channels = response.payload.get("availableChannel")
+    cbsd.available_frequencies = None
     if not available_channels:
         logger.warning(
             "Could not create channel from spectrumInquiryResponse. Response missing 'availableChannel' object",
@@ -183,6 +184,7 @@ def process_grant_response(obj: ResponseDBProcessor, response: DBResponse, sessi
         new_state = obj.grant_states_map[GrantStates.GRANTED.value]
     else:
         new_state = obj.grant_states_map[GrantStates.IDLE.value]
+        unset_frequency(grant)
     logger.info(
         f'process_grant_responses: Updating grant state from {grant.state} to {new_state}',
     )
@@ -216,6 +218,7 @@ def process_heartbeat_response(obj: ResponseDBProcessor, response: DBResponse, s
         new_state = obj.grant_states_map[GrantStates.UNSYNC.value]
     elif response.response_code == ResponseCodes.TERMINATED_GRANT.value:
         new_state = obj.grant_states_map[GrantStates.IDLE.value]
+        unset_frequency(grant)
     elif response.response_code == ResponseCodes.DEREGISTER.value:
         _terminate_all_grants_from_response(response, session)
         return
@@ -271,6 +274,30 @@ def process_deregistration_response(obj: ResponseDBProcessor, response: DBRespon
         f'process_deregistration_response: Unregistering {response.payload}',
     )
     _unregister_cbsd(response, session)
+
+
+def unset_frequency(grant: DBGrant):
+    """
+    Unset available frequency on the nth position of available frequencies for the given frequency
+    Args:
+        grant (DBGrant): Grant whose low and high frequencies are the base for the calculation
+
+    Returns:
+        None
+    """
+    frequencies = grant.cbsd.available_frequencies
+    low = grant.low_frequency
+    high = grant.high_frequency
+
+    if not all([frequencies, low, high]):
+        return
+
+    bw_hz = high - low
+    mid = (low + high) // 2
+    bit_to_unset = (mid - int(3550 * 1e6)) // int(5 * 1e6)
+    bw_index = bw_hz // int(5 * 1e6) - 1
+
+    frequencies[bw_index] = frequencies[bw_index] & ~(1 << int(bit_to_unset))
 
 
 def _get_or_create_grant_from_response(

--- a/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
+++ b/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
@@ -279,6 +279,7 @@ def process_deregistration_response(obj: ResponseDBProcessor, response: DBRespon
 def unset_frequency(grant: DBGrant):
     """
     Unset available frequency on the nth position of available frequencies for the given frequency
+
     Args:
         grant (DBGrant): Grant whose low and high frequencies are the base for the calculation
 
@@ -297,7 +298,7 @@ def unset_frequency(grant: DBGrant):
     bit_to_unset = (mid - int(3550 * 1e6)) // int(5 * 1e6)
     bw_index = bw_hz // int(5 * 1e6) - 1
 
-    frequencies[bw_index] = frequencies[bw_index] & ~(1 << int(bit_to_unset))
+    frequencies[bw_index] = frequencies[bw_index] & ~(1 << int(bit_to_unset))  # noqa: WPS465
 
 
 def _get_or_create_grant_from_response(

--- a/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
@@ -17,6 +17,7 @@ import responses
 from magma.configuration_controller.response_processor.response_db_processor import (
     ResponseDBProcessor,
 )
+from magma.configuration_controller.response_processor.strategies.response_processing import unset_frequency
 from magma.configuration_controller.response_processor.strategies.strategies_mapping import (
     processor_strategies,
 )
@@ -340,8 +341,8 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
     def test_channel_params_set_on_grant_response(self):
         # Given
         cbsd_id = "foo"
-        low_frequency = 1
-        high_frequency = 2
+        low_frequency = 3560000000
+        high_frequency = 3561000000
         max_eirp = 3
 
         fixture = self._build_grant_request(
@@ -403,6 +404,44 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
             self.assertTrue(state.name == expected_cbsd_sate)
             for state in states
         ]
+
+    @parameterized.expand([
+        (None, 3560000000, 3580000000, None),
+        ([0b1111, 0b110, 0b1100, 0b1010], 3562500000, 3567500000, [0b0111, 0b110, 0b1100, 0b1010]),  # 5 MHz bw
+        ([0b0, 0b110, 0b1100, 0b1010], 3550000000, 3560000000, [0b0, 0b100, 0b1100, 0b1010]),  # 10 MHz bw
+        ([0b0, 0b110, 0b1111100, 0b1010], 3572500000, 3587500000, [0b0, 0b110, 0b0111100, 0b1010]),  # 15 MHz bw
+        ([0b0, 0b110, 0b1111100, 0b10101], 3560000000, 3580000000, [0b0, 0b110, 0b1111100, 0b00101]),  # 20 MHz bw
+    ])
+    def test_unset_frequency(self, orig_avail_freqs, low_freq, high_freq, expected_avail_freq):
+        # Given
+        cbsd = DBCbsd(
+            cbsd_id="some_cbsd_id",
+            fcc_id="some_fcc_id",
+            cbsd_serial_number="some_serial_number",
+            user_id="some_user_id",
+            state_id=1,
+            desired_state_id=1,
+            available_frequencies=orig_avail_freqs
+        )
+
+        grant = DBGrant(
+            cbsd=cbsd,
+            state_id=1,
+            grant_id="some_grant_id",
+            low_frequency=low_freq,
+            high_frequency=high_freq,
+            max_eirp=15,
+        )
+
+        self.session.add_all([cbsd, grant])
+        self.session.commit()
+
+        # When
+        unset_frequency(grant)
+        cbsd = self.session.query(DBCbsd).filter(DBCbsd.id == cbsd.id).scalar()
+
+        # Then
+        self.assertEqual(expected_avail_freq, cbsd.available_frequencies)
 
     def _process_response(self, request_type_name, response, db_requests):
         processor = self._get_response_processor(request_type_name)
@@ -481,6 +520,7 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
             user_id=user_id,
             state=cbsd_state,
             desired_state=cbsd_state,
+            available_frequencies=[0b11111100, 0b11110111, 0b11001111, 0b11110001]
         )
 
         self.session.add(cbsd)
@@ -521,17 +561,6 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
         self.session.add(channel)
         self.session.commit()
         return channel
-
-    def _create_grant(self, grant_id, channel, cbsd, state):
-        grant = DBGrant(
-            channel=channel,
-            cbsd=cbsd,
-            state=state,
-            grant_id=grant_id,
-        )
-        self.session.add(grant)
-        self.session.commit()
-        return grant
 
     def _create_db_requests_from_fixture(self, request_type, fixture, cbsd_state):
         db_requests = []

--- a/dp/cloud/python/magma/fixtures/fake_requests/grant_requests.py
+++ b/dp/cloud/python/magma/fixtures/fake_requests/grant_requests.py
@@ -20,8 +20,8 @@ grant_requests = [
                     "maxEirp": 100,
                     "operationFrequencyRange":
                         {
-                            "lowFrequency": 1,
-                            "highFrequency": 1000,
+                            "lowFrequency": 3560000000,
+                            "highFrequency": 3561000000,
                         },
                 },
             },
@@ -35,8 +35,8 @@ grant_requests = [
                     "maxEirp": 100,
                     "operationFrequencyRange":
                         {
-                            "lowFrequency": 1,
-                            "highFrequency": 1000,
+                            "lowFrequency": 3560000000,
+                            "highFrequency": 3561000000,
                         },
                 },
             },


### PR DESCRIPTION
feat(dp): Unsetting frequency for failed grant

## Summary

Frequency is unset for failed grant for bandwidth specified by the allowed frequencies

## Test Plan

Unit tests added