### PR TITLE
chore: py production scripts are bazelified

### DIFF
--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -51,6 +51,8 @@ envoy>=0.0.3
 jinja2>=2.8
 fire>=0.2.0
 python-dateutil==2.8.1
+docker>=4.0.2
+pystemd>=0.5.0
 
 # bazelbase container requirements
 hiredis

--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -46,6 +46,12 @@ tinyrpc==1.1.4
 webob==1.8.7
 ovs==2.16.0
 
+# scripts requirements
+envoy>=0.0.3
+jinja2>=2.8
+fire>=0.2.0
+python-dateutil==2.8.1
+
 # bazelbase container requirements
 hiredis
 deprecated

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -270,6 +270,10 @@ dnspython==1.16.0 \
     --hash=sha256:36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01 \
     --hash=sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d
     # via eventlet
+envoy==0.0.3 \
+    --hash=sha256:22b02009cfda2cf2cdb94a75a15ac3fd910aea8685c53e8e03715c7e9d8e8bde \
+    --hash=sha256:789d274f8bc00401848678c0ee18199c1a57901749ed6b1a03a3ea53ec72ceef
+    # via -r requirements.in
 eventlet==0.30.2 \
     --hash=sha256:1811b122d9a45eb5bafba092d36911bca825f835cb648a862bbf984030acff9d \
     --hash=sha256:89cc6dbfef47c4629cefead5fde21c5f2b33464d57f7df5fc5148f8b4de3fbb5
@@ -277,6 +281,9 @@ eventlet==0.30.2 \
 fakeredis==1.7.1 \
     --hash=sha256:7c2c4ba1b42e0a75337c54b777bf0671056b4569650e3ff927e4b9b385afc8ec \
     --hash=sha256:be3668e50f6b57d5fc4abfd27f9f655bed07a2c5aecfc8b15d0aad59f997c1ba
+    # via -r requirements.in
+fire==0.4.0 \
+    --hash=sha256:c5e2b8763699d1142393a46d0e3e790c5eb2f0706082df8f647878842c216a62
     # via -r requirements.in
 flask==2.0.3 \
     --hash=sha256:59da8a3170004800a2837844bfa84d49b022550616070f7cb1a659682b2e7c9f \
@@ -580,7 +587,9 @@ itsdangerous==2.1.0 \
 jinja2==3.0.3 \
     --hash=sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8 \
     --hash=sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7
-    # via flask
+    # via
+    #   -r requirements.in
+    #   flask
 js-regex==1.0.1 \
     --hash=sha256:08e4181bba68878bb2b29ff275f734a34ac2a4fed706977365d1aa527273e5a7 \
     --hash=sha256:de27bbf11b135a9cc7b03fc35f586705e286d6cd4fbbe112eaa577ed1c82a69f
@@ -1100,10 +1109,11 @@ pytest-cov==3.0.0 \
     --hash=sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6 \
     --hash=sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470
     # via -r requirements.in
-python-dateutil==2.8.2 \
-    --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
-    --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
+python-dateutil==2.8.1 \
+    --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
+    --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a
     # via
+    #   -r requirements.in
     #   bravado-core
     #   freezegun
 python-redis-lock==3.7.0 \
@@ -1267,6 +1277,7 @@ six==1.16.0 \
     #   bravado-core
     #   eventlet
     #   fakeredis
+    #   fire
     #   grpcio
     #   jsonschema
     #   python-dateutil
@@ -1299,6 +1310,9 @@ swagger-spec-validator==2.7.4 \
 systemd==0.16.1 \
     --hash=sha256:f44a02434cb1e6ff686bc7d25a7a665cc7af665965e933df3e76fa02d351a75b
     # via -r requirements.in
+termcolor==1.1.0 \
+    --hash=sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b
+    # via fire
 tinyrpc==1.1.4 \
     --hash=sha256:c99f412e5d9849c2deb468ea37fee2faf12fbc95bdd3616ae5c276ea195ed6bd
     # via -r requirements.in

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -270,6 +270,10 @@ dnspython==1.16.0 \
     --hash=sha256:36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01 \
     --hash=sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d
     # via eventlet
+docker==5.0.3 \
+    --hash=sha256:7a79bb439e3df59d0a72621775d600bc8bc8b422d285824cb37103eab91d1ce0 \
+    --hash=sha256:d916a26b62970e7c2f554110ed6af04c7ccff8e9f81ad17d0d40c75637e227fb
+    # via -r requirements.in
 envoy==0.0.3 \
     --hash=sha256:22b02009cfda2cf2cdb94a75a15ac3fd910aea8685c53e8e03715c7e9d8e8bde \
     --hash=sha256:789d274f8bc00401848678c0ee18199c1a57901749ed6b1a03a3ea53ec72ceef
@@ -1099,6 +1103,9 @@ pyrsistent==0.18.1 \
     --hash=sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5 \
     --hash=sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6
     # via jsonschema
+pystemd==0.10.0 \
+    --hash=sha256:d74a814bfda01085db1a8ad90be3cb27daf23a51ab6b03e7e29ec811fa2ae859
+    # via -r requirements.in
 pytest==7.0.1 \
     --hash=sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db \
     --hash=sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171
@@ -1186,6 +1193,7 @@ requests==2.27.1 \
     --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
     # via
     #   -r requirements.in
+    #   docker
     #   oslo-config
 rfc3986==2.0.0 \
     --hash=sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd \
@@ -1339,6 +1347,10 @@ webob==1.8.7 \
     --hash=sha256:73aae30359291c14fa3b956f8b5ca31960e420c28c1bec002547fb04928cf89b \
     --hash=sha256:b64ef5141be559cfade448f044fa45c2260351edcb6a8ef6b7e00c7dcef0c323
     # via -r requirements.in
+websocket-client==1.3.3 \
+    --hash=sha256:5d55652dc1d0b3c734f044337d929aaf83f4f9138816ec680c1aefefb4dc4877 \
+    --hash=sha256:d58c5f284d6a9bf8379dab423259fe8f85b70d5fa5d2916d5791a84594b122b1
+    # via docker
 werkzeug==2.0.3 \
     --hash=sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8 \
     --hash=sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c

--- a/bazel/scripts/check_py_bazel.sh
+++ b/bazel/scripts/check_py_bazel.sh
@@ -57,9 +57,6 @@ DENY_LIST_NOT_YET_BAZELIFIED=(
   "./orc8r/gateway/python/magma/common/health/docker_health_service.py"
   "./orc8r/gateway/python/magma/common/health/health_service.py"
   "./orc8r/gateway/python/magma/common/health/entities.py"
-  "./lte/gateway/python/magma/health/health_service.py"
-  "./lte/gateway/python/magma/health/entities.py"
-  "./lte/gateway/python/magma/pipelined/pg_set_session_msg.py"
   # TODO: GH12755 access via absolut path on the VM,
   # this needs to be refactored when make is not used anymore
   "./lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py"

--- a/bazel/scripts/check_py_bazel.sh
+++ b/bazel/scripts/check_py_bazel.sh
@@ -46,6 +46,7 @@ DENY_LIST_NOT_RELEVANT=(
   "./show-tech"
   "./third_party"
   "./hil_testing"
+  "./.git"
 )
 
 # Folders and files that are relevant for building with bazel.
@@ -53,10 +54,6 @@ DENY_LIST_NOT_RELEVANT=(
 DENY_LIST_NOT_YET_BAZELIFIED=(
   # TODO: GH12752 tests should be bazelified
   "./lte/gateway/python/integ_tests"
-  # TODO: GH12754 move to (lte|orc8r)/gateway/python/scripts/
-  "./orc8r/gateway/python/magma/common/health/docker_health_service.py"
-  "./orc8r/gateway/python/magma/common/health/health_service.py"
-  "./orc8r/gateway/python/magma/common/health/entities.py"
   # TODO: GH12755 access via absolut path on the VM,
   # this needs to be refactored when make is not used anymore
   "./lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py"

--- a/feg/protos/BUILD.bazel
+++ b/feg/protos/BUILD.bazel
@@ -72,6 +72,17 @@ cpp_grpc_library(
     deps = [":csfb_cpp_proto"],
 )
 
+python_proto_library(
+    name = "csfb_python_proto",
+    protos = [":csfb_proto"],
+)
+
+python_grpc_library(
+    name = "csfb_python_grpc",
+    protos = [":csfb_proto"],
+    deps = ["//orc8r/protos:common_python_proto"],
+)
+
 proto_library(
     name = "s8_proxy_proto",
     srcs = ["s8_proxy.proto"],
@@ -123,4 +134,41 @@ python_grpc_library(
     name = "hss_service_python_grpc",
     protos = [":hss_service_proto"],
     deps = [":hss_service_python_proto"],
+)
+
+proto_library(
+    name = "hello_proto",
+    srcs = ["hello.proto"],
+    deps = ["@com_google_protobuf//:timestamp_proto"],
+)
+
+python_grpc_library(
+    name = "hello_python_grpc",
+    protos = [":hello_proto"],
+)
+
+proto_library(
+    name = "mock_core_proto",
+    srcs = ["mock_core.proto"],
+    deps = [
+        ":csfb_proto",
+        "//lte/protos:policydb_proto",
+        "//lte/protos:session_manager_proto",
+        "//lte/protos:subscriberdb_proto",
+        "//orc8r/protos:common_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+python_grpc_library(
+    name = "mock_core_python_grpc",
+    protos = [":mock_core_proto"],
+    deps = [
+        ":csfb_python_proto",
+        "//lte/protos:policydb_python_proto",
+        "//lte/protos:session_manager_python_proto",
+        "//lte/protos:subscriberdb_python_proto",
+        "//orc8r/protos:common_python_proto",
+    ],
 )

--- a/lte/gateway/python/load_tests/BUILD.bazel
+++ b/lte/gateway/python/load_tests/BUILD.bazel
@@ -1,0 +1,87 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+MAGMA_ROOT = "../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+py_library(
+    name = "common",
+    srcs = ["common.py"],
+    deps = ["//lte/protos:subscriberdb_python_proto"],
+)
+
+py_binary(
+    name = "loadtest_mobilityd",
+    srcs = ["loadtest_mobilityd.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        ":common",
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        "//lte/protos:mobilityd_python_grpc",
+        "//lte/protos:subscriberdb_python_grpc",
+        "//orc8r/gateway/python/magma/common:service_registry",
+        requirement("protobuf"),
+    ],
+)
+
+py_binary(
+    name = "loadtest_pipelined",
+    srcs = ["loadtest_pipelined.py"],
+    imports = [LTE_ROOT],
+    legacy_create_init = False,
+    deps = [
+        ":common",
+        "//lte/gateway/python/magma/pipelined:policy_converters",
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        "//lte/gateway/python/scripts:pipelined_cli",
+        "//lte/protos:pipelined_python_proto",
+        requirement("protobuf"),
+    ],
+)
+
+py_binary(
+    name = "loadtest_sessiond",
+    srcs = ["loadtest_sessiond.py"],
+    imports = [LTE_ROOT],
+    legacy_create_init = False,
+    deps = [
+        ":common",
+        "//lte/protos:session_manager_python_proto",
+        requirement("protobuf"),
+    ],
+)
+
+py_binary(
+    name = "loadtest_subscriberdb",
+    srcs = ["loadtest_subscriberdb.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        ":common",
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        "//lte/protos:subscriberdb_python_grpc",
+        "//orc8r/gateway/python/magma/common:service_registry",
+        requirement("protobuf"),
+    ],
+)

--- a/lte/gateway/python/magma/health/BUILD.bazel
+++ b/lte/gateway/python/magma/health/BUILD.bazel
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 MAGMA_ROOT = "../../../../../"
@@ -45,5 +46,21 @@ py_library(
         "//orc8r/gateway/python/magma/common:job",
         "//orc8r/gateway/python/magma/common/health:service_state_wrapper",
         "//orc8r/gateway/python/magma/magmad/check:subprocess_workflow",
+    ],
+)
+
+py_library(
+    name = "health_service",
+    srcs = [
+        "entities.py",
+        "health_service.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lte/protos:enodebd_python_grpc",
+        "//lte/protos:mobilityd_python_grpc",
+        "//orc8r/gateway/python/magma/common:service_registry",
+        "//orc8r/gateway/python/magma/configuration:mconfig_managers",
+        requirement("python-dateutil"),
     ],
 )

--- a/lte/gateway/python/magma/mobilityd/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/BUILD.bazel
@@ -44,36 +44,65 @@ py_library(
     name = "mobilityd_lib",
     srcs = [
         "dhcp_client.py",
-        "dhcp_desc.py",
         "ip_address_man.py",
         "ip_allocator_base.py",
         "ip_allocator_dhcp.py",
         "ip_allocator_multi_apn.py",
         "ip_allocator_pool.py",
         "ip_allocator_static.py",
-        "ip_descriptor.py",
-        "ip_descriptor_map.py",
         "ipv6_allocator_pool.py",
-        "mac.py",
         "metrics.py",
-        "mobility_store.py",
         "rpc_servicer.py",
         "serialize_utils.py",
         "subscriberdb_client.py",
-        "uplink_gw.py",
-        "utils.py",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":dhcp_desc",
+        ":mobility_store",
         "//lte/gateway/python/magma/subscriberdb:sid",
-        "//lte/protos:keyval_python_proto",
         "//lte/protos:mobilityd_python_grpc",
         "//lte/protos:mobilityd_python_proto",
         "//lte/protos:subscriberdb_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
         "//orc8r/gateway/python/magma/common/redis:client",
-        requirement("netifaces"),
         requirement("scapy"),
         requirement("prometheus_client"),
     ],
+)
+
+py_library(
+    name = "mobility_store",
+    srcs = [
+        "ip_descriptor_map.py",
+        "mobility_store.py",
+        "uplink_gw.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":serialize_utils",
+        "//orc8r/gateway/python/magma/common/redis:containers",
+        requirement("redis"),
+        requirement("netifaces"),
+    ],
+)
+
+py_library(
+    name = "dhcp_desc",
+    srcs = [
+        "dhcp_desc.py",
+        "mac.py",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "serialize_utils",
+    srcs = [
+        "ip_descriptor.py",
+        "serialize_utils.py",
+        "utils.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["//lte/protos:keyval_python_proto"],
 )

--- a/lte/gateway/python/magma/pipelined/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/BUILD.bazel
@@ -247,3 +247,8 @@ py_library(
     name = "gw_mac_address",
     srcs = ["gw_mac_address.py"],
 )
+
+py_library(
+    name = "pg_set_session_msg",
+    srcs = ["pg_set_session_msg.py"],
+)

--- a/lte/gateway/python/magma/pipelined/tests/app/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/tests/app/BUILD.bazel
@@ -50,7 +50,6 @@ py_library(
 
 py_library(
     name = "subscriber",
-    testonly = True,
     srcs = ["subscriber.py"],
     deps = [
         "//lte/gateway/python/magma/subscriberdb:sid",

--- a/lte/gateway/python/magma/policydb/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/BUILD.bazel
@@ -45,24 +45,54 @@ py_binary(
 py_library(
     name = "policydb_lib",
     srcs = [
-        "apn_rule_map_store.py",
-        "basename_store.py",
-        "rating_group_store.py",
         "reauth_handler.py",
-        "rule_map_store.py",
-        "rule_store.py",
         "streamer_callback.py",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":apn_rule_map_store",
+        ":basename_store",
         ":default_rules",
+        ":rating_group_store",
+        ":rule_map_store",
+        ":rule_store",
         "//orc8r/gateway/python/magma/common:rpc_utils",
         "//orc8r/gateway/python/magma/common:sentry",
         "//orc8r/gateway/python/magma/common:serialization_utils",
         "//orc8r/gateway/python/magma/common:service",
         "//orc8r/gateway/python/magma/common:streamer",
-        "//orc8r/gateway/python/magma/common/redis:client",
     ],
+)
+
+py_library(
+    name = "rule_store",
+    srcs = ["rule_store.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "rule_map_store",
+    srcs = ["rule_map_store.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "rating_group_store",
+    srcs = ["rating_group_store.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "basename_store",
+    srcs = ["basename_store.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "apn_rule_map_store",
+    srcs = ["apn_rule_map_store.py"],
+    visibility = ["//visibility:public"],
+    deps = ["//orc8r/gateway/python/magma/common/redis:client"],
 )
 
 py_library(

--- a/lte/gateway/python/scripts/BUILD.bazel
+++ b/lte/gateway/python/scripts/BUILD.bazel
@@ -1,0 +1,428 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary")
+
+MAGMA_ROOT = "../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
+
+SCRIPTS_ROOT = "{}orc8r/gateway/python/scripts".format(MAGMA_ROOT)
+
+py_binary(
+    name = "agw_health_cli",
+    srcs = ["agw_health_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/gateway/python/magma/health:health_service",
+        requirement("fire"),
+    ],
+)
+
+py_binary(
+    name = "config_stateless_agw",
+    srcs = ["config_stateless_agw.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/protos:mconfigs_python_proto",
+        "//orc8r/gateway/python/magma/common/redis:client",
+        "//orc8r/gateway/python/magma/configuration:mconfig_managers",
+    ],
+)
+
+py_binary(
+    name = "cpe_monitoring_cli",
+    srcs = ["cpe_monitoring_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/protos:mobilityd_python_grpc",
+        "//orc8r/gateway/python/magma/common:service_registry",
+        requirement("fire"),
+    ],
+)
+
+py_binary(
+    name = "create_oai_certs",
+    srcs = ["create_oai_certs.py"],
+    legacy_create_init = False,
+    deps = [requirement("envoy")],
+)
+
+py_binary(
+    name = "dp_probe_cli",
+    srcs = ["dp_probe_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/protos:mconfigs_python_proto",
+        "//orc8r/gateway/python/magma/common:service",
+    ],
+)
+
+py_binary(
+    name = "enodebd_cli",
+    srcs = ["enodebd_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/protos:enodebd_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+    ],
+)
+
+py_binary(
+    name = "fake_user",
+    srcs = ["fake_user.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/gateway/python/magma/pipelined:imsi",
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        "//lte/protos:session_manager_python_grpc",
+        "//orc8r/gateway/python/magma/common:service_registry",
+        "//orc8r/gateway/python/magma/configuration:environment",
+        requirement("netifaces"),
+    ],
+)
+
+py_binary(
+    name = "feg_hello_cli",
+    srcs = ["feg_hello_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//feg/protos:hello_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+    ],
+)
+
+py_binary(
+    name = "generate_dnsd_config",
+    srcs = ["generate_dnsd_config.py"],
+    imports = [
+        ORC8R_ROOT,
+        SCRIPTS_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//orc8r/gateway/python/magma/common:misc_utils",
+        "//orc8r/gateway/python/scripts:generate_service_config",
+    ],
+)
+
+py_binary(
+    name = "generate_oai_config",
+    srcs = ["generate_oai_config.py"],
+    imports = [
+        ORC8R_ROOT,
+        SCRIPTS_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        ":create_oai_certs",
+        "//orc8r/gateway/python/magma/common:misc_utils",
+        "//orc8r/gateway/python/scripts:generate_service_config",
+    ],
+)
+
+py_binary(
+    name = "ha_cli",
+    srcs = ["ha_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/protos:ha_service_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        requirement("grpcio"),
+    ],
+)
+
+py_binary(
+    name = "hello_cli",
+    srcs = ["hello_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//feg/protos:hello_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+    ],
+)
+
+py_binary(
+    name = "icmpv6",
+    srcs = ["icmpv6.py"],
+    legacy_create_init = False,
+    deps = [requirement("scapy")],
+)
+
+py_binary(
+    name = "mobility_cli",
+    srcs = ["mobility_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        "//lte/protos:mobilityd_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+    ],
+)
+
+py_binary(
+    name = "mobility_dhcp_cli",
+    srcs = ["mobility_dhcp_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/gateway/python/magma/mobilityd:dhcp_desc",
+        "//lte/gateway/python/magma/mobilityd:mobility_store",
+    ],
+)
+
+py_binary(
+    name = "ocs_cli",
+    srcs = ["ocs_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//feg/protos:mock_core_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        requirement("grpcio"),
+    ],
+)
+
+py_binary(
+    name = "packet_ryu_cli",
+    srcs = ["packet_ryu_cli.py"],
+    imports = [LTE_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//lte/gateway/python/integ_tests/s1aptests/ovs:rest_api",
+        requirement("scapy"),
+    ],
+)
+
+py_binary(
+    name = "packet_tracer_cli",
+    srcs = ["packet_tracer_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = ["//orc8r/gateway/python/magma/configuration:service_configs"],
+)
+
+py_binary(
+    name = "pcrf_cli",
+    srcs = ["pcrf_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//feg/protos:mock_core_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        requirement("grpcio"),
+    ],
+)
+
+py_binary(
+    name = "pipelined_cli",
+    srcs = ["pipelined_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/gateway/python/magma/pipelined:ng_set_session_msg",
+        "//lte/gateway/python/magma/pipelined:pg_set_session_msg",
+        "//lte/gateway/python/magma/pipelined:service_manager",
+        "//lte/gateway/python/magma/pipelined/app:enforcement",
+        "//lte/gateway/python/magma/pipelined/qos:common",
+        "//lte/protos:apn_python_proto",
+        "//lte/protos:pipelined_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+    ],
+)
+
+py_binary(
+    name = "policydb_cli",
+    srcs = ["policydb_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/gateway/python/magma/policydb:apn_rule_map_store",
+        "//lte/gateway/python/magma/policydb:basename_store",
+        "//lte/gateway/python/magma/policydb:rating_group_store",
+        "//lte/gateway/python/magma/policydb:rule_map_store",
+        "//lte/gateway/python/magma/policydb:rule_store",
+        "//lte/protos:mobilityd_python_proto",
+        "//lte/protos:policydb_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        requirement("grpcio"),
+        requirement("protobuf"),
+    ],
+)
+
+py_binary(
+    name = "s6a_proxy_cli",
+    srcs = ["s6a_proxy_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//feg/protos:s6a_proxy_grpc_proto",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        requirement("grpcio"),
+    ],
+)
+
+py_binary(
+    name = "s6a_service_cli",
+    srcs = ["s6a_service_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//lte/protos:s6a_service_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+    ],
+)
+
+py_binary(
+    name = "session_manager_cli",
+    srcs = ["session_manager_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//feg/protos:mock_core_python_grpc",
+        "//lte/gateway/python/magma/pipelined:policy_converters",
+        "//lte/gateway/python/magma/pipelined/tests/app:subscriber",
+        "//lte/protos:abort_session_python_grpc",
+        "//lte/protos:session_manager_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        requirement("grpcio"),
+    ],
+)
+
+py_binary(
+    name = "sgs_cli",
+    srcs = ["sgs_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//feg/protos:csfb_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        requirement("grpcio"),
+    ],
+)
+
+py_binary(
+    name = "sms_cli",
+    srcs = ["sms_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//lte/protos:sms_orc8r_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        requirement("grpcio"),
+    ],
+)
+
+py_binary(
+    name = "spgw_service_cli",
+    srcs = ["spgw_service_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        "//lte/protos:policydb_python_proto",
+        "//lte/protos:spgw_service_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+    ],
+)
+
+py_binary(
+    name = "state_cli",
+    srcs = ["state_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/gateway/python/magma/mobilityd:serialize_utils",
+        "//lte/protos:keyval_python_proto",
+        "//lte/protos:policydb_python_proto",
+        "//lte/protos/oai:mme_nas_state_python_proto",
+        "//lte/protos/oai:s1ap_state_python_proto",
+        "//orc8r/gateway/python/magma/common/redis:client",
+        requirement("fire"),
+        requirement("jsonpickle"),
+    ],
+)
+
+py_binary(
+    name = "subscriber_cli",
+    srcs = ["subscriber_cli.py"],
+    imports = [
+        LTE_ROOT,
+        ORC8R_ROOT,
+    ],
+    legacy_create_init = False,
+    deps = [
+        "//lte/gateway/python/magma/subscriberdb:sid",
+        "//lte/protos:subscriberdb_python_grpc",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+    ],
+)
+
+py_binary(
+    name = "user_trace_cli",
+    srcs = ["user_trace_cli.py"],
+    legacy_create_init = False,
+)

--- a/lte/gateway/python/scripts/BUILD.bazel
+++ b/lte/gateway/python/scripts/BUILD.bazel
@@ -270,6 +270,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    visibility = ["//lte/gateway/python/load_tests:__pkg__"],
     deps = [
         "//lte/gateway/python/magma/pipelined:ng_set_session_msg",
         "//lte/gateway/python/magma/pipelined:pg_set_session_msg",

--- a/lte/protos/BUILD.bazel
+++ b/lte/protos/BUILD.bazel
@@ -321,6 +321,11 @@ python_proto_library(
 python_grpc_library(
     name = "pipelined_python_grpc",
     protos = [":pipelined_proto"],
+    deps = [
+        ":policydb_python_proto",
+        ":session_manager_python_proto",
+        "//orc8r/protos:common_python_proto",
+    ],
 )
 
 cpp_grpc_library(
@@ -375,6 +380,11 @@ proto_library(
         ":policydb_proto",
         ":subscriberdb_proto",
     ],
+)
+
+python_grpc_library(
+    name = "spgw_service_python_grpc",
+    protos = [":spgw_service_proto"],
 )
 
 proto_library(
@@ -536,12 +546,19 @@ proto_library(
 python_proto_library(
     name = "enodebd_python_proto",
     protos = [":enodebd_proto"],
-    deps = ["//orc8r/protos:service303_python_proto"],
+    deps = [
+        "//orc8r/protos:common_python_proto",
+        "//orc8r/protos:service303_python_proto",
+    ],
 )
 
 python_grpc_library(
     name = "enodebd_python_grpc",
     protos = [":enodebd_proto"],
+    deps = [
+        "//orc8r/protos:common_python_proto",
+        "//orc8r/protos:service303_python_proto",
+    ],
 )
 
 python_grpc_library(

--- a/lte/protos/oai/BUILD.bazel
+++ b/lte/protos/oai/BUILD.bazel
@@ -94,6 +94,49 @@ cpp_proto_library(
     ],
 )
 
+python_proto_library(
+    name = "spgw_state_python_proto",
+    protos = [":spgw_state_proto"],
+    deps = [
+        ":common_types_python_proto",
+        ":std_3gpp_types_python_proto",
+    ],
+)
+
+python_proto_library(
+    name = "nas_state_python_proto",
+    protos = [":nas_state_proto"],
+    deps = [
+        ":common_types_python_proto",
+        ":spgw_state_python_proto",
+    ],
+)
+
+python_proto_library(
+    name = "common_types_python_proto",
+    protos = [":common_types_proto"],
+)
+
+python_proto_library(
+    name = "std_3gpp_types_python_proto",
+    protos = [":std_3gpp_types_proto"],
+)
+
+python_proto_library(
+    name = "mme_nas_state_python_proto",
+    protos = [":mme_nas_state_proto"],
+    deps = [
+        ":common_types_python_proto",
+        ":nas_state_python_proto",
+        ":std_3gpp_types_python_proto",
+    ],
+)
+
+python_proto_library(
+    name = "s1ap_state_python_proto",
+    protos = [":s1ap_state_proto"],
+)
+
 proto_library(
     name = "s1ap_state_proto",
     srcs = ["s1ap_state.proto"],

--- a/orc8r/gateway/python/magma/common/BUILD.bazel
+++ b/orc8r/gateway/python/magma/common/BUILD.bazel
@@ -28,7 +28,10 @@ py_library(
 py_library(
     name = "rpc_utils",
     srcs = ["rpc_utils.py"],
-    deps = [":service_registry"],
+    deps = [
+        ":service_registry",
+        requirement("grpcio"),
+    ],
 )
 
 py_library(
@@ -43,7 +46,10 @@ py_library(
 py_library(
     name = "cert_utils",
     srcs = ["cert_utils.py"],
-    deps = [requirement("cryptography")],
+    deps = [
+        ":serialization_utils",
+        requirement("cryptography"),
+    ],
 )
 
 py_library(
@@ -95,7 +101,7 @@ py_library(
     name = "streamer",
     srcs = ["streamer.py"],
     deps = [
-        "//orc8r/gateway/python/magma/common:rpc_utils",
+        ":rpc_utils",
         "//orc8r/protos:streamer_python_grpc",
     ],
 )

--- a/orc8r/gateway/python/magma/common/health/BUILD.bazel
+++ b/orc8r/gateway/python/magma/common/health/BUILD.bazel
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -19,5 +20,24 @@ py_library(
     deps = [
         "//orc8r/gateway/python/magma/common/redis:client",
         "//orc8r/protos:service_status_python_proto",
+    ],
+)
+
+py_library(
+    name = "docker_health_service",
+    srcs = [
+        "docker_health_service.py",
+        "entities.py",
+        "health_service.py",
+    ],
+    deps = [
+        "//orc8r/gateway/python/magma/common:service",
+        "//orc8r/gateway/python/magma/magmad:metrics",
+        "//orc8r/gateway/python/magma/magmad:service_poller",
+        "//orc8r/protos:common_python_proto",
+        "//orc8r/protos:magmad_python_grpc",
+        requirement("python-dateutil"),
+        requirement("docker"),
+        requirement("pystemd"),
     ],
 )

--- a/orc8r/gateway/python/magma/magmad/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/BUILD.bazel
@@ -43,31 +43,27 @@ py_library(
         "config_manager.py",
         "events.py",
         "gateway_status.py",
-        "metrics.py",
         "metrics_collector.py",
         "proxy_client.py",
         "rpc_servicer.py",
         "service_health_watchdog.py",
         "service_manager.py",
-        "service_poller.py",
         "state_reporter.py",
         "sync_rpc_client.py",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":metrics",
+        ":service_poller",
         "//orc8r/gateway/python/magma/common:cert_utils",
         "//orc8r/gateway/python/magma/common:cert_validity",
         "//orc8r/gateway/python/magma/common:misc_utils",
-        "//orc8r/gateway/python/magma/common:rpc_utils",
         "//orc8r/gateway/python/magma/common:sdwatchdog",
-        "//orc8r/gateway/python/magma/common:sentry",
         "//orc8r/gateway/python/magma/common:service",
         "//orc8r/gateway/python/magma/common:stateless_agw",
         "//orc8r/gateway/python/magma/common:streamer",
-        "//orc8r/gateway/python/magma/common/health:service_state_wrapper",
         "//orc8r/gateway/python/magma/magmad/check/kernel_check:kernel_versions",
         "//orc8r/gateway/python/magma/magmad/check/machine_check:cpu_info",
-        "//orc8r/gateway/python/magma/magmad/check/network_check:ping",
         "//orc8r/gateway/python/magma/magmad/check/network_check:routing_table",
         "//orc8r/protos:bootstrapper_python_grpc",
         "//orc8r/protos:magmad_python_grpc",
@@ -77,7 +73,27 @@ py_library(
         "//orc8r/protos:sync_rpc_service_python_grpc",
         "//orc8r/swagger:magmad_events_v1",
         "@aioh2_repo//:aioh2",
-        requirement("psutil"),
         requirement("requests"),
+    ],
+)
+
+py_library(
+    name = "metrics",
+    srcs = ["metrics.py"],
+    visibility = ["//visibility:public"],  # TODO restrict?
+    deps = [
+        "//orc8r/gateway/python/magma/common/health:service_state_wrapper",
+        "//orc8r/gateway/python/magma/magmad/check/network_check:ping",
+        requirement("psutil"),
+    ],
+)
+
+py_library(
+    name = "service_poller",
+    srcs = ["service_poller.py"],
+    visibility = ["//visibility:public"],  # TODO restrict?
+    deps = [
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/gateway/python/magma/common:sentry",
     ],
 )

--- a/orc8r/gateway/python/scripts/BUILD.bazel
+++ b/orc8r/gateway/python/scripts/BUILD.bazel
@@ -10,11 +10,82 @@
 # limitations under the License.
 
 load("@python_deps//:requirements.bzl", "requirement")
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary")
 
-py_library(
+MAGMA_ROOT = "../../../../"
+
+ORC8R_ROOT = "{}orc8r/gateway/python".format(MAGMA_ROOT)
+
+py_binary(
+    name = "checkin_cli",
+    srcs = ["checkin_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//orc8r/gateway/python/magma/common:cert_utils",
+        "//orc8r/gateway/python/magma/common:cert_validity",
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/protos:service303_python_proto",
+        "//orc8r/protos:state_python_grpc",
+        requirement("snowflake"),
+    ],
+)
+
+py_binary(
+    name = "ctraced_cli",
+    srcs = ["ctraced_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/protos:ctraced_python_grpc",
+    ],
+)
+
+py_binary(
+    name = "directoryd_cli",
+    srcs = ["directoryd_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    deps = [
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/protos:directoryd_python_grpc",
+        requirement("grpcio"),
+    ],
+)
+
+py_binary(
+    name = "generate_fluent_bit_config",
+    srcs = ["generate_fluent_bit_config.py"],
+    legacy_create_init = False,
+    deps = [":generate_service_config"],
+)
+
+py_binary(
+    name = "generate_lighttpd_config",
+    srcs = ["generate_lighttpd_config.py"],
+    legacy_create_init = False,
+    deps = [
+        ":generate_service_config",
+        "//orc8r/gateway/python/magma/common:misc_utils",
+    ],
+)
+
+py_binary(
+    name = "generate_nghttpx_config",
+    srcs = ["generate_nghttpx_config.py"],
+    legacy_create_init = False,
+    deps = [
+        ":generate_service_config",
+        "//orc8r/gateway/python/magma/configuration:environment",
+    ],
+)
+
+py_binary(
     name = "generate_service_config",
     srcs = ["generate_service_config.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
     visibility = ["//visibility:public"],
     deps = [
         "//orc8r/gateway/python/magma/common:serialization_utils",
@@ -22,4 +93,86 @@ py_library(
         "//orc8r/gateway/python/magma/configuration:service_configs",
         requirement("jinja2"),
     ],
+)
+
+py_binary(
+    name = "health_cli",
+    srcs = ["health_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/gateway/python/magma/common/health:docker_health_service",
+        requirement("fire"),
+    ],
+)
+
+py_binary(
+    name = "magma_conditional_service",
+    srcs = ["magma_conditional_service.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    visibility = ["//visibility:public"],
+    deps = ["//orc8r/gateway/python/magma/configuration:mconfig_managers"],
+)
+
+py_binary(
+    name = "magma_get_config",
+    srcs = ["magma_get_config.py"],
+    legacy_create_init = False,
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
+    name = "magmad_cli",
+    srcs = ["magmad_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/protos:magmad_python_grpc",
+        "//orc8r/protos:mconfig_python_proto",
+        requirement("protobuf"),
+    ],
+)
+
+py_binary(
+    name = "service303_cli",
+    srcs = ["service303_cli.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/protos:service303_python_grpc",
+    ],
+)
+
+py_binary(
+    name = "service_util",
+    srcs = ["service_util.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    visibility = ["//visibility:public"],
+    deps = ["//orc8r/gateway/python/magma/common/health:service_state_wrapper"],
+)
+
+py_binary(
+    name = "show_gateway_info",
+    srcs = ["show_gateway_info.py"],
+    imports = [ORC8R_ROOT],
+    legacy_create_init = False,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:cert_utils",
+        requirement("snowflake"),
+    ],
+)
+
+py_binary(
+    name = "traffic_cli",
+    srcs = ["traffic_cli.py"],
+    legacy_create_init = False,
+    visibility = ["//visibility:public"],
 )

--- a/orc8r/gateway/python/scripts/BUILD.bazel
+++ b/orc8r/gateway/python/scripts/BUILD.bazel
@@ -9,17 +9,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library")
 
-package(default_visibility = ["//visibility:public"])
-
 py_library(
-    name = "constants",
-    srcs = ["__init__.py"],
-)
-
-py_library(
-    name = "rest_api",
-    srcs = ["rest_api.py"],
-    deps = [":constants"],
+    name = "generate_service_config",
+    srcs = ["generate_service_config.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/gateway/python/magma/common:serialization_utils",
+        "//orc8r/gateway/python/magma/configuration:mconfig_managers",
+        "//orc8r/gateway/python/magma/configuration:service_configs",
+        requirement("jinja2"),
+    ],
 )


### PR DESCRIPTION
## Summary

This change creates `py_binary` targets for all python scripts that are packaged into a magma debian build. This is a preparation for #13416.

## Test Plan

* make sure that all relevant scripts are bazelified
  * a recent magma debian package can be downloaded from https://artifactory.magmacore.org/artifactory/debian-test/pool/focal-ci/ and the output of `dpkg -c magma_foo.deb | grep "/usr/local/bin" | grep "\.py"` can be compared with the list of bazelified scripts.
* make sure that the targets do not have missing dependencies - basically run them and see that there are no ModuleNotFound issues [1]
* verify that the scripts behave the same as for the make build - this is the hard part, because almost all scripts do not run ootb on the magma vm. This needs a vm where `lte/gateway $ make run` was executed and magma is running.
  * run make scripts
    * `sudo source /etc/environment`
    * `sudo chmod a+r /var/log/syslog`
    * link scripts to `/usr/local/bin` [2]
    * run a script, e.g., `agw_health_cli.py`
  * run bazel scripts
    * do a fresh ssh login (in order to revert `source /etc/environment` from above)
    * fyi: we need to also link everything because some scripts call other scripts via subprocess calls
    * build all binaries [3]
    * link all binaries [4]
    * run a script, e.g., `agw_health_cli.py`

[1]
```
bazel run lte/gateway/python/scripts:agw_health_cli
bazel run lte/gateway/python/scripts:config_stateless_agw
bazel run lte/gateway/python/scripts:cpe_monitoring_cli
bazel run lte/gateway/python/scripts:create_oai_certs
bazel run lte/gateway/python/scripts:dp_probe_cli
bazel run lte/gateway/python/scripts:enodebd_cli
bazel run lte/gateway/python/scripts:fake_user
bazel run lte/gateway/python/scripts:feg_hello_cli
bazel run lte/gateway/python/scripts:generate_dnsd_config
bazel run lte/gateway/python/scripts:generate_oai_config
bazel run lte/gateway/python/scripts:ha_cli
bazel run lte/gateway/python/scripts:hello_cli
bazel run lte/gateway/python/scripts:icmpv6
bazel run lte/gateway/python/scripts:mobility_cli
bazel run lte/gateway/python/scripts:mobility_dhcp_cli
bazel run lte/gateway/python/scripts:ocs_cli
bazel run lte/gateway/python/scripts:packet_ryu_cli
bazel run lte/gateway/python/scripts:packet_tracer_cli
bazel run lte/gateway/python/scripts:pcrf_cli
bazel run lte/gateway/python/scripts:pipelined_cli
bazel run lte/gateway/python/scripts:policydb_cli
bazel run lte/gateway/python/scripts:s6a_proxy_cli
bazel run lte/gateway/python/scripts:s6a_service_cli
bazel run lte/gateway/python/scripts:session_manager_cli
bazel run lte/gateway/python/scripts:sgs_cli
bazel run lte/gateway/python/scripts:sms_cli
bazel run lte/gateway/python/scripts:spgw_service_cli
bazel run lte/gateway/python/scripts:state_cli
bazel run lte/gateway/python/scripts:subscriber_cli
bazel run lte/gateway/python/scripts:user_trace_cli
bazel run orc8r/gateway/python/scripts:checkin_cli
bazel run orc8r/gateway/python/scripts:ctraced_cli
bazel run orc8r/gateway/python/scripts:directoryd_cli
bazel run orc8r/gateway/python/scripts:generate_fluent_bit_config
bazel run orc8r/gateway/python/scripts:generate_lighttpd_config
bazel run orc8r/gateway/python/scripts:generate_nghttpx_config
bazel run orc8r/gateway/python/scripts:generate_service_config
bazel run orc8r/gateway/python/scripts:health_cli
bazel run orc8r/gateway/python/scripts:magma_conditional_service
bazel run orc8r/gateway/python/scripts:magma_get_config
bazel run orc8r/gateway/python/scripts:magmad_cli
bazel run orc8r/gateway/python/scripts:service303_cli
bazel run orc8r/gateway/python/scripts:service_util
bazel run orc8r/gateway/python/scripts:show_gateway_info
bazel run orc8r/gateway/python/scripts:traffic_cli
bazel run //lte/gateway/python/load_tests:loadtest_mobilityd
bazel run //lte/gateway/python/load_tests:loadtest_pipelined
bazel run //lte/gateway/python/load_tests:loadtest_sessiond
bazel run //lte/gateway/python/load_tests:loadtest_subscriberdb
```

[2]
```
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/agw_health_cli.py /usr/local/bin/agw_health_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/config_stateless_agw.py /usr/local/bin/config_stateless_agw.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/cpe_monitoring_cli.py /usr/local/bin/cpe_monitoring_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/create_oai_certs.py /usr/local/bin/create_oai_certs.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/dp_probe_cli.py /usr/local/bin/dp_probe_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/enodebd_cli.py /usr/local/bin/enodebd_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/fake_user.py /usr/local/bin/fake_user.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/feg_hello_cli.py /usr/local/bin/feg_hello_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/generate_dnsd_config.py /usr/local/bin/generate_dnsd_config.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/generate_oai_config.py /usr/local/bin/generate_oai_config.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/ha_cli.py /usr/local/bin/ha_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/hello_cli.py /usr/local/bin/hello_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/icmpv6.py /usr/local/bin/icmpv6.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/mobility_cli.py /usr/local/bin/mobility_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/mobility_dhcp_cli.py /usr/local/bin/mobility_dhcp_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/ocs_cli.py /usr/local/bin/ocs_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/packet_ryu_cli.py /usr/local/bin/packet_ryu_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/packet_tracer_cli.py /usr/local/bin/packet_tracer_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/pcrf_cli.py /usr/local/bin/pcrf_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/pipelined_cli.py /usr/local/bin/pipelined_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/policydb_cli.py /usr/local/bin/policydb_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/s6a_proxy_cli.py /usr/local/bin/s6a_proxy_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/s6a_service_cli.py /usr/local/bin/s6a_service_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/session_manager_cli.py /usr/local/bin/session_manager_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/sgs_cli.py /usr/local/bin/sgs_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/sms_cli.py /usr/local/bin/sms_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/spgw_service_cli.py /usr/local/bin/spgw_service_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/state_cli.py /usr/local/bin/state_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/subscriber_cli.py /usr/local/bin/subscriber_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/scripts/user_trace_cli.py /usr/local/bin/user_trace_cli.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/checkin_cli.py /usr/local/bin/checkin_cli.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/ctraced_cli.py /usr/local/bin/ctraced_cli.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/directoryd_cli.py /usr/local/bin/directoryd_cli.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/generate_fluent_bit_config.py /usr/local/bin/generate_fluent_bit_config.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/generate_lighttpd_config.py /usr/local/bin/generate_lighttpd_config.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/generate_nghttpx_config.py /usr/local/bin/generate_nghttpx_config.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/generate_service_config.py /usr/local/bin/generate_service_config.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/health_cli.py /usr/local/bin/health_cli.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/magma_conditional_service.py /usr/local/bin/magma_conditional_service.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/magma_get_config.py /usr/local/bin/magma_get_config.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/magmad_cli.py /usr/local/bin/magmad_cli.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/service303_cli.py /usr/local/bin/service303_cli.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/service_util.py /usr/local/bin/service_util.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/show_gateway_info.py /usr/local/bin/show_gateway_info.py
sudo ln -sf /home/vagrant/magma/orc8r/gateway/python/scripts/traffic_cli.py /usr/local/bin/traffic_cli.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/load_tests/loadtest_mobilityd.py /usr/local/bin/loadtest_mobilityd.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/load_tests/loadtest_pipelined.py /usr/local/bin/loadtest_pipelined.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/load_tests/loadtest_sessiond.py /usr/local/bin/loadtest_sessiond.py
sudo ln -sf /home/vagrant/magma/lte/gateway/python/load_tests/loadtest_subscriberdb.py /usr/local/bin/loadtest_subscriberdb.py
```

[3]
```
bazel build lte/gateway/python/scripts:agw_health_cli lte/gateway/python/scripts:config_stateless_agw lte/gateway/python/scripts:cpe_monitoring_cli lte/gateway/python/scripts:create_oai_certs lte/gateway/python/scripts:dp_probe_cli lte/gateway/python/scripts:enodebd_cli lte/gateway/python/scripts:fake_user lte/gateway/python/scripts:feg_hello_cli lte/gateway/python/scripts:generate_dnsd_config lte/gateway/python/scripts:generate_oai_config lte/gateway/python/scripts:ha_cli lte/gateway/python/scripts:hello_cli lte/gateway/python/scripts:icmpv6 lte/gateway/python/scripts:mobility_cli lte/gateway/python/scripts:mobility_dhcp_cli lte/gateway/python/scripts:ocs_cli lte/gateway/python/scripts:packet_ryu_cli lte/gateway/python/scripts:packet_tracer_cli lte/gateway/python/scripts:pcrf_cli lte/gateway/python/scripts:pipelined_cli lte/gateway/python/scripts:policydb_cli lte/gateway/python/scripts:s6a_proxy_cli lte/gateway/python/scripts:s6a_service_cli lte/gateway/python/scripts:session_manager_cli lte/gateway/python/scripts:sgs_cli lte/gateway/python/scripts:sms_cli lte/gateway/python/scripts:spgw_service_cli lte/gateway/python/scripts:state_cli lte/gateway/python/scripts:subscriber_cli lte/gateway/python/scripts:user_trace_cli orc8r/gateway/python/scripts:checkin_cli orc8r/gateway/python/scripts:ctraced_cli orc8r/gateway/python/scripts:directoryd_cli orc8r/gateway/python/scripts:generate_fluent_bit_config orc8r/gateway/python/scripts:generate_lighttpd_config orc8r/gateway/python/scripts:generate_nghttpx_config orc8r/gateway/python/scripts:generate_service_config orc8r/gateway/python/scripts:health_cli orc8r/gateway/python/scripts:magma_conditional_service orc8r/gateway/python/scripts:magma_get_config orc8r/gateway/python/scripts:magmad_cli orc8r/gateway/python/scripts:service303_cli orc8r/gateway/python/scripts:service_util orc8r/gateway/python/scripts:show_gateway_info orc8r/gateway/python/scripts:traffic_cli //lte/gateway/python/load_tests:loadtest_mobilityd //lte/gateway/python/load_tests:loadtest_pipelined //lte/gateway/python/load_tests:loadtest_sessiond //lte/gateway/python/load_tests:loadtest_subscriberdb
```

[4]
```
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/agw_health_cli /usr/local/bin/agw_health_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/config_stateless_agw /usr/local/bin/config_stateless_agw.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/cpe_monitoring_cli /usr/local/bin/cpe_monitoring_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/create_oai_certs /usr/local/bin/create_oai_certs.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/dp_probe_cli /usr/local/bin/dp_probe_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/enodebd_cli /usr/local/bin/enodebd_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/fake_user /usr/local/bin/fake_user.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/feg_hello_cli /usr/local/bin/feg_hello_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/generate_dnsd_config /usr/local/bin/generate_dnsd_config.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/generate_oai_config /usr/local/bin/generate_oai_config.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/ha_cli /usr/local/bin/ha_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/hello_cli /usr/local/bin/hello_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/icmpv6 /usr/local/bin/icmpv6.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/mobility_cli /usr/local/bin/mobility_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/mobility_dhcp_cli /usr/local/bin/mobility_dhcp_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/ocs_cli /usr/local/bin/ocs_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/packet_ryu_cli /usr/local/bin/packet_ryu_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/packet_tracer_cli /usr/local/bin/packet_tracer_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/pcrf_cli /usr/local/bin/pcrf_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/pipelined_cli /usr/local/bin/pipelined_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/policydb_cli /usr/local/bin/policydb_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/s6a_proxy_cli /usr/local/bin/s6a_proxy_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/s6a_service_cli /usr/local/bin/s6a_service_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/session_manager_cli /usr/local/bin/session_manager_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/sgs_cli /usr/local/bin/sgs_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/sms_cli /usr/local/bin/sms_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/spgw_service_cli /usr/local/bin/spgw_service_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/state_cli /usr/local/bin/state_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/subscriber_cli /usr/local/bin/subscriber_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/scripts/user_trace_cli /usr/local/bin/user_trace_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/checkin_cli /usr/local/bin/checkin_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/ctraced_cli /usr/local/bin/ctraced_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/directoryd_cli /usr/local/bin/directoryd_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/generate_fluent_bit_config /usr/local/bin/generate_fluent_bit_config.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/generate_lighttpd_config /usr/local/bin/generate_lighttpd_config.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/generate_nghttpx_config /usr/local/bin/generate_nghttpx_config.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/generate_service_config /usr/local/bin/generate_service_config.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/health_cli /usr/local/bin/health_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/magma_conditional_service /usr/local/bin/magma_conditional_service.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/magma_get_config /usr/local/bin/magma_get_config.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/magmad_cli /usr/local/bin/magmad_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/service303_cli /usr/local/bin/service303_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/service_util /usr/local/bin/service_util.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/show_gateway_info /usr/local/bin/show_gateway_info.py
sudo ln -sf /home/vagrant/magma/bazel-bin/orc8r/gateway/python/scripts/traffic_cli /usr/local/bin/traffic_cli.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/load_tests/loadtest_mobilityd /usr/local/bin/loadtest_mobilityd.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/load_tests/loadtest_pipelined /usr/local/bin/loadtest_pipelined.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/load_tests/loadtest_sessiond /usr/local/bin/loadtest_sessiond.py
sudo ln -sf /home/vagrant/magma/bazel-bin/lte/gateway/python/load_tests/loadtest_subscriberdb /usr/local/bin/loadtest_subscriberdb.py
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
