### PR TITLE
refactor(nms): Migrate Alert Rules Overview to new style

### DIFF
--- a/nms/app/views/alarms/components/AlertRules.tsx
+++ b/nms/app/views/alarms/components/AlertRules.tsx
@@ -12,21 +12,26 @@
  */
 import * as React from 'react';
 import AddEditRule from './rules/AddEditRule';
+import Button from '@mui/material/Button';
+import CardTitleRow from '../../../components/layout/CardTitleRow';
 import CircularProgress from '@mui/material/CircularProgress';
 import Grid from '@mui/material/Grid';
 import SeverityIndicator from './severity/SeverityIndicator';
 import SimpleTable, {SimpleTableProps} from './table/SimpleTable';
 import TableActionDialog from './table/TableActionDialog';
-import TableAddButton from './table/TableAddButton';
 import axios from 'axios';
+import nullthrows from '../../../../shared/util/nullthrows';
+
+import {NotificationsActive} from '@mui/icons-material';
 import {PROMETHEUS_RULE_TYPE, useAlarmContext} from './AlarmContext';
 import {Parse} from './prometheus/PromQLParser';
-import {makeStyles} from '@mui/styles';
-import {useLoadRules} from './hooks';
-import {useSnackbars} from '../../../hooks/useSnackbar';
-
 import {Theme} from '@mui/material/styles';
+import {colors} from '../../../theme/default';
 import {getErrorMessage} from '../../../util/ErrorUtils';
+import {makeStyles} from '@mui/styles';
+import {triggerAlertSync} from '../../../util/SyncAlerts';
+import {useEnqueueSnackbar, useSnackbars} from '../../../hooks/useSnackbar';
+import {useLoadRules} from './hooks';
 import {useParams} from 'react-router-dom';
 import type {GenericRule} from './rules/RuleInterface';
 
@@ -34,22 +39,75 @@ const useStyles = makeStyles<Theme>(theme => ({
   root: {
     paddingTop: theme.spacing(4),
   },
-  addButton: {
-    position: 'fixed',
-    bottom: 0,
-    right: 0,
-    margin: theme.spacing(2),
-  },
   loading: {
     display: 'flex',
     height: '100%',
     alignItems: 'center',
     justifyContent: 'center',
   },
-  helpButton: {
-    color: 'black',
+  emptyRulesTitle: {
+    color: colors.primary.comet,
+  },
+  emptyRulesDescription: {
+    color: colors.primary.comet,
+    fontSize: '12px',
+    marginBottom: '8px',
   },
 }));
+
+function AlertRulesFilter(props: {
+  onAddRuleClick: () => void;
+  refresh: () => void;
+}) {
+  const params = useParams();
+  const networkId = nullthrows(params.networkId);
+  const enqueueSnackbar = useEnqueueSnackbar();
+  return (
+    <Grid container justifyContent="center" alignItems="center" spacing={2}>
+      <Grid item>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={() => {
+            void triggerAlertSync(networkId, enqueueSnackbar);
+            props.refresh();
+          }}>
+          Sync Predefined Alerts
+        </Button>
+      </Grid>
+      <Grid item>
+        <Button
+          data-testid="add-edit-alert-button"
+          variant="contained"
+          color="primary"
+          onClick={() => props.onAddRuleClick()}>
+          Create Custom Rule
+        </Button>
+      </Grid>
+    </Grid>
+  );
+}
+
+function AlertRulesEmpty(props: {
+  onAddRuleClick: () => void;
+  refresh: () => void;
+}) {
+  const classes = useStyles();
+
+  return (
+    <Grid container direction="column" alignItems="center">
+      <div className={classes.emptyRulesTitle}>No Rules Added</div>
+      <div className={classes.emptyRulesDescription}>
+        Find out about possible issues in the network by syncing predefined
+        alerts or creating custom rules.
+      </div>
+      <AlertRulesFilter
+        onAddRuleClick={() => props.onAddRuleClick()}
+        refresh={() => props.refresh()}
+      />
+    </Grid>
+  );
+}
 
 export default function AlertRules<TRuleUnion>() {
   const {apiUtil, ruleMap} = useAlarmContext();
@@ -162,6 +220,11 @@ export default function AlertRules<TRuleUnion>() {
     [],
   );
 
+  const openAddRule = () => {
+    setIsNewAlert(true);
+    setSelectedRow(null);
+    setIsAddEditAlert(true);
+  };
   if (isAddEditAlert) {
     return (
       <AddEditRule
@@ -178,7 +241,27 @@ export default function AlertRules<TRuleUnion>() {
 
   return (
     <Grid className={classes.root}>
+      <CardTitleRow
+        label="Alert rules"
+        icon={NotificationsActive}
+        filter={() => (
+          <AlertRulesFilter
+            onAddRuleClick={() => openAddRule()}
+            refresh={() => setLastRefreshTime(new Date().toLocaleString())}
+          />
+        )}
+      />
       <SimpleTable
+        localization={{
+          body: {
+            emptyDataSourceMessage: (
+              <AlertRulesEmpty
+                onAddRuleClick={() => openAddRule()}
+                refresh={() => setLastRefreshTime(new Date().toLocaleString())}
+              />
+            ),
+          },
+        }}
         onRowClick={row => setSelectedRow(row)}
         columnStruct={columns}
         tableData={rules || []}
@@ -233,15 +316,6 @@ export default function AlertRules<TRuleUnion>() {
           }
         />
       )}
-      <TableAddButton
-        onClick={() => {
-          setIsNewAlert(true);
-          setSelectedRow(null);
-          setIsAddEditAlert(true);
-        }}
-        label="Add Alert"
-        data-testid="add-edit-alert-button"
-      />
     </Grid>
   );
 }

--- a/nms/app/views/alarms/components/table/SimpleTable.tsx
+++ b/nms/app/views/alarms/components/table/SimpleTable.tsx
@@ -64,6 +64,7 @@ export type SimpleTableProps<T extends object> = {
   actions?: MaterialTableProps<T>['actions'];
   tableData: MaterialTableProps<T>['data'];
   dataTestId?: string;
+  localization?: MaterialTableProps<T>['localization'];
 };
 
 const renderLabelValue = (labelValue: LabelVal) => {
@@ -266,6 +267,7 @@ export default function SimpleTable<T extends object>(
           toolbar: false,
         }}
         localization={{
+          ...(props.localization || {}),
           // hide 'Actions' in table header
           header: {actions: ''},
         }}


### PR DESCRIPTION
Signed-off-by: HannaFar <hannafarag159@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Migrate Alert Rules Overview to new style

Closes #13489 

New style:
<img width="1792" alt="Capture d’écran 2022-08-11 à 15 50 20" src="https://user-images.githubusercontent.com/26038920/184148902-67cb9072-ccdd-4f94-9707-6a6774e49357.png">



## Test Plan

yarn test and verified manually

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
