### PR TITLE
chore(lte): Bazelify the S1AP extended tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -57,6 +57,7 @@ build --test_env=PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin
 # Use MAGMA_ROOT from the host system in tests.
 # Needed by python tests (e.g. freedomfi_one_tests in enodebd)
 build --test_env=MAGMA_ROOT
+build --test_env=S1AP_TESTER_ROOT
 
 # MME specific compile time defines
 # Compile mme libraries with unit test flag

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -128,6 +128,12 @@ new_local_repository(
     path = "/",
 )
 
+new_local_repository(
+    name = "s1ap_test_util",
+    build_file = "//bazel/external:s1ap_test_util.BUILD",
+    path = "/",
+)
+
 load("//bazel:python_dependencies.bzl", "configure_python_dependencies")
 
 configure_python_dependencies()

--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -60,3 +60,6 @@ freezegun
 pytest
 pytest-cov
 coverage-lcov
+
+# s1ap test requirements
+iperf3

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -570,6 +570,9 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
+iperf3==0.1.11 \
+    --hash=sha256:d50eebbf2dcf445a173f98a82f9c433e0302d3dfb7987e1f21b86b35ef63ce26
+    # via -r requirements.in
 itsdangerous==2.1.0 \
     --hash=sha256:29285842166554469a56d427addc0843914172343784cb909695fdbe90a3e129 \
     --hash=sha256:d848fcb8bc7d507c4546b448574e8a44fc4ea2ba84ebf8d783290d53e81992f5
@@ -882,7 +885,7 @@ oslo-config==8.8.0 \
     --hash=sha256:96933d3011dae15608a11616bfb00d947e22da3cb09b6ff37ddd7576abd4764c \
     --hash=sha256:b1e2a398450ea35a8e5630d8b23057b8939838c4433cd25a20cc3a36d5df9e3b
     # via -r requirements.in
-oslo.i18n==5.1.0 \
+oslo-i18n==5.1.0 \
     --hash=sha256:6bf111a6357d5449640852de4640eae4159b5562bbba4c90febb0034abc095d0 \
     --hash=sha256:75086cfd898819638ca741159f677e2073a78ca86a9c9be8d38b46800cdf2dc9
     # via oslo-config
@@ -904,7 +907,7 @@ pbr==5.8.1 \
     --hash=sha256:27108648368782d07bbf1cb468ad2e2eeef29086affd14087a6d04b7de8af4ec \
     --hash=sha256:66bc5a34912f408bb3925bf21231cb6f59206267b7f63f3503ef865c1a292e25
     # via
-    #   oslo.i18n
+    #   oslo-i18n
     #   stevedore
 pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
@@ -914,7 +917,7 @@ priority==1.3.0 \
     --hash=sha256:6bc1961a6d7fcacbfc337769f1a382c8e746566aaa365e78047abe9f66b2ffbe \
     --hash=sha256:be4fcb94b5e37cdeb40af5533afe6dd603bd665fe9c8b3052610fc1001d5d1eb
     # via -r requirements.in
-prometheus_client==0.3.1 \
+prometheus-client==0.3.1 \
     --hash=sha256:17bc24c09431644f7c65d7bce9f4237252308070b6395d6d8e87767afe867e24
     # via -r requirements.in
 protobuf==3.19.4 \
@@ -1164,7 +1167,7 @@ redis-collections==0.11.0 \
     --hash=sha256:0f6cda00666fdd26e3b8ca47da13a653eaf4cc4e45470a3b09f17d65061fea8a \
     --hash=sha256:d23e8c0f6bf50de10c98a14a3b636ff1bb21119386f884f2641c906832bc4ec9
     # via -r requirements.in
-repoze.lru==0.7 \
+repoze-lru==0.7 \
     --hash=sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77 \
     --hash=sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea
     # via routes

--- a/bazel/external/s1ap_test_util.BUILD
+++ b/bazel/external/s1ap_test_util.BUILD
@@ -13,15 +13,21 @@ load("@rules_python//python:defs.bzl", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 
-py_library(
-    name = "constants",
-    testonly = 1,
-    srcs = ["__init__.py"],
+# The s1ap framework is only present on the magma_test environment
+config_setting(
+    name = "expect_s1ap_framework",
+    values = {"define": "on_magma_test=1"},
 )
 
 py_library(
-    name = "rest_api",
-    testonly = 1,
-    srcs = ["rest_api.py"],
-    deps = [":constants"],
+    name = "s1ap_types",
+    srcs = select({
+        ":expect_s1ap_framework": ["home/vagrant/s1ap-tester/bin/s1ap_types.py"],
+        "//conditions:default": [],
+    }),
+    imports = select({
+        ":expect_s1ap_framework": ["home/vagrant/s1ap-tester/bin/"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
 )

--- a/bazel/python_test.bzl
+++ b/bazel/python_test.bzl
@@ -34,7 +34,7 @@ from bazel.python_utils.coverage_decorator import coverage_decorator
 
 if __name__ == "__main__":
     with coverage_decorator():
-        args =  ["-ra", "-vv"]  + %s + sys.argv[1:] + %s
+        args =  ["-s", "-vv"]  + %s + sys.argv[1:] + %s
         sys.exit(pytest.main(args))"""
 
 PYTEST_DEPS = [

--- a/bazel/scripts/run_integ_tests.sh
+++ b/bazel/scripts/run_integ_tests.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -euo pipefail
+
+###############################################################################
+# FUNCTION DECLARATIONS
+###############################################################################
+
+help() {
+    echo "Executes all integration tests."
+    echo "Usage:"
+    echo "   $(basename "$0")" 
+    echo "      Execute all integration tests in the magma repository." 
+    echo "   $(basename "$0") path_to_tests_directory:bazel_test_target_name"
+    echo "      Execute the specified test."
+    echo "   $(basename "$0") --list"
+    echo "      List all integration tests."
+    echo "   $(basename "$0") --list-extended"
+    echo "      List the extended integration tests."
+    echo "   $(basename "$0") --list-traffic-server"
+    echo "      List all integration tests that use the traffic server."
+    echo "   $(basename "$0") --setup-extended"
+    echo "      Execute the setup test for the extended tests."
+    echo "   $(basename "$0") --teardown-extended"
+    echo "      Execute the teardown test for the extended tests."
+    echo "   $(basename "$0") --skip-setup-teardown-extended"
+    echo "      Execute all integration tests in the magma repository," 
+    echo "      except the setup and teardown for extended tests." 
+    echo "   $(basename "$0") --skip-setup-teardown-extended path_to_tests_directory:bazel_test_target_name"
+    echo "      Execute the specified test, without executing"
+    echo "      the setup and teardown for extended tests." 
+    echo "   $(basename "$0") --help"
+    echo "      Display this help message."
+}
+
+categorize_test() {
+    local TARGET=$1
+    if bazel query "attr(tags, extended_test, kind(py_test, ${TARGET}))";
+    then
+        EXTENDED_TEST_TARGETS=( "${TARGET}" )
+    else
+        echo "ERROR: Could not categorize the provided test."
+        exit 1
+    fi
+    # TODO: other tests
+}
+
+create_test_targets() {
+    if [[ "${TARGET_PATH}" == *":"* ]];
+    then
+        echo "Single target specified - running test:"
+        categorize_test "${TARGET_PATH}"
+    else
+        echo "Multiple targets specified - running tests:"
+        create_extended_test_targets
+        # TODO: other tests
+    fi
+    if [[ "${#EXTENDED_TEST_TARGETS[@]}" -eq 0 ]]; # TODO other tests
+    then
+        echo "ERROR: No test found."
+        help
+        exit 1
+    fi
+    for TARGET in "${EXTENDED_TEST_TARGETS[@]}"
+    do
+        echo "${TARGET}"
+    done
+}
+
+create_extended_test_targets() {
+    mapfile -t EXTENDED_TEST_TARGETS < <(bazel query "attr(tags, extended_test, kind(py_test, //lte/gateway/python/integ_tests/s1aptests/...))")
+}
+
+list_all_tests() {
+    echo "All integration tests:"
+    list_extended_tests
+    # TODO: other tests
+    exit 0
+}
+
+list_extended_tests() {
+    echo "Extended tests:"
+    create_extended_test_targets
+    for TARGET in "${EXTENDED_TEST_TARGETS[@]}"
+    do
+        echo "${TARGET}"
+    done
+}
+
+list_traffic_server_tests() {
+    echo "Tests that require the traffic server:"
+    bazel query "attr(tags, traffic_server_test, kind(py_test, //lte/gateway/python/integ_tests/s1aptests/...))"
+    exit 0
+}
+
+setup_extended_tests() {
+    echo "Setting up the environment for the extended tests."
+    echo "Building..."
+    bazel build "//lte/gateway/python/integ_tests/s1aptests:test_modify_mme_config_for_sanity" --define=on_magma_test=1
+    echo "Executing..."
+    sudo "${MAGMA_ROOT}/bazel-bin/lte/gateway/python/integ_tests/s1aptests/test_modify_mme_config_for_sanity"
+    echo "Setup finished successfully."
+}
+
+teardown_extended_tests() {
+    if [[ -f "${EXTENDED_TEST_CLEANUP_FILE_NAME}" ]];
+    then
+        echo "Cleaning up the environment after the extended tests."
+        echo "Building..."
+        bazel build "//lte/gateway/python/integ_tests/s1aptests:test_restore_mme_config_after_sanity" --define=on_magma_test=1
+        echo "Executing..."
+        sudo "${MAGMA_ROOT}/bazel-bin/lte/gateway/python/integ_tests/s1aptests/test_restore_mme_config_after_sanity"
+        echo "Cleanup finished successfully."
+    else
+        echo "No backup file found, skipping cleanup."
+    fi
+}
+
+run_test() {
+    local TARGET=$1
+    local TARGET_PATH=${TARGET%:*}
+    local SHORT_TARGET=${TARGET#*:}
+    (
+        echo "BUILDING TEST: ${TARGET}"
+        set -x
+        bazel build "${TARGET}" --define=on_magma_test=1
+        set +x
+        echo "RUNNING TEST: ${TARGET}"
+        set -x
+        sudo "${MAGMA_ROOT}/bazel-bin/${TARGET_PATH}/${SHORT_TARGET}"
+    )
+}
+
+print_summary() {
+    local NUM_SUCCESS=$1
+    local TOTAL_TESTS=$2
+    echo "SUMMARY: ${NUM_SUCCESS}/${TOTAL_TESTS} tests were successful."
+    for TARGET in "${!TEST_RESULTS[@]}"
+    do
+        echo "  ${TARGET}: ${TEST_RESULTS[${TARGET}]}"
+    done
+}
+
+###############################################################################
+# SCRIPT SECTION
+###############################################################################
+
+declare -a EXTENDED_TEST_TARGETS
+declare -A TEST_RESULTS
+NUM_SUCCESS=0
+NUM_RUN=1
+
+cd "${MAGMA_ROOT}"
+
+EXTENDED_TEST_SETUP="lte/gateway/python/integ_tests/s1aptests:test_modify_mme_config_for_sanity"
+EXTENDED_TEST_TEARDOWN="lte/gateway/python/integ_tests/s1aptests:test_restore_mme_config_after_sanity"
+SKIP_EXTENDED_SETUP_AND_TEARDOWN="false"
+EXTENDED_TEST_CLEANUP_FILE_NAME="${MAGMA_ROOT}/lte/gateway/configs/templates/mme.conf.template.bak"
+
+declare -a POSITIONAL_ARGS
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --list)
+      list_all_tests
+      ;;
+    --list-extended)
+      list_extended_tests
+      exit 0
+      ;;
+    --list-traffic-server)
+      list_traffic_server_tests
+      ;;
+    --setup-extended)
+      setup_extended_tests
+      exit 0
+      ;;
+    --teardown-extended)
+      teardown_extended_tests
+      exit 0
+      ;;
+    --skip-setup-teardown-extended)
+      SKIP_EXTENDED_SETUP_AND_TEARDOWN="true"
+      shift
+      ;;
+    --help)
+      help
+      exit 0
+      ;;
+    --*|-*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+set -- "${POSITIONAL_ARGS[@]}"
+
+TARGET_PATH="${1:-}"
+
+if [[ "${TARGET_PATH}" == *"${EXTENDED_TEST_SETUP}" ]];
+then
+    setup_extended_tests
+    exit 0
+fi
+
+if [[ "${TARGET_PATH}" == *"${EXTENDED_TEST_TEARDOWN}" ]];
+then
+    teardown_extended_tests
+    exit 0
+fi
+
+create_test_targets
+
+TOTAL_TESTS=${#EXTENDED_TEST_TARGETS[@]}
+# TODO TOTAL_TESTS=$((TOTAL_TESTS + PRECOMMIT))
+
+if [[ "${SKIP_EXTENDED_SETUP_AND_TEARDOWN}" == "false" ]];
+then
+    setup_extended_tests
+fi
+
+for TARGET in "${EXTENDED_TEST_TARGETS[@]}"
+do
+    echo "Starting test ${NUM_RUN}/${TOTAL_TESTS}: ${TARGET}"
+    if run_test "${TARGET}";
+    then
+        NUM_SUCCESS=$((NUM_SUCCESS + 1))
+        TEST_RESULTS["${TARGET}"]="PASSED"
+    else
+        TEST_RESULTS["${TARGET}"]="FAILED"
+    fi
+    NUM_RUN=$((NUM_RUN + 1))
+done
+
+if [[ "${SKIP_EXTENDED_SETUP_AND_TEARDOWN}" == "false" ]];
+then
+    teardown_extended_tests
+fi
+# TODO other tests
+
+print_summary "${NUM_SUCCESS}" "${TOTAL_TESTS}"
+
+[[ "${TOTAL_TESTS}" == "${NUM_SUCCESS}" ]]

--- a/bazel/test_constants.bzl
+++ b/bazel/test_constants.bzl
@@ -33,3 +33,8 @@ TAG_MANUAL = ["manual"]
 # privileges. This is a restriction mainly known for some Python tests.
 # Note: for now a sudo test is also tagged as "manual".
 TAG_SUDO_TEST = ["sudo_test"] + TAG_MANUAL
+
+TAG_EXTENDED_TEST = ["extended_test"] + TAG_MANUAL
+TAG_EXTENDED_TEST_SETUP = ["extended_test_setup"] + TAG_MANUAL
+TAG_EXTENDED_TEST_TEARDOWN = ["extended_test_teardown"] + TAG_MANUAL
+TAG_TRAFFIC_SERVER_TEST = ["traffic_server_test"]

--- a/feg/protos/BUILD.bazel
+++ b/feg/protos/BUILD.bazel
@@ -100,3 +100,27 @@ python_grpc_library(
     name = "s6a_proxy_grpc_proto",
     protos = [":s6a_proxy_proto"],
 )
+
+proto_library(
+    name = "hss_service_proto",
+    srcs = ["hss_service.proto"],
+    deps = [
+        "//lte/protos:subscriberdb_proto",
+        "//orc8r/protos:common_proto",
+    ],
+)
+
+python_proto_library(
+    name = "hss_service_python_proto",
+    protos = [":hss_service_proto"],
+    deps = [
+        "//lte/protos:subscriberdb_python_proto",
+        "//orc8r/protos:common_python_proto",
+    ],
+)
+
+python_grpc_library(
+    name = "hss_service_python_grpc",
+    protos = [":hss_service_proto"],
+    deps = [":hss_service_python_proto"],
+)

--- a/lte/gateway/deploy/magma_dev_focal.yml
+++ b/lte/gateway/deploy/magma_dev_focal.yml
@@ -48,6 +48,7 @@
         go_build: /home/{{ ansible_user }}/go/bin/
         magma_repo: /home/{{ ansible_user }}/magma-packages
         magma_deps: /home/{{ ansible_user }}/magma-deps
+    - role: bazel
     - role: fluent_bit
     - role: pyvenv
 

--- a/lte/gateway/deploy/magma_test.yml
+++ b/lte/gateway/deploy/magma_test.yml
@@ -22,3 +22,4 @@
         go_build: /home/{{ ansible_user }}/go/bin/
     - role: magma_test
       become: no
+    - role: bazel

--- a/lte/gateway/deploy/roles/bazel/tasks/main.yml
+++ b/lte/gateway/deploy/roles/bazel/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Symlink system wide bazelrc into the VM
+  file:
+    src: '/home/vagrant/magma/bazel/bazelrcs/vm.bazelrc'
+    path: '/etc/bazelrc'
+    state: link
+    force: yes
+
+- name: Symlink bazel disk cache configuration into the VM
+  file:
+    src: '/home/vagrant/magma/.bazel-cache'
+    path: '/var/cache/bazel-cache'
+    state: link
+    force: yes
+
+- name: Symlink bazel disk repository cache configuration into the VM
+  file:
+    src: '/home/vagrant/magma/.bazel-cache-repo'
+    path: '/var/cache/bazel-cache-repo'
+    state: link
+    force: yes

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -482,27 +482,6 @@
     state: link
     force: yes
 
-- name: Symlink system wide bazelrc into the VM
-  file:
-    src: '/home/vagrant/magma/bazel/bazelrcs/vm.bazelrc'
-    path: '/etc/bazelrc'
-    state: link
-    force: yes
-
-- name: Symlink bazel disk cache configuration into the VM
-  file:
-    src: '/home/vagrant/magma/.bazel-cache'
-    path: '/var/cache/bazel-cache'
-    state: link
-    force: yes
-
-- name: Symlink bazel disk repository cache configuration into the VM
-  file:
-    src: '/home/vagrant/magma/.bazel-cache-repo'
-    path: '/var/cache/bazel-cache-repo'
-    state: link
-    force: yes
-
 # TODO: Fix magma-dev VM box and remove this step.
 - name: Install Magma dependencies
   retries: 5

--- a/lte/gateway/python/integ_tests/common/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/common/BUILD.bazel
@@ -1,0 +1,55 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "magmad_client",
+    testonly = True,
+    srcs = ["magmad_client.py"],
+    deps = [
+        "//lte/gateway/python/integ_tests/gateway:rpc",
+        requirement("grpcio"),
+    ],
+)
+
+py_library(
+    name = "mobility_service_client",
+    testonly = True,
+    srcs = ["mobility_service_client.py"],
+    deps = [
+        "//lte/protos:mobilityd_python_grpc",
+    ],
+)
+
+py_library(
+    name = "service303_utils",
+    testonly = True,
+    srcs = ["service303_utils.py"],
+    deps = [
+        "//orc8r/protos:metrics_python_proto",
+        "//orc8r/protos:service303_python_grpc",
+    ],
+)
+
+py_library(
+    name = "subscriber_db_client",
+    testonly = True,
+    srcs = ["subscriber_db_client.py"],
+    deps = [
+        "//feg/protos:hss_service_python_grpc",
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        "//lte/protos:subscriberdb_python_grpc",
+    ],
+)

--- a/lte/gateway/python/integ_tests/gateway/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/gateway/BUILD.bazel
@@ -13,15 +13,19 @@ load("@rules_python//python:defs.bzl", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 
-py_library(
-    name = "constants",
-    testonly = 1,
-    srcs = ["__init__.py"],
-)
+MAGMA_ROOT = "../../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
 
 py_library(
-    name = "rest_api",
-    testonly = 1,
-    srcs = ["rest_api.py"],
-    deps = [":constants"],
+    name = "rpc",
+    testonly = True,
+    srcs = ["rpc.py"],
+    imports = [ORC8R_ROOT],
+    deps = [
+        "//orc8r/gateway/python/magma/common:service_registry",
+        "//orc8r/gateway/python/magma/configuration:mconfigs",
+        "//orc8r/protos:magmad_python_grpc",
+        "//orc8r/protos:mconfig_python_proto",
+    ],
 )

--- a/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
@@ -1,0 +1,489 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("//bazel:python_test.bzl", "pytest_test")
+load(
+    "//bazel:test_constants.bzl",
+    "TAG_EXTENDED_TEST",
+    "TAG_EXTENDED_TEST_SETUP",
+    "TAG_EXTENDED_TEST_TEARDOWN",
+    "TAG_TRAFFIC_SERVER_TEST",
+)
+
+MAGMA_ROOT = "../../../../../"
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+py_library(
+    name = "s1ap_utils",
+    testonly = True,
+    srcs = [
+        "s1ap_utils.py",
+    ],
+    deps = [
+        "//lte/gateway/python/integ_tests/s1aptests/ovs:rest_api",
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        "//lte/protos:abort_session_python_grpc",
+        "//lte/protos:ha_service_python_grpc",
+        "//lte/protos:mobilityd_python_proto",
+        "//lte/protos:policydb_python_proto",
+        "//lte/protos:session_manager_python_grpc",
+        "//lte/protos:spgw_service_grpc_proto",
+        "//orc8r/protos:directoryd_python_grpc",
+        "@s1ap_test_util//:s1ap_types",
+    ],
+)
+
+py_library(
+    name = "s1ap_wrapper",
+    testonly = True,
+    srcs = [
+        "s1ap_wrapper.py",
+    ],
+    deps = [
+        ":s1ap_utils",
+        "//lte/gateway/python/integ_tests/common:magmad_client",
+        "//lte/gateway/python/integ_tests/common:mobility_service_client",
+        "//lte/gateway/python/integ_tests/common:service303_utils",
+        "//lte/gateway/python/integ_tests/common:subscriber_db_client",
+        "//lte/gateway/python/integ_tests/s1aptests/util:traffic_util",
+    ],
+)
+
+pytest_test(
+    name = "test_modify_mme_config_for_sanity",
+    size = "medium",
+    srcs = ["test_modify_mme_config_for_sanity.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST_SETUP,
+    deps = [
+        ":s1ap_utils",
+        "//lte/gateway/python/integ_tests/common:magmad_client",
+    ],
+)
+
+pytest_test(
+    name = "test_attach_detach_multi_ue_looped",
+    size = "small",
+    srcs = ["test_attach_detach_multi_ue_looped.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_ps_service_not_available",
+    size = "small",
+    srcs = ["test_attach_detach_ps_service_not_available.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_with_he_policy",
+    size = "small",
+    srcs = ["test_attach_detach_with_he_policy.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_rar_tcp_he",
+    size = "small",
+    srcs = ["test_attach_detach_rar_tcp_he.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_restricted_plmn",
+    size = "small",
+    srcs = ["test_attach_restricted_plmn.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_imei_restriction_smc",
+    size = "small",
+    srcs = ["test_imei_restriction_smc.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_imei_restriction_no_imeisv_in_smc",
+    size = "small",
+    srcs = ["test_imei_restriction_no_imeisv_in_smc.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_imei_restriction_wildcard_snr",
+    size = "small",
+    srcs = ["test_imei_restriction_wildcard_snr.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_dedicated",
+    size = "small",
+    srcs = ["test_attach_detach_dedicated.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_dedicated_looped",
+    size = "small",
+    srcs = ["test_attach_detach_dedicated_looped.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_dedicated_bearer_deactivation_invalid_lbi",
+    size = "small",
+    srcs = ["test_attach_detach_dedicated_bearer_deactivation_invalid_lbi.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_dedicated_bearer_deactivation_invalid_ebi",
+    size = "small",
+    srcs = ["test_attach_detach_dedicated_bearer_deactivation_invalid_ebi.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_dedicated_bearer_activation_invalid_lbi",
+    size = "small",
+    srcs = ["test_attach_detach_dedicated_bearer_activation_invalid_lbi.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_dedicated_activation_timer_expiry",
+    size = "small",
+    srcs = ["test_attach_detach_dedicated_activation_timer_expiry.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_dedicated_deactivation_timer_expiry",
+    size = "small",
+    srcs = ["test_attach_detach_dedicated_deactivation_timer_expiry.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_dedicated_bearer_activation_idle_mode",
+    size = "small",
+    srcs = ["test_dedicated_bearer_activation_idle_mode.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_secondary_pdn",
+    size = "small",
+    srcs = ["test_attach_detach_secondary_pdn.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_secondary_pdn_looped",
+    size = "small",
+    srcs = ["test_attach_detach_secondary_pdn_looped.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_service_with_multi_pdns_and_bearers",
+    size = "small",
+    srcs = ["test_attach_service_with_multi_pdns_and_bearers.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_secondary_pdn_with_dedicated_bearer",
+    size = "small",
+    srcs = ["test_attach_detach_secondary_pdn_with_dedicated_bearer.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_secondary_pdn_with_dedicated_bearer_looped",
+    size = "small",
+    srcs = ["test_attach_detach_secondary_pdn_with_dedicated_bearer_looped.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_service_with_multi_pdns_and_bearers_looped",
+    size = "small",
+    srcs = ["test_attach_service_with_multi_pdns_and_bearers_looped.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_dedicated_bearer_activation_idle_mode_paging_timer_expiry",
+    size = "small",
+    srcs = ["test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_multi_enb_multi_ue_diff_plmn",
+    size = "small",
+    srcs = ["test_multi_enb_multi_ue_diff_plmn.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_x2_handover",
+    size = "small",
+    srcs = ["test_x2_handover.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_x2_handover_ping_pong",
+    size = "small",
+    srcs = ["test_x2_handover_ping_pong.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_s1_handover",
+    size = "small",
+    srcs = ["test_s1_handover.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_rar_tcp_data",
+    size = "small",
+    srcs = ["test_attach_detach_rar_tcp_data.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_with_mme_restart",
+    size = "medium",
+    srcs = ["test_attach_detach_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_with_mobilityd_restart",
+    size = "medium",
+    srcs = ["test_attach_detach_with_mobilityd_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_idle_mode_with_mme_restart",
+    size = "small",
+    srcs = ["test_idle_mode_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_3485_timer_for_dedicated_bearer_with_mme_restart",
+    size = "small",
+    srcs = ["test_3485_timer_for_dedicated_bearer_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_3485_timer_for_default_bearer_with_mme_restart",
+    size = "small",
+    srcs = ["test_3485_timer_for_default_bearer_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_paging_after_mme_restart",
+    size = "small",
+    srcs = ["test_paging_after_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_nw_initiated_detach_fail",
+    size = "small",
+    srcs = ["test_attach_nw_initiated_detach_fail.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_tau_ta_updating",
+    size = "small",
+    srcs = ["test_tau_ta_updating.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_tau_ta_updating_reject",
+    size = "small",
+    srcs = ["test_tau_ta_updating_reject.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_tau_mixed_partial_lists",
+    size = "small",
+    srcs = ["test_tau_mixed_partial_lists.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_eps_bearer_context_status_multiple_ded_bearer_deact",
+    size = "small",
+    srcs = ["test_eps_bearer_context_status_multiple_ded_bearer_deact.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_guti_attach_with_zero_mtmsi",
+    size = "small",
+    srcs = ["test_guti_attach_with_zero_mtmsi.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_ics_timer_expiry_with_mme_restart",
+    size = "small",
+    srcs = ["test_ics_timer_expiry_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_mobile_reachability_timer_expiry",
+    size = "large",
+    srcs = ["test_attach_mobile_reachability_timer_expiry.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_implicit_detach_timer_expiry",
+    size = "large",
+    srcs = ["test_attach_implicit_detach_timer_expiry.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_mobile_reachability_tmr_with_mme_restart",
+    size = "large",
+    srcs = ["test_mobile_reachability_tmr_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_implicit_detach_timer_with_mme_restart",
+    size = "large",
+    srcs = ["test_implicit_detach_timer_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_restore_mme_config_after_sanity",
+    size = "small",
+    srcs = ["test_restore_mme_config_after_sanity.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST_TEARDOWN,
+    deps = [
+        ":s1ap_utils",
+        "//lte/gateway/python/integ_tests/common:magmad_client",
+    ],
+)

--- a/lte/gateway/python/integ_tests/s1aptests/util/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/util/BUILD.bazel
@@ -9,19 +9,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library")
 
 package(default_visibility = ["//visibility:public"])
 
 py_library(
-    name = "constants",
-    testonly = 1,
-    srcs = ["__init__.py"],
-)
-
-py_library(
-    name = "rest_api",
-    testonly = 1,
-    srcs = ["rest_api.py"],
-    deps = [":constants"],
+    name = "traffic_util",
+    testonly = True,
+    srcs = [
+        "traffic_messages.py",
+        "traffic_util.py",
+    ],
+    deps = [
+        requirement("iperf3"),
+        requirement("pyroute2"),
+    ],
 )

--- a/lte/protos/BUILD.bazel
+++ b/lte/protos/BUILD.bazel
@@ -48,6 +48,11 @@ proto_library(
     srcs = ["abort_session.proto"],
 )
 
+python_grpc_library(
+    name = "abort_session_python_grpc",
+    protos = [":abort_session_proto"],
+)
+
 cpp_proto_library(
     name = "apn_cpp_proto",
     protos = [":apn_proto"],
@@ -327,6 +332,15 @@ cpp_grpc_library(
     ],
 )
 
+python_grpc_library(
+    name = "spgw_service_grpc_proto",
+    protos = [":spgw_service_proto"],
+    deps = [
+        "policydb_python_proto",
+        "subscriberdb_python_proto",
+    ],
+)
+
 cpp_proto_library(
     name = "spgw_service_cpp_proto",
     protos = [":spgw_service_proto"],
@@ -482,6 +496,11 @@ cpp_grpc_library(
 proto_library(
     name = "ha_service_proto",
     srcs = ["ha_service.proto"],
+)
+
+python_grpc_library(
+    name = "ha_service_python_grpc",
+    protos = [":ha_service_proto"],
 )
 
 cpp_proto_library(


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR bazelifies the extended S1AP integration tests and introduces a wrapper script for executing them.
The script has multiple ways to be executed, these are detailed in the help message:
`$MAGMA_ROOT/bazel/scripts/run_integ_tests.sh --help`
```
Executes all integration tests.
Usage:
   run_integ_tests.sh
      Execute all integration tests in the magma repository.
   run_integ_tests.sh path_to_tests_directory:bazel_test_target_name
      Execute the specified test.
   run_integ_tests.sh --list
      List all integration tests.
   run_integ_tests.sh --list-extended
      List all tests that use the traffic server.
   run_integ_tests.sh --list-traffic-server
      List the extended integration tests.
   run_integ_tests.sh --setup-extended
      Execute the setup test for the extended tests.
   run_integ_tests.sh --teardown-extended
      Execute the teardown test for the extended tests.
   run_integ_tests.sh --skip-setup-teardown-extended
      Execute all tests in the magma repository,
      except the setup and teardown for extended tests.
   run_integ_tests.sh --skip-setup-teardown-extended path_to_tests_directory:bazel_test_target_name
      Execute the specified test, without executing
      the setup and teardown for extended tests.
   run_integ_tests.sh --help
      Display this help message.
```

## Test Plan

Use the script as mentioned above.
The script runs on the magma_test VM and it needs the same preparation as if the integration tests were executed with make. More info about the setup here: https://docs.magmacore.org/docs/lte/s1ap_tests#s1ap-integration-tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
