### PR TITLE
fix(agw): agw_health_cli.py fails sometimes due to presence of unread…

### DIFF
--- a/lte/gateway/python/magma/health/health_service.py
+++ b/lte/gateway/python/magma/health/health_service.py
@@ -65,7 +65,7 @@ class AGWHealth:
         return table.entries
 
     def get_registration_success_rate(self, mme_log_file):
-        with open(mme_log_file, 'r', encoding="utf-8") as f:
+        with open(mme_log_file, 'r', encoding="utf-8", errors='ignore') as f:
             log = f.read()
 
         return RegistrationSuccessRate(


### PR DESCRIPTION
…able chars in mme log files

Signed-off-by: sujay <sujay@radtonics.com>


    fix(agw): agw_health_cli.py fails sometimes due to presence of unreadable chars in mme log files


## Summary

The error was seen more often when mme log level was increased to debug, and usually seen after attaching a UE
Change is to ignore the errors while opening mme log file 

## Test Plan

Verified the CLI by loading the changed image and keeping mme log level to debug. Attached UE and repeated CLI again
CLI did not give any errors, it worked fine. 

