### PR TITLE
refactor(enodebd): remove duplicated implementations of DataModel methods

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Dict, Type
 
 from magma.common.service import MagmaService
 from magma.enodebd.data_models import transform_for_enb, transform_for_magma
@@ -257,55 +257,6 @@ class BaicellsTrDataModel(DataModel):
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181,
     }
-
-    @classmethod
-    def get_parameter(cls, param_name: ParameterName) -> Optional[TrParam]:
-        return cls.PARAMETERS.get(param_name)
-
-    @classmethod
-    def _get_magma_transforms(
-        cls,
-    ) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_MAGMA
-
-    @classmethod
-    def _get_enb_transforms(cls) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_ENB
-
-    @classmethod
-    def get_load_parameters(cls) -> List[ParameterName]:
-        return cls.LOAD_PARAMETERS
-
-    @classmethod
-    def get_num_plmns(cls) -> int:
-        return cls.NUM_PLMNS_IN_CONFIG
-
-    @classmethod
-    def get_parameter_names(cls) -> List[ParameterName]:
-        excluded_params = [
-            str(ParameterName.DEVICE),
-            str(ParameterName.FAP_SERVICE),
-        ]
-        names = list(
-            filter(
-                lambda x: (not str(x).startswith('PLMN'))
-                and (str(x) not in excluded_params),
-                cls.PARAMETERS.keys(),
-            ),
-        )
-        return names
-
-    @classmethod
-    def get_numbered_param_names(cls) -> Dict[ParameterName, List[ParameterName]]:
-        names = {}
-        for i in range(1, cls.NUM_PLMNS_IN_CONFIG + 1):
-            params = []
-            params.append(ParameterName.PLMN_N_CELL_RESERVED % i)
-            params.append(ParameterName.PLMN_N_ENABLE % i)
-            params.append(ParameterName.PLMN_N_PRIMARY % i)
-            params.append(ParameterName.PLMN_N_PLMNID % i)
-            names[ParameterName.PLMN_N % i] = params
-        return names
 
 
 class BaicellsTrConfigurationInitializer(EnodebConfigurationPostProcessor):

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Dict, Type
 
 from magma.common.service import MagmaService
 from magma.enodebd.data_models import transform_for_enb, transform_for_magma
@@ -272,56 +272,6 @@ class BaicellsTrOldDataModel(DataModel):
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181,
     }
-
-    @classmethod
-    def get_parameter(cls, param_name: ParameterName) -> Optional[TrParam]:
-        return cls.PARAMETERS.get(param_name)
-
-    @classmethod
-    def _get_magma_transforms(
-        cls,
-    ) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_MAGMA
-
-    @classmethod
-    def _get_enb_transforms(cls) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_ENB
-
-    @classmethod
-    def get_load_parameters(cls) -> List[ParameterName]:
-        return cls.LOAD_PARAMETERS
-
-    @classmethod
-    def get_num_plmns(cls) -> int:
-        return cls.NUM_PLMNS_IN_CONFIG
-
-    @classmethod
-    def get_parameter_names(cls) -> List[ParameterName]:
-        excluded_params = [
-            str(ParameterName.DEVICE),
-            str(ParameterName.FAP_SERVICE),
-        ]
-        names = list(
-            filter(
-                lambda x: (not str(x).startswith('PLMN'))
-                and (str(x) not in excluded_params),
-                cls.PARAMETERS.keys(),
-            ),
-        )
-        return names
-
-    @classmethod
-    def get_numbered_param_names(cls) -> Dict[ParameterName, List[ParameterName]]:
-        names = {}
-        for i in range(1, cls.NUM_PLMNS_IN_CONFIG + 1):
-            params = []
-            params.append(ParameterName.PLMN_N_CELL_RESERVED % i)
-            params.append(ParameterName.PLMN_N_ENABLE % i)
-            params.append(ParameterName.PLMN_N_PRIMARY % i)
-            params.append(ParameterName.PLMN_N_PLMNID % i)
-            names[ParameterName.PLMN_N % i] = params
-
-        return names
 
 
 class BaicellsTrOldConfigurationInitializer(EnodebConfigurationPostProcessor):

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafa.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafa.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Dict, Type
 
 from magma.common.service import MagmaService
 from magma.enodebd.data_models import transform_for_enb, transform_for_magma
@@ -202,67 +202,15 @@ class BaicellsQAFATrDataModel(DataModel):
         PARAMETERS[ParameterName.PLMN_N_PRIMARY % i] = TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.IsPrimary' % i, True, TrParameterType.BOOLEAN, False)
         PARAMETERS[ParameterName.PLMN_N_PLMNID % i] = TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.EPC.PLMNList.%d.PLMNID' % i, True, TrParameterType.STRING, False)
 
+    # Parameters to query when reading eNodeB config
+    LOAD_PARAMETERS = list(PARAMETERS.keys())
+
     TRANSFORMS_FOR_ENB[ParameterName.ADMIN_STATE] = transform_for_enb.admin_state
     TRANSFORMS_FOR_MAGMA = {
         # We don't set these parameters
         ParameterName.BAND_CAPABILITY: transform_for_magma.band_capability,
         ParameterName.DUPLEX_MODE_CAPABILITY: transform_for_magma.duplex_mode,
     }
-
-    @classmethod
-    def get_parameter(cls, param_name: ParameterName) -> Optional[TrParam]:
-        return cls.PARAMETERS.get(param_name)
-
-    @classmethod
-    def _get_magma_transforms(
-        cls,
-    ) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_MAGMA
-
-    @classmethod
-    def _get_enb_transforms(cls) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_ENB
-
-    @classmethod
-    def get_load_parameters(cls) -> List[ParameterName]:
-        """
-        Load all the parameters instead of a subset.
-        """
-        return list(cls.PARAMETERS.keys())
-
-    @classmethod
-    def get_num_plmns(cls) -> int:
-        return cls.NUM_PLMNS_IN_CONFIG
-
-    @classmethod
-    def get_parameter_names(cls) -> List[ParameterName]:
-        excluded_params = [
-            str(ParameterName.DEVICE),
-            str(ParameterName.FAP_SERVICE),
-        ]
-        names = list(
-            filter(
-                lambda x: (not str(x).startswith('PLMN'))
-                and (str(x) not in excluded_params),
-                cls.PARAMETERS.keys(),
-            ),
-        )
-        return names
-
-    @classmethod
-    def get_numbered_param_names(
-        cls,
-    ) -> Dict[ParameterName, List[ParameterName]]:
-        names = {}
-        for i in range(1, cls.NUM_PLMNS_IN_CONFIG + 1):
-            params = []
-            params.append(ParameterName.PLMN_N_CELL_RESERVED % i)
-            params.append(ParameterName.PLMN_N_ENABLE % i)
-            params.append(ParameterName.PLMN_N_PRIMARY % i)
-            params.append(ParameterName.PLMN_N_PLMNID % i)
-            names[ParameterName.PLMN_N % i] = params
-
-        return names
 
 
 class BaicellsQAFATrConfigurationInitializer(EnodebConfigurationPostProcessor):

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Dict, List, Type
 
 from magma.common.service import MagmaService
 from magma.enodebd.data_models import transform_for_enb, transform_for_magma
@@ -442,67 +442,15 @@ class BaicellsQAFBTrDataModel(DataModel):
         PARAMETERS[ParameterName.PLMN_N_PRIMARY % i] = TrParam(FAPSERVICE_PATH + 'CellConfig.1.LTE.EPC.PLMNList.%d.IsPrimary' % i, True, TrParameterType.BOOLEAN, False)
         PARAMETERS[ParameterName.PLMN_N_PLMNID % i] = TrParam(FAPSERVICE_PATH + 'CellConfig.1.LTE.EPC.PLMNList.%d.PLMNID' % i, True, TrParameterType.STRING, False)
 
+    # Parameters to query when reading eNodeB config
+    LOAD_PARAMETERS = list(PARAMETERS.keys())
+
     TRANSFORMS_FOR_ENB[ParameterName.ADMIN_STATE] = transform_for_enb.admin_state
     TRANSFORMS_FOR_MAGMA = {
         # We don't set these parameters
         ParameterName.BAND_CAPABILITY: transform_for_magma.band_capability,
         ParameterName.DUPLEX_MODE_CAPABILITY: transform_for_magma.duplex_mode,
     }
-
-    @classmethod
-    def get_parameter(cls, param_name: ParameterName) -> Optional[TrParam]:
-        return cls.PARAMETERS.get(param_name)
-
-    @classmethod
-    def _get_magma_transforms(
-        cls,
-    ) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_MAGMA
-
-    @classmethod
-    def _get_enb_transforms(cls) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_ENB
-
-    @classmethod
-    def get_load_parameters(cls) -> List[ParameterName]:
-        """
-        Load all the parameters instead of a subset.
-        """
-        return list(cls.PARAMETERS.keys())
-
-    @classmethod
-    def get_num_plmns(cls) -> int:
-        return cls.NUM_PLMNS_IN_CONFIG
-
-    @classmethod
-    def get_parameter_names(cls) -> List[ParameterName]:
-        excluded_params = [
-            str(ParameterName.DEVICE),
-            str(ParameterName.FAP_SERVICE),
-        ]
-        names = list(
-            filter(
-                lambda x: (not str(x).startswith('PLMN'))
-                and (str(x) not in excluded_params),
-                cls.PARAMETERS.keys(),
-            ),
-        )
-        return names
-
-    @classmethod
-    def get_numbered_param_names(
-        cls,
-    ) -> Dict[ParameterName, List[ParameterName]]:
-        names = {}
-        for i in range(1, cls.NUM_PLMNS_IN_CONFIG + 1):
-            params = []
-            params.append(ParameterName.PLMN_N_CELL_RESERVED % i)
-            params.append(ParameterName.PLMN_N_ENABLE % i)
-            params.append(ParameterName.PLMN_N_PRIMARY % i)
-            params.append(ParameterName.PLMN_N_PLMNID % i)
-            names[ParameterName.PLMN_N % i] = params
-
-        return names
 
 
 class BaicellsQAFBTrConfigurationInitializer(EnodebConfigurationPostProcessor):

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qrtb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qrtb.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from distutils.util import strtobool
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict
 
 from dp.protos.cbsd_pb2 import CBSDStateResult
 from magma.common.service import MagmaService
@@ -906,93 +906,13 @@ class BaicellsQRTBTrDataModel(DataModel):
             is_optional=False,
         )
 
+    TRANSFORMS_FOR_ENB: Dict[ParameterName, Callable[[Any], Any]] = {}
     TRANSFORMS_FOR_MAGMA = {
         # We don't set GPS, so we don't need transform for enb
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181,
     }
     PARAMETERS.update(CarrierAggregationParameters.CA_PARAMETERS)  # noqa: WPS604
-
-    @classmethod
-    def get_parameter(cls, param_name: ParameterName) -> Optional[TrParam]:
-        """
-        Retrieve parameter by its name
-
-        Args:
-            param_name (ParameterName): parameter name to retrieve
-
-        Returns:
-            Optional[TrParam]
-        """
-        return cls.PARAMETERS.get(param_name)
-
-    @classmethod
-    def _get_magma_transforms(
-            cls,
-    ) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_MAGMA
-
-    @classmethod
-    def _get_enb_transforms(cls) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return {}
-
-    @classmethod
-    def get_load_parameters(cls) -> List[ParameterName]:
-        """
-        Retrieve all load parameters
-
-        Returns:
-             List[ParameterName]
-        """
-        return cls.LOAD_PARAMETERS
-
-    @classmethod
-    def get_num_plmns(cls) -> int:
-        """
-        Retrieve the number of all PLMN parameters
-
-        Returns:
-            int
-        """
-        return cls.NUM_PLMNS_IN_CONFIG
-
-    @classmethod
-    def get_parameter_names(cls) -> List[ParameterName]:
-        """
-        Retrieve all parameter names
-
-        Returns:
-            List[ParameterName]
-        """
-        excluded_params = [
-            str(ParameterName.DEVICE),
-            str(ParameterName.FAP_SERVICE),
-        ]
-        names = list(
-            filter(
-                lambda x: (not str(x).startswith('PLMN')) and (str(x) not in excluded_params),
-                cls.PARAMETERS.keys(),
-            ),
-        )
-        return names
-
-    @classmethod
-    def get_numbered_param_names(cls) -> Dict[ParameterName, List[ParameterName]]:
-        """
-        Retrieve parameter names of all objects
-
-        Returns:
-            Dict[ParameterName, List[ParameterName]]
-        """
-        names = {}
-        for i in range(1, cls.NUM_PLMNS_IN_CONFIG + 1):
-            params = []
-            params.append(ParameterName.PLMN_N_CELL_RESERVED % i)
-            params.append(ParameterName.PLMN_N_ENABLE % i)
-            params.append(ParameterName.PLMN_N_PRIMARY % i)
-            params.append(ParameterName.PLMN_N_PLMNID % i)
-            names[ParameterName.PLMN_N % i] = params
-        return names
 
 
 class BaicellsQRTBTrConfigurationInitializer(EnodebConfigurationPostProcessor):

--- a/lte/gateway/python/magma/enodebd/devices/baicells_rts.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_rts.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Dict, Type
 
 from magma.common.service import MagmaService
 from magma.enodebd.data_models import transform_for_enb, transform_for_magma
@@ -253,55 +253,6 @@ class BaicellsRTSTrDataModel(DataModel):
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181,
     }
-
-    @classmethod
-    def get_parameter(cls, param_name: ParameterName) -> Optional[TrParam]:
-        return cls.PARAMETERS.get(param_name)
-
-    @classmethod
-    def _get_magma_transforms(
-            cls,
-    ) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_MAGMA
-
-    @classmethod
-    def _get_enb_transforms(cls) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_ENB
-
-    @classmethod
-    def get_load_parameters(cls) -> List[ParameterName]:
-        return cls.LOAD_PARAMETERS
-
-    @classmethod
-    def get_num_plmns(cls) -> int:
-        return cls.NUM_PLMNS_IN_CONFIG
-
-    @classmethod
-    def get_parameter_names(cls) -> List[ParameterName]:
-        excluded_params = [
-            str(ParameterName.DEVICE),
-            str(ParameterName.FAP_SERVICE),
-        ]
-        names = list(
-            filter(
-                lambda x: (not str(x).startswith('PLMN'))
-                and (str(x) not in excluded_params),
-                cls.PARAMETERS.keys(),
-            ),
-        )
-        return names
-
-    @classmethod
-    def get_numbered_param_names(cls) -> Dict[ParameterName, List[ParameterName]]:
-        names = {}
-        for i in range(1, cls.NUM_PLMNS_IN_CONFIG + 1):
-            params = []
-            params.append(ParameterName.PLMN_N_CELL_RESERVED % i)
-            params.append(ParameterName.PLMN_N_ENABLE % i)
-            params.append(ParameterName.PLMN_N_PRIMARY % i)
-            params.append(ParameterName.PLMN_N_PLMNID % i)
-            names[ParameterName.PLMN_N % i] = params
-        return names
 
 
 class BaicellsRTSTrConfigurationInitializer(EnodebConfigurationPostProcessor):

--- a/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Dict, Optional, Type
 
 from magma.common.service import MagmaService
 from magma.enodebd.data_models import transform_for_enb, transform_for_magma
@@ -302,6 +302,8 @@ class CaviumTrDataModel(DataModel):
     Class to represent relevant data model parameters from TR-196/TR-098/TR-181.
     This class is effectively read-only
     """
+    # Parameters to query when reading eNodeB config
+    LOAD_PARAMETERS = [ParameterName.DEVICE]
     # Mapping of TR parameter paths to aliases
     DEVICE_PATH = 'Device.'
     FAPSERVICE_PATH = DEVICE_PATH + 'Services.FAPService.1.'
@@ -429,60 +431,6 @@ class CaviumTrDataModel(DataModel):
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181,
     }
-
-    @classmethod
-    def get_parameter(cls, param_name: ParameterName) -> Optional[TrParam]:
-        return cls.PARAMETERS.get(param_name)
-
-    @classmethod
-    def _get_magma_transforms(
-        cls,
-    ) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_MAGMA
-
-    @classmethod
-    def _get_enb_transforms(cls) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_ENB
-
-    @classmethod
-    def get_load_parameters(cls) -> List[ParameterName]:
-        """
-        Load all the parameters instead of a subset.
-        """
-        return [ParameterName.DEVICE]
-
-    @classmethod
-    def get_num_plmns(cls) -> int:
-        return cls.NUM_PLMNS_IN_CONFIG
-
-    @classmethod
-    def get_parameter_names(cls) -> List[ParameterName]:
-        excluded_params = [
-            str(ParameterName.DEVICE),
-            str(ParameterName.FAP_SERVICE),
-        ]
-        names = list(
-            filter(
-                lambda x: (not str(x).startswith('PLMN'))
-                and (str(x) not in excluded_params),
-                cls.PARAMETERS.keys(),
-            ),
-        )
-        return names
-
-    @classmethod
-    def get_numbered_param_names(
-        cls,
-    ) -> Dict[ParameterName, List[ParameterName]]:
-        names = {}
-        for i in range(1, cls.NUM_PLMNS_IN_CONFIG + 1):
-            params = []
-            params.append(ParameterName.PLMN_N_CELL_RESERVED % i)
-            params.append(ParameterName.PLMN_N_ENABLE % i)
-            params.append(ParameterName.PLMN_N_PRIMARY % i)
-            params.append(ParameterName.PLMN_N_PLMNID % i)
-            names[ParameterName.PLMN_N % i] = params
-        return names
 
 
 class CaviumTrConfigurationInitializer(EnodebConfigurationPostProcessor):

--- a/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
+++ b/lte/gateway/python/magma/enodebd/devices/freedomfi_one.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import logging
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List
 
 from dp.protos.cbsd_pb2 import CBSDStateResult
 from magma.enodebd.data_models import transform_for_magma
@@ -911,7 +911,7 @@ class FreedomFiOneTrDataModel(DataModel):
             is_optional=False,
         ),
     }
-    TRANSFORMS_FOR_ENB: Dict[ParameterName, Callable[[Any], Any]] = {}
+
     NUM_PLMNS_IN_CONFIG = 1
     for i in range(1, NUM_PLMNS_IN_CONFIG + 1):  # noqa: WPS604
         PARAMETERS[ParameterName.PLMN_N % i] = TrParam(
@@ -953,6 +953,10 @@ class FreedomFiOneTrDataModel(DataModel):
     PARAMETERS.update(StatusParameters.DERIVED_STATUS_PARAMETERS)  # noqa: WPS604
     PARAMETERS.update(CarrierAggregationParameters.CA_PARAMETERS)  # noqa: WPS604
 
+    # Parameters to query when reading eNodeB config
+    LOAD_PARAMETERS = list(PARAMETERS.keys())
+
+    TRANSFORMS_FOR_ENB: Dict[ParameterName, Callable[[Any], Any]] = {}
     TRANSFORMS_FOR_MAGMA = {
         # We don't set these parameters
         ParameterName.BAND_CAPABILITY: transform_for_magma.band_capability,
@@ -960,92 +964,6 @@ class FreedomFiOneTrDataModel(DataModel):
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181,
     }
-
-    @classmethod
-    def get_parameter(cls, param_name: ParameterName) -> Optional[TrParam]:
-        """
-        Retrieve parameter by its name
-
-        Args:
-            param_name (ParameterName): parameter name to retrieve
-
-        Returns:
-            Optional[TrParam]
-        """
-        return cls.PARAMETERS.get(param_name)
-
-    @classmethod
-    def _get_magma_transforms(
-            cls,
-    ) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_MAGMA
-
-    @classmethod
-    def _get_enb_transforms(cls) -> Dict[ParameterName, Callable[[Any], Any]]:
-        return cls.TRANSFORMS_FOR_ENB
-
-    @classmethod
-    def get_load_parameters(cls) -> List[ParameterName]:
-        """
-        Retrieve all load parameters
-
-        Returns:
-             List[ParameterName]
-        """
-        return list(cls.PARAMETERS.keys())
-
-    @classmethod
-    def get_num_plmns(cls) -> int:
-        """
-        Retrieve the number of all PLMN parameters
-
-        Returns:
-            int
-        """
-        return cls.NUM_PLMNS_IN_CONFIG
-
-    @classmethod
-    def get_parameter_names(cls) -> List[ParameterName]:
-        """
-        Retrieve all parameter names
-
-        Returns:
-            List[ParameterName]
-        """
-        excluded_params = [
-            str(ParameterName.DEVICE),
-            str(ParameterName.FAP_SERVICE),
-        ]
-        names = list(
-            filter(
-                lambda x: (not str(x).startswith('PLMN'))
-                and (str(x) not in excluded_params),
-                cls.PARAMETERS.keys(),
-            ),
-        )
-        return names
-
-    @classmethod
-    def get_numbered_param_names(
-            cls,
-    ) -> Dict[ParameterName, List[ParameterName]]:
-        """
-        Retrieve parameter names of all objects
-
-        Returns:
-            Dict[ParameterName, List[ParameterName]]
-        """
-        names = {}
-        for i in range(1, cls.NUM_PLMNS_IN_CONFIG + 1):
-            params = [
-                ParameterName.PLMN_N_CELL_RESERVED % i,
-                ParameterName.PLMN_N_ENABLE % i,
-                ParameterName.PLMN_N_PRIMARY % i,
-                ParameterName.PLMN_N_PLMNID % i,
-            ]
-            names[ParameterName.PLMN_N % i] = params
-
-        return names
 
     @classmethod
     def get_sas_param_names(cls) -> Iterable[ParameterName]:


### PR DESCRIPTION
Signed-off-by: Jarosław Jaszczuk <jaroslaw@freedomfi.com>

I've been getting into enodebd a bit and noticed that base `DataModel` class requires child classes to implement some of its method, but each of devices implements these methods in exactly the same way. Wanted to suggest a possible improvement.

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
All of devices in enodebd base on `DataModel` abstract class and implement its abstract methods. Every device declares the same set of attributes on its data model and implements abstract methods using these attributes in the same way, so there's no reason to keep them abstract and enforce copy pasting the implementations for each one of devices.
* data models for devices no longer implement `DataModel` abstract methods
* base `DataModel` class is no longer abstract and has no abstract methods
* base `DataModel` class now has typed parameters that have to be declared in child classes
* base `DataModel` class now implements on its own previously abstract methods

<!-- Enumerate changes you made and why you made them -->

## Test Plan
* no changes to implementation of enodebd devices' logic
* all existing test cases for enodebd pass

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
