### PR TITLE
refactor: remove xwf functionality from backend

### DIFF
--- a/cwf/cloud/go/services/cwf/obsidian/models/network_carrier_wifi_configs_swaggergen.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/network_carrier_wifi_configs_swaggergen.go
@@ -38,10 +38,6 @@ type NetworkCarrierWifiConfigs struct {
 	// eap sim
 	EapSim *models2.EapSim `json:"eap_sim,omitempty"`
 
-	// is xwfm variant
-	// Example: false
-	IsXwfmVariant bool `json:"is_xwfm_variant,omitempty"`
-
 	// li ues
 	LiUes *LiUes `json:"li_ues,omitempty"`
 

--- a/cwf/cloud/go/services/cwf/obsidian/models/swagger.v1.yml
+++ b/cwf/cloud/go/services/cwf/obsidian/models/swagger.v1.yml
@@ -972,9 +972,6 @@ definitions:
         $ref: './feg-swagger.yml#/definitions/aaa_server'
       li_ues:
         $ref: '#/definitions/li_ues'
-      is_xwfm_variant:
-        type: boolean
-        example: false
 
   allowed_gre_peer:
     type: object

--- a/nms/generated/api.ts
+++ b/nms/generated/api.ts
@@ -4585,12 +4585,6 @@ export interface NetworkCarrierWifiConfigs {
     'eap_sim'?: EapSim;
     /**
      * 
-     * @type {boolean}
-     * @memberof NetworkCarrierWifiConfigs
-     */
-    'is_xwfm_variant'?: boolean;
-    /**
-     * 
      * @type {LiUes}
      * @memberof NetworkCarrierWifiConfigs
      */

--- a/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
@@ -9509,9 +9509,6 @@ definitions:
         $ref: '#/definitions/eap_aka'
       eap_sim:
         $ref: '#/definitions/eap_sim'
-      is_xwfm_variant:
-        example: false
-        type: boolean
       li_ues:
         $ref: '#/definitions/li_ues'
       network_services:


### PR DESCRIPTION
## Summary

[Merge after #13603.]

Relates to #13546. This PR removes xwf functionality from backend (swagger interfaces). It is removed from front end in https://github.com/magma/magma/pull/13603.

## Test Plan

- CI
- [x] Check if xwf field is removed from swagger API (https://localhost:9443/swagger/v1/ui)
Used endpoints, that do not require a gateway ID, to check. `is_xwfm_variant` disappeared in post method of /cwf and example models of various other endpoints.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
