### PR TITLE
docs(agw): Fix link to docker installation script in Readme

### DIFF
--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -3,12 +3,12 @@
 This folder contains container image definitions for AGW services.
 
 The containers need to run on a host that has a patched Open vSwitch installation.
-The script [../agw_install_docker.sh](../agw_install_docker.sh) can configure an Ubuntu machine to act as a
+The script [agw_install_docker.sh](../deploy/agw_install_docker.sh) can configure an Ubuntu machine to act as a
 host system for the containerized AGW.
 
 There are Ansible playbooks that create an EC2 instance and prepare it to act as
 a host for the containerized AGW. Currently the preparation is not complete and
-still requires to run `../agw_install_docker.sh` at the end, see [Deploying the
+still requires to run `agw_install_docker.sh` at the end, see [Deploying the
 containerized AGW on AWS](#deploying-the-containerized-agw-on-aws).
 
 ## Building the images


### PR DESCRIPTION
## Summary

The link was wrong.

## Test Plan

Clicking the link in the rendered markdown opens the file in my IDE.

## Additional Information

- [ ] This change is backwards-breaking