### PR TITLE
feat(ci): Publishing feg-integ test result in firebase

### DIFF
--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -178,6 +178,17 @@ jobs:
         with:
           name: test-logs
           path: lte/gateway/logs.tar.gz
+      - name: Publish results to Firebase
+        if: always() && github.event.workflow_run.event == 'push'
+        env:
+          FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
+          REPORT_FILENAME: "feg_integ_test_${{ env.SHA }}.html"
+        run: |
+          npm install -g xunit-viewer
+          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
+          [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
+          [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
+          python ci-scripts/firebase_publish_report.py -id ${{ env.SHA }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} lte --url $URL
       - name: Publish Unit Test Results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action/composite@v1

--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -74,6 +74,25 @@ def lte_integ_test(args):
     publish_report('lte_integ_test', args.build_id, verdict, report)
 
 
+def feg_integ_test(args):
+    """Prepare and publish FEG Integ Test report"""
+    report = url_to_html_redirect(args.run_id, args.url)
+    # Possible args.verdict values are success, failure, or canceled
+    verdict = 'inconclusive'
+
+    # As per the recent change, CI process runs all integ tests ignoring the
+    # failing test cases, because of which CI report always shows feg integ
+    # test as success. Here we read the CI status from file for more accurate
+    # feg integ test execution status
+    if os.path.exists("test_status.txt"):
+        with open('test_status.txt', 'r') as file:
+            status_file_content = file.read().rstrip()
+            expected_verdict_list = ["pass", "fail"]
+            if status_file_content in expected_verdict_list:
+                verdict = status_file_content
+    publish_report('feg_integ_test', args.build_id, verdict, report)
+
+
 def cwf_integ_test(args):
     """Prepare and publish CWF Integ Test report"""
     report = url_to_html_redirect(args.run_id, args.url)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!--  -->
1. Added a step in federated-integ-test.yml github workflow to publish the feg-integ test results in firebase
2. Added a function in ci-scripts/firebase_publish_report.py to publish the feg-integ test results to firebase 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

Can not check the changes on local environment, they are dependent/connected with ci-dashboard.

## Additional Information

- This change is backwards-breaking

No

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->