### PR TITLE
chore(deps): bump numpy from 1.20.3 to 1.22.0

### DIFF
--- a/dp/tools/harness/requirements.txt
+++ b/dp/tools/harness/requirements.txt
@@ -1,6 +1,6 @@
 six===1.16.0
 pyopenssl===20.0.1
-numpy===1.20.3
+numpy===1.22.0
 psutil===5.8.0
 pycurl===7.43.0
 jsonschema===3.2.0


### PR DESCRIPTION
Redo https://github.com/magma/magma/pull/13049, which is stuck in the CI with a hung test. I don't have permissions to kill the stuck PR, so I'm redoing it manually.

Signed-off-by: Lucas Gonze <lucas@gonze.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
