### PR TITLE
fix(ci): disabling unstable integ test for now

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -131,7 +131,6 @@ s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
 s1aptests/test_service_req_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_detach_setsessionrules_tcp_data.py \
 s1aptests/test_enable_ipv6_iface.py \
-s1aptests/test_ipv6_non_nat_dp_ul_tcp.py \
 s1aptests/test_disable_ipv6_iface.py
 
 EXTENDED_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \
@@ -275,6 +274,7 @@ s1aptests/test_restore_config_after_non_sanity.py
 #s1aptests/test_ipv6_non_nat_dp_dl_tcp.py
 #s1aptests/test_ipv6_non_nat_dp_ul_udp.py
 #s1aptests/test_ipv6_non_nat_dp_dl_udp.py
+#s1aptests/test_ipv6_non_nat_dp_ul_tcp.py
 #---------------
 
 # TODO: Add ipv6 tests to integ test suite


### PR DESCRIPTION
## Summary

The ipv6 non nat integ test is failing on ci and locally. It fails with the current and previous vm on a fresh settup.
s1aptests/test_ipv6_non_nat_dp_ul_tcp.py

# Additional info

Ticket to reeanble the test https://github.com/magma/magma/issues/13596