### PR TITLE
chore: bazel base image is pinned

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -28,7 +28,7 @@ concurrency:
 
 env:
   DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:sha-4a878d8"
   CACHE_KEY: bazel-base-image
   REMOTE_DOWNLOAD_OPTIMIZATION: true
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -27,7 +27,7 @@ on:
     # Run four times a day to build bazel cache
     - cron: '0 0,6,12,18 * * *'
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:sha-4a878d8"
   CACHE_KEY: bazel-base-image
   REMOTE_DOWNLOAD_OPTIMIZATION: true
 

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -26,7 +26,7 @@ on:
       - master
       - 'v1.*'
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:sha-4a878d8"
   CACHE_KEY: bazel-base-image
   REMOTE_DOWNLOAD_OPTIMIZATION: true
 


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This is the first PR for #13755 (see merge strategy in issue).

Note: the devcontainer image in `.github/workflows/agw-workflow.yml` should not be relevant because no bazel builds are executed on that image.

## Test Plan

* make sure correct sha is used - https://github.com/magma/magma/pkgs/container/magma%2Fbazel-base
* make sure all bazel base images in workflows are pinned

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
