### PR TITLE
chore(dp): Update deployment to use go 1.18 for AMC

### DIFF
--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Run Go linter
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # pin@v2
         with:
-          version: v1.45.0
+          version: v1.46.2
           working-directory: dp/cloud/go/active_mode_controller
           skip-go-installation: true
 

--- a/dp/cloud/docker/go/active_mode_controller/Dockerfile
+++ b/dp/cloud/docker/go/active_mode_controller/Dockerfile
@@ -1,4 +1,16 @@
-FROM golang:1.16.14-alpine3.14 AS build
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG GOLANG_VERSION="1.18.3"
+FROM golang:${GOLANG_VERSION}-alpine3.16 AS build
 COPY dp/cloud/go/active_mode_controller /active_mode_controller
 WORKDIR /active_mode_controller/cmd
 RUN go build


### PR DESCRIPTION
## Summary

Update golangci-lint version in AMC workflow.
Update go version in AMC docker.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>