### PR TITLE
test(orc8r): Wait in flaky subscriberdb test

### DIFF
--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -822,6 +822,9 @@ func TestListSubscriberStates(t *testing.T) {
 	directoryState := directorydTypes.DirectoryRecord{LocationHistory: []string{"foo", "bar"}}
 	test_utils.ReportState(t, ctx, orc8r.DirectoryRecordType, "IMSI1234567890", &directoryState, serdes.State)
 
+	// Give subscriber state reindexer time to run
+	time.Sleep(1 * time.Second)
+
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            testURLRoot,


### PR DESCRIPTION
## Summary

Previously the test setup was modified to make it less flaky. Unfortunately, it is still sometimes red so it might be useful to add an explicit waiting step.

See #13565 for more context.

Still happens with a 1 second sleep statement so this is probably not a good solution.
https://github.com/magma/magma/runs/7998325221

## Test Plan

Run repeatedly in the CI.

## Additional Information

- [ ] This change is backwards-breaking
