### PR TITLE
fix(ci): Add missing paths to the path filter in the bazel workflow

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -51,14 +51,19 @@ jobs:
             files_changed:
               - '.github/workflows/bazel.yml'
               - 'orc8r/gateway/**'
+              - 'orc8r/lib/go/**'
               - 'orc8r/protos/**'
+              - 'feg/cloud/go/**'
+              - 'feg/gateway/**'
               - 'lte/gateway/**'
+              - 'lte/cloud/go/**'
               - 'lte/protos/**'
               - 'src/go/**'
               - '**/BUILD'
               - '**/*.BUILD'
               - '**/*.bazel'
               - '**/*.bzl'
+              - '.bazelrc'
 
   bazel_build_and_test:
     needs: path_filter


### PR DESCRIPTION
Co-authored-by: Lars Kreutzer lars.kreutzer@tngtech.com
Co-authored-by: Krisztián Varga krisztian.varga@tngtech.com
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Add missing paths to the path filter in the bazel workflow
- Resolves #13569

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
