### PR TITLE
fix(orc8r): Fix typos in swagger spec

### DIFF
--- a/nms/app/views/events/EventsTable.tsx
+++ b/nms/app/views/events/EventsTable.tsx
@@ -25,7 +25,6 @@ import Text from '../../theme/design-system/Text';
 import moment from 'moment';
 import nullthrows from '../../../shared/util/nullthrows';
 import {DateTimePicker} from '@material-ui/pickers';
-import {Event as MagmaEvent} from '../../../generated';
 import {MaterialTableProps} from '@material-table/core';
 import {Theme} from '@material-ui/core/styles';
 import {colors} from '../../theme/default';
@@ -181,7 +180,7 @@ async function handleEventQuery(
         ...filters,
       })
     ).data;
-    const eventResp = (
+    const unfiltered = (
       await MagmaAPI.events.eventsNetworkIdGet({
         networkId: networkId,
         hwIds: hardwareId,
@@ -198,8 +197,6 @@ async function handleEventQuery(
       eventCount < query.page * query.pageSize
         ? eventCount / query.pageSize
         : query.page;
-    // TODO[ts-migration] There is a serious type mismatch here. Investigate!
-    const unfiltered = (eventResp as unknown) as Array<MagmaEvent>;
     const data = unfiltered.map(event => {
       return {
         ts: event.timestamp,

--- a/nms/app/views/events/__tests__/EventsTableTest.tsx
+++ b/nms/app/views/events/__tests__/EventsTableTest.tsx
@@ -107,11 +107,7 @@ const mockEvents = [
 describe('<EventsTable />', () => {
   beforeEach(() => {
     mockAPI(MagmaAPI.events, 'eventsNetworkIdAboutCountGet', mockEvents.length);
-    mockAPI(
-      MagmaAPI.events,
-      'eventsNetworkIdGet',
-      (mockEvents as unknown) as Array<string>,
-    );
+    mockAPI(MagmaAPI.events, 'eventsNetworkIdGet', mockEvents);
   });
 
   const Wrapper = () => {

--- a/nms/generated/api.ts
+++ b/nms/generated/api.ts
@@ -17485,7 +17485,7 @@ export const EventsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async eventsNetworkIdGet(networkId: string, streams?: string, events?: string, tags?: string, hwIds?: string, from?: string, size?: string, start?: string, end?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<string>>> {
+        async eventsNetworkIdGet(networkId: string, streams?: string, events?: string, tags?: string, hwIds?: string, from?: string, size?: string, start?: string, end?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Event>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.eventsNetworkIdGet(networkId, streams, events, tags, hwIds, from, size, start, end, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -17500,7 +17500,7 @@ export const EventsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async eventsNetworkIdStreamNameGet(networkId: string, streamName: string, eventType?: string, hardwareId?: string, tag?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<string>>> {
+        async eventsNetworkIdStreamNameGet(networkId: string, streamName: string, eventType?: string, hardwareId?: string, tag?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Event>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.eventsNetworkIdStreamNameGet(networkId, streamName, eventType, hardwareId, tag, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -17545,7 +17545,7 @@ export const EventsApiFactory = function (configuration?: Configuration, basePat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        eventsNetworkIdGet(networkId: string, streams?: string, events?: string, tags?: string, hwIds?: string, from?: string, size?: string, start?: string, end?: string, options?: any): AxiosPromise<Array<string>> {
+        eventsNetworkIdGet(networkId: string, streams?: string, events?: string, tags?: string, hwIds?: string, from?: string, size?: string, start?: string, end?: string, options?: any): AxiosPromise<Array<Event>> {
             return localVarFp.eventsNetworkIdGet(networkId, streams, events, tags, hwIds, from, size, start, end, options).then((request) => request(axios, basePath));
         },
         /**
@@ -17559,7 +17559,7 @@ export const EventsApiFactory = function (configuration?: Configuration, basePat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        eventsNetworkIdStreamNameGet(networkId: string, streamName: string, eventType?: string, hardwareId?: string, tag?: string, options?: any): AxiosPromise<Array<string>> {
+        eventsNetworkIdStreamNameGet(networkId: string, streamName: string, eventType?: string, hardwareId?: string, tag?: string, options?: any): AxiosPromise<Array<Event>> {
             return localVarFp.eventsNetworkIdStreamNameGet(networkId, streamName, eventType, hardwareId, tag, options).then((request) => request(axios, basePath));
         },
     };

--- a/orc8r/cloud/go/services/eventd/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/eventd/obsidian/models/swagger.v1.yml
@@ -68,7 +68,7 @@ paths:
           schema:
             type: array
             items:
-              - $ref: '#/definitions/event'
+              $ref: '#/definitions/event'
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
@@ -154,7 +154,7 @@ paths:
           schema:
             type: array
             items:
-              - $ref: '#/definitions/event'
+              $ref: '#/definitions/event'
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 

--- a/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
@@ -1127,7 +1127,7 @@ paths:
           description: Success
           schema:
             items:
-            - $ref: '#/definitions/event'
+              $ref: '#/definitions/event'
             type: array
         default:
           $ref: '#/responses/UnexpectedError'
@@ -1164,7 +1164,7 @@ paths:
           description: Success
           schema:
             items:
-            - $ref: '#/definitions/event'
+              $ref: '#/definitions/event'
             type: array
         default:
           $ref: '#/responses/UnexpectedError'


### PR DESCRIPTION
## Summary

`items` may not be a list https://swagger.io/docs/specification/data-models/data-types/#array

- fixes #13512
