### PR TITLE
chore(ci): Run the LTE integ_tests with Bazel

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -22,7 +22,8 @@ on:
       - completed
 
 env:
-  CACHE_KEY: magma-dev-vm
+  CACHE_KEY_MAGMA_DEV: magma-dev-vm
+  CACHE_KEY_MAGMA_TEST: magma-test-vm
   REMOTE_DOWNLOAD_OPTIMIZATION: false
 
 jobs:
@@ -77,7 +78,7 @@ jobs:
       - name: Build all services and scripts with bazel
         run: |
           cd lte/gateway
-          vagrant ssh -c 'cd ~/magma; bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}";' magma
+          vagrant ssh -c 'cd ~/magma; bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY_MAGMA_DEV }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}";' magma
           vagrant ssh -c 'sudo sed -i "s@#precedence ::ffff:0:0/96  100@precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
           vagrant ssh -c 'cd ~/magma; bazel build --profile=bazel_profile_lte_integ_tests `bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/...)"`;' magma
           vagrant ssh -c 'sudo sed -i "s@precedence ::ffff:0:0/96  100@#precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
@@ -85,12 +86,21 @@ jobs:
         run: |
           cd lte/gateway
           vagrant ssh -c 'cd ~/magma; bazel/scripts/link_scripts_for_bazel_integ_tests.sh;' magma
-      - name: Run the integ test
+      - name: Setup magma test VM and traffic server VM
         run: |
           cd lte/gateway
           export MAGMA_DEV_CPUS=3
           export MAGMA_DEV_MEMORY_MB=9216
           fab bazel_integ_test_post_build
+          vagrant ssh -c 'bash -ci "disable-tcp-checksumming"' magma
+          vagrant ssh -c 'bash -ci "disable-tcp-checksumming"' magma_test
+          vagrant ssh -c 'bash -ci "disable-tcp-checksumming"' magma_trfserver
+      - name: Run the integ tests
+        run: |
+          cd lte/gateway
+          vagrant ssh -c 'cd ~/magma; bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY_MAGMA_TEST }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}";' magma
+          # The ssh option '-ttt' is forcing tty allocation, even if ssh has no local tty.
+          vagrant ssh -c 'cd ~/magma; bash -c "bazel/scripts/run_integ_tests.sh --retry-on-failure"' magma_test -- -ttt
       - name: Get test results
         if: always()
         run: |

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -391,14 +391,6 @@ def bazel_integ_test_post_build(
     else:
         ansible_setup(test_host, "test", "magma_test.yml")
 
-    execute(_make_integ_tests)
-    execute(_run_integ_tests, gateway_ip)
-
-    if not gateway_host:
-        setup_env_vagrant()
-    else:
-        env.hosts = [gateway_host]
-
 
 def _setup_vm(host, name, ansible_role, ansible_file, destroy_vm, provision_vm):
     ip = None


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>
Co-authored-by: Lars Kreutzer <lars.kreutzer@tngtech.com>
Co-authored-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

In the LTE integ test Bazel workflow the integration tests are now run with Bazel.
This closes #13381 

## Test Plan

For testing see: https://github.com/magma/magma/issues/13381

Final config run (With some unrelated test failures, which happen at master too.): 
- https://github.com/vktng/magma/runs/7997130758?check_suite_focus=true
- https://github.com/LKreutzer/magma/runs/8010104491?check_suite_focus=true
- https://github.com/vktng/magma/runs/8067865104?check_suite_focus=true

Run without sudo tests:
- https://github.com/vktng/magma/runs/8067945830?check_suite_focus=true

Runs with good list:
with sudo tests:
- https://github.com/vktng/magma/runs/8074534983?check_suite_focus=true
  - 2h 3m with 1 failing test
  - Bazel
- https://github.com/vktng/magma/runs/8089413333?check_suite_focus=true
  - Bazel
  - flaky test removed
  - publishing results
- https://github.com/vktng/magma/runs/8074530090?check_suite_focus=true
  - Make

Without sudo tests:
- https://github.com/vktng/magma/runs/8074913942?check_suite_focus=true

New runs after rebase:
- https://github.com/vktng/magma/runs/8110989651?check_suite_focus=true
- https://github.com/vktng/magma/runs/8130071536?check_suite_focus=true
  - with disable checksumming

Run with fix from https://github.com/magma/magma/pull/13803: 
https://github.com/LKreutzer/magma/runs/8152381609?check_suite_focus=true


## Additional Information


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
