### PR TITLE
fix(amf): AMF should support SUCI-Profile Encryption in case of Ident…

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -659,6 +659,7 @@ status_code_e amf_handle_identity_response(
   supi_as_imsi_t supi_imsi;
   amf_guti_m5g_t amf_guti;
   guti_m5_t* amf_ctx_guti = NULL;
+  ue_m5gmm_context_s* ue_context = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
 
   /* This is SUCI message identity type is SUPI as IMSI type
    * Extract the SUPI from SUCI directly as scheme is NULL */
@@ -691,12 +692,8 @@ status_code_e amf_handle_identity_response(
         imsi.u.value[2] = ((supi_imsi.plmn.mnc_digit2 << 4) & 0xf0) |
                           (supi_imsi.plmn.mnc_digit3 & 0xf);
       }
-      /* SUPI as IMSI retrieved from SUSI. Generate GUTI based on incoming
-       * PLMN and amf_config file and fill the SUPI-GUTI MAP
-       * Note: GUTI generation supposed to be done after verifying
-       * subscriber data with AUSF/UDM. But currently we are not supporting
-       * AUSF/UDM and directly generating GUTI.
-       * If authentication request rejected by UE, the MAP has to be cleared
+      /* SUPI as IMSI retrieved from SUCI.Generate GUTI based on incoming
+       * PLMN and amf_config file and fill the SUPI-GUTI MAP.
        */
       amf_app_generate_guti_on_supi(&amf_guti, &supi_imsi);
       OAILOG_DEBUG(LOG_NAS_AMF, "5G-TMSI as 0x%08" PRIx32 "\n",
@@ -705,28 +702,29 @@ status_code_e amf_handle_identity_response(
       /* Need to store guti in amf_ctx as well for quick access
        * which will be used to send in DL message during registration
        * accept message
-       * TODO Note:currently adapting the way
        */
-      amf_ctx_guti = (guti_m5_t*)&amf_guti;
+      amf_ctx_guti = reinterpret_cast<guti_m5_t*>(&amf_guti);
 
       imsi64_t imsi64 = amf_imsi_to_imsi64(&imsi);
 
-      ue_m5gmm_context_s* ue_context =
-          amf_ue_context_exists_amf_ue_ngap_id(ue_id);
       if (ue_context) {
         ue_context->amf_context.reg_id_type = M5GSMobileIdentityMsg_SUCI_IMSI;
-        amf_ue_context_on_new_guti(ue_context, (guti_m5_t*)&amf_guti);
+        amf_ue_context_on_new_guti(ue_context,
+                                   reinterpret_cast<guti_m5_t*>(&amf_guti));
       }
 
       /*
        * Execute the identification completion procedure
        */
       rc = amf_proc_identification_complete(ue_id, p_imsi, p_imei, p_imeisv,
-                                            (uint32_t*)(p_tmsi), amf_ctx_guti);
+                                            reinterpret_cast<uint32_t*>(p_tmsi),
+                                            amf_ctx_guti);
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
     } else {
-      ue_m5gmm_context_s* ue_context =
-          amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+      /*
+       * Call subscriberdb to decode the SUPI or IMSI from SUCI as scheme
+       * output is encrypted
+       */
       ue_context->amf_context.reg_id_type = M5GSMobileIdentityMsg_SUCI_IMSI;
       amf_copy_plmn_to_context(msg->mobile_identity.imsi, ue_context);
 

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -921,16 +921,27 @@ int amf_decrypt_msin_info_answer(itti_amf_decrypted_msin_info_ans_t* aia) {
   OAILOG_DEBUG(LOG_AMF_APP, "Handling imsi" IMSI_64_FMT "\n", imsi64);
 
   params->decode_status = ue_context->amf_context.decode_status;
-  /*
-   * Execute the requested new UE registration procedure
-   * This will initiate identity req in DL.
-   */
-  rc = amf_proc_registration_request(aia->ue_id, is_amf_ctx_new, params);
-  if (rc == RETURNerror) {
-    OAILOG_ERROR(LOG_AMF_APP,
-                 "processing registration request failed for ue-id "
-                 ": " AMF_UE_NGAP_ID_FMT,
-                 aia->ue_id);
+  imsi_t* p_imsi = params->imsi;
+  imeisv_t* p_imeisv = NULL;
+  tmsi_t* p_tmsi = NULL;
+  imei_t* p_imei = NULL;
+  guti_m5_t* amf_ctx_guti = reinterpret_cast<guti_m5_t*>(&amf_guti);
+  nas_amf_ident_proc_t* ident_proc =
+      get_5g_nas_common_procedure_identification(amf_ctxt_p);
+  if (ident_proc != NULL) {
+    rc = amf_proc_identification_complete(aia->ue_id, p_imsi, p_imei, p_imeisv,
+                                          (uint32_t*)(p_tmsi), amf_ctx_guti);
+    delete (params->imsi);
+    delete (params);
+    OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);
+  } else {
+    rc = amf_proc_registration_request(aia->ue_id, is_amf_ctx_new, params);
+    if (rc == RETURNerror) {
+      OAILOG_ERROR(LOG_AMF_APP,
+                   "processing registration request failed for ue-id "
+                   ": " AMF_UE_NGAP_ID_FMT,
+                   aia->ue_id);
+    }
   }
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
 }

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -930,7 +930,8 @@ int amf_decrypt_msin_info_answer(itti_amf_decrypted_msin_info_ans_t* aia) {
       get_5g_nas_common_procedure_identification(amf_ctxt_p);
   if (ident_proc != NULL) {
     rc = amf_proc_identification_complete(aia->ue_id, p_imsi, p_imei, p_imeisv,
-                                          (uint32_t*)(p_tmsi), amf_ctx_guti);
+                                          reinterpret_cast<uint32_t*>(p_tmsi),
+                                          amf_ctx_guti);
     delete (params->imsi);
     delete (params);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, rc);

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -138,6 +138,13 @@ class AMFAppProcedureTest : public ::testing::Test {
       0x5c, 0x00, 0x0d, 0x01, 0x22, 0x62, 0x54, 0xf0, 0xff,
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
 
+  const uint8_t identity_response_profile_a[59] = {
+      0x7e, 0x00, 0x5c, 0x00, 0x35, 0x01, 0x22, 0x62, 0x54, 0xf0, 0xff, 0x01,
+      0x01, 0xa1, 0xae, 0x7e, 0x56, 0x1b, 0x54, 0x4b, 0x7c, 0x74, 0x03, 0x09,
+      0x89, 0xa9, 0x21, 0x55, 0xd7, 0x8b, 0xbf, 0x28, 0x53, 0x5f, 0xb5, 0x94,
+      0x23, 0xb4, 0xcb, 0x64, 0x0e, 0x6c, 0x1e, 0xd4, 0x37, 0x15, 0xe8, 0x3c,
+      0x72, 0x39, 0x1f, 0x15, 0x8a, 0x9d, 0x7a, 0xcc, 0x09, 0x4b, 0x00};
+
   const uint8_t ue_auth_response_hexbuf[21] = {
       0x7e, 0x0,  0x57, 0x2d, 0x10, 0x25, 0x70, 0x6f, 0x9a, 0x5b, 0x90,
       0xb6, 0xc9, 0x57, 0x50, 0x6c, 0x88, 0x3d, 0x76, 0xcc, 0x63};
@@ -638,6 +645,82 @@ TEST_F(AMFAppProcedureTest, TestRegistrationProcGutiBased) {
 
   amf_app_handle_deregistration_req(ue_id);
   EXPECT_TRUE(expected_Ids == AMFClientServicer::getInstance().msgtype_stack);
+}
+
+TEST_F(AMFAppProcedureTest, TestRegistrationProcGutiBasedEncryption) {
+  amf_ue_ngap_id_t ue_id = 0;
+  send_initial_ue_message_no_tmsi(
+      amf_app_desc_p, 36, 1, 1, 0, plmn,
+      guti_initial_ue_reregister_message_hexbuf,
+      sizeof(guti_initial_ue_reregister_message_hexbuf));
+
+  EXPECT_TRUE(validate_identification_procedure(0, &ue_id));
+
+  int rc = RETURNok;
+  rc = send_uplink_nas_identity_response_message(
+      amf_app_desc_p, ue_id, plmn, identity_response_profile_a,
+      sizeof(identity_response_profile_a));
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_t* ue_context_p =
+      amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+
+  rc = amf_decrypt_msin_info_answer(&decrypted_msin);
+  EXPECT_TRUE(rc == RETURNok);
+
+  ue_m5gmm_context_s* context_encrypted_imsi =
+      amf_get_ue_context_from_imsi((char*)decrypted_imsi.c_str());
+
+  // Check if UE Context is created with correct imsi
+  bool res = false;
+  res = get_ue_id_from_imsi(amf_app_desc_p,
+                            context_encrypted_imsi->amf_context.imsi64, &ue_id);
+  EXPECT_TRUE(res == true);
+
+  // Send the authentication response message from subscriberdb
+  rc = send_proc_authentication_info_answer(decrypted_imsi, ue_id, true);
+  EXPECT_TRUE(rc == RETURNok);
+
+  // Validate if authentication procedure is initialized as expected
+  res = validate_auth_procedure(ue_id, 0);
+  EXPECT_TRUE(res == true);
+
+  // Send uplink nas message for auth response from UE
+  rc = send_uplink_nas_message_ue_auth_response(
+      amf_app_desc_p, ue_id, plmn, ue_auth_response_hexbuf,
+      sizeof(ue_auth_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  // Check whether security mode procedure is initiated
+  res = validate_smc_procedure(ue_id, 0);
+  EXPECT_TRUE(res == true);
+
+  // Send uplink nas message for security mode complete response from UE
+  rc = send_uplink_nas_message_ue_smc_response(amf_app_desc_p, ue_id, plmn,
+                                               ue_smc_response_hexbuf,
+                                               sizeof(ue_smc_response_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  s6a_update_location_ans_t ula_ans = util_amf_send_s6a_ula(decrypted_imsi);
+  rc = amf_handle_s6a_update_location_ans(&ula_ans);
+  EXPECT_EQ(rc, RETURNok);
+
+  // Send uplink nas message for registration complete response from UE
+  rc = send_uplink_nas_registration_complete(
+      amf_app_desc_p, ue_id, plmn, ue_registration_complete_hexbuf,
+      sizeof(ue_registration_complete_hexbuf));
+  EXPECT_TRUE(rc == RETURNok);
+
+  /* Send uplink nas message for deregistration complete response from UE */
+  rc = send_uplink_nas_ue_deregistration_request(
+      amf_app_desc_p, ue_id, plmn, ue_initiated_dereg_hexbuf,
+      sizeof(ue_initiated_dereg_hexbuf));
+
+  EXPECT_TRUE(rc == RETURNok);
+
+  send_ue_context_release_complete_message(amf_app_desc_p, 1, 1, ue_id);
+  ue_context_p = amf_ue_context_exists_amf_ue_ngap_id(ue_id);
+  delete ue_context_p;
 }
 
 TEST_F(AMFAppProcedureTest, TestMobileUpdatingRegistrationProcGutiBased) {


### PR DESCRIPTION
…ity-Procedure

Signed-off-by: Rajeshs23 <rajesh.sure@wavelabs.ai>

<!--
    fix(amf):AMF should support SUCI-Profile Encryption in case of Identity-Procedure.
-->

## Summary
Amf supports only null encryption in case of Identity procedure. so changes are made in AMF to support Identity-Procedure with SUCI-Profile-A / Profile-B and accordingly unit test is written and the unit test case is passing.



## Test Plan
- Tested using ueransim
- Tested on spirent
- Tested on abot

## Additional Information

![sucitestcase](https://user-images.githubusercontent.com/91061578/180922944-06bf6b32-3186-4f66-a7e9-d56c42d8b27f.PNG)
