### PR TITLE
chore(ci): Make it possible to manually start the Bazel build and test job

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -52,10 +52,12 @@ jobs:
   bazel_build_and_test:
     needs: path_filter
     # Only run workflow if this is a scheduled run on master branch,
-    # or a pull_request that skip-duplicate-action wants to run again.
+    # if the workflow has been triggered manually or if it is a pull_request
+    # that skip-duplicate-action wants to run again.
     if: |
       (github.event_name == 'schedule' && github.ref == 'refs/heads/master') ||
-      needs.path_filter.outputs.files_changed == 'true'
+      needs.path_filter.outputs.files_changed == 'true' ||
+      github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -206,10 +208,12 @@ jobs:
   bazel_package:
     needs: path_filter
     # Only run workflow if this is a scheduled run on master branch,
-    # or a pull_request that skip-duplicate-action wants to run again.
+    # if the workflow has been triggered manually or if it is a pull_request
+    # that skip-duplicate-action wants to run again.
     if: |
       (github.event_name == 'schedule' && github.ref == 'refs/heads/master') ||
-      needs.path_filter.outputs.files_changed == 'true'
+      needs.path_filter.outputs.files_changed == 'true' ||
+      github.event_name == 'workflow_dispatch'
     name: Bazel Package Job
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The `workflow_dispatch` trigger on the bazel workflow leads to a run of the bazel build and test job.
- ~~This does not apply to the package job (do we want that?)~~ (added it there too)

## Test Plan

- Test run with `workflow_dispatch` on fork: https://github.com/LKreutzer/magma/actions/runs/2832839838

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
