### PR TITLE
fix(orc8r): Fix orc8r helm chart bugs

### DIFF
--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/orc8r_minikube_values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/orc8r_minikube_values.yaml
@@ -8,6 +8,7 @@ secret:
     orc8r: orc8r-secrets-configs-orc8r
   envdir: orc8r-secrets-envdir
 
+
 controller:
   tolerations: []
   affinity: {}
@@ -165,3 +166,11 @@ dp:
       orc8r.io/swagger_spec: "true"
     annotations:
       orc8r.io/obsidian_handlers_path_prefixes: /magma/v1/dp
+
+secrets:
+  configs:
+    enabled: true
+    orc8r:
+      elastic.yml: |-
+        elasticHost: "elasticsearch"
+        elasticPort: 9200

--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/orc8r_secrets_values.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/orc8r_secrets_values.yaml
@@ -1,0 +1,8 @@
+---
+secret:
+  configs:
+    enabled: true
+    orc8r:
+      elastic.yml: |-
+        elasticHost: "elasticsearch"
+        elasticPort: 9200

--- a/dp/tools/skaffold_hooks/hooks.sh
+++ b/dp/tools/skaffold_hooks/hooks.sh
@@ -71,6 +71,7 @@ apply_secrets() {
   cd "$MAGMA_ROOT/orc8r/cloud/helm/orc8r" || exit 1
   helm template orc8r charts/secrets \
     --namespace default \
+    -f "${MAGMA_ROOT}/dp/cloud/helm/dp/charts/domain-proxy/examples/orc8r_secrets_values.yaml" \
     --set-string secret.certs.enabled=true \
     --set-file secret.certs.files."rootCA\.pem=${CERTS_DIR}/rootCA.pem" \
     --set-file secret.certs.files."bootstrapper\.key=${CERTS_DIR}/bootstrapper.key" \

--- a/orc8r/cloud/helm/orc8r/charts/logging/templates/fluentd-daemon.configmap.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/logging/templates/fluentd-daemon.configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.fluentd_daemon.create }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -317,3 +318,4 @@ data:
     @include /fluentd/etc/kubernetes.conf
     @include /fluentd/etc/systemd.conf
     @include /fluentd/etc/output.conf
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/dp.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dp.deployment.yaml
@@ -31,6 +31,13 @@ spec:
         - name: config-volume
           configMap:
             name: orc8r-domain-proxy
+        {{- if .Values.secret.configs }}
+        {{- range $module, $secretName := .Values.secret.configs }}
+        - name: {{ $secretName }}-{{ $module }}
+          secret:
+            secretName: {{ $secretName }}
+        {{- end }}
+        {{- end }}
       containers:
       -
 {{ include "orc8rlib.container" (list . "domain-proxy.container")}}
@@ -60,4 +67,11 @@ volumeMounts:
   - name: config-volume
     mountPath: /etc/magma/configs/dp/dp.yml
     subPath: dp.yml
+  {{- if .Values.secret.configs }}
+  {{- range $module, $secretName := .Values.secret.configs }}
+  - name: {{ $secretName }}-{{ $module }}
+    mountPath: {{ print "/var/opt/magma/configs/" $module }}
+    readOnly: true
+  {{- end }}
+  {{- end }}
 {{- end -}}


### PR DESCRIPTION
- Don't install fluentd_daemon config-map when it's disabled, it's avoid conflicts when more then one installation of orc8r is made on one k8s cluster. As the fluentd_daemon resources always want to install itself in kube-system. Will not let install it for second orc8r instance
```
Error: INSTALLATION FAILED: rendered manifests contain a resource that already exists. Unable to continue with install: ConfigMap "orc8r-fluentd-es-configs" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "orc8r": current value is "orc8r-stage" deploying "orc8r": install: exit status 1
```
- Mount extra configuration in DP pod e.g. elasticsearch

Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] Install two instance of orc8r in two seperate ns one with fluent_daemon enabled, second one without
- [x] Deploy orc8r and domain proxy charts and check logs flow

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
