### PR TITLE
chore(agw): Bazelify test_s1ap_mme_handlers_with_injected_state

### DIFF
--- a/bazel/scripts/check_c_cpp_bazel.sh
+++ b/bazel/scripts/check_c_cpp_bazel.sh
@@ -40,10 +40,6 @@ DENY_LIST_NOT_YET_BAZELIFIED=(
   # TODO: GH12771 add MME_BENCHMARK support and bazelify files
   "./lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.hpp"
   "./lte/gateway/c/core/oai/tasks/mme_app/experimental/mme_app_serialization.cpp"
-  # TODO: GH12775 tests that need to be bazelified
-  "./lte/gateway/c/core/oai/test/s1ap_task/mock_s1ap_op.h"
-  "./lte/gateway/c/core/oai/test/s1ap_task/mock_s1ap_op.cpp"
-  "./lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers_with_injected_state.cpp"
 )
 
 DENY_LIST=( "${DENY_LIST_NOT_RELEVANT[@]}" "${DENY_LIST_NOT_YET_BAZELIFIED[@]}" )

--- a/lte/gateway/c/core/oai/test/s1ap_task/BUILD.bazel
+++ b/lte/gateway/c/core/oai/test/s1ap_task/BUILD.bazel
@@ -76,3 +76,29 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "mock_s1ap_op",
+    testonly = True,
+    srcs = ["mock_s1ap_op.cpp"],
+    hdrs = ["mock_s1ap_op.h"],
+    deps = [
+        "//lte/gateway/c/core:lib_agw_of",
+        "//lte/gateway/c/core/common:common_defs",
+    ],
+)
+
+cc_test(
+    name = "s1ap_mme_handlers_with_injected_state_test",
+    size = "small",
+    srcs = ["test_s1ap_mme_handlers_with_injected_state.cpp"],
+    deps = [
+        ":mock_s1ap_op",
+        ":s1ap_mme_test_utils",
+        "//lte/gateway/c/core:lib_agw_of",
+        "//lte/gateway/c/core/common:dynamic_memory_check",
+        "//lte/gateway/c/core/oai/lib/bstr:bstrlib",
+        "//lte/gateway/c/core/oai/test/mock_tasks",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/s1ap_mme_test_utils.cpp
@@ -31,7 +31,7 @@ extern "C" {
 namespace magma {
 namespace lte {
 
-extern task_zmq_ctx_t task_zmq_ctx_main_s1ap;
+task_zmq_ctx_t task_zmq_ctx_main_s1ap;
 
 status_code_e setup_new_association(s1ap_state_t* state,
                                     sctp_assoc_id_t assoc_id) {

--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers.cpp
@@ -36,7 +36,7 @@ extern task_zmq_ctx_t task_zmq_ctx_mme;
 namespace magma {
 namespace lte {
 
-task_zmq_ctx_t task_zmq_ctx_main_s1ap;
+extern task_zmq_ctx_t task_zmq_ctx_main_s1ap;
 
 static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
   MessageDef* received_message_p = receive_msg(reader);


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The `s1ap_mme_handlers_with_injected_state_test` is bazelified.
- In the `s1ap_mme_test_utils.cpp` file the line `extern task_zmq_ctx_t task_zmq_ctx_main_s1ap;` leads to an error when building/linking the `s1ap_mme_handlers_with_injected_state_test` **on its own** because `task_zmq_ctx_main_s1ap` is not defined anywhere.
  - When building the `s1ap_mme_handlers_with_injected_state_test` and the `s1ap_mme_handlers_test` as a test suite this issue does not occur because `task_zmq_ctx_main_s1ap` is defined in `test_s1ap_mme_handlers.cpp`.
  - The `s1ap_mme_handlers_with_injected_state_test` should work as a stand-alone test. In order to achieve this the `extern` has to be removed in `s1ap_mme_test_utils.cpp`. It can instead be added in the `test_s1ap_mme_handlers.cpp`.
  - Alternatives would be:
    - Add the definition `task_zmq_ctx_t task_zmq_ctx_main_s1ap;` to `s1ap_mme_handlers_with_injected_state_test` - where it is not actually used.
    - Build and run the tests only in a suite. Which is not desirable and makes the tests less granular.

## Test Plan
Bazel test checking for flakiness and with asan/lsan configs:
- `bazel test //lte/gateway/c/core/oai/test/s1ap_task:s1ap_mme_handlers_with_injected_state_test  --test_output=all --runs_per_test=100`
- `bazel test //lte/gateway/c/core/oai/test/s1ap_task:s1ap_mme_handlers_with_injected_state_test  --test_output=all --config=asan`
- `bazel test //lte/gateway/c/core/oai/test/s1ap_task:s1ap_mme_handlers_with_injected_state_test  --test_output=all --config=lsan`
- CI

Check that `s1ap_mme_handlers_test` is still working:
- `bazel test //lte/gateway/c/core/oai/test/s1ap_task:s1ap_mme_handlers_test`

## Additional Information
- This is a partial fix for https://github.com/magma/magma/issues/12775
- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
