### PR TITLE
fix(amf): Proper Rejection or notification has to be sent to UE when  there is a static-IP configured for a subscriber is with in the subnet of IP_Pool Configured in Mobilityd

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -956,7 +956,7 @@ status_code_e amf_smf_handle_ip_address_response(
       }
     }
 
-    if (response_p->paa.pdn_type == IPv6) {
+    else if (response_p->paa.pdn_type == IPv6) {
       char ip_v6_str[INET6_ADDRSTRLEN] = {};
 
       inet_ntop(AF_INET6, &(response_p->paa.ipv6_address.s6_addr), ip_v6_str,
@@ -971,7 +971,7 @@ status_code_e amf_smf_handle_ip_address_response(
       }
     }
 
-    if (response_p->paa.pdn_type == IPv4_AND_v6) {
+    else if (response_p->paa.pdn_type == IPv4_AND_v6) {
       char ip_v4_str[INET_ADDRSTRLEN] = {};
       char ip_v6_str[INET6_ADDRSTRLEN] = {};
 
@@ -991,6 +991,11 @@ status_code_e amf_smf_handle_ip_address_response(
         OAILOG_ERROR(LOG_AMF_APP, "Create IPV4V6 Session \n");
       }
     }
+  } else {
+    amf_ue_ngap_id_t ue_id = ue_context->amf_ue_ngap_id;
+    int amf_cause = AMF_CAUSE_PROTOCOL_ERROR;
+    rc = amf_pdu_session_establishment_reject(ue_id, response_p->pdu_session_id,
+                                              response_p->pti, amf_cause);
   }
 
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -129,7 +129,7 @@ class IPAllocatorStaticWrapper(IPAllocator):
         if ip_addr_info.ip.version != self._ip_version:
             logging.debug("IP version mismatch, expected version: %d", self._ip_version)
             return None
-        # Validate static IP is not in any of IP pool.
+#Validate static IP is not in any of IP pool.
         for ip_pool in self._store.assigned_ip_blocks:
             if ip_addr_info.ip in ip_pool:
                 log_error_and_raise(
@@ -138,14 +138,15 @@ class IPAllocatorStaticWrapper(IPAllocator):
                     ip_addr_info.ip,
                     ip_pool,
                 )
+                return IPDesc()
 
-        # update gw info if available.
+#update gw info if available.
         if ip_addr_info.net_info.gw_ip:
             self._store.dhcp_gw_info.update_ip(
                 ip_addr_info.net_info.gw_ip,
                 ip_addr_info.net_info.vlan,
             )
-            # update mac if IP is present.
+#update mac if IP is present.
             if ip_addr_info.net_info.gw_mac != "":
                 self._store.dhcp_gw_info.update_mac(
                     ip_addr_info.net_info.gw_ip,


### PR DESCRIPTION


Signed-off-by: Rajeshs23 <rajesh.sure@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
