### PR TITLE
[v1.8] fix(agw): Fixed SCTP abort issue by setting finite timeout in sctp_sendmsg (#13146)

### DIFF
--- a/lte/gateway/c/sctpd/src/sctp_connection.cpp
+++ b/lte/gateway/c/sctpd/src/sctp_connection.cpp
@@ -85,8 +85,9 @@ void SctpConnection::Send(uint32_t assoc_id, uint32_t stream,
 
   auto buf = msg.c_str();
   auto n = msg.size();
+  // 100 indicates a timetolive of 100 ms
   auto rc = sctp_sendmsg(assoc.sd, buf, n, NULL, 0, htonl(assoc.ppid), 0,
-                         stream, 0, 0);
+                         stream, 100, 0);
 
   if (rc < 0) {
     MLOG_perror("sctp_sendmsg");


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [fix(agw): Fixed SCTP abort issue by setting finite timeout in sctp_sendmsg (#13146)](https://github.com/magma/magma/pull/13146)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)