### PR TITLE
fix(ci): allow backports to v1.8 branch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch: null
 
 jobs:
   backport:

--- a/.github/workflows/scripts/fabfile.py
+++ b/.github/workflows/scripts/fabfile.py
@@ -27,6 +27,7 @@ RELEASE_BRANCHES = (
     'v1.5',
     'v1.6',
     'v1.7',
+    'v1.8',
     'magma-5G',
 )
 


### PR DESCRIPTION
## Summary

- branch `v1.8` needs to be made available for backports to work
- additionally added a manual trigger, such that one has not to wait for the next push on master.

## Test Plan

- Possible only after merge for items from [the respective list](https://github.com/magma/magma/issues?q=label%3Aapply-v1.8+is%3Aclosed).
