### PR TITLE
fix(ci): Fix debug logging for bazel dependency

### DIFF
--- a/bazel/python_repositories.bzl
+++ b/bazel/python_repositories.bzl
@@ -40,7 +40,7 @@ def python_repositories(name = ""):
         remote = "https://github.com/magma/deb-python-aioeventlet.git",
         build_file = "//bazel/external:aioeventlet.BUILD",
         commit = "86130360db113430370ed6c64d42aee3b47cd619",
-        shallow_since = "1655813728",
+        shallow_since = "1656345625 +0200",
     )
 
     # TODO: This is not a nice solution, because it is not really hermetic.


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Bazel suggests a certain format for the `shallow_since` property, this is adopted to get rid of the debug logging:
![Screenshot from 2022-08-26 11-02-11](https://user-images.githubusercontent.com/34488763/186869670-df10f596-77fa-4599-adbc-7f96060d6f77.png)



## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
