### PR TITLE
feat(lte): Add EPS Authenticator support for APN Configs & APN Resources in S6a ULA

### DIFF
--- a/lte/cloud/go/services/eps_authentication/servicers/ai.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ai.go
@@ -51,7 +51,7 @@ func (srv *EPSAuthServer) AuthenticationInformation(
 		metrics.NetworkIDErrors.Inc()
 		return nil, err
 	}
-	config, err := getConfig(networkID)
+	config, err := GetConfig(networkID)
 	if err != nil {
 		glog.V(2).Infof("could not lookup config for networkID '%s': %v", networkID, err.Error())
 		metrics.ConfigErrors.Inc()

--- a/lte/cloud/go/services/eps_authentication/servicers/ai_test.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ai_test.go
@@ -77,7 +77,7 @@ func (suite *EpsAuthTestSuite) TestAuthenticationInformation_UnknownSubscriber()
 	aia, err := suite.AuthenticationInformation(air)
 	suite.EqualError(
 		err,
-		"rpc error: code = NotFound desc = error loading subscriber entity for NID: test, SID: sub_unknown: Not found")
+		"rpc error: code = NotFound desc = error loading subscriber ent for network ID: test, SID: sub_unknown: Not found")
 	suite.checkAIA(aia, fegprotos.ErrorCode_USER_UNKNOWN, 0)
 }
 

--- a/lte/cloud/go/services/eps_authentication/servicers/config.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/config.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -27,25 +28,50 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 )
 
+// ConfigCacheTTL is a TTL of cached configs instances
 const ConfigCacheTTL = time.Minute * 10
 
-// EpsAuthConfig stores all the configs needed to run the service.
+// EpsAuthConfig stores network related configs needed
 type EpsAuthConfig struct {
-	LteAuthOp   []byte
-	LteAuthAmf  []byte
-	SubProfiles map[string]models.NetworkEpcConfigsSubProfilesAnon
-	lastUpdate  time.Time
+	LteAuthOp          []byte
+	LteAuthAmf         []byte
+	SubProfiles        map[string]models.NetworkEpcConfigsSubProfilesAnon
+	ApnConfigs         map[string]*models.ApnConfiguration
+	ApnResources       map[string]*models.ApnResource
+	ApnResourcesByName map[string]*models.ApnResource
+	lastUpdate         time.Time
 }
 
+// epsCfgCache is a cache of network related configs for the service
 type epsCfgCache struct {
 	sync.RWMutex
 	configs map[string]*EpsAuthConfig
 }
 
-var cfgCache = epsCfgCache{configs: map[string]*EpsAuthConfig{}}
+// GwApnResources stores gateway related configs needed
+type GwApnResources struct {
+	apnResources map[string]*models.ApnResource
+	lastUpdate   time.Time
+}
 
-// getConfig returns the EpsAuthConfig config for a given networkId.
-func getConfig(networkID string) (*EpsAuthConfig, error) {
+// GwApnResourcesKey is a key for gateway related configs cache
+type GwApnResourcesKey struct {
+	networkID, gatewayID string
+}
+
+// epsGwCfgCache is a cache of gateway related configs for the service
+type epsGwCfgCache struct {
+	sync.RWMutex
+	resources map[GwApnResourcesKey]*GwApnResources
+}
+
+var (
+	cfgCache          = epsCfgCache{configs: map[string]*EpsAuthConfig{}}
+	apnResourcesCache = epsGwCfgCache{resources: map[GwApnResourcesKey]*GwApnResources{}}
+)
+
+// GetConfig returns the EpsAuthConfig config for a given networkId.
+func GetConfig(networkID string) (*EpsAuthConfig, error) {
 	now := time.Now()
 	cfgCache.RLock()
 	cfg, found := cfgCache.configs[networkID]
@@ -68,16 +94,111 @@ func getConfig(networkID string) (*EpsAuthConfig, error) {
 		return nil, status.Error(codes.FailedPrecondition, "failed to convert config")
 	}
 	epc := cellularConfig.Epc
-	cfg = &EpsAuthConfig{
-		LteAuthOp:   epc.LteAuthOp,
-		LteAuthAmf:  epc.LteAuthAmf,
-		SubProfiles: epc.SubProfiles,
-		lastUpdate:  now,
-	}
 
+	apnCfgs, err := loadApnsByName(networkID)
+	if err != nil {
+		glog.Errorf("failed to get APNs by name for network '%s': %v", networkID, err)
+	}
+	networkApnResources, networkApnResourcesByName, err := loadApnsResources(networkID)
+	if err != nil {
+		glog.Errorf("failed to get APN Resources for network '%s': %v", networkID, err)
+	}
+	cfg = &EpsAuthConfig{
+		LteAuthOp:          epc.LteAuthOp,
+		LteAuthAmf:         epc.LteAuthAmf,
+		SubProfiles:        epc.SubProfiles,
+		ApnConfigs:         apnCfgs,
+		ApnResources:       networkApnResources,
+		ApnResourcesByName: networkApnResourcesByName,
+		lastUpdate:         now,
+	}
 	cfgCache.Lock()
 	cfgCache.configs[networkID] = cfg
 	cfgCache.Unlock()
 
 	return cfg, nil
+}
+
+// GetGwApnResources returns the APN Resources configured for the given AGW & network
+func GetGwApnResources(
+	networkID, gwID string,
+	networkApnResources, networkApnResourcesByName map[string]*models.ApnResource) map[string]*models.ApnResource {
+
+	key := GwApnResourcesKey{networkID: networkID, gatewayID: gwID}
+	now := time.Now()
+	apnResourcesCache.RLock()
+	rsrs, found := apnResourcesCache.resources[key]
+	apnResourcesCache.RUnlock()
+
+	if found && rsrs != nil && rsrs.apnResources != nil && now.Before(rsrs.lastUpdate.Add(ConfigCacheTTL)) {
+		return rsrs.apnResources
+	}
+	lteGateway, err := configurator.LoadEntity(
+		context.Background(), networkID, lte.CellularGatewayEntityType, gwID,
+		configurator.EntityLoadCriteria{LoadAssocsFromThis: true}, serdes.Entity)
+	if err != nil {
+		glog.Errorf("load cellular gateway for network:gateway '%s:%s': %v", networkID, gwID, err)
+		// in case of an error return all network APN Resources
+		return networkApnResourcesByName
+	}
+	gwApnResourceIds := lteGateway.Associations.Filter(lte.APNResourceEntityType).Keys()
+	res := map[string]*models.ApnResource{}
+	for _, resourceId := range gwApnResourceIds {
+		if resource, found := networkApnResources[resourceId]; found && resource != nil {
+			res[string(resource.ApnName)] = resource
+		} else {
+			glog.Errorf("unmatched APN resource ID '%s' for network:gateway %s:%s", resourceId, networkID, gwID)
+		}
+	}
+	apnResourcesCache.Lock()
+	apnResourcesCache.resources[key] = &GwApnResources{apnResources: res, lastUpdate: now}
+	apnResourcesCache.Unlock()
+	return res
+}
+
+func loadApnsByName(networkID string) (map[string]*models.ApnConfiguration, error) {
+	apns, _, err := configurator.LoadAllEntitiesOfType(
+		context.Background(),
+		networkID, lte.APNEntityType,
+		configurator.EntityLoadCriteria{LoadConfig: true},
+		serdes.Entity,
+	)
+	apnsByName := map[string]*models.ApnConfiguration{}
+	if err != nil {
+		return apnsByName, err
+	}
+	for _, ent := range apns {
+		apn, ok := ent.Config.(*models.ApnConfiguration)
+		if !ok {
+			glog.Errorf("attempt to convert entity %+v of type %T into ApnConfiguration failed.", ent.Key, ent)
+			continue
+		}
+		apnsByName[ent.Key] = apn
+	}
+	return apnsByName, err
+}
+
+// loadApnsResources returns two ApnResource maps, first - keyed by the resource name & second - keyed by apn name
+func loadApnsResources(networkID string) (map[string]*models.ApnResource, map[string]*models.ApnResource, error) {
+	apns, _, err := configurator.LoadAllEntitiesOfType(
+		context.Background(),
+		networkID, lte.APNResourceEntityType,
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
+	)
+	apnsResourcesByResourceId, apnsResourcesByApnName :=
+		map[string]*models.ApnResource{}, map[string]*models.ApnResource{}
+	if err != nil {
+		return apnsResourcesByResourceId, apnsResourcesByApnName, err
+	}
+	for _, ent := range apns {
+		apnRes, ok := ent.Config.(*models.ApnResource)
+		if !ok {
+			glog.Errorf("attempt to convert entity %+v of type %T into ApnResource failed.", ent.Key, ent)
+			continue
+		}
+		apnsResourcesByResourceId[ent.Key] = apnRes
+		apnsResourcesByApnName[string(apnRes.ApnName)] = apnRes
+	}
+	return apnsResourcesByResourceId, apnsResourcesByApnName, err
 }

--- a/lte/cloud/go/services/eps_authentication/servicers/pur_test.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/pur_test.go
@@ -20,7 +20,7 @@ func (suite *EpsAuthTestSuite) TestPurgeUE_UnknownSubscriber() {
 	answer, err := suite.PurgeUE(purge)
 	suite.EqualError(
 		err,
-		"rpc error: code = NotFound desc = error loading subscriber entity for NID: test, SID: sub_unknown: Not found")
+		"rpc error: code = NotFound desc = error loading subscriber ent for network ID: test, SID: sub_unknown: Not found")
 	suite.Equal(protos.ErrorCode_USER_UNKNOWN, answer.ErrorCode)
 }
 

--- a/lte/cloud/go/services/eps_authentication/servicers/server.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/server.go
@@ -38,11 +38,8 @@ func NewEPSAuthServer(store storage.SubscriberDBStorage) (*EPSAuthServer, error)
 }
 
 // lookupSubscriber returns a subscriber's data or an error.
-func (srv *EPSAuthServer) lookupSubscriber(
-	userName, networkID string) (*lteprotos.SubscriberData, fegprotos.ErrorCode, error) {
-	subscriber, err := srv.store.GetSubscriberData(
-		&lteprotos.SubscriberID{Id: userName}, &protos.NetworkID{Id: networkID})
-
+func (srv *EPSAuthServer) lookupSubscriber(user, nid string) (*lteprotos.SubscriberData, fegprotos.ErrorCode, error) {
+	subscriber, err := srv.store.GetSubscriberData(&lteprotos.SubscriberID{Id: user}, &protos.NetworkID{Id: nid})
 	if err != nil {
 		if status.Convert(err).Code() == codes.NotFound {
 			return nil, fegprotos.ErrorCode_USER_UNKNOWN, err
@@ -50,4 +47,19 @@ func (srv *EPSAuthServer) lookupSubscriber(
 		return nil, fegprotos.ErrorCode_AUTHENTICATION_DATA_UNAVAILABLE, err
 	}
 	return subscriber, fegprotos.ErrorCode_SUCCESS, nil
+}
+
+// lookupSubscriberProfile returns a subscriber's data & profile or an error.
+func (srv *EPSAuthServer) lookupSubscriberProfile(
+	userName, networkID string) (*lteprotos.SubscriberData, map[string]string, []string, fegprotos.ErrorCode, error) {
+
+	subscriber, staticIps, subApns, err := srv.store.GetSubscriberDataProfile(
+		&lteprotos.SubscriberID{Id: userName}, &protos.NetworkID{Id: networkID})
+	if err != nil {
+		if status.Convert(err).Code() == codes.NotFound {
+			return nil, staticIps, subApns, fegprotos.ErrorCode_USER_UNKNOWN, err
+		}
+		return nil, staticIps, subApns, fegprotos.ErrorCode_AUTHENTICATION_DATA_UNAVAILABLE, err
+	}
+	return subscriber, staticIps, subApns, fegprotos.ErrorCode_SUCCESS, nil
 }

--- a/lte/cloud/go/services/eps_authentication/servicers/test_utils/test_subscribers.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/test_utils/test_subscribers.go
@@ -31,6 +31,7 @@ func GetTestSubscribers() []*protos.SubscriberData {
 
 	// Default subscriber
 	sub := generateDefaultSub("sub1")
+	sub.Non_3Gpp.ApnConfig[0].ServiceSelection = "apn"
 	subs = append(subs, sub)
 
 	// Default Subs with a blank AAA server


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Add EPS Authenticator support for APN Configs & APN Resources in S6a ULA.

In order to replace insecure subscriberdb based authentication with EPS Authenticator we need to pass required APN information as well as optional static user IPs (which were previously stuffed into streamed subscriberdb data) in the Authenticator's S6a ULA responses.

## Test Plan

Amend & run unit tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
