### PR TITLE
fix(nms): clean up node installation with make

### DIFF
--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -174,28 +174,11 @@ else ifeq ($(OS_NAME),Darwin)
 	$(MAKE) nms_prereqs_osx
 endif
 
-nms_prereqs_ubuntu: nms_node_ubuntu
-	NODE="$(shell which nodejs)"; ln -s $$NODE /usr/local/bin/node
-	# update nodejs to latest
+nms_prereqs_ubuntu:
 	curl -sL https://deb.nodesource.com/setup_lts.x | bash -
-	apt-get install -y nodejs
-	# get codegen dependency
+	apt install -y nodejs
 	npm install --global yarn
 	yarn
-
-nms_node_ubuntu:
-	# install pre-reqs
-	apt update
-	# Handle certificate verification
-	apt-get install -y libgnutls30
-	# Get a newer version of nodejs
-	curl -fSL https://deb.nodesource.com/setup_14.x | bash -
-	apt-get install -y nodejs
-	# And now install npm
-	apt install -y aptitude
-	aptitude install -y npm
-	# symlink nodejs executable
-	mkdir -p /usr/local/bin
 
 nms_prereqs_osx:
 	node --version || brew install node


### PR DESCRIPTION
## Summary

The NMS setup for code generation was buggy and overly complex. Especially there were two different node versions installed at the same time, which lead to package conflicts.

## Test Plan

- `magma/orc/cloud$ make nms_fullgen`
- `magma/orc/cloud/docker$ ./build.py --generate`
  - :heavy_check_mark: https://github.com/magma/magma/runs/7581342542?check_suite_focus=true#step:5:1963

## Additional Information

- Node JS automatically also installs npm.
- `libgnutls30` is already installed on Ubuntu.
- Installing stuff with apt does not need extra linking into the bin folder.
- Noticed during testing of https://github.com/magma/magma/issues/13460.