### PR TITLE
chore(sessiond): Remove legacy subscriber_state

### DIFF
--- a/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
+++ b/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
@@ -45,8 +45,6 @@ OpState get_operational_states(magma::lte::SessionStore* session_store) {
 
   for (auto& it : session_map) {
     std::map<std::string, std::string> state;
-    state[TYPE] = SUBSCRIBER_STATE_TYPE;
-    state[DEVICE_ID] = it.first;
     nlohmann::json sessions_by_apn = nlohmann::json::object();
 
     for (auto& session : it.second) {
@@ -56,9 +54,7 @@ OpState get_operational_states(magma::lte::SessionStore* session_store) {
       }
       sessions_by_apn[apn].push_back(get_dynamic_session_state(session));
     }
-    state[VALUE] = sessions_by_apn.dump();
-    states.push_back(state);
-    subscribers[state[DEVICE_ID]] = sessions_by_apn;
+    subscribers[it.first] = sessions_by_apn;
   }
   std::map<std::string, std::string> gateway_subscriber_state;
   gateway_subscriber_state[TYPE] = GATEWAY_SUBSCRIBER_STATE_TYPE;

--- a/lte/gateway/c/session_manager/test/test_operational_states_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_operational_states_handler.cpp
@@ -71,41 +71,36 @@ TEST_F(OperationalStatesHandlerTest, test_get_operational_states) {
       create_session_vec(IMSI2, IP2, SESSION_START_TIME_2, SESSION_ID_2);
   session_store->create_sessions(IMSI2, std::move(session_vec));
   states = get_operational_states(session_store.get());
-  EXPECT_EQ(states.size(), 3);
+  EXPECT_EQ(states.size(), 1);
 
-  for (std::map<std::string, std::string> subscriber_state : states) {
-    std::map<std::string, std::string>::iterator subscriber_state_it =
-        subscriber_state.find(TYPE);
-    EXPECT_FALSE(subscriber_state_it == subscriber_state.end());
+  std::map<std::string, std::string> subscriber_state = states.front();
+  std::map<std::string, std::string>::iterator subscriber_state_it =
+      subscriber_state.find(TYPE);
+  EXPECT_FALSE(subscriber_state_it == subscriber_state.end());
+  EXPECT_EQ(subscriber_state_it->second, GATEWAY_SUBSCRIBER_STATE_TYPE);
 
-    if (subscriber_state_it != subscriber_state.end() &&
-        subscriber_state_it->second == GATEWAY_SUBSCRIBER_STATE_TYPE) {
-      EXPECT_EQ(subscriber_state_it->second, GATEWAY_SUBSCRIBER_STATE_TYPE);
-      subscriber_state_it = subscriber_state.find(VALUE);
-      EXPECT_FALSE(subscriber_state_it == subscriber_state.end());
-      json_value = nlohmann::json::parse(subscriber_state_it->second);
-      nlohmann::json gateway_subscribers = json_value[SUBSCRIBERS];
-      nlohmann::json content = gateway_subscribers[IMSI1][APN1];
-      EXPECT_EQ(content.size(), 1);
-      content = content[0];
-      EXPECT_EQ(content["lifecycle_state"],
-                session_fsm_state_to_str(SESSION_ACTIVE));
-      EXPECT_EQ(content["session_start_time"], SESSION_START_TIME_1);
-      EXPECT_EQ(content["apn"], APN1);
-      EXPECT_EQ(content["ipv4"], IP1);
-      EXPECT_EQ(content["session_id"], SESSION_ID_1);
+  subscriber_state_it = subscriber_state.find(VALUE);
+  EXPECT_FALSE(subscriber_state_it == subscriber_state.end());
+  json_value = nlohmann::json::parse(subscriber_state_it->second);
+  nlohmann::json gateway_subscribers = json_value[SUBSCRIBERS];
+  nlohmann::json content = gateway_subscribers[IMSI1][APN1];
+  EXPECT_EQ(content.size(), 1);
+  content = content[0];
+  EXPECT_EQ(content["lifecycle_state"],
+            session_fsm_state_to_str(SESSION_ACTIVE));
+  EXPECT_EQ(content["session_start_time"], SESSION_START_TIME_1);
+  EXPECT_EQ(content["apn"], APN1);
+  EXPECT_EQ(content["ipv4"], IP1);
+  EXPECT_EQ(content["session_id"], SESSION_ID_1);
 
-      content = gateway_subscribers[IMSI2][APN1];
-      EXPECT_EQ(content.size(), 1);
-      content = content[0];
-      EXPECT_EQ(content["lifecycle_state"],
-                session_fsm_state_to_str(SESSION_ACTIVE));
-      EXPECT_EQ(content["session_start_time"], SESSION_START_TIME_2);
-      EXPECT_EQ(content["apn"], APN1);
-      EXPECT_EQ(content["ipv4"], IP2);
-      EXPECT_EQ(content["session_id"], SESSION_ID_2);
-      break;
-    }
-  }
+  content = gateway_subscribers[IMSI2][APN1];
+  EXPECT_EQ(content.size(), 1);
+  content = content[0];
+  EXPECT_EQ(content["lifecycle_state"],
+            session_fsm_state_to_str(SESSION_ACTIVE));
+  EXPECT_EQ(content["session_start_time"], SESSION_START_TIME_2);
+  EXPECT_EQ(content["apn"], APN1);
+  EXPECT_EQ(content["ipv4"], IP2);
+  EXPECT_EQ(content["session_id"], SESSION_ID_2);
 }
 }  // namespace magma


### PR DESCRIPTION
## Summary

Sessiond now reports a combined `gateway_subscriber_state` and the old `subscriber_state` is no longer used in orc8r so it can be removed.

Closes #13538.

## Test Plan

* Sessiond unit tests.
* Tested on my machine that the `gateway_subscriber_state` is still sent to the cloud but no more `subscriber_state`s appear.

## Additional Information

- [ ] This change is backwards-breaking