### PR TITLE
chore: obsolete vagrant plugin vagrant-disksize is removed

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML
-          vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-vbguest vagrant-mutate
+          vagrant plugin install vagrant-vbguest vagrant-vbguest vagrant-mutate
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
-          vagrant plugin install vagrant-vbguest vagrant-disksize
+          vagrant plugin install vagrant-vbguest
       - uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # pin@v2
         with:
           name: docker-images

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
-          vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-scp
+          vagrant plugin install vagrant-vbguest vagrant-scp
       - name: Vagrant Host prerequisites for federated integ test
         run: |
           cd ${{ env.AGW_ROOT }} && fab open_orc8r_port_in_vagrant

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
-          vagrant plugin install vagrant-vbguest vagrant-disksize
+          vagrant plugin install vagrant-vbguest
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
-          vagrant plugin install vagrant-vbguest vagrant-disksize
+          vagrant plugin install vagrant-vbguest
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/

--- a/cwf/gateway/Vagrantfile
+++ b/cwf/gateway/Vagrantfile
@@ -16,18 +16,12 @@
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.require_version ">=1.9.1"
 
-# Install vagrant-disksize to allow resizing the vagrant box disk.
-unless Vagrant.has_plugin?("vagrant-disksize")
-    raise  Vagrant::Errors::VagrantError.new, "vagrant-disksize plugin is missing. Please install it using 'vagrant plugin install vagrant-disksize' and rerun 'vagrant up'"
-end
-
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Mount magma directory
   config.vm.synced_folder "../..", "/home/vagrant/magma"
 
   config.vm.define :cwag, primary: true do |cwag|
     cwag.vm.box = "generic/ubuntu2004"
-    cwag.disksize.size = '50GB'
     cwag.vm.box_version = "4.0.2"
     cwag.vbguest.auto_update = false
     cwag.vm.hostname = "cwag-dev"
@@ -82,7 +76,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # mutually exclusive with :cwag
     # INTENTIONAL IP ADDRESS CONFLICT
     cwag_centos7.vm.box = "bento/centos-7"
-#    cwag_centos7.disksize.size = '50GB'
     cwag_centos7.vm.box_version = "202005.21.0"
     cwag_centos7.vbguest.auto_update = false
     cwag_centos7.vm.hostname = "cwag-dev-centos7"

--- a/docs/readmes/cwf/dev_testing.md
+++ b/docs/readmes/cwf/dev_testing.md
@@ -41,14 +41,6 @@ To run all existing unit tests, run
 
 ## Run integration tests
 
-### Prerequisite
-
-You need to install a vagrant plugin:
-
-```bash
-vagrant plugin install vagrant-disksize
-```
-
 ### Test setup
 
 CWF integration tests use 3 separate VMs listed below.


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Extends #13571. It looks like the plugin is needed nowhere.
* removed from workflows
* removed from documentation (only from current - for 1.7 this still holds)

## Test Plan

for cwag
* `~/magma/cwf/gateway$ vagrant plugin uninstall vagrant-disksize`
* `~/magma/cwf/gateway$ vagrant up cwag`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
