### PR TITLE
[v1.8] fix(sessiond) fix the session modification bug (#13716)

### DIFF
--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -1176,8 +1176,6 @@ bool SessionStateEnforcer::m5g_modification_session(
   session->process_get_mod_rule_installs(qospolicy, &pending_activation,
                                          &pending_deactivation);
 
-  MLOG(MDEBUG) << "pending_activation : " << pending_activation[0].rule;
-  MLOG(MDEBUG) << "pending_deactivation : " << pending_deactivation[0].rule;
   uint32_t cur_version = session->get_current_version();
   session->set_current_version(++cur_version, &session_uc);
   session->set_all_pdrs(PdrState::MODI);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [fix(sessiond) fix the session modification bug (#13716)](https://github.com/magma/magma/pull/13716)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)