### PR TITLE
feat(nms): Add carrier aggregation fields to CBSD

### DIFF
--- a/nms/app/views/domain-proxy/CbsdEdit.tsx
+++ b/nms/app/views/domain-proxy/CbsdEdit.tsx
@@ -117,6 +117,9 @@ type CbsdFormData = {
   frequenciesMhz: Array<number | string>;
   cbsdCategory: CbsdCategoryEnum;
   singleStepEnabled: boolean;
+  grantRedundancyEnabled: boolean;
+  carrierAggreGationEnabled: boolean;
+  maxIbw: number | string;
 };
 
 const convertToCbsdFormData = (cbsd?: Cbsd): CbsdFormData => {
@@ -134,6 +137,12 @@ const convertToCbsdFormData = (cbsd?: Cbsd): CbsdFormData => {
     frequenciesMhz: cbsd?.frequency_preferences?.frequencies_mhz || [0],
     cbsdCategory: cbsd?.cbsd_category === 'b' ? 1 : 0,
     singleStepEnabled: cbsd?.single_step_enabled || false,
+    grantRedundancyEnabled:
+      cbsd?.grant_redundancy === undefined
+        ? true
+        : Boolean(cbsd?.grant_redundancy),
+    carrierAggreGationEnabled: cbsd?.carrier_aggregation_enabled || false,
+    maxIbw: cbsd?.capabilities?.max_ibw_mhz || 150,
   };
 };
 
@@ -168,10 +177,10 @@ export function CbsdAddEditDialog(props: DialogProps) {
           min_power: parseInt(cbsdFormData.minPower as string),
           max_power: parseInt(cbsdFormData.maxPower as string),
           number_of_antennas: parseInt(cbsdFormData.numberOfAntennas as string),
-          max_ibw_mhz: 150,
+          max_ibw_mhz: parseInt(cbsdFormData.maxIbw as string),
         },
-        carrier_aggregation_enabled: false,
-        grant_redundancy: true,
+        carrier_aggregation_enabled: cbsdFormData.carrierAggreGationEnabled,
+        grant_redundancy: cbsdFormData.grantRedundancyEnabled,
         installation_param: {
           antenna_gain: parseInt(cbsdFormData.antennaGain as string),
         },
@@ -226,6 +235,38 @@ export function CbsdAddEditDialog(props: DialogProps) {
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const handleCarrierAggregationChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const {checked} = event.target;
+    const shouldEnableGrantRedundancy = checked;
+    const grantRedundancyEnabled = shouldEnableGrantRedundancy
+      ? true
+      : cbsdFormData.grantRedundancyEnabled;
+
+    setCbsdFormData({
+      ...cbsdFormData,
+      carrierAggreGationEnabled: checked,
+      grantRedundancyEnabled,
+    });
+  };
+
+  const handleGrantRedundancyChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const {checked} = event.target;
+    const shouldDisableCarrierAggregation = !checked;
+    const carrierAggreGationEnabled = shouldDisableCarrierAggregation
+      ? false
+      : cbsdFormData.carrierAggreGationEnabled;
+
+    setCbsdFormData({
+      ...cbsdFormData,
+      grantRedundancyEnabled: checked,
+      carrierAggreGationEnabled,
+    });
   };
 
   return (
@@ -408,6 +449,57 @@ export function CbsdAddEditDialog(props: DialogProps) {
                 />
               }
               label={''}
+            />
+          </AltFormField>
+
+          <AltFormField label={'Grant Redundancy Enabled'}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  inputProps={
+                    ({
+                      'data-testid': 'grant-redundancy-enabled-input',
+                    } as unknown) as React.InputHTMLAttributes<HTMLInputElement>
+                  }
+                  checked={cbsdFormData.grantRedundancyEnabled}
+                  onChange={handleGrantRedundancyChange}
+                  color="primary"
+                />
+              }
+              label={''}
+            />
+          </AltFormField>
+
+          <AltFormField label={'eNB Carrier Aggregation Enabled'}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  inputProps={
+                    ({
+                      'data-testid': 'carrier-aggregation-enabled-input',
+                    } as unknown) as React.InputHTMLAttributes<HTMLInputElement>
+                  }
+                  checked={cbsdFormData.carrierAggreGationEnabled}
+                  onChange={handleCarrierAggregationChange}
+                  color="primary"
+                />
+              }
+              label={''}
+            />
+          </AltFormField>
+
+          <AltFormField label={'Max Instantaneous BandWidth (IBW) MHz'}>
+            <OutlinedInput
+              fullWidth
+              inputProps={{
+                'data-testid': 'max-ibw-input',
+              }}
+              type="number"
+              disabled={isLoading}
+              value={cbsdFormData.maxIbw}
+              onChange={({target}) =>
+                setCbsdFormData({...cbsdFormData, maxIbw: target.value})
+              }
             />
           </AltFormField>
 


### PR DESCRIPTION
## Summary
- Add 3 carrier aggregation inputs with default values to the CBSD add/edit form:
  - `carrier_aggregation_enabled` (default `false`)
  - `grant_redundancy` (default `true`)
  - `capabilities.max_ibw_mhz` (default `150`)
- Send them in the POST and PUT requests.
- Add carrier aggregation and grant redundancy interdependence logic:
  - If `carrier_aggregation_enabled` checkbox is set to `true`, `grant_redundancy` checkbox is set to `true` automatically.
  - If `grant_redundancy` checkbox  is set to `false`, `carrier_aggregation_enabled` checkbox is set set to `false` automatically.

Signed-off-by: Ivan Sergiienko <ivan@freedomfi.com>

## Test Plan

### Fields in the form

<img width="728" alt="new-fields" src="https://user-images.githubusercontent.com/104149278/179277794-adb87a0b-cfc2-4c48-92a1-e06381a30d4e.png">

### Checkbox interdependence

![checkboxes](https://user-images.githubusercontent.com/104149278/179277955-4dcbf44b-c617-48cd-9656-3b8ab44aa2fe.gif)

### POST request (create new CBSD)

<img width="750" alt="image" src="https://user-images.githubusercontent.com/104149278/179279816-6ea95286-1c43-4b17-8f4b-c495d13e4edd.png">

### PUT request (edit CBSD)

<img width="736" alt="image" src="https://user-images.githubusercontent.com/104149278/179280710-053085b2-5f13-4f60-9d86-0205f41c2f3e.png">
