### PR TITLE
refactor(orc8r): Simplify protected server logic

### DIFF
--- a/cwf/gateway/services/gateway_health/gateway_health/main.go
+++ b/cwf/gateway/services/gateway_health/gateway_health/main.go
@@ -45,7 +45,7 @@ const (
 
 func main() {
 	// Create the service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.GatewayHealth)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.GatewayHealth)
 	if err != nil {
 		glog.Fatalf("Error creating %s service: %s", registry.GatewayHealth, err)
 	}

--- a/cwf/gateway/services/uesim/uesim/main.go
+++ b/cwf/gateway/services/uesim/uesim/main.go
@@ -48,7 +48,7 @@ func main() {
 	flag.Parse()
 	glog.Info("Starting UESim service")
 
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.UeSim)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.UeSim)
 	if err != nil {
 		glog.Fatalf("Error creating UeSim service: %s", err)
 	}

--- a/feg/gateway/services/aaa/aaa_server/main.go
+++ b/feg/gateway/services/aaa/aaa_server/main.go
@@ -50,7 +50,7 @@ func main() {
 	sessions := store.NewMemorySessionTable()
 
 	// Create the EAP AKA Provider service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.AAA_SERVER)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.AAA_SERVER)
 	if err != nil {
 		glog.Fatalf("Error creating AAA service: %s", err)
 	}

--- a/feg/gateway/services/aaa/test/pipelined/main.go
+++ b/feg/gateway/services/aaa/test/pipelined/main.go
@@ -93,7 +93,7 @@ func main() {
 	flag.Parse() // for glog
 
 	// Dummy Pipelined service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.PIPELINED)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.PIPELINED)
 	if err != nil {
 		glog.Fatalf("Error creating %s service: %v", registry.PIPELINED, err)
 	}

--- a/feg/gateway/services/csfb/csfb/main.go
+++ b/feg/gateway/services/csfb/csfb/main.go
@@ -37,7 +37,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.CSFB)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.CSFB)
 	if err != nil {
 		glog.Fatalf("Error creating CSFB service: %s", err)
 	}

--- a/feg/gateway/services/eap/eap_router/main.go
+++ b/feg/gateway/services/eap/eap_router/main.go
@@ -31,7 +31,7 @@ type eapRouter struct {
 
 func main() {
 	// Create the EAP AKA Provider service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.EAP)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP)
 	if err != nil {
 		glog.Fatalf("Error creating EAP Router service: %s", err)
 	}

--- a/feg/gateway/services/eap/providers/aka/eap_aka/main.go
+++ b/feg/gateway/services/eap/providers/aka/eap_aka/main.go
@@ -35,7 +35,7 @@ func init() {
 
 func main() {
 	// Create the EAP AKA Provider service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.EAP_AKA)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP_AKA)
 	if err != nil {
 		glog.Fatalf("Error creating EAP AKA service: %s", err)
 	}

--- a/feg/gateway/services/eap/providers/sim/eap_sim/main.go
+++ b/feg/gateway/services/eap/providers/sim/eap_sim/main.go
@@ -35,7 +35,7 @@ func init() {
 
 func main() {
 	// Create the EAP SIM Provider service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.EAP_SIM)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.EAP_SIM)
 	if err != nil {
 		glog.Fatalf("Error creating EAP SIM service: %s", err)
 	}

--- a/feg/gateway/services/envoy_controller/main.go
+++ b/feg/gateway/services/envoy_controller/main.go
@@ -69,7 +69,7 @@ func init() {
 func main() {
 	// Create the service
 	glog.Infof("Creating '%s' Service", registry.ENVOY_CONTROLLER)
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.ENVOY_CONTROLLER)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.ENVOY_CONTROLLER)
 	if err != nil {
 		glog.Fatalf("Error creating Envoy Controller service: %s", err)
 	}

--- a/feg/gateway/services/feg_hello/main.go
+++ b/feg/gateway/services/feg_hello/main.go
@@ -30,7 +30,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.FEG_HELLO)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.FEG_HELLO)
 	if err != nil {
 		glog.Fatalf("Error creating FEG_HELLO service: %s", err)
 	}

--- a/feg/gateway/services/gateway_health/gateway_health/main.go
+++ b/feg/gateway/services/gateway_health/gateway_health/main.go
@@ -30,7 +30,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.HEALTH)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.HEALTH)
 	if err != nil {
 		glog.Fatalf("Error creating HEALTH service: %s", err)
 	}

--- a/feg/gateway/services/n7_n40_proxy/n7_n40_proxy/main.go
+++ b/feg/gateway/services/n7_n40_proxy/n7_n40_proxy/main.go
@@ -33,7 +33,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.N7_N40_PROXY)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.N7_N40_PROXY)
 	if err != nil {
 		glog.Fatalf("Error creating N7_N40 Proxy service: %s", err)
 	}

--- a/feg/gateway/services/radiusd/radiusd/main.go
+++ b/feg/gateway/services/radiusd/radiusd/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	// Create the service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.RADIUSD)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.RADIUSD)
 	if err != nil {
 		glog.Fatalf("Error creating RADIUSD service: %s", err)
 	}

--- a/feg/gateway/services/s6a_proxy/s6a_proxy/main.go
+++ b/feg/gateway/services/s6a_proxy/s6a_proxy/main.go
@@ -32,7 +32,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.S6A_PROXY)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.S6A_PROXY)
 	if err != nil {
 		log.Fatalf("Error creating S6a Proxy service: %s", err)
 	}

--- a/feg/gateway/services/s8_proxy/s8_proxy/main.go
+++ b/feg/gateway/services/s8_proxy/s8_proxy/main.go
@@ -30,7 +30,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.S8_PROXY)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.S8_PROXY)
 	if err != nil {
 		glog.Fatalf("Error creating S8 Proxy service: %s", err)
 	}

--- a/feg/gateway/services/session_proxy/session_proxy/main.go
+++ b/feg/gateway/services/session_proxy/session_proxy/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	// Create the service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.SESSION_PROXY)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.SESSION_PROXY)
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}

--- a/feg/gateway/services/swx_proxy/swx_proxy/main.go
+++ b/feg/gateway/services/swx_proxy/swx_proxy/main.go
@@ -31,7 +31,7 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.SWX_PROXY)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.SWX_PROXY)
 	if err != nil {
 		glog.Fatalf("Error creating Swx Proxy service: %s", err)
 	}

--- a/feg/gateway/services/testcore/hss/hss/main.go
+++ b/feg/gateway/services/testcore/hss/hss/main.go
@@ -30,7 +30,7 @@ import (
 
 func main() {
 	flag.Parse()
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.MOCK_HSS)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_HSS)
 	if err != nil {
 		log.Fatalf("Error creating hss service: %s", err)
 	}

--- a/feg/gateway/services/testcore/ocs/main.go
+++ b/feg/gateway/services/testcore/ocs/main.go
@@ -76,7 +76,7 @@ func main() {
 		},
 	)
 
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, serviceName)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName)
 	if err != nil {
 		log.Fatalf("Error creating mock %s service: %s", serviceName, err)
 	}

--- a/feg/gateway/services/testcore/pcf/pcf/main.go
+++ b/feg/gateway/services/testcore/pcf/pcf/main.go
@@ -28,7 +28,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error reading N7 config: %s", err)
 	}
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, registry.MOCK_PCF)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_PCF)
 	if err != nil {
 		log.Fatalf("Error creating mock %s service: %s", registry.MOCK_PCF, err)
 	}

--- a/feg/gateway/services/testcore/pcrf/main.go
+++ b/feg/gateway/services/testcore/pcrf/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	pcrfServer := mock_pcrf.NewPCRFServer(gxCliConf, gxServConf)
 
-	srv, err := service.NewGatewayServiceWithOptions(registry.ModuleName, serviceName)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName)
 	if err != nil {
 		log.Fatalf("Error creating mock %s service: %s", serviceName, err)
 	}

--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -90,7 +90,7 @@ func NewOrchestratorService(moduleName string, serviceName string, serverOptions
 	grpc_prometheus.EnableHandlingTimeHistogram()
 	serverOptions = append(serverOptions, unary.GetInterceptorOpt())
 
-	platformService, err := platform_service.NewOrc8rServiceWithOptions(moduleName, serviceName, serverOptions...)
+	platformService, err := platform_service.NewServiceWithOptions(moduleName, serviceName, serverOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/go/service/test_utils.go
+++ b/orc8r/cloud/go/service/test_utils.go
@@ -27,7 +27,7 @@ func NewTestService(t *testing.T, moduleName string, serviceType string) (*platf
 	if t == nil {
 		panic("for tests only")
 	}
-	return platform_service.NewOrc8rServiceWithOptions(moduleName, serviceType, unary.GetInterceptorOpt())
+	return platform_service.NewServiceWithOptions(moduleName, serviceType, unary.GetInterceptorOpt())
 }
 
 // NewTestOrchestratorService returns a new gRPC orchestrator service without
@@ -37,7 +37,7 @@ func NewTestOrchestratorService(t *testing.T, moduleName string, serviceType str
 	if t == nil {
 		panic("for tests only")
 	}
-	platformService, err := platform_service.NewOrc8rServiceWithOptions(moduleName, serviceType, unary.GetInterceptorOpt())
+	platformService, err := platform_service.NewServiceWithOptions(moduleName, serviceType, unary.GetInterceptorOpt())
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/gateway/go/services/magmad/service/magmad.go
+++ b/orc8r/gateway/go/services/magmad/service/magmad.go
@@ -226,7 +226,7 @@ func NewMagmadService() protos.MagmadServer {
 // StartMagmadServer runs instance of the magmad grpc service
 // StartMagmadServer only returns on error and has to be run in its own Go routine or main thread
 func StartMagmadServer() error {
-	srv, err := service.NewGatewayServiceWithOptions("", strings.ToUpper(definitions.MagmadServiceName))
+	srv, err := service.NewServiceWithOptions("", strings.ToUpper(definitions.MagmadServiceName))
 	if err != nil {
 		return fmt.Errorf("error creating '%s' service: %v", definitions.MagmadServiceName, err)
 	}


### PR DESCRIPTION
Fixes #13484

Signed-off-by: Moritz Huebner <moritz.huebner@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
<!-- Enumerate changes you made and why you made them -->
- Consolidated `NewGatewayServiceWithOptions` and `NewOrc8rServiceWithOptions` back into `NewServiceWithOptions`
- Eliminated `protected303Server` argument in `NewServiceWithOptions`
- Service type is now identified by the available ports, using `registry.GetServicePort`
  - `registry.GetServicePort` returns `0` if and only if not protected port exists
  
## Test 

- [x] Manually check that services get the correct port:
  - [x] cwf
  - [x] feg
  - [x] orc8r (using minikube)
- [x] Run federated integ tests.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
