### PR TITLE
fix(nms): Make sure that policy is not removed from subscriber when it is updated

### DIFF
--- a/nms/app/components/context/PolicyContext.ts
+++ b/nms/app/components/context/PolicyContext.ts
@@ -32,6 +32,7 @@ export type PolicyContextType = {
     val?: PolicyRule,
     isNetworkWide?: boolean,
   ) => Promise<void>;
+  refetch: () => void;
 };
 
 export default React.createContext<PolicyContextType>({} as PolicyContextType);

--- a/nms/app/components/lte/LteContext.tsx
+++ b/nms/app/components/lte/LteContext.tsx
@@ -595,79 +595,76 @@ export function PolicyProvider(props: Props) {
     fegNetworkId = lteNetworkCtx.state?.federation?.feg_network_id;
   }
 
-  useEffect(() => {
-    const fetchState = async () => {
-      try {
-        setPolicies(
-          (
-            await MagmaAPI.policies.networksNetworkIdPoliciesRulesviewfullGet({
-              networkId,
-            })
-          ).data,
-        );
-
-        // Base Names
-        const baseNameIDs: Array<string> = (
-          await MagmaAPI.policies.networksNetworkIdPoliciesBaseNamesGet({
+  const fetchState = useCallback(async () => {
+    try {
+      setPolicies(
+        (
+          await MagmaAPI.policies.networksNetworkIdPoliciesRulesviewfullGet({
             networkId,
           })
-        ).data;
-        const baseNameRecords = await Promise.all(
-          baseNameIDs.map(baseNameID =>
-            MagmaAPI.policies.networksNetworkIdPoliciesBaseNamesBaseNameGet({
-              networkId,
-              baseName: baseNameID,
-            }),
-          ),
-        );
-        const newBaseNames: Record<string, BaseNameRecord> = {};
-        baseNameRecords.map(({data: record}) => {
-          newBaseNames[record.name] = record;
-        });
-        setBaseNames(newBaseNames);
+        ).data,
+      );
 
-        setRatingGroups(
-          // TODO[TS-migration] What is the actual type here?
-          ((
-            await MagmaAPI.ratingGroups.networksNetworkIdRatingGroupsGet({
-              networkId,
-            })
-          ).data as unknown) as Record<string, RatingGroup>,
-        );
-        setQosProfiles(
+      // Base Names
+      const baseNameIDs: Array<string> = (
+        await MagmaAPI.policies.networksNetworkIdPoliciesBaseNamesGet({
+          networkId,
+        })
+      ).data;
+      const baseNameRecords = await Promise.all(
+        baseNameIDs.map(baseNameID =>
+          MagmaAPI.policies.networksNetworkIdPoliciesBaseNamesBaseNameGet({
+            networkId,
+            baseName: baseNameID,
+          }),
+        ),
+      );
+      const newBaseNames: Record<string, BaseNameRecord> = {};
+      baseNameRecords.map(({data: record}) => {
+        newBaseNames[record.name] = record;
+      });
+      setBaseNames(newBaseNames);
+
+      setRatingGroups(
+        // TODO[TS-migration] What is the actual type here?
+        ((
+          await MagmaAPI.ratingGroups.networksNetworkIdRatingGroupsGet({
+            networkId,
+          })
+        ).data as unknown) as Record<string, RatingGroup>,
+      );
+      setQosProfiles(
+        (
+          await MagmaAPI.policies.lteNetworkIdPolicyQosProfilesGet({
+            networkId,
+          })
+        ).data,
+      );
+      if (fegNetworkId) {
+        setFegNetwork(
           (
-            await MagmaAPI.policies.lteNetworkIdPolicyQosProfilesGet({
-              networkId,
+            await MagmaAPI.federationNetworks.fegNetworkIdGet({
+              networkId: fegNetworkId,
             })
           ).data,
         );
-        if (fegNetworkId) {
-          setFegNetwork(
-            (
-              await MagmaAPI.federationNetworks.fegNetworkIdGet({
-                networkId: fegNetworkId,
-              })
-            ).data,
-          );
-          setFegPolicies(
-            (
-              await MagmaAPI.policies.networksNetworkIdPoliciesRulesviewfullGet(
-                {
-                  networkId: fegNetworkId,
-                },
-              )
-            ).data,
-          );
-        }
-      } catch (e) {
-        enqueueSnackbar?.('failed fetching policy information', {
-          variant: 'error',
-        });
+        setFegPolicies(
+          (
+            await MagmaAPI.policies.networksNetworkIdPoliciesRulesviewfullGet({
+              networkId: fegNetworkId,
+            })
+          ).data,
+        );
       }
-      setIsLoading(false);
-    };
-    void fetchState();
-  }, [networkId, fegNetworkId, networkType, enqueueSnackbar]);
+    } catch (e) {
+      enqueueSnackbar?.('failed fetching policy information', {
+        variant: 'error',
+      });
+    }
+    setIsLoading(false);
+  }, [networkId, fegNetworkId, enqueueSnackbar]);
+
+  useEffect(() => void fetchState(), [fetchState, networkType]);
 
   if (isLoading) {
     return <LoadingFiller />;
@@ -827,6 +824,7 @@ export function PolicyProvider(props: Props) {
             }
           }
         },
+        refetch: () => void fetchState(),
       }}>
       {props.children}
     </PolicyContext.Provider>

--- a/nms/app/views/network/__tests__/NetworkTest.tsx
+++ b/nms/app/views/network/__tests__/NetworkTest.tsx
@@ -293,6 +293,7 @@ describe('<NetworkDashboard />', () => {
       setRatingGroups: async () => {},
       setQosProfiles: async () => {},
       setState: async () => {},
+      refetch: () => {},
     } as PolicyContextType;
     const enodebCtx = {
       state: {enbInfo},

--- a/nms/app/views/subscriber/SubscriberTrafficPolicyEdit.tsx
+++ b/nms/app/views/subscriber/SubscriberTrafficPolicyEdit.tsx
@@ -69,7 +69,10 @@ export default function EditSubscriberTrafficPolicy(
               id="activeApnTestId"
               value={props.subscriberState.active_apns ?? []}
               onChange={({target}) => {
-                props.onSubscriberChange('active_apns', target.value as string);
+                props.onSubscriberChange(
+                  'active_apns',
+                  target.value as Array<string>,
+                );
               }}
               renderValue={selected => (selected as Array<string>).join(', ')}
               input={<OutlinedInput />}>
@@ -97,7 +100,7 @@ export default function EditSubscriberTrafficPolicy(
               onChange={({target}) => {
                 props.onSubscriberChange(
                   'active_base_names',
-                  target.value as string,
+                  target.value as Array<string>,
                 );
               }}
               renderValue={selected => (selected as Array<string>).join(', ')}
@@ -127,7 +130,7 @@ export default function EditSubscriberTrafficPolicy(
               onChange={({target}) => {
                 props.onSubscriberChange(
                   'active_policies',
-                  target.value as string,
+                  target.value as Array<string>,
                 );
               }}
               renderValue={selected => (selected as Array<string>).join(', ')}

--- a/nms/app/views/subscriber/SubscriberUtils.tsx
+++ b/nms/app/views/subscriber/SubscriberUtils.tsx
@@ -18,11 +18,7 @@ import Link from '@material-ui/core/Link';
 import React, {useContext} from 'react';
 import ReactJson from 'react-json-view';
 import SubscriberContext from '../../components/context/SubscriberContext';
-import {
-  LteSubscription,
-  MutableSubscriber,
-  Subscriber,
-} from '../../../generated';
+import {MutableSubscriber, Subscriber} from '../../../generated';
 import {SubscriberRowType} from '../../state/lte/SubscriberState';
 import {isValidHex} from '../../util/strings';
 import {useNavigate} from 'react-router-dom';
@@ -192,9 +188,9 @@ export type subscriberForbiddenNetworkTypes = {
 
 export type EditSubscriberProps = {
   subscriberState: Subscriber;
-  onSubscriberChange: (
-    key: string,
-    val: string | number | LteSubscription | undefined,
+  onSubscriberChange: <K extends keyof Subscriber>(
+    key: K,
+    val: Subscriber[K],
   ) => void;
   inputClass: string;
   onTrafficPolicyChange: (

--- a/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.tsx
+++ b/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.tsx
@@ -251,6 +251,7 @@ describe('<AddSubscriberButton />', () => {
       setRatingGroups: async () => {},
       setQosProfiles: async () => {},
       setState: async () => {},
+      refetch: () => {},
     };
 
     const apnCtx = {
@@ -301,7 +302,7 @@ describe('<AddSubscriberButton />', () => {
     const [subscribers, setSubscribers] = useState(subscribersMock);
     const [sessionState, setSessionState] = useState({});
     const [forbiddenNetworkTypes] = useState({});
-    const policyCtx = {
+    const policyCtx: PolicyContextType = {
       state: policies,
       baseNames: {},
       qosProfiles: {},
@@ -310,6 +311,7 @@ describe('<AddSubscriberButton />', () => {
       setRatingGroups: async () => {},
       setQosProfiles: async () => {},
       setState: async () => {},
+      refetch: () => {},
     };
 
     const apnCtx = {

--- a/nms/app/views/traffic/__tests__/TrafficOverviewTest.tsx
+++ b/nms/app/views/traffic/__tests__/TrafficOverviewTest.tsx
@@ -13,7 +13,9 @@
 import ApnContext from '../../../components/context/ApnContext';
 import MagmaAPI from '../../../api/MagmaAPI';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
-import PolicyContext from '../../../components/context/PolicyContext';
+import PolicyContext, {
+  PolicyContextType,
+} from '../../../components/context/PolicyContext';
 import React from 'react';
 import TrafficDashboard from '../TrafficOverview';
 import defaultTheme from '../../../theme/default';
@@ -133,7 +135,7 @@ const ratingGroups: Record<string, RatingGroup> = {
 
 describe('<TrafficDashboard />', () => {
   const networkId = 'test';
-  const policyCtx = {
+  const policyCtx: PolicyContextType = {
     state: policies,
     baseNames: {},
     qosProfiles,
@@ -166,6 +168,7 @@ describe('<TrafficDashboard />', () => {
         value,
       });
     },
+    refetch: () => {},
   };
 
   const apnCtx = {
@@ -381,7 +384,7 @@ describe('<TrafficDashboard APNs/>', () => {
   });
 
   const networkId = 'test';
-  const policyCtx = {
+  const policyCtx: PolicyContextType = {
     state: policies,
     baseNames: {},
     qosProfiles: {},
@@ -398,6 +401,7 @@ describe('<TrafficDashboard APNs/>', () => {
         value,
       });
     },
+    refetch: () => {},
   };
   const apnCtx = {
     state: apns,


### PR DESCRIPTION
## Summary

Reload policies after a policy is assigned to a subscriber to make sure that the association between subscribers and policies are is always up to date.

- fixes: #6926

## Test Plan

- Assign a policy to subscriber
- Change the config of the policy
- Make sure that the policy is still assigned to the subscriber

