### PR TITLE
fix(agw): Removed leaking sysctl from sessiond

### DIFF
--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -248,10 +248,7 @@ services:
       retries: 3
     cap_drop:
       - ALL
-    command: >
-      sh -c "mkdir -p /var/opt/magma/docker/cores &&
-        sysctl -w kernel.core_pattern=/var/opt/magma/docker/cores/core.%e.%t &&
-        /usr/local/bin/sessiond"
+    command: /usr/local/bin/sessiond
 
   mobilityd:
     <<: *pyservice


### PR DESCRIPTION
## Summary

Moved core file creation to different directory as the old  dir could not be written from inside the container. Removed sysctl from inside of the container and moved it to the host. kernel.core_pattern is a systemwide sysctl anyway.

**Update**
```
Turns out are cores are captured by the host system anyway. So the systemctl code can just be deleted.
vagrant@magma-dev:~/magma/lte/gateway/docker$ docker-compose exec sessiond /bin/bash
root@magma-dev:/# ./crash 
Segmentation fault (core dumped)
root@magma-dev:/# exit
exit
vagrant@magma-dev:~/magma/lte/gateway/docker$ ls /var/core
core-1661521523-a.out-533.tgz  core-1661521584-crash-558.tgz
vagrant@magma-dev:~/magma/lte/gateway/docker$ tar tzf /var/core/core-1661521584-crash-558.tgz
./
./core-1661521584-crash-558.gz
./syslog
./mme.log
./version
```

## Test Plan

Setup test vm and tested if core dump gets written
