### PR TITLE
fix(nms): Omit qos_profile for feg lte profile creation

### DIFF
--- a/nms/app/components/lte/LteContext.tsx
+++ b/nms/app/components/lte/LteContext.tsx
@@ -24,6 +24,7 @@ import NetworkContext from '../context/NetworkContext';
 import PolicyContext from '../context/PolicyContext';
 import SubscriberContext from '../context/SubscriberContext';
 import TraceContext from '../context/TraceContext';
+import {omit} from 'lodash';
 import type {
   Apn,
   BaseNameRecord,
@@ -743,7 +744,7 @@ export function PolicyProvider(props: Props) {
                 setPolicies: setFegPolicies,
                 networkId: fegNetworkID,
                 key,
-                value,
+                value: omit(value, 'qos_profile'),
               });
             }
           } else {


### PR DESCRIPTION
## Summary

When creating a policy rule With QoS profile for a FEG_LTE network omit the profile when adding the policy to the FEG network.

 - Fixes: #9820

## Test Plan


Follow the steps to reproduce in #9820 make sure there is no error anymore.

