### PR TITLE
chore: magma deb build is bazelified

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,11 +5,18 @@ startup --host_jvm_args="-Xmx8g"
 build --announce_rc
 build --color=yes
 
-build:production --config=lsan --strip=never --copt=-O3
+build:production --config=lsan --copt=-O3
 
 # C/C++ CONFIGS
 build --cxxopt=-std=c++14
-build --compilation_mode=dbg
+# Create debug information only for magma binaries (not for external dependencies).
+# --compilation_mode=dbg would also create debug information of external dependencies 
+# and increase the size of artifacts drastically.
+# Needs --strip=never so that debug information is not removed by the linker.
+# See https://bazel.build/docs/user-manual#compilation-mode and
+# https://bazel.build/docs/user-manual#strip
+build --strip=never
+build --per_file_copt=^lte/gateway/c/.*$@-g
 
 # DEFAULT TEST CONFIGURATION
 # Please read the GH issue #13073 before adding "test" options.

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -150,12 +150,13 @@ load("//bazel:python_repositories.bzl", "python_repositories")
 
 python_repositories()
 
+# TODO: GH13522 upgrade to >0.7.0 when landed - see issue
 http_archive(
     name = "rules_pkg",
-    sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
+    sha256 = "bdac8d3d178467c89f246e1e894b59c26c784569e91798901fb81291de834708",
+    strip_prefix = "rules_pkg-7f7bcf9c93bed9ee693b5bfedde5d72f9a2d6ea4",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/archive/7f7bcf9c93bed9ee693b5bfedde5d72f9a2d6ea4.zip",
     ],
 )
 

--- a/bazel/deb_build.bzl
+++ b/bazel/deb_build.bzl
@@ -1,0 +1,23 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Constants for building debian packages.
+"""
+
+PY_VERSION = "python3.8"
+
+PY_PKG_LOC = "dist-packages"
+
+PY_DEST = "/usr/local/lib/{version}/{pkg_loc}".format(
+    pkg_loc = PY_PKG_LOC,
+    version = PY_VERSION,
+)

--- a/bazel/runfiles.bzl
+++ b/bazel/runfiles.bzl
@@ -1,0 +1,128 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Inspired by https://github.com/aspect-build/rules_container/blob/main/language/runfiles.bzl by @thesayyn
+# Contributed to https://github.com/aspect-build/rules_container under Apache-2.0
+
+"""
+This file represents a workaround for the current state of https://github.com/bazelbuild/rules_pkg.
+Dependencies are not packaged (even internal dependencies). The rule here expands all
+internal and external dependencies into a PackageFilesInfo so that the files can be used in
+package rules.
+
+The dependencies are not put into service specific paths. This means, that, e.g., pip dependencies and
+proto files that are used by multiple services are only added once in the packaging process.
+
+This rule is currently only applied to python dependencies (go and c/c++ dependencies are linked statically
+into the binaries).
+
+Additionally this rule
+* renames the relative path of files so that they can be found correctly in the target system (usually
+  packaged into the "dist-packages" folder of the used python interpreter)
+* excludes files that are not needed during runtime
+"""
+
+load("@rules_pkg//:providers.bzl", "PackageFilesInfo")
+
+STRIP_PATHS = [
+    "lte/gateway/python/",
+    "orc8r/gateway/python/",
+    "lte/swagger/specs_root/",
+    "orc8r/swagger/specs_root/",
+]
+
+# beware: order matters here, e.g., "lte/protos/oai/" needs to be before "lte/protos/"
+STRIP_PATHS_PROTOS = [
+    "dp/protos/",
+    "feg/protos/",
+    "lte/protos/oai/",
+    "lte/protos/",
+    "orc8r/protos/",
+    "orc8r/swagger/magmad_events_v1",
+]
+
+EXCLUDES = [
+    # external protobuf is only needed during compile time
+    "../com_google_protobuf",
+    # external grpc is only needed during compile time
+    "../com_github_grpc_grpc",
+    # bazel compiled grpc library
+    "_solib_k8/libexternal_Scom_Ugithub_Ugrpc_Ugrpc_Slibgrpc.so",
+]
+
+def _is_excluded(file):
+    for exclude in EXCLUDES:
+        if file.short_path.startswith(exclude):
+            return True
+    return False
+
+def _runfile_path(file):
+    path = file.short_path
+    if path.startswith("../"):
+        return _strip_external(path)
+    return _strip_internal(path, file)
+
+def _strip_external(path):
+    path_clean = path.replace("../", "")
+
+    # removes the first folder
+    path_wo_first_folder = path_clean.partition("/")[2]
+
+    # special case: grpc is packaged in subfolders (stripped here)
+    if path_wo_first_folder.startswith("src/python/grpcio/"):
+        return path_wo_first_folder.replace("src/python/grpcio/", "")
+
+    return path_wo_first_folder
+
+def _strip_internal(path, file):
+    for prefix in STRIP_PATHS:
+        if path.startswith(prefix):
+            # lte/gateway/python/magma/foo/bar.py -> magma/foo/bar.py
+            return path.replace(prefix, "", 1)
+
+    for prefix in STRIP_PATHS_PROTOS:
+        if path.startswith(prefix):
+            # lte/protos/target_name/lte/protos/foo_pb2.py -> lte/protos/foo_pb2.py
+            return path.replace(prefix, "", 1).replace(file.owner.name + "/", "", 1)
+
+    print("Unhandled path: " + path)  # buildifier: disable=print
+
+    return "FIXME"  # needs to be handled
+
+def _runfiles_impl(ctx):
+    py_infos = [target[PyInfo] for target in ctx.attr.targets]
+    def_infos = [target[DefaultInfo] for target in ctx.attr.targets]
+
+    files = depset(transitive = [py_info.transitive_sources for py_info in py_infos] + [def_info.default_runfiles.files for def_info in def_infos])
+    file_map = {}
+    mapped_files = []
+
+    for file in files.to_list():
+        if not _is_excluded(file):
+            file_map[_runfile_path(file)] = file
+            mapped_files = mapped_files + [file]
+
+    files = depset(transitive = [files])
+
+    return [
+        PackageFilesInfo(
+            dest_src_map = file_map,
+            attributes = {"mode": "0755"},
+        ),
+        DefaultInfo(files = depset(mapped_files)),
+    ]
+
+expand_runfiles = rule(
+    implementation = _runfiles_impl,
+    attrs = {
+        "targets": attr.label_list(providers = [PyInfo]),
+    },
+)

--- a/bazel/test/BUILD.bazel
+++ b/bazel/test/BUILD.bazel
@@ -1,0 +1,16 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel/test:runfiles_test.bzl", "runfiles_test_suite")
+
+runfiles_test_suite(
+    name = "runfiles_test_suite_target",
+)

--- a/bazel/test/runfiles_test.bzl
+++ b/bazel/test/runfiles_test.bzl
@@ -1,0 +1,123 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for runfiles.bzl.
+See https://bazel.build/rules/testing for general bazel rule testing documentation.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_pkg//:providers.bzl", "PackageFilesInfo")
+load("//bazel:runfiles.bzl", "expand_runfiles")
+
+# test suite
+
+def runfiles_test_suite(name):
+    _setup_empty_targets_returns_empty_providers_test()
+    _setup_targets_are_correctly_expanded_test()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":empty_targets_returns_empty_providers_test",
+            ":targets_are_correctly_expanded_test",
+        ],
+    )
+
+# setup for rule to be tested
+
+def _setup_empty_targets_returns_empty_providers_test():
+    expand_runfiles(
+        name = "expand_empty_targets",
+        tags = ["manual"],  # should only be build here
+    )
+
+    rule_empty_targets_returns_empty_providers_test(
+        name = "empty_targets_returns_empty_providers_test",
+        target_under_test = ":expand_empty_targets",
+    )
+
+def _setup_targets_are_correctly_expanded_test():
+    # testing an actually magma target instead of an artificial one
+    # mconfigs proto should be sufficiently stable
+    expand_runfiles(
+        name = "expand_targets",
+        tags = ["manual"],  # should only be build here
+        targets = ["//lte/protos:mconfigs_python_proto"],
+    )
+
+    rule_targets_are_correctly_expanded_test(
+        name = "targets_are_correctly_expanded_test",
+        target_under_test = ":expand_targets",
+    )
+
+# asserts
+
+def _empty_targets_returns_empty_providers_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target_under_test = analysistest.target_under_test(env)
+
+    asserts.equals(
+        env,
+        expected = {"mode": "0755"},
+        actual = target_under_test[PackageFilesInfo].attributes,
+    )
+    asserts.equals(
+        env,
+        expected = {},
+        actual = target_under_test[PackageFilesInfo].dest_src_map,
+    )
+    asserts.equals(
+        env,
+        expected = depset([]),
+        actual = target_under_test[DefaultInfo].files,
+    )
+
+    return analysistest.end(env)
+
+expected_mapping = (
+    "{" +
+    '"orc8r/protos/common_pb2.py": <generated file orc8r/protos/common_python_proto_pb/orc8r/protos/common_pb2.py>, ' +
+    '"lte/protos/mconfig/mconfigs_pb2.py": <generated file lte/protos/mconfigs_python_proto_pb/lte/protos/mconfig/mconfigs_pb2.py>' +
+    "}"
+)
+
+expected_depset = (
+    "depset([" +
+    "<generated file orc8r/protos/common_python_proto_pb/orc8r/protos/common_pb2.py>, " +
+    "<generated file lte/protos/mconfigs_python_proto_pb/lte/protos/mconfig/mconfigs_pb2.py>" +
+    "])"
+)
+
+def _targets_are_correctly_expanded_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target_under_test = analysistest.target_under_test(env)
+
+    asserts.equals(
+        env,
+        expected = expected_mapping,
+        actual = str(target_under_test[PackageFilesInfo].dest_src_map),
+    )
+    asserts.equals(
+        env,
+        expected = expected_depset,
+        actual = str(target_under_test[DefaultInfo].files),
+    )
+
+    return analysistest.end(env)
+
+# creating rules for asserts
+
+rule_empty_targets_returns_empty_providers_test = analysistest.make(_empty_targets_returns_empty_providers_test_impl)
+
+rule_targets_are_correctly_expanded_test = analysistest.make(_targets_are_correctly_expanded_test_impl)

--- a/feg/gateway/services/envoy_controller/BUILD.bazel
+++ b/feg/gateway/services/envoy_controller/BUILD.bazel
@@ -29,5 +29,5 @@ go_library(
 go_binary(
     name = "envoy_controller",
     embed = [":envoy_controller_lib"],
-    visibility = ["//visibility:private"],
+    visibility = ["//lte/gateway/release:__pkg__"],
 )

--- a/lte/gateway/c/connection_tracker/src/BUILD.bazel
+++ b/lte/gateway/c/connection_tracker/src/BUILD.bazel
@@ -14,6 +14,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 cc_binary(
     name = "connectiond",
     srcs = ["main.cpp"],
+    visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":event_tracker",
         "//lte/protos:mconfigs_cpp_proto",

--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1185,6 +1185,7 @@ cc_binary(
     srcs = ["oai/oai_mme/oai_mme.c"],
     copts = ["-DEMBEDDED_SGW=1"],
     linkstatic = True,
+    visibility = ["//lte/gateway/release:__pkg__"],
     deps = [":lib_agw_of"],
 )
 

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -16,6 +16,7 @@ package(default_visibility = ["//lte/gateway/c/li_agent/src:__subpackages__"])
 cc_binary(
     name = "liagentd",
     srcs = ["main.cpp"],
+    visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":interface_monitor",
         "//orc8r/gateway/c/common/config:mconfig_loader",

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -427,6 +427,7 @@ cc_binary(
     # From bazel doc: this flag makes it so all user libraries are linked statically (if a static version is available),
     #                 but where system libraries (excluding C/C++ runtime libraries) are linked dynamically
     linkstatic = True,
+    visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":operational_states_handler",
         ":policy_loader",

--- a/lte/gateway/configs/BUILD.bazel
+++ b/lte/gateway/configs/BUILD.bazel
@@ -1,0 +1,72 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "pkg_mklink")
+
+pkg_filegroup(
+    name = "magma_config_files",
+    srcs = [
+        ":lte_configs",
+        ":pipelined_symlink",
+        ":sessiond_symlink",
+    ],
+    visibility = ["//lte/gateway/release:__pkg__"],
+)
+
+pkg_mklink(
+    name = "pipelined_symlink",
+    link_name = "/etc/magma/pipelined.yml",
+    target = "/etc/magma/pipelined.yml_prod",
+)
+
+pkg_mklink(
+    name = "sessiond_symlink",
+    link_name = "/etc/magma/sessiond.yml",
+    target = "/etc/magma/sessiond.yml_prod",
+)
+
+# The files pipelined.yml and sessiond.yml are not packaged for a production .deb.
+# Symbolic links are created to pipelined.yml_prod and sessiond.yml_prod.
+# TODO control_proxy.yml is packaged as default - but is a possible parameter.
+pkg_files(
+    name = "lte_configs",
+    srcs = [
+        ":control_proxy.yml",
+        ":ctraced.yml",
+        ":directoryd.yml",
+        ":dnsd.yml",
+        ":dnsmasq.conf",
+        ":enodebd.yml",
+        ":eventd.yml",
+        ":gateway.mconfig",
+        ":health.yml",
+        ":kernsnoopd.yml",
+        ":liagentd.yml",
+        ":lighttpd.yml",
+        ":logfiles.txt",
+        ":magmad.yml",
+        ":mme.yml",
+        ":mobilityd.yml",
+        ":monitord.yml",
+        ":pipelined.yml_prod",
+        ":policydb.yml",
+        ":redirectd.yml",
+        ":redis.yml",
+        ":sctpd.yml",
+        ":service_registry.yml",
+        ":sessiond.yml_prod",
+        ":smsd.yml",
+        ":spgw.yml",
+        ":state.yml",
+        ":streamer.yml",
+        ":subscriberdb.yml",
+    ],
+)

--- a/lte/gateway/configs/templates/BUILD.bazel
+++ b/lte/gateway/configs/templates/BUILD.bazel
@@ -1,0 +1,26 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+pkg_files(
+    name = "magma_lte_config_template_files",
+    srcs = [
+        ":dnsd.conf.template",
+        ":hss_oai.json",
+        ":lighttpd.conf.template",
+        ":mme.conf.template",
+        ":mme_fd.conf.template",
+        ":spgw.conf.template",
+    ],
+    prefix = "templates",
+    visibility = ["//lte/gateway/release:__pkg__"],
+)

--- a/lte/gateway/deploy/roles/magma/files/BUILD.bazel
+++ b/lte/gateway/deploy/roles/magma/files/BUILD.bazel
@@ -1,0 +1,93 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
+
+pkg_files(
+    name = "magma_modules_load_conf",
+    srcs = [":magma_modules_load"],
+    prefix = "/etc/modules-load.d",
+    renames = {":magma_modules_load": "magma.conf"},
+)
+
+pkg_files(
+    name = "magma_usr_local_bin",
+    srcs = [
+        ":configure_envoy_namespace.sh",
+        ":coredump",
+        ":magma-bridge-reset.sh",
+        ":magma-create-gtp-port.sh",
+        ":magma-setup-wg.sh",
+        ":ovs-kmod-upgrade.sh",
+        ":set_irq_affinity",
+    ],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "/usr/local/bin",
+)
+
+pkg_files(
+    name = "magma_envoy_yaml",
+    srcs = [":envoy.yaml"],
+    prefix = "/var/opt/magma",
+)
+
+pkg_files(
+    name = "magma_logrotate",
+    srcs = [
+        ":logrotate_oai.conf",
+        ":logrotate_rsyslog.conf",
+    ],
+    prefix = "/etc/logrotate.d",
+    renames = {
+        ":logrotate_oai.conf": "oai",
+        ":logrotate_rsyslog.conf": "rsyslog.magma",
+    },
+)
+
+pkg_files(
+    name = "magma_local_cdn",
+    srcs = [":local-cdn/index.html"],
+    prefix = "/var/www/local-cdn",
+)
+
+pkg_files(
+    name = "magma_99_magma_conf",
+    srcs = [":99-magma.conf"],
+    prefix = "/etc/sysctl.d",
+)
+
+pkg_files(
+    name = "magma_magma_ifaces_gtp",
+    srcs = [":magma_ifaces_gtp"],
+    prefix = "/etc/network/interfaces.d",
+    renames = {":magma_ifaces_gtp": "gtp"},
+)
+
+pkg_files(
+    name = "magma_20auto_upgrades",
+    srcs = [":20auto-upgrades"],
+    prefix = "/etc/apt/apt.conf.d",
+)
+
+pkg_filegroup(
+    name = "ansible_configs",
+    srcs = [
+        ":magma_20auto_upgrades",
+        ":magma_99_magma_conf",
+        ":magma_envoy_yaml",
+        ":magma_local_cdn",
+        ":magma_logrotate",
+        ":magma_magma_ifaces_gtp",
+        ":magma_modules_load_conf",
+        ":magma_usr_local_bin",
+    ],
+    visibility = ["//lte/gateway/release:__pkg__"],
+)

--- a/lte/gateway/deploy/roles/magma/files/systemd/BUILD.bazel
+++ b/lte/gateway/deploy/roles/magma/files/systemd/BUILD.bazel
@@ -9,4 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exports_files(["sctpd.service"])
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+pkg_files(
+    name = "sctpd_service_definition",
+    srcs = ["sctpd.service"],
+    prefix = "/etc/systemd/system/",
+    visibility = ["//lte/gateway/release:__pkg__"],
+)

--- a/lte/gateway/deploy/roles/magma/files/systemd/BUILD.bazel
+++ b/lte/gateway/deploy/roles/magma/files/systemd/BUILD.bazel
@@ -17,3 +17,36 @@ pkg_files(
     prefix = "/etc/systemd/system/",
     visibility = ["//lte/gateway/release:__pkg__"],
 )
+
+pkg_files(
+    name = "magma_lte_service_definitions",
+    srcs = [
+        ":magma_connectiond.service",
+        ":magma_dnsd.service",
+        ":magma_dp_envoy.service",
+        ":magma_envoy_controller.service",
+        ":magma_lighttpd.service",
+        ":magma_magmad.service",
+        ":magma_mme.service",
+        ":magma_mobilityd.service",
+        ":magma_pipelined.service",
+        ":magma_redirectd.service",
+        ":magma_redis.service",
+        ":magma_sessiond.service",
+    ],
+    renames = {
+        ":magma_connectiond.service": "magma@connectiond.service",
+        ":magma_dnsd.service": "magma@dnsd.service",
+        ":magma_dp_envoy.service": "magma_dp@envoy.service",
+        ":magma_envoy_controller.service": "magma@envoy_controller.service",
+        ":magma_lighttpd.service": "magma@lighttpd.service",
+        ":magma_magmad.service": "magma@magmad.service",
+        ":magma_mme.service": "magma@mme.service",
+        ":magma_mobilityd.service": "magma@mobilityd.service",
+        ":magma_pipelined.service": "magma@pipelined.service",
+        ":magma_redirectd.service": "magma@redirectd.service",
+        ":magma_redis.service": "magma@redis.service",
+        ":magma_sessiond.service": "magma@sessiond.service",
+    },
+    visibility = ["//lte/gateway/release:__pkg__"],
+)

--- a/lte/gateway/python/load_tests/BUILD.bazel
+++ b/lte/gateway/python/load_tests/BUILD.bazel
@@ -10,7 +10,42 @@
 # limitations under the License.
 
 load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_mklink")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:deb_build.bzl", "PY_DEST")
+load("//bazel:runfiles.bzl", "expand_runfiles")
+
+SCRIPTS = [
+    "loadtest_mobilityd",
+    "loadtest_pipelined",
+    "loadtest_sessiond",
+    "loadtest_subscriberdb",
+]
+
+expand_runfiles(
+    name = "scripts_expanded",
+    targets = [":{script}".format(script = script) for script in SCRIPTS],
+)
+
+[
+    pkg_mklink(
+        name = "{script}_symlink".format(script = script),
+        link_name = "/usr/local/bin/{script}.py".format(script = script),
+        target = "{dest}/load_tests/{script}.py".format(
+            dest = PY_DEST,
+            script = script,
+        ),
+    )
+    for script in SCRIPTS
+]
+
+pkg_filegroup(
+    name = "magma_lte_loadtest_scripts",
+    srcs = [":scripts_expanded"] +
+           ["{script}_symlink".format(script = script) for script in SCRIPTS],
+    prefix = PY_DEST,
+    visibility = ["//lte/gateway/release:__pkg__"],
+)
 
 MAGMA_ROOT = "../../../../"
 

--- a/lte/gateway/python/magma/health/BUILD.bazel
+++ b/lte/gateway/python/magma/health/BUILD.bazel
@@ -29,7 +29,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
-    visibility = ["//visibility:private"],
+    visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":health_lib",
         "//orc8r/gateway/python/magma/common:sentry",

--- a/lte/gateway/python/magma/kernsnoopd/BUILD.bazel
+++ b/lte/gateway/python/magma/kernsnoopd/BUILD.bazel
@@ -21,10 +21,6 @@ LTE_ROOT = "{}lte/gateway/python".format(MAGMA_ROOT)
 py_binary(
     name = "kernsnoopd",
     srcs = ["main.py"],
-    data = [
-        "ebpf/byte_count.bpf.c",
-        "ebpf/common.bpf.h",
-    ],
     imports = [
         LTE_ROOT,
         ORC8R_ROOT,

--- a/lte/gateway/python/magma/kernsnoopd/BUILD.bazel
+++ b/lte/gateway/python/magma/kernsnoopd/BUILD.bazel
@@ -29,7 +29,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
-    visibility = ["//visibility:private"],
+    visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":kernsnoopd_lib",
         "//orc8r/gateway/python/magma/common:sentry",

--- a/lte/gateway/python/magma/kernsnoopd/ebpf/BUILD.bazel
+++ b/lte/gateway/python/magma/kernsnoopd/ebpf/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+filegroup(
+    name = "ebpf_data_files",
+    srcs = [
+        "byte_count.bpf.c",
+        "common.bpf.h",
+    ],
+)
+
+pkg_files(
+    name = "magma_ebpf_kernsnoopd",
+    srcs = [":ebpf_data_files"],
+    prefix = "kernsnoopd",
+    visibility = ["//lte/gateway/release:__pkg__"],
+)

--- a/lte/gateway/python/magma/mobilityd/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/BUILD.bazel
@@ -29,7 +29,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
-    visibility = ["//visibility:private"],
+    visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":mobilityd_lib",
         "//lte/protos:mconfigs_python_proto",

--- a/lte/gateway/python/magma/monitord/BUILD.bazel
+++ b/lte/gateway/python/magma/monitord/BUILD.bazel
@@ -28,7 +28,7 @@ py_binary(
     # legacy_create_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
     legacy_create_init = False,
     main = "main.py",
-    visibility = ["//visibility:private"],
+    visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":monitord_lib",
         "//lte/protos:mconfigs_python_proto",

--- a/lte/gateway/python/magma/pipelined/ebpf/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/ebpf/BUILD.bazel
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_python//python:defs.bzl", "py_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -25,4 +26,14 @@ py_library(
         requirement("pyroute2"),
         requirement("scapy"),
     ],
+)
+
+pkg_files(
+    name = "magma_ebpf_pipelined",
+    srcs = [
+        ":ebpf_dl_handler.c",
+        ":ebpf_manager.py",
+        ":ebpf_ul_handler.c",
+    ],
+    visibility = ["//lte/gateway/release:__pkg__"],
 )

--- a/lte/gateway/python/magma/policydb/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/BUILD.bazel
@@ -28,7 +28,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
-    visibility = ["//visibility:private"],
+    visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":policydb_lib",
         "//lte/gateway/python/magma/policydb/servicers:policy_servicer",

--- a/lte/gateway/python/magma/redirectd/BUILD.bazel
+++ b/lte/gateway/python/magma/redirectd/BUILD.bazel
@@ -29,7 +29,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
-    visibility = ["//visibility:private"],
+    visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":redirect_server",
         "//lte/protos:mconfigs_python_proto",

--- a/lte/gateway/python/magma/smsd/BUILD.bazel
+++ b/lte/gateway/python/magma/smsd/BUILD.bazel
@@ -28,7 +28,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
-    visibility = ["//visibility:private"],
+    visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":smsd_lib",
         "//lte/protos:sms_orc8r_python_grpc",

--- a/lte/gateway/python/scripts/BUILD.bazel
+++ b/lte/gateway/python/scripts/BUILD.bazel
@@ -10,7 +10,68 @@
 # limitations under the License.
 
 load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_mklink")
 load("@rules_python//python:defs.bzl", "py_binary")
+load("//bazel:deb_build.bzl", "PY_DEST")
+load("//bazel:runfiles.bzl", "expand_runfiles")
+
+SCRIPTS = [
+    "agw_health_cli",
+    "config_stateless_agw",
+    "cpe_monitoring_cli",
+    "create_oai_certs",
+    "dp_probe_cli",
+    "enodebd_cli",
+    "fake_user",
+    "feg_hello_cli",
+    "generate_dnsd_config",
+    "generate_oai_config",
+    "ha_cli",
+    "hello_cli",
+    "icmpv6",
+    "mobility_cli",
+    "mobility_dhcp_cli",
+    "ocs_cli",
+    "packet_ryu_cli",
+    "packet_tracer_cli",
+    "pcrf_cli",
+    "pipelined_cli",
+    "policydb_cli",
+    "s6a_proxy_cli",
+    "s6a_service_cli",
+    "session_manager_cli",
+    "sgs_cli",
+    "sms_cli",
+    "spgw_service_cli",
+    "state_cli",
+    "subscriber_cli",
+    "user_trace_cli",
+]
+
+expand_runfiles(
+    name = "scripts_expanded",
+    targets = [":{script}".format(script = script) for script in SCRIPTS],
+)
+
+[
+    pkg_mklink(
+        name = "{script}_symlink".format(script = script),
+        link_name = "/usr/local/bin/{script}.py".format(script = script),
+        target = "{dest}/scripts/{script}.py".format(
+            dest = PY_DEST,
+            script = script,
+        ),
+    )
+    for script in SCRIPTS
+]
+
+pkg_filegroup(
+    name = "magma_lte_scripts",
+    srcs = [":scripts_expanded"] +
+           ["{script}_symlink".format(script = script) for script in SCRIPTS],
+    prefix = PY_DEST,
+    visibility = ["//lte/gateway/release:__pkg__"],
+)
 
 MAGMA_ROOT = "../../../../"
 

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -18,6 +18,7 @@ bazel build lte/gateway/release:sctpd_deb_pkg --config=production
 load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//bazel:deb_build.bzl", "PY_DEST")
 
 SCTPD_PKGNAME = "magma-sctpd"
 
@@ -131,6 +132,15 @@ pkg_files(
 )
 
 pkg_filegroup(
+    name = "magma_python_services",
+    srcs = [
+        "//lte/gateway/python:magma_python_lte_services",
+        "//orc8r/gateway/python:magma_python_orc8r_services",
+    ],
+    prefix = PY_DEST,
+)
+
+pkg_filegroup(
     name = "magma_configs",
     srcs = [
         "//lte/gateway/configs:magma_config_files",
@@ -155,6 +165,7 @@ pkg_tar(
         ":magma_ebpf",
         ":magma_go_binaries",
         ":magma_python_scripts",
+        ":magma_python_services",
         ":magma_service_definitions",
         "//lte/gateway/deploy/roles/magma/files:ansible_configs",
         "//orc8r/tools/ansible/roles/fluent_bit/files:magma_config_fluent_bit",

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -111,6 +111,13 @@ pkg_filegroup(
 )
 
 pkg_files(
+    name = "magma_go_binaries",
+    srcs = ["//feg/gateway/services/envoy_controller"],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "/usr/local/bin",
+)
+
+pkg_files(
     name = "magma_c_binaries",
     srcs = [
         "//lte/gateway/c/connection_tracker/src:connectiond",
@@ -146,6 +153,7 @@ pkg_tar(
         ":magma_config_stretch_snapshot",
         ":magma_configs",
         ":magma_ebpf",
+        ":magma_go_binaries",
         ":magma_python_scripts",
         ":magma_service_definitions",
         "//lte/gateway/deploy/roles/magma/files:ansible_configs",

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -16,7 +16,7 @@ bazel build lte/gateway/release:sctpd_deb_pkg --config=production
 """
 
 load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 SCTPD_PKGNAME = "magma-sctpd"
@@ -92,9 +92,19 @@ pkg_filegroup(
     prefix = "/etc/systemd/system",
 )
 
+pkg_filegroup(
+    name = "magma_ebpf",
+    srcs = [
+        "//lte/gateway/python/magma/kernsnoopd/ebpf:magma_ebpf_kernsnoopd",
+        "//lte/gateway/python/magma/pipelined/ebpf:magma_ebpf_pipelined",
+    ],
+    prefix = "/var/opt/magma/ebpf",
+)
+
 pkg_tar(
     name = "magma_content",
     srcs = [
+        ":magma_ebpf",
         ":magma_service_definitions",
     ],
     package_file_name = "{fname}.tar".format(fname = MAGMA_FILE_NAME),

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -114,10 +114,28 @@ pkg_files(
     renames = {"//lte/gateway/c/core:agw_of": "mme"},
 )
 
+pkg_filegroup(
+    name = "magma_configs",
+    srcs = [
+        "//lte/gateway/configs:magma_config_files",
+        "//lte/gateway/configs/templates:magma_lte_config_template_files",
+        "//orc8r/gateway/configs/templates:magma_orc8r_config_template_files",
+    ],
+    prefix = "/etc/magma",
+)
+
+pkg_files(
+    name = "magma_config_stretch_snapshot",
+    srcs = [":stretch_snapshot"],
+    prefix = "/usr/local/share/magma",
+)
+
 pkg_tar(
     name = "magma_content",
     srcs = [
         ":magma_c_binaries",
+        ":magma_config_stretch_snapshot",
+        ":magma_configs",
         ":magma_ebpf",
         ":magma_service_definitions",
     ],

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -25,7 +25,7 @@ VERSION = "1.8.0"
 
 ARCH = "amd64"
 
-FILE_NAME = "{name}_{ver}_{arch}".format(
+SCTPD_FILE_NAME = "{name}_{ver}_{arch}".format(
     name = SCTPD_PKGNAME,
     arch = ARCH,
     ver = VERSION,
@@ -44,12 +44,6 @@ pkg_files(
 )
 
 pkg_files(
-    name = "sctpd_service_definition",
-    srcs = ["//lte/gateway/deploy/roles/magma/files/systemd:sctpd.service"],
-    prefix = "/etc/systemd/system/",
-)
-
-pkg_files(
     name = "sctpd_binary",
     srcs = ["//lte/gateway/c/sctpd/src:sctpd"],
     attributes = pkg_attributes(mode = "0755"),
@@ -60,11 +54,10 @@ pkg_tar(
     name = "sctpd_content",
     srcs = [
         ":sctpd_binary",
-        ":sctpd_service_definition",
         ":sctpd_version",
+        "//lte/gateway/deploy/roles/magma/files/systemd:sctpd_service_definition",
     ],
-    package_dir = "./",
-    package_file_name = "{fname}.tar".format(fname = FILE_NAME),
+    package_file_name = "{fname}.tar".format(fname = SCTPD_FILE_NAME),
 )
 
 pkg_deb(
@@ -73,6 +66,6 @@ pkg_deb(
     description = "Magma SCTPD",
     maintainer = "Copyright (c) 2022 The Magma Authors",
     package = SCTPD_PKGNAME,
-    package_file_name = "{fname}.deb".format(fname = FILE_NAME),
+    package_file_name = "{fname}.deb".format(fname = SCTPD_FILE_NAME),
     version = VERSION,
 )

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -101,9 +101,23 @@ pkg_filegroup(
     prefix = "/var/opt/magma/ebpf",
 )
 
+pkg_files(
+    name = "magma_c_binaries",
+    srcs = [
+        "//lte/gateway/c/connection_tracker/src:connectiond",
+        "//lte/gateway/c/core:agw_of",
+        "//lte/gateway/c/li_agent/src:liagentd",
+        "//lte/gateway/c/session_manager:sessiond",
+    ],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "/usr/local/bin",
+    renames = {"//lte/gateway/c/core:agw_of": "mme"},
+)
+
 pkg_tar(
     name = "magma_content",
     srcs = [
+        ":magma_c_binaries",
         ":magma_ebpf",
         ":magma_service_definitions",
     ],

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -101,6 +101,15 @@ pkg_filegroup(
     prefix = "/var/opt/magma/ebpf",
 )
 
+pkg_filegroup(
+    name = "magma_python_scripts",
+    srcs = [
+        "//lte/gateway/python/load_tests:magma_lte_loadtest_scripts",
+        "//lte/gateway/python/scripts:magma_lte_scripts",
+        "//orc8r/gateway/python/scripts:magma_orc8r_scripts",
+    ],
+)
+
 pkg_files(
     name = "magma_c_binaries",
     srcs = [
@@ -137,6 +146,7 @@ pkg_tar(
         ":magma_config_stretch_snapshot",
         ":magma_configs",
         ":magma_ebpf",
+        ":magma_python_scripts",
         ":magma_service_definitions",
         "//lte/gateway/deploy/roles/magma/files:ansible_configs",
         "//orc8r/tools/ansible/roles/fluent_bit/files:magma_config_fluent_bit",

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -19,6 +19,7 @@ load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bazel:deb_build.bzl", "PY_DEST")
+load(":deb_dependencies.bzl", "MAGMA_DEPS", "OAI_DEPS", "OVS_DEPS")
 
 SCTPD_PKGNAME = "magma-sctpd"
 
@@ -176,7 +177,7 @@ pkg_tar(
 pkg_deb(
     name = "magma_deb_pkg",
     data = ":magma_content",
-    depends = [],
+    depends = MAGMA_DEPS + OAI_DEPS + OVS_DEPS,
     description = "Magma Access Gateway",
     maintainer = "Copyright (c) 2022 The Magma Authors",
     package = MAGMA_PKGNAME,

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -31,6 +31,16 @@ SCTPD_FILE_NAME = "{name}_{ver}_{arch}".format(
     ver = VERSION,
 )
 
+MAGMA_PKGNAME = "magma"
+
+MAGMA_FILE_NAME = "{name}_{ver}_{arch}".format(
+    name = MAGMA_PKGNAME,
+    arch = ARCH,
+    ver = VERSION,
+)
+
+### SCTPD BUILD
+
 genrule(
     name = "gen_sctpd_version",
     outs = ["version"],
@@ -67,5 +77,28 @@ pkg_deb(
     maintainer = "Copyright (c) 2022 The Magma Authors",
     package = SCTPD_PKGNAME,
     package_file_name = "{fname}.deb".format(fname = SCTPD_FILE_NAME),
+    version = VERSION,
+)
+
+### MAGMA BUILD
+
+pkg_tar(
+    name = "magma_content",
+    srcs = [
+
+    ],
+    package_file_name = "{fname}.tar".format(fname = MAGMA_FILE_NAME),
+)
+
+pkg_deb(
+    name = "magma_deb_pkg",
+    data = ":magma_content",
+    depends = [],
+    description = "Magma Access Gateway",
+    maintainer = "Copyright (c) 2022 The Magma Authors",
+    package = MAGMA_PKGNAME,
+    package_file_name = "{fname}.deb".format(fname = MAGMA_FILE_NAME),
+    provides = [MAGMA_PKGNAME],
+    replaces = [MAGMA_PKGNAME],
     version = VERSION,
 )

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -82,10 +82,20 @@ pkg_deb(
 
 ### MAGMA BUILD
 
+pkg_filegroup(
+    name = "magma_service_definitions",
+    srcs = [
+        "//lte/gateway/deploy/roles/magma/files/systemd:magma_lte_service_definitions",
+        "//orc8r/tools/ansible/roles/fluent_bit/files:magma_fluent_bit_service_definition",
+        "//orc8r/tools/ansible/roles/gateway_services/files:magma_orc8r_service_definitions",
+    ],
+    prefix = "/etc/systemd/system",
+)
+
 pkg_tar(
     name = "magma_content",
     srcs = [
-
+        ":magma_service_definitions",
     ],
     package_file_name = "{fname}.tar".format(fname = MAGMA_FILE_NAME),
 )

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -182,6 +182,7 @@ pkg_deb(
     maintainer = "Copyright (c) 2022 The Magma Authors",
     package = MAGMA_PKGNAME,
     package_file_name = "{fname}.deb".format(fname = MAGMA_FILE_NAME),
+    postinst = ":magma-postinst-bazel",
     provides = [MAGMA_PKGNAME],
     replaces = [MAGMA_PKGNAME],
     version = VERSION,

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -138,6 +138,8 @@ pkg_tar(
         ":magma_configs",
         ":magma_ebpf",
         ":magma_service_definitions",
+        "//lte/gateway/deploy/roles/magma/files:ansible_configs",
+        "//orc8r/tools/ansible/roles/fluent_bit/files:magma_config_fluent_bit",
     ],
     package_file_name = "{fname}.tar".format(fname = MAGMA_FILE_NAME),
 )

--- a/lte/gateway/release/deb_dependencies.bzl
+++ b/lte/gateway/release/deb_dependencies.bzl
@@ -1,0 +1,77 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+External dependencies of the magma debian build.
+"""
+
+SCTPD_MIN_VERSION = "1.8.0"  # earliest version of sctpd with which this magma version is compatible
+
+# Magma system dependencies: anything that we depend on at the top level, add
+# here.
+MAGMA_DEPS = [
+    "grpc-dev (>= 1.15.0)",
+    "lighttpd (>= 1.4.45)",
+    "libxslt1.1",
+    "nghttp2-proxy (>= 1.18.1)",
+    "redis-server (>= 3.2.0)",
+    "sudo",
+    "dnsmasq (>= 2.7)",
+    "net-tools",  # for ifconfig
+    "python3-pip",
+    "python3-apt",  # The version in pypi is abandoned and broken on stretch
+    "libsystemd-dev",
+    "libyaml-cpp-dev",  # install yaml parser
+    "libgoogle-glog-dev",
+    "python-redis",
+    "magma-cpp-redis",
+    "libfolly-dev",  # required for C++ services
+    "libdouble-conversion-dev",  # required for folly
+    "libboost-chrono-dev",  # required for folly
+    "ntpdate",  # required for eventd time synchronization
+    "tshark",  # required for call tracing
+    "libtins-dev",  # required for Connection tracker
+    "libmnl-dev",  # required for Connection tracker
+    "getenvoy-envoy",  # for envoy dep
+    "uuid-dev",  # for liagentd
+    "libprotobuf17 (>= 3.0.0)",
+    "nlohmann-json3-dev",
+    "sentry-native",  # sessiond
+    "td-agent-bit (>= 1.7.8)",
+    # eBPF compile and load tools for kernsnoopd and AGW datapath
+    # Ubuntu bcc lib (bpfcc-tools) is pretty old, use magma repo package
+    "bcc-tools",
+    "wireguard",
+]
+
+# OAI runtime dependencies
+OAI_DEPS = [
+    "libconfig9",
+    "oai-asn1c",
+    "oai-gnutls (>= 3.1.23)",
+    "oai-nettle (>= 1.0.1)",
+    "prometheus-cpp-dev (>= 1.0.2)",
+    "liblfds710",
+    "libsctp-dev",
+    "magma-sctpd (>= {min_version})".format(min_version = SCTPD_MIN_VERSION),
+    "libczmq-dev (>= 4.0.2-7)",
+    "libasan5",
+    "oai-freediameter (>= 0.0.2)",
+]
+
+# OVS runtime dependencies
+OVS_DEPS = [
+    "magma-libfluid (>= 0.1.0.7)",
+    "libopenvswitch (>= 2.15.4-8)",
+    "openvswitch-switch (>= 2.15.4-8)",
+    "openvswitch-common (>= 2.15.4-8)",
+    "openvswitch-datapath-dkms (>= 2.15.4-8)",
+]

--- a/lte/gateway/release/magma-postinst-bazel
+++ b/lte/gateway/release/magma-postinst-bazel
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Delete OVS bridge on boot
+sed -i "s/.*OVS_CTL_OPTS.*/OVS_CTL_OPTS='--delete-bridges'/" /etc/default/openvswitch-switch
+
+# Create /var/core directory
+mkdir -p /var/core
+
+value=`cat /usr/local/share/magma/commit_hash`
+if grep -q "COMMIT_HASH" /etc/environment
+then
+    sudo sed -i -e "s/^COMMIT_HASH.*/$value/" /etc/environment
+else
+    echo "$value" | sudo tee -a /etc/environment
+fi
+
+# Set magmad service to start on boot
+systemctl enable -f magma@magmad.service
+
+# Installation of the redis-server Debian package has a post-install
+# script that starts a redis-server process. We kill and disable this
+# process, allowing us to manage the process using magmad and our own
+# systemd files.
+systemctl stop redis-server
+systemctl disable redis-server
+
+# Dnsmasq also starts up post-install.
+systemctl stop dnsmasq
+systemctl disable dnsmasq
+
+# Lighttpd also starts up post-install.
+systemctl stop lighttpd
+systemctl disable lighttpd
+
+# Restart rsyslog to pick up fluent-bit config, create fluent-bit DB directory
+cp /etc/logrotate.d/rsyslog /etc/logrotate.d/rsyslog.orig
+cp /etc/logrotate.d/rsyslog.magma /etc/logrotate.d/rsyslog
+systemctl restart rsyslog
+mkdir -p /var/opt/magma/fluent-bit
+
+# Restart all services on package install
+if [ -f /var/run/sctpd.version ]; then
+    /usr/bin/env python3 -c 'from distutils.version import LooseVersion; import sys; ver = lambda n: LooseVersion(open(n).read()); sys.exit(1) if ver("/var/run/sctpd.version") < ver("/usr/local/share/magma/sctpd_min_version") else sys.exit(0)' || systemctl restart sctpd
+else
+    killall -9 sctpd || true
+fi
+systemctl restart magma@* || true

--- a/orc8r/gateway/configs/templates/BUILD.bazel
+++ b/orc8r/gateway/configs/templates/BUILD.bazel
@@ -1,0 +1,23 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+pkg_files(
+    name = "magma_orc8r_config_template_files",
+    srcs = [
+        ":nghttpx.conf.template",
+        ":redis.conf.template",
+        ":td-agent-bit.conf.template",
+    ],
+    prefix = "templates",
+    visibility = ["//lte/gateway/release:__pkg__"],
+)

--- a/orc8r/gateway/python/BUILD.bazel
+++ b/orc8r/gateway/python/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2021 The Magma Authors.
+# Copyright 2022 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -12,31 +12,26 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 load("//bazel:runfiles.bzl", "expand_runfiles")
 
-LTE_PY_SERVICES = [
-    "enodebd",
-    "health",
-    "kernsnoopd",
-    "mobilityd",
-    "monitord",
-    "pipelined",
-    "policydb",
-    "redirectd",
-    "smsd",
-    "subscriberdb",
+ORC8R_PY_SERVICES = [
+    "ctraced",
+    "directoryd",
+    "eventd",
+    "magmad",
+    "state",
 ]
 
 [
     expand_runfiles(
         name = "{py_service}_expanded".format(py_service = py_service),
         targets = [
-            "//lte/gateway/python/magma/{py_service}:{py_service}".format(py_service = py_service),
+            "//orc8r/gateway/python/magma/{py_service}:{py_service}".format(py_service = py_service),
         ],
     )
-    for py_service in LTE_PY_SERVICES
+    for py_service in ORC8R_PY_SERVICES
 ]
 
 pkg_filegroup(
-    name = "magma_python_lte_services",
-    srcs = ["{py_service}_expanded".format(py_service = py_service) for py_service in LTE_PY_SERVICES],
+    name = "magma_python_orc8r_services",
+    srcs = ["{py_service}_expanded".format(py_service = py_service) for py_service in ORC8R_PY_SERVICES],
     visibility = ["//lte/gateway/release:__pkg__"],
 )

--- a/orc8r/gateway/python/magma/eventd/BUILD.bazel
+++ b/orc8r/gateway/python/magma/eventd/BUILD.bazel
@@ -29,7 +29,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
-    visibility = ["//visibility:private"],
+    visibility = ["//orc8r/gateway/python:__pkg__"],
     deps = [
         ":eventd_lib",
         "//orc8r/gateway/python/magma/common:sentry",

--- a/orc8r/gateway/python/scripts/BUILD.bazel
+++ b/orc8r/gateway/python/scripts/BUILD.bazel
@@ -10,7 +10,53 @@
 # limitations under the License.
 
 load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_mklink")
 load("@rules_python//python:defs.bzl", "py_binary")
+load("//bazel:deb_build.bzl", "PY_DEST")
+load("//bazel:runfiles.bzl", "expand_runfiles")
+
+SCRIPTS = [
+    "checkin_cli",
+    "ctraced_cli",
+    "directoryd_cli",
+    "generate_fluent_bit_config",
+    "generate_lighttpd_config",
+    "generate_nghttpx_config",
+    "generate_service_config",
+    "health_cli",
+    "magma_conditional_service",
+    "magma_get_config",
+    "magmad_cli",
+    "service303_cli",
+    "service_util",
+    "show_gateway_info",
+    "traffic_cli",
+]
+
+expand_runfiles(
+    name = "scripts_expanded",
+    targets = [":{script}".format(script = script) for script in SCRIPTS],
+)
+
+[
+    pkg_mklink(
+        name = "{script}_symlink".format(script = script),
+        link_name = "/usr/local/bin/{script}.py".format(script = script),
+        target = "{dest}/scripts/{script}.py".format(
+            dest = PY_DEST,
+            script = script,
+        ),
+    )
+    for script in SCRIPTS
+]
+
+pkg_filegroup(
+    name = "magma_orc8r_scripts",
+    srcs = [":scripts_expanded"] +
+           ["{script}_symlink".format(script = script) for script in SCRIPTS],
+    prefix = PY_DEST,
+    visibility = ["//lte/gateway/release:__pkg__"],
+)
 
 MAGMA_ROOT = "../../../../"
 

--- a/orc8r/tools/ansible/roles/fluent_bit/files/BUILD.bazel
+++ b/orc8r/tools/ansible/roles/fluent_bit/files/BUILD.bazel
@@ -1,0 +1,19 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+pkg_files(
+    name = "magma_fluent_bit_service_definition",
+    srcs = [":magma_td-agent-bit.service"],
+    renames = {":magma_td-agent-bit.service": "magma@td-agent-bit.service"},
+    visibility = ["//lte/gateway/release:__pkg__"],
+)

--- a/orc8r/tools/ansible/roles/fluent_bit/files/BUILD.bazel
+++ b/orc8r/tools/ansible/roles/fluent_bit/files/BUILD.bazel
@@ -17,3 +17,10 @@ pkg_files(
     renames = {":magma_td-agent-bit.service": "magma@td-agent-bit.service"},
     visibility = ["//lte/gateway/release:__pkg__"],
 )
+
+pkg_files(
+    name = "magma_config_fluent_bit",
+    srcs = [":60-fluent-bit.conf"],
+    prefix = "/etc/rsyslog.d",
+    visibility = ["//lte/gateway/release:__pkg__"],
+)

--- a/orc8r/tools/ansible/roles/gateway_services/files/BUILD.bazel
+++ b/orc8r/tools/ansible/roles/gateway_services/files/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+pkg_files(
+    name = "magma_orc8r_service_definitions",
+    srcs = [
+        ":magma.service",
+        ":magma_control_proxy.service",
+    ],
+    renames = {
+        ":magma.service": "magma@.service",
+        ":magma_control_proxy.service": "magma@control_proxy.service",
+    },
+    visibility = ["//lte/gateway/release:__pkg__"],
+)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This change introduces a first throw for a magma debian build with bazel.
* this approach tries to be as near as possible to the make build - but there are differences
  * especially, the services are not packaged hermetically, i.e., common dependencies are only packaged once
* far less dependencies are needed because bazel builds as hermetic as possible

### known issues
* the resulting package is very large `(~900mb)` and with `--config=production` even larger
* there is some debug logging (basically warnings) during a build because files are overridden during packaging - these should only be generated proto files that are used by different services

## Test Plan

* build magma debian package on VM [edit] ~~or bazelBase/devcontainer~~ (the bazelBase/devcontainer sessiond services is currently not compatible with magma_deb)
  * `bazel build //lte/gateway/release:magma_deb_pkg`
  * add `--config=production` to be closer to the make debian build
  * ~~note: in rebuild the vscode container setup because of recent needed changes (#13743)~~
* copy the artifact to an accessible place[edit]: `~/magma$ cp bazel-bin/lte/gateway/release/magma_1.8.0_amd64.deb .`
* in `lte/gateway/deploy/roles/magma_deploy/tasks/main.yml` modify "Installing magma."
  * `# name: "{{ packages }}"`
  * add `deb: "/home/vagrant/magma/magma_1.8.0_amd64.deb"`
* run `~/magma/lte/gateway$ vagrant up magma_deb`
* check `magma_deb` for issues, services running, logging, ...
* integration tests can be run vs `magma_deb`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
