### PR TITLE
fix(amf): Adding Reject if Static ip configured is in subset of ip_pool

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -928,6 +928,16 @@ status_code_e amf_smf_handle_ip_address_response(
                  reinterpret_cast<char*>(response_p->pdu_session_id));
     return rc;
   }
+  if (response_p->result != SGI_STATUS_OK) {
+    rc = amf_pdu_session_establishment_reject(
+        ue_context->amf_ue_ngap_id, response_p->pdu_session_id, response_p->pti,
+        AMF_CAUSE_PROTOCOL_ERROR);
+    ue_context->amf_context.smf_ctxt_map.erase(response_p->pdu_session_id);
+    OAILOG_ERROR(LOG_AMF_APP,
+                 "Ip address allocation failed. Rejecting with cause %d",
+                 AMF_CAUSE_PROTOCOL_ERROR);
+    OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);
+  }
 
   rc = amf_update_smf_context_pdu_ip(smf_ctx, &(response_p->paa));
 


### PR DESCRIPTION
Signed-off-by: Sathyaj27 <sathya.jayadev@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
When static ip is configured in subset of ip_pool reject should be handled instead of no response.


<!-- Enumerate changes you made and why you made them -->

## Test Plan
-Tested on UEransim
<img width="936" alt="Rajeshsnew" src="https://user-images.githubusercontent.com/94469973/182345622-a67b9a69-a5d7-41f3-a58a-4847773643fc.PNG">

4g Cases working fine. Ran s1ap integration test.
<img width="957" alt="4G" src="https://user-images.githubusercontent.com/94469973/186882454-950b33eb-aacc-4ad5-bf13-8ff30fb5e5b9.PNG">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is not backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
