### PR TITLE
fix(ci): Fix slack notification on bazel LTE integ test failure

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -111,12 +111,10 @@ jobs:
           check_run_annotations: all tests
       - name: Notify failure to slack
         if: failure() && github.repository_owner == 'magma'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
-          SLACK_TITLE: "Bazel LTE integ tests"
-          SLACK_USERNAME: "Bazel LTE integ tests"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
+          SLACK_USERNAME: "LTE integ tests bazel"
+          SLACK_AVATAR: ":boom:"
+        with:
+          args: "Bazel LTE integration test failed in run: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Slack notification on bazel LTE integ tests is fixed.
  - The new action is the same as in the standard Make integ test workflow, which also works on the macOS runner. 
- See https://github.com/magma/magma/issues/13393 

## Test Plan

- [Test message to slack](https://magmacore.slack.com/archives/C037YBMD7K9/p1658504747639129)
- [Updated version](https://magmacore.slack.com/archives/C037YBMD7K9/p1658506010613169)
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
