### PR TITLE
chore: Remove unused bazelrc files

### DIFF
--- a/.devcontainer/bazel-base/bazelrcs/devcontainer.bazelrc
+++ b/.devcontainer/bazel-base/bazelrcs/devcontainer.bazelrc
@@ -1,1 +1,0 @@
-common --config=devcontainer

--- a/.devcontainer/bazel-base/bazelrcs/docker.bazelrc
+++ b/.devcontainer/bazel-base/bazelrcs/docker.bazelrc
@@ -1,1 +1,0 @@
-common --config=docker

--- a/.devcontainer/bazel-base/bazelrcs/vm.bazelrc
+++ b/.devcontainer/bazel-base/bazelrcs/vm.bazelrc
@@ -1,1 +1,0 @@
-common --config=vm


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The bazelrc files in `.devcontainer/bazel-base/bazelrcs/` are not used anymore. This PR removes them.

## Test Plan

CI.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
