### PR TITLE
fix(dp): CBSD might get accidentally removed when removing grant

### DIFF
--- a/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
@@ -244,6 +244,7 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
             expected_grants_states,
             [g.state.name for g in self.session.query(DBGrant).order_by(DBGrant.id).all()],
         )
+        self.assertEqual(self.session.query(DBCbsd).count(), 1)
 
     @parameterized.expand([
         (0, CbsdStates.REGISTERED),

--- a/dp/cloud/python/magma/db_service/models.py
+++ b/dp/cloud/python/magma/db_service/models.py
@@ -97,10 +97,7 @@ class DBGrantState(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False, unique=True)
 
-    grants = relationship(
-        "DBGrant", back_populates="state", cascade="all, delete",
-        passive_deletes=True,
-    )
+    grants = relationship("DBGrant", back_populates="state")
 
     def __repr__(self):
         """
@@ -141,14 +138,8 @@ class DBGrant(Base):
         server_default=now(), onupdate=now(),
     )
 
-    state = relationship(
-        "DBGrantState", back_populates="grants", cascade="all, delete",
-        passive_deletes=True,
-    )
-    cbsd = relationship(
-        "DBCbsd", back_populates="grants", cascade="all, delete",
-        passive_deletes=True,
-    )
+    state = relationship("DBGrantState", back_populates="grants")
+    cbsd = relationship("DBCbsd", back_populates="grants")
 
     def __repr__(self):
         """
@@ -247,26 +238,11 @@ class DBCbsd(Base):
         server_default=now(), onupdate=now(),
     )
 
-    state = relationship(
-        "DBCbsdState", cascade="all, delete",
-        foreign_keys=[state_id], passive_deletes=True,
-    )
-    desired_state = relationship(
-        "DBCbsdState", cascade="all, delete",
-        foreign_keys=[desired_state_id], passive_deletes=True,
-    )
-    requests = relationship(
-        "DBRequest", back_populates="cbsd", cascade="all, delete",
-        passive_deletes=True,
-    )
-    grants = relationship(
-        "DBGrant", back_populates="cbsd", cascade="all, delete",
-        passive_deletes=True,
-    )
-    channels = relationship(
-        "DBChannel", back_populates="cbsd", cascade="all, delete",
-        passive_deletes=True,
-    )
+    state = relationship("DBCbsdState", foreign_keys=[state_id])
+    desired_state = relationship("DBCbsdState", foreign_keys=[desired_state_id])
+    requests = relationship("DBRequest", back_populates="cbsd")
+    grants = relationship("DBGrant", back_populates="cbsd")
+    channels = relationship("DBChannel", back_populates="cbsd")
 
     def __repr__(self):
         """
@@ -304,10 +280,7 @@ class DBChannel(Base):
         server_default=now(), onupdate=now(),
     )
 
-    cbsd = relationship(
-        "DBCbsd", back_populates="channels", cascade="all, delete",
-        passive_deletes=True,
-    )
+    cbsd = relationship("DBCbsd", back_populates="channels")
 
     def __repr__(self):
         """


### PR DESCRIPTION
Signed-off-by: Jarosław Jaszczuk <jaroslaw@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
Due to how relationships are declared in `dp` models (`cascade` and `passive_delete` arguments) when removing an object it makes ORM remove objects related to it if they were loaded by accessing relationship attributes. For example if we're removing grant by `session.delete(grant)`, but previously accessed this grants `grant.cbsd` attribute it causes CBSD record to also be removed and this does not work as expected - CBSD should not be removed when removing grant, at all. 

## Summary
* remove `cascade` and `passive_delete` arguments from relationships in domain proxy models
<!-- Enumerate changes you made and why you made them -->

## Test Plan
* expand response processor test cases to check if CBSD was not removed during the test

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
Purely ORM mechanism, no migration or other actions required.

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
