### PR TITLE
refactor: remove xwf entry from dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,8 +61,6 @@
 
 !protos/
 
-!xwf/gateway/
-
 !bazel/
 !*.bzl
 !*.bazel


### PR DESCRIPTION
## Summary

Removes deleted xwf directory from dockerignore file. 

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
