### PR TITLE
fix: sentry_sdk is pinned to <1.9

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -105,7 +105,7 @@ setup(
         'spyne>=2.13.15',
         'scapy==2.4.4',
         'flask>=1.0.2',
-        'sentry_sdk>=1.5.0',
+        'sentry_sdk>=1.5.0,<1.9',
         'aiodns>=1.1.1',
         'pymemoize>=1.0.2',
         'wsgiserver>=1.3',

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -77,7 +77,7 @@ setup(
         'PyYAML>=3.12',
         'pytz>=2014.4',
         'prometheus_client==0.3.1',
-        'sentry_sdk>=1.5.0',
+        'sentry_sdk>=1.5.0,<1.9',
         'snowflake>=0.0.3',
         'psutil==5.8.0',
         'cryptography>=1.9',


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

see #13645

## Test Plan

* see that `build_all` works correctly (after merge)
* see #13645 on how to check that `checkin_cli.py` works correctly in a docker environment

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
