### PR TITLE
fix(ci): refine backport title & allow dependent job exection

### DIFF
--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -33,6 +33,10 @@ jobs:
         )
       )
     steps:
+      - run: |
+          echo '{
+            "prTitle": "{commitMessages} [backport to {targetBranch}]"
+          }' > .backportrc.json
       - name: Backport Action
         uses: sqren/backport-github-action@f54e19901f2a57f8b82360f2490d47ee82ec82c6 # pin@v8.9.3
         with:


### PR DESCRIPTION
## Summary

- The PR title for the new backporting workflow does not align with the semantic commit:
  - https://github.com/magma/magma/pull/13633
  - https://github.com/magma/magma/pull/13634
  - https://github.com/magma/magma/pull/13635

  As a new title format it is proposed to append the `[backport to v1.8]` instead of prefixing it.

## Test Plan

- The target branch is post-pended not prepended:
  - https://github.com/sqren/backport/blob/main/docs/config-file-options.md#prtitle
  - Postpending works: https://github.com/Neudrino/magma/pull/20

## Additional information

- This is a follow up to https://github.com/magma/magma/pull/13607.