### PR TITLE
fix(nms): Fix cwf policy precedence becomes NaN if the field is cleared

### DIFF
--- a/nms/app/components/network/PolicyRuleEditDialog.tsx
+++ b/nms/app/components/network/PolicyRuleEditDialog.tsx
@@ -42,8 +42,10 @@ import {
 } from '../../../generated';
 import {base64ToHex, decodeBase64} from '../../util/strings';
 import {coalesceNetworkType} from '../../../shared/types/network';
+import {getErrorMessage} from '../../util/ErrorUtils';
 import {makeStyles} from '@material-ui/styles';
 import {useEffect, useState} from 'react';
+import {useEnqueueSnackbar} from '../../hooks/useSnackbar';
 import {useParams} from 'react-router-dom';
 
 const useStyles = makeStyles(() => ({
@@ -62,6 +64,8 @@ export default function PolicyRuleEditDialog(props: Props) {
   const classes = useStyles();
   const networkId = useParams().networkId!;
   const {qosProfiles, mirrorNetwork} = props;
+  const enqueueSnackbar = useEnqueueSnackbar();
+
   const [networkType, setNetworkType] = useState<NetworkType | null>(null);
   const [
     mirrorNetworkType,
@@ -159,55 +163,64 @@ export default function PolicyRuleEditDialog(props: Props) {
   };
 
   const onSave = async () => {
-    const ruleData = [
-      {
+    try {
+      const ruleData = [
+        {
+          networkId: nullthrows(networkId),
+          ruleId: rule.id,
+          policyRule: rule,
+        },
+      ];
+
+      if (mirrorNetwork) {
+        ruleData.push({
+          networkId: mirrorNetwork,
+          ruleId: rule.id,
+          policyRule: rule,
+        });
+      }
+
+      if (props.rule) {
+        await Promise.all(
+          ruleData.map(d =>
+            MagmaAPI.policies.networksNetworkIdPoliciesRulesRuleIdPut(d),
+          ),
+        );
+      } else {
+        await Promise.all(
+          ruleData.map(d =>
+            MagmaAPI.policies.networksNetworkIdPoliciesRulesPost(d),
+          ),
+        );
+      }
+
+      const networkWideRuleData = {
         networkId: nullthrows(networkId),
         ruleId: rule.id,
-        policyRule: rule,
-      },
-    ];
+      };
+      if (isNetworkWide) {
+        await postNetworkWideRuleID(networkWideRuleData, networkType!);
+        if (mirrorNetwork) {
+          networkWideRuleData.networkId = mirrorNetwork;
+          await postNetworkWideRuleID(networkWideRuleData, mirrorNetworkType!);
+        }
+      } else {
+        await deleteNetworkWideRuleID(networkWideRuleData, networkType!);
+        if (mirrorNetwork) {
+          networkWideRuleData.networkId = mirrorNetwork;
+          await deleteNetworkWideRuleID(
+            networkWideRuleData,
+            mirrorNetworkType!,
+          );
+        }
+      }
 
-    if (mirrorNetwork) {
-      ruleData.push({
-        networkId: mirrorNetwork,
-        ruleId: rule.id,
-        policyRule: rule,
+      props.onSave(rule.id);
+    } catch (error) {
+      enqueueSnackbar(getErrorMessage(error), {
+        variant: 'error',
       });
     }
-
-    if (props.rule) {
-      await Promise.all(
-        ruleData.map(d =>
-          MagmaAPI.policies.networksNetworkIdPoliciesRulesRuleIdPut(d),
-        ),
-      );
-    } else {
-      await Promise.all(
-        ruleData.map(d =>
-          MagmaAPI.policies.networksNetworkIdPoliciesRulesPost(d),
-        ),
-      );
-    }
-
-    const networkWideRuleData = {
-      networkId: nullthrows(networkId),
-      ruleId: rule.id,
-    };
-    if (isNetworkWide) {
-      await postNetworkWideRuleID(networkWideRuleData, networkType!);
-      if (mirrorNetwork) {
-        networkWideRuleData.networkId = mirrorNetwork;
-        await postNetworkWideRuleID(networkWideRuleData, mirrorNetworkType!);
-      }
-    } else {
-      await deleteNetworkWideRuleID(networkWideRuleData, networkType!);
-      if (mirrorNetwork) {
-        networkWideRuleData.networkId = mirrorNetwork;
-        await deleteNetworkWideRuleID(networkWideRuleData, mirrorNetworkType!);
-      }
-    }
-
-    props.onSave(rule.id);
   };
 
   return (
@@ -228,7 +241,8 @@ export default function PolicyRuleEditDialog(props: Props) {
           className={classes.input}
           label="Precendence"
           margin="normal"
-          value={rule.priority}
+          value={isNaN(rule.priority) ? '' : rule.priority}
+          type="number"
           onChange={({target}) =>
             setRule({...rule, priority: parseInt(target.value)})
           }
@@ -260,11 +274,14 @@ export default function PolicyRuleEditDialog(props: Props) {
           value={decodeBase64(rule.monitoring_key ?? '')}
         />
         <TextField
-          required
           className={classes.input}
           label="Rating Group"
           margin="normal"
-          value={rule.rating_group}
+          value={
+            rule.rating_group === undefined || isNaN(rule.rating_group)
+              ? ''
+              : rule.rating_group
+          }
           type="number"
           onChange={({target}) =>
             setRule({


### PR DESCRIPTION
## Summary

Make sure that the policy precedence field can handle non-number inputs.

- fixes #13207

## Test Plan

* Open the policy page on a CWF network
* Add a new policy 
  * clear the policy field
  * there should be no error and the field should be empty i.e. not show NaN

