### PR TITLE
fix(amf): AMF support SuciProfile Encryption in Identity procedure

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
@@ -129,11 +129,13 @@ int M5GSMobileIdentityMsg::DecodeImsiMobileIdentityMsg(
      2  bytes for Routing indicator
      1  byte  for Protection scheme id
      1  byte  for Home network id
-     32 bytes for EPHEMERAL PUBLIC KEY LENGTH
+     32 bytes for EPHEMERAL PUBLIC KEY LENGTH for ProfileA
+     or
+     33 bytes for EPHEMERAL PUBLIC KEY LENGTH for ProfileB
      *  variable bytes for ciphertext
      8  bytes for MAC TAG LENGTH */
 
-  int cipherTextLen = ielen - 48;
+  int cipherTextLen = 0;
   imsi->spare2 = (*(buffer + decoded) >> 7) & 0x1;
   imsi->supi_format = (*(buffer + decoded) >> 4) & 0x7;
   imsi->spare1 = (*(buffer + decoded) >> 3) & 0x1;
@@ -192,12 +194,17 @@ int M5GSMobileIdentityMsg::DecodeImsiMobileIdentityMsg(
              EPHEMERAL_PUBLIC_KEY_LENGTH);
       decoded += EPHEMERAL_PUBLIC_KEY_LENGTH;
       imsi->empheral_public_key[EPHEMERAL_PUBLIC_KEY_LENGTH] = '\0';
+      cipherTextLen = ielen - 48;
+      OAILOG_DEBUG(LOG_NAS5G, "PROFILE-A ciphertext length: %d", cipherTextLen);
+
     } else {
       memcpy(&imsi->empheral_public_key, buffer + decoded,
              EPHEMERAL_PUBLIC_KEY_LENGTH + PROFILE_B_LEN);
       decoded += (EPHEMERAL_PUBLIC_KEY_LENGTH + PROFILE_B_LEN);
       imsi->empheral_public_key[EPHEMERAL_PUBLIC_KEY_LENGTH + PROFILE_B_LEN] =
           '\0';
+      cipherTextLen = ielen - 48 - PROFILE_B_LEN;
+      OAILOG_DEBUG(LOG_NAS5G, "PROFILE-B ciphertext length: %d", cipherTextLen);
     }
 
     imsi->ciphertext = blk2bstr(buffer + decoded, cipherTextLen);


### PR DESCRIPTION
Signed-off-by: Akshayp77 <aksahy.patidar@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Fix #13038 , #13708
Handle SUCI-GUTI Registration
AMF Should support SUCI Profile Encryption in case of Identity Procedure.
Add support for SUCI registration in case of Profile B failing due to public key length.
## Test Plan

- Tested with UT
- Tested with Abot
- Tested with Spirent
[SUCI_logs.zip](https://github.com/magma/magma/files/9699019/SUCI_logs.zip)

<!--
    How did you test your change? How do you know it works?
[SUCI_logs.zip](https://github.com/magma/magma/files/9699015/SUCI_logs.zip)

    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
![UT_snapshot](https://user-images.githubusercontent.com/87304387/193629582-16986643-a49b-4a68-a3a0-89c0ca8ee8be.png)
