### PR TITLE
feat(nms): Run e2e tests against prod build

### DIFF
--- a/nms/docker-compose-e2e.yml
+++ b/nms/docker-compose-e2e.yml
@@ -40,7 +40,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: "/usr/local/bin/wait-for-it.sh -s -t 30 postgres:5432 -- yarn run start:dev"
+    command: "/usr/local/bin/wait-for-it.sh -s -t 30 postgres:5432 -- yarn run start:prod"
     volumes:
       - ./api:/usr/src/api
       - ./app:/usr/src/app

--- a/nms/docker/docker_ssl_proxy/proxy_ssl.conf
+++ b/nms/docker/docker_ssl_proxy/proxy_ssl.conf
@@ -6,5 +6,6 @@ server {
   location / {
      proxy_pass http://magmalte:8081;
      proxy_set_header Host $http_host;
+     proxy_set_header X-Forwarded-Proto $scheme;
   }
 }


### PR DESCRIPTION
## Summary

Changes the e2e test to run against the production build. The e2e test used to run against the dev build and the production build was never tested. 

- depends on #13572

## Test Plan

The e2e are green https://github.com/magma/magma/runs/7771874264?check_suite_focus=true

