### PR TITLE
chore(dp): Get rid of NMS UI from integration tests targets

### DIFF
--- a/dp/Makefile
+++ b/dp/Makefile
@@ -85,7 +85,7 @@ clean:
 
 .PHONY: dev_orc8r
 dev_orc8r:
-	skaffold dev -p orc8r-deployment$(APPEND_METRICS_PROFILE) --trigger=manual
+	skaffold dev -p orc8r-deployment,nms-deployment$(APPEND_METRICS_PROFILE) --trigger=manual
 
 .PHONY: dev
 dev:

--- a/dp/cloud/docker/python/test_runner/entrypoint.sh
+++ b/dp/cloud/docker/python/test_runner/entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 if [ "$TESTS_DEV" = true ] ; then
+    echo "This container will sleep infinitely when TESTS_DEV env is set to true, it's for tests development"
     sleep infinity
 else
     python "$@"

--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/nms_overrides.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/nms_overrides.yaml
@@ -1,0 +1,3 @@
+---
+nms:
+  enabled: true

--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/orc8r_minikube_values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/orc8r_minikube_values.yaml
@@ -112,6 +112,7 @@ nginx:
   spec:
     hostname: localhost
 nms:
+  enabled: false
   nginx:
     deployment:
       spec:

--- a/dp/skaffold.yaml
+++ b/dp/skaffold.yaml
@@ -246,8 +246,8 @@ profiles:
           namespace: default
           version: "0.2.5"
           artifactOverrides:
-            magmalte:
-              image: magmalte
+            controller:
+              image: controller
           imageStrategy:
             helm: {}
       - op: add
@@ -281,6 +281,17 @@ profiles:
                 - "/var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator || exit 0"
       - op: remove
         path: /deploy/helm/hooks/before/6
+  - name: nms-deployment
+    patches:
+      - op: add
+        path: /deploy/helm/releases/2/artifactOverrides
+        value:
+          nms:
+            magmalte:
+              image: magmalte
+      - op: add
+        path: /deploy/helm/releases/2/valuesFiles/-
+        value: ./cloud/helm/dp/charts/domain-proxy/examples/nms_overrides.yaml
   - name: metrics
     patches:
       - op: add


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Remove NMS from integration tests make targets, as is not using there
