### PR TITLE
fix(nms): Remove non-existing parameter

### DIFF
--- a/nms/app/views/events/EventsTable.tsx
+++ b/nms/app/views/events/EventsTable.tsx
@@ -173,9 +173,6 @@ async function handleEventQuery(
         streams: streams,
         hwIds: hardwareId,
         tags: tags,
-        // TODO[ts-migration] "from" does not appear in API
-        // @ts-ignore
-        from,
         start: start.toISOString(),
         end: end.toISOString(),
         ...filters,


### PR DESCRIPTION
## Summary

- Fixes https://github.com/magma/magma/issues/13530

- The `from` parameter defaults to zero in this generic code block https://github.com/magma/magma/blob/be8d0b6a5fbebf92b538c0d1da9ecae0459a5dc1/orc8r/cloud/go/services/eventd/obsidian/handlers/handlers.go#L190
- And it is actually not used for the particular endpoint, therefore it makes sense that it is missing from the swagger spec.
https://github.com/magma/magma/blob/13b485a9b6da5874761919c840e4c0a8be81641d/orc8r/cloud/go/services/eventd/eventd_client/eventd_client.go#L107

