### PR TITLE
fix(ci): Fix LSAN errors in `s1ap_mme_handlers_with_injected_state` test

### DIFF
--- a/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers_with_injected_state.cpp
+++ b/lte/gateway/c/core/oai/test/s1ap_task/test_s1ap_mme_handlers_with_injected_state.cpp
@@ -94,6 +94,7 @@ class S1apMmeHandlersWithInjectedStatesTest : public ::testing::Test {
     mock_read_s1ap_ue_state_db(name_of_ue_samples);
 
     state = S1apStateManager::getInstance().get_state(false);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 
   virtual void TearDown() {


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

## Summary

- Merging this PR should **fix the very flaky MME test job in the agw-workflow**.
- Fix LSAN errors in `s1ap_mme_handlers_with_injected_state` test 
  - Done by adding a sleep for 100ms at the end of the setup.
    - 10ms is sufficient, but I chose 100ms to be safe on slower machines as well.
   - This is in analogy to the very similar `s1ap_mme_handlers` test    
- See analysis in https://github.com/magma/magma/issues/13343
  - Without the sleep: there are LSAN errors in 5% of the runs
  - With the sleep: No errors in >2000 runs. 

## Test Plan

- Cherry-pick the bazlification from https://github.com/magma/magma/pull/13334
  - Run the test with LSAN checks for 1000 times:
    - `bazel test //lte/gateway/c/core/oai/test/s1ap_task:s1ap_mme_handlers_with_injected_state_test --config=lsan --runs_per_test=1000`  

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
