### PR TITLE
chore(ci): github runner for build_all is bumped from macos10.15 to 12

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -2,6 +2,7 @@
 name: build-all
 
 on:
+  workflow_dispatch: null
   push:
     branches:
       - master
@@ -101,7 +102,7 @@ jobs:
           python ci-scripts/helm_repo_rotation.py
   agw-build:
     if: github.event_name == 'push' && github.repository_owner == 'magma'
-    runs-on: macos-10.15
+    runs-on: macos-12
     outputs:
       artifacts: ${{ steps.publish_packages.outputs.artifacts }}
     steps:
@@ -113,10 +114,6 @@ jobs:
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
           key: vagrant-box-magma-dev
-      - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
-        with:
-          default: 3.8.5
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.10'


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

**Context**
* github is deprecating macos-10.15 runners. Alternatives are macos-11 and 12 runners.
* This goes along with "brownouts" - one day per week macos-10.15 runners are not usable - see https://github.com/actions/virtual-environments/issues/5583
* Slack discussion: https://magmacore.slack.com/archives/C01MDUQDFC3/p1658411534798269
* We have 4(5) jobs using macos-10.15 runners
  * CWF
  * FED
  * LTE integ tests (make and bazel)
  * build_all
* CWF, FED, LTE are using the traffic server which has a known issue on macos >=11 - see https://github.com/magma/magma/issues/13245
  * here we need the base image bumped to ubuntu 20.04 - this is ongoing (issue link TBD)

**Here**
* the build_all job is not using the trf server and can be bumped
* we decided to use macos 12 because
  * its more recent
  * it already has vagrant and virtualbox pre-installed - the 11 image does not
* I also took the liberty to add a **workflow_dispatch** trigger for easy testing
* setup pyenv (gabrielfalcao/pyenv-action, with py 3.8.5) does not work with macos 11/12 - but it seems in a test run that it is not needed ... looks like tech debt -> removed

<!-- Enumerate changes you made and why you made them -->

## Test Plan

* real change will only run on master first
* test run on branch (with tweaks to be runable): https://github.com/nstng/magma/actions/runs/2713097965

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
