### PR TITLE
fix(nms): clean up the e2e test after execution

### DIFF
--- a/nms/e2e_test_setup.sh
+++ b/nms/e2e_test_setup.sh
@@ -42,4 +42,6 @@ exit_code=$?
 docker-compose -f docker-compose-e2e.yml logs magmalte &> /tmp/nms_artifacts/magmalte.log
 docker-compose -f docker-compose-e2e.yml logs mock_server &> /tmp/nms_artifacts/mock_server.log
 
+docker-compose -f docker-compose-e2e.yml --env-file .env.mock down
+
 exit $exit_code


### PR DESCRIPTION
## Summary

This cleanup should be best practice, as you will otherwise get errors during local execution due to not cleaned up network interfaces.

## Test Plan

- CI
