### PR TITLE
fix: folly can be installed on systems without sudo

### DIFF
--- a/third_party/build/bin/folly_build.sh
+++ b/third_party/build/bin/folly_build.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "${SCRIPT_DIR}"/../lib/util.sh
 
 GIT_VERSION=2018.02.26.00
-ITERATION=6
+ITERATION=7
 PKGNAME=libfolly-dev
 VERSION="${GIT_VERSION}-${ITERATION}"
 
@@ -86,7 +86,7 @@ fi
 mkdir ${WORK_DIR}
 
 # post-install script
-echo sudo /sbin/ldconfig > "${WORK_DIR}"/after_install.sh
+echo /sbin/ldconfig > "${WORK_DIR}"/after_install.sh
 
 cd ${WORK_DIR}
 DESTDIR=${WORK_DIR}/install


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary
The pre-build folly library can not be installed on docker environments without sudo - the post install script executeds `sudo ldconfig`. The sudo is unnecessary as post install scripts are always executed as root.

This change updates the build script that was used to create the attached library. The library needs to be uploaded to focal-ci after this PR is merged.
[folly.zip](https://github.com/magma/magma/files/9426891/folly.zip)

-> uploaded to focal-ci 2022-08-25


## Test Plan

* build library on magma vm (takes some time): `~/magma/third_party/build$ ./build.py folly`
* current library can not be installed in the bazel base container
* new library can be installed in bazel build container and bazel build still works (tested for `bazel test ...`)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
