### PR TITLE
refactor(orc8r): Replace moriyoshi routewrapper

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -104,7 +104,6 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olivere/elastic/v7 v7.0.6 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -366,8 +366,6 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39 h1:diqTAr+wSpYUQHsyj80KOYO+TUf9RqjnKsARAsDDxaE=
-github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39/go.mod h1:58NWw+g5pMuFB1BxO0ZVEQRDC09iqiiI5JHBGtl5Jyk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -114,7 +114,6 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olivere/elastic/v7 v7.0.6 // indirect
 	github.com/ory/viper v1.7.5 // indirect
@@ -134,6 +133,8 @@ require (
 	github.com/tklauser/numcpus v0.2.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
+	github.com/vishvananda/netlink v1.1.0 // indirect
+	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
 	go.mongodb.org/mongo-driver v1.8.2 // indirect
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
 	golang.org/x/mod v0.5.1 // indirect

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -620,8 +620,6 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39 h1:diqTAr+wSpYUQHsyj80KOYO+TUf9RqjnKsARAsDDxaE=
-github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39/go.mod h1:58NWw+g5pMuFB1BxO0ZVEQRDC09iqiiI5JHBGtl5Jyk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -784,7 +782,9 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52WA1u4=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad h1:W0LEBv82YCGEtcmPA3uNZBI33/qF//HAAs3MawDjRa0=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=

--- a/orc8r/gateway/go/go.mod
+++ b/orc8r/gateway/go/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/shirou/gopsutil/v3 v3.21.5
 	github.com/stretchr/testify v1.7.0
+	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
 	google.golang.org/grpc v1.43.0
 	magma/orc8r/lib/go v0.0.0-00010101000000-000000000000
@@ -41,6 +42,7 @@ require (
 	github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 // indirect
 	github.com/tklauser/go-sysconf v0.3.4 // indirect
 	github.com/tklauser/numcpus v0.2.1 // indirect
+	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
 	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/orc8r/gateway/go/go.mod
+++ b/orc8r/gateway/go/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39
 	github.com/prometheus/client_model v0.2.0
 	github.com/shirou/gopsutil/v3 v3.21.5
 	github.com/stretchr/testify v1.7.0

--- a/orc8r/gateway/go/go.sum
+++ b/orc8r/gateway/go/go.sum
@@ -135,6 +135,10 @@ github.com/tklauser/go-sysconf v0.3.4 h1:HT8SVixZd3IzLdfs/xlpq0jeSfTX57g1v6wB1Eu
 github.com/tklauser/go-sysconf v0.3.4/go.mod h1:Cl2c8ZRWfHD5IrfHo9VN+FX9kCFjIOyVklgXycLB6ek=
 github.com/tklauser/numcpus v0.2.1 h1:ct88eFm+Q7m2ZfXJdan1xYoXKlmwsfP+k88q05KvlZc=
 github.com/tklauser/numcpus v0.2.1/go.mod h1:9aU+wOc6WjUIZEwWMP62PL/41d65P+iks1gBkr4QyP8=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da h1:NimzV1aGyq29m5ukMK0AMWEhFaL/lrEOaephfuoiARg=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
@@ -177,6 +181,7 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/orc8r/gateway/go/go.sum
+++ b/orc8r/gateway/go/go.sum
@@ -90,8 +90,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39 h1:diqTAr+wSpYUQHsyj80KOYO+TUf9RqjnKsARAsDDxaE=
-github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39/go.mod h1:58NWw+g5pMuFB1BxO0ZVEQRDC09iqiiI5JHBGtl5Jyk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/orc8r/gateway/go/status/gateway_status.go
+++ b/orc8r/gateway/go/status/gateway_status.go
@@ -323,6 +323,9 @@ func UnixMs(t time.Time) int64 {
 func getIPInterfaceNameMap() map[string]int {
 	ipNameMapNI := make(map[string]int)
 	for i, nf := range netInterfaces {
+		if len(nf.Addrs) == 0 {
+			continue
+		}
 		nfIP, _, _ := net.ParseCIDR(nf.Addrs[0].Addr)
 		ipNameMapNI[nfIP.To4().String()] = i
 	}

--- a/orc8r/gateway/go/status/gateway_status.go
+++ b/orc8r/gateway/go/status/gateway_status.go
@@ -148,39 +148,6 @@ func GetNetworkInfo() *NetworkInfo {
 		}
 		interfaces[i] = netIface
 	}
-	// for i, rt := range hostRoutes {
-	// 	dest := rt.Destination.IP.To4()
-	// 	if dest == nil {
-	// 		dest = rt.Destination.IP
-	// 	}
-	// 	gw := rt.Gateway.To4()
-	// 	if gw == nil {
-	// 		gw = rt.Gateway
-	// 		if len(gw) == 0 {
-	// 			if len(dest) == net.IPv4len {
-	// 				gw = []byte{0, 0, 0, 0}
-	// 			} else {
-	// 				gw = net.IP([]byte{0, 0, 0, 0}).To16()
-	// 			}
-	// 		}
-	// 	}
-	// 	maskStr := rt.Destination.Mask.String()
-	// 	if len(dest) == net.IPv4len {
-	// 		maskV4 := net.IP(rt.Destination.Mask).To4()
-	// 		if maskV4 != nil {
-	// 			maskStr = maskV4.String()
-	// 		}
-	// 	}
-	// 	route := &Route{
-	// 		DestinationIp: dest.String(),
-	// 		GatewayIp:     gw.String(),
-	// 		Genmask:       maskStr,
-	// 	}
-	// 	if rt.Interface != nil {
-	// 		route.NetworkInterfaceId = rt.Interface.Name
-	// 	}
-	// 	routes[i] = route
-	// }
 
 	ipNameMapNI := getIPInterfaceNameMap()
 	linkList, _ := netlink.LinkList()

--- a/orc8r/gateway/go/status/gateway_status.go
+++ b/orc8r/gateway/go/status/gateway_status.go
@@ -24,6 +24,7 @@ import (
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/mem"
+	gopsutil_net "github.com/shirou/gopsutil/v3/net"
 	"github.com/vishvananda/netlink"
 
 	"magma/gateway/config"
@@ -181,7 +182,7 @@ func getRoutes(hRoutes []netlink.Route) ([]*Route, map[string]string, []netlink.
 			continue
 		}
 
-		index := r.LinkIndex - 1
+		index := r.LinkIndex
 
 		dest := getDestinationIP(r).IP.To4()
 		if dest == nil {
@@ -206,9 +207,6 @@ func getRoutes(hRoutes []netlink.Route) ([]*Route, map[string]string, []netlink.
 			if maskV4 != nil {
 				maskStr = maskV4.String()
 			}
-		}
-		if index >= len(netInterfaces) {
-			continue
 		}
 
 		convertedIface := getNetInterface(index)
@@ -289,7 +287,13 @@ func UnixMs(t time.Time) int64 {
 }
 
 func getNetInterface(index int) net.Interface {
-	iface := netInterfaces[index]
+	var iface gopsutil_net.InterfaceStat
+	for _, nif := range netInterfaces {
+		if nif.Index == index {
+			iface = nif
+		}
+	}
+	// iface := netInterfaces[index]
 	parsedAddr, _ := net.ParseMAC(iface.HardwareAddr)
 	// hex.DecodeString(iface.HardwareAddr)
 	convertedIface := net.Interface{

--- a/orc8r/gateway/go/status/gateway_status.go
+++ b/orc8r/gateway/go/status/gateway_status.go
@@ -175,9 +175,6 @@ func getRoutes(hostRoutes []netlink.Route, recursiveResolving bool) []*Route {
 		}
 
 		dest := getDestinationIP(hostRoute).IP.To4()
-		if dest == nil {
-			continue
-		}
 		gw := getGatewayIP(hostRoute, dest)
 		maskStr := getMaskStr(hostRoute, dest)
 
@@ -325,11 +322,7 @@ func getGatewayIP(hostRoute netlink.Route, dest net.IP) string {
 	if gw == nil {
 		gw = hostRoute.Gw
 		if len(gw) == 0 {
-			if len(dest) == net.IPv4len {
-				gw = []byte{0, 0, 0, 0}
-			} else {
-				gw = net.IP([]byte{0, 0, 0, 0}).To16()
-			}
+			gw = []byte{0, 0, 0, 0}
 		}
 	}
 	return gw.String()
@@ -339,11 +332,9 @@ func getGatewayIP(hostRoute netlink.Route, dest net.IP) string {
 // destination IP. Selects IPv4/6 format depending on the destination IP.
 func getMaskStr(hostRoute netlink.Route, dest net.IP) string {
 	maskStr := getDestinationIP(hostRoute).Mask.String()
-	if len(dest) == net.IPv4len {
-		maskV4 := net.IP(getDestinationIP(hostRoute).Mask).To4()
-		if maskV4 != nil {
-			maskStr = maskV4.String()
-		}
+	maskV4 := net.IP(getDestinationIP(hostRoute).Mask).To4()
+	if maskV4 != nil {
+		maskStr = maskV4.String()
 	}
 	return maskStr
 }

--- a/orc8r/gateway/go/status/host_info.go
+++ b/orc8r/gateway/go/status/host_info.go
@@ -14,6 +14,7 @@ limitations under the License.
 package status
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/emakeev/snowflake"
@@ -22,6 +23,7 @@ import (
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/host"
 	gopsutil_net "github.com/shirou/gopsutil/v3/net"
+	"github.com/vishvananda/netlink"
 )
 
 var (
@@ -31,11 +33,13 @@ var (
 	hostInfo      *host.InfoStat
 	netInterfaces []gopsutil_net.InterfaceStat
 	disksInfo     []disk.PartitionStat
-	hostRoutes    []routewrapper.Route
-	bootTime      uint64
-	vpnIp         string
-	machineInfo   *MachineInfo
-	platformInfo  *PlatformInfo
+	// hostRoutes    []routewrapper.Route
+	hostRoutes []netlink.Route
+	// hostRoutesNew []
+	bootTime     uint64
+	vpnIp        string
+	machineInfo  *MachineInfo
+	platformInfo *PlatformInfo
 )
 
 func init() {
@@ -78,10 +82,42 @@ func init() {
 	}
 	disksInfo, _ = disk.Partitions(true)
 
+	var oldHostRoutes []routewrapper.Route
 	w, err := routewrapper.NewRouteWrapper()
 	if err == nil {
-		hostRoutes, _ = w.Routes()
+		oldHostRoutes, _ = w.Routes()
 	}
+	fmt.Print(oldHostRoutes)
+
+	hostRoutes, _ = netlink.RouteList(nil, 0)
+	addr, _ := netlink.AddrList(nil, 0)
+	print(addr)
+	// var hostRoutesNew []routewrapper.Route
+	//
+	// for _, r := range routeList {
+	// 	src := getSourceIP(r)
+	//
+	// 	index, exists := ipNameMapNI[src]
+	// 	if !exists {
+	// 		continue
+	// 	}
+	// 	convertedIface := getNetInterface(index)
+	//
+	// 	dst := getDestinationIP(r)
+	// 	if dst.IP.To4() == nil {
+	// 		continue
+	// 	}
+	//
+	// 	hostRoute := routewrapper.Route{
+	// 		Destination: dst,
+	// 		Gateway:     r.Gw,
+	// 		Interface:   &convertedIface,
+	// 		Flags:       nil,
+	// 		Expire:      0,
+	// 		Metric:      r.Priority} // Expire was always set to zero before
+	// 	hostRoutesNew = append(hostRoutesNew, hostRoute)
+	// }
+
 	machineInfo = GetMachineInfo()
 	platformInfo = GetPlatformInfo()
 }

--- a/orc8r/gateway/go/status/host_info.go
+++ b/orc8r/gateway/go/status/host_info.go
@@ -14,11 +14,9 @@ limitations under the License.
 package status
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/emakeev/snowflake"
-	"github.com/moriyoshi/routewrapper"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/host"
@@ -33,13 +31,11 @@ var (
 	hostInfo      *host.InfoStat
 	netInterfaces []gopsutil_net.InterfaceStat
 	disksInfo     []disk.PartitionStat
-	// hostRoutes    []routewrapper.Route
-	hostRoutes []netlink.Route
-	// hostRoutesNew []
-	bootTime     uint64
-	vpnIp        string
-	machineInfo  *MachineInfo
-	platformInfo *PlatformInfo
+	hostRoutes    []netlink.Route
+	bootTime      uint64
+	vpnIp         string
+	machineInfo   *MachineInfo
+	platformInfo  *PlatformInfo
 )
 
 func init() {
@@ -82,15 +78,7 @@ func init() {
 	}
 	disksInfo, _ = disk.Partitions(true)
 
-	var oldHostRoutes []routewrapper.Route
-	w, err := routewrapper.NewRouteWrapper()
-	if err == nil {
-		oldHostRoutes, _ = w.Routes()
-	}
-	fmt.Print(oldHostRoutes)
-
 	hostRoutes, _ = netlink.RouteList(nil, 0)
-
 	machineInfo = GetMachineInfo()
 	platformInfo = GetPlatformInfo()
 }

--- a/orc8r/gateway/go/status/host_info.go
+++ b/orc8r/gateway/go/status/host_info.go
@@ -90,33 +90,6 @@ func init() {
 	fmt.Print(oldHostRoutes)
 
 	hostRoutes, _ = netlink.RouteList(nil, 0)
-	addr, _ := netlink.AddrList(nil, 0)
-	print(addr)
-	// var hostRoutesNew []routewrapper.Route
-	//
-	// for _, r := range routeList {
-	// 	src := getSourceIP(r)
-	//
-	// 	index, exists := ipNameMapNI[src]
-	// 	if !exists {
-	// 		continue
-	// 	}
-	// 	convertedIface := getNetInterface(index)
-	//
-	// 	dst := getDestinationIP(r)
-	// 	if dst.IP.To4() == nil {
-	// 		continue
-	// 	}
-	//
-	// 	hostRoute := routewrapper.Route{
-	// 		Destination: dst,
-	// 		Gateway:     r.Gw,
-	// 		Interface:   &convertedIface,
-	// 		Flags:       nil,
-	// 		Expire:      0,
-	// 		Metric:      r.Priority} // Expire was always set to zero before
-	// 	hostRoutesNew = append(hostRoutesNew, hostRoute)
-	// }
 
 	machineInfo = GetMachineInfo()
 	platformInfo = GetPlatformInfo()

--- a/orc8r/gateway/go/status/host_info.go
+++ b/orc8r/gateway/go/status/host_info.go
@@ -78,7 +78,7 @@ func init() {
 	}
 	disksInfo, _ = disk.Partitions(true)
 
-	hostRoutes, _ = netlink.RouteList(nil, 0)
+	hostRoutes, _ = netlink.RouteList(nil, netlink.FAMILY_V4)
 	machineInfo = GetMachineInfo()
 	platformInfo = GetPlatformInfo()
 }


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Replaces "github.com/moriyoshi/routewrapper" package with "github.com/vishvananda/netlink".

I also did refactored some of the existing logic into separate functions. Unfortunately, the individual commits may be somewhat messy.

## Test Plan

`routewrapper` uses the `ip route` command to retrieve routing table information, so we can manually compare the new routing table with the changes to the one we get with `ip route` and also the one we used to get with `netlink`. 

I spun up some docker images and the vagrant machines to add some more routing table entries.

In the image below, I used the IntelliJ debugger to look in the routing table before (left) and after (right) I made the changes. The order has changed somewhat because of how the information is retrieved. However, the order in the routing table does not matter. I highlighted in red the routing table entries that are identical.

![Manual comparison](https://user-images.githubusercontent.com/8889531/179510261-ca3acf72-1f67-49c2-84db-f1f7d69acee0.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
