### PR TITLE
chore(ci): Use the bazel-built envoy_controller service in the LTE integ test bazel workflow

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           cd lte/gateway
           vagrant ssh -c 'sudo sed -i "s@#precedence ::ffff:0:0/96  100@precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
-          vagrant ssh -c 'cd ~/magma; bazel build --profile=bazel_profile_lte_integ_tests `bazel query "kind(.*_binary, //orc8r/... union //lte/...)"`;' magma
+          vagrant ssh -c 'cd ~/magma; bazel build --profile=bazel_profile_lte_integ_tests `bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/...)"`;' magma
           vagrant ssh -c 'sudo sed -i "s@precedence ::ffff:0:0/96  100@#precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
       - name: Run the integ test
         run: |

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@envoy_controller.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@envoy_controller.service
@@ -1,0 +1,37 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[Unit]
+Description=Magma envoy controller service
+PartOf=magma@pipelined.service
+Before=magma@pipelined.service
+Requires=magma_dp@envoy.service
+Before=magma_dp@envoy.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStartPre=/bin/bash /usr/local/bin/configure_envoy_namespace.sh setup
+ExecStart=/home/vagrant/magma/bazel-bin/feg/gateway/services/envoy_controller/envoy_controller_/envoy_controller  --log_dir="/var/log"
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py envoy_controller
+ExecStopPost=/bin/bash /usr/local/bin/configure_envoy_namespace.sh destroy
+MemoryAccounting=yes
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=envoy_controller
+User=root
+Restart=always
+RestartSec=5
+LimitCORE=infinity
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The bazel-built envoy_controller service is build and run in the LTE integ test bazel workflow
- Resolves https://github.com/magma/magma/issues/13520

## Test Plan

- See comment https://github.com/magma/magma/issues/13520#issuecomment-1211704812

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
