### PR TITLE
chore(agw): Increase disk size for agw vm 

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML
-          vagrant plugin install vagrant-vbguest vagrant-vbguest vagrant-mutate
+          vagrant plugin install vagrant-disksize vagrant-vbguest vagrant-mutate
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
-          vagrant plugin install vagrant-vbguest vagrant-scp
+          vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-scp
       - name: Vagrant Host prerequisites for federated integ test
         run: |
           cd ${{ env.AGW_ROOT }} && fab open_orc8r_port_in_vagrant

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
-          vagrant plugin install vagrant-vbguest
+          vagrant plugin install vagrant-vbguest vagrant-disksize
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
-          vagrant plugin install vagrant-vbguest
+          vagrant plugin install vagrant-vbguest vagrant-disksize
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/

--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -42,7 +42,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    pyenv install 3.8.10
    pyenv global 3.8.10
    pip3 install ansible fabric3 jsonpickle requests PyYAML
-   vagrant plugin install vagrant-vbguest
+   vagrant plugin install vagrant-vbguest vagrant-disksize
    ```
 
    **Note**: In the case where installation of `fabric3` through pip was unsuccessful,

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -11,6 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+#
+
+# Install vagrant-disksize to allow resizing the vagrant box disk.
+unless Vagrant.has_plugin?("vagrant-disksize")
+    raise  Vagrant::Errors::VagrantError.new, "vagrant-disksize plugin is missing. Please install it using 'vagrant plugin install vagrant-disksize' and rerun 'vagrant up'"
+end
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -23,10 +29,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define :magma, primary: true do |magma|
     magma.vm.box = "magmacore/magma_dev"
     magma.vm.box_version = "1.2.20220801"
+    magma.disksize.size = '75GB'
+
      # Enable Dynamic Swap Space to prevent Out of Memory crashes
     magma.vm.provision :shell, inline: "swapoff -a && fallocate -l 4G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile && echo '/swapfile none swap sw 0 0' >> /etc/fstab && swapon -a"
     magma.vm.provision :shell, inline: "echo vm.swappiness = 10 >> /etc/sysctl.conf && echo vm.vfs_cache_pressure = 50 >> /etc/sysctl.conf && sysctl -p"
-
     magma.vbguest.auto_update = false
 
     # Create a private network, which allows host-only access to the machine

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -525,3 +525,30 @@
     pkg:
       - libsqlite3-dev
   when: full_provision
+
+- name: Extend sda2
+  community.general.parted:
+    device: /dev/sda
+    number: 2
+    part_end: "100%"
+    resize: true
+    state: present
+  when: full_provision
+
+- name: Extend sda5
+  community.general.parted:
+    device: /dev/sda
+    number: 5
+    part_end: "100%"
+    resize: true
+    state: present
+  when: full_provision
+
+- name: Extend lvm volumes
+  become: yes
+  block:
+    - shell: pvresize /dev/sda5
+    - shell: lvextend -l +100%FREE /dev/mapper/vgmagma--dev-root
+      ignore_errors: yes
+    - shell: resize2fs /dev/mapper/vgmagma--dev-root
+  when: full_provision


### PR DESCRIPTION
## Summary

Disk size for agw containers was increased to 75GB to accomdate build of dockerized agw containers. Vagrant cannot
handle file system resizing for the container - probably because it uses lvm.

## Test Plan

Tested increased container size locally. You need to remove all your vms from virtualbox (including the base vm virtualboxes uses for quicker vm setup) to test this.

AGW integ run: https://github.com/crasu/magma/actions/workflows/lte-integ-test.yml