### PR TITLE
test(orc8r): Stabilize flaky test TestListSubscriberStates

### DIFF
--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -768,30 +768,7 @@ func TestListSubscriberStates(t *testing.T) {
 	clock.SetAndFreezeClock(t, time.Unix(frozenClock, 0))
 	defer clock.UnfreezeClock(t)
 
-	icmpStatus := &subscriberModels.IcmpStatus{LatencyMs: f32Ptr(12.34)}
 	ctx := test_utils.GetContextWithCertificate(t, "hw0")
-	test_utils.ReportState(t, ctx, lte.ICMPStateType, "IMSI1234567890", icmpStatus, serdes.State)
-	mmeState := state.ArbitraryJSON{"mme": "foo"}
-	test_utils.ReportState(t, ctx, lte.MMEStateType, "IMSI1234567890", &mmeState, serdes.State)
-	spgwState := state.ArbitraryJSON{"spgw": "foo"}
-	test_utils.ReportState(t, ctx, lte.SPGWStateType, "IMSI1234567890", &spgwState, serdes.State)
-	s1apState := state.ArbitraryJSON{"s1ap": "foo"}
-	test_utils.ReportState(t, ctx, lte.S1APStateType, "IMSI1234567890", &s1apState, serdes.State)
-	// Report 2 allocated IP addresses for the subscriber
-	mobilitydState1 := state.ArbitraryJSON{
-		"ip": map[string]interface{}{
-			"address": "wKiArg==",
-		},
-	}
-	mobilitydState2 := state.ArbitraryJSON{
-		"ip": map[string]interface{}{
-			"address": "wKiAhg==",
-		},
-	}
-	test_utils.ReportState(t, ctx, lte.MobilitydStateType, "IMSI1234567890.oai.ipv4", &mobilitydState1, serdes.State)
-	test_utils.ReportState(t, ctx, lte.MobilitydStateType, "IMSI1234567890.magma.apn", &mobilitydState2, serdes.State)
-	directoryState := directorydTypes.DirectoryRecord{LocationHistory: []string{"foo", "bar"}}
-	test_utils.ReportState(t, ctx, orc8r.DirectoryRecordType, "IMSI1234567890", &directoryState, serdes.State)
 
 	subState0 := state.ArbitraryJSON{
 		"subscriber_state": state.ArbitraryJSON{
@@ -820,6 +797,30 @@ func TestListSubscriberStates(t *testing.T) {
 	}
 	test_utils.ReportState(t, ctx, lte.GatewaySubscriberStateType, "hw0", &gwSubState, serdes.State)
 	assert.NoError(t, err)
+
+	icmpStatus := &subscriberModels.IcmpStatus{LatencyMs: f32Ptr(12.34)}
+	test_utils.ReportState(t, ctx, lte.ICMPStateType, "IMSI1234567890", icmpStatus, serdes.State)
+	mmeState := state.ArbitraryJSON{"mme": "foo"}
+	test_utils.ReportState(t, ctx, lte.MMEStateType, "IMSI1234567890", &mmeState, serdes.State)
+	spgwState := state.ArbitraryJSON{"spgw": "foo"}
+	test_utils.ReportState(t, ctx, lte.SPGWStateType, "IMSI1234567890", &spgwState, serdes.State)
+	s1apState := state.ArbitraryJSON{"s1ap": "foo"}
+	test_utils.ReportState(t, ctx, lte.S1APStateType, "IMSI1234567890", &s1apState, serdes.State)
+	// Report 2 allocated IP addresses for the subscriber
+	mobilitydState1 := state.ArbitraryJSON{
+		"ip": map[string]interface{}{
+			"address": "wKiArg==",
+		},
+	}
+	mobilitydState2 := state.ArbitraryJSON{
+		"ip": map[string]interface{}{
+			"address": "wKiAhg==",
+		},
+	}
+	test_utils.ReportState(t, ctx, lte.MobilitydStateType, "IMSI1234567890.oai.ipv4", &mobilitydState1, serdes.State)
+	test_utils.ReportState(t, ctx, lte.MobilitydStateType, "IMSI1234567890.magma.apn", &mobilitydState2, serdes.State)
+	directoryState := directorydTypes.DirectoryRecord{LocationHistory: []string{"foo", "bar"}}
+	test_utils.ReportState(t, ctx, orc8r.DirectoryRecordType, "IMSI1234567890", &directoryState, serdes.State)
 
 	tc = tests.Test{
 		Method:         "GET",


### PR DESCRIPTION
## Summary

Most likely, the test is flaky because there's a race condition between the reindexer and the assertion. With this change, the gateway subscriber state is updated before all other state updates, which gives the reindexer more time to run before the state is asserted.

This turns out to make the test reliable without adding any explicit waiting.

Part of #13537.

## Test Plan

I have not been able to get the test red on my machine even in over 100 runs.

- [x] Retrigger it in the CI and check if it's still flaky.
  - 6 successful CI runs on this PR, no failures of TestListSubscriberStates so far. I don't have statistics but I am confident we should have seen an error by now if the test was still as flaky as it is on master.
    - https://github.com/magma/magma/runs/7766828563
    - https://github.com/magma/magma/runs/7767411021
    - https://github.com/magma/magma/runs/7767936329
    - https://github.com/magma/magma/runs/7768551842
    - https://github.com/magma/magma/runs/7769078532
    - https://github.com/magma/magma/runs/7770489016
  - There was a single failed CI run due to another flaky test.
    - https://github.com/magma/magma/runs/7769685515

## Additional Information

- [ ] This change is backwards-breaking