### PR TITLE
chore: missing patches are added to bazel ryu setup

### DIFF
--- a/bazel/python_repositories.bzl
+++ b/bazel/python_repositories.bzl
@@ -30,6 +30,8 @@ def python_repositories(name = ""):
         patches = [
             "//lte/gateway/deploy/roles/magma/files/patches:ryu_ipfix_args.patch",
             "//lte/gateway/deploy/roles/magma/files/patches:0001-Set-unknown-dpid-ofctl-log-to-debug.patch",
+            "//lte/gateway/deploy/roles/magma/files/patches:0002-QFI-value-set-in-Openflow-controller-using-RYU.patch",
+            "//lte/gateway/deploy/roles/magma/files/patches:0003-QFI-value-set-in-Openflow-controller-using-RYU.patch",
         ],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

The patches were introduced in #12514 and added to the make build, but not to the bazel setup. Adding these patches is a requirement for #12529.

## Test Plan

There is afaik currently no test on master for this functionality (otherwise bazel test would be failing). A successful bazel build in CI should suffice for testing.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
