### PR TITLE
refactor(agw): Replace scapy getmacbyip[6].

### DIFF
--- a/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
@@ -14,6 +14,7 @@ limitations under the License.
 from __future__ import annotations
 
 import ctypes
+from getmac import get_mac_address
 import logging
 import socket
 import struct
@@ -24,8 +25,6 @@ from bcc import BPF
 from lte.protos.mobilityd_pb2 import IPAddress
 from magma.pipelined.mobilityd_client import get_mobilityd_gw_info
 from pyroute2 import IPRoute, NetlinkError
-from scapy.layers.inet6 import getmacbyip6
-from scapy.layers.l2 import getmacbyip
 
 LOG = logging.getLogger("pipelined.ebpf")
 
@@ -313,10 +312,10 @@ class EbpfManager:
     def _get_mac_address_of_ip(self, ip_addr: IPAddress):
         if ip_addr.version == IPAddress.IPV4:
             ip_str = socket.inet_ntop(socket.AF_INET, ip_addr.address)
-            addr_str = getmacbyip(ip_str)
+            addr_str = get_mac_address(ip=ip_str)
         else:
             ip_str = socket.inet_ntop(socket.AF_INET6, ip_addr.address)
-            addr_str = getmacbyip6(ip_str)
+            addr_str = get_mac_address(ip6=ip_str)
         if not addr_str:
             LOG.error("Coudn't find mac for IP: %s, disabling ebpf" % (ip_str))
             return None

--- a/lte/gateway/python/magma/pipelined/gw_mac_address.py
+++ b/lte/gateway/python/magma/pipelined/gw_mac_address.py
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from getmac import get_mac_address
 import ipaddress
 import logging
 
@@ -18,7 +19,6 @@ from lte.protos.mobilityd_pb2 import IPAddress
 from scapy.arch import get_if_addr, get_if_hwaddr
 from scapy.data import ETH_P_ALL, ETHER_BROADCAST
 from scapy.error import Scapy_Exception
-from scapy.layers.inet6 import getmacbyip6
 from scapy.layers.l2 import ARP, Dot1Q, Ether
 from scapy.sendrecv import srp1
 
@@ -105,7 +105,7 @@ def _get_gw_mac_address_v4(ip: IPAddress, vlan: str, non_nat_arp_egress_port: st
 def _get_gw_mac_address_v6(ip: IPAddress) -> str:
     try:
         gw_ip = ipaddress.ip_address(ip.address)
-        mac = getmacbyip6(str(gw_ip))
+        mac = get_mac_address(ip6=str(gw_ip))
         logging.debug("Got mac %s for IP: %s", mac, gw_ip)
         return mac
 

--- a/lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py
+++ b/lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py
@@ -2,12 +2,12 @@
 
 # sudo /home/vagrant/build/python/bin/python gtp-cmd.py 192.168.60.141 192.168.60.142 192.168.128.12 192.168.129.42 eth1
 
+from getmac import get_mac_address
 import sys
 import time
 
 from scapy.all import IP, UDP, Ether, sendp
 from scapy.contrib.gtp import GTP_U_Header
-from scapy.layers.l2 import getmacbyip
 
 ip_src = sys.argv[1]
 ip_dst = sys.argv[2]
@@ -15,7 +15,7 @@ i_ip_src = sys.argv[3]
 i_ip_dst = sys.argv[4]
 egress_dev = sys.argv[5]
 
-dst_mac = getmacbyip(ip_dst)
+dst_mac = get_mac_address(ip=ip_dst)
 
 eth = Ether(src='08:00:27:d3:52:d1', dst=dst_mac)
 ip = IP(src=ip_src, dst=ip_dst)

--- a/lte/gateway/python/magma/pipelined/tests/script/ip-packet.py
+++ b/lte/gateway/python/magma/pipelined/tests/script/ip-packet.py
@@ -2,17 +2,17 @@
 
 # sudo /home/vagrant/build/python/bin/python gtp-cmd.py 192.168.128.12 192.168.129.42 eth1
 
+from getmac import get_mac_address
 import sys
 import time
 
 from scapy.all import IP, Ether, sendp
-from scapy.layers.l2 import getmacbyip
 
 ip_src = sys.argv[1]
 ip_dst = sys.argv[2]
 egress_dev = sys.argv[3]
 
-dst_mac = getmacbyip(ip_dst)
+dst_mac = get_mac_address(ip=ip_dst)
 
 eth = Ether(src='08:00:27:d3:52:d1', dst=dst_mac)
 ip = IP(src=ip_src, dst=ip_dst)

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -548,7 +548,7 @@ def mocked_setmacbyip6(ipv6_addr: str, mac: str):
         ipv6_mac_table[ipv6_addr] = mac
 
 
-def mocked_getmacbyip6(ipv6_addr: str) -> Optional[str]:
+def mocked_get_mac_address(ipv6_addr: str) -> Optional[str]:
     global ipv6_mac_table
     with gw_info_lock:
         return ipv6_mac_table.get(ipv6_addr)
@@ -633,7 +633,7 @@ class InOutTestNonNATBasicFlowsIPv6(unittest.TestCase):
         time.sleep(1)
         clear_gw_info_map()
 
-    @unittest.mock.patch('magma.pipelined.gw_mac_address.getmacbyip6', mocked_getmacbyip6)
+    @unittest.mock.patch('magma.pipelined.gw_mac_address.get_mac_address', mocked_get_mac_address)
     def testFlowSnapshotMatch(self):
         ipv6_addr1 = "2002::22"
         mac_addr1 = "11:22:33:44:55:88"

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -104,6 +104,7 @@ setup(
         'ryu>=4.34',
         'spyne>=2.13.15',
         'scapy==2.4.4',
+        'getmac==0.8.3'
         'flask>=1.0.2',
         'sentry_sdk>=1.5.0',
         'aiodns>=1.1.1',


### PR DESCRIPTION
Use `getmac.get_mac_address` instead.

Signed-off-by: Moritz Huebner <moritz.huebner@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
