### PR TITLE
chore(dp): add 401 GRANT_CONFLICT response handling

### DIFF
--- a/dp/cloud/python/magma/configuration_controller/custom_types/custom_types.py
+++ b/dp/cloud/python/magma/configuration_controller/custom_types/custom_types.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Dict, List, NamedTuple
+from typing import Any, Dict, List, NamedTuple, Optional
 
 from magma.db_service.models import DBRequest
 
@@ -20,6 +20,25 @@ RequestsMap = Dict[str, List[DBRequest]]
 
 
 class DBResponse(NamedTuple):
+    """ Class representing single response from SAS. """
     response_code: int
     payload: Dict[str, Any]
     request: DBRequest
+
+    @property
+    def cbsd_id(self) -> Optional[str]:
+        """ Get cbsd_id that request refers to.
+
+        Returns:
+            string
+        """
+        return self.payload.get('cbsdId') or self.request.payload.get('cbsdId')
+
+    @property
+    def grant_id(self) -> Optional[str]:
+        """ Get grant_id that request refers to.
+
+        Returns:
+            string
+        """
+        return self.payload.get('grantId') or self.request.payload.get('grantId')

--- a/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
+++ b/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
@@ -334,10 +334,11 @@ def _remove_grant_from_response(
     if not grant:
         return
 
+    logger.info(f'Terminating grant {grant.grant_id}')
+
     if unset_freq:
         unset_frequency(grant)
     session.delete(grant)
-    logger.info('Terminated grant')
 
 
 def _update_grant_from_request(response: DBResponse, grant: DBGrant) -> None:

--- a/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
+++ b/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
@@ -171,21 +171,17 @@ def process_grant_response(obj: ResponseDBProcessor, response: DBResponse, sessi
     Returns:
         None
     """
-
-    grant = _get_grant_from_response(response, session)
-
     # Grant response codes worth considering here also are:
     # 400 - INTERFERENCE
-    # 401 - GRANT_CONFLICT
-    # Might need better processing, for now we set the state to IDLE in all cases other than SUCCESS
-    if response.response_code != ResponseCodes.SUCCESS.value:
-        if grant:
-            unset_frequency(grant)
-            session.delete(grant)
-            logger.info(f'process_grant_responses: Terminated grant')
+    if response.response_code == ResponseCodes.GRANT_CONFLICT.value:
+        _unsync_conflict_from_response(obj, response, session)
+        return
+    elif response.response_code != ResponseCodes.SUCCESS.value:
+        _remove_grant_from_response(response, session, unset_freq=True)
         return
 
     new_state = obj.grant_states_map[GrantStates.GRANTED.value]
+    grant = _get_grant_from_response(response, session)
     if not grant:
         grant = _create_grant_from_response(response, new_state, session)
     else:
@@ -209,13 +205,8 @@ def process_heartbeat_response(obj: ResponseDBProcessor, response: DBResponse, s
     Returns:
         None
     """
-    grant = _get_grant_from_response(response, session)
-
     if response.response_code == ResponseCodes.TERMINATED_GRANT.value:
-        if grant:
-            unset_frequency(grant)
-            session.delete(grant)
-            logger.info(f'process_heartbeat_responses: Terminated grant')
+        _remove_grant_from_response(response, session, unset_freq=True)
         return
 
     if response.response_code == ResponseCodes.SUCCESS.value:
@@ -227,6 +218,7 @@ def process_heartbeat_response(obj: ResponseDBProcessor, response: DBResponse, s
     else:
         return
 
+    grant = _get_grant_from_response(response, session)
     if not grant:
         grant = _create_grant_from_response(response, new_state, session)
     else:
@@ -252,13 +244,11 @@ def process_relinquishment_response(obj: ResponseDBProcessor, response: DBRespon
     Returns:
         None
     """
-    grant = _get_grant_from_response(response, session)
-
     if response.response_code == ResponseCodes.SUCCESS.value:
-        if grant:
-            session.delete(grant)
-            logger.info(f'process_relinquishment_responses: Terminated grant')
+        _remove_grant_from_response(response, session)
         return
+
+    grant = _get_grant_from_response(response, session)
     _update_grant_from_response(response, grant)
 
 
@@ -307,8 +297,8 @@ def _get_grant_from_response(
         response: DBResponse,
         session: Session,
 ) -> Optional[DBGrant]:
-    cbsd_id = response.payload.get(CBSD_ID) or response.request.payload.get(CBSD_ID)
-    grant_id = response.payload.get(GRANT_ID) or response.request.payload.get(GRANT_ID)
+    cbsd_id = response.cbsd_id
+    grant_id = response.grant_id
     if not grant_id:
         return None
 
@@ -322,19 +312,32 @@ def _create_grant_from_response(
         response: DBResponse,
         state: DBGrantState,
         session: Session,
+        grant_id: str = None,
 ) -> Optional[DBGrant]:
-    cbsd_id = response.payload.get(CBSD_ID) or response.request.payload.get(CBSD_ID)
-    grant_id = response.payload.get(GRANT_ID) or response.request.payload.get(GRANT_ID)
+    grant_id = grant_id or response.grant_id
     if not grant_id:
         return None
 
-    cbsd = session.query(DBCbsd).filter(DBCbsd.cbsd_id == cbsd_id).scalar()
+    cbsd = session.query(DBCbsd).filter(DBCbsd.cbsd_id == response.cbsd_id).scalar()
     grant = DBGrant(cbsd=cbsd, grant_id=grant_id, state=state)
     _update_grant_from_request(response, grant)
     session.add(grant)
 
     logger.info(f'Created new grant {grant}')
     return grant
+
+
+def _remove_grant_from_response(
+        response: DBResponse, session: Session, unset_freq: bool = False,
+) -> None:
+    grant = _get_grant_from_response(response, session)
+    if not grant:
+        return
+
+    if unset_freq:
+        unset_frequency(grant)
+    session.delete(grant)
+    logger.info('Terminated grant')
 
 
 def _update_grant_from_request(response: DBResponse, grant: DBGrant) -> None:
@@ -375,6 +378,21 @@ def _terminate_all_grants_from_response(response: DBResponse, session: Session) 
     session.query(DBGrant).filter(DBGrant.cbsd == cbsd).delete()
     logger.info(f"Deleting all channels for {cbsd_id=}")
     session.query(DBChannel).filter(DBChannel.cbsd == cbsd).delete()
+
+
+def _unsync_conflict_from_response(obj: ResponseDBProcessor, response: DBResponse, session: Session) -> None:
+    state = obj.grant_states_map[GrantStates.UNSYNC.value]
+
+    conflicts_ids = set(response.payload.get("response", {}).get("responseData", []))
+    existing_grants = session.query(DBGrant).filter(DBGrant.grant_id.in_(conflicts_ids)).all()
+    existing_grants_ids = {g.id for g in existing_grants}
+
+    unsync_grants = list(conflicts_ids - existing_grants_ids)
+    if not unsync_grants:
+        return
+
+    grant_id = unsync_grants[0]
+    _create_grant_from_response(response, state, session, grant_id=grant_id)
 
 
 def _unregister_cbsd(response: DBResponse, session: Session) -> None:

--- a/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
@@ -242,7 +242,7 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
         # Then
         self.assertListEqual(
             expected_grants_states,
-            [g.state.name for g in self.session.query(DBGrant).all()],
+            [g.state.name for g in self.session.query(DBGrant).order_by(DBGrant.id).all()],
         )
 
     @parameterized.expand([

--- a/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
@@ -125,45 +125,36 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
 
     @parameterized.expand([
         (
-            GRANT_REQ, ResponseCodes.SUCCESS.value,
-            GrantStates.GRANTED.value,
+            GRANT_REQ, ResponseCodes.SUCCESS.value, None, GrantStates.GRANTED.value,
         ),
         (
-            GRANT_REQ, ResponseCodes.INTERFERENCE.value,
-            None,
+            GRANT_REQ, ResponseCodes.INTERFERENCE.value, None, None,
         ),
         (
-            GRANT_REQ, ResponseCodes.GRANT_CONFLICT.value,
-            None,
+            GRANT_REQ, ResponseCodes.GRANT_CONFLICT.value, ['grant1', 'grant2'], GrantStates.UNSYNC.value,
         ),
         (
-            GRANT_REQ, ResponseCodes.TERMINATED_GRANT.value,
-            None,
+            GRANT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, None,
         ),
         (
-            HEARTBEAT_REQ, ResponseCodes.SUCCESS.value,
-            GrantStates.AUTHORIZED.value,
+            HEARTBEAT_REQ, ResponseCodes.SUCCESS.value, None, GrantStates.AUTHORIZED.value,
         ),
         (
-            HEARTBEAT_REQ,
-            ResponseCodes.TERMINATED_GRANT.value, None,
+            HEARTBEAT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, None,
         ),
         (
-            HEARTBEAT_REQ, ResponseCodes.SUSPENDED_GRANT.value,
-            GrantStates.GRANTED.value,
+            HEARTBEAT_REQ, ResponseCodes.SUSPENDED_GRANT.value, None, GrantStates.GRANTED.value,
         ),
         (
-            HEARTBEAT_REQ, ResponseCodes.UNSYNC_OP_PARAM.value,
-            GrantStates.UNSYNC.value,
+            HEARTBEAT_REQ, ResponseCodes.UNSYNC_OP_PARAM.value, None, GrantStates.UNSYNC.value,
         ),
         (
-            RELINQUISHMENT_REQ, ResponseCodes.SUCCESS.value,
-            None,
+            RELINQUISHMENT_REQ, ResponseCodes.SUCCESS.value, None, None,
         ),
     ])
     @responses.activate
     def test_grant_state_after_response(
-            self, request_type_name, response_code, expected_grant_state_name,
+            self, request_type_name, response_code, response_data, expected_grant_state_name,
     ):
         # Given
         requests_fixtures = _fake_requests_map[request_type_name]
@@ -171,7 +162,7 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
             request_type_name, requests_fixtures,
         )
         response = self._prepare_response_from_db_requests(
-            db_requests=db_requests, response_code=response_code,
+            db_requests=db_requests, response_code=response_code, response_data=response_data,
         )
 
         # When
@@ -185,6 +176,72 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
         self._verify_processed_requests_were_deleted()
         self.assertListEqual(
             expected_grant_state * nr_of_requests,
+            [g.state.name for g in self.session.query(DBGrant).all()],
+        )
+
+    @parameterized.expand([
+        (
+            GRANT_REQ, ResponseCodes.SUCCESS.value, None, [GrantStates.GRANTED.value],
+        ),
+        (
+            GRANT_REQ, ResponseCodes.INTERFERENCE.value, None, [],
+        ),
+        (
+            GRANT_REQ, ResponseCodes.GRANT_CONFLICT.value,
+            ['test_grant_id_for_1', 'test_grant_id_for_2'],
+            [GrantStates.GRANTED.value, GrantStates.UNSYNC.value],
+        ),
+        (
+            GRANT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, [],
+        ),
+        (
+            HEARTBEAT_REQ, ResponseCodes.SUCCESS.value, None, [GrantStates.AUTHORIZED.value],
+        ),
+        (
+            HEARTBEAT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, [],
+        ),
+        (
+            HEARTBEAT_REQ, ResponseCodes.SUSPENDED_GRANT.value, None, [GrantStates.GRANTED.value],
+        ),
+        (
+            HEARTBEAT_REQ, ResponseCodes.UNSYNC_OP_PARAM.value, None, [GrantStates.UNSYNC.value],
+        ),
+        (
+            RELINQUISHMENT_REQ, ResponseCodes.SUCCESS.value, None, [],
+        ),
+    ])
+    @responses.activate
+    def test_preexisting_grant_state_after_response(
+            self, request_type_name, response_code, response_data, expected_grants_states,
+    ):
+        # Given
+        requests_fixtures = [_fake_requests_map[request_type_name][0]]
+        db_requests = self._create_db_requests(request_type_name, requests_fixtures)
+
+        grant_id = db_requests[0].payload.get('grantId') or "test_grant_id_for_1"
+        grant = DBGrant(
+            cbsd=db_requests[0].cbsd,
+            state_id=1,
+            grant_id=grant_id,
+            low_frequency=3560000000,
+            high_frequency=3580000000,
+            max_eirp=15,
+        )
+        self.session.add(grant)
+        self.session.commit()
+
+        response = self._prepare_response_from_db_requests(
+            db_requests=db_requests, response_code=response_code, response_data=response_data,
+        )
+
+        # When
+        self._process_response(
+            request_type_name=request_type_name, response=response, db_requests=db_requests,
+        )
+
+        # Then
+        self.assertListEqual(
+            expected_grants_states,
             [g.state.name for g in self.session.query(DBGrant).all()],
         )
 


### PR DESCRIPTION
Signed-off-by: Jarosław Jaszczuk <jaroslaw@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Add handling of 401 GRANT CONFLICT response to Configuration Controller, so upon receiving such response from SAS grant is created in UNSYNC state, which should get it relinquished and resolve the conflict.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Added unit tests cases.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
