### PR TITLE
fix(amf): Support for 5GS network feature support

### DIFF
--- a/lte/gateway/c/core/oai/include/amf_config.hpp
+++ b/lte/gateway/c/core/oai/include/amf_config.hpp
@@ -50,6 +50,7 @@
 #define AMF_CONFIG_STRING_AMF_REGION_ID "AMF_REGION_ID"
 #define AMF_CONFIG_STRING_AMF_SET_ID "AMF_SET_ID"
 #define AMF_CONFIG_STRING_AMF_POINTER "AMF_POINTER"
+#define AMF_CONFIG_STRING_NAS_ENABLE_IMS_VoPS_3GPP "ENABLE_IMS_VoPS_3GPP"
 
 typedef struct nas5g_config_s {
   uint8_t preferred_integrity_algorithm[8];
@@ -70,6 +71,7 @@ typedef struct nas5g_config_s {
   bool force_reject_tau;
   bool force_reject_sr;
   bool disable_esm_information;
+  bool enable_IMS_VoPS_3GPP;
 } nas5g_config_t;
 
 typedef struct m5g_apn_map_s {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -513,7 +513,8 @@ int amf_reg_acceptmsg(const guti_m5_t* guti, const tai_t* tai,
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
       .network_feature.IMS_VoPS_N3GPP = 0;
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
-      .network_feature.IMS_VoPS_3GPP = 0;
+      .network_feature.IMS_VoPS_3GPP =
+      amf_config.nas_config.enable_IMS_VoPS_3GPP;
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
       .network_feature.MCSI = 0;
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg

--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -63,6 +63,7 @@ void nas5g_config_init(nas5g_config_t* nas_conf) {
   nas_conf->force_reject_tau = true;
   nas_conf->force_reject_sr = true;
   nas_conf->disable_esm_information = false;
+  nas_conf->enable_IMS_VoPS_3GPP = false;
 }
 
 /***************************************************************************
@@ -573,6 +574,8 @@ void amf_config_display(amf_config_t* config_pP) {
   OAILOG_DEBUG(LOG_CONFIG, "- PARTIAL TAIs\n");
   OAILOG_DEBUG(LOG_CONFIG, "- Num of partial lists=%d\n",
                config_pP->num_par_lists);
+  OAILOG_INFO(LOG_CONFIG, " ENABLE_IMS_VoPS_3GPP .......: %s\n",
+              config_pP->nas_config.enable_IMS_VoPS_3GPP ? "true" : "false");
   for (uint8_t itr = 0; itr < config_pP->num_par_lists; itr++) {
     if (config_pP->partial_list) {
       switch (config_pP->partial_list[itr].list_type) {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -574,8 +574,6 @@ void amf_config_display(amf_config_t* config_pP) {
   OAILOG_DEBUG(LOG_CONFIG, "- PARTIAL TAIs\n");
   OAILOG_DEBUG(LOG_CONFIG, "- Num of partial lists=%d\n",
                config_pP->num_par_lists);
-  OAILOG_INFO(LOG_CONFIG, " ENABLE_IMS_VoPS_3GPP .......: %s\n",
-              config_pP->nas_config.enable_IMS_VoPS_3GPP ? "true" : "false");
   for (uint8_t itr = 0; itr < config_pP->num_par_lists; itr++) {
     if (config_pP->partial_list) {
       switch (config_pP->partial_list[itr].list_type) {

--- a/lte/gateway/configs/mme.yml
+++ b/lte/gateway/configs/mme.yml
@@ -36,4 +36,3 @@ accept_combined_attach_tau_wo_csfb: true
 
 # Enable IPv6 support for S1AP SCTP endpoint
 s1ap_ipv6_enabled: true
-enable_IMS_VoPS_3GPP: false

--- a/lte/gateway/configs/mme.yml
+++ b/lte/gateway/configs/mme.yml
@@ -36,3 +36,4 @@ accept_combined_attach_tau_wo_csfb: true
 
 # Enable IPv6 support for S1AP SCTP endpoint
 s1ap_ipv6_enabled: true
+enable_IMS_VoPS_3GPP: false

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -355,4 +355,7 @@ AMF :
     GUAMFI_LIST = (
      { MCC="{{ mcc }}" ; MNC="{{ mnc }}"; AMF_REGION_ID="{{ amf_region_id }}" ; AMF_SET_ID="{{ amf_set_id }}"; AMF_POINTER="{{ amf_pointer }}"}
     );
+
+    # IMP VoPS FEATURE
+    ENABLE_IMS_VoPS_3GPP = "{{ enable_IMS_VoPS_3GPP }}";
 };


### PR DESCRIPTION
Signed-off-by: priya-wavelabs <priya.agrawal@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Added IE in registration accept to support for 5GS network feature support, added boolean flag for IMS-VoPS in mme.yml.

## Test Plan

-  Verified with Unit Test.
![image](https://user-images.githubusercontent.com/102359835/180945360-83e428a4-133b-462a-915d-5b583dbf2b31.png)

- Done basic sanity (basic registration, pdu session accept) with UERANSIM, Network feature support field is added to the registration accept message.
- Screen shot of the PCAP.
Change enable_IMS_VoPS_3GPP: true

![image](https://user-images.githubusercontent.com/102359835/180946879-acb4cb90-4fe8-4e65-9438-57c2631dfb0b.png)

Change enable_IMS_VoPS_3GPP: false

       
![image](https://user-images.githubusercontent.com/102359835/180946914-90b2f868-9dc1-4dbe-97bb-91570a707cab.png)

     

- PCAP in zip file.
[Packet_network_feature_support.zip](https://github.com/magma/magma/files/9187436/Packet_network_feature_support.zip)

- mme log.
[mme_network_feature_support.log](https://github.com/magma/magma/files/9187672/mme_network_feature_support.log)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
