### PR TITLE
fix(mme): Supporting multiple qos policies for a given IMSI

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -180,22 +180,37 @@ Status AmfServiceImpl::SetSmfSessionContext(
     itti_msg.qos_flow_list.item[i]
         .qos_flow_req_item.qos_flow_level_qos_param.qos_characteristic
         .non_dynamic_5QI_desc.fiveQI = qos_rule.qos().qos().qci();  // enum
-    itti_msg.qos_flow_list.item[i]
-        .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
-        .priority_level =
-        qos_rule.qos().qos().arp().priority_level();  // uint32
-    itti_msg.qos_flow_list.item[i]
-        .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
-        .pre_emption_cap = (pre_emption_capability)qos_rule.qos()
-                               .qos()
-                               .arp()
-                               .pre_capability();  // enum
-    itti_msg.qos_flow_list.item[i]
-        .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
-        .pre_emption_vul = (pre_emption_vulnerability)qos_rule.qos()
-                               .qos()
-                               .arp()
-                               .pre_vulnerability();  // enum
+    if (qos_rule.qos().qos().arp().priority_level()) {
+      itti_msg.qos_flow_list.item[i]
+          .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
+          .priority_level =
+          qos_rule.qos().qos().arp().priority_level();  // uint32
+      itti_msg.qos_flow_list.item[i]
+          .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
+          .pre_emption_cap = (pre_emption_capability)qos_rule.qos()
+                                 .qos()
+                                 .arp()
+                                 .pre_capability();  // enum
+      itti_msg.qos_flow_list.item[i]
+          .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
+          .pre_emption_vul = (pre_emption_vulnerability)qos_rule.qos()
+                                 .qos()
+                                 .arp()
+                                 .pre_vulnerability();  // enum
+    } else {
+      itti_msg.qos_flow_list.item[i]
+          .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
+          .priority_level =
+          req_m5g.subscribed_qos().priority_level();  // uint32
+      itti_msg.qos_flow_list.item[i]
+          .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
+          .pre_emption_cap = (pre_emption_capability)req_m5g.subscribed_qos()
+                                 .preemption_capability();  // enum
+      itti_msg.qos_flow_list.item[i]
+          .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
+          .pre_emption_vul = (pre_emption_vulnerability)req_m5g.subscribed_qos()
+                                 .preemption_vulnerability();  // enum
+    }
     itti_msg.qos_flow_list.item[i].qos_flow_req_item.qos_flow_action =
         (qos_flow_action_t)qos_rule.policy_action();  // enum
     itti_msg.qos_flow_list.item[i].qos_flow_req_item.qos_flow_version =
@@ -218,12 +233,21 @@ Status AmfServiceImpl::SetSmfSessionContext(
       itti_msg.qos_flow_list.item[i]
           .qos_flow_req_item.qos_flow_descriptor.mbr_ul =
           qos_rule.qos().qos().max_req_bw_ul();
-      itti_msg.qos_flow_list.item[i]
-          .qos_flow_req_item.qos_flow_descriptor.gbr_dl =
-          qos_rule.qos().qos().gbr_dl();
-      itti_msg.qos_flow_list.item[i]
-          .qos_flow_req_item.qos_flow_descriptor.gbr_ul =
-          qos_rule.qos().qos().gbr_ul();
+      if (qos_rule.qos().qos().gbr_dl()) {
+        itti_msg.qos_flow_list.item[i]
+            .qos_flow_req_item.qos_flow_descriptor.gbr_dl =
+            qos_rule.qos().qos().gbr_dl();
+        itti_msg.qos_flow_list.item[i]
+            .qos_flow_req_item.qos_flow_descriptor.gbr_ul =
+            qos_rule.qos().qos().gbr_ul();
+      } else {
+        itti_msg.qos_flow_list.item[i]
+            .qos_flow_req_item.qos_flow_descriptor.gbr_dl =
+            qos_rule.qos().qos().max_req_bw_dl();
+        itti_msg.qos_flow_list.item[i]
+            .qos_flow_req_item.qos_flow_descriptor.gbr_ul =
+            qos_rule.qos().qos().max_req_bw_ul();
+      }
     }
     for (const auto& flow : qos_rule.qos().flow_list()) {
       if (flow.action() == FlowDescription::DENY) {

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -1142,6 +1142,9 @@ int ngap_fill_pdu_session_resource_setup_request_transfer(
   transfer_request_ie->value.present =
       Ngap_PDUSessionResourceSetupRequestTransferIEs__value_PR_QosFlowSetupRequestList;
 
+  asn_set_empty(
+      &transfer_request_ie->value.choice.QosFlowSetupRequestList.list);
+
   for (int i = 0; i < qos_list->maxNumOfQosFlows; i++) {
     Ngap_QosFlowSetupRequestItem_t* qos_item =
         (Ngap_QosFlowSetupRequestItem_t*)calloc(
@@ -1155,8 +1158,6 @@ int ngap_fill_pdu_session_resource_setup_request_transfer(
         &(qos_item->qosFlowLevelQosParameters);
     ngap_fill_qos_flow_level_qos_parameters(qos_list, qos_flow_params, i);
 
-    asn_set_empty(
-        &transfer_request_ie->value.choice.QosFlowSetupRequestList.list);
     ASN_SEQUENCE_ADD(
         &transfer_request_ie->value.choice.QosFlowSetupRequestList.list,
         qos_item);
@@ -1268,6 +1269,9 @@ int ngap_fill_pdu_session_resource_modify_request_transfer(
   qos_flow_add_or_modify_request_list_t* qos_list =
       &session_transfer->qos_flow_add_or_mod_request_list;
 
+  asn_set_empty(
+      &transfer_request_ie->value.choice.QosFlowAddOrModifyRequestList.list);
+
   for (int i = 0; i < qos_list->maxNumOfQosFlows; i++) {
     Ngap_QosFlowAddOrModifyRequestItem_t* qos_item =
         (Ngap_QosFlowAddOrModifyRequestItem_t*)calloc(
@@ -1285,8 +1289,6 @@ int ngap_fill_pdu_session_resource_modify_request_transfer(
 
     ngap_fill_qos_flow_level_qos_parameters(qos_list, qos_flow_params, i);
 
-    asn_set_empty(
-        &transfer_request_ie->value.choice.QosFlowAddOrModifyRequestList.list);
     ASN_SEQUENCE_ADD(
         &transfer_request_ie->value.choice.QosFlowAddOrModifyRequestList.list,
         qos_item);


### PR DESCRIPTION
Signed-off-by: sreedharkumartn <sreedhar.kumar@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Issue 1: While performing SUCI registration with multiple QOS policies attached to a IMSI, PDU retry is happening. ( Zenhub task ticket #13310 )
![image](https://user-images.githubusercontent.com/89978170/180421117-b86f2d75-6893-4dbb-9038-2decd300f124.png)
![image](https://user-images.githubusercontent.com/89978170/180421139-c6e7f7bd-43aa-49a9-984e-a436891c5cfb.png)

Issue 2: Information regarding multiple QOS policies attached to a IMSI not observing in PDU Session accept message. ( Zenhub task ticket #11935 )
QOS policies info getting updated in sessiond.
![image](https://user-images.githubusercontent.com/89978170/180421263-31397d1d-ee5d-4872-9210-995695e3eab5.png)
QOS policies info not observing in pdu session accept message. (PCAP link - https://app.zenhub.com/files/170803235/ae8d39f9-2267-4594-b6f5-fc4b973561c3/download)
![image](https://user-images.githubusercontent.com/89978170/180421477-1ac9a902-6108-4f3a-a3c3-6061823ce971.png)

Fix for the above issues:
Fixed the Issue of printing the qos policy attached information in pdu session accept message.


<!-- Enumerate changes you made and why you made them -->

## Test Plan
1. Tested the Multi QOS policy attached to a IMSI using spirent setup.
QOS Policies attached to the IMSI.
![policies information](https://user-images.githubusercontent.com/89978170/180427294-c499c528-4702-4c91-9147-79b52c3c19af.png)

QOS Information in pcap at pdu session accept message.
a. In NAS message:
![image](https://user-images.githubusercontent.com/89978170/180427772-ded0e25e-494b-4319-be39-41fcdc948c6e.png)
![image](https://user-images.githubusercontent.com/89978170/180427916-88b9f0e5-3805-462b-b973-0345f3e98379.png)
b. In NGAP message:
![image](https://user-images.githubusercontent.com/89978170/180428080-53a072bd-084c-4633-a49d-ea929be396e5.png)
![image](https://user-images.githubusercontent.com/89978170/180428128-f4db0911-6d75-48df-8917-32eac99d7210.png)

mme log:
[mme_2_qos_22july.log](https://github.com/magma/magma/files/9167243/mme_2_qos_22july.log)
syslog:
[syslog_2_qos_22july.log](https://github.com/magma/magma/files/9167251/syslog_2_qos_22july.log)

2. Checked basic sanity using UERANSIM.
Pcap:
![image](https://user-images.githubusercontent.com/89978170/180429002-a90305f5-976a-4234-aa17-1d8c4c2bfa34.png)
![image](https://user-images.githubusercontent.com/89978170/180429043-962ba526-747f-48a9-a50c-9f2fbbea8de3.png)

mme log:
[mme_basic_sanity.log](https://github.com/magma/magma/files/9167263/mme_basic_sanity.log)

3. Checked service request using UERANSIM.
Pcap:
![image](https://user-images.githubusercontent.com/89978170/180429400-2cbc7f91-221e-49b7-a258-ccfeb826c166.png)

mme log:
[mme_service_request.log](https://github.com/magma/magma/files/9167290/mme_service_request.log)

4. Checked UT.
![UT_2_qos_policy](https://user-images.githubusercontent.com/89978170/180429514-4cd6c36d-8d8a-432d-ab9c-ab0fc9a9814c.png)



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
