### PR TITLE
fix(ci): magma logo location has changed

### DIFF
--- a/ci-scripts/html-templates/file-header.htm
+++ b/ci-scripts/html-templates/file-header.htm
@@ -11,9 +11,9 @@
   <br>
   <table width = "100%" style="border-collapse: collapse; border: none;">
    <tr style="border-collapse: collapse; border: none;">
-     <td bgcolor="#5602a4" style="border-collapse: collapse; border: none;">
+     <td style="border-collapse: collapse; border: none;">
        <a href="https://www.magmacore.org/">
-          <img src="https://www.magmacore.org/img/magma-logo.svg" alt="" border="none" height=50 width=150>
+          <img src="https://magmacore.org/wp-content/uploads/sites/5/2022/03/purple-logo.svg" alt="" border="none" height=50 width=150>
           </img>
        </a>
      </td>


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

Looking at https://jenkins-oai.eurecom.fr/job/MAGMA-MME-production/17493/artifact/build_results_magma_oai_mme.html I saw that the magma logo moved.

## Test Plan

None. CI pipeline should take care of it.

## Additional Information

- [ ] This change is backwards-breaking
