### PR TITLE
chore: Remove deleted xwf path from ansible config

### DIFF
--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/.ansible.cfg
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/.ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-roles_path = roles:/root/magma/xwf/gateway/deploy/roles
+roles_path = roles


### PR DESCRIPTION
## Summary

Delete xwf roles_path entry in ansible config file of ocr8r_deployer.

## Test Plan

- [x] Check whether deleted xwf roles are used in `orc8r/cloud/deploy/orc8r_deployer/docker/root`
-> no, they are not
![Screenshot 2022-08-19 at 12 57 17](https://user-images.githubusercontent.com/82914459/185604475-711280cb-e672-4eee-b99c-8563263f9e74.png)

- [x] build and run orc8r_deployer container with `run_deployer.bash`. (Though ansible playbooks are only executed if cli commands like certs, install, update etc. are executed) 

## Additional Information

- [ ] This change is backwards-breaking
