### PR TITLE
fix: bazel base uses same folly version as magma vm

### DIFF
--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -19,7 +19,6 @@ RUN echo "Install general purpose packages" && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
         apt-utils \
-        # dependencies of FreeDiameter
         bison \
         build-essential \
         ca-certificates \
@@ -29,39 +28,30 @@ RUN echo "Install general purpose packages" && \
         git \
         gnupg2 \
         g++ \
-        # dependency of mobilityd (tests)
-        iproute2 \
-        # dependency of python services (e.g. magmad)
-        iputils-ping \
+        iproute2 `# dependency of mobilityd (tests)` \
+        iputils-ping `# dependency of python services (e.g. magmad)` \
         flex \
         libconfig-dev \
-        # dependency of @sentry_native//:sentry
-        libcurl4-openssl-dev \
-        # dependencies of oai/mme
+        libcurl4-openssl-dev `# dependency of @sentry_native//:sentry` \
         libczmq-dev \
         libgcrypt-dev \
         libgmp3-dev \
         libidn11-dev \
         libsctp1 \
         libsqlite3-dev \
-        # dependency of sctpd
-        libsctp-dev \
+        libsctp-dev `# dependency of sctpd` \
         libssl-dev \
-        # dependency of pip systemd
-        libsystemd-dev \
+        libsystemd-dev `# dependency of pip systemd` \
         lld \
-        # dependency of python services (e.g. magmad)
-        net-tools \
-        # dependency of python services (e.g. pipelined)
-        netbase \
+        net-tools `# dependency of python services (e.g. magmad)` \
+        netbase `# dependency of python services (e.g. pipelined)` \
         python${PYTHON_VERSION} \
         python-is-python3 \
+        python3-distutils `# dependency of bazel pip_parse rule` \
         software-properties-common \
-        # dependency of python services (e.g. magmad)
-        systemd \
+        systemd `# dependency of python services (e.g. magmad)` \
         unzip \
-        # dependency of liagent
-        uuid-dev \
+        uuid-dev `# dependency of liagent` \
         vim \
         wget \
         zip
@@ -82,38 +72,13 @@ RUN apt-get install -y --no-install-recommends \
         libpcap-dev=1.9.1-3 \
         libmnl-dev=1.0.4-2
 
-## Install Fmt (Folly Dep)
-RUN git clone https://github.com/fmtlib/fmt.git && \
-    cd fmt && \
-    mkdir _build && \
-    cd _build && \
-    cmake -DBUILD_SHARED_LIBS=ON -DFMT_TEST=0 .. && \
-    make -j"$(nproc)" && \
-    make install && \
-    cd / && \
-    rm -rf fmt
-
-# Facebook Folly C++ lib
-# Note: "Because folly does not provide any ABI compatibility guarantees from
-#        commit to commit, we generally recommend building folly as a static library."
-# Here we checkout the hash for v2021.02.22.00 (arbitrary recent version)
-RUN git clone --depth 1 --branch v2021.02.15.00 https://github.com/facebook/folly && \
-    cd /folly && \
-    mkdir _build && \
-    cd _build && \
-    cmake -DBUILD_SHARED_LIBS=ON .. && \
-    make -j"$(nproc)" && \
-    make install && \
-    cd / && \
-    rm -rf folly
-
 # setup magma artifactories and install magma dependencies
 RUN wget -qO - https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public | apt-key add - && \
     add-apt-repository 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main' && \
-    add-apt-repository 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-1.7.0 main' && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
         bcc-tools \
+        libfolly-dev \
         liblfds710 \
         oai-asn1c \
         oai-gnutls \


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

**Note: this change was reverted in #13753 - this will be redone and needs a more sophisticated release strategy**

This change makes the bazel base container use the same folly version as the magma vm. If this is not the case then sessiond builds can not run the respective other environment.

Also did small changes I will add as comments in the code here.

This change must not be merged until the updated folly debian file in #13741 is uploaded to focal-ci. [edit] done
* can be checked the (currently red) job "Build Docker image for Bazel Base and DevContainer" on this PR.

## Test Plan

* Build and run bazel base
  * `docker build -f .devcontainer/bazel-base/Dockerfile -t bb:latest .`
  * `docker run -v ${MAGMA_ROOT}:/workspaces/magma/ -v ${MAGMA_ROOT}/lte/gateway/configs:/etc/magma/ -it bb:latest /bin/bash`
  * make sure bazel sessiond build works and runs also in the vm
  * make sure bazel build still works (tested with `bazel test ...`)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
