### PR TITLE
chore(ci): Remove setup pyenv step from agw-workflow

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -68,10 +68,6 @@ jobs:
       SKIP_SUDO_TESTS: 1
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
-      - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
-        with:
-          default: 3.8.10
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.10'


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Remove unnecessary pyenv setup step in agw-workflow LTE test job
  - This saves ca. **2 min** in the workflow 

## Test Plan

- [Successful LTE test job run on fork](https://github.com/LKreutzer/magma/actions/runs/2717489844)
- [Successful run on PR](https://github.com/magma/magma/runs/7465486710?check_suite_focus=true)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
