### PR TITLE
fix(ci): token needs to be specified during clone

### DIFF
--- a/.github/workflows/scripts/fabfile.py
+++ b/.github/workflows/scripts/fabfile.py
@@ -101,7 +101,7 @@ def find_release_commits(  # noqa: S107
     local('mkdir -p .gitclone/magma')
     local('git config --global user.email "tim@magmacore.org"')
     local('git config --global user.name "backport-bot"')
-    local(f'git clone https://github.com/{repo_name}.git .gitclone/magma')
+    local(f'git clone https://{token}@github.com/{repo_name}.git .gitclone/magma')
 
     for rel in RELEASE_BRANCHES:
         if rel not in commits_by_release:


### PR DESCRIPTION
... to allow for push access.

:warning: This would only be a workaround. I hope that Github will mask the token in the log output.

It would be much cleaner, to use a proper Github action, e.g. https://github.com/tibdex/backport.
I'd personally prefer the cleaner solution over the overly complicated current implementation.