### PR TITLE
chore(agw): Changes for new magma-dev base image

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v20220727
+          key: vagrant-box-magma-dev-v1.2.20220801
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.10'

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -130,6 +130,7 @@ jobs:
           sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
       - name: Build AGW
         run: |
+          export MAGMA_DEV_MEMORY_MB=4096
           cd lte/gateway
           fab release package:destroy_vm=True
           mkdir magma-packages

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.1.20210618-patched
+          key: vagrant-box-magma-dev-v20220727
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.10'

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v20220727
+          key: vagrant-box-magma-dev-v1.2.20220801
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.1.20210618-patched
+          key: vagrant-box-magma-dev-v20220727
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v20220727
+          key: vagrant-box-magma-dev-v1.2.20220801
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.1.20210618-patched
+          key: vagrant-box-magma-dev-v20220727
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v20220727
+          key: vagrant-box-magma-dev-v1.2.20220801
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.1.20210618-patched
+          key: vagrant-box-magma-dev-v20220727
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define :magma, primary: true do |magma|
     config.vm.box = "magmacore/magma_dev"
     config.vm.hostname = "magma-dev"
-    config.vm.box_version = "1.1.20220727"
+    config.vm.box_version = "1.2.20220801"
      # Enable Dynamic Swap Space to prevent Out of Memory crashes
     config.vm.provision :shell, inline: "swapoff -a && fallocate -l 4G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile && echo '/swapfile none swap sw 0 0' >> /etc/fstab && swapon -a"
     config.vm.provision :shell, inline: "echo vm.swappiness = 10 >> /etc/sysctl.conf && echo vm.vfs_cache_pressure = 50 >> /etc/sysctl.conf && sysctl -p"

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -22,6 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define :magma, primary: true do |magma|
     config.vm.box = "magmacore/magma_dev"
+    config.vm.hostname = "magma-dev"
     config.vm.box_version = "1.1.20220727"
      # Enable Dynamic Swap Space to prevent Out of Memory crashes
     config.vm.provision :shell, inline: "swapoff -a && fallocate -l 4G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile && echo '/swapfile none swap sw 0 0' >> /etc/fstab && swapon -a"

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -21,10 +21,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder "../..", "/home/vagrant/magma"
 
   config.vm.define :magma, primary: true do |magma|
-    # Get our prepackaged box from the atlas cloud, based on
-    # - debian/contrib-jessie64
-    # - linux kernel from debian jessie backports
-    # - updated vbguest-tool
     config.vm.box = "magmacore/magma_dev"
     config.vm.box_version = "1.1.20210618-patched"
      # Enable Dynamic Swap Space to prevent Out of Memory crashes

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define :magma, primary: true do |magma|
     config.vm.box = "magmacore/magma_dev"
-    config.vm.box_version = "1.1.20210618-patched"
+    config.vm.box_version = "1.1.20220727"
      # Enable Dynamic Swap Space to prevent Out of Memory crashes
     config.vm.provision :shell, inline: "swapoff -a && fallocate -l 4G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile && echo '/swapfile none swap sw 0 0' >> /etc/fstab && swapon -a"
     config.vm.provision :shell, inline: "echo vm.swappiness = 10 >> /etc/sysctl.conf && echo vm.vfs_cache_pressure = 50 >> /etc/sysctl.conf && sysctl -p"

--- a/lte/gateway/deploy/magma_dev_focal.yml
+++ b/lte/gateway/deploy/magma_dev_focal.yml
@@ -23,14 +23,6 @@
     full_provision: true
 
   roles:
-    # This role is commented out for now because as it turns out, it's very
-    # difficult to install Debian on a box without also installing packages
-    # from an upstream mirror. Even if we pin a snapshot to before the 4.9.0-11
-    # cutover, a freshly installed box will still end up with some packages
-    # from after the cutover (e.g. libsystemd0). Pinning to the snapshot
-    # repository after these packages are installed will result in a situation
-    # where it's impossible to proceed with provisioning.
-    #- role: stretch_snapshot
     - role: gateway_dev
       vars:
         distribution: "focal"

--- a/lte/gateway/deploy/roles/bazel/tasks/main.yml
+++ b/lte/gateway/deploy/roles/bazel/tasks/main.yml
@@ -16,6 +16,7 @@
     path: '/etc/bazelrc'
     state: link
     force: yes
+    follow: false
 
 - name: Symlink bazel disk cache configuration into the VM
   file:

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -433,10 +433,9 @@
       - unattended-upgrades
 
 - name: Install LLDB debugger
-  # TODO: Make this preburn
   apt:
     pkg: lldb
     state: present
     update_cache: no
   retries: 5
-  when: full_provision
+  when: preburn

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -49,7 +49,10 @@
     state: restarted
 
 - name: Install ansible community collection
-  shell: su - {{ ansible_user }} -c 'ansible-galaxy collection install community.general'
+  become: yes
+  become_method: su
+  become_user: "{{ ansible_user }}"
+  command: ansible-galaxy collection install community.general
   ignore_errors: yes
 
 - name: Set build environment variables

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -11,7 +11,11 @@
 # limitations under the License.
 
 - name: Fix resolve conf
-  shell: ln -sf /var/run/systemd/resolve/resolv.conf /etc/resolv.conf
+  ansible.builtin.file:
+    src: /var/run/systemd/resolve/resolv.conf
+    dest: /etc/resolv.conf
+    state: link
+    force: yes
 
 - name: Include vars of all.yaml
   include_vars:

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Fix resove conf
+- name: Fix resolve conf
   shell: ln -sf /var/run/systemd/resolve/resolv.conf /etc/resolv.conf
 
 - name: Include vars of all.yaml
@@ -244,17 +244,15 @@
       # install prometheus
       - prometheus-cpp-dev
       # install openvswitch
+      - libopenvswitch
+      - libopenvswitch-dev
+      - magma-libfluid
+      - openvswitch-common
+      - openvswitch-datapath-dkms
+      - openvswitch-doc
       - openvswitch-switch
       - openvswitch-test
-      - libopenvswitch
-      - openvswitch-datapath-dkms
-      - openvswitch-common
-      - libopenvswitch-dev
       - python3-openvswitch
-      - openvswitch-doc
-      - openvswitch-pki
-      - openvswitch-test
-      - magma-libfluid
       # install lxml
       - python3-lxml
       - bridge-utils
@@ -262,12 +260,12 @@
       - libyaml-cpp-dev
       - libgoogle-glog-dev
       # folly deps
-      - libfolly-dev
-      - libdouble-conversion-dev
       - libboost-chrono-dev
-      - redis-server
-      - python-redis
+      - libdouble-conversion-dev
+      - libfolly-dev
       - magma-cpp-redis
+      - python-redis
+      - redis-server
       # Time synchronization with NTP for eventd
       - ntpdate
       # For call tracing
@@ -330,28 +328,19 @@
     - gmock
   when: preburn
 
-- name: Remove existing golang installation
-  # TODO: make golang installation preburn and delete this step
-  # it is necessary because the old golang installation has to be removed
-  # before installing the new one (https://go.dev/doc/install)
-  shell: rm -rf /usr/local/go
-  when: full_provision
-
 - name: Download golang tar
-  # TODO: make this preburn again
   get_url:
     url: "https://artifactory.magmacore.org/artifactory/generic/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
     dest: "{{ all_vars.WORK_DIR }}"
     mode: 0440
-  when: full_provision
+  when: preburn
 
 - name: Extract Go tarball
-  # TODO: make this preburn again
   unarchive:
     src: "{{all_vars.WORK_DIR}}/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
     dest: /usr/local
     copy: no
-  when: full_provision
+  when: preburn
 
 - name: Set Go environment vars in profile
   lineinfile:
@@ -361,7 +350,7 @@
   with_items:
     - export PATH=$PATH:/usr/local/bin/go/
     - export PATH=$PATH:$(go env GOPATH)/bin/
-  when: full_provision
+  when: preburn
 
 - name: Install dnsmasq
   apt: pkg=dnsmasq state=present update_cache=yes
@@ -456,7 +445,6 @@
     src: patches/aioeventlet_fd_exception.patch
     dest: /usr/local/lib/python3.8/dist-packages/aioeventlet.py
 
-# TODO: preburn this
 - name: Install dev requirements only used for Magma VM
   retries: 5
   apt:
@@ -465,22 +453,23 @@
       - clangd-12
       - lld
       - clang-format-11
+  when: preburn
 
-# TODO: preburn this
 - name: Create a symlink for clangd
   file:
     src: '/usr/bin/clangd-12'
     path: '/usr/bin/clangd'
     state: link
     force: yes
+  when: preburn
 
-# TODO: preburn this
 - name: Create a symlink for clang-format
   file:
     src: '/usr/bin/clang-format-11'
     path: '/usr/bin/clang-format'
     state: link
     force: yes
+  when: preburn
 
 # TODO: Fix magma-dev VM box and remove this step.
 - name: Install Magma dependencies

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -191,6 +191,15 @@
   sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
   when: full_provision
 
+# Explicitly set policy to stop docker from blocking everything
+# https://docs.docker.com/network/iptables/#docker-on-a-router
+- name: Allow forwarding in iptables
+  iptables:
+    chain: FORWARD
+    policy: ACCEPT
+  become: yes
+  when: full_provision
+
 - name: Install OpenAirInterface (OAI) dependencies
   retries: 5
   when: preburn

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -10,9 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 - name: Remove all old registries
-  shell: rm -rf /etc/apt/sources.list.d/*.list
   become: yes
   ignore_errors: yes
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/*.list
+    state: absent
 
 - name: Wait for APT Lock
   shell: |

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -60,8 +60,7 @@
     state: present
 
 - name: Configuring the registry in sources.list.d
-  ansible.builtin.shell:
-    cmd: echo 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main' > /etc/apt/sources.list.d/magma.list
+  shell: "echo 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main' > /etc/apt/sources.list.d/magma.list"
 
 - name: Update apt
   apt:

--- a/orc8r/tools/packer/magma-focal-virtualbox.json
+++ b/orc8r/tools/packer/magma-focal-virtualbox.json
@@ -75,7 +75,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "magma"
+      "vm_name": "magma-dev"
     }
   ],
   "post-processors": [
@@ -105,8 +105,13 @@
       "type": "shell"
     },
     {
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-      "script": "scripts/setup.sh",
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
+      "scripts": [
+        "scripts/third_party/chef_bento/update_ubuntu.sh",
+        "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
+        "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
+      ],
       "type": "shell"
     },
     {
@@ -116,34 +121,20 @@
       "inventory_groups": "focal_dev",
       "playbook_file": "../../../lte/gateway/deploy/magma_dev_focal.yml",
       "role_paths": [
+        "../../../lte/gateway/deploy/roles/bazel",
+        "../../../lte/gateway/deploy/roles/dev_common",
+        "../../../lte/gateway/deploy/roles/magma",
+        "../../../lte/gateway/deploy/roles/pyvenv",
         "../../../orc8r/tools/ansible/roles/apt_cache",
-        "../../../orc8r/tools/ansible/roles/distro_snapshot",
         "../../../orc8r/tools/ansible/roles/docker",
         "../../../orc8r/tools/ansible/roles/fluent_bit",
         "../../../orc8r/tools/ansible/roles/gateway_dev",
         "../../../orc8r/tools/ansible/roles/gateway_services",
-        "../../../orc8r/tools/ansible/roles/golang",
         "../../../orc8r/tools/ansible/roles/pkgrepo",
         "../../../orc8r/tools/ansible/roles/python_dev",
-        "../../../orc8r/tools/ansible/roles/resolv_conf",
-        "../../../orc8r/tools/ansible/roles/test_certs",
-        "../../../lte/gateway/deploy/roles/envoy",
-        "../../../lte/gateway/deploy/roles/stretch_snapshot",
-        "../../../lte/gateway/deploy/roles/dev_common",
-        "../../../lte/gateway/deploy/roles/magma",
-        "../../../lte/gateway/deploy/roles/dev_common",
-        "../../../lte/gateway/deploy/roles/magma",
-        "../../../lte/gateway/deploy/roles/magma_test",
-        "../../../lte/gateway/deploy/roles/pyvenv",
-        "../../../lte/gateway/deploy/roles/stretch_snapshot",
-        "../../../lte/gateway/deploy/roles/trfserver",
-        "../../../lte/gateway/deploy/roles/uselocalpkgrepo"
+        "../../../orc8r/tools/ansible/roles/test_certs"
       ],
       "type": "ansible-local"
     }
-  ],
-  "variables": {
-    "cloud_token": "{{ env `ATLAS_TOKEN` }}",
-    "version": "1.0.{{timestamp}}"
-  }
+  ]
 }

--- a/orc8r/tools/packer/magma-focal-virtualbox.json
+++ b/orc8r/tools/packer/magma-focal-virtualbox.json
@@ -33,7 +33,9 @@
       "http_directory": "http",
       "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
       "iso_url": "https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
-      "memory": 2048,
+      "memory": 8192,
+      "cpus": 4,
+      "hard_drive_interface": "scsi",
       "name": "magma",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_handshake_attempts": "20",
@@ -89,7 +91,10 @@
   "provisioners": [
     {
       "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
-      "script": "scripts/ubuntu_setup.sh",
+      "scripts": [
+        "scripts/ubuntu_setup.sh",
+        "scripts/vagrant_key.sh"
+      ],
       "type": "shell"
     },
     {
@@ -100,17 +105,10 @@
       "type": "shell"
     },
     {
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
-      "script": "scripts/vagrant_key.sh",
-      "type": "shell"
-    },
-    {
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
-        "scripts/third_party/chef_bento/update_ubuntu.sh",
-        "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
-        "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
+        "scripts/third_party/chef_bento/update_ubuntu.sh"
       ],
       "type": "shell"
     },
@@ -135,6 +133,15 @@
         "../../../orc8r/tools/ansible/roles/test_certs"
       ],
       "type": "ansible-local"
+    },
+    {
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
+      "scripts": [
+        "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
+        "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
+      ],
+      "type": "shell"
     }
   ]
 }

--- a/orc8r/tools/packer/magma-focal-virtualbox.json
+++ b/orc8r/tools/packer/magma-focal-virtualbox.json
@@ -28,7 +28,7 @@
       ],
       "boot_wait": "5s",
       "guest_additions_mode": "upload",
-      "guest_os_type": "ubuntu-64",
+      "guest_os_type": "Ubuntu_64",
       "headless": true,
       "http_directory": "http",
       "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",

--- a/orc8r/tools/packer/magma-focal-virtualbox.json
+++ b/orc8r/tools/packer/magma-focal-virtualbox.json
@@ -55,25 +55,6 @@
           "{{.Name}}",
           "--cpus",
           "4"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--uart1",
-          "0x3F8",
-          "4"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--nestedpaging",
-          "off"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--paravirtprovider",
-          "hyperv"
         ]
       ],
       "virtualbox_version_file": ".vbox_version",

--- a/orc8r/tools/packer/magma-focal-virtualbox.json
+++ b/orc8r/tools/packer/magma-focal-virtualbox.json
@@ -89,9 +89,7 @@
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
-        "scripts/third_party/chef_bento/update_ubuntu.sh",
-        "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
-        "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
+        "scripts/third_party/chef_bento/update_ubuntu.sh"
       ],
       "type": "shell"
     },
@@ -116,6 +114,14 @@
         "../../../orc8r/tools/ansible/roles/test_certs"
       ],
       "type": "ansible-local"
+    },
+    {
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
+      "scripts": [
+        "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
+      ],
+      "type": "shell"
     }
   ]
 }

--- a/orc8r/tools/packer/magma-focal-virtualbox.json
+++ b/orc8r/tools/packer/magma-focal-virtualbox.json
@@ -89,7 +89,9 @@
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
-        "scripts/third_party/chef_bento/update_ubuntu.sh"
+        "scripts/third_party/chef_bento/update_ubuntu.sh",
+        "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
+        "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
       ],
       "type": "shell"
     },
@@ -114,15 +116,6 @@
         "../../../orc8r/tools/ansible/roles/test_certs"
       ],
       "type": "ansible-local"
-    },
-    {
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
-      "expect_disconnect": true,
-      "scripts": [
-        "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
-        "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
-      ],
-      "type": "shell"
     }
   ]
 }

--- a/orc8r/tools/packer/vagrant-box-upload.sh
+++ b/orc8r/tools/packer/vagrant-box-upload.sh
@@ -9,7 +9,7 @@ BOX_FILE=$1
 
 USER=magmacore
 BOX=$(basename $BOX_FILE | cut -d_ -f1-2 | cut -d. -f1)
-VERSION="1.1.$(date +"%Y%m%d")"
+VERSION="1.2.$(date +"%Y%m%d")"
 BOX_PROVIDER=virtualbox
 if echo $BOX_FILE | grep -q libvirt; then
   BOX_PROVIDER=libvirt


### PR DESCRIPTION
## Summary

Creating a new base image of `magma-dev` on Ubuntu focal.

- Make many steps preburn again that changed in the last year
- openvswitch version `*.2.15.4-9-magma` is installed
- Several Ansible hints are addressed.
- Packing of VM is improved in the same way as in https://github.com/magma/magma/pull/13427

Closes #13179.

## Test Plan

- [x] [AGW build](https://github.com/crasu/magma/runs/7628256379?check_suite_focus=true)
- [x] Unit tests
- [x] Sudo tests
- [x] [LTE integration tests](https://github.com/sebathomas/magma/runs/7762509725) 
- [x] [Federated integration tests](https://github.com/sebathomas/magma/actions/runs/2780364051)

## Additional Information

- [ ] This change is backwards-breaking
