### PR TITLE
feat(agw): Run integ tests vs containerized AGW

### DIFF
--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -40,7 +40,7 @@ containerized AGW by running the following steps inside the VM:
 ```
 cd $MAGMA_ROOT/lte/gateway && make run  # You can skip this if you have built the AGW with make before
 for component in redis nghttpx td-agent-bit; do cp "${MAGMA_ROOT}"/{orc8r,lte}/gateway/configs/templates/${component}.conf.template; done
-sudo systemctl stop 'magma@*'  # We don't want the systemd-based AGW to run when we start the containerized AGW
+sudo systemctl stop 'magma@*' 'sctpd' # We don't want the systemd-based AGW to run when we start the containerized AGW
 cd $MAGMA_ROOT/lte/gateway/docker
 docker-compose build
 docker-compose up
@@ -51,3 +51,18 @@ on a VM. However we are not there yet as the containerized AGW currently depends
 on a patched Open vSwitch installation on the host machine. The magma VM happens
 to have the right packages installed, and thus can currently be used as a quick
 and dirty way to run the containers locally.
+
+### Running the S1AP integration tests against the containerized AGW
+
+At present, of the S1AP integration tests, it has been verified that `test_attach_detach` can be run versus the containerized AGW.
+To run this test, development mode needs to be enabled when starting the containers, which can be done by using an override
+file `docker-compose.dev.yaml`:
+
+```
+cd $MAGMA_ROOT/lte/gateway/docker
+docker-compose down # If containers are already running
+docker-compose -f docker-compose.yaml -f docker-compose.dev.yaml up
+```
+
+The test VM can then be set up and the test executed by following
+[these instructions](https://docs.magmacore.org/docs/next/lte/s1ap_tests#test-vm-setup).

--- a/lte/gateway/docker/docker-compose.dev.yaml
+++ b/lte/gateway/docker/docker-compose.dev.yaml
@@ -1,0 +1,102 @@
+---
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.7"
+
+services:
+  magmad:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  redis:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  directoryd:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  subscriberdb:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  enodebd:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  state:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  policydb:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  health:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  monitord:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  redirectd:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  smsd:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  control_proxy:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  ctraced:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  sctpd:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  oai_mme:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  pipelined:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  sessiond:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  mobilityd:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  td-agent-bit:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  eventd:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  connectiond:
+    environment:
+      - MAGMA_DEV_MODE=1
+
+  liagentd:
+    environment:
+      - MAGMA_DEV_MODE=1


### PR DESCRIPTION
## Summary

Works towards getting all integration tests running versus the containerized AGW, starting with `test_attach_detach`. Modifies system restarts to account for Docker. Also modifies the readme to explain the present situation and how to run the test, as well as adding sctpd to the services that need to be stopped before starting the Docker containers.   

This aims to be a non-breaking PR which can be built upon in the future to get further tests running.

## Test Plan

At present, `test_attach_detach` runs successfully if `MAGMA_DEV_MODE` is set to 1 in the `.env` file.

Notes:
- In the future, we may want to use a Docker override file to set the required environment variable instead of modifying the `.env` file.
- Containers can be started following the instructions here: https://github.com/magma/magma/blob/master/lte/gateway/docker/README.md#running-the-containerized-agw-locally-on-the-magma-vm.

