### PR TITLE
fix(ci): Use yarn for reviewdog eslint

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -127,6 +127,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
+      - name: setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: install dependencies
+        run: yarn install
+        working-directory: 'nms/'
       - name: eslint
         uses: reviewdog/action-eslint@v1
         with:


### PR DESCRIPTION
## Summary

The reviewdog eslint workflow uses npm to build the NMS. Npm seems to be unhappy about unmet peer dependancies after the react upgrade and refuses to build. This is not the case for yarn. Also when using npm the lock file will not be used.

![Screenshot 2022-07-28 at 18 44 20](https://user-images.githubusercontent.com/102796295/181593232-5b2d4f69-003c-4b2f-a58f-265049723648.png)

   

Here is a successful run
https://github.com/magma/magma/runs/7575020742?check_suite_focus=true
