### PR TITLE
fix(dp): fix unique constraint error handling in sqlite

### DIFF
--- a/orc8r/cloud/go/sqorc/error_checker.go
+++ b/orc8r/cloud/go/sqorc/error_checker.go
@@ -44,8 +44,8 @@ func GetErrorChecker() ErrorChecker {
 
 func (c SQLiteErrorChecker) GetError(err error) error {
 	if e, ok := err.(sqlite3.Error); ok {
-		switch e.Code {
-		case sqlite3.ErrConstraint:
+		switch e.ExtendedCode {
+		case sqlite3.ErrConstraintUnique, sqlite3.ErrConstraintPrimaryKey:
 			return merrors.ErrAlreadyExists
 		}
 	}

--- a/orc8r/cloud/go/sqorc/error_checker_test.go
+++ b/orc8r/cloud/go/sqorc/error_checker_test.go
@@ -80,10 +80,18 @@ func (s *ErrorCheckerTestSuite) TestErrorCheckerDefaultsToPostgres() {
 func (s *ErrorCheckerTestSuite) TestSQLiteGetError() {
 	testCases := []sqliteGetErrorTestCase{
 		{
-			name:    "test sqlite constraint error with SQLiteErrorChecker",
+			name:    "test unique constraint error with SQLiteErrorChecker",
 			checker: SQLiteErrorChecker{},
 			err: sqlite3.Error{
-				Code: sqlite3.ErrConstraint,
+				ExtendedCode: sqlite3.ErrConstraintUnique,
+			},
+			expectedError: merrors.ErrAlreadyExists,
+		},
+		{
+			name:    "test pk constraint error with SQLiteErrorChecker",
+			checker: SQLiteErrorChecker{},
+			err: sqlite3.Error{
+				ExtendedCode: sqlite3.ErrConstraintPrimaryKey,
 			},
 			expectedError: merrors.ErrAlreadyExists,
 		},


### PR DESCRIPTION
In tests all sqlite constraint errors were treated as unique constraint violation. Used ExtendedCode to allow for more granularity.