### PR TITLE
chore: new integ tests are bazelified

### DIFF
--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -71,3 +71,4 @@ coverage-lcov
 
 # s1ap test requirements
 iperf3
+flaky

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -289,6 +289,10 @@ fakeredis==1.7.1 \
 fire==0.4.0 \
     --hash=sha256:c5e2b8763699d1142393a46d0e3e790c5eb2f0706082df8f647878842c216a62
     # via -r requirements.in
+flaky==3.7.0 \
+    --hash=sha256:3ad100780721a1911f57a165809b7ea265a7863305acb66708220820caf8aa0d \
+    --hash=sha256:d6eda73cab5ae7364504b7c44670f70abed9e75f77dd116352f662817592ec9c
+    # via -r requirements.in
 flask==2.0.3 \
     --hash=sha256:59da8a3170004800a2837844bfa84d49b022550616070f7cb1a659682b2e7c9f \
     --hash=sha256:e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d
@@ -898,7 +902,7 @@ oslo-config==8.8.0 \
     --hash=sha256:96933d3011dae15608a11616bfb00d947e22da3cb09b6ff37ddd7576abd4764c \
     --hash=sha256:b1e2a398450ea35a8e5630d8b23057b8939838c4433cd25a20cc3a36d5df9e3b
     # via -r requirements.in
-oslo-i18n==5.1.0 \
+oslo.i18n==5.1.0 \
     --hash=sha256:6bf111a6357d5449640852de4640eae4159b5562bbba4c90febb0034abc095d0 \
     --hash=sha256:75086cfd898819638ca741159f677e2073a78ca86a9c9be8d38b46800cdf2dc9
     # via oslo-config
@@ -920,7 +924,7 @@ pbr==5.8.1 \
     --hash=sha256:27108648368782d07bbf1cb468ad2e2eeef29086affd14087a6d04b7de8af4ec \
     --hash=sha256:66bc5a34912f408bb3925bf21231cb6f59206267b7f63f3503ef865c1a292e25
     # via
-    #   oslo-i18n
+    #   oslo.i18n
     #   stevedore
 pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
@@ -930,7 +934,7 @@ priority==1.3.0 \
     --hash=sha256:6bc1961a6d7fcacbfc337769f1a382c8e746566aaa365e78047abe9f66b2ffbe \
     --hash=sha256:be4fcb94b5e37cdeb40af5533afe6dd603bd665fe9c8b3052610fc1001d5d1eb
     # via -r requirements.in
-prometheus-client==0.3.1 \
+prometheus_client==0.3.1 \
     --hash=sha256:17bc24c09431644f7c65d7bce9f4237252308070b6395d6d8e87767afe867e24
     # via -r requirements.in
 protobuf==3.19.4 \
@@ -1184,7 +1188,7 @@ redis-collections==0.11.0 \
     --hash=sha256:0f6cda00666fdd26e3b8ca47da13a653eaf4cc4e45470a3b09f17d65061fea8a \
     --hash=sha256:d23e8c0f6bf50de10c98a14a3b636ff1bb21119386f884f2641c906832bc4ec9
     # via -r requirements.in
-repoze-lru==0.7 \
+repoze.lru==0.7 \
     --hash=sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77 \
     --hash=sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea
     # via routes

--- a/bazel/scripts/check_py_bazel.sh
+++ b/bazel/scripts/check_py_bazel.sh
@@ -33,6 +33,7 @@ DENY_LIST_NOT_RELEVANT=(
   "./lte/gateway/deploy"
   # manually executed script
   "./lte/gateway/c/core/oai/tasks/s1ap/messages/asn1/asn1tostruct.py"
+  "./lte/gateway/python/build"
   # used for manual testing
   "./lte/gateway/python/magma/pipelined/tests/envoy-tests/http-serve.py"
   "./lte/gateway/python/magma/tests/pylint_wrapper.py"
@@ -53,7 +54,41 @@ DENY_LIST_NOT_RELEVANT=(
 # This list needs to be updated if respected structures are bazelified.
 DENY_LIST_NOT_YET_BAZELIFIED=(
   # TODO: GH12752 tests should be bazelified
-  "./lte/gateway/python/integ_tests"
+  "./lte/gateway/python/integ_tests/cloud"
+  "./lte/gateway/python/integ_tests/cloud_tests"
+  "./lte/gateway/python/integ_tests/federated_tests"
+  "./lte/gateway/python/integ_tests/gxgy_tests"
+  "./lte/gateway/python/integ_tests/s1aptests/workflow"
+  "./lte/gateway/python/integ_tests/s1aptests/test_agw_offload_mixed_idle_active_multiue.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_attach_detach_two_pdns_with_tcptraffic.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_multi_ue.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej_ded_bearer_activation.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_attach_dl_udp_data_multi_ue.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ul_tcp.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_attach_ul_tcp_data_multi_ue.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_attach_dl_ul_tcp_data_multi_ue.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_default_bearer.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_dl_tcp.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_dl_udp.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_ded_bearer_ul_tcp.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ded_bearer_dl_tcp.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ded_bearer_ul_tcp.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_ded_bearer_dl_tcp.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_ul_tcp.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_scalability_attach_detach_multi_ue.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_attach_dl_tcp_data_multi_ue.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_enable_ipv6_iface.py"
+  "./lte/gateway/python/integ_tests/s1aptests/test_disable_ipv6_iface.py"
+  # TODO: GH12754 move to (lte|orc8r)/gateway/python/scripts/
+  "./orc8r/gateway/python/magma/common/health/docker_health_service.py"
+  "./orc8r/gateway/python/magma/common/health/health_service.py"
+  "./orc8r/gateway/python/magma/common/health/entities.py"
+  "./lte/gateway/python/magma/health/health_service.py"
+  "./lte/gateway/python/magma/health/entities.py"
+  "./lte/gateway/python/magma/pipelined/pg_set_session_msg.py"
   # TODO: GH12755 access via absolut path on the VM,
   # this needs to be refactored when make is not used anymore
   "./lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py"

--- a/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library")
 load("//bazel:python_test.bzl", "pytest_test")
 load(
@@ -50,9 +51,7 @@ py_library(
 py_library(
     name = "s1ap_wrapper",
     testonly = True,
-    srcs = [
-        "s1ap_wrapper.py",
-    ],
+    srcs = ["s1ap_wrapper.py"],
     deps = [
         ":s1ap_utils",
         "//lte/gateway/python/integ_tests/common:magmad_client",
@@ -1128,6 +1127,18 @@ pytest_test(
     deps = [
         ":s1ap_utils",
         "//lte/gateway/python/integ_tests/common:magmad_client",
+    ],
+)
+
+pytest_test(
+    name = "test_attach_detach_flaky_retry_success",
+    size = "small",
+    srcs = ["test_attach_detach_flaky_retry_success.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST,
+    deps = [
+        ":s1ap_wrapper",
+        requirement("flaky"),
     ],
 )
 

--- a/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
@@ -49,6 +49,12 @@ py_library(
 )
 
 py_library(
+    name = "gpp_types",
+    testonly = True,
+    srcs = ["gpp_types.py"],
+)
+
+py_library(
     name = "s1ap_wrapper",
     testonly = True,
     srcs = ["s1ap_wrapper.py"],
@@ -140,7 +146,10 @@ pytest_test(
     srcs = ["test_attach_detach_after_ue_context_release.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -185,7 +194,10 @@ pytest_test(
     srcs = ["test_attach_ue_ctxt_release_cmp_delay.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -266,7 +278,10 @@ pytest_test(
     srcs = ["test_tau_periodic_inactive.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -275,7 +290,10 @@ pytest_test(
     srcs = ["test_tau_periodic_active.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -293,7 +311,10 @@ pytest_test(
     srcs = ["test_eps_bearer_context_status_def_bearer_deact.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -302,7 +323,10 @@ pytest_test(
     srcs = ["test_eps_bearer_context_status_ded_bearer_deact.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -311,7 +335,10 @@ pytest_test(
     srcs = ["test_attach_service.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -329,7 +356,10 @@ pytest_test(
     srcs = ["test_attach_service_ue_radio_capability.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -338,7 +368,10 @@ pytest_test(
     srcs = ["test_attach_service_multi_ue.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -431,7 +464,10 @@ pytest_test(
     srcs = ["test_attach_detach_emm_status.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -440,7 +476,10 @@ pytest_test(
     srcs = ["test_attach_detach_enb_rlf_initial_ue_msg.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -836,7 +875,10 @@ pytest_test(
     srcs = ["test_ics_timer_expiry_ue_registered.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -863,7 +905,10 @@ pytest_test(
     srcs = ["test_attach_service_with_multi_pdns_and_bearers_multi_ue.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -872,7 +917,10 @@ pytest_test(
     srcs = ["test_attach_service_with_multi_pdns_and_bearers_failure.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -881,7 +929,10 @@ pytest_test(
     srcs = ["test_dedicated_bearer_activation_idle_mode_multi_ue.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -935,7 +986,10 @@ pytest_test(
     srcs = ["test_ipv6_paging_with_dedicated_bearer.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -944,7 +998,10 @@ pytest_test(
     srcs = ["test_ipv4v6_paging_with_dedicated_bearer.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1016,7 +1073,10 @@ pytest_test(
     srcs = ["test_attach_service_with_multi_pdns_and_bearers_mt_data.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST + TAG_TRAFFIC_SERVER_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1106,7 +1166,10 @@ pytest_test(
     srcs = ["test_service_req_ul_udp_data_with_mme_restart.py"],
     imports = [LTE_ROOT],
     tags = TAG_PRECOMMIT_TEST + TAG_TRAFFIC_SERVER_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1157,7 +1220,10 @@ pytest_test(
     srcs = ["test_attach_detach_ps_service_not_available.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1283,7 +1349,10 @@ pytest_test(
     srcs = ["test_dedicated_bearer_activation_idle_mode.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1310,7 +1379,10 @@ pytest_test(
     srcs = ["test_attach_service_with_multi_pdns_and_bearers.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1337,7 +1409,10 @@ pytest_test(
     srcs = ["test_attach_service_with_multi_pdns_and_bearers_looped.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1346,7 +1421,10 @@ pytest_test(
     srcs = ["test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1418,7 +1496,10 @@ pytest_test(
     srcs = ["test_idle_mode_with_mme_restart.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1445,7 +1526,10 @@ pytest_test(
     srcs = ["test_paging_after_mme_restart.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST + TAG_TRAFFIC_SERVER_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1463,7 +1547,10 @@ pytest_test(
     srcs = ["test_tau_ta_updating.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1472,7 +1559,10 @@ pytest_test(
     srcs = ["test_tau_ta_updating_reject.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1481,7 +1571,10 @@ pytest_test(
     srcs = ["test_tau_mixed_partial_lists.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1490,7 +1583,10 @@ pytest_test(
     srcs = ["test_eps_bearer_context_status_multiple_ded_bearer_deact.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1499,7 +1595,10 @@ pytest_test(
     srcs = ["test_guti_attach_with_zero_mtmsi.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1508,7 +1607,10 @@ pytest_test(
     srcs = ["test_ics_timer_expiry_with_mme_restart.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1517,7 +1619,10 @@ pytest_test(
     srcs = ["test_attach_mobile_reachability_timer_expiry.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1526,7 +1631,10 @@ pytest_test(
     srcs = ["test_attach_implicit_detach_timer_expiry.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1535,7 +1643,10 @@ pytest_test(
     srcs = ["test_mobile_reachability_tmr_with_mme_restart.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1544,7 +1655,10 @@ pytest_test(
     srcs = ["test_implicit_detach_timer_with_mme_restart.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1604,7 +1718,10 @@ pytest_test(
     srcs = ["test_paging_with_mme_restart.py"],
     imports = [LTE_ROOT],
     tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1829,7 +1946,10 @@ pytest_test(
     srcs = ["test_attach_service_without_mac.py"],
     imports = [LTE_ROOT],
     tags = TAG_NON_SANITY_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1838,7 +1958,10 @@ pytest_test(
     srcs = ["test_paging_request.py"],
     imports = [LTE_ROOT],
     tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1847,7 +1970,10 @@ pytest_test(
     srcs = ["test_multi_enb_paging_request.py"],
     imports = [LTE_ROOT],
     tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1892,7 +2018,10 @@ pytest_test(
     srcs = ["test_attach_inactive_tau_with_combined_tala_update_reattach.py"],
     imports = [LTE_ROOT],
     tags = TAG_NON_SANITY_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(
@@ -1901,7 +2030,10 @@ pytest_test(
     srcs = ["test_attach_active_tau_with_combined_tala_update_reattach.py"],
     imports = [LTE_ROOT],
     tags = TAG_NON_SANITY_TEST,
-    deps = [":s1ap_wrapper"],
+    deps = [
+        ":gpp_types",
+        ":s1ap_wrapper",
+    ],
 )
 
 pytest_test(


### PR DESCRIPTION
## Summary

Main target here was to do #13588. But it came up that one python file - `gpp_types.py` - was not yet bazelified (this is used in integ tests, but somehow bazel has access on magma_test) and that there are three new integ tests that need to be bazelified.

~~Note that two of the integ tests seem to be setup and tear down "tests" for not yet activated ipv6 tests. But imho it is a good idea to bazelify them for now so that this logic is tested as well.~~ The basilification of those tests was removed after a review discussion. This will be re-added when respective tests for these setup and teardown "tests" are added. Or they are included in the respective tests directly.

## Test Plan

### new tests
* `./bazel/scripts/run_integ_tests.sh lte/gateway/python/integ_tests/s1aptests:test_attach_detach_flaky_retry_success`

### `gpp_types`
On a vm `!= magma_test` check if `bazel run` produces ModuleNotFound exceptions (the tests will fail! but the ModuleNotFound exception should come before the test failure). E.g., use
```
#!/usr/bin/env bash

LOGGING_FILE="/tmp/test_import_logging.log"

A=$(bazel query "kind(py_test, //lte/gateway/python/integ_tests/s1aptests/...)")
for test in $A
do
  echo "CHECKING ${test}"
  bazel run "${test}" --define=on_magma_test=1 2>&1  | tee "${LOGGING_FILE}"
  RESULT=$(grep -m 1 "ModuleNotFoundError" "${LOGGING_FILE}" || [[ $? == 1 ]])
  if [[ "${RESULT}" != "" ]];
  then
    exit 1
  fi
done
```

### updated py files check
In `bazel/scripts/check_py_bazel.sh` remove line 56-81and check that the output corresponds to the removed lines. Note that some files are covered by excluding complete directories. 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
