### PR TITLE
fix(pipelined): fix lte integration issue

### DIFF
--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_qfi_gtp.QfigtpTest.test_qfi_delete_tunnel_flows.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_qfi_gtp.QfigtpTest.test_qfi_delete_tunnel_flows.snapshot
@@ -1,3 +1,3 @@
- cookie=0x0, table=classifier(main_table), n_packets=3, n_bytes=250, priority=0 actions=resubmit(,ingress(main_table))
- cookie=0x0, table=classifier(main_table), n_packets=0, n_bytes=0, priority=0,in_port=15578 actions=resubmit(,201)
- cookie=0x0, table=classifier(main_table), n_packets=0, n_bytes=0, priority=0,in_port=15579 actions=resubmit(,202)
+ priority=0 actions=resubmit(,ingress(main_table))
+ priority=0,in_port=15578 actions=resubmit(,201)
+ priority=0,in_port=15579 actions=resubmit(,202)

--- a/lte/gateway/python/magma/pipelined/tests/test_qfi_gtp.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qfi_gtp.py
@@ -138,6 +138,7 @@ class QfigtpTest(unittest.TestCase):
         snapshot_verifier = SnapshotVerifier(
             self, self.BRIDGE,
             self.service_manager,
+            include_stats=False,
         )
         with snapshot_verifier:
             pass


### PR DESCRIPTION
Signed-off-by: prabina pattnaik <prabinak@wavelabs.ai>
## Summary
magma/pipelined/tests/test_qfi_gtp.py (QfigtpTest::test_qfi_delete_tunnel_flows) fails with packet and byte count errors.
Changed the snapshot verifier with include_stats=False for ```test_qfi_delete_tunnel_flows``` test case.

## Test Plan
make test_python
