### PR TITLE
feat(dp): Add Carrier Aggregation framework to Active Mode Controller

### DIFF
--- a/dp/cloud/go/active_mode_controller/go.mod
+++ b/dp/cloud/go/active_mode_controller/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang/protobuf v1.5.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75
 	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.27.1
 )
@@ -14,7 +15,7 @@ require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 	golang.org/x/text v0.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect

--- a/dp/cloud/go/active_mode_controller/go.sum
+++ b/dp/cloud/go/active_mode_controller/go.sum
@@ -38,8 +38,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
@@ -57,6 +57,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75 h1:x03zeu7B2B11ySp+daztnwM5oBJ/8wGUSqrwcw9L0RA=
+golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -77,8 +79,9 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -86,7 +89,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/eirp/calculator.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/eirp/calculator.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eirp
+
+import (
+	"math"
+
+	"magma/dp/cloud/go/active_mode_controller/protos/active_mode"
+)
+
+type calculator struct {
+	minPower    float64
+	maxPower    float64
+	antennaGain float64
+	noPorts     float64
+}
+
+func NewCalculator(antennaGain float32, capabilities *active_mode.EirpCapabilities) *calculator {
+	return &calculator{
+		minPower:    float64(capabilities.GetMinPower()),
+		maxPower:    float64(capabilities.GetMaxPower()),
+		antennaGain: float64(antennaGain),
+		noPorts:     float64(capabilities.GetNumberOfPorts()),
+	}
+}
+
+func (c *calculator) CalcLowerBound(bandwidthHz int) float64 {
+	return math.Ceil(c.calcEirp(c.minPower, bandwidthHz))
+}
+
+func (c *calculator) CalcUpperBound(bandwidthHz int) float64 {
+	return math.Floor(c.calcEirp(c.maxPower, bandwidthHz))
+}
+
+func (c *calculator) calcEirp(power float64, bandwidthHz int) float64 {
+	bwMHz := float64(bandwidthHz / 1e6)
+	return power + c.antennaGain - 10*math.Log10(bwMHz/c.noPorts)
+}

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/eirp/calculator_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/eirp/calculator_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eirp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/message_generator/sas/eirp"
+	"magma/dp/cloud/go/active_mode_controller/protos/active_mode"
+)
+
+func TestCalcLowerBound(t *testing.T) {
+	ec := &active_mode.EirpCapabilities{
+		MinPower:      0,
+		MaxPower:      20,
+		NumberOfPorts: 2,
+	}
+	c := eirp.NewCalculator(15, ec)
+
+	actual := c.CalcLowerBound(10 * 1e6)
+	assert.Equal(t, 9.0, actual)
+}
+
+func TestCalcUpperBound(t *testing.T) {
+	ec := &active_mode.EirpCapabilities{
+		MinPower:      0,
+		MaxPower:      20,
+		NumberOfPorts: 2,
+	}
+	c := eirp.NewCalculator(15, ec)
+
+	actual := c.CalcUpperBound(10 * 1e6)
+	assert.Equal(t, 28.0, actual)
+}

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/eirp/max_eirp.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/eirp/max_eirp.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eirp
+
+import (
+	"golang.org/x/exp/constraints"
+
+	"magma/dp/cloud/go/active_mode_controller/protos/active_mode"
+)
+
+const (
+	minSASEirp = -137
+	maxSASEirp = 37
+)
+
+func CalculateMaxEirp(channels []*active_mode.Channel, lowFrequencyHz int64, highFrequencyHz int64, maxEirp float32) float32 {
+	bw := int((highFrequencyHz - lowFrequencyHz) / 1e6)
+	eirps := make([]float32, bw+1)
+	for i := range eirps {
+		eirps[i] = minSASEirp
+	}
+	for _, c := range channels {
+		if c.HighFrequencyHz >= lowFrequencyHz && c.LowFrequencyHz <= highFrequencyHz {
+			updateMaxEirpsForChannel(c, eirps, lowFrequencyHz, highFrequencyHz)
+		}
+	}
+	eirp := min(maxEirp, float32(maxSASEirp))
+	for _, e := range eirps {
+		eirp = min(eirp, e)
+	}
+	return eirp
+}
+
+func updateMaxEirpsForChannel(c *active_mode.Channel, eirps []float32, lowFrequencyHz int64, highFrequencyHz int64) {
+	low := max(lowFrequencyHz, c.LowFrequencyHz)
+	high := min(highFrequencyHz, c.HighFrequencyHz)
+	l := int((low - lowFrequencyHz + 1e6 - 1) / 1e6)
+	r := int((high - lowFrequencyHz) / 1e6)
+	eirp := float32(maxSASEirp)
+	if c.MaxEirp != nil {
+		eirp = c.MaxEirp.Value
+	}
+	for ; l <= r; l++ {
+		eirps[l] = max(eirps[l], eirp)
+	}
+
+}
+
+func min[T constraints.Ordered](a T, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max[T constraints.Ordered](a T, b T) T {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/eirp/max_eirp_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/eirp/max_eirp_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eirp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/message_generator/sas/eirp"
+	"magma/dp/cloud/go/active_mode_controller/protos/active_mode"
+)
+
+func TestCalculateMaxEirp(t *testing.T) {
+	data := []struct {
+		name            string
+		channels        []*active_mode.Channel
+		lowFrequencyHz  int64
+		highFrequencyHz int64
+		maxEirp         float32
+		expected        float32
+	}{{
+		name: "Should calculate eirp for channel matching exactly",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3595e6,
+			HighFrequencyHz: 3605e6,
+			MaxEirp:         wrapperspb.Float(20),
+		}},
+		lowFrequencyHz:  3595e6,
+		highFrequencyHz: 3605e6,
+		maxEirp:         30,
+		expected:        20,
+	}, {
+		name: "Should calculate eirp for non overlapping channels",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3590e6,
+			HighFrequencyHz: 3600e6,
+			MaxEirp:         wrapperspb.Float(25),
+		}, {
+			LowFrequencyHz:  3600e6,
+			HighFrequencyHz: 3610e6,
+			MaxEirp:         wrapperspb.Float(20),
+		}},
+		lowFrequencyHz:  3590e6,
+		highFrequencyHz: 3610e6,
+		maxEirp:         30,
+		expected:        20,
+	}, {
+		name: "Should calculate eirp for overlapping channels",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3585e6,
+			HighFrequencyHz: 3595e6,
+			MaxEirp:         wrapperspb.Float(25),
+		}, {
+			LowFrequencyHz:  3590e6,
+			HighFrequencyHz: 3600e6,
+			MaxEirp:         wrapperspb.Float(15),
+		}, {
+			LowFrequencyHz:  3595e6,
+			HighFrequencyHz: 3615e6,
+			MaxEirp:         wrapperspb.Float(20),
+		}},
+		lowFrequencyHz:  3590e6,
+		highFrequencyHz: 3610e6,
+		maxEirp:         30,
+		expected:        20,
+	}, {
+		name: "Should use given max eirp is it is smallest",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3590e6,
+			HighFrequencyHz: 3610e6,
+			MaxEirp:         wrapperspb.Float(25),
+		}},
+		lowFrequencyHz:  3590e6,
+		highFrequencyHz: 3610e6,
+		maxEirp:         20,
+		expected:        20,
+	}, {
+		name: "Should use max sas eirp by default",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3590e6,
+			HighFrequencyHz: 3610e6,
+		}},
+		lowFrequencyHz:  3590e6,
+		highFrequencyHz: 3610e6,
+		maxEirp:         40,
+		expected:        37,
+	}, {
+		name: "Should skip outside channels",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3590e6,
+			HighFrequencyHz: 3610e6,
+		}, {
+			LowFrequencyHz:  3550e6,
+			HighFrequencyHz: 3570e6,
+			MaxEirp:         wrapperspb.Float(20),
+		}},
+		lowFrequencyHz:  3590e6,
+		highFrequencyHz: 3610e6,
+		maxEirp:         40,
+		expected:        37,
+	}}
+	for _, tt := range data {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := eirp.CalculateMaxEirp(tt.channels, tt.lowFrequencyHz, tt.highFrequencyHz, tt.maxEirp)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/frequency/const.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/frequency/const.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frequency
+
+const (
+	LowestHz  = 3550 * 1e6
+	HighestHz = 3700 * 1e6
+)

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/available_frequencies.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/available_frequencies.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grant
+
+import (
+	"sort"
+
+	"magma/dp/cloud/go/active_mode_controller/protos/active_mode"
+)
+
+func CalcAvailableFrequencies(channels []*active_mode.Channel, calc eirpCalculator) []uint32 {
+	masks := make([]uint32, 4)
+	sort.Slice(channels, func(i, j int) bool {
+		return channels[i].LowFrequencyHz < channels[j].LowFrequencyHz
+	})
+	for i := 0; i < 4; i++ {
+		bw := (i + 1) * unitToHz
+		minEirp := float32(calc.CalcLowerBound(bw))
+		masks[i] = calcAvailableFrequenciesForBandwidth(channels, minEirp, int64(bw))
+	}
+	return masks
+}
+
+type eirpCalculator interface {
+	CalcLowerBound(bandwidthHz int) float64
+}
+
+func calcAvailableFrequenciesForBandwidth(channels []*active_mode.Channel, minEirp float32, band int64) uint32 {
+	mask, begin, end := uint32(0), int64(0), int64(0)
+	for _, c := range channels {
+		if c.MaxEirp != nil && c.MaxEirp.Value < minEirp {
+			continue
+		}
+		if c.LowFrequencyHz > end {
+			mask |= makeMaskForRange(begin, end, band)
+			begin = c.LowFrequencyHz
+		}
+		if c.HighFrequencyHz > end {
+			end = c.HighFrequencyHz
+		}
+	}
+	return mask | makeMaskForRange(begin, end, band)
+}
+
+func makeMaskForRange(begin int64, end int64, band int64) uint32 {
+	if end == 0 {
+		return 0
+	}
+	l := hzToMask(begin + band/2 + unitToHz - 1)
+	r := hzToMask(end - band/2)
+	if r < l {
+		return 0
+	}
+	return r<<1 - l
+}

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/available_frequencies_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/available_frequencies_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grant_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant"
+	"magma/dp/cloud/go/active_mode_controller/protos/active_mode"
+)
+
+func TestCalcAvailableFrequencies(t *testing.T) {
+	testData := []struct {
+		name     string
+		channels []*active_mode.Channel
+		eirps    []float64
+		expected []uint32
+	}{{
+		name:     "Should handle no channels",
+		channels: nil,
+		eirps:    []float64{0, 0, 0, 0},
+		expected: []uint32{0, 0, 0, 0},
+	}, {
+		name: "Should handle single channel",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3590e6,
+			HighFrequencyHz: 3610e6,
+		}},
+		eirps: []float64{0, 0, 0, 0},
+		expected: []uint32{
+			1<<9 | 1<<10 | 1<<11,
+			1<<9 | 1<<10 | 1<<11,
+			1 << 10,
+			1 << 10,
+		},
+	}, {
+		name: "Should handle joined channels",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3590e6,
+			HighFrequencyHz: 3600e6,
+		}, {
+			LowFrequencyHz:  3600e6,
+			HighFrequencyHz: 3610e6,
+		}},
+		eirps: []float64{0, 0, 0, 0},
+		expected: []uint32{
+			1<<9 | 1<<10 | 1<<11,
+			1<<9 | 1<<10 | 1<<11,
+			1 << 10,
+			1 << 10,
+		},
+	}, {
+		name: "Should handle disjoint channels",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3590e6,
+			HighFrequencyHz: 3600e6,
+		}, {
+			LowFrequencyHz:  3610e6,
+			HighFrequencyHz: 3620e6,
+		}},
+		eirps: []float64{0, 0, 0, 0},
+		expected: []uint32{
+			1<<9 | 1<<13,
+			1<<9 | 1<<13,
+			0,
+			0,
+		},
+	}, {
+		name: "Should handle nested channels",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3595e6,
+			HighFrequencyHz: 3605e6,
+		}, {
+			LowFrequencyHz:  3590e6,
+			HighFrequencyHz: 3610e6,
+		}},
+		eirps: []float64{0, 0, 0, 0},
+		expected: []uint32{
+			1<<9 | 1<<10 | 1<<11,
+			1<<9 | 1<<10 | 1<<11,
+			1 << 10,
+			1 << 10,
+		},
+	}, {
+		name: "Should handle borders",
+		channels: []*active_mode.Channel{{
+			LowFrequencyHz:  3550e6,
+			HighFrequencyHz: 3700e6,
+		}},
+		eirps: []float64{0, 0, 0, 0},
+		expected: []uint32{
+			1<<30 - 1<<1,
+			1<<30 - 1<<1,
+			1<<29 - 1<<2,
+			1<<29 - 1<<2,
+		},
+	},
+		{
+			name: "Should calculate channels not aligned to multiple of 5MHz",
+			channels: []*active_mode.Channel{{
+				LowFrequencyHz:  3591e6,
+				HighFrequencyHz: 3600e6,
+			}, {
+				LowFrequencyHz:  3610e6,
+				HighFrequencyHz: 3629e6,
+			}},
+			eirps: []float64{0, 0, 0, 0},
+			expected: []uint32{
+				1<<9 | 1<<13 | 1<<14 | 1<<15,
+				1<<13 | 1<<14,
+				1 << 14,
+				0,
+			},
+		}, {
+			name: "Should skip channels with too low eirp",
+			channels: []*active_mode.Channel{{
+				LowFrequencyHz:  3590e6,
+				HighFrequencyHz: 3610e6,
+				MaxEirp:         wrapperspb.Float(-1),
+			}},
+			eirps:    []float64{0, 0, 0, 0},
+			expected: []uint32{0, 0, 0, 0},
+		}, {
+			name: "Should use correct eirp per bandwidth",
+			channels: []*active_mode.Channel{{
+				LowFrequencyHz:  3590e6,
+				HighFrequencyHz: 3600e6,
+				MaxEirp:         wrapperspb.Float(5),
+			}, {
+				LowFrequencyHz:  3600e6,
+				HighFrequencyHz: 3610e6,
+				MaxEirp:         wrapperspb.Float(10),
+			}},
+			eirps: []float64{11, 10, 9, 5},
+			expected: []uint32{
+				0,
+				1 << 11,
+				0,
+				1 << 10,
+			},
+		}}
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			calc := &stubEirpCalculator{eirps: tt.eirps}
+			actual := grant.CalcAvailableFrequencies(tt.channels, calc)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+type stubEirpCalculator struct {
+	eirps []float64
+}
+
+func (s *stubEirpCalculator) CalcLowerBound(bandwidthHz int) float64 {
+	return s.eirps[(bandwidthHz/5e6)-1]
+}

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/per_bandwidth.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/per_bandwidth.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package sas
+package grant
 
 import "math/bits"
 

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/per_bandwidth_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/per_bandwidth_test.go
@@ -11,14 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package sas_test
+package grant_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"magma/dp/cloud/go/active_mode_controller/internal/message_generator/sas"
+	"magma/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant"
 )
 
 const msg = "\nexpected: %b\nactual:   %b"
@@ -125,7 +125,7 @@ func TestSelectGrantsWithRedundancy(t *testing.T) {
 	}}
 	for _, tt := range data {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := sas.SelectGrantsWithRedundancy(tt.available, tt.grants, tt.pref, tt.minWidth, tt.maxWidth, tt.index)
+			actual := grant.SelectGrantsWithRedundancy(tt.available, tt.grants, tt.pref, tt.minWidth, tt.maxWidth, tt.index)
 			assert.Equal(t, tt.expected, actual, msg, tt.expected, actual)
 		})
 	}
@@ -154,7 +154,7 @@ func TestSelectGrantsWithoutRedundancy(t *testing.T) {
 	}}
 	for _, tt := range data {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := sas.SelectGrantsWithoutRedundancy(tt.available, tt.grants, tt.pref, tt.index)
+			actual := grant.SelectGrantsWithoutRedundancy(tt.available, tt.grants, tt.pref, tt.index)
 			assert.Equal(t, tt.expected, actual, msg, tt.expected, actual)
 		})
 	}

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/preferences.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/preferences.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grant
+
+import "magma/dp/cloud/go/active_mode_controller/protos/active_mode"
+
+type SelectionData struct {
+	BandwidthHz   int64
+	UseRedundancy RedundancyType
+}
+type RedundancyType uint8
+
+const (
+	NoRedundancy RedundancyType = iota
+	MustHaveTwo
+	BestEffort
+)
+
+func PickBandwidthSelectionOrder(settings *active_mode.GrantSettings, maxBandwidthHz int64, oldBandwidthHz int64) []*SelectionData {
+	if oldBandwidthHz != 0 {
+		redundancy := NoRedundancy
+		if settings.GrantRedundancyEnabled {
+			redundancy = BestEffort
+		}
+		return []*SelectionData{{
+			BandwidthHz:   oldBandwidthHz,
+			UseRedundancy: redundancy,
+		}}
+	}
+	order := bandwidthSelectionOrder[2]
+	if settings.GrantRedundancyEnabled {
+		order = bandwidthSelectionOrder[1]
+	}
+	if settings.CarrierAggregationEnabled {
+		order = bandwidthSelectionOrder[0]
+	}
+	return filterBandwidth(order, maxBandwidthHz)
+}
+
+var bandwidthSelectionOrder = [][]*SelectionData{{
+	{BandwidthHz: 20e6, UseRedundancy: BestEffort},
+	{BandwidthHz: 10e6, UseRedundancy: MustHaveTwo},
+	{BandwidthHz: 15e6, UseRedundancy: BestEffort},
+	{BandwidthHz: 10e6, UseRedundancy: NoRedundancy},
+	{BandwidthHz: 5e6, UseRedundancy: BestEffort},
+}, {
+	{BandwidthHz: 20e6, UseRedundancy: BestEffort},
+	{BandwidthHz: 15e6, UseRedundancy: BestEffort},
+	{BandwidthHz: 10e6, UseRedundancy: BestEffort},
+	{BandwidthHz: 5e6, UseRedundancy: BestEffort},
+}, {
+	{BandwidthHz: 20e6, UseRedundancy: NoRedundancy},
+	{BandwidthHz: 15e6, UseRedundancy: NoRedundancy},
+	{BandwidthHz: 10e6, UseRedundancy: NoRedundancy},
+	{BandwidthHz: 5e6, UseRedundancy: NoRedundancy},
+}}
+
+func filterBandwidth(data []*SelectionData, bandwidthHz int64) []*SelectionData {
+	filtered := make([]*SelectionData, 0, len(data))
+	for _, d := range data {
+		if d.BandwidthHz <= bandwidthHz {
+			filtered = append(filtered, d)
+		}
+	}
+	return filtered
+}

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/preferences_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/preferences_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grant_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant"
+	"magma/dp/cloud/go/active_mode_controller/protos/active_mode"
+)
+
+func TestPickBandwidthSelectionOrder(t *testing.T) {
+	testData := []struct {
+		name           string
+		settings       *active_mode.GrantSettings
+		maxBandwidthHz int64
+		oldBandwidthHz int64
+		expected       []*grant.SelectionData
+	}{{
+		name:           "Should pick no redundancy order when redundancy is disabled",
+		settings:       &active_mode.GrantSettings{},
+		maxBandwidthHz: 20e6,
+		expected: []*grant.SelectionData{
+			{BandwidthHz: 20e6, UseRedundancy: grant.NoRedundancy},
+			{BandwidthHz: 15e6, UseRedundancy: grant.NoRedundancy},
+			{BandwidthHz: 10e6, UseRedundancy: grant.NoRedundancy},
+			{BandwidthHz: 5e6, UseRedundancy: grant.NoRedundancy},
+		},
+	}, {
+		name: "Should pick best effort order for redundancy without carrier aggregation",
+		settings: &active_mode.GrantSettings{
+			GrantRedundancyEnabled: true,
+		},
+		maxBandwidthHz: 20e6,
+		expected: []*grant.SelectionData{
+			{BandwidthHz: 20e6, UseRedundancy: grant.BestEffort},
+			{BandwidthHz: 15e6, UseRedundancy: grant.BestEffort},
+			{BandwidthHz: 10e6, UseRedundancy: grant.BestEffort},
+			{BandwidthHz: 5e6, UseRedundancy: grant.BestEffort},
+		},
+	}, {
+		name: "Should pick custom order for carrier aggregation",
+		settings: &active_mode.GrantSettings{
+			GrantRedundancyEnabled:    true,
+			CarrierAggregationEnabled: true,
+		},
+		maxBandwidthHz: 20e6,
+		expected: []*grant.SelectionData{
+			{BandwidthHz: 20e6, UseRedundancy: grant.BestEffort},
+			{BandwidthHz: 10e6, UseRedundancy: grant.MustHaveTwo},
+			{BandwidthHz: 15e6, UseRedundancy: grant.BestEffort},
+			{BandwidthHz: 10e6, UseRedundancy: grant.NoRedundancy},
+			{BandwidthHz: 5e6, UseRedundancy: grant.BestEffort},
+		},
+	}, {
+		name: "Should filter out too large bandwidths",
+		settings: &active_mode.GrantSettings{
+			GrantRedundancyEnabled:    true,
+			CarrierAggregationEnabled: true,
+		},
+		maxBandwidthHz: 10e6,
+		expected: []*grant.SelectionData{
+			{BandwidthHz: 10e6, UseRedundancy: grant.MustHaveTwo},
+			{BandwidthHz: 10e6, UseRedundancy: grant.NoRedundancy},
+			{BandwidthHz: 5e6, UseRedundancy: grant.BestEffort},
+		},
+	}, {
+		name:           "Should pick no redundancy for existing bandwidth without redundancy",
+		settings:       &active_mode.GrantSettings{},
+		maxBandwidthHz: 20e6,
+		oldBandwidthHz: 15e6,
+		expected: []*grant.SelectionData{
+			{BandwidthHz: 15e6, UseRedundancy: grant.NoRedundancy},
+		},
+	}, {
+		name: "Should pick best effort for existing bandwidth with redundancy",
+		settings: &active_mode.GrantSettings{
+			GrantRedundancyEnabled: true,
+		},
+		maxBandwidthHz: 20e6,
+		oldBandwidthHz: 15e6,
+		expected: []*grant.SelectionData{
+			{BandwidthHz: 15e6, UseRedundancy: grant.BestEffort},
+		},
+	}}
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := grant.PickBandwidthSelectionOrder(tt.settings, tt.maxBandwidthHz, tt.oldBandwidthHz)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/selection.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/selection.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grant
+
+import (
+	"math/bits"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/message_generator/sas/frequency"
+	"magma/dp/cloud/go/active_mode_controller/protos/active_mode"
+)
+
+type Processor[T any] interface {
+	ProcessGrant(frequency int64, bandwidth int64) T
+}
+
+type Processors[T any] struct {
+	Keep Processor[T]
+	Del  Processor[T]
+	Add  Processor[T]
+}
+
+func ProcessGrants[T any](
+	grants []*active_mode.Grant, pref *active_mode.FrequencyPreferences,
+	settings *active_mode.GrantSettings, processors Processors[T], index int,
+) []T {
+	oldBw, oldGrants := calculateOldGrants(grants)
+	bw, newGrants := selectGrants(pref, settings, oldGrants, oldBw, index)
+	return processGrants(processors, oldGrants, newGrants, bw)
+}
+
+func calculateOldGrants(grants []*active_mode.Grant) (int64, uint32) {
+	mask := uint32(0)
+	bw := int64(0)
+	for i, g := range grants {
+		mask |= hzToMask((g.HighFrequencyHz + g.LowFrequencyHz) / 2)
+		if i == 0 {
+			bw = g.HighFrequencyHz - g.LowFrequencyHz
+		}
+	}
+	return bw, mask
+}
+
+func hzToMask(hz int64) uint32 {
+	return 1 << ((hz - frequency.LowestHz) / unitToHz)
+}
+
+const unitToHz = 5e6
+
+func selectGrants(
+	pref *active_mode.FrequencyPreferences, settings *active_mode.GrantSettings,
+	oldGrants uint32, oldBandwidthHz int64, index int,
+) (int64, uint32) {
+	prefMask := preferencesToMask(pref.FrequenciesMhz)
+	order := PickBandwidthSelectionOrder(settings, int64(pref.BandwidthMhz)*1e6, oldBandwidthHz)
+	for _, o := range order {
+		newGrants := selectGrantsForBandwidth(o, settings, oldGrants, prefMask, index)
+		if newGrants != 0 {
+			return o.BandwidthHz, newGrants
+		}
+	}
+	return 0, 0
+}
+
+func preferencesToMask(frequenciesMHz []int32) []uint32 {
+	masks := make([]uint32, len(frequenciesMHz))
+	for i, f := range frequenciesMHz {
+		masks[i] = hzToMask(int64(f) * 1e6)
+	}
+	return masks
+}
+
+func selectGrantsForBandwidth(data *SelectionData, settings *active_mode.GrantSettings, grants uint32, pref []uint32, index int) uint32 {
+	minWidth := int(data.BandwidthHz/unitToHz - 1)
+	maxWidth := int((int64(settings.MaxIbwMhz)*1e6 - data.BandwidthHz) / unitToHz)
+	available := settings.AvailableFrequencies[minWidth]
+	if minWidth > maxWidth {
+		maxWidth = minWidth
+	}
+	if data.UseRedundancy == NoRedundancy {
+		return SelectGrantsWithoutRedundancy(available, grants, pref, index)
+	}
+	newGrants := SelectGrantsWithRedundancy(available, grants, pref, minWidth, maxWidth, index)
+	if newGrants != 0 || data.UseRedundancy == MustHaveTwo {
+		return newGrants
+	}
+	return SelectGrantsWithoutRedundancy(available, grants, pref, index)
+}
+
+func processGrants[T any](processors Processors[T], oldGrants uint32, newGrants uint32, bandwidthHz int64) []T {
+	toKeep := oldGrants & newGrants
+	toDel := oldGrants &^ newGrants
+	toAdd := newGrants &^ oldGrants
+	r1 := processTypedGrants(processors.Del, toDel, bandwidthHz)
+	r2 := processTypedGrants(processors.Add, toAdd, bandwidthHz)
+	r3 := processTypedGrants(processors.Keep, toKeep, bandwidthHz)
+	return append(append(r1, r2...), r3...)
+}
+
+func processTypedGrants[T any](processor Processor[T], grants uint32, bandwidthHz int64) []T {
+	reqs := make([]T, 0, bits.OnesCount32(grants))
+	for grants > 0 {
+		x := grants & -grants
+		grants -= x
+		reqs = append(reqs, processor.ProcessGrant(maskToHz(x), bandwidthHz))
+	}
+	return reqs
+}
+
+func maskToHz(mask uint32) int64 {
+	return int64(bits.TrailingZeros32(mask))*unitToHz + frequency.LowestHz
+}

--- a/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/selection_test.go
+++ b/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant/selection_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grant_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/dp/cloud/go/active_mode_controller/internal/message_generator/sas/grant"
+	"magma/dp/cloud/go/active_mode_controller/protos/active_mode"
+)
+
+func TestProcessGrants(t *testing.T) {
+	testData := []struct {
+		name     string
+		grants   []*active_mode.Grant
+		pref     *active_mode.FrequencyPreferences
+		settings *active_mode.GrantSettings
+		expected []grantData
+	}{{
+		name:   "Should do nothing when no grants or available frequencies",
+		grants: nil,
+		pref: &active_mode.FrequencyPreferences{
+			BandwidthMhz: 20,
+		},
+		settings: &active_mode.GrantSettings{
+			MaxIbwMhz:            150,
+			AvailableFrequencies: []uint32{0, 0, 0, 0},
+		},
+		expected: []grantData{},
+	}, {
+		name:   "Should select only one grant in no redundancy mode",
+		grants: nil,
+		pref: &active_mode.FrequencyPreferences{
+			BandwidthMhz: 20,
+		},
+		settings: &active_mode.GrantSettings{
+			MaxIbwMhz:            150,
+			AvailableFrequencies: allAvailable,
+		},
+		expected: []grantData{{
+			action:    add,
+			frequency: 3560e6,
+			bandwidth: 20e6,
+		}},
+	}, {
+		name: "Should select keep existing grant in no redundancy mode",
+		grants: []*active_mode.Grant{{
+			LowFrequencyHz:  3590e6,
+			HighFrequencyHz: 3610e6,
+		}},
+		pref: &active_mode.FrequencyPreferences{
+			BandwidthMhz: 20,
+		},
+		settings: &active_mode.GrantSettings{
+			MaxIbwMhz:            150,
+			AvailableFrequencies: allAvailable,
+		},
+		expected: []grantData{{
+			action:    keep,
+			frequency: 3600e6,
+			bandwidth: 20e6,
+		}},
+	}, {
+		name:   "Should select grants for redundancy",
+		grants: nil,
+		pref: &active_mode.FrequencyPreferences{
+			BandwidthMhz: 20,
+		},
+		settings: &active_mode.GrantSettings{
+			GrantRedundancyEnabled: true,
+			MaxIbwMhz:              150,
+			AvailableFrequencies:   allAvailable,
+		},
+		expected: []grantData{{
+			action:    add,
+			frequency: 3560e6,
+			bandwidth: 20e6,
+		}, {
+			action:    add,
+			frequency: 3580e6,
+			bandwidth: 20e6,
+		}},
+	}, {
+		name:   "Should use custom ordering in carrier aggregation mode",
+		grants: nil,
+		pref: &active_mode.FrequencyPreferences{
+			BandwidthMhz: 15,
+		},
+		settings: &active_mode.GrantSettings{
+			GrantRedundancyEnabled:    true,
+			CarrierAggregationEnabled: true,
+			MaxIbwMhz:                 150,
+			AvailableFrequencies:      allAvailable,
+		},
+		expected: []grantData{{
+			action:    add,
+			frequency: 3555e6,
+			bandwidth: 10e6,
+		}, {
+			action:    add,
+			frequency: 3565e6,
+			bandwidth: 10e6,
+		}},
+	}, {
+		name:   "Should use frequency and bandwidth preferences",
+		grants: nil,
+		pref: &active_mode.FrequencyPreferences{
+			BandwidthMhz:   15,
+			FrequenciesMhz: []int32{3570},
+		},
+		settings: &active_mode.GrantSettings{
+			GrantRedundancyEnabled: true,
+			MaxIbwMhz:              150,
+			AvailableFrequencies:   allAvailable,
+		},
+		expected: []grantData{{
+			action:    add,
+			frequency: 3570e6,
+			bandwidth: 15e6,
+		}, {
+			action:    add,
+			frequency: 3585e6,
+			bandwidth: 15e6,
+		}},
+	}, {
+		name:   "Should add only one grant if only available in standard redundancy",
+		grants: nil,
+		pref: &active_mode.FrequencyPreferences{
+			BandwidthMhz: 20,
+		},
+		settings: &active_mode.GrantSettings{
+			GrantRedundancyEnabled: true,
+			MaxIbwMhz:              30,
+			AvailableFrequencies:   allAvailable,
+		},
+		expected: []grantData{{
+			action:    add,
+			frequency: 3560e6,
+			bandwidth: 20e6,
+		}},
+	}, {
+		name:   "Should go to next bandwidth if only one available in carrier aggregation mode",
+		grants: nil,
+		pref: &active_mode.FrequencyPreferences{
+			BandwidthMhz: 20,
+		},
+		settings: &active_mode.GrantSettings{
+			GrantRedundancyEnabled:    true,
+			CarrierAggregationEnabled: true,
+			MaxIbwMhz:                 150,
+			AvailableFrequencies:      []uint32{0, 1 << 10, 1 << 10, 0},
+		},
+		expected: []grantData{{
+			action:    add,
+			frequency: 3600e6,
+			bandwidth: 15e6,
+		}},
+	}}
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			p := grant.Processors[grantData]{
+				Keep: &stubGrantProcessor{action: keep},
+				Del:  &stubGrantProcessor{action: del},
+				Add:  &stubGrantProcessor{action: add},
+			}
+			actual := grant.ProcessGrants[grantData](tt.grants, tt.pref, tt.settings, p, 0)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+var allAvailable = []uint32{
+	1<<30 - 1<<1,
+	1<<30 - 1<<1,
+	1<<29 - 1<<2,
+	1<<29 - 1<<2,
+}
+
+type stubGrantProcessor struct {
+	action action
+}
+
+type action uint8
+
+const (
+	keep action = iota
+	del
+	add
+)
+
+func (s *stubGrantProcessor) ProcessGrant(frequency int64, bandwidth int64) grantData {
+	return grantData{
+		action:    s.action,
+		frequency: frequency,
+		bandwidth: bandwidth,
+	}
+}
+
+type grantData struct {
+	action    action
+	frequency int64
+	bandwidth int64
+}


### PR DESCRIPTION
## Summary

Add Carrier Aggregation framework to Active Mode Controller

Add eirp calculator for calculating eirp for
available channels and grant requests.

Add grant selector which decides what to do with each grant
(keep or delete or add new).

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>
