### PR TITLE
fix(ci): Update macos runner to versions 12

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -59,7 +59,7 @@ jobs:
           args: 'CWF integration test: docker build step failed on [${{ env.SHA }}](${{github.event.repository.owner.html_url}}/magma/commits/${{ env.SHA }}): ${{ steps.commit.outputs.title}}'
   cwf-integ-test:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-10.15
+    runs-on: macos-12
     needs: docker-build
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
@@ -70,10 +70,6 @@ jobs:
         with:
           path: ~/.vagrant.d/boxes
           key: vagrant-boxes-cwf-v20220722
-      - name: Setup Python env
-        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
-        with:
-          default: 3.8.5
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.10'

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -68,7 +68,7 @@ jobs:
 
   federated-integ-test:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-10.15
+    runs-on: macos-12
     env:
       SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
       MAGMA_ROOT: "${{ github.workspace }}"
@@ -77,10 +77,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.SHA }}
-      - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@v8"
-        with:
-          default: 3.8.5
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8.5'

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -3,7 +3,7 @@
 name: Federated integ test
 
 on:  # yamllint disable-line rule:truthy
-  workflow_dispatch:
+  workflow_dispatch: null
   workflow_run:
     workflows:
       - build-all
@@ -16,6 +16,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   # Build images on ubuntu which is faster than MacOs.
   docker-build-orc8r:
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
@@ -41,6 +42,7 @@ jobs:
           path: images
 
   docker-build-feg:
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       MAGMA_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   lte-integ-test-bazel:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-10.15
+    runs-on: macos-12
     env:
       SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
     steps:
@@ -38,10 +38,6 @@ jobs:
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v20220722
-      - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
-        with:
-          default: 3.8.5
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.10'

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   lte-integ-test:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-10.15
+    runs-on: macos-12
     env:
       SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
     steps:
@@ -38,10 +38,6 @@ jobs:
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v20220722
-      - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
-        with:
-          default: 3.8.5
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.10'


### PR DESCRIPTION


## Summary

macos 10 is no longer supported by github.

## Test Plan

