### PR TITLE
fix(ci): Make markdown check compatible with new linter version

### DIFF
--- a/docs/readmes/Makefile
+++ b/docs/readmes/Makefile
@@ -1,9 +1,14 @@
 .PHONY: precommit precommit_fix
 
+FILES_TO_IGNORE = --ignore proposals/p010_vendor_neutral_dp.md \
+                  --ignore proposals/p010_subscriber_scaling.md \
+                  --ignore proposals/p015_tech_debt_week.md \
+                  --ignore proposals/p018_control_network_metrics.md
+
 precommit:
 	docker build -t magma_readmes .
-	docker-compose run readmes markdownlint --ignore proposals/p010_vendor_neutral_dp.md . && echo PASSED
+	docker-compose run readmes markdownlint $(FILES_TO_IGNORE) . && echo PASSED
 
 precommit_fix:
 	docker build -t magma_readmes .
-	docker-compose run readmes markdownlint --fix --ignore proposals/p010_vendor_neutral_dp.md . && echo PASSED
+	docker-compose run readmes markdownlint --fix $(FILES_TO_IGNORE) . && echo PASSED


### PR DESCRIPTION
## Summary

The required Markdown lint check is currently broken, e.g. here https://github.com/magma/magma/runs/7397977462?check_suite_focus=true. This is because a new version of [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli), 0.32, was released three days ago, which introduced three new checks (MD051, MD052, MD053). Three proposals pages violate these checks, which leads to the workflow failing. Rather than fixing the old proposals, I propose that we ignore them, as was already the case with another proposal page.

## Test Plan

- [x] Markdown lint check passes
