### PR TITLE
chore: Allow Bazel commands to run in repository subdirectories

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,7 +48,7 @@ run:remote_caching_ro --remote_download_toplevel
 
 # Import the bazel caching config, with default disk cache,
 # which in CI gets overwritten by the remote caching config. 
-import bazel/bazelrcs/cache.bazelrc
+import %workspace%/bazel/bazelrcs/cache.bazelrc
 
 # TEST CONFIGS
 # Bazel test runtime default: PATH=/bin:/usr/bin:/usr/local/bin


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Since https://github.com/magma/magma/pull/12987 was merged, the bazel commands will only work in the magma folder, because the cache setup was reworked to use a relative path: bazel/bazelrcs/cache.bazelrc
This PR changes the path to use the workspace root.

## Test Plan

Try using Bazel in subdirectories.
For example: `cd $MAGMA_ROOT/lte/gateway && bazel build //:buildifier`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
