### PR TITLE
feat(ci): deactivate useless linter warnings for yaml document start

### DIFF
--- a/.github/workflows/config/yamllint_config.yml
+++ b/.github/workflows/config/yamllint_config.yml
@@ -12,7 +12,7 @@ ignore: |
   **/templates/**/*.yaml
 
 rules:
-  braces: 
+  braces:
     max-spaces-inside: 1
     min-spaces-inside: 1
   brackets:
@@ -25,9 +25,8 @@ rules:
   comments-indentation:
     level: warning
   document-end: disable
-  document-start:
-    level: warning
-  empty-lines: 
+  document-start: disable
+  empty-lines:
     max: 3
   empty-values: disable
   hyphens: enable


### PR DESCRIPTION
The document start is really a big pain and only bloats the files. This the yaml linter for it is deactivated with this commit.

This PR is required for a PR coming to add copyright headers (https://github.com/magma/magma/issues/13280). The PR will be opened if this one is merged, to avoid the heaps of annotations, which would be generated otherwise.