### PR TITLE
chore(ci): Reconfigure bazel workflow trigger

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -21,11 +21,7 @@ on:
   push:
     branches:
       - master
-    paths:
-      - .github/workflows/bazel.yml
-  schedule:
-    # Run four times a day to build bazel cache
-    - cron: '0 0,6,12,18 * * *'
+
 env:
   BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   CACHE_KEY: bazel-base-image


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The bazel workflow will now be triggered for opened PRs, workflow trigger and pushes to master (even if the workflow file itself was not touched).
  - The path filter step decides which jobs are run. 
- There are no more scheduled runs.  
- Resolves #13400 

## Test Plan

- Test PR on fork triggered the workflow (with these changes on the master).
- Merging the test PR triggered another run.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
