### PR TITLE
chore(dp): make CRLValidator always enabled for SAS POSTs, add error handling

### DIFF
--- a/dp/cloud/python/magma/configuration_controller/config.py
+++ b/dp/cloud/python/magma/configuration_controller/config.py
@@ -68,7 +68,6 @@ class Config(object):
     SAS_CERT_PATH = os.environ.get(
         'SAS_CERT_PATH', '/backend/configuration_controller/certs/ca.crt',
     )
-    VERIFY_SAS_CRL = os.environ.get('VERIFY_SAS_CRL') == '1'
     CRL_CACHE_TIME = int(os.environ.get('CRL_CACHE_TIME', '3600'))
 
 

--- a/dp/cloud/python/magma/configuration_controller/crl_validator/certificate.py
+++ b/dp/cloud/python/magma/configuration_controller/crl_validator/certificate.py
@@ -10,27 +10,28 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import logging
 import socket
 import ssl
-from typing import List
+from typing import List, Optional
 
 import requests
 from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-from requests.exceptions import SSLError
+from requests.exceptions import RequestException, SSLError
 
-_x509_backend = default_backend()
+logger = logging.getLogger(__name__)
 
 
-def get_certificate(
-        hostname: str,
-        port: int = 443,
-) -> x509.Certificate:
-    """ Retrieve certificate of given host.
+def get_certificate(hostname: str, port: int = 443) -> Optional[x509.Certificate]:
+    """ Retrieve SSL certificate of given host.
 
     Args:
         hostname: host from which certificate will be retrieved
         port: SSL port of the host
+
+    Raises:
+        ConnectionError: if there was an error while trying to get certificate from host
+        ValueError: if data received from host is not valid DER certificate
 
     Returns:
         x509.Certificate
@@ -38,18 +39,27 @@ def get_certificate(
     context = ssl.SSLContext(protocol=ssl.PROTOCOL_SSLv23)
     context.minimum_version = ssl.TLSVersion.TLSv1_2
 
-    with socket.create_connection((hostname, port)) as sock:
-        sock = context.wrap_socket(sock, server_hostname=hostname)
-        binary_certificate = sock.getpeercert(binary_form=True)
-        sock.shutdown(socket.SHUT_RDWR)
+    try:
+        with socket.create_connection((hostname, port)) as sock:
+            sock = context.wrap_socket(sock, server_hostname=hostname)
+            binary_certificate = sock.getpeercert(binary_form=True)
+            sock.shutdown(socket.SHUT_RDWR)
+    except socket.error as e:
+        msg = f'Unable to get SSL certificate for {hostname}: {e}'
+        logger.warning(msg)
+        raise ConnectionError(msg)
 
-    return x509.load_der_x509_certificate(data=binary_certificate, backend=_x509_backend)
+    try:
+        return x509.load_der_x509_certificate(data=binary_certificate)
+    except ValueError as e:
+        msg = f'Unable to read SSL certificate for {hostname}: {e}'
+        logger.warning(msg)
+        raise ValueError(msg)
 
 
-def get_certificate_crls(
-        certificate: x509.Certificate,
-) -> List[x509.CertificateRevocationList]:
-    """ Extract CRLs from given certificate.
+def get_certificate_crls(certificate: x509.Certificate) -> List[x509.CertificateRevocationList]:
+    """ Extract CRLs from given certificate. CRLs are not mandatory, so it's not a problem
+    if for whatever reason they cannot be fetched or read at this exact moment.
 
     Args:
         certificate: SSL certificate of which CRLs will be retrieved from
@@ -57,10 +67,6 @@ def get_certificate_crls(
     Returns:
         list of Certificate Revocation Lists
     """
-
-    def get_crl(url: str) -> x509.CertificateRevocationList:
-        data = requests.get(url=url).content
-        return x509.load_der_x509_crl(data=data, backend=_x509_backend)
 
     try:
         distribution_points = certificate.extensions.get_extension_for_oid(
@@ -74,7 +80,16 @@ def get_certificate_crls(
         for crl in distribution_point.full_name:
             crl_urls.append(crl.value)
 
-    return [get_crl(url=url) for url in crl_urls]
+    crls = []
+    for url in crl_urls:
+        try:
+            data = requests.get(url=url).content
+            crl = x509.load_der_x509_crl(data=data)
+        except (RequestException, ValueError) as e:
+            logger.warning(f'Could not get the CRL from {url}: {e}')
+        else:
+            crls.append(crl)
+    return crls
 
 
 def is_certificate_revoked(

--- a/dp/cloud/python/magma/configuration_controller/crl_validator/certificate.py
+++ b/dp/cloud/python/magma/configuration_controller/crl_validator/certificate.py
@@ -45,16 +45,12 @@ def get_certificate(hostname: str, port: int = 443) -> Optional[x509.Certificate
             binary_certificate = sock.getpeercert(binary_form=True)
             sock.shutdown(socket.SHUT_RDWR)
     except socket.error as e:
-        msg = f'Unable to get SSL certificate for {hostname}: {e}'
-        logger.warning(msg)
-        raise ConnectionError(msg)
+        raise ConnectionError(f'Unable to get SSL certificate for {hostname}: {e}')
 
     try:
         return x509.load_der_x509_certificate(data=binary_certificate)
     except ValueError as e:
-        msg = f'Unable to read SSL certificate for {hostname}: {e}'
-        logger.warning(msg)
-        raise ValueError(msg)
+        raise ValueError(f'Unable to read SSL certificate for {hostname}: {e}')
 
 
 def get_certificate_crls(certificate: x509.Certificate) -> List[x509.CertificateRevocationList]:

--- a/dp/cloud/python/magma/configuration_controller/crl_validator/crl_validator.py
+++ b/dp/cloud/python/magma/configuration_controller/crl_validator/crl_validator.py
@@ -20,6 +20,8 @@ from magma.configuration_controller.crl_validator.certificate import (
 )
 from rwmutex import RWLock
 
+CERTIFICATE_UNAVAILABLE = 'certificate unavailable'
+
 
 def get_host(url: str) -> str:
     """ Get host from url.
@@ -72,11 +74,19 @@ class CRLValidator(object):
         try:
             with self._lock.read:
                 certificate = self._certificates[host]
-                crls = self._crls[certificate.serial_number]
+                if certificate is CERTIFICATE_UNAVAILABLE:
+                    # If certificate is not available now it should be considered valid.
+                    # We can't get CRLs without having the certificate, but CRLs are not mandatory in any way
+                    # and certificate is needed here only to validate it against its CRLs. If we don't have it
+                    # now we'll get it on next update, and if there was anything wrong with the SSL, but it
+                    # wasn't related to CRLs then requests will catch that while making the call to that host.
+                    return True
+
+                crls = self._crls.get(certificate.serial_number, [])
         except KeyError:
             raise KeyError(
-                f'{host} certificates unavailable, host was not given upon initialization'
-                f'so it was not prefetched. Available certificates: {self._hosts}',
+                f'{host} CRL validation unavailable, host was not given upon initialization, '
+                f'so certificates were not prefetched. Available hosts: {self._hosts}',
             )
 
         return not is_certificate_revoked(certificate=certificate, crls=crls)
@@ -89,7 +99,13 @@ class CRLValidator(object):
         Returns: None
         """
         for host in self._hosts:
-            certificate = get_certificate(hostname=host)
+            try:
+                certificate = get_certificate(hostname=host)
+            except (ConnectionError, ValueError):
+                with self._lock.write:
+                    self._certificates[host] = CERTIFICATE_UNAVAILABLE
+                continue
+
             crls = get_certificate_crls(certificate=certificate)
 
             with self._lock.write:

--- a/dp/cloud/python/magma/configuration_controller/run.py
+++ b/dp/cloud/python/magma/configuration_controller/run.py
@@ -83,7 +83,7 @@ def run():
         max_overflow=config.SQLALCHEMY_ENGINE_MAX_OVERFLOW,
     )
     session_manager = SessionManager(db_engine=db_engine)
-    ssl_validator = CRLValidator(urls=[config.SAS_URL]) if config.VERIFY_SAS_CRL else None
+    ssl_validator = CRLValidator(urls=[config.SAS_URL])
     router = RequestRouter(
         sas_url=config.SAS_URL,
         rc_ingest_url=config.RC_INGEST_URL,
@@ -128,15 +128,14 @@ def run():
         max_instances=1,
         name="metrics_processing_job",
     )
-    if config.VERIFY_SAS_CRL:
-        scheduler.add_job(
-            CRLValidator.update_certificates,
-            trigger=IntervalTrigger(
-                seconds=config.CRL_CACHE_TIME,
-            ),
-            max_instances=1,
-            name="crl_validator_certs_update_job",
-        )
+    scheduler.add_job(
+        ssl_validator.update_certificates,
+        trigger=IntervalTrigger(
+            seconds=config.CRL_CACHE_TIME,
+        ),
+        max_instances=1,
+        name="crl_validator_certs_update_job",
+    )
     scheduler.start()
 
     while True:

--- a/dp/cloud/python/magma/configuration_controller/tests/unit/fixtures/crl/certs.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/fixtures/crl/certs.py
@@ -11,6 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import os
+import socket
+
+import requests
 
 
 def _load_certificate_file(file: str) -> bytes:
@@ -34,4 +37,16 @@ REVOKED_CRL_CERT = _load_certificate_file(file='revoked.crt')
 REVOKED_CERT_CRLS_DATA = {
     'http://crl3.digicert.com/RapidSSLTLSDVRSAMixedSHA2562020CA-1.crl': _load_certificate_file(file='revoked_1.crl'),
     'http://crl4.digicert.com/RapidSSLTLSDVRSAMixedSHA2562020CA-1.crl': _load_certificate_file(file='revoked_2.crl'),
+}
+
+INVALID_CRL_CERT = b'invalid crl data'
+INVALID_CERT_CRLS_DATA = {
+    'http://crl3.digicert.com/DigiCertTLSHybridECCSHA3842020CA1-1.crl': b'invalid crl 1',
+    'http://crl4.digicert.com/DigiCertTLSHybridECCSHA3842020CA1-1.crl': b'invalid crl 2',
+}
+
+CERT_SOCKET_EXCEPTION = socket.error('Socket error')
+CRLS_CONNECTION_EXCEPTION = {
+    'http://crl3.digicert.com/DigiCertTLSHybridECCSHA3842020CA1-1.crl': requests.exceptions.RequestException('Request error'),
+    'http://crl4.digicert.com/DigiCertTLSHybridECCSHA3842020CA1-1.crl': requests.exceptions.RequestException('Request error'),
 }


### PR DESCRIPTION
Signed-off-by: Jarosław Jaszczuk <jaroslaw@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
`CRLValidator` is used only to validate specific cert against its CRLs, because `requests` package does its own certificates validation upon sending requests. Additionally CRLs are not required in certs, so we cannot revoke a cert because for example we had a problem while trying to download CRLs.   
With this `CRLValidator` required additional changes to be production ready:
* make SAS CRL validation always enabled for Configuration Controller
* mark certificate as valid  if unable to get cert or CRLs
* add error handling for getting certs and CRLs 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
* Added new test cases covering the changes made
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
