### PR TITLE
fix(pipelined): Updating pipelined production configuration (#13656) [Backport to v1.8]

### DIFF
--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -153,6 +153,10 @@ ovs_gtp_port_number: 32768
 # Internal port for monitoring service
 ovs_mtr_port_number: 15577
 
+# Internal port for processing internal sampling packets
+ovs_internal_sampling_port_number: 15578
+# # Table to forward packets from the internal sampling port
+ovs_internal_sampling_fwd_tbl_number: 201
 # Be careful changing these default values
 # enable_nat: True
 non_nat_gw_probe_frequency: 20
@@ -167,11 +171,21 @@ he_proxy_eth_mac: 'e6:8f:a2:80:80:80'
 
 ovs_gtp_stats_polling_interval: 180
 
+# Make as a True when gnb ip will support for uplink
+ovs_multi_tunnel: False
+# Paging timeout value for idle mode
+paging_timeout: 30
+# ID used for RYU controller identification
+classifier_controller_id: 5
+
 # Internal port for processing internal conntrack
 ovs_internal_conntrack_port_number: 15579
 
 # Table to forward packets from the internal conntrack
 ovs_internal_conntrack_fwd_tbl_number: 202
+
+# UPF node ID
+upf_node_identifier: 192.168.200.1
 
 dp_irq:
  enable: True


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [fix(pipelined): Updating pipelined production configuration (#13656)](https://github.com/magma/magma/pull/13656)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)