### PR TITLE
fix(agw): Fixed ci lte integ test execution issue

### DIFF
--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -63,9 +63,9 @@ endif
 endif
 
 .PHONY: fed_integ_test
-export FEDERATED_MODE = True
 fed_integ_test: $(PYTHON_BUILD)/setupinteg_env $(BIN)/pytest
 	. $(PYTHON_BUILD)/bin/activate
+	$(eval export FEDERATED_MODE = True)
 ifdef TESTS
 	$(call execute_test,$(TESTS))
 else

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -82,7 +82,10 @@ class TestWrapper(object):
         self._enBConfig(ip_version)
 
         federated_mode = (os.environ.get("FEDERATED_MODE") == "True")
-        print(f"\n *** Running the test in {'Non-' if not federated_mode else ''}Federated Mode")
+        print(
+            f"\n *** Running the test in {'Non-' if not federated_mode else ''}"
+            "Federated Mode\n",
+        )
 
         if self._test_oai_upstream:
             subscriber_client = SubscriberDbCassandra()


### PR DESCRIPTION
## Title
fix(agw): Fixed ci lte integ test execution issue

## Summary
The lte integ test runs in ci are failing because of federated mode variable exported incorrectly. The variable was exported out of the target making it available for all the scenarios, whereas this needed to be exported only for the fed_integ_test scenario. This PR fixes the issue.

## Test plan
Verified with sanity and in CI
Successful CI execution log:
https://github.com/VinashakAnkitAman/magma/actions/runs/2912539002

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>