### PR TITLE
chore(ci): Add option for remote download optimization to bazel remote cache setup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,19 +32,17 @@ common:disk_cache --repository_cache=/var/cache/bazel-cache-repo
 # REMOTE CACHING READ AND WRITE CONFIGS
 # The file bazel/bazelrcs/remote_caching_rw.bazelrc is templated in CI
 # The full config is then written to bazel/bazelrcs/cache.bazelrc
-build:remote_caching_rw --remote_download_minimal
-# --remote_download_toplevel instead of --remote_download_minimal is
-# needed for 'bazel run' due to https://github.com/bazelbuild/bazel/issues/11920
-run:remote_caching_rw --remote_download_toplevel
 
 # REMOTE CACHING READ-ONLY CONFIGS
 # The file bazel/bazelrcs/remote_caching_ro.bazelrc is templated in CI
 # The full config is then written to bazel/bazelrcs/cache.bazelrc
 build:remote_caching_ro --remote_upload_local_results=false 
-build:remote_caching_ro --remote_download_minimal
+
+# REMOTE DOWNLOAD OPTIMIZATION
+build:remote_download_optimization --remote_download_minimal
 # --remote_download_toplevel instead of --remote_download_minimal is
 # needed for 'bazel run' due to https://github.com/bazelbuild/bazel/issues/11920
-run:remote_caching_ro --remote_download_toplevel
+run:remote_download_optimization --remote_download_toplevel
 
 # Import the bazel caching config, with default disk cache,
 # which in CI gets overwritten by the remote caching config. 

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -20,6 +20,7 @@ env:
   DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
   BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   CACHE_KEY: bazel-base-image
+  REMOTE_DOWNLOAD_OPTIMIZATION: true
 
 jobs:
   path_filter:
@@ -287,7 +288,7 @@ jobs:
           options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
             cd $MAGMA_ROOT
-            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178
             # Coverage in bazel is flaky for remote caches - the flags below are helping. See GH13026 for details.
             # TODO: GH11936 Omit OAI coverage until it is tested. We need to determine what the behavior is for doing both CMake and Bazel based coverage at the same time

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -19,6 +19,7 @@ on:
 env:
   BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   CACHE_KEY: bazel-base-image
+  REMOTE_DOWNLOAD_OPTIMIZATION: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -98,7 +99,7 @@ jobs:
             printf '\r%s\r' '###############################' 1>&2
             printf '\r%s\r' 'Configuring bazel remote cache.' 1>&2
             printf '\r%s\r\r' '###############################' 1>&2
-            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
 
             printf '\r%s\r' '###############################' 1>&2
             printf '\r%s\r' 'Executing bazel build ${{ matrix.bazel-config }}' 1>&2
@@ -238,7 +239,7 @@ jobs:
           options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |
             cd /workspaces/magma
-            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             bazel build lte/gateway/release:sctpd_deb_pkg \
               --config=production \
               --profile=Bazel_build_package_profile

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -17,6 +17,7 @@ on:
 env:
   BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   CACHE_KEY: bazel-base-image
+  REMOTE_DOWNLOAD_OPTIMIZATION: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -79,7 +80,7 @@ jobs:
           options: -v ${{ github.workspace }}:/workspaces/magma
           run: |
             cd /workspaces/magma
-            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
             ./.github/workflows/generate-gcc-warnings.sh "${{ steps.changed_files.outputs.all }}"
       - name: Publish bazel profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3

--- a/bazel/scripts/remote_cache_bazelrc_setup.sh
+++ b/bazel/scripts/remote_cache_bazelrc_setup.sh
@@ -28,8 +28,17 @@ then
   exit 1
 fi
 
-# The BAZEL_REMOTE_PASSWORD is an optional second argument.
-BAZEL_REMOTE_PASSWORD=${2:-}
+# The REMOTE_DOWNLOAD_OPTIMIZATION is the mandatory second argument.
+REMOTE_DOWNLOAD_OPTIMIZATION=${2:-}
+
+if [[ -z "$REMOTE_DOWNLOAD_OPTIMIZATION" ]]
+then
+  echo "Required argument REMOTE_DOWNLOAD_OPTIMIZATION ('true'|'false') not set!" >&2
+  exit 1
+fi
+
+# The BAZEL_REMOTE_PASSWORD is an optional third argument.
+BAZEL_REMOTE_PASSWORD=${3:-}
 
 ###############################################################################
 # FUNCTIONS SECTION
@@ -37,12 +46,19 @@ BAZEL_REMOTE_PASSWORD=${2:-}
 
 create_config () {
   local cache_key=$1
-  local bazel_remote_password=$2
+  local remote_download_optimization=$2
+  local bazel_remote_password=$3
   if [[ -n "$bazel_remote_password" ]]
   then
-    create_config_for_rw_remote_cache "$cache_key" "$bazel_remote_password"
+    create_config_for_rw_remote_cache "$cache_key" "$bazel_remote_password" > bazel/bazelrcs/cache.bazelrc
   else
-    create_config_for_ro_remote_cache "$cache_key"
+    create_config_for_ro_remote_cache "$cache_key" > bazel/bazelrcs/cache.bazelrc
+  fi
+
+  if [[ "${remote_download_optimization,,}" == "true" ]]
+  then
+    echo "The REMOTE_DOWNLOAD_OPTIMIZATION option has been set."
+    echo "build --config=remote_download_optimization" >> bazel/bazelrcs/cache.bazelrc
   fi
 }
 
@@ -68,4 +84,4 @@ create_config_for_ro_remote_cache () {
 # SCRIPT SECTION
 ###############################################################################
 
-create_config "$CACHE_KEY" "$BAZEL_REMOTE_PASSWORD" > bazel/bazelrcs/cache.bazelrc
+create_config "$CACHE_KEY" "$REMOTE_DOWNLOAD_OPTIMIZATION" "$BAZEL_REMOTE_PASSWORD"


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Add option for remote download optimization to bazel remote cache setup
  - See the wiki page https://github.com/magma/magma/wiki/Bazel-remote-caching for documentation on how to use the script.
  - Resolves https://github.com/magma/magma/issues/13651 
- Refactor workflows to use the same remote download options as before.

## Test Plan

- CI
- See https://github.com/magma/magma/issues/13651#issuecomment-1219282131

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
