### PR TITLE
chore(ci): Use the bazel remote cache in the bazel LTE integ test workflow

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -13,6 +13,10 @@ on:
     types:
       - completed
 
+env:
+  CACHE_KEY: magma-dev-vm
+  REMOTE_DOWNLOAD_OPTIMIZATION: false
+
 jobs:
   lte-integ-test-bazel:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
@@ -61,6 +65,7 @@ jobs:
       - name: Build all services with bazel
         run: |
           cd lte/gateway
+          vagrant ssh -c 'cd ~/magma; bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}";' magma
           vagrant ssh -c 'sudo sed -i "s@#precedence ::ffff:0:0/96  100@precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
           vagrant ssh -c 'cd ~/magma; bazel build --profile=bazel_profile_lte_integ_tests `bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/...)"`;' magma
           vagrant ssh -c 'sudo sed -i "s@precedence ::ffff:0:0/96  100@#precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Use the remote cache in the bazel LTE integ test workflow
- New cache key `magma-dev-vm`
  - The cache is already pre-filled for this key. 

## Test Plan

- Testing is done in https://github.com/magma/magma/issues/13383
  - See comment https://github.com/magma/magma/issues/13383#issuecomment-1219359758

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
