### PR TITLE
fix(pipelined): missing sudo test is bazelified

### DIFF
--- a/lte/gateway/python/magma/pipelined/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/tests/BUILD.bazel
@@ -27,6 +27,8 @@ py_library(
     deps = [
         "//lte/gateway/python/magma/pipelined:service_manager",
         "//lte/gateway/python/magma/pipelined/tests/app:flow_query",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/gateway/python/magma/pipelined/tests/app:table_isolation",
         requirement("fakeredis"),
     ],
 )
@@ -854,4 +856,23 @@ pytest_test(
         ORC8R_ROOT,
     ],
     deps = ["//lte/gateway/python/magma/pipelined:gtp_stats_collector"],
+)
+
+pytest_test(
+    name = "test_non_nat",
+    size = "small",
+    srcs = ["test_non_nat.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    tags = TAG_SUDO_TEST,
+    deps = [
+        ":pipelined_test_util",
+        "//lte/gateway/python/magma/pipelined:bridge_util",
+        "//lte/gateway/python/magma/pipelined/app:testing",
+        "//lte/gateway/python/magma/pipelined/tests/app:start_pipelined",
+        "//lte/protos:mobilityd_python_proto",
+        "//lte/protos:pipelined_python_proto",
+    ],
 )


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

This PR fixes two things:
* in #13288 a new pipelined sudo test was added that was not bazelified
  * this broke a CI check that tests if all python files are bazelified - it is under investigation why the slack notification was not triggered
* in #13093 `lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py` was refactored and the changes were not reflected in Bazel
  * this broke the bazel sudo tests in general - they are not yet executed in CI

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
