### PR TITLE
fix(ci): Don't tag and push xwfm docker images

### DIFF
--- a/.github/workflows/deploy-build-from-pr.yml
+++ b/.github/workflows/deploy-build-from-pr.yml
@@ -142,18 +142,6 @@ jobs:
           docker image load --input gateway_pipelined.tar
           ./ci-scripts/tag-push-docker.sh --images 'cwag_go|gateway_go|gateway_python|gateway_sessiond|gateway_pipelined' --tag "${ISSUE_NUMBER}" --tag-latest true --project cwf
           rm cwag_go.tar gateway_go.tar gateway_python.tar gateway_sessiond.tar gateway_pipelined.tar
-      - name: Tag and push xwfm docker images
-        if: always() && steps.extract_images.outcome=='success'
-        env:
-          DOCKER_REGISTRY: "orc8r-ci.artifactory.magmacore.org"
-          DOCKER_USERNAME: "${{ secrets.JFROG_USERNAME }}"
-          DOCKER_PASSWORD: "${{ secrets.JFROG_PASSWORD }}"
-          ISSUE_NUMBER: "${{ steps.save_metadata.outputs.issue_number }}"
-        run: |
-          docker image load --input goradius.tar
-          docker image load --input xwfm-integ-tests.tar
-          ./ci-scripts/tag-push-docker.sh --images 'goradius|xwfm-integ-tests' --tag "${ISSUE_NUMBER}" --tag-latest true
-          rm goradius.tar xwfm-integ-tests.tar
       - name: Tag and push feg docker images
         if: always() && steps.extract_images.outcome=='success'
         env:


### PR DESCRIPTION
## Summary

The xwf folder was removed in #13545 and the image doesn't exist any more. This job [just failed](https://github.com/magma/magma/runs/7803503872) on master.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking