### PR TITLE
chore: Improve integ test wrapper script

### DIFF
--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -65,8 +65,8 @@ fakeredis==1.7.1
 lupa==1.10
 parameterized==0.8.1
 freezegun
-pytest
-pytest-cov
+pytest==7.1.2
+pytest-cov==3.0.0
 coverage-lcov
 
 # s1ap test requirements

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -1110,9 +1110,9 @@ pyrsistent==0.18.1 \
 pystemd==0.10.0 \
     --hash=sha256:d74a814bfda01085db1a8ad90be3cb27daf23a51ab6b03e7e29ec811fa2ae859
     # via -r requirements.in
-pytest==7.0.1 \
-    --hash=sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db \
-    --hash=sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171
+pytest==7.1.2 \
+    --hash=sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c \
+    --hash=sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45
     # via
     #   -r requirements.in
     #   pytest-cov

--- a/bazel/python_test.bzl
+++ b/bazel/python_test.bzl
@@ -41,6 +41,7 @@ PYTEST_DEPS = [
     requirement("pytest"),
     requirement("pytest-cov"),
     requirement("coverage-lcov"),
+    requirement("flaky"),
 ]
 
 def _stringify(paths):

--- a/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library")
 load("//bazel:python_test.bzl", "pytest_test")
 load(
@@ -1199,10 +1198,7 @@ pytest_test(
     srcs = ["test_attach_detach_flaky_retry_success.py"],
     imports = [LTE_ROOT],
     tags = TAG_EXTENDED_TEST,
-    deps = [
-        ":s1ap_wrapper",
-        requirement("flaky"),
-    ],
+    deps = [":s1ap_wrapper"],
 )
 
 pytest_test(

--- a/lte/gateway/python/scripts/runtime_report.py
+++ b/lte/gateway/python/scripts/runtime_report.py
@@ -46,12 +46,16 @@ def merge_all_report(working_dir, list_xml_report_paths, output_path):
         xml_file_path = working_dir + "/" + xml_file_path
         test_result = ET.parse(xml_file_path)
         test_suites_data = test_result.getroot()
-
+        # for the integration tests pytest generates the XML files with a slightly different structure
+        integration_tests = test_suites_data.attrib == {}
+        if integration_tests:
+            test_suites_data.attrib = test_suites_data[0].attrib
         num_all_failures += int(test_suites_data.attrib['failures'])
         num_all_tests += int(test_suites_data.attrib['tests'])
         total_time += float(test_suites_data.attrib['time'])
         num_all_errors += int(test_suites_data.attrib['errors'])
-        num_all_disabled += int(test_suites_data.attrib['disabled'])
+        if not integration_tests:
+            num_all_disabled += int(test_suites_data.attrib['disabled'])
         init_time = min(init_time, datetime.fromisoformat(test_suites_data.attrib['timestamp']))
 
         for single_test_suite_data in test_suites_data:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The integration test wrapper script for Bazel was lacking some desired features, this PR aims to resolve 4 of them:

1. The option `--retry-on-failure` and `--retry-attempts N` was added. With these you can rerun failing tests N times and they will only be considered failed if all attempts fail.
2. Multiple test targets can be specified. You can provide your own list of targets that can contain tests from all categories and the order does not matter.
3. After every run there will be a Junit XML report generated.
4. With the `--rerun-previously-failed` option you can rerun all previously failed tests. 

## Test Plan

Use options as described in `bazel/scripts/run_integ_tests.sh  --help`.

Some examples:

- Quick, only precommit tests:
```bash
bazel/scripts/run_integ_tests.sh  //lte/gateway/python/integ_tests/s1aptests:test_attach_detach //lte/gateway/python/integ_tests/s1aptests:test_attach_detach_static_ip //lte/gateway/python/integ_tests/s1aptests:test_gateway_metrics_attach_detach //lte/gateway/python/integ_tests/s1aptests:test_attach_without_ips_available
```
- More flaky and longer nonsanity tests:
```bash
bazel/scripts/run_integ_tests.sh  //lte/gateway/python/integ_tests/s1aptests:test_outoforder_erab_setup_rsp_dedicated_bearer  //lte/gateway/python/integ_tests/s1aptests:test_attach_detach_multi_ue_looped //lte/gateway/python/integ_tests/s1aptests:test_attach_detach_nw_triggered_delete_secondary_pdn //lte/gateway/python/integ_tests/s1aptests:test_attach_detach_ipv6
```
- Retry:
```bash
bazel/scripts/run_integ_tests.sh --retry-on-failure //lte/gateway/python/integ_tests/s1aptests:test_outoforder_erab_setup_rsp_dedicated_bearer --retry-attempts 1 //lte/gateway/python/integ_tests/s1aptests:test_attach_detach_multi_ue_looped //lte/gateway/python/integ_tests/s1aptests:test_attach_detach_nw_triggered_delete_secondary_pdn //lte/gateway/python/integ_tests/s1aptests:test_attach_detach_ipv6
```
- Rerun:
```bash
bazel/scripts/run_integ_tests.sh  --rerun-previously-failed
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
