### PR TITLE
chore: Bazelify the envoy_controller service

### DIFF
--- a/bazel/go_repositories.bzl
+++ b/bazel/go_repositories.bzl
@@ -69,6 +69,7 @@ def go_repositories():
         importpath = "github.com/census-instrumentation/opencensus-proto",
         sum = "h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=",
         version = "v0.2.1",
+        build_extra_args = ["-exclude=src"],
     )
     go_repository(
         name = "com_github_cespare_xxhash",
@@ -175,14 +176,14 @@ def go_repositories():
     go_repository(
         name = "com_github_envoyproxy_go_control_plane",
         importpath = "github.com/envoyproxy/go-control-plane",
-        sum = "h1:dulLQAYQFYtG5MTplgNGHWuV2D+OBD+Z8lmDBmbLg+s=",
-        version = "v0.9.9-0.20210512163311-63b5d3c536b0",
+        sum = "h1:fP+fF0up6oPY49OrjPrhIJ8yQfdIM85NXMLkMg1EXVs=",
+        version = "v0.9.10-0.20210907150352-cf90f659a021",
     )
     go_repository(
         name = "com_github_envoyproxy_protoc_gen_validate",
         importpath = "github.com/envoyproxy/protoc-gen-validate",
-        sum = "h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=",
-        version = "v0.1.0",
+        sum = "h1:JiO+kJTpmYGjEodY7O1Zk8oZcNz1+f30UtwtXoFUPzE=",
+        version = "v0.6.2",
     )
     go_repository(
         name = "com_github_etcd_io_bbolt",
@@ -279,6 +280,36 @@ def go_repositories():
         importpath = "github.com/golang/glog",
         sum = "h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=",
         version = "v0.0.0-20160126235308-23def4e6c14b",
+    )
+    go_repository(
+        name = "com_github_prometheus_client_golang",
+        importpath = "github.com/prometheus/client_golang",
+        sum = "h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=",
+        version = "v0.9.3",
+    )
+    go_repository(
+        name = "com_github_prometheus_procfs",
+        importpath = "github.com/prometheus/procfs",
+        sum = "h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=",
+        version = "v0.0.0-20190507164030-5867b95ac084",
+    )
+    go_repository(
+        name = "com_github_beorn7_perks",
+        importpath = "github.com/beorn7/perks",
+        sum = "h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=",
+        version = "v1.0.0",
+    )
+    go_repository(
+        name = "com_github_prometheus_common",
+        importpath = "github.com/prometheus/common",
+        sum = "h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=",
+        version = "v0.4.0",
+    )
+    go_repository(
+        name = "com_github_matttproud_golang_protobuf_extensions",
+        importpath = "github.com/matttproud/golang_protobuf_extensions",
+        sum = "h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=",
+        version = "v1.0.1",
     )
     go_repository(
         name = "com_github_golang_mock",

--- a/feg/cloud/go/protos/BUILD.bazel
+++ b/feg/cloud/go/protos/BUILD.bazel
@@ -1,0 +1,42 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "envoy_controller_go_proto",
+    srcs = ["envoy_controller.pb.go"],
+    importpath = "magma/feg/cloud/go/protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lte/cloud/go/protos:mobilityd_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+        "@org_golang_google_protobuf//runtime/protoimpl",
+    ],
+)
+
+go_library(
+    name = "hello_go_proto",
+    srcs = ["hello.pb.go"],
+    importpath = "magma/feg/cloud/go/protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+        "@org_golang_google_protobuf//runtime/protoimpl",
+    ],
+)

--- a/feg/gateway/registry/BUILD.bazel
+++ b/feg/gateway/registry/BUILD.bazel
@@ -1,0 +1,43 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "registry",
+    srcs = [
+        "cloud_registry.go",
+        "local_registry.go",
+    ],
+    importpath = "magma/feg/gateway/registry",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/gateway/go/service_registry",
+        "//orc8r/lib/go/protos:common_go_proto",
+        "//orc8r/lib/go/registry",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "registry_test",
+    srcs = ["registry_test.go"],
+    deps = [
+        "//feg/cloud/go/protos:hello_go_proto",
+        "//feg/gateway/registry",
+        "//orc8r/gateway/go/service_registry",
+        "//orc8r/lib/go/registry",
+        "//orc8r/lib/go/service/config",
+        "@com_github_stretchr_testify//assert",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//metadata",
+    ],
+)

--- a/feg/gateway/services/envoy_controller/BUILD.bazel
+++ b/feg/gateway/services/envoy_controller/BUILD.bazel
@@ -1,0 +1,33 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "envoy_controller_lib",
+    srcs = ["main.go"],
+    importpath = "magma/feg/gateway/services/envoy_controller",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//feg/cloud/go/protos:envoy_controller_go_proto",
+        "//feg/gateway/registry",
+        "//feg/gateway/services/envoy_controller/control_plane",
+        "//feg/gateway/services/envoy_controller/servicers:envoy_controller_servicers",
+        "//orc8r/lib/go/service",
+        "@com_github_golang_glog//:glog",
+    ],
+)
+
+go_binary(
+    name = "envoy_controller",
+    embed = [":envoy_controller_lib"],
+    visibility = ["//visibility:private"],
+)

--- a/feg/gateway/services/envoy_controller/control_plane/BUILD.bazel
+++ b/feg/gateway/services/envoy_controller/control_plane/BUILD.bazel
@@ -1,0 +1,42 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "control_plane",
+    srcs = ["control_plane.go"],
+    importpath = "magma/feg/gateway/services/envoy_controller/control_plane",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//feg/cloud/go/protos:envoy_controller_go_proto",
+        "@com_github_envoyproxy_go_control_plane//envoy/config/cluster/v3:cluster",
+        "@com_github_envoyproxy_go_control_plane//envoy/config/core/v3:core",
+        "@com_github_envoyproxy_go_control_plane//envoy/config/listener/v3:listener",
+        "@com_github_envoyproxy_go_control_plane//envoy/config/route/v3:route",
+        "@com_github_envoyproxy_go_control_plane//envoy/extensions/filters/listener/original_src/v3:original_src",
+        "@com_github_envoyproxy_go_control_plane//envoy/extensions/filters/network/http_connection_manager/v3:http_connection_manager",
+        "@com_github_envoyproxy_go_control_plane//envoy/service/cluster/v3:cluster",
+        "@com_github_envoyproxy_go_control_plane//envoy/service/discovery/v3:discovery",
+        "@com_github_envoyproxy_go_control_plane//envoy/service/endpoint/v3:endpoint",
+        "@com_github_envoyproxy_go_control_plane//envoy/service/listener/v3:listener",
+        "@com_github_envoyproxy_go_control_plane//envoy/service/route/v3:route",
+        "@com_github_envoyproxy_go_control_plane//pkg/cache/types",
+        "@com_github_envoyproxy_go_control_plane//pkg/cache/v3:cache",
+        "@com_github_envoyproxy_go_control_plane//pkg/resource/v3:resource",
+        "@com_github_envoyproxy_go_control_plane//pkg/server/v3:server",
+        "@com_github_envoyproxy_go_control_plane//pkg/wellknown",
+        "@com_github_golang_glog//:glog",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
+        "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)

--- a/feg/gateway/services/envoy_controller/control_plane/mocks/BUILD.bazel
+++ b/feg/gateway/services/envoy_controller/control_plane/mocks/BUILD.bazel
@@ -1,0 +1,24 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "envoy_controller_mocks",
+    testonly = True,
+    srcs = ["EnvoyController.go"],
+    importpath = "magma/feg/gateway/services/envoy_controller/control_plane/mocks",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//feg/gateway/services/envoy_controller/control_plane",
+        "@com_github_stretchr_testify//mock",
+    ],
+)

--- a/feg/gateway/services/envoy_controller/servicers/BUILD.bazel
+++ b/feg/gateway/services/envoy_controller/servicers/BUILD.bazel
@@ -1,0 +1,45 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "envoy_controller_servicers",
+    srcs = ["envoy_controller.go"],
+    importpath = "magma/feg/gateway/services/envoy_controller/servicers",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//feg/cloud/go/protos:envoy_controller_go_proto",
+        "//feg/gateway/services/envoy_controller/control_plane",
+        "@com_github_golang_glog//:glog",
+    ],
+)
+
+go_test(
+    name = "envoy_controller_test",
+    srcs = ["envoy_controller_test.go"],
+    deps = [
+        "//feg/cloud/go/protos:envoy_controller_go_proto",
+        "//feg/gateway/services/envoy_controller/control_plane",
+        "//feg/gateway/services/envoy_controller/control_plane/mocks:envoy_controller_mocks",
+        "//feg/gateway/services/envoy_controller/servicers:envoy_controller_servicers",
+        "//lte/cloud/go/protos:mobilityd_go_proto",
+        "@com_github_envoyproxy_go_control_plane//envoy/config/core/v3:core",
+        "@com_github_envoyproxy_go_control_plane//envoy/config/listener/v3:listener",
+        "@com_github_envoyproxy_go_control_plane//envoy/config/route/v3:route",
+        "@com_github_envoyproxy_go_control_plane//envoy/extensions/filters/listener/original_src/v3:original_src",
+        "@com_github_envoyproxy_go_control_plane//envoy/extensions/filters/network/http_connection_manager/v3:http_connection_manager",
+        "@com_github_envoyproxy_go_control_plane//pkg/wellknown",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
+        "@com_github_stretchr_testify//assert",
+        "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
+    ],
+)

--- a/lte/cloud/go/protos/BUILD.bazel
+++ b/lte/cloud/go/protos/BUILD.bazel
@@ -1,0 +1,90 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "policydb_go_proto",
+    srcs = ["policydb.pb.go"],
+    embed = [":mobilityd_go_proto"],
+    importpath = "magma/lte/cloud/go/protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+        "@org_golang_google_protobuf//runtime/protoimpl",
+    ],
+)
+
+go_library(
+    name = "mobilityd_go_proto",
+    srcs = ["mobilityd.pb.go"],
+    embed = [":subscriberdb_go_proto"],
+    importpath = "magma/lte/cloud/go/protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+        "@org_golang_google_protobuf//runtime/protoimpl",
+    ],
+)
+
+go_library(
+    name = "subscriberdb_go_proto",
+    srcs = ["subscriberdb.pb.go"],
+    embed = [":apn_go_proto"],
+    importpath = "magma/lte/cloud/go/protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/lib/go/protos:common_go_proto",
+        "@io_bazel_rules_go//proto/wkt:field_mask_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+        "@org_golang_google_protobuf//runtime/protoimpl",
+    ],
+)
+
+go_library(
+    name = "apn_go_proto",
+    srcs = ["apn.pb.go"],
+    importpath = "magma/lte/cloud/go/protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+        "@org_golang_google_protobuf//runtime/protoimpl",
+    ],
+)
+
+go_library(
+    name = "sid",
+    srcs = ["sid.go"],
+    embed = [":subscriberdb_go_proto"],
+    importpath = "magma/lte/cloud/go/protos",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "sid_test",
+    srcs = ["sid_test.go"],
+    deps = [
+        ":sid",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/orc8r/gateway/go/service_registry/BUILD.bazel
+++ b/orc8r/gateway/go/service_registry/BUILD.bazel
@@ -1,0 +1,32 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "service_registry",
+    srcs = [
+        "registry.go",
+        "shared_registry.go",
+    ],
+    importpath = "magma/orc8r/gateway/go/service_registry",
+    # Equivalent to replace directives in go.mod files.
+    importpath_aliases = ["magma/gateway/service_registry"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/lib/go/initflag",
+        "//orc8r/lib/go/protos:common_go_proto",
+        "//orc8r/lib/go/registry",
+        "//orc8r/lib/go/service/config",
+        "@com_github_golang_glog//:glog",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)

--- a/orc8r/lib/go/initflag/BUILD.bazel
+++ b/orc8r/lib/go/initflag/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# This empty library is needed to satisfy the side-effect imports of
+# this package. E.g. in orc8r/lib/go/service/config/service_config.go
+go_library(
+    name = "initflag",
+    importpath = "magma/orc8r/lib/go/initflag",
+    visibility = ["//visibility:public"],
+)

--- a/orc8r/lib/go/metrics/BUILD.bazel
+++ b/orc8r/lib/go/metrics/BUILD.bazel
@@ -1,0 +1,34 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "metrics_export",
+    srcs = ["metrics_export.go"],
+    importpath = "magma/orc8r/lib/go/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_model//go",
+    ],
+)
+
+go_test(
+    name = "metrics_export_test",
+    srcs = ["metrics_export_test.go"],
+    deps = [
+        "//orc8r/lib/go/metrics:metrics_export",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_model//go",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/orc8r/lib/go/protos/BUILD.bazel
+++ b/orc8r/lib/go/protos/BUILD.bazel
@@ -1,0 +1,76 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "common_go_proto",
+    srcs = [
+        "common.pb.go",
+        "digest.pb.go",
+        "mconfig.pb.go",
+        "metricsd.pb.go",
+        "service303.pb.go",
+        "service_registry.pb.go",
+    ],
+    importpath = "magma/orc8r/lib/go/protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_prometheus_client_model//go",
+        "@io_bazel_rules_go//proto/wkt:any_go_proto",
+        "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+        "@org_golang_google_protobuf//runtime/protoimpl",
+    ],
+)
+
+go_library(
+    name = "fillin",
+    srcs = ["fillin.go"],
+    importpath = "magma/orc8r/lib/go/protos",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "fill_in_test",
+    srcs = ["fill_in_test.go"],
+    deps = [
+        ":fillin",
+        "@com_github_stretchr_testify//assert",
+    ],
+)
+
+go_library(
+    name = "marshaler",
+    srcs = ["marshaler.go"],
+    embed = [":common_go_proto"],
+    importpath = "magma/orc8r/lib/go/protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_glog//:glog",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "marshaler_test",
+    srcs = ["marshaler_test.go"],
+    deps = [
+        ":marshaler",
+        "//orc8r/lib/go/protos/mconfig",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/orc8r/lib/go/protos/mconfig/BUILD.bazel
+++ b/orc8r/lib/go/protos/mconfig/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mconfig",
+    testonly = True,
+    srcs = ["mconfigs.pb.go"],
+    importpath = "magma/orc8r/lib/go/protos/mconfig",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/lib/go/protos:marshaler",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+        "@org_golang_google_protobuf//runtime/protoimpl",
+    ],
+)

--- a/orc8r/lib/go/registry/BUILD.bazel
+++ b/orc8r/lib/go/registry/BUILD.bazel
@@ -1,0 +1,45 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "registry",
+    srcs = [
+        "cloud_connection.go",
+        "global_registry.go",
+        "interceptors.go",
+        "registry.go",
+        "service_registry.go",
+        "shared_cloud_conn.go",
+    ],
+    importpath = "magma/orc8r/lib/go/registry",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/lib/go/protos:common_go_proto",
+        "//orc8r/lib/go/registry/client:client_api",
+        "//orc8r/lib/go/service/config",
+        "@com_github_golang_glog//:glog",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//backoff",
+        "@org_golang_google_grpc//connectivity",
+        "@org_golang_google_grpc//credentials",
+        "@org_golang_google_grpc//keepalive",
+        "@org_golang_google_grpc//metadata",
+    ],
+)
+
+go_test(
+    name = "registry_test",
+    srcs = ["registry_test.go"],
+    embed = [":registry"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/orc8r/lib/go/registry/client/BUILD.bazel
+++ b/orc8r/lib/go/registry/client/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "client_api",
+    srcs = ["client_api.go"],
+    importpath = "magma/orc8r/lib/go/registry/client",
+    visibility = ["//visibility:public"],
+    deps = ["//orc8r/lib/go/protos:common_go_proto"],
+)

--- a/orc8r/lib/go/service/BUILD.bazel
+++ b/orc8r/lib/go/service/BUILD.bazel
@@ -1,0 +1,36 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "service",
+    srcs = [
+        "logcodec.go",
+        "service.go",
+        "service303.go",
+    ],
+    importpath = "magma/orc8r/lib/go/service",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/lib/go/metrics:metrics_export",
+        "//orc8r/lib/go/protos:common_go_proto",
+        "//orc8r/lib/go/registry",
+        "//orc8r/lib/go/service/config",
+        "@com_github_golang_glog//:glog",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//encoding",
+        "@org_golang_google_grpc//encoding/proto",
+        "@org_golang_google_grpc//keepalive",
+    ],
+)

--- a/orc8r/lib/go/service/config/BUILD.bazel
+++ b/orc8r/lib/go/service/config/BUILD.bazel
@@ -1,0 +1,35 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "config",
+    srcs = [
+        "config_map.go",
+        "service_config.go",
+    ],
+    importpath = "magma/orc8r/lib/go/service/config",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//orc8r/lib/go/initflag",
+        "@com_github_golang_glog//:glog",
+        "@in_gopkg_yaml_v2//:yaml_v2",
+    ],
+)
+
+go_test(
+    name = "service_config_test",
+    srcs = ["service_config_test.go"],
+    embed = [":config"],
+    flaky = True,
+    deps = ["@com_github_stretchr_testify//assert"],
+)


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The `envoy_controller` Go service is bazelified
- See the linked issue https://github.com/magma/magma/issues/13414 for technical details 

## Test Plan

- Run tests: `bazel test //feg/... //lte/cloud/go/protos/... //orc8r/lib/go/...`
- Build service: `bazel build feg/gateway/services/envoy_controller:envoy_controller`

## Additional Information

- The dependency graph can be generated with:
  `bazel query 'filter("(^[^@])", filter("^(?!.*external)", deps(//feg/gateway/services/envoy_controller )))' --output graph | dot -Tsvg > envoy_deps.svg`

- The resulting graph is:

![envoy_deps](https://user-images.githubusercontent.com/34488763/183053816-76ef62b2-058a-4711-8990-f36be2fa704b.svg)


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
