### PR TITLE
chore: Add improvements to the bazel sudo wrapper script

### DIFF
--- a/bazel/scripts/run_integ_tests.sh
+++ b/bazel/scripts/run_integ_tests.sh
@@ -285,7 +285,7 @@ run_test() {
 create_xml_report() {
     rm -f "${MERGED_REPORT_FOLDER}/"*.xml
     mkdir -p "${MERGED_REPORT_FOLDER}"
-    python3 lte/gateway/python/scripts/runtime_report.py -i ".+\.xml" -w "${INTEGTEST_REPORT_FOLDER}" -o "${MERGED_REPORT_FOLDER}/report_all_tests.xml" 
+    python3 lte/gateway/python/scripts/runtime_report.py -i "[^\/]+\.xml" -w "${INTEGTEST_REPORT_FOLDER}" -o "${MERGED_REPORT_FOLDER}/integtests_report.xml" 
     rm -f "${INTEGTEST_REPORT_FOLDER}/"*.xml
 }
 
@@ -330,7 +330,7 @@ RERUN_PREVIOUSLY_FAILED="false"
 FAILED_LIST=()
 FAILED_LIST_FILE="/tmp/last_failed_integration_tests.txt"
 INTEGTEST_REPORT_FOLDER="/var/tmp/test_results"
-MERGED_REPORT_FOLDER="${INTEGTEST_REPORT_FOLDER}/merged"
+MERGED_REPORT_FOLDER="${INTEGTEST_REPORT_FOLDER}/integtest_merged_report"
 
 BOLD='\033[1m'
 RED='\033[0;31m'

--- a/bazel/scripts/run_sudo_tests.sh
+++ b/bazel/scripts/run_sudo_tests.sh
@@ -20,13 +20,22 @@ set -euo pipefail
 ###############################################################################
 
 help() {
-    echo "Executes all bazel tests that are tagged as sudo_test inside the"
+    echo -e "${BOLD}Executes all bazel tests that are tagged as sudo_test inside the"
     echo "specified directory (recursively), or one single test if a test name"
     echo "is provided."
-    echo "Usage:"
+    echo -e "Usage:${NO_FORMATTING}"
+    echo "   $(basename "$0") --help"
+    echo "      Display this help message."
     echo "   $(basename "$0")  # execute all tests in the magma repository" 
     echo "   $(basename "$0") path_to_tests_directory/"
     echo "   $(basename "$0") path_to_tests_directory:test_name"
+    echo "   --list"
+    echo "      List all sudo test targets."
+    echo "   --retry-on-failure"
+    echo "      Retry twice for every test in case of failure."
+    echo "   --retry-attempts N"
+    echo "      Retry N times for every test in case of failure."
+    echo "      Should be used together with --retry-on-failure."
     exit 1
 }
 
@@ -68,7 +77,7 @@ print_summary() {
     echo "SUMMARY: ${NUM_SUCCESS}/${TOTAL_TESTS} tests were successful."
     for TARGET in "${!TEST_RESULTS[@]}"
     do
-        echo "  ${TARGET}: ${TEST_RESULTS[${TARGET}]}"
+        echo -e "  ${TARGET}: ${TEST_RESULTS[${TARGET}]}"
     done
 }
 
@@ -76,12 +85,54 @@ print_summary() {
 # SCRIPT SECTION
 ###############################################################################
 
-TARGET_PATH="${1:-}"
-
+TARGET_PATH=""
 declare -a TEST_TARGETS
 declare -A TEST_RESULTS
+FLAKY_ARGS=()
 NUM_SUCCESS=0
 NUM_RUN=1
+RETRY_ON_FAILURE="false"
+RETRY_ATTEMPTS=2
+
+BOLD='\033[1m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NO_FORMATTING='\033[0m'
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --list)
+      bazel query "attr(tags, sudo_test, kind(py_test, //...))" 2>/dev/null
+      exit 0
+      ;;
+    --retry-on-failure)
+      RETRY_ON_FAILURE="true"
+      shift
+      ;;
+    --retry-attempts)
+      shift
+      RETRY_ATTEMPTS="$1"
+      shift
+      ;;
+    --help)
+      help
+      exit 0
+      ;;
+    --*|-*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      TARGET_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ "${RETRY_ON_FAILURE}" == "true" ]];
+then
+    FLAKY_ARGS=( --force-flaky --no-flaky-report "--max-runs=$((RETRY_ATTEMPTS + 1))" "--min-passes=1" )
+fi
 
 cd "${MAGMA_ROOT}"
 
@@ -96,9 +147,9 @@ do
     if run_test "${TARGET}";
     then
         NUM_SUCCESS=$((NUM_SUCCESS + 1))
-        TEST_RESULTS["${TARGET}"]="PASSED"
+        TEST_RESULTS["${TARGET}"]="${GREEN}PASSED${NO_FORMATTING}"
     else
-        TEST_RESULTS["${TARGET}"]="FAILED"
+        TEST_RESULTS["${TARGET}"]="${RED}FAILED${NO_FORMATTING}"
     fi
     NUM_RUN=$((NUM_RUN + 1))
 done


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR adds 2 new features to the `bazel/scripts/run_sudo_tests.sh` script:

1. Failed tests can now be rerun a set amount of times with the options: `--retry-on-failure` and `--retry-attempts`
2. Every test run generates a report XML file.

## Test Plan

Use the script according to the help output:
`bazel/scripts/run_sudo_tests.sh --help`
```
Executes all bazel tests that are tagged as sudo_test inside the
specified directory (recursively), or one single test if a test name
is provided.
Usage:
   run_sudo_tests.sh --help
      Display this help message.
   run_sudo_tests.sh  # execute all tests in the magma repository
   run_sudo_tests.sh path_to_tests_directory/
   run_sudo_tests.sh path_to_tests_directory:test_name
   --list
      List all sudo test targets.
   --retry-on-failure
      Retry twice for every test in case of failure.
   --retry-attempts N
      Retry N times for every test in case of failure.
      Should be used together with --retry-on-failure.
```
 For example:
`bazel/scripts/run_sudo_tests.sh //lte/gateway/python/magma/pipelined/tests:test_access_control --retry-on-failure --retry-attempts 1`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
