### PR TITLE
fix(ci): the semantic-pr should also run on additional actions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -6,8 +6,10 @@ on:
   pull_request_target:
     types:
       - opened
+      - reopened
       - edited
       - synchronize
+      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Semantic PR should also run on reopened PRs
- And while we are at it, running it at the transition from draft to real PR should also be included imho
