### PR TITLE
chore: Remove unused Bazel target eventd_cpp_proto

### DIFF
--- a/orc8r/protos/BUILD.bazel
+++ b/orc8r/protos/BUILD.bazel
@@ -89,14 +89,6 @@ proto_library(
     deps = ["@com_google_protobuf//:any_proto"],
 )
 
-cpp_proto_library(
-    name = "eventd_cpp_proto",
-    protos = [":eventd_proto"],
-    deps = [
-        ":common_cpp_proto",
-    ],
-)
-
 cpp_grpc_library(
     name = "eventd_cpp_grpc",
     protos = [":eventd_proto"],


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

We discovered in https://github.com/magma/magma/pull/13058 that the eventd_cpp_proto target is not needed by MME and it is not referenced anywhere else. This PR removes it.

## Test Plan

CI.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
