### PR TITLE
fix(feg): fix snowflake issue in feg integ test

### DIFF
--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Vagrant Host prerequisites for federated integ test
         run: |
           cd ${{ env.AGW_ROOT }} && fab open_orc8r_port_in_vagrant
-          cd ${{ env.MAGMA_ROOT }} && mkdir -p .cache/test_certs/ && mkdir -p .cache/feg/ && touch snowflake
+          cd ${{ env.MAGMA_ROOT }} && mkdir -p .cache/test_certs/ && mkdir -p .cache/feg/
           cd ${{ env.MAGMA_ROOT }}/.cache/feg/ && touch snowflake
       - name: Open up network interfaces for VM
         run: |

--- a/docs/readmes/feg/s1ap_federated_tests.md
+++ b/docs/readmes/feg/s1ap_federated_tests.md
@@ -118,9 +118,9 @@ You can then [run the tests manually](#run-tests-manually).
 
 If you want to build the environment manually, you can carry out the following steps.
 
-*Note that commands for the AGW have to be run inside the Vagrant VM. For this reason,
+*Note that commands for the AGW and FeG have to be run inside the Vagrant VM. For this reason,
 all such commands include the `vagrant ssh magma` command first. To leave
-Vagrant, just type `exit`. FeG and Orc8r will need to be run on the
+Vagrant, just type `exit`. Orc8r will need to be run on the
 host itself (no Vagrant involved).*
 
 - AGW:
@@ -148,7 +148,7 @@ vagrant ssh magma
 # inside vagrant vm
 cd magma/lte/gateway/python/integ_tests/federated_tests/docker
 docker-compose build
-docker-compose up -d
+./run.py
 ```
 
 - Orc8r:

--- a/lte/gateway/python/integ_tests/federated_tests/docker/run.py
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/run.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+"""
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+MAGMA_ROOT = os.environ["MAGMA_ROOT"]
+SNOWFLAKE_PATH = MAGMA_ROOT + '/.cache/feg/'
+SNOWFLAKE_FILE = MAGMA_ROOT + '/.cache/feg/snowflake'
+
+
+def main() -> None:
+    """ create a snowflake file if necessary, then start docker containers """
+    args = _parse_args()
+    if not os.path.isfile(SNOWFLAKE_FILE):
+        _create_snowflake_file()
+    _exec_docker_cmd(args)
+
+
+def _create_snowflake_file() -> None:
+    if os.path.isdir(SNOWFLAKE_FILE):
+        _exec_cmd(['rm', '-r', SNOWFLAKE_FILE])
+    print("Creating snowflake file")
+    _exec_cmd(['mkdir', '-p', SNOWFLAKE_PATH])
+    _exec_cmd(['touch', SNOWFLAKE_FILE])
+
+
+def _exec_docker_cmd(args) -> None:
+    cmd = ['docker-compose', 'up', '-d']
+    if args.down:
+        cmd = ['docker-compose', 'down']
+    print(f"Running {' '.join(cmd)}...")
+    _exec_cmd(cmd)
+
+
+def _exec_cmd(cmd) -> None:
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as err:
+        sys.exit(err.returncode)
+
+
+def _parse_args() -> argparse.Namespace:
+    """ Parse the command line args """
+    parser = argparse.ArgumentParser(description='FeG run tool')
+
+    # Other actions
+    parser.add_argument(
+        '--down', '-d',
+        action='store_true',
+        help='Stop running containers',
+    )
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == '__main__':
+    main()

--- a/lte/gateway/python/integ_tests/federated_tests/fabfile.py
+++ b/lte/gateway/python/integ_tests/federated_tests/fabfile.py
@@ -201,7 +201,7 @@ def build_feg():
     with cd(feg_docker_integ_test_path_vagrant):
         run('docker-compose down')
         run('docker-compose build')
-        run('docker-compose up -d')
+        run('./run.py')
 
 
 def _build_feg_on_host():
@@ -218,7 +218,7 @@ def _build_feg_on_host():
         cwd=feg_docker_integ_test_path,
     )
     subprocess.check_call(
-        'docker-compose up -d', shell=True,
+        './run.py', shell=True,
         cwd=feg_docker_integ_test_path,
     )
 
@@ -229,7 +229,7 @@ def start_feg():
     """
     vagrant_setup('magma', destroy_vm=False)
     with cd(feg_docker_integ_test_path_vagrant):
-        run('docker-compose up -d')
+        run('./run.py')
 
 
 def _start_feg_on_host():
@@ -237,7 +237,7 @@ def _start_feg_on_host():
     start FEG locally on Docker
     """
     subprocess.check_call(
-        'docker-compose up -d', shell=True,
+        './run.py', shell=True,
         cwd=feg_docker_integ_test_path,
     )
 


### PR DESCRIPTION
## Summary

fixes #13540 

Merge after #13781 

This PR creates a file `run.py`, which is to be used instead of `docker-compose up -d` to start the FeG containers. It creates the snowflake file in `/magma/.cache/feg/` if it does not exist already (if there is a directory `snowflake` in its place instead, it removes it first). Further related changes in this PR:
- adapt the automatic and semi-automatic build processes to use `./run.py`
- change the documentation of the manual build process accordingly
- remove a superfluous creation of a snowflake file in the wrong directory in the ci workflow
- remove an unused, empty snowflake file in `lte/gateway/python/.cache/feg/`

## Test Plan

- Spin up the AGW, FeG, and orc8r and run the FeG integ tests and the connectivity test (automatic, semiautomatic, and manual should all work).
- Check that if there is a folder `magma/.cache/feg/snowflake/`, the script will now automatically replace it with a snowflake file, which gets filled with an UUID.

## Additional Information

- [ ] This change is backwards-breaking
