### PR TITLE
Revert "chore(ci): reboot after dist upgrade in fabfile"

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -750,12 +750,6 @@ def _dist_upgrade():
     """ Upgrades OS packages on dev box """
     run('sudo apt-get update')
     run('sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade')
-    try:
-        run('sudo reboot')
-    except Exception as e:
-        print(e)
-    finally:
-        time.sleep(60)
 
 
 def _build_magma():


### PR DESCRIPTION
Reverts magma/magma#13503

There seems to be issues, pointed out be @nstng:  https://github.com/magma/magma/runs/7836234941?check_suite_focus=true

We investigate whether the reboot is the cause.