### PR TITLE
chore(lte): Bazelify the S1AP nonsanity tests 

### DIFF
--- a/bazel/scripts/run_integ_tests.sh
+++ b/bazel/scripts/run_integ_tests.sh
@@ -20,22 +20,29 @@ set -euo pipefail
 ###############################################################################
 
 help() {
-    echo "Executes all integration tests."
-    echo "Usage:"
-    echo "   $(basename "$0")" 
-    echo "      Execute all integration tests in the magma repository." 
+    echo -e "${BOLD}Executes all integration tests."
+    echo -e "Usage:${NO_FORMATTING}"
+    echo "   $(basename "$0") --help"
+    echo "      Display this help message."
+    echo "   $(basename "$0")"
+    echo "      Execute all precommit and extended integration tests in the magma repository."
     echo "   $(basename "$0") path_to_tests_directory:bazel_test_target_name"
     echo "      Execute the specified test."
+    echo -e "${BOLD}List tests:${NO_FORMATTING}"
     echo "   $(basename "$0") --list"
     echo "      List all integration tests."
     echo "   $(basename "$0") --list-precommit"
     echo "      List the precommit integration tests."
     echo "   $(basename "$0") --list-extended"
-    echo "      List the extended integration tests."
+    echo "      List the precommit integration tests."
+    echo "   $(basename "$0") --list-nonsanity"
+    echo "      List the nonsanity integration tests."
     echo "   $(basename "$0") --list-traffic-server"
     echo "      List all integration tests that use the traffic server."
+    echo -e "${BOLD}Execute precommit:${NO_FORMATTING}"
     echo "   $(basename "$0") --precommit"
     echo "      Run all precommit integration tests."
+    echo -e "${BOLD}Execute extended:${NO_FORMATTING}"
     echo "   $(basename "$0") --extended"
     echo "      Run all extended integration tests."
     echo "   $(basename "$0") --setup-extended"
@@ -43,13 +50,29 @@ help() {
     echo "   $(basename "$0") --teardown-extended"
     echo "      Execute the teardown test for the extended tests."
     echo "   $(basename "$0") --skip-setup-teardown-extended"
-    echo "      Execute all integration tests in the magma repository," 
-    echo "      except the setup and teardown for extended tests." 
+    echo "      Execute all precommit and extended integration tests in the magma repository," 
+    echo "      except the setup and teardown for extended tests."
+    echo "      Should be combined with an extended test target or --extended."
     echo "   $(basename "$0") --skip-setup-teardown-extended path_to_tests_directory:bazel_test_target_name"
     echo "      Execute the specified test, without executing"
-    echo "      the setup and teardown for extended tests." 
-    echo "   $(basename "$0") --help"
-    echo "      Display this help message."
+    echo "      the setup and teardown for extended tests."
+    echo -e "${BOLD}Execute nonsanity:${NO_FORMATTING}"
+    echo "   $(basename "$0") --nonsanity"
+    echo "      Run all nonsanity integration tests."
+    echo "   $(basename "$0") --setup-nonsanity"
+    echo "      Execute the setup test for the nonsanity tests."
+    echo "   $(basename "$0") --teardown-nonsanity"
+    echo "      Execute the teardown test for the nonsanity tests."
+    echo "   $(basename "$0") --skip-setup-teardown-nonsanity"
+    echo "      Execute all precommit and extended integration tests in the magma repository,"
+    echo "      except the setup and teardown for nonsanity tests."
+    echo "      Should be combined with a nonsanity test target or --nonsanity."
+    echo "   $(basename "$0") --skip-setup-teardown-nonsanity --nonsanity"
+    echo "      Execute the nonsanity tests, without executing"
+    echo "      the setup and teardown for them."
+    echo "   $(basename "$0") --skip-setup-teardown-nonsanity path_to_tests_directory:bazel_test_target_name"
+    echo "      Execute the specified test, without executing"
+    echo "      the setup and teardown for nonsanity tests."
 }
 
 categorize_test() {
@@ -60,6 +83,9 @@ categorize_test() {
     elif [[ $(bazel query attr\(tags, extended_test, kind\(py_test, "${TARGET}"\)\)) == *"${TARGET}" ]];
     then
         EXTENDED_TEST_TARGETS=( "${TARGET}" )
+    elif [[ $(bazel query attr\(tags, nonsanity_test, kind\(py_test, "${TARGET}"\)\)) == *"${TARGET}" ]];
+    then
+        NONSANITY_TEST_TARGETS=( "${TARGET}" )
     else
         echo "ERROR: Could not categorize the provided test."
         exit 1
@@ -78,13 +104,23 @@ create_test_targets() {
         then
             echo "Multiple targets specified - running tests:"
         fi
-        create_precommit_test_targets
-        create_extended_test_targets
+        if [[ "${RUN_ALL}" == "true" || "${PRECOMMIT}" == "true" ]];
+        then
+            create_precommit_test_targets
+        fi
+        if [[ "${RUN_ALL}" == "true" || "${EXTENDED}" == "true" ]];
+        then
+            create_extended_test_targets
+        fi
+        if [[ "${RUN_ALL}" == "false" && "${NONSANITY}" == "true" ]];
+        then
+            create_nonsanity_test_targets
+        fi
     else
         echo "ERROR: Invalid test target name."
         exit 1
     fi
-    ALL_TARGETS=( "${PRECOMMIT_TEST_TARGETS[@]}" "${EXTENDED_TEST_TARGETS[@]}" )
+    ALL_TARGETS=( "${PRECOMMIT_TEST_TARGETS[@]}" "${EXTENDED_TEST_TARGETS[@]}" "${NONSANITY_TEST_TARGETS[@]}" )
     for TARGET in "${ALL_TARGETS[@]}"
     do
         echo "${TARGET}"
@@ -97,6 +133,10 @@ create_precommit_test_targets() {
 
 create_extended_test_targets() {
     mapfile -t EXTENDED_TEST_TARGETS < <(bazel query "attr(tags, extended_test, kind(py_test, //lte/gateway/python/integ_tests/s1aptests/...))")
+}
+
+create_nonsanity_test_targets() {
+    mapfile -t NONSANITY_TEST_TARGETS < <(bazel query "attr(tags, nonsanity_test, kind(py_test, //lte/gateway/python/integ_tests/s1aptests/...))")
 }
 
 list_all_tests() {
@@ -124,6 +164,15 @@ list_extended_tests() {
     done
 }
 
+list_nonsanity_tests() {
+    echo "Nonsanity tests:"
+    create_nonsanity_test_targets
+    for TARGET in "${NONSANITY_TEST_TARGETS[@]}"
+    do
+        echo "${TARGET}"
+    done
+}
+
 list_traffic_server_tests() {
     echo "Tests that require the traffic server:"
     bazel query "attr(tags, traffic_server_test, kind(py_test, //lte/gateway/python/integ_tests/s1aptests/...))"
@@ -140,13 +189,36 @@ setup_extended_tests() {
 }
 
 teardown_extended_tests() {
-    if [[ -f "${EXTENDED_TEST_CLEANUP_FILE_NAME}" ]];
+    if [[ -f "${TEST_CLEANUP_FILE_NAME}" ]];
     then
         echo "Cleaning up the environment after the extended tests."
         echo "Building..."
         bazel build "//lte/gateway/python/integ_tests/s1aptests:test_restore_mme_config_after_sanity" --define=on_magma_test=1
         echo "Executing..."
         sudo "${MAGMA_ROOT}/bazel-bin/lte/gateway/python/integ_tests/s1aptests/test_restore_mme_config_after_sanity"
+        echo "Cleanup finished successfully."
+    else
+        echo "No backup file found, skipping cleanup."
+    fi
+}
+
+setup_nonsanity_tests() {
+    echo "Setting up the environment for the nonsanity tests."
+    echo "Building..."
+    bazel build "//lte/gateway/python/integ_tests/s1aptests:test_modify_config_for_non_sanity" --define=on_magma_test=1
+    echo "Executing..."
+    sudo "${MAGMA_ROOT}/bazel-bin/lte/gateway/python/integ_tests/s1aptests/test_modify_config_for_non_sanity"
+    echo "Setup finished successfully."
+}
+
+teardown_nonsanity_tests() {
+    if [[ -f "${TEST_CLEANUP_FILE_NAME}" ]];
+    then
+        echo "Cleaning up the environment after the nonsanity tests."
+        echo "Building..."
+        bazel build "//lte/gateway/python/integ_tests/s1aptests:test_restore_config_after_non_sanity" --define=on_magma_test=1
+        echo "Executing..."
+        sudo "${MAGMA_ROOT}/bazel-bin/lte/gateway/python/integ_tests/s1aptests/test_restore_config_after_non_sanity"
         echo "Cleanup finished successfully."
     else
         echo "No backup file found, skipping cleanup."
@@ -160,9 +232,9 @@ run_test_batch() {
         if run_test "${TARGET}";
         then
             NUM_SUCCESS=$((NUM_SUCCESS + 1))
-            TEST_RESULTS["${TARGET}"]="${GREEN}PASSED${NO_COLOR}"
+            TEST_RESULTS["${TARGET}"]="${GREEN}PASSED${NO_FORMATTING}"
         else
-            TEST_RESULTS["${TARGET}"]="${RED}FAILED${NO_COLOR}"
+            TEST_RESULTS["${TARGET}"]="${RED}FAILED${NO_FORMATTING}"
         fi
         NUM_RUN=$((NUM_RUN + 1))
     done
@@ -199,9 +271,13 @@ print_summary() {
 
 PRECOMMIT_TEST_TARGETS=()
 EXTENDED_TEST_TARGETS=()
+NONSANITY_TEST_TARGETS=()
 declare -A TEST_RESULTS
 NUM_SUCCESS=0
 NUM_RUN=1
+PRECOMMIT="false"
+EXTENDED="false"
+NONSANITY="false"
 RUN_ALL="true"
 
 cd "${MAGMA_ROOT}"
@@ -209,11 +285,15 @@ cd "${MAGMA_ROOT}"
 EXTENDED_TEST_SETUP="lte/gateway/python/integ_tests/s1aptests:test_modify_mme_config_for_sanity"
 EXTENDED_TEST_TEARDOWN="lte/gateway/python/integ_tests/s1aptests:test_restore_mme_config_after_sanity"
 SKIP_EXTENDED_SETUP_AND_TEARDOWN="false"
-EXTENDED_TEST_CLEANUP_FILE_NAME="${MAGMA_ROOT}/lte/gateway/configs/templates/mme.conf.template.bak"
+NONSANITY_TEST_SETUP="lte/gateway/python/integ_tests/s1aptests:test_modify_config_for_non_sanity"
+NONSANITY_TEST_TEARDOWN="lte/gateway/python/integ_tests/s1aptests:test_restore_config_after_non_sanity"
+SKIP_NONSANITY_SETUP_AND_TEARDOWN="false"
+TEST_CLEANUP_FILE_NAME="${MAGMA_ROOT}/lte/gateway/configs/templates/mme.conf.template.bak"
 
+BOLD='\033[1m'
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-NO_COLOR='\033[0m'
+NO_FORMATTING='\033[0m'
 
 declare -a POSITIONAL_ARGS
 
@@ -230,18 +310,27 @@ while [[ $# -gt 0 ]]; do
       list_extended_tests
       exit 0
       ;;
+    --list-nonsanity)
+      list_nonsanity_tests
+      exit 0
+      ;;
     --list-traffic-server)
       list_traffic_server_tests
       ;;
     --precommit)
-      create_precommit_test_targets
       RUN_ALL="false"
-      break
+      PRECOMMIT="true"
+      shift
       ;;
     --extended)
-      create_extended_test_targets
       RUN_ALL="false"
-      break
+      EXTENDED="true"
+      shift
+      ;;
+    --nonsanity)
+      RUN_ALL="false"
+      NONSANITY="true"
+      shift
       ;;
     --setup-extended)
       setup_extended_tests
@@ -253,6 +342,18 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-setup-teardown-extended)
       SKIP_EXTENDED_SETUP_AND_TEARDOWN="true"
+      shift
+      ;;
+    --setup-nonsanity)
+      setup_nonsanity_tests
+      exit 0
+      ;;
+    --teardown-nonsanity)
+      teardown_nonsanity_tests
+      exit 0
+      ;;
+    --skip-setup-teardown-nonsanity)
+      SKIP_NONSANITY_SETUP_AND_TEARDOWN="true"
       shift
       ;;
     --help)
@@ -286,13 +387,23 @@ then
     exit 0
 fi
 
-if [[ "${RUN_ALL}" == "true" ]];
+if [[ "${TARGET_PATH}" == *"${NONSANITY_TEST_SETUP}" ]];
 then
-    create_test_targets
+    setup_nonsanity_tests
+    exit 0
 fi
+
+if [[ "${TARGET_PATH}" == *"${NONSANITY_TEST_TEARDOWN}" ]];
+then
+    teardown_nonsanity_tests
+    exit 0
+fi
+
+create_test_targets
 
 TOTAL_TESTS=${#PRECOMMIT_TEST_TARGETS[@]}
 TOTAL_TESTS=$((TOTAL_TESTS + ${#EXTENDED_TEST_TARGETS[@]}))
+TOTAL_TESTS=$((TOTAL_TESTS + ${#NONSANITY_TEST_TARGETS[@]}))
 
 declare -a TEST_BATCH_TO_RUN
 
@@ -321,6 +432,25 @@ then
     if [[ "${SKIP_EXTENDED_SETUP_AND_TEARDOWN}" == "false" ]];
     then
         teardown_extended_tests
+    fi
+fi
+
+if [[ ${#NONSANITY_TEST_TARGETS[@]} -gt 0 ]];
+then
+    echo "#######################################"
+    echo "NONSANITY TESTS"
+    echo "#######################################"
+    if [[ "${SKIP_NONSANITY_SETUP_AND_TEARDOWN}" == "false" ]];
+    then
+        setup_nonsanity_tests
+    fi
+
+    TEST_BATCH_TO_RUN=( "${NONSANITY_TEST_TARGETS[@]}" )
+    run_test_batch
+
+    if [[ "${SKIP_NONSANITY_SETUP_AND_TEARDOWN}" == "false" ]];
+    then
+        teardown_nonsanity_tests
     fi
 fi
 

--- a/bazel/test_constants.bzl
+++ b/bazel/test_constants.bzl
@@ -38,4 +38,7 @@ TAG_PRECOMMIT_TEST = ["precommit_test"] + TAG_MANUAL
 TAG_EXTENDED_TEST = ["extended_test"] + TAG_MANUAL
 TAG_EXTENDED_TEST_SETUP = ["extended_setup"] + TAG_MANUAL
 TAG_EXTENDED_TEST_TEARDOWN = ["extended_teardown"] + TAG_MANUAL
+TAG_NON_SANITY_TEST = ["nonsanity_test"] + TAG_MANUAL
+TAG_NON_SANITY_TEST_SETUP = ["nonsanity_setup"] + TAG_MANUAL
+TAG_NON_SANITY_TEST_TEARDOWN = ["nonsanity_teardown"] + TAG_MANUAL
 TAG_TRAFFIC_SERVER_TEST = ["traffic_server_test"]

--- a/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
@@ -16,6 +16,9 @@ load(
     "TAG_EXTENDED_TEST",
     "TAG_EXTENDED_TEST_SETUP",
     "TAG_EXTENDED_TEST_TEARDOWN",
+    "TAG_NON_SANITY_TEST",
+    "TAG_NON_SANITY_TEST_SETUP",
+    "TAG_NON_SANITY_TEST_TEARDOWN",
     "TAG_PRECOMMIT_TEST",
     "TAG_TRAFFIC_SERVER_TEST",
 )
@@ -1539,6 +1542,534 @@ pytest_test(
     srcs = ["test_restore_mme_config_after_sanity.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST_TEARDOWN,
+    deps = [
+        ":s1ap_utils",
+        "//lte/gateway/python/integ_tests/common:magmad_client",
+    ],
+)
+
+pytest_test(
+    name = "test_modify_config_for_non_sanity",
+    size = "medium",
+    srcs = ["test_modify_config_for_non_sanity.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST_SETUP,
+    deps = [
+        ":s1ap_utils",
+        "//lte/gateway/python/integ_tests/common:magmad_client",
+    ],
+)
+
+pytest_test(
+    name = "test_attach_detach_non_nat_dp_ul_tcp",
+    size = "large",
+    srcs = ["test_attach_detach_non_nat_dp_ul_tcp.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_no_auth_resp_with_mme_restart_reattach",
+    size = "small",
+    srcs = ["test_no_auth_resp_with_mme_restart_reattach.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_rar_activation_reject",
+    size = "small",
+    srcs = ["test_attach_detach_rar_activation_reject.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_paging_with_mme_restart",
+    size = "medium",
+    srcs = ["test_paging_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_no_identity_rsp_with_mme_restart",
+    size = "small",
+    srcs = ["test_no_identity_rsp_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_agw_offload_idle_active_ue",
+    size = "small",
+    srcs = ["test_agw_offload_idle_active_ue.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_standalone_pdn_conn_req_with_apn_correction",
+    size = "medium",
+    srcs = ["test_standalone_pdn_conn_req_with_apn_correction.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_esm_info_with_apn_correction",
+    size = "medium",
+    srcs = ["test_attach_esm_info_with_apn_correction.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_enb_partial_reset_multi_ue",
+    size = "small",
+    srcs = ["test_enb_partial_reset_multi_ue.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_with_pco_ipcp",
+    size = "small",
+    srcs = ["test_attach_detach_with_pco_ipcp.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_complete_after_ics_timer_expiry",
+    size = "small",
+    srcs = ["test_attach_complete_after_ics_timer_expiry.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_send_error_ind_for_dl_nas_with_auth_req",
+    size = "small",
+    srcs = ["test_send_error_ind_for_dl_nas_with_auth_req.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_send_error_ind_for_erab_setup_req",
+    size = "small",
+    srcs = ["test_send_error_ind_for_erab_setup_req.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_with_ipv6_pcscf_and_dns_addr",
+    size = "small",
+    srcs = ["test_attach_detach_with_ipv6_pcscf_and_dns_addr.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_concurrent_secondary_pdns",
+    size = "small",
+    srcs = ["test_concurrent_secondary_pdns.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_concurrent_secondary_pdn_reject",
+    size = "small",
+    srcs = ["test_concurrent_secondary_pdn_reject.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_ipv6",
+    size = "small",
+    srcs = ["test_attach_detach_ipv6.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_ipv4v6_secondary_pdn_rs_retransmit",
+    size = "small",
+    srcs = ["test_ipv4v6_secondary_pdn_rs_retransmit.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_ipv4v6_secondary_pdn_spgw_initiated_ded_bearer",
+    size = "small",
+    srcs = ["test_ipv4v6_secondary_pdn_spgw_initiated_ded_bearer.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_ipv6_secondary_pdn_rs_retransmit",
+    size = "small",
+    srcs = ["test_ipv6_secondary_pdn_rs_retransmit.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_ipv4v6_secondary_pdn",
+    size = "small",
+    srcs = ["test_ipv4v6_secondary_pdn.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_ipv4v6_secondary_pdn_multi_ue",
+    size = "medium",
+    srcs = ["test_ipv4v6_secondary_pdn_multi_ue.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_ipv4v6_secondary_pdn_with_ded_bearer",
+    size = "small",
+    srcs = ["test_ipv4v6_secondary_pdn_with_ded_bearer.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_ipv6_secondary_pdn_with_ded_bearer",
+    size = "small",
+    srcs = ["test_ipv6_secondary_pdn_with_ded_bearer.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue",
+    size = "medium",
+    srcs = ["test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_outoforder_erab_setup_rsp_dedicated_bearer",
+    size = "small",
+    srcs = ["test_outoforder_erab_setup_rsp_dedicated_bearer.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_secondary_pdn_with_dedicated_bearer_multiple_services_restart",
+    size = "medium",
+    srcs = ["test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_esm_info_timerexpiration_max_retries",
+    size = "small",
+    srcs = ["test_attach_esm_info_timerexpiration_max_retries.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_service_without_mac",
+    size = "small",
+    srcs = ["test_attach_service_without_mac.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_paging_request",
+    size = "small",
+    srcs = ["test_paging_request.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_multi_enb_paging_request",
+    size = "small",
+    srcs = ["test_multi_enb_paging_request.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_multi_enb_multi_ue_diff_tac",
+    size = "small",
+    srcs = ["test_multi_enb_multi_ue_diff_tac.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_enb_partial_reset_with_unknown_ue_s1ap_ids",
+    size = "small",
+    srcs = ["test_enb_partial_reset_with_unknown_ue_s1ap_ids.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_auth_mac_failure",
+    size = "small",
+    srcs = ["test_attach_auth_mac_failure.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_esm_information_timerexpiration",
+    size = "small",
+    srcs = ["test_attach_esm_information_timerexpiration.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_inactive_tau_with_combined_tala_update_reattach",
+    size = "small",
+    srcs = ["test_attach_inactive_tau_with_combined_tala_update_reattach.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_active_tau_with_combined_tala_update_reattach",
+    size = "small",
+    srcs = ["test_attach_active_tau_with_combined_tala_update_reattach.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_activate_deactivate_multiple_dedicated",
+    size = "small",
+    srcs = ["test_activate_deactivate_multiple_dedicated.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_sctp_shutdown_while_mme_is_stopped",
+    size = "small",
+    srcs = ["test_sctp_shutdown_while_mme_is_stopped.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_3495_timer_for_default_bearer_with_mme_restart",
+    size = "small",
+    srcs = ["test_3495_timer_for_default_bearer_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_3495_timer_for_dedicated_bearer_with_mme_restart",
+    size = "small",
+    srcs = ["test_3495_timer_for_dedicated_bearer_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_with_corrupt_stateless_mme",
+    size = "medium",
+    srcs = ["test_attach_detach_with_corrupt_stateless_mme.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_enb_partial_reset_multi_ue_with_mme_restart",
+    size = "small",
+    srcs = ["test_enb_partial_reset_multi_ue_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_ics_drop_with_mme_restart",
+    size = "small",
+    srcs = ["test_attach_ics_drop_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_mme_restart_detach_multi_ue",
+    size = "small",
+    srcs = ["test_attach_mme_restart_detach_multi_ue.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_no_auth_response_with_mme_restart",
+    size = "medium",
+    srcs = ["test_no_auth_response_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_no_esm_information_rsp_with_mme_restart",
+    size = "small",
+    srcs = ["test_no_esm_information_rsp_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_no_smc_with_mme_restart_reattach",
+    size = "small",
+    srcs = ["test_no_smc_with_mme_restart_reattach.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_no_attach_complete_with_mme_restart",
+    size = "small",
+    srcs = ["test_no_attach_complete_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_ics_failure_with_mme_restart",
+    size = "small",
+    srcs = ["test_attach_ics_failure_with_mme_restart.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_continuous_random_attach",
+    size = "medium",
+    srcs = ["test_continuous_random_attach.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_s1_handover_ping_pong",
+    size = "small",
+    srcs = ["test_s1_handover_ping_pong.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_s1_handover_cancel",
+    size = "small",
+    srcs = ["test_s1_handover_cancel.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_s1_handover_failure",
+    size = "small",
+    srcs = ["test_s1_handover_failure.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_s1_handover_timer_expiry",
+    size = "small",
+    srcs = ["test_s1_handover_timer_expiry.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue",
+    size = "large",
+    srcs = ["test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_restore_config_after_non_sanity",
+    size = "medium",
+    srcs = ["test_restore_config_after_non_sanity.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST_TEARDOWN,
     deps = [
         ":s1ap_utils",
         "//lte/gateway/python/integ_tests/common:magmad_client",


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR bazelifies the nonsanity integration tests and adds them to the wrapper script for convenient execution.

## Test Plan

Execute the script with different flags and parameters. You can get the help message with this command:
`"${MAGMA_ROOT}"/bazel/scripts/run_integ_tests.sh --help`
```
Executes all integration tests.
Usage:
   run_integ_tests.sh --help
      Display this help message.
   run_integ_tests.sh
      Execute all precommit and extended integration tests in the magma repository.
   run_integ_tests.sh path_to_tests_directory:bazel_test_target_name
      Execute the specified test.
List tests:
   run_integ_tests.sh --list
      List all integration tests.
   run_integ_tests.sh --list-precommit
      List the precommit integration tests.
   run_integ_tests.sh --list-extended
      List the precommit integration tests.
   run_integ_tests.sh --list-nonsanity
      List the nonsanity integration tests.
   run_integ_tests.sh --list-traffic-server
      List all integration tests that use the traffic server.
Execute precommit:
   run_integ_tests.sh --precommit
      Run all precommit integration tests.
Execute extended:
   run_integ_tests.sh --extended
      Run all extended integration tests.
   run_integ_tests.sh --setup-extended
      Execute the setup test for the extended tests.
   run_integ_tests.sh --teardown-extended
      Execute the teardown test for the extended tests.
   run_integ_tests.sh --skip-setup-teardown-extended
      Execute all precommit and extended integration tests in the magma repository,
      except the setup and teardown for extended tests.
      Should be combined with an extended test target or --extended.
   run_integ_tests.sh --skip-setup-teardown-extended path_to_tests_directory:bazel_test_target_name
      Execute the specified test, without executing
      the setup and teardown for extended tests.
Execute nonsanity:
   run_integ_tests.sh --nonsanity
      Run all nonsanity integration tests.
   run_integ_tests.sh --setup-nonsanity
      Execute the setup test for the nonsanity tests.
   run_integ_tests.sh --teardown-nonsanity
      Execute the teardown test for the nonsanity tests.
   run_integ_tests.sh --skip-setup-teardown-nonsanity
      Execute all precommit and extended integration tests in the magma repository,
      except the setup and teardown for nonsanity tests.
      Should be combined with a nonsanity test target or --nonsanity.
   run_integ_tests.sh --skip-setup-teardown-nonsanity --nonsanity
      Execute the nonsanity tests, without executing
      the setup and teardown for them.
   run_integ_tests.sh --skip-setup-teardown-nonsanity path_to_tests_directory:bazel_test_target_name
      Execute the specified test, without executing
      the setup and teardown for nonsanity tests.
```

These tests are really flaky, but most of them passed at least once.
There are 3 tests that I never managed to make green, not even with Make:

1. test_activate_deactivate_multiple_dedicated
2. test_sctp_shutdown_while_mme_is_stopped
3. test_3495_timer_for_dedicated_bearer_with_mme_restart

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
