### PR TITLE
chore(agw): bump version of ovs that is required

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -166,10 +166,10 @@ OAI_DEPS=(
 # OVS runtime dependencies
 OVS_DEPS=(
       "magma-libfluid >= 0.1.0.7"
-      "libopenvswitch >= 2.15.4-8"
-      "openvswitch-switch >= 2.15.4-8"
-      "openvswitch-common >= 2.15.4-8"
-      "openvswitch-datapath-dkms >= 2.15.4-8"
+      "libopenvswitch >= 2.15.4-9-magma"
+      "openvswitch-switch >= 2.15.4-9-magma"
+      "openvswitch-common >= 2.15.4-9-magma"
+      "openvswitch-datapath-dkms >= 2.15.4-9-magma"
       )
 
 # generate string for FPM


### PR DESCRIPTION
## Summary

since we require features from `ovs >= 2.15.4-9-magma` also the fpm command composing the deb package needs to be updated.
