### PR TITLE
[v1.8] fix(agw): Enhanced debugging in CI for agw (#13423)

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -568,6 +568,7 @@ def get_test_logs(
     local('mkdir /tmp/build_logs/trfserver')
     dev_files = [
         '/var/log/mme.log',
+        '/var/log/MME.magma*log*',
         '/var/log/syslog',
         '/var/log/envoy.log',
         '/var/log/openvswitch/ovs*.log',
@@ -875,7 +876,7 @@ def _run_integ_tests(gateway_ip='192.168.60.142', tests=None, federated_mode=Fal
         ' sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off;'
         ' source ~/build/python/bin/activate;'
         ' export GATEWAY_IP=%s;'
-        ' make -i %s enable-flaky-retry=true %s\''
+        ' make %s enable-flaky-retry=true %s\''
         % (key, host, port, gateway_ip, test_mode, tests),
     )
 

--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -22,17 +22,18 @@ $(PYTHON_BUILD)/setupinteg_env:
 	@echo export PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) >> $(PYTHON_BUILD)/bin/activate
 	touch $(PYTHON_BUILD)/setupinteg_env
 
-# TODO T21489739 - Don't sleep and don't stop after a failure
 RESULTS_DIR := /var/tmp/test_results
 ifdef enable-flaky-retry
 	FLAKY_CMD_ARGS := --force-flaky --no-flaky-report --max-runs=3 --min-passes=1
 else
 	FLAKY_CMD_ARGS :=
 endif
+# Don't remove the ending comment from function execute_test. Somehow without
+# any ending statement the failing testcases are missing status update
 define execute_test
 	echo "Running test: $(1)"
 	timeout --foreground -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(BIN)/pytest $(FLAKY_CMD_ARGS) --capture=tee-sys --junit-xml=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x $(1) || (echo "fail" > $(MAGMA_ROOT)/test_status.txt && exit 1)
-	sleep 1
+	# Testcase $(1) execution completed
 endef
 
 .PHONY: precommit
@@ -51,7 +52,14 @@ ifdef TESTS
 	$(call execute_test,$(TESTS))
 else
 	echo "pass" > $(MAGMA_ROOT)/test_status.txt
+ifndef enable-flaky-retry
+	echo "Flaky test retries are disabled"
 	$(foreach test,$(EXTENDED_TESTS) $(PRECOMMIT_TESTS),$(call execute_test,$(test));)
+else
+	echo "Flaky test retries are enabled"
+	-$(foreach test,$(EXTENDED_TESTS) $(PRECOMMIT_TESTS),$(call execute_test,$(test));)
+	if [ ! -z `grep -s pass $(MAGMA_ROOT)/test_status.txt` ]; then echo "Final integ_test status: Passed"; else echo "Final integ_test status: Failed"; exit 1; fi
+endif
 endif
 
 .PHONY: fed_integ_test
@@ -61,7 +69,14 @@ ifdef TESTS
 	$(call execute_test,$(TESTS))
 else
 	echo "pass" > $(MAGMA_ROOT)/test_status.txt
+ifndef enable-flaky-retry
+	echo "Flaky test retries are disabled"
 	$(foreach test,$(FEDERATED_TESTS),$(call execute_test,$(test));)
+else
+	echo "Flaky test retries are enabled"
+	-$(foreach test,$(FEDERATED_TESTS),$(call execute_test,$(test));)
+	if [ ! -z `grep -s pass $(MAGMA_ROOT)/test_status.txt` ]; then echo "Final fed_integ_test status: Passed"; else echo "Final fed_integ_test status: Failed"; exit 1; fi
+endif
 endif
 
 .PHONY: nonsanity


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [fix(agw): Enhanced debugging in CI for agw (#13423)](https://github.com/magma/magma/pull/13423)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)