### PR TITLE
feat(ci): Added initial build and upload workflow

### DIFF
--- a/.github/workflows/build_magma_dep.yml
+++ b/.github/workflows/build_magma_dep.yml
@@ -1,0 +1,78 @@
+---
+name: "Build Nettle and Upload to Artifactory"
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Artifactory Repository'
+        required: false
+        default: 'debian-test'
+      distribution:
+        description: 'Distribution'
+        required: false
+        default: 'focal-ci'
+      dry_run:
+        description: 'Dry Run (only preview all files that would be uploaded)'
+        required: true
+        default: true
+
+env:
+  MAGMA_PACKAGE_DIR: /home/runner/magma-packages
+  LIBNETTLE_PATH: /usr/lib/libnettle.so
+  ARTIFACTORY_URL: https://artifactory.magmacore.org:443/artifactory/
+
+jobs:
+  build_deps:
+    runs-on: ubuntu-20.04
+    if: contains('["maxhbr", "nstng", "Neudrino", "tmdzk", "alexzurbonsen", "MoritzThomasHuebner"]', github.actor)
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - name: Install fpm
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install -y ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
+      - name: Build nettle
+        shell: bash
+        run: |
+          mkdir -p ${MAGMA_PACKAGE_DIR}
+          cd third_party/build
+          ./build.py nettle --no-install
+          cp *.deb $MAGMA_PACKAGE_DIR
+      - name: Testing if .deb file can be installed
+        shell: bash
+        run: |
+          sudo apt install -y ${MAGMA_PACKAGE_DIR}/*.deb
+      - name: Testing is libnettle.so exists.
+        shell: bash
+        run: |
+          if test -f "$LIBNETTLE_PATH"; then
+              echo "$LIBNETTLE_PATH exists."
+          else
+              echo "$LIBNETTLE_PATH does not exist. Build failed. Exiting..."
+              exit 2
+          fi
+      - name: Upload zipped nettle.deb to Github
+        uses: actions/upload-artifact@v3
+        with:
+          name: nettle
+          path: ${{ env.MAGMA_PACKAGE_DIR }}
+      - name: Setup JFROG CLI
+        uses: jfrog/setup-jfrog-cli@v2
+        env:
+          JF_ENV_1: ${{ secrets.JFROG_TOKEN }}
+      - name: Set dry run environment variable
+        id: is_dry
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        run: |
+          echo "IS_DRY=--dry-run" >> $GITHUB_ENV
+      - name: Publish debian packages
+        run: |
+          jf rt u \
+            --recursive=false \
+            --url=${ARTIFACTORY_URL} \
+            --detailed-summary \
+            ${{ env.IS_DRY }} \
+            --target-props="deb.distribution=${{ github.event.inputs.distribution }};deb.component=main;deb.architecture=amd64" \
+            "~/magma-packages/(*).deb" ${{ github.event.inputs.repo }}/pool/${{ github.event.inputs.distribution }}/{1}.deb


### PR DESCRIPTION
Relating to #13450

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
Created in pairing with @alexzurbonsen 

## Summary
- Workflow builds nettle into a .deb file using fpm
- Workflow installs nettle with the .deb to test if the .deb works
- Extra check to see if the libnettle.so file exists
- Upload artifact to github
- Upload to artifactory
- Access is currently restricted to a certain set of users.

The actor can configure:
- The repository (default debian-test)
- The distribution (default focal-ci)
- Whether to do a try run, i.e. not actually upload the .deb (default true)

The magma repository probably still needs an access token for the artifactory. Currently, authentication works via username/password secrets. 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Manually tested using the dry-run option. Also tested with a temporary folder on the artifactory (janheidbrink) with a temporary token:
https://artifactory.magmacore.org/ui/repos/tree/General/janheidbrink%2Fpool%2Ffocal-ci%2Foai-nettle_2.5-1ubuntu20.04_amd64.deb

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
