### PR TITLE
chore: codespaces use remote cache

### DIFF
--- a/.devcontainer/post-create-commands.sh
+++ b/.devcontainer/post-create-commands.sh
@@ -9,14 +9,11 @@ echo "alias magtivate='source /home/vscode/build/python/bin/activate'" >> ~/.bas
 # Locally opened Devcontainer has access to persistent cache directory in .bazel-cache and .bazel-cache-repo.
 # This is a little hacky, but GITHUB_CODESPACE_TOKEN should only be defined for the Codespace case
 if [[ -z $GITHUB_CODESPACE_TOKEN ]]; then
-    echo "Assuming the devcontainer is opened locally, not pulling in Bazel cache..."
+    echo "Assuming the devcontainer is opened locally, not using Bazel remote cache..."
 else
-    echo "Assuming the devcontainer is opened in GitHub Codespaces, pulling in Bazel cache..."
-    # Pull in cache to speed up Bazel build. The cache is populated by a GitHub Action job periodically (.github/workflows/bazel-cache-push.yml)
-    # Fetch repository cache
-    wget -qO- https://magma-cache.s3.amazonaws.com/bazel-cache-repo-devcontainer.tar.gz | tar xvfz -
-    # Fetch build cache
-    wget -qO- https://magma-cache.s3.amazonaws.com/bazel-cache-devcontainer.tar.gz | tar xvfz -
+    echo "Assuming the devcontainer is opened in GitHub Codespaces, using read-only Bazel remote cache..."
+    cache_key=bazel-base-image  #  the devcontainer is based on the bazel-base container
+    (cd "$1" && bazel/scripts/remote_cache_bazelrc_setup.sh $cache_key)
 fi
 
 echo "Generating compile_commands.json for C/C++ code navigation"


### PR DESCRIPTION
## Summary

Relates to #12210

Instead of preparing a folder to be used as disk cache and using S3 to propagate it to the codespaces environments, we use the Bazel remote cache. This should ideally improve performance as the cache download is more granular. On the other hand, we cannot use the remote cache as a repository cache, so we drop the repository cache altogether. 

## Performance impact

I did some measurements on 16 CPU-core codespaces to understand the performance improvements that the action cache and repository cache gave us. Unfortunately the codespace performance varies a lot and the changes in build times can be attributed mostly to those variations, so the following numbers are very rough estimates.
The build time using the action cache and the repo cache is roughly 8 minutes. The action cache saves us about a minute, and the repo cache saves us about half a minute. However, downloading the whole action cache also takes more than 1 minute, and downloading the whole repo cache takes 15 seconds. This suprisingly small improvement is probably due to only 800 actions being read from cache while about 5000 still have to be built.

With this change, it seems that the bazel build takes slightly longer (~15 seconds more). However we save around 90 seconds for downloading the zipped caches when starting the codespace, so we are faster overall.

## Test Plan

Launched a codespace on my branch and run `bazel build ...`

## Additional Information

- [ ] This change is backwards-breaking