### PR TITLE
refactor(nms): correct swagger spec for `networksNetworkIdTracingGet`

### DIFF
--- a/nms/app/context/TraceContext.tsx
+++ b/nms/app/context/TraceContext.tsx
@@ -47,8 +47,7 @@ async function initTraceState(params: {
     ).data;
 
     if (traces) {
-      // TODO[ts-migration] type of generated API is incorrect - fix swagger.yaml
-      setTraceMap((traces as unknown) as Record<string, CallTrace>);
+      setTraceMap(traces);
     }
   } catch (e) {
     enqueueSnackbar?.('failed fetching call trace information', {

--- a/nms/generated/api.ts
+++ b/nms/generated/api.ts
@@ -10061,7 +10061,7 @@ export const CallTracingApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async networksNetworkIdTracingGet(networkId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<string>>> {
+        async networksNetworkIdTracingGet(networkId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: CallTrace; }>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.networksNetworkIdTracingGet(networkId, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -10143,7 +10143,7 @@ export const CallTracingApiFactory = function (configuration?: Configuration, ba
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        networksNetworkIdTracingGet(networkId: string, options?: any): AxiosPromise<Array<string>> {
+        networksNetworkIdTracingGet(networkId: string, options?: any): AxiosPromise<{ [key: string]: CallTrace; }> {
             return localVarFp.networksNetworkIdTracingGet(networkId, options).then((request) => request(axios, basePath));
         },
         /**

--- a/orc8r/cloud/go/services/ctraced/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/ctraced/obsidian/models/swagger.v1.yml
@@ -40,9 +40,9 @@ paths:
         '200':
           description: Success
           schema:
-            type: array
-            items:
-              - $ref: '#/definitions/call_trace'
+            type: object
+            additionalProperties:
+              $ref: '#/definitions/call_trace'
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
     post:

--- a/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
@@ -5666,9 +5666,9 @@ paths:
         "200":
           description: Success
           schema:
-            items:
-            - $ref: '#/definitions/call_trace'
-            type: array
+            additionalProperties:
+              $ref: '#/definitions/call_trace'
+            type: object
         default:
           $ref: '#/responses/UnexpectedError'
       summary: List all call traces for a network


### PR DESCRIPTION
## Summary

- Fixes https://github.com/magma/magma/issues/13486

## Test Plan

- `.build.py --generate`
- `yarn tsc`
- CI

## Additional information

- the `cloud-workflow` seems to be flaky :crossed_fingers: 
- the `cloud-workflow` has a strange interaction with the totally unrelated `Semantic PR` check
