### PR TITLE
[v1.8] chore(dp): freeze skaffold version in dp integration tests (#13702)

### DIFF
--- a/dp/Makefile
+++ b/dp/Makefile
@@ -116,7 +116,7 @@ endif
 _install_skaffold_ci:
 # Check whether skaffold is present on PATH
 ifeq (, $(shell which skaffold))
-	curl -Lo /tmp/skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 && \
+	curl -Lo /tmp/skaffold https://storage.googleapis.com/skaffold/releases/v1.39.2/skaffold-linux-amd64 && \
         sudo install /tmp/skaffold /usr/local/bin/
 endif
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [chore(dp): freeze skaffold version in dp integration tests (#13702)](https://github.com/magma/magma/pull/13702)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)