### PR TITLE
refactor(nms): Migrate Alerts Receivers Overview to new style

### DIFF
--- a/nms/app/views/alarms/components/alertmanager/Receivers/Receivers.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/Receivers.tsx
@@ -14,22 +14,23 @@
 import * as React from 'react';
 import AddEditReceiver from './AddEditReceiver';
 import Button from '@mui/material/Button';
+import CardTitleRow from '../../../../../components/layout/CardTitleRow';
 import CircularProgress from '@mui/material/CircularProgress';
 import GlobalConfig from './GlobalConfig';
 import Grid from '@mui/material/Grid';
+import GroupIcon from '@mui/icons-material/Group';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import SettingsIcon from '@mui/icons-material/Settings';
 import SimpleTable, {LabelsCell} from '../../table/SimpleTable';
 import TableActionDialog from '../../table/TableActionDialog';
-import TableAddButton from '../../table/TableAddButton';
+
 import {Theme} from '@mui/material/styles';
+import {colors} from '../../../../../theme/default';
+import {getErrorMessage} from '../../../../../util/ErrorUtils';
 import {makeStyles} from '@mui/styles';
 import {useAlarmContext} from '../../AlarmContext';
 import {useNetworkId} from '../../hooks';
 import {useSnackbars} from '../../../../../hooks/useSnackbar';
-
-import {getErrorMessage} from '../../../../../util/ErrorUtils';
 import type {AlertReceiver} from '../../AlarmAPIType';
 
 const useStyles = makeStyles<Theme>(theme => ({
@@ -41,6 +42,10 @@ const useStyles = makeStyles<Theme>(theme => ({
     height: '100%',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  emptyReceiverTitle: {
+    color: colors.primary.comet,
+    marginBottom: '8px',
   },
 }));
 
@@ -58,6 +63,55 @@ const receiverColumns = [
     },
   },
 ];
+
+function CreateReceiverButton(props: {onAddReceiverClick: () => void}) {
+  return (
+    <Grid item>
+      <Button
+        data-testid="add-receiver-button"
+        variant="contained"
+        color="primary"
+        onClick={() => props.onAddReceiverClick()}>
+        Create Receiver
+      </Button>
+    </Grid>
+  );
+}
+
+function ReceiverFilter(props: {
+  onAddReceiverClick: () => void;
+  showGlobalConfig: boolean;
+  setShowGlobalSettings: () => void;
+}) {
+  return (
+    <Grid container justifyContent="flex-end" alignItems="center" spacing={2}>
+      {props.showGlobalConfig === true && (
+        <Grid item>
+          <Button
+            onClick={() => props.setShowGlobalSettings()}
+            variant="outlined">
+            Settings
+          </Button>
+        </Grid>
+      )}
+      <CreateReceiverButton
+        onAddReceiverClick={() => props.onAddReceiverClick()}
+      />
+    </Grid>
+  );
+}
+
+function ReceiverEmpty(props: {onAddReceiverClick: () => void}) {
+  const classes = useStyles();
+  return (
+    <Grid container direction="column" alignItems="center">
+      <div className={classes.emptyReceiverTitle}>No Receiver Added</div>
+      <CreateReceiverButton
+        onAddReceiverClick={() => props.onAddReceiverClick()}
+      />
+    </Grid>
+  );
+}
 
 export default function Receivers() {
   const {apiUtil, alertManagerGlobalConfigEnabled} = useAlarmContext();
@@ -132,6 +186,12 @@ export default function Receivers() {
     snackbars.error(`Unable to load receivers: ${getErrorMessage(error)}`);
   }
 
+  const openAddReceiver = () => {
+    setIsNewReceiver(true);
+    setIsAddEditReceiver(true);
+    setSelectedRow(null);
+  };
+
   const receiversData = response || [];
 
   if (isAddEditReceiver) {
@@ -160,39 +220,45 @@ export default function Receivers() {
 
   return (
     <Grid className={classes.root} container spacing={2} direction="column">
-      {alertManagerGlobalConfigEnabled === true && (
-        <Grid item>
-          <Button
-            onClick={() => setIsEditGlobalSettings(true)}
-            startIcon={<SettingsIcon />}
-            variant="outlined">
-            Settings
-          </Button>
-        </Grid>
-      )}
       <Grid item>
-        <>
-          <SimpleTable
-            onRowClick={row => setSelectedRow(row)}
-            columnStruct={receiverColumns}
-            tableData={receiversData}
-            dataTestId="receiver"
-            menuItems={[
-              {
-                name: 'View',
-                handleFunc: () => handleViewDialogOpen(),
-              },
-              {
-                name: 'Edit',
-                handleFunc: () => handleEdit(),
-              },
-              {
-                name: 'Delete',
-                handleFunc: () => handleDelete(),
-              },
-            ]}
-          />
-        </>
+        <CardTitleRow
+          label="Alert rules"
+          icon={GroupIcon}
+          filter={() => (
+            <ReceiverFilter
+              showGlobalConfig={alertManagerGlobalConfigEnabled ?? false}
+              setShowGlobalSettings={() => setIsEditGlobalSettings(true)}
+              onAddReceiverClick={() => openAddReceiver()}
+            />
+          )}
+        />
+        <SimpleTable
+          localization={{
+            body: {
+              emptyDataSourceMessage: (
+                <ReceiverEmpty onAddReceiverClick={() => openAddReceiver()} />
+              ),
+            },
+          }}
+          onRowClick={row => setSelectedRow(row)}
+          columnStruct={receiverColumns}
+          tableData={receiversData}
+          dataTestId="receiver"
+          menuItems={[
+            {
+              name: 'View',
+              handleFunc: () => handleViewDialogOpen(),
+            },
+            {
+              name: 'Edit',
+              handleFunc: () => handleEdit(),
+            },
+            {
+              name: 'Delete',
+              handleFunc: () => handleDelete(),
+            },
+          ]}
+        />
       </Grid>
       {isLoading && receiversData.length === 0 && (
         <div className={classes.loading}>
@@ -215,15 +281,6 @@ export default function Receivers() {
         row={selectedRow || {}}
         showCopyButton={true}
         showDeleteButton={false}
-      />
-      <TableAddButton
-        label="Add Receiver"
-        onClick={() => {
-          setIsNewReceiver(true);
-          setIsAddEditReceiver(true);
-          setSelectedRow(null);
-        }}
-        data-testid="add-receiver-button"
       />
     </Grid>
   );

--- a/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/Receivers-test.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/Receivers-test.tsx
@@ -117,7 +117,7 @@ describe('Receivers', () => {
       ...defaultResponse,
       response: [],
     });
-    const {getByTestId, queryByTestId} = render(
+    const {getAllByTestId, getByTestId, queryByTestId} = render(
       <AlarmsWrapper>
         <Receivers />
       </AlarmsWrapper>,
@@ -125,7 +125,7 @@ describe('Receivers', () => {
 
     expect(queryByTestId('add-edit-receiver')).not.toBeInTheDocument();
     act(() => {
-      fireEvent.click(getByTestId('add-receiver-button'));
+      fireEvent.click(getAllByTestId('add-receiver-button')[0]);
     });
     expect(getByTestId('add-edit-receiver')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

- Migrate Alerts Receivers Overview to new style
- Closes #13490 
- Depends on https://github.com/magma/magma/pull/13582

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
