### PR TITLE
fix(sessiond): Fix the session modification bug

### DIFF
--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -1175,7 +1175,6 @@ bool SessionStateEnforcer::m5g_modification_session(
   }
   session->process_get_mod_rule_installs(qospolicy, &pending_activation,
                                          &pending_deactivation);
-
   uint32_t cur_version = session->get_current_version();
   session->set_current_version(++cur_version, &session_uc);
   session->set_all_pdrs(PdrState::MODI);

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -1176,8 +1176,6 @@ bool SessionStateEnforcer::m5g_modification_session(
   session->process_get_mod_rule_installs(qospolicy, &pending_activation,
                                          &pending_deactivation);
 
-  MLOG(MDEBUG) << "pending_activation : " << pending_activation[0].rule;
-  MLOG(MDEBUG) << "pending_deactivation : " << pending_deactivation[0].rule;
   uint32_t cur_version = session->get_current_version();
   session->set_current_version(++cur_version, &session_uc);
   session->set_all_pdrs(PdrState::MODI);

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -1175,8 +1175,7 @@ bool SessionStateEnforcer::m5g_modification_session(
   }
   session->process_get_mod_rule_installs(qospolicy, &pending_activation,
                                          &pending_deactivation);
-  
-  
+
   uint32_t cur_version = session->get_current_version();
   session->set_current_version(++cur_version, &session_uc);
   session->set_all_pdrs(PdrState::MODI);

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -1175,6 +1175,8 @@ bool SessionStateEnforcer::m5g_modification_session(
   }
   session->process_get_mod_rule_installs(qospolicy, &pending_activation,
                                          &pending_deactivation);
+  
+  
   uint32_t cur_version = session->get_current_version();
   session->set_current_version(++cur_version, &session_uc);
   session->set_all_pdrs(PdrState::MODI);


### PR DESCRIPTION
Signed-off-by: prabina pattnaik <prabinak@wavelabs.ai>

## Summary
Fixed the sessiond crash issue during session modification add qos policy.
We have put logs for pending_activation and pending_deactivation structure value without checking whether these structures are empty or not 

## Test Plan
Verified with spirent and CLI command.

## Additional Information
[SM_syslog_24_bin.log](https://github.com/magma/magma/files/9417467/SM_syslog_24_bin.log)
