### PR TITLE
chore(orc8r): Add sources to initflag library in bazel

### DIFF
--- a/orc8r/lib/go/initflag/BUILD.bazel
+++ b/orc8r/lib/go/initflag/BUILD.bazel
@@ -11,10 +11,16 @@
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-# This empty library is needed to satisfy the side-effect imports of
+# This library is needed to satisfy the side-effect imports of
 # this package. E.g. in orc8r/lib/go/service/config/service_config.go
 go_library(
     name = "initflag",
+    srcs = [
+        "initflag.go",
+        "parse_flag_debug.go",
+        "parse_flag_release.go",
+        "syslog.go",
+    ],
     importpath = "magma/orc8r/lib/go/initflag",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>


## Summary

- Sources are added to the `initflag` bazel target
  - The sources are needed for the `init()` function to run during side-effect imports. 

## Test Plan

- `bazel build //orc8r/lib/go/initflag`
- In the `orc8r/lib/go/initflag/initflag.go` file add a line `	panic("This is the init function!")` to the `init` function and run `bazel run //feg/gateway/services/envoy_controller`, see that the `init` function is used. If the sources are not added then the `panic` does not have an effect.


## Additional Information

- [ ] This change is backwards-breaking


