### PR TITLE
fix(ci): fix ipv6 uplink test

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -131,6 +131,7 @@ s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
 s1aptests/test_service_req_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_detach_setsessionrules_tcp_data.py \
 s1aptests/test_enable_ipv6_iface.py \
+s1aptests/test_ipv6_non_nat_dp_ul_tcp.py \
 s1aptests/test_disable_ipv6_iface.py
 
 EXTENDED_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \
@@ -274,7 +275,6 @@ s1aptests/test_restore_config_after_non_sanity.py
 #s1aptests/test_ipv6_non_nat_dp_dl_tcp.py
 #s1aptests/test_ipv6_non_nat_dp_ul_udp.py
 #s1aptests/test_ipv6_non_nat_dp_dl_udp.py
-#s1aptests/test_ipv6_non_nat_dp_ul_tcp.py
 #---------------
 
 # TODO: Add ipv6 tests to integ test suite

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -409,7 +409,7 @@ class TrafficTest(object):
             ifname=TrafficTest._net_iface_ipv6,
         )[0]
         TrafficTest._iproute.addr(
-            'add', index=net_iface_index, address=ip.exploded,
+            'add', index=net_iface_index, address=ip.exploded, prefixlen=128
         )
         os.system(
             'sudo route -A inet6 add 3001::10/64 dev eth3',

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -409,7 +409,7 @@ class TrafficTest(object):
             ifname=TrafficTest._net_iface_ipv6,
         )[0]
         TrafficTest._iproute.addr(
-            'add', index=net_iface_index, address=ip.exploded, prefixlen=128
+            'add', index=net_iface_index, address=ip.exploded, prefixlen=128,
         )
         os.system(
             'sudo route -A inet6 add 3001::10/64 dev eth3',

--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -256,6 +256,14 @@ class UplinkBridgeController(MagmaController):
             actions = "output:LOCAL"
             self._install_flow(flows.MEDIUM_PRIORITY + 1, match, actions)
 
+        # forward the node solicite msg to host and UE
+        addr = SOLICITED_NODE_MULTICAST
+        match = "in_port=%s,ipv6,ipv6_dst=%s" % (
+                self.config.uplink_eth_port_name,
+                addr,
+        )
+        self._install_flow(flows.MEDIUM_PRIORITY + 1, match, "output:LOCAL")
+
     def _delete_all_flows(self):
         if self.config.uplink_bridge is None:
             return

--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -256,11 +256,10 @@ class UplinkBridgeController(MagmaController):
             actions = "output:LOCAL"
             self._install_flow(flows.MEDIUM_PRIORITY + 1, match, actions)
 
-        # forward the node solicite msg to host and UE
-        addr = SOLICITED_NODE_MULTICAST
+        # forward the node solicite msg to local machine
         match = "in_port=%s,ipv6,ipv6_dst=%s" % (
                 self.config.uplink_eth_port_name,
-                addr,
+                SOLICITED_NODE_MULTICAST,
         )
         self._install_flow(flows.MEDIUM_PRIORITY + 1, match, "output:LOCAL")
 

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
@@ -4,6 +4,7 @@
  priority=100,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=101,ip,in_port=3,nw_dst=1.1.11.1 actions=LOCAL
  priority=101,ipv6,in_port=3,ipv6_dst=fe80::48a3:2cff:fe1a:abcd actions=LOCAL
+ priority=101,ipv6,in_port=3,ipv6_dst=ff02::1:ff00:0/104 actions=LOCAL
  priority=100,ip,in_port=3,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=3,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=0,arp,in_port=3 actions=output:1,output:2,LOCAL

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
@@ -5,6 +5,7 @@
  priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=101,ip,in_port=3,nw_dst=1.1.11.1 actions=LOCAL
  priority=101,ipv6,in_port=3,ipv6_dst=fe80::48a3:2cff:fe1a:dd47 actions=LOCAL
+ priority=101,ipv6,in_port=3,ipv6_dst=ff02::1:ff00:0/104 actions=LOCAL
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
@@ -5,6 +5,7 @@
  priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=101,ip,in_port=3,nw_dst=1.6.5.7 actions=LOCAL
  priority=101,ipv6,in_port=3,ipv6_dst=fe80::48a3:2cff:fe1a:cccc actions=LOCAL
+ priority=101,ipv6,in_port=3,ipv6_dst=ff02::1:ff00:0/104 actions=LOCAL
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN_GW.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN_GW.testFlowSnapshotMatch.snapshot
@@ -5,6 +5,7 @@
  priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=101,ip,in_port=3,nw_dst=1.6.5.7 actions=LOCAL
  priority=101,ipv6,in_port=3,ipv6_dst=fe80::48a3:2cff:aaaa:dd47 actions=LOCAL
+ priority=101,ipv6,in_port=3,ipv6_dst=ff02::1:ff00:0/104 actions=LOCAL
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNatUplinkConnect_Static_IP_Test.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNatUplinkConnect_Static_IP_Test.testFlowSnapshotMatch.snapshot
@@ -4,6 +4,7 @@
  priority=100,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:200
  priority=101,ip,in_port=200,nw_dst=10.55.0.41 actions=LOCAL
  priority=101,ipv6,in_port=200,ipv6_dst=fc00::55:0:111 actions=LOCAL
+ priority=101,ipv6,in_port=200,ipv6_dst=ff02::1:ff00:0/104 actions=LOCAL
  priority=100,ip,in_port=200,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=200,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=200,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNatUplinkConnect_Test.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNatUplinkConnect_Test.testFlowSnapshotMatch.snapshot
@@ -4,6 +4,7 @@
  priority=100,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:200
  priority=101,ip,in_port=200,nw_dst=10.55.0.20 actions=LOCAL
  priority=101,ipv6,in_port=200,ipv6_dst=fe80::b0a6:34ff:fee0:b640 actions=LOCAL
+ priority=101,ipv6,in_port=200,ipv6_dst=ff02::1:ff00:0/104 actions=LOCAL
  priority=100,ip,in_port=200,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ipv6,in_port=200,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=200,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70


### PR DESCRIPTION
## Summary

Fixes the ipv6 lte integ test. By adding a flow for ipv6 neighbour soliciation messages/announcement to the dev_vm.

Fixes #13596

## Test Plan

[Run lte integ test ](https://github.com/crasu/magma/actions/runs/2888748740)

## Additional Information
Before the fix the icmp6 neighbour announcement from the test vm was not answered by the dev vm, while the ovs was running on the dev vm.

By adding a flow for multicast the neighbour announcement the announcement is now generated.

There might be some issues related to vagrant interface assignment left. An approach to fix those could be using vbox internal nets. Currently [this](https://github.com/hashicorp/vagrant/issues/12839) is keeping us from using internal nets with the dev vm.

Orginal fixes provided by @pshelar and @pruthvihebbani. Thank you!

## To reproduce locally:

The neighbour can be added/flushed permanently by running these commands:

```
sudo ip -6 neigh del 3001::10 lladdr <dev vm eth3 mac addr> dev eth3; sudo ip -6 neigh add 3001::10 lladdr <dev vm eth3 mac addr> dev eth3
sudo ip -6 neigh  flush all
```