### PR TITLE
fix(ci): Revert start traffic_server only once (#13501)

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -814,7 +814,8 @@ def _start_trfserver():
     local(
         'ssh -f -i %s -o UserKnownHostsFile=/dev/null'
         ' -o StrictHostKeyChecking=no -tt %s -p %s'
-        ' sh -c "sudo ethtool --offload eth2 rx off tx off";'
+        ' sh -c "sudo ethtool --offload eth2 rx off tx off; '
+        'nohup sudo /usr/local/bin/traffic_server.py 192.168.60.144 62462 > /dev/null 2>&1";'
         % (key, host, port),
     )
     local(


### PR DESCRIPTION
## Summary

Reverted traffic server clean up

## Test Plan
not tested - master is red for the traffic server tests anyway
