### PR TITLE
fix(nms): set e2e test timeout including setup

### DIFF
--- a/nms/app/e2e/__tests__/Apn-test.ts
+++ b/nms/app/e2e/__tests__/Apn-test.ts
@@ -14,10 +14,10 @@
 import puppeteer, {Browser} from 'puppeteer';
 import {ARTIFACTS_DIR, SimulateNMSLogin} from '../LoginUtils';
 
+jest.setTimeout(60000);
+
 let browser: Browser;
 beforeEach(async () => {
-  jest.setTimeout(60000);
-
   browser = await puppeteer.launch({
     args: ['--ignore-certificate-errors', '--window-size=1920,1080'],
     headless: true,
@@ -54,7 +54,7 @@ describe('NMS', () => {
     await page.screenshot({
       path: ARTIFACTS_DIR + 'apn_dashboard.png',
     });
-  }, 60000);
+  });
 });
 
 describe('NMS Apn Add', () => {
@@ -92,7 +92,7 @@ describe('NMS Apn Add', () => {
     await page.screenshot({
       path: ARTIFACTS_DIR + 'apn_add.png',
     });
-  }, 60000);
+  });
 });
 
 describe('NMS APN Edit', () => {
@@ -131,5 +131,5 @@ describe('NMS APN Edit', () => {
     await page.screenshot({
       path: ARTIFACTS_DIR + 'apn_edit.png',
     });
-  }, 60000);
+  });
 });

--- a/nms/app/e2e/__tests__/App-test.ts
+++ b/nms/app/e2e/__tests__/App-test.ts
@@ -14,9 +14,10 @@
 import puppeteer, {Browser} from 'puppeteer';
 import {ARTIFACTS_DIR, SimulateNMSLogin} from '../LoginUtils';
 
+jest.setTimeout(60000);
+
 let browser: Browser;
 beforeEach(async () => {
-  jest.setTimeout(60000);
   browser = await puppeteer.launch({
     args: ['--ignore-certificate-errors', '--window-size=1920,1080'],
     headless: true,
@@ -42,5 +43,5 @@ describe('NMS dashboard', () => {
 
     await page.screenshot({path: ARTIFACTS_DIR + 'dashboard.png'});
     await browser.close();
-  }, 60000);
+  });
 });

--- a/nms/app/e2e/__tests__/FegLte-test.ts
+++ b/nms/app/e2e/__tests__/FegLte-test.ts
@@ -20,9 +20,10 @@ const ADMIN_NW_SELECTOR = `//a[starts-with(@href, '/nms/test/admin/networks')]`;
 const PROFILE_BUTTON_SELECTOR = `//*[@data-testid='profileButton']`;
 const NETWORK_SELECTOR_SELECTOR = `//*[@data-testid='networkSelector']`;
 
+jest.setTimeout(60000);
+
 let browser: Browser;
 beforeEach(async () => {
-  jest.setTimeout(60000);
   browser = await puppeteer.launch({
     args: ['--ignore-certificate-errors', '--window-size=1920,1080'],
     headless: true,
@@ -82,7 +83,7 @@ describe('Admin component', () => {
       path: ARTIFACTS_DIR + 'organization_network_list.png',
     });
     await page.close();
-  }, 60000);
+  });
 });
 
 describe('NMS', () => {
@@ -172,7 +173,7 @@ describe('NMS', () => {
       await page.close();
       throw err;
     }
-  }, 60000);
+  });
 
   test('verifying feg_lte dashboard', async () => {
     const page = await browser.newPage();
@@ -225,5 +226,5 @@ describe('NMS', () => {
     await page.screenshot({
       path: ARTIFACTS_DIR + 'feg_lte_network_dashboard.png',
     });
-  }, 60000);
+  });
 });

--- a/nms/app/e2e/__tests__/Policy-test.ts
+++ b/nms/app/e2e/__tests__/Policy-test.ts
@@ -14,9 +14,10 @@
 import puppeteer, {Browser} from 'puppeteer';
 import {ARTIFACTS_DIR, SimulateNMSLogin} from '../LoginUtils';
 
+jest.setTimeout(60000);
+
 let browser: Browser;
 beforeEach(async () => {
-  jest.setTimeout(60000);
   browser = await puppeteer.launch({
     args: ['--ignore-certificate-errors', '--window-size=1920,1080'],
     headless: true,
@@ -54,7 +55,7 @@ describe('NMS', () => {
     await page.screenshot({
       path: ARTIFACTS_DIR + 'policy_dashboard.png',
     });
-  }, 60000);
+  });
 });
 
 // TODO (andreilee): Get these tests working again without flakiness
@@ -126,7 +127,7 @@ describe('NMS', () => {
 //     await page.screenshot({
 //       path: ARTIFACTS_DIR + 'policy_add.png',
 //     });
-//   }, 60000);
+//   });
 // });
 
 // describe('NMS Policy Edit', () => {
@@ -168,5 +169,5 @@ describe('NMS', () => {
 //     await page.screenshot({
 //       path: ARTIFACTS_DIR + 'policy_edit.png',
 //     });
-//   }, 60000);
+//   });
 // });

--- a/nms/app/e2e/__tests__/Subscriber-test.ts
+++ b/nms/app/e2e/__tests__/Subscriber-test.ts
@@ -14,9 +14,10 @@
 import puppeteer, {Browser} from 'puppeteer';
 import {ARTIFACTS_DIR, SimulateNMSLogin} from '../LoginUtils';
 
+jest.setTimeout(60000);
+
 let browser: Browser;
 beforeEach(async () => {
-  jest.setTimeout(60000);
   browser = await puppeteer.launch({
     args: ['--ignore-certificate-errors', '--window-size=1920,1080'],
     headless: true,
@@ -55,7 +56,7 @@ describe('NMS', () => {
     await page.screenshot({
       path: ARTIFACTS_DIR + 'subscriber_dashboard.png',
     });
-  }, 60000);
+  });
 });
 
 // describe('NMS Subscriber Add', () => {
@@ -123,7 +124,7 @@ describe('NMS', () => {
 //     await page.screenshot({
 //       path: ARTIFACTS_DIR + 'subscriber_add.png',
 //     });
-//   }, 60000);
+//   });
 // });
 
 // describe('NMS Subscriber Edit', () => {
@@ -180,5 +181,5 @@ describe('NMS', () => {
 //     await page.screenshot({
 //       path: ARTIFACTS_DIR + 'subscriber_edit.png',
 //     });
-//   }, 60000);
+//   });
 // });


### PR DESCRIPTION
## Summary

- tests would be flaky at the puppeteer execution before.

## Test Plan

- run nms-e2e-test CI 5 times in a row green on this PR
  - https://github.com/magma/magma/actions/runs/2783345884 see runs on top right.