### PR TITLE
fix(ci): path filter is always true is prevented

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -54,8 +54,8 @@ jobs:
     # Only run workflow if this is a scheduled run on master branch,
     # or a pull_request that skip-duplicate-action wants to run again.
     if: |
-      (github.event_name == `schedule` && github.ref == 'refs/heads/master')
-        || ${{ needs.path_filter.outputs.files_changed == 'true' }}
+      (github.event_name == 'schedule' && github.ref == 'refs/heads/master') ||
+      needs.path_filter.outputs.files_changed == 'true'
     name: Bazel Build & Test Job
     runs-on: ubuntu-latest
     steps:
@@ -143,8 +143,8 @@ jobs:
     # Only run workflow if this is a scheduled run on master branch,
     # or a pull_request that skip-duplicate-action wants to run again.
     if: |
-      (github.event_name == `schedule` && github.ref == 'refs/heads/master')
-        || ${{ needs.path_filter.outputs.files_changed == 'true' }}
+      (github.event_name == 'schedule' && github.ref == 'refs/heads/master') ||
+      needs.path_filter.outputs.files_changed == 'true'
     name: Bazel Package Job
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

It seems a job guard of the example form `condition1 && ${{ condition2 }}` is problematic - and resulted in the case here to return always true. Assumption is that the syntax must not be mixed.
This is, use either `condition1 && condition2` or `${{ condition1 && condition2 }}`.

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
