### PR TITLE
chore(ci): OVS packages are upgraded in magma_dev VM

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev
+          key: vagrant-box-magma-dev-v1.1.20210618-patched
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.10'

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev
+          key: vagrant-box-magma-dev-v1.1.20210618-patched
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev
+          key: vagrant-box-magma-dev-v1.1.20210618-patched
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev
+          key: vagrant-box-magma-dev-v1.1.20210618-patched
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # - linux kernel from debian jessie backports
     # - updated vbguest-tool
     config.vm.box = "magmacore/magma_dev"
-    config.vm.box_version = "1.1.20210618"
+    config.vm.box_version = "1.1.20210618-patched"
      # Enable Dynamic Swap Space to prevent Out of Memory crashes
     config.vm.provision :shell, inline: "swapoff -a && fallocate -l 4G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile && echo '/swapfile none swap sw 0 0' >> /etc/fstab && swapon -a"
     config.vm.provision :shell, inline: "echo vm.swappiness = 10 >> /etc/sysctl.conf && echo vm.vfs_cache_pressure = 50 >> /etc/sysctl.conf && sysctl -p"

--- a/orc8r/tools/packer/magma-focal-virtualbox-patch-upgrade-ovs-1.1.20210618.json
+++ b/orc8r/tools/packer/magma-focal-virtualbox-patch-upgrade-ovs-1.1.20210618.json
@@ -1,0 +1,24 @@
+{
+  "builders": [
+    {
+      "communicator": "ssh",
+      "source_path": "https://app.vagrantup.com/magmacore/boxes/magma_dev/versions/1.1.20210618/providers/virtualbox.box",
+      "provider": "virtualbox",
+      "add_force": true,
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "script": "scripts/upgrade-ovs-patch-1.1.20210618.sh",
+      "type": "shell"
+    },
+    {
+      "expect_disconnect": true,
+      "inline": [
+        "sudo reboot"
+      ],
+      "type": "shell"
+    }
+  ]
+}

--- a/orc8r/tools/packer/scripts/upgrade-ovs-patch-1.1.20210618.sh
+++ b/orc8r/tools/packer/scripts/upgrade-ovs-patch-1.1.20210618.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -euo pipefail
+set -x
+
+export version="2.15.4-9-magma"
+export DEBIAN_FRONTEND="noninteractive"
+
+sudo rm -rf /etc/apt/sources.list.d/*.list
+sudo rm -rf /var/cache/apt/
+
+echo "Installing certificates ..."
+sudo apt-get update
+sudo apt-get install -y ca-certificates
+
+echo "Adding artifactory ..."
+echo 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main' | sudo tee /etc/apt/sources.list.d/magma.list
+
+echo "Upgrading OVS packages ..."
+sudo apt-get update
+sudo apt-get install -y \
+    libopenvswitch=$version \
+    libopenvswitch-dev=$version \
+    openvswitch-common=$version \
+    openvswitch-datapath-dkms=$version \
+    openvswitch-switch=$version \
+    openvswitch-test=$version \
+    python3-openvswitch=$version


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- A new `magma_dev` image was created based on the image `1.1.20210618`
  - The VM was created with the Packer file
    `orc8r/tools/packer/magma-focal-virtualbox-patch-upgrade-ovs-1.1.20210618.json` 
  - The version of the OVS packages is upgraded to `2.15.4-9-magma`
  - The Vagrant file and GitHub actions cache keys are adapted accordingly

## Test Plan

- [x] [Build all (AGW build only)](https://github.com/LKreutzer/magma/runs/7654247296?check_suite_focus=true)
- [x] [LTE integ tests](https://github.com/LKreutzer/magma/runs/7654322742?check_suite_focus=true)
- [x] [LTE integ tests bazel](https://github.com/LKreutzer/magma/runs/7654187616?check_suite_focus=true)
- [x] [FEG integ tests](https://github.com/LKreutzer/magma/runs/7654180144?check_suite_focus=true)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
