### PR TITLE
fix(dp): add max_ibw_mhz validation

### DIFF
--- a/dp/cloud/go/services/dp/obsidian/cbsd/handlers_test.go
+++ b/dp/cloud/go/services/dp/obsidian/cbsd/handlers_test.go
@@ -265,6 +265,14 @@ func (s *HandlersTestSuite) TestCreateCbsd() {
 		expectedStatus: http.StatusBadRequest,
 		expectedError:  "grant_redundancy cannot be set to false when carrier_aggregation_enabled is enabled",
 	}, {
+		name: "test create with max_ibw_mhz lesser than bandwidth_mhz",
+		inputPayload: b.NewMutableCbsdModelPayloadBuilder().
+			WithBandwidth(10).
+			WithMaxIbwMhz(5).
+			Payload,
+		expectedStatus: http.StatusBadRequest,
+		expectedError:  "max_ibw_mhz cannot be less than bandwidth_mhz",
+	}, {
 		name: "test failed model validation raises 400",
 		inputPayload: b.NewMutableCbsdModelPayloadBuilder().
 			WithSingleStepEnabled(nil).

--- a/dp/cloud/go/services/dp/obsidian/models/capabilities_swaggergen.go
+++ b/dp/cloud/go/services/dp/obsidian/models/capabilities_swaggergen.go
@@ -22,7 +22,6 @@ type Capabilities struct {
 	// this is the maximum allowed difference in MHz between leftmost end of leftmost channel and rightmost end of rightmost channel used by a Base Station (eNB)
 	// Required: true
 	// Maximum: 150
-	// Minimum: 5
 	// Multiple Of: 5
 	MaxIbwMhz int64 `json:"max_ibw_mhz"`
 
@@ -71,10 +70,6 @@ func (m *Capabilities) Validate(formats strfmt.Registry) error {
 func (m *Capabilities) validateMaxIbwMhz(formats strfmt.Registry) error {
 
 	if err := validate.Required("max_ibw_mhz", "body", int64(m.MaxIbwMhz)); err != nil {
-		return err
-	}
-
-	if err := validate.MinimumInt("max_ibw_mhz", "body", m.MaxIbwMhz, 5, false); err != nil {
 		return err
 	}
 

--- a/dp/cloud/go/services/dp/obsidian/models/capabilities_swaggergen.go
+++ b/dp/cloud/go/services/dp/obsidian/models/capabilities_swaggergen.go
@@ -21,6 +21,9 @@ type Capabilities struct {
 
 	// this is the maximum allowed difference in MHz between leftmost end of leftmost channel and rightmost end of rightmost channel used by a Base Station (eNB)
 	// Required: true
+	// Maximum: 150
+	// Minimum: 5
+	// Multiple Of: 5
 	MaxIbwMhz int64 `json:"max_ibw_mhz"`
 
 	// max tx power available on cbsd
@@ -68,6 +71,18 @@ func (m *Capabilities) Validate(formats strfmt.Registry) error {
 func (m *Capabilities) validateMaxIbwMhz(formats strfmt.Registry) error {
 
 	if err := validate.Required("max_ibw_mhz", "body", int64(m.MaxIbwMhz)); err != nil {
+		return err
+	}
+
+	if err := validate.MinimumInt("max_ibw_mhz", "body", m.MaxIbwMhz, 5, false); err != nil {
+		return err
+	}
+
+	if err := validate.MaximumInt("max_ibw_mhz", "body", m.MaxIbwMhz, 150, false); err != nil {
+		return err
+	}
+
+	if err := validate.MultipleOfInt("max_ibw_mhz", "body", m.MaxIbwMhz, 5); err != nil {
 		return err
 	}
 

--- a/dp/cloud/go/services/dp/obsidian/models/conversion.go
+++ b/dp/cloud/go/services/dp/obsidian/models/conversion.go
@@ -14,10 +14,6 @@ limitations under the License.
 package models
 
 import (
-	"context"
-	"fmt"
-
-	oerrors "github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 
 	"magma/dp/cloud/go/protos"
@@ -77,21 +73,6 @@ func CbsdFromBackend(details *protos.CbsdDetails) *Cbsd {
 		CbsdCategory:              details.Data.CbsdCategory,
 		InstallationParam:         getModelInstallationParam(details.Data.InstallationParam),
 	}
-}
-
-func (m *MutableCbsd) ValidateModel(ctx context.Context) error {
-	if err := m.Validate(strfmt.Default); err != nil {
-		return err
-	}
-	var res []error
-	if !*m.GrantRedundancy && *m.CarrierAggregationEnabled {
-		err := fmt.Errorf("grant_redundancy cannot be set to false when carrier_aggregation_enabled is enabled")
-		res = append(res, err)
-	}
-	if len(res) > 0 {
-		return oerrors.CompositeValidationError(res...)
-	}
-	return nil
 }
 
 func makeSliceNotNil(s []int64) []int64 {

--- a/dp/cloud/go/services/dp/obsidian/models/swagger.v1.yml
+++ b/dp/cloud/go/services/dp/obsidian/models/swagger.v1.yml
@@ -22,7 +22,6 @@ definitions:
         type: integer
         x-nullable: false
         maximum: 150
-        minimum: 5
         multipleOf: 5
       min_power:
         description: min tx power available on cbsd

--- a/dp/cloud/go/services/dp/obsidian/models/swagger.v1.yml
+++ b/dp/cloud/go/services/dp/obsidian/models/swagger.v1.yml
@@ -21,6 +21,9 @@ definitions:
         description: this is the maximum allowed difference in MHz between leftmost end of leftmost channel and rightmost end of rightmost channel used by a Base Station (eNB)
         type: integer
         x-nullable: false
+        maximum: 150
+        minimum: 5
+        multipleOf: 5
       min_power:
         description: min tx power available on cbsd
         type: number

--- a/dp/cloud/go/services/dp/obsidian/models/validation.go
+++ b/dp/cloud/go/services/dp/obsidian/models/validation.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
+)
+
+func (m *MutableCbsd) ValidateModel(_ context.Context) error {
+	if err := m.Validate(strfmt.Default); err != nil {
+		return err
+	}
+	var res []error
+	if !*m.GrantRedundancy && *m.CarrierAggregationEnabled {
+		err := fmt.Errorf("grant_redundancy cannot be set to false when carrier_aggregation_enabled is enabled")
+		res = append(res, err)
+	}
+	if m.Capabilities.MaxIbwMhz < m.FrequencyPreferences.BandwidthMhz {
+		err := fmt.Errorf("max_ibw_mhz cannot be less than bandwidth_mhz")
+		res = append(res, err)
+	}
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/dp/cloud/go/services/dp/obsidian/models/validation_test.go
+++ b/dp/cloud/go/services/dp/obsidian/models/validation_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"magma/dp/cloud/go/services/dp/obsidian/to_pointer"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 
 	b "magma/dp/cloud/go/services/dp/builders"
 	"magma/dp/cloud/go/services/dp/obsidian/models"
+	"magma/dp/cloud/go/services/dp/obsidian/to_pointer"
 )
 
 func TestMutableCbsd_Validate(t *testing.T) {

--- a/dp/cloud/go/services/dp/obsidian/models/validation_test.go
+++ b/dp/cloud/go/services/dp/obsidian/models/validation_test.go
@@ -1,7 +1,10 @@
 package models_test
 
 import (
+	"context"
 	"testing"
+
+	"magma/dp/cloud/go/services/dp/obsidian/to_pointer"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
@@ -95,6 +98,33 @@ func TestMutableCbsd_Validate(t *testing.T) {
 	for _, tt := range testData {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.data.Validate(strfmt.Default)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}
+
+func TestMutableCbsd_ValidateModel(t *testing.T) {
+	testData := []struct {
+		name          string
+		data          *models.MutableCbsd
+		expectedError string
+	}{{
+		name: "Should validate grant_redundancy false with carrier aggregation enabled",
+		data: b.NewMutableCbsdModelPayloadBuilder().
+			WithGrantRedundancy(to_pointer.Bool(false)).
+			WithCarrierAggregationEnabled(to_pointer.Bool(true)).
+			Payload,
+		expectedError: "grant_redundancy cannot be set to false when carrier_aggregation_enabled is enabled",
+	}, {
+		name: "Should validate max ibw mhz lesser than bandwidth mhz",
+		data: b.NewMutableCbsdModelPayloadBuilder().
+			WithMaxIbwMhz(5).WithBandwidth(10).Payload,
+		expectedError: "max_ibw_mhz cannot be less than bandwidth_mhz",
+	}}
+	c := context.TODO()
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.data.ValidateModel(c)
 			assert.Contains(t, err.Error(), tt.expectedError)
 		})
 	}

--- a/dp/cloud/go/services/dp/obsidian/models/validation_test.go
+++ b/dp/cloud/go/services/dp/obsidian/models/validation_test.go
@@ -83,6 +83,18 @@ func TestMutableCbsd_Validate(t *testing.T) {
 		name:          "Should validate max ibw mhz",
 		data:          b.NewMutableCbsdModelPayloadBuilder().WithMaxIbwMhz(0).Payload,
 		expectedError: "max_ibw_mhz in body is required",
+	}, {
+		name:          "Should validate max ibw mhz too high",
+		data:          b.NewMutableCbsdModelPayloadBuilder().WithMaxIbwMhz(151).Payload,
+		expectedError: "max_ibw_mhz in body should be less than or equal to 150",
+	}, {
+		name:          "Should validate max ibw mhz too low",
+		data:          b.NewMutableCbsdModelPayloadBuilder().WithMaxIbwMhz(4).Payload,
+		expectedError: "max_ibw_mhz in body should be greater than or equal to 5",
+	}, {
+		name:          "Should validate max ibw mhz not multiple of 5",
+		data:          b.NewMutableCbsdModelPayloadBuilder().WithMaxIbwMhz(7).Payload,
+		expectedError: "max_ibw_mhz in body should be a multiple of 5",
 	}}
 	for _, tt := range testData {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dp/cloud/go/services/dp/obsidian/models/validation_test.go
+++ b/dp/cloud/go/services/dp/obsidian/models/validation_test.go
@@ -88,10 +88,6 @@ func TestMutableCbsd_Validate(t *testing.T) {
 		data:          b.NewMutableCbsdModelPayloadBuilder().WithMaxIbwMhz(151).Payload,
 		expectedError: "max_ibw_mhz in body should be less than or equal to 150",
 	}, {
-		name:          "Should validate max ibw mhz too low",
-		data:          b.NewMutableCbsdModelPayloadBuilder().WithMaxIbwMhz(4).Payload,
-		expectedError: "max_ibw_mhz in body should be greater than or equal to 5",
-	}, {
 		name:          "Should validate max ibw mhz not multiple of 5",
 		data:          b.NewMutableCbsdModelPayloadBuilder().WithMaxIbwMhz(7).Payload,
 		expectedError: "max_ibw_mhz in body should be a multiple of 5",

--- a/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
@@ -6850,7 +6850,6 @@ definitions:
           end of leftmost channel and rightmost end of rightmost channel used by a
           Base Station (eNB)
         maximum: 150
-        minimum: 5
         multipleOf: 5
         type: integer
         x-nullable: false

--- a/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
@@ -6849,6 +6849,9 @@ definitions:
         description: this is the maximum allowed difference in MHz between leftmost
           end of leftmost channel and rightmost end of rightmost channel used by a
           Base Station (eNB)
+        maximum: 150
+        minimum: 5
+        multipleOf: 5
         type: integer
         x-nullable: false
       max_power:


### PR DESCRIPTION
Signed-off-by: Jarosław Jaszczuk <jaroslaw.jaszczuk@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Added validation for `max_ibw_mhz` field, that ensures the value is:
- `>= 5`
- `<= 150`
- multiple of 5

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Added test cases.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
