### PR TITLE
fix(agw): both IPv4 and IPv6 downlink route returns are evaluated

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -135,15 +135,15 @@ class TrafficUtil(object):
 
     def update_dl_route(self, ue_ip_block):
         """Update downlink route in TRF server"""
-        ret_code = self.exec_command(
+        ret_code_ipv4 = self.exec_command(
             "sudo ip route flush via 192.168.129.1 && sudo ip route "
             "replace " + ue_ip_block + " via 192.168.129.1 dev eth2",
         )
-        ret_code = self.exec_command(
+        ret_code_ipv6 = self.exec_command(
             "sudo ip -6 route flush via " + self.agw_ipv6 + " && sudo ip -6 route "
             "replace " + self.ue_ipv6_block + " via " + self.agw_ipv6 + " dev eth3",
         )
-        return ret_code == 0
+        return ret_code_ipv4 == 0 and ret_code_ipv6 == 0
 
     def close_running_iperf_servers(self):
         """Close running Iperf3 servers in TRF server VM"""


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

At the moment, the return values of the downlink routes for IPv4 and IPv6 are stored in the same variable and the function return value only evaluates the IPv6 return. This PR changes this behavior. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
