### PR TITLE
feat(ci): add non activated option to really use host docker socket

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
 		"stackbuild.bazel-stack-vscode-cc",
 		"augustocdias.tasks-shell-input",
 		"ryuta46.multi-command",
-		"coolchyni.beyond-debug",
+		"coolchyni.beyond-debug"
 	],
 	"initializeCommand": "docker pull ghcr.io/magma/magma/devcontainer:latest",
 	"image": "ghcr.io/magma/magma/devcontainer:latest",
@@ -44,7 +44,7 @@
 		},
 		"files.watcherExclude": {
 			"**/.bazel-cache/**": true,
-			"**/.bazel-cache-repo/**": true,
+			"**/.bazel-cache-repo/**": true
 		},
 		"bsv.bazel.buildFlags": [],
 		"bsv.bazel.testFlags": [],
@@ -61,14 +61,14 @@
 		"clangd.arguments": [
 			"-log=verbose",
 			"-pretty",
-			"--background-index",
+			"--background-index"
 		],
 		"clangd.onConfigChanged": "restart",
 		"editor.formatOnSave": true,
 		// Update this field with any new Bazel targets that need compilation database generation
 		"bsv.cc.compdb.targets": [
 			"//orc8r/gateway/c/...",
-			"//lte/gateway/c/...",
+			"//lte/gateway/c/..."
 		],
 		"multiCommand.commands": [
 			{
@@ -109,7 +109,7 @@
 		"--init"
 	],
 	"remoteEnv": {
-		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
 	},
-	"remoteUser": "vscode",
+	"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -97,9 +97,12 @@
 			}
 		}
 	},
+	// Also see https://github.com/magma/magma/blob/77bc3e4a1c8a76e723fff2aa355a04445d04a3c6/.devcontainer/Dockerfile#L25
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
 	],
+	// Uncomment the following line to use the docker socket of the host  machine
+	//"overrideCommand": false,
 	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/post-create-commands.sh ${containerWorkspaceFolder}",
 	// multiple postCreateCommands: currently only possible with '&&'/';' or shell script (https://github.com/microsoft/vscode-remote-release/issues/3527)
 	"runArgs": [


### PR DESCRIPTION
## Summary

- The implementation of using host docker sock was not fully complete with the respect that an option was still missing.
- The option was added with a comment.
- The option was defaulted to `off` as it has security implications, but is _very_ helpful for development. Every developer should take an educated decision.

- The IntelliJ json linter complains about trailing commata. Thus I removed them.

## Test Plan

- Tested by @jheidbrink before.

## Additional Information

- Done in pairing with @jheidbrink.