### PR TITLE
chore(ci): Reconfigure the LTE integ test bazel workflow trigger to only run on master branch

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -18,7 +18,6 @@ on:
       - build-all
     branches:
       - master
-      - 'v1.*'
     types:
       - completed
 


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Until the bazel switchover the LTE integ tests bazel should only run on the master branch.
  - Running the workflow on the 1.8 branch leads to failures as this branch is using an older VM image. 
  - See issue https://github.com/magma/magma/issues/13709


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
