### PR TITLE
chore(agw): Bazelify the session_state_5g_test

### DIFF
--- a/bazel/scripts/check_c_cpp_bazel.sh
+++ b/bazel/scripts/check_c_cpp_bazel.sh
@@ -44,8 +44,6 @@ DENY_LIST_NOT_YET_BAZELIFIED=(
   "./lte/gateway/c/core/oai/test/s1ap_task/mock_s1ap_op.h"
   "./lte/gateway/c/core/oai/test/s1ap_task/mock_s1ap_op.cpp"
   "./lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers_with_injected_state.cpp"
-  "./lte/gateway/c/session_manager/test/test_session_state_5g.cpp"
-  "./lte/gateway/c/session_manager/test/SessionStateTester5g.hpp"
   # TODO: GH12776 dead code
   "./lte/gateway/c/session_manager/upf-demo-struct.h"
 )

--- a/lte/gateway/c/session_manager/test/BUILD.bazel
+++ b/lte/gateway/c/session_manager/test/BUILD.bazel
@@ -296,3 +296,18 @@ cc_test(
         "@github_nlohmann_json//:json",
     ],
 )
+
+cc_test(
+    name = "session_state_5g_test",
+    size = "small",
+    srcs = [
+        "SessionStateTester5g.hpp",
+        "test_session_state_5g.cpp",
+    ],
+    deps = [
+        ":consts",
+        ":protobuf_creators",
+        ":sessiond_mocks",
+        "//orc8r/gateway/c/common/logging",
+    ],
+)


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The `session_state_5g_test` is bazelified

## Test Plan
Bazel test checking for flakiness and with asan/lsan configs:
- `bazel test //lte/gateway/c/session_manager/test:session_state_5g_test --test_output=all --runs_per_test=100`
- `bazel test //lte/gateway/c/session_manager/test:session_state_5g_test --test_output=all --config=asan`
- `bazel test //lte/gateway/c/session_manager/test:session_state_5g_test --test_output=all --config=lsan`
- CI

## Additional Information
- This is a partial fix for https://github.com/magma/magma/issues/12775

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
