### PR TITLE
fix(agw): Stop redis service in containerized AGW readme

### DIFF
--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -40,7 +40,7 @@ containerized AGW by running the following steps inside the VM:
 ```
 cd $MAGMA_ROOT/lte/gateway && make run  # You can skip this if you have built the AGW with make before
 for component in redis nghttpx td-agent-bit; do cp "${MAGMA_ROOT}"/{orc8r,lte}/gateway/configs/templates/${component}.conf.template; done
-sudo systemctl stop 'magma@*' 'sctpd' # We don't want the systemd-based AGW to run when we start the containerized AGW
+sudo systemctl stop 'magma@*' 'sctpd' 'redis' # We don't want the systemd-based AGW to run when we start the containerized AGW
 cd $MAGMA_ROOT/lte/gateway/docker
 docker-compose build
 docker-compose up


### PR DESCRIPTION
## Summary

In the containerized AGW, redis is containerized so the systemd redis service should be stopped when running it. This updates the readme accordingly.
