### PR TITLE
chore(ci): reboot after dist upgrade in fabfile

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -749,6 +749,12 @@ def _dist_upgrade():
     """ Upgrades OS packages on dev box """
     run('sudo apt-get update')
     run('sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade')
+    try:
+        run('sudo reboot')
+    except Exception as e:
+        print(e)
+    finally:
+        time.sleep(60)
 
 
 def _build_magma():


### PR DESCRIPTION
## Summary

fab does do a dist upgrade, but that only has full effect if there is a
reboot afterwards (e.g. to load new kernel modules).

## Test Plan

tbd.
