### PR TITLE
[v1.8] fix: sentry_sdk is pinned to <1.9 (#13652)

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -105,7 +105,7 @@ setup(
         'spyne>=2.13.15',
         'scapy==2.4.4',
         'flask>=1.0.2',
-        'sentry_sdk>=1.5.0',
+        'sentry_sdk>=1.5.0,<1.9',
         'aiodns>=1.1.1',
         'pymemoize>=1.0.2',
         'wsgiserver>=1.3',

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -77,7 +77,7 @@ setup(
         'PyYAML>=3.12',
         'pytz>=2014.4',
         'prometheus_client==0.3.1',
-        'sentry_sdk>=1.5.0',
+        'sentry_sdk>=1.5.0,<1.9',
         'snowflake>=0.0.3',
         'psutil==5.8.0',
         'cryptography>=1.9',


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [fix: sentry_sdk is pinned to <1.9 (#13652)](https://github.com/magma/magma/pull/13652)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)