### PR TITLE
docs(cwg): Document plugin requirements of CWF Integ Tests

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.7.0/cwf/dev_testing.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/cwf/dev_testing.md
@@ -42,6 +42,16 @@ To run all existing unit tests, run
 
 ## Run integration tests
 
+### Prerequisite
+
+You need to install a vagrant plugin:
+
+```bash
+vagrant plugin install vagrant-disksize
+```
+
+### Test setup
+
 CWF integration tests use 3 separate VMs listed below.
 `cwf/gateway/fabfile.py` can be used to automate all setup work.
 

--- a/docs/readmes/cwf/dev_testing.md
+++ b/docs/readmes/cwf/dev_testing.md
@@ -41,6 +41,16 @@ To run all existing unit tests, run
 
 ## Run integration tests
 
+### Prerequisite
+
+You need to install a vagrant plugin:
+
+```bash
+vagrant plugin install vagrant-disksize
+```
+
+### Test setup
+
 CWF integration tests use 3 separate VMs listed below.
 `cwf/gateway/fabfile.py` can be used to automate all setup work.
 


### PR DESCRIPTION
## Summary

Mention the vagrant plugin in the documentation.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking

