### PR TITLE
feat(nms): Integrate FEG gateway upgrade UI into equipment page

### DIFF
--- a/nms/app/components/feg/FEGContext.tsx
+++ b/nms/app/components/feg/FEGContext.tsx
@@ -15,6 +15,7 @@ import * as React from 'react';
 import {FEGGatewayContextProvider} from '../../context/FEGGatewayContext';
 import {FEGNetworkContextProvider} from '../../context/FEGNetworkContext';
 import {FEGSubscriberContextProvider} from '../../context/FEGSubscriberContext';
+import {GatewayTierContextProvider} from '../../context/GatewayTierContext';
 import {NetworkId} from '../../../shared/types/network';
 
 /**
@@ -31,9 +32,11 @@ export function FEGContextProvider(props: {
   return (
     <FEGNetworkContextProvider networkId={networkId}>
       <FEGSubscriberContextProvider networkId={networkId}>
-        <FEGGatewayContextProvider networkId={networkId}>
-          {props.children}
-        </FEGGatewayContextProvider>
+        <GatewayTierContextProvider networkId={networkId}>
+          <FEGGatewayContextProvider networkId={networkId}>
+            {props.children}
+          </FEGGatewayContextProvider>
+        </GatewayTierContextProvider>
       </FEGSubscriberContextProvider>
     </FEGNetworkContextProvider>
   );

--- a/nms/app/views/equipment/EquipmentGateway.tsx
+++ b/nms/app/views/equipment/EquipmentGateway.tsx
@@ -434,7 +434,7 @@ function UpgradeTable() {
             });
             const dataUpdate = [...lteGatewayUpgradeRows];
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            const index = (oldData as any).tableData.id as number;
+            const index = (oldData as any).tableData.index as number;
             dataUpdate[index] = newData;
             setLteGatewayUpgradeRows([...dataUpdate]);
           } catch (e) {

--- a/nms/app/views/equipment/FEGEquipmentDashboard.tsx
+++ b/nms/app/views/equipment/FEGEquipmentDashboard.tsx
@@ -21,6 +21,8 @@ import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import React from 'react';
 import TopBar from '../../components/TopBar';
+import UpgradeButton from './UpgradeTiersDialog';
+
 import {FEGAddGatewayButton} from '../../components/feg/FEGGatewayDialog';
 import {Navigate, Route, Routes} from 'react-router-dom';
 import {Theme} from '@material-ui/core/styles';
@@ -67,7 +69,20 @@ function EquipmentDashboardInternal() {
             label: 'Federation Gateways',
             to: 'gateway',
             icon: CellWifiIcon,
-            filters: <FEGAddGatewayButton />,
+            filters: (
+              <Grid
+                container
+                justifyContent="flex-end"
+                alignItems="center"
+                spacing={2}>
+                <Grid item>
+                  <UpgradeButton />
+                </Grid>
+                <Grid item>
+                  <FEGAddGatewayButton />
+                </Grid>
+              </Grid>
+            ),
           },
         ]}
       />

--- a/nms/app/views/equipment/FEGGatewayTable.tsx
+++ b/nms/app/views/equipment/FEGGatewayTable.tsx
@@ -21,13 +21,21 @@ import CellWifiIcon from '@material-ui/icons/CellWifi';
 import CheckIcon from '@material-ui/icons/Check';
 import DeviceStatusCircle from '../../theme/design-system/DeviceStatusCircle';
 import FEGGatewayContext from '../../context/FEGGatewayContext';
+import GatewayTierContext from '../../context/GatewayTierContext';
 import Grid from '@material-ui/core/Grid';
 import Link from '@material-ui/core/Link';
+import MenuItem from '@material-ui/core/MenuItem';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
 import React, {useContext, useState} from 'react';
+import Select from '@material-ui/core/Select';
+import Text from '../../theme/design-system/Text';
+
 import withAlert from '../../components/Alert/withAlert';
 import {GatewayId} from '../../../shared/types/network';
 import {GatewayTypeEnum, HEALTHY_STATUS} from '../../components/GatewayUtils';
 import {REFRESH_INTERVAL} from '../../context/AppContext';
+import {SelectEditComponent} from '../../components/ActionTable';
+import {getErrorMessage} from '../../util/ErrorUtils';
 import {useEnqueueSnackbar} from '../../hooks/useSnackbar';
 import {useInterval} from '../../hooks';
 import {useNavigate} from 'react-router-dom';
@@ -45,6 +53,10 @@ type EquipmentFegGatewayRowType = {
   csfb: string;
 };
 
+const ViewTypes = {
+  STATUS: 'Status',
+  UPGRADE: 'Upgrade',
+};
 /**
  * Displays the number of federation gateways alonside with a table showing
  * each federation gateway.
@@ -52,6 +64,9 @@ type EquipmentFegGatewayRowType = {
 export default function GatewayTable() {
   const ctx = useContext(FEGGatewayContext);
   const [refresh, setRefresh] = useState(true);
+  const [currentView, setCurrentView] = useState<
+    typeof ViewTypes[keyof typeof ViewTypes]
+  >('Status');
 
   return (
     <>
@@ -65,16 +80,38 @@ export default function GatewayTable() {
             justifyContent="flex-end"
             alignItems="center"
             spacing={1}>
+            {currentView !== ViewTypes.UPGRADE && (
+              <Grid item>
+                <AutorefreshCheckbox
+                  autorefreshEnabled={refresh}
+                  onToggle={() => setRefresh(current => !current)}
+                />
+              </Grid>
+            )}
             <Grid item>
-              <AutorefreshCheckbox
-                autorefreshEnabled={refresh}
-                onToggle={() => setRefresh(current => !current)}
-              />
+              <Text variant="body3">View</Text>
+            </Grid>
+            <Grid item>
+              <Select
+                value={currentView}
+                input={<OutlinedInput />}
+                onChange={({target}) => setCurrentView(target.value as string)}>
+                <MenuItem key={ViewTypes.STATUS} value={ViewTypes.STATUS}>
+                  Status
+                </MenuItem>
+                <MenuItem key={ViewTypes.UPGRADE} value={ViewTypes.UPGRADE}>
+                  Upgrade
+                </MenuItem>
+              </Select>
             </Grid>
           </Grid>
         )}
       />
-      <StatusTable refresh={refresh} />
+      {currentView === ViewTypes.UPGRADE ? (
+        <UpgradeTable />
+      ) : (
+        <StatusTable refresh={refresh} />
+      )}
     </>
   );
 }
@@ -209,3 +246,113 @@ function GatewayStatusTable(props: WithAlert & {refresh: boolean}) {
   );
 }
 const StatusTable = withAlert(GatewayStatusTable);
+
+type EquipmentGatewayUpgradeType = {
+  name: string;
+  id: GatewayId;
+  hardwareId: string;
+  tier: string;
+  currentVersion: string;
+};
+function UpgradeTable() {
+  const tierCtx = useContext(GatewayTierContext);
+  const gwCtx = useContext(FEGGatewayContext);
+  const navigate = useNavigate();
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  const fegGatewayRows: Array<EquipmentGatewayUpgradeType> = [];
+  Object.keys(gwCtx.state)
+    .map((gwId: string) => gwCtx.state[gwId])
+    .map((gateway: FederationGateway) => {
+      const packages = gateway.status?.platform_info?.packages || [];
+      fegGatewayRows.push({
+        name: gateway.name,
+        id: gateway.id,
+        hardwareId: gateway.device?.hardware_id || '-',
+        tier: gateway.tier,
+        currentVersion:
+          packages.find(p => p.name === 'magma')?.version || 'Not Reported',
+      });
+    });
+  const [fegGatewayUpgradeRows, setFegGatewayUpgradeRows] = useState(
+    fegGatewayRows,
+  );
+  return (
+    <ActionTable
+      data={fegGatewayUpgradeRows}
+      columns={[
+        {title: 'Name', field: 'name', editable: 'never'},
+        {
+          title: 'ID',
+          field: 'id',
+          editable: 'never',
+          render: currRow => (
+            <Link
+              variant="body2"
+              component="button"
+              onClick={() => navigate(currRow.id)}>
+              {currRow.id}
+            </Link>
+          ),
+        },
+        {
+          title: 'Hardware ID',
+          field: 'hardwareId',
+          editable: 'never',
+        },
+        {
+          title: 'Current Version',
+          field: 'currentVersion',
+          editable: 'never',
+          width: 250,
+        },
+        {
+          title: 'Tier',
+          field: 'tier',
+          width: 100,
+          editComponent: props => (
+            <SelectEditComponent
+              {...props}
+              defaultValue={props.value as string}
+              value={props.value as string}
+              content={Object.keys(tierCtx.state.tiers)}
+              onChange={value => props.onChange(value)}
+            />
+          ),
+        },
+      ]}
+      options={{
+        actionsColumnIndex: -1,
+        pageSizeOptions: [5, 10],
+      }}
+      editable={{
+        onRowUpdate: async (newData, oldData) => {
+          try {
+            if (newData.tier) {
+              // Update tier id
+              await gwCtx.updateGateway({
+                gatewayId: newData.id,
+                tierId: newData.tier,
+              });
+              const dataUpdate = [...fegGatewayUpgradeRows];
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              const index = (oldData as any).tableData.index as number;
+              dataUpdate[index] = newData;
+              setFegGatewayUpgradeRows([...dataUpdate]);
+            } else {
+              throw Error('Invalid tier');
+            }
+          } catch (e) {
+            enqueueSnackbar(
+              `failed saving gateway tier information: ${getErrorMessage(e)}`,
+              {
+                variant: 'error',
+              },
+            );
+            throw e;
+          }
+        },
+      }}
+    />
+  );
+}

--- a/nms/app/views/equipment/__tests__/FEGGatewayConnectionStatusTest.tsx
+++ b/nms/app/views/equipment/__tests__/FEGGatewayConnectionStatusTest.tsx
@@ -89,6 +89,7 @@ describe('<FEGGatewayConnectionStatus />', () => {
             value={{
               state: fegGateways,
               setState: async () => {},
+              updateGateway: async () => {},
               refetch: () => {},
               health: fegGatewaysHealth,
               activeFegGatewayId: mockGw0.id,

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.tsx
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.tsx
@@ -138,6 +138,7 @@ describe('<FEGGatewayDetailStatus />', () => {
             value={{
               state: fegGateways,
               setState: async () => {},
+              updateGateway: async () => {},
               refetch: () => {},
               health: fegGatewaysHealth,
               activeFegGatewayId: mockGw0.id,

--- a/nms/app/views/equipment/__tests__/FEGGatewaySummaryTest.tsx
+++ b/nms/app/views/equipment/__tests__/FEGGatewaySummaryTest.tsx
@@ -106,6 +106,7 @@ describe('<FEGEquipmentGateway />', () => {
             value={{
               state: fegGateways,
               setState: async () => {},
+              updateGateway: async () => {},
               refetch: () => {},
               health: fegGatewaysHealth,
               activeFegGatewayId: mockGw0.id,


### PR DESCRIPTION
Signed-off-by: HannaFar <hannafarag159@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Add gateway upgrade button and gateways upgrade view to feg gateway
fix minor bug in gateway equipment upgrade


 
<img width="1790" alt="Capture d’écran 2022-07-28 à 17 47 50" src="https://user-images.githubusercontent.com/26038920/181581544-819af4b8-3911-46f4-a27b-e509fc1f2694.png">

Closes #13372

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
