### PR TITLE
chore(agw):  Magma prod vm

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -198,4 +198,37 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   end
 
+  config.vm.define :magma_prod, autostart: false do |magma_prod|
+
+    magma_prod.vm.box = "ubuntu/focal64"
+    magma_prod.vm.box_version = "20220627.1.0 "
+    magma_prod.vm.hostname = "magma-prod"
+    magma_prod.vbguest.auto_update = false
+
+    # Create a private network, which allows host-only access to the machine
+    # using a specific IP.
+    magma_prod.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
+    # iperf3 trfserver routable IP.
+    magma_prod.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
+    magma_prod.vm.network "private_network", ip: "3001::10", nic_type: "82540EM"
+
+    magma_prod.vm.provider "virtualbox" do |vb|
+      vb.name = "magma_prod"
+      vb.linked_clone = true
+      vb.customize ["modifyvm", :id, "--memory", ENV.fetch("MAGMA_DEV_MEMORY_MB", "8192")]
+      vb.customize ["modifyvm", :id, "--cpus", ENV.fetch("MAGMA_DEV_CPUS", "4")]
+      vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
+      vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
+    end
+    
+    magma_prod.vm.provision "ansible" do |ansible|
+      ansible.host_key_checking = false
+      ansible.playbook = "deploy/magma_prod.yml"
+      ansible.inventory_path = "deploy/hosts"
+      ansible.raw_arguments = ENV.fetch("ANSIBLE_ARGS", "").split(";") +
+                              ["--timeout=30"]
+      ansible.verbose = 'v'
+    end
+  end
+
 end

--- a/lte/gateway/deploy/hosts
+++ b/lte/gateway/deploy/hosts
@@ -7,6 +7,9 @@ magma ansible_ssh_host=192.168.60.142 ansible_ssh_port=22 ansible_user=vagrant
 [focal_dev]
 magma ansible_ssh_host=192.168.60.142 ansible_ssh_port=22 ansible_user=vagrant
 
+[prod]
+magma_prod ansible_ssh_host=192.168.60.142 ansible_ssh_port=22 ansible_user=vagrant
+
 [trfserver]
 magma_trfserver ansible_ssh_host=192.168.60.144 ansible_ssh_port=22 ansible_user=vagrant
 

--- a/lte/gateway/deploy/magma_prod.yml
+++ b/lte/gateway/deploy/magma_prod.yml
@@ -1,0 +1,23 @@
+---
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+- name: Set up Magma prod environment on a local machine
+  hosts: prod
+  become: yes
+
+  roles:
+    - role: magma_prod
+      vars:
+        magma_version: master
+        skip_precheck: ok

--- a/lte/gateway/deploy/roles/magma_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/magma_deploy/vars/all.yaml
@@ -12,9 +12,9 @@
 ################################################################################
 
 magma_pkgrepo_proto: https
-magma_pkgrepo_host: artifactory.magmacore.org/artifactory/debian
+magma_pkgrepo_host: artifactory.magmacore.org/artifactory/debian-test
 magma_pkgrepo_path: ""
-magma_pkgrepo_dist: focal-1.7.0
+magma_pkgrepo_dist: focal-ci
 magma_pkgrepo_component: main
 magma_pkgrepo_name: "magma"
 

--- a/lte/gateway/deploy/roles/magma_prod/files/magma-preferences
+++ b/lte/gateway/deploy/roles/magma_prod/files/magma-preferences
@@ -1,0 +1,3 @@
+Package: *
+Pin: origin artifactory.magmacore.org
+Pin-Priority: 900

--- a/lte/gateway/deploy/roles/magma_prod/files/post_install_changes.sh
+++ b/lte/gateway/deploy/roles/magma_prod/files/post_install_changes.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+service magma@* stop
+mkdir /var/opt/magma/configs
+ln -s home/vagrant/magma/lte/gateway/configs/control_proxy.yml /var/opt/magma/configs/control_proxy.yml
+cp /home/vagrant/magma/.cache/test_certs/rootCA.* /var/opt/magma/certs/
+
+mv /etc/magma/pipelined.yml /etc/magma/pipelined.yml_BKP
+mv /etc/magma/sessiond.yml /etc/magma/sessiond.yml_BKP
+ln -s /home/vagrant/magma/lte/gateway/configs/pipelined.yml /etc/magma/pipelined.yml
+ln -s /home/vagrant/magma/lte/gateway/configs/sessiond.yml /etc/magma/sessiond.yml
+
+cp /home/vagrant/magma/lte/gateway/deploy/roles/dev_common/files/sshd_config /etc/ssh
+service ssh reload
+
+mkdir -p /home/vagrant/build/python/bin
+touch /home/vagrant/build/python/bin/activate
+ln -s /usr/bin/python3 /home/vagrant/build/python/bin/python3
+
+service magma@magmad start
+

--- a/lte/gateway/deploy/roles/magma_prod/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_prod/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#- name: Adapt install script
+#  ansible.builtin.shell: sudo sed -i '19 c MAGMA_USER="vagrant"' agw_install_ubuntu.sh
+    
+#- name: Execute install script
+#  ansible.builtin.shell: sudo bash ./home/vagrant/magma/lte/gateway/deploy/agw_install_ubuntu.sh
+
+- name: Enable IP forwarding
+  sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
+
+- name: Set a convenience function for disabling TCP checksumming for traffic test
+  lineinfile:
+    dest: /home/{{ ansible_user }}/.bashrc
+    state: present
+    line: "alias disable-tcp-checksumming='sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off'"
+
+- name: Seting magma environment variables
+  lineinfile:
+    dest: /etc/environment
+    state: present
+    line: "{{ item }}"
+  with_items:
+    - MAGMA_ROOT=/home/vagrant/magma/
+    - MAGMA_DEV_MODE=1
+
+
+- name: Set MAGMA_ROOT environment variable
+  lineinfile:
+    dest: /etc/environment
+    state: present
+    line: MAGMA_ROOT=/home/vagrant/magma/
+
+- name: Copy preferences file for backports
+  copy: src=magma-preferences dest=/etc/apt/preferences.d/magma-preferences
+
+- name: Change network settings
+  ansible.builtin.shell: sudo bash /home/vagrant/magma/lte/gateway/deploy/agw_network_ubuntu.sh
+
+- name: Reboot the machine (Wait for 180s)
+  ansible.builtin.reboot:
+    reboot_timeout: 180
+
+- name: Install magma
+  ansible.builtin.shell: sudo env "SKIP_PRECHECK={{ skip_precheck }}" bash /home/vagrant/magma/lte/gateway/deploy/agw_install_ubuntu.sh
+
+- name: Reboot the machine (Wait for 180s)
+  ansible.builtin.reboot:
+    reboot_timeout: 180
+
+- name: Post install changes
+  ansible.builtin.shell: sudo bash /home/vagrant/magma/lte/gateway/deploy/roles/magma_prod/files/post_install_changes.sh


### PR DESCRIPTION
## Summary

The PR provides the Magma prod VM generated via Vagrant and Ansible. The Magma AGW installation is based  on deb packages downloaded from Artifactory. 

## Test Plan

Required: [S1AP Integration Test setup](https://docs.magmacore.org/docs/lte/s1ap_tests) with **Magma prod** instead of Magma dev, **Magma test**, **Magma traffic** server
- Magma prod: `host:~/magma/lte/gateway/$ vagrant magma_prod`

**Run precommit tests**
```
 vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make precommit 
```
- [ ] Precommit tests

**Run Integ-tests**
```
 vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make integ_test 
    TESTS=s1aptests/test_modify_mme_config_for_sanity.py
```
```
vagrant@magma-prod:~$ sudo cp /home/vagrant/magma/lte/gateway/configs/templates/mme.conf.template 
    /etc/magma/templates/mme.conf.template && sudo service magma@mme restart
```
```
 vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make integ_test
```
Cleanup
```
 vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make integ_test 
    TESTS=s1aptests/test_restore_mme_config_after_sanity.py
```
```
vagrant@magma-prod:~$ sudo cp /home/vagrant/magma/lte/gateway/configs/templates/mme.conf.template 
    /etc/magma/templates/mme.conf.template && sudo service magma@mme restart
```
- [ ] Integ tests

  
**Run Non-sanity Tests**
 ```
 vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make integ_test 
    TESTS=s1aptests/test_modify_config_for_non_sanity.py
```
```
vagrant@magma-prod:~$ sudo cp /home/vagrant/magma/lte/gateway/configs/templates/mme.conf.template 
    /etc/magma/templates/mme.conf.template && sudo service magma@mme restart
```
```
 vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make nonsanity
```
Cleanup
 ```
 vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make integ_test 
    TESTS=s1aptests/test_restore_config_after_non_sanity.py
```
```
vagrant@magma-prod:~$ sudo cp /home/vagrant/magma/lte/gateway/configs/templates/mme.conf.template 
    /etc/magma/templates/mme.conf.template &&  sudo service magma@mme restart
```
- [ ] Non-sanity tests

## Additional Information

This change is not backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
