### PR TITLE
feat(agw): Create magma VM based on debian package

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -31,6 +31,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # Create a private network, which allows host-only access to the machine
     # using a specific IP.
+    # WARNING: The same networking is used for magma and magma_deb. Therefore:
+    # 1. Only one of these VMs should be running at any one time
+    # 2. Any changes to the magma networking should be propagated to magma_deb
     magma.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
     # iperf3 trfserver routable IP.
     magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
@@ -190,6 +193,42 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
     end
 
+  end
+
+  config.vm.define :magma_deb, autostart: false do |magma_deb|
+
+    magma_deb.vm.box = "ubuntu/focal64"
+    magma_deb.vm.box_version = "20220804.0.0"
+    magma_deb.vm.hostname = "magma-deb"
+    magma_deb.vbguest.auto_update = false
+
+    # Create a private network, which allows host-only access to the machine
+    # using a specific IP.
+    # WARNING: The same networking is used for magma and magma_deb. Therefore:
+    # 1. Only one of these VMs should be running at any one time
+    # 2. Any changes to the magma networking should be propagated to magma_deb
+    magma_deb.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
+    # iperf3 trfserver routable IP.
+    magma_deb.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
+    magma_deb.vm.network "private_network", ip: "3001::10", nic_type: "82540EM"
+
+    magma_deb.vm.provider "virtualbox" do |vb|
+      vb.name = "magma_deb"
+      vb.linked_clone = true
+      vb.customize ["modifyvm", :id, "--memory", ENV.fetch("MAGMA_DEV_MEMORY_MB", "8192")]
+      vb.customize ["modifyvm", :id, "--cpus", ENV.fetch("MAGMA_DEV_CPUS", "4")]
+      vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
+      vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
+    end
+    
+    magma_deb.vm.provision "ansible" do |ansible|
+      ansible.host_key_checking = false
+      ansible.playbook = "deploy/magma_deb.yml"
+      ansible.inventory_path = "deploy/hosts"
+      ansible.raw_arguments = ENV.fetch("ANSIBLE_ARGS", "").split(";") +
+                              ["--timeout=30"]
+      ansible.verbose = 'v'
+    end
   end
 
 end

--- a/lte/gateway/deploy/agw_install_ubuntu_vm.sh
+++ b/lte/gateway/deploy/agw_install_ubuntu_vm.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Setting up env variable, user and project path
+set -x
+
+MAGMA_USER="vagrant"
+AGW_INSTALL_CONFIG="/lib/systemd/system/agw_installation.service"
+DEPLOY_PATH="/home/$MAGMA_USER/magma/lte/gateway/deploy"
+SUCCESS_MESSAGE="ok"
+WHOAMI=$(whoami)
+
+echo "Checking if the script has been executed by root user"
+if [ "$WHOAMI" != "root" ]; then
+  echo "You're executing the script as $WHOAMI instead of root.. exiting"
+  exit 1
+fi
+
+echo "Checking if Ubuntu is installed"
+if ! grep -q 'Ubuntu' /etc/issue; then
+  echo "Ubuntu is not installed"
+  exit 1
+fi
+
+echo "Checking if magma has been installed"
+MAGMA_INSTALLED=$(apt-cache show magma >  /dev/null 2>&1 echo "$SUCCESS_MESSAGE")
+if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
+  echo "Magma not installed, processing installation"
+  apt-get -y install curl make virtualenv zip rsync git software-properties-common python3-pip python-dev apt-transport-https
+
+  alias python=python3
+  pip3 install ansible==5.10.0
+
+  echo "Generating localhost hostfile for Ansible"
+  echo "[magma_deploy]
+  127.0.0.1 ansible_connection=local" > $DEPLOY_PATH/agw_hosts
+
+  # install magma and its dependencies including OVS.
+  su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='/home/$MAGMA_USER/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts -e \"use_master=True\" $DEPLOY_PATH/magma_deploy.yml"
+
+  echo "Cleanup temp files"
+  cd /root || exit
+  rm -rf $AGW_INSTALL_CONFIG
+  rm -f $DEPLOY_PATH/agw_hosts
+
+else
+  echo "Magma already installed, skipping.."
+fi

--- a/lte/gateway/deploy/agw_network_ubuntu.sh
+++ b/lte/gateway/deploy/agw_network_ubuntu.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Setting up env variable, user and project path
+set -x
+
+MAGMA_USER="vagrant"
+WHOAMI=$(whoami)
+CLOUD_INSTALL="cloud"
+INTERFACE_DIR="/etc/network/interfaces.d"
+
+echo "Checking if the script has been executed by root user"
+if [ "$WHOAMI" != "root" ]; then
+  echo "You're executing the script as $WHOAMI instead of root.. exiting"
+  exit 1
+fi
+
+echo "Checking if Ubuntu is installed"
+if ! grep -q 'Ubuntu' /etc/issue; then
+  echo "Ubuntu is not installed"
+  exit 1
+fi
+
+apt-get update
+
+echo "Need to check if both interfaces are named eth0 and eth1"
+INTERFACES=$(ip -br a)
+if [[ $1 != "$CLOUD_INSTALL" ]] && ( [[ ! $INTERFACES == *'eth0'*  ]] || [[ ! $INTERFACES == *'eth1'* ]] || ! grep -q 'GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"' /etc/default/grub); then
+  # changing intefaces name
+  sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
+  sed -i 's/enp0s3/eth0/g' /etc/netplan/50-cloud-init.yaml
+  # changing interface name
+  grub-mkconfig -o /boot/grub/grub.cfg
+
+  # name server config
+  ln -sf /var/run/systemd/resolve/resolv.conf /etc/resolv.conf
+  sed -i 's/#DNS=/DNS=8.8.8.8 208.67.222.222/' /etc/systemd/resolved.conf
+  service systemd-resolved restart
+
+  # interface config
+  apt install -y ifupdown net-tools ipcalc
+  mkdir -p "$INTERFACE_DIR"
+  echo "source-directory $INTERFACE_DIR" > /etc/network/interfaces
+
+  # DHCP allocated interface IP
+  echo "auto eth0
+  iface eth0 inet dhcp" > "$INTERFACE_DIR"/eth0
+
+  # configuring eth1
+  echo "auto eth1
+  iface eth1 inet static
+  address 192.168.60.142
+  netmask 255.255.255.0" > "$INTERFACE_DIR"/eth1
+
+  # get rid of netplan
+  systemctl unmask networking
+  systemctl enable networking
+
+  apt-get --assume-yes purge nplan netplan.i
+
+else
+  echo "Interfaces name are correct, let's check if network and DNS are up"
+  while ! nslookup google.com; do
+    echo "DNS not reachable"
+    sleep 1
+  done
+
+  while ! ping -c 1 -W 1 -I eth0 8.8.8.8; do
+    echo "Network not ready yet"
+    sleep 1
+  done
+fi
+
+echo "Making sure $MAGMA_USER user is sudoers"
+if ! grep -q "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" /etc/sudoers; then
+  apt install -y sudo
+  adduser --disabled-password --gecos "" $MAGMA_USER
+  adduser $MAGMA_USER sudo
+  echo "$MAGMA_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+fi

--- a/lte/gateway/deploy/hosts
+++ b/lte/gateway/deploy/hosts
@@ -7,6 +7,9 @@ magma ansible_ssh_host=192.168.60.142 ansible_ssh_port=22 ansible_user=vagrant
 [focal_dev]
 magma ansible_ssh_host=192.168.60.142 ansible_ssh_port=22 ansible_user=vagrant
 
+[deb]
+magma_deb ansible_ssh_host=192.168.60.142 ansible_ssh_port=22 ansible_user=vagrant
+
 [trfserver]
 magma_trfserver ansible_ssh_host=192.168.60.144 ansible_ssh_port=22 ansible_user=vagrant
 

--- a/lte/gateway/deploy/magma_deb.yml
+++ b/lte/gateway/deploy/magma_deb.yml
@@ -1,0 +1,20 @@
+---
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+- name: Set up Magma environment based on debian package for integration testing
+  hosts: deb
+  become: yes
+
+  roles:
+    - role: magma_deb

--- a/lte/gateway/deploy/roles/magma_deb/files/magma-preferences
+++ b/lte/gateway/deploy/roles/magma_deb/files/magma-preferences
@@ -1,0 +1,3 @@
+Package: *
+Pin: origin artifactory.magmacore.org
+Pin-Priority: 900

--- a/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
@@ -1,0 +1,158 @@
+---
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+- name: Enable IP forwarding
+  sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
+
+- name: Set a convenience function for disabling TCP checksumming for traffic test
+  lineinfile:
+    dest: /home/{{ ansible_user }}/.bashrc
+    state: present
+    line: "alias disable-tcp-checksumming='sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off'"
+
+- name: Setting magma environment variables
+  lineinfile:
+    dest: /etc/environment
+    state: present
+    line: "{{ item }}"
+  with_items:
+    - MAGMA_ROOT=/home/vagrant/magma/
+    - MAGMA_DEV_MODE=1
+
+- name: Create python binary directory
+  file:
+    path: /home/vagrant/build/python/bin
+    state: directory
+    recurse: yes
+
+# Fake python environment so magma_test ssh calls on activate will not fail
+- name: Create python activate file
+  file:
+    path: /home/vagrant/build/python/bin/activate
+    state: touch
+
+# Make magma_test ssh calls on python3 possible
+- name: Link python3 binary
+  file:
+    src: /usr/bin/python3
+    dest: /home/vagrant/build/python/bin/python3
+    state: link
+    force: yes
+
+- name: Copy preferences file for backports
+  copy: src=magma-preferences dest=/etc/apt/preferences.d/magma-preferences
+
+- name: Change network settings
+  ansible.builtin.shell: sudo bash /home/vagrant/magma/lte/gateway/deploy/agw_network_ubuntu.sh
+
+- name: Reboot the machine (Wait for 180s)
+  ansible.builtin.reboot:
+    reboot_timeout: 180
+
+- name: Install magma
+  ansible.builtin.shell: sudo bash /home/vagrant/magma/lte/gateway/deploy/agw_install_ubuntu_vm.sh
+
+- name: Copy ssh configuration
+  copy:
+    src: /home/vagrant/magma/lte/gateway/deploy/roles/dev_common/files/sshd_config
+    dest: /etc/ssh
+    remote_src: yes
+    force: yes
+
+- name: Reload ssh
+  become: yes
+  service:
+    name: ssh
+    state: reloaded
+
+- name: Create configuration directory
+  file:
+    path: /var/opt/magma/configs
+    state: directory
+    recurse: yes
+
+- name: Use non-production control proxy configuration
+  file:
+    src: /home/vagrant/magma/lte/gateway/configs/control_proxy.yml
+    dest: /var/opt/magma/configs/control_proxy.yml
+    state: link
+    force: yes
+
+- name: Create test certificates directory
+  file:
+    path: /var/opt/magma/certs/
+    state: directory
+    recurse: yes
+
+- name: Copy test certificates
+  copy:
+    src: "/home/vagrant/magma/.cache/test_certs/rootCA{{ item }}"
+    dest: /var/opt/magma/certs/
+    remote_src: yes
+  with_items:
+    - .key
+    - .pem
+    - .srl
+
+- name: Override pipelined and sessiond production configuration
+  file:
+    src: "/home/vagrant/magma/lte/gateway/configs/{{ item }}"
+    dest: "/etc/magma/{{ item }}"
+    state: link
+    force: yes
+  loop:
+    - pipelined.yml
+    - sessiond.yml
+
+- name: Ensure changes in repository are used in services
+  file:
+    src: "/home/vagrant/magma/lte/gateway/configs/{{ item }}"
+    dest: "/etc/magma/{{ item }}"
+    state: link
+    force: yes
+  loop:
+    - templates/mme.conf.template
+    - gateway.mconfig
+
+- name: Clear existing service files
+  shell: rm -f /etc/systemd/system/magma*
+
+- name: Override production service configurations with test configurations
+  copy:
+    src: "/home/vagrant/magma/{{ item.src }}"
+    dest: "/etc/systemd/system/{{ item.dest }}"
+    remote_src: yes
+  with_items:
+    - { src: 'orc8r/tools/ansible/roles/gateway_services/files/magma.service', dest: 'magma@.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_connectiond.service', dest: 'magma@connectiond.service' }
+    - { src: 'orc8r/tools/ansible/roles/gateway_services/files/magma_control_proxy.service', dest: 'magma@control_proxy.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_ctraced.service', dest: 'magma@ctraced.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_dnsd.service', dest: 'magma@dnsd.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_envoy_controller.service', dest: 'magma@envoy_controller.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service', dest: 'magma@eventd.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_liagentd.service', dest: 'magma@liagentd.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_lighttpd.service', dest: 'magma@lighttpd.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_magmad.service', dest: 'magma@magmad.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_mme.service', dest: 'magma@mme.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_mobilityd.service', dest: 'magma@mobilityd.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_pipelined.service', dest: 'magma@pipelined.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_redirectd.service', dest: 'magma@redirectd.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_redis.service', dest: 'magma@redis.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_sessiond.service', dest: 'magma@sessiond.service' }
+    - { src: 'orc8r/tools/ansible/roles/fluent_bit/files/magma_td-agent-bit.service', dest: 'magma@td-agent-bit.service' }
+    - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_dp_envoy.service', dest: 'magma_dp@envoy.service' }
+
+- name: Reboot the machine (Wait for 180s)
+  ansible.builtin.reboot:
+    reboot_timeout: 180

--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -14,6 +14,15 @@
 - name: Include vars of all.yaml
   include_vars:
     file: all.yaml
+  when: use_master is not defined
+  tags:
+    - agwc
+    - base
+
+- name: Include vars of all_master.yaml
+  include_vars:
+    file: all_master.yaml
+  when: use_master is defined
   tags:
     - agwc
     - base

--- a/lte/gateway/deploy/roles/magma_deploy/vars/all_master.yaml
+++ b/lte/gateway/deploy/roles/magma_deploy/vars/all_master.yaml
@@ -1,0 +1,24 @@
+---
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+magma_pkgrepo_proto: https
+magma_pkgrepo_host: artifactory.magmacore.org/artifactory/debian-test
+magma_pkgrepo_path: ""
+magma_pkgrepo_dist: focal-ci
+magma_pkgrepo_component: main
+magma_pkgrepo_name: "magma"
+
+magma_pkgrepo_key: "https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public"
+magma_pkgrepo_key_fingerprint: ""
+magma_use_pkgrepo: yes


### PR DESCRIPTION
## Summary

Closes https://github.com/magma/magma/issues/13263.

Known issues associated with this PR:
* In some cases, we see that pipelined is not reachable. This seems to be due to a problem with restarting this service in this set-up. This could be related to https://github.com/magma/magma/issues/13551.
* `agw_install_ubuntu.sh` is basically duplicated into `agw_install_ubuntu_vm.sh` and `agw_network_ubuntu.sh`. The reason is that the `agw_install_ubuntu.sh` is the official installation script and it seems wrong to mix this with planned CI set-up. A flag was introduced into the magma_deploy role to get around this.

## Test Plan

* `lte/gateway $ vagrant up magma_deb` + same for magma_test + magma_trfserver + execute all relevant integration tests
* All `precommit` and `extended` LTE integ tests ran green locally at least once
