### PR TITLE
feat(agw): All integ tests run vs dockerized agw

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -26,6 +26,7 @@ from typing import List, Optional
 
 import grpc
 import s1ap_types
+from integ_tests.common.magmad_client import MagmadServiceGrpc
 from integ_tests.gateway.rpc import get_rpc_channel
 from integ_tests.s1aptests.ovs.rest_api import (
     get_datapath,
@@ -843,12 +844,12 @@ class MagmadUtil(object):
 
     _init_system = None
 
-    def __init__(self, magmad_client):
+    def __init__(self, magmad_client: MagmadServiceGrpc):
         """
         Init magmad util.
 
         Args:
-            magmad_client: MagmadServiceClient
+            magmad_client: MagmadServiceGrpc
         """
         self._magmad_client = magmad_client
 
@@ -952,10 +953,10 @@ class MagmadUtil(object):
         return is_installed
 
     @property
-    def init_system(self):
+    def init_system(self) -> InitMode:
         return self._init_system
 
-    def config_stateless(self, cmd):
+    def config_stateless(self, cmd: str):
         """
         Configure the stateless mode on the access gateway
 
@@ -1046,7 +1047,7 @@ class MagmadUtil(object):
             time.sleep(WAIT_INTERVAL_SECONDS)
             wait_time_seconds += WAIT_INTERVAL_SECONDS
 
-    def restart_services(self, services, wait_time=0):
+    def restart_services(self, services: List[str], wait_time: int = 0):
         """
         Restart a list of magmad services.
         Hint:
@@ -1099,7 +1100,7 @@ class MagmadUtil(object):
 
         self.wait_for_restart_to_finish(wait_time)
 
-    def wait_for_restart_to_finish(self, wait_time):
+    def wait_for_restart_to_finish(self, wait_time: int):
         """wait for started services to become active or until timeout
 
         Args:
@@ -1121,7 +1122,7 @@ class MagmadUtil(object):
         elif self._init_system == InitMode.SYSTEMD:
             time.sleep(wait_time)
 
-    def enable_service(self, service):
+    def enable_service(self, service: str):
         """Enable a magma service on magma_dev VM and starts it
 
         Args:
@@ -1134,7 +1135,7 @@ class MagmadUtil(object):
         elif self._init_system == InitMode.DOCKER:
             self.exec_command(f"docker start {service_name}")
 
-    def disable_service(self, service):
+    def disable_service(self, service: str):
         """Disables a magma service on magma_dev VM, preventing from
         starting again
 
@@ -1184,7 +1185,7 @@ class MagmadUtil(object):
                 return False
         return True
 
-    def is_service_active(self, service) -> bool:
+    def is_service_active(self, service: str) -> bool:
         """Check if a magma service on magma_dev VM is active
 
         Args:
@@ -1213,7 +1214,7 @@ class MagmadUtil(object):
             )
         return False
 
-    def check_service_activity(self, is_active_service_cmd):
+    def check_service_activity(self, is_active_service_cmd: str) -> str:
         try:
             result_str = self.exec_command_output(is_active_service_cmd)
         except subprocess.CalledProcessError as e:
@@ -1222,7 +1223,7 @@ class MagmadUtil(object):
             result_str = e.output
         return result_str
 
-    def get_service_name_from_init_system(self, service):
+    def get_service_name_from_init_system(self, service: str) -> str:
         """Get the correct service name depending on the init system
 
         Args:
@@ -1242,8 +1243,9 @@ class MagmadUtil(object):
                 return "oai_mme"
             else:
                 return service
+        return service
 
-    def update_mme_config_for_sanity(self, cmd):
+    def update_mme_config_for_sanity(self, cmd: str):
         """Update MME configuration for all sanity test cases"""
         mme_config_update_script = (
             "/home/vagrant/magma/lte/gateway/deploy/roles/magma/files/"
@@ -1284,7 +1286,7 @@ class MagmadUtil(object):
                 + " MME configuration. Error: Unknown error"
             )
 
-    def update_mme_config_for_non_sanity(self, cmd):
+    def update_mme_config_for_non_sanity(self, cmd: str):
         """Update mme config file to test non-sanity testcases
 
         Args:
@@ -1332,7 +1334,7 @@ class MagmadUtil(object):
                 + " MME configuration. Error: Unknown error",
             )
 
-    def config_apn_correction(self, cmd):
+    def config_apn_correction(self, cmd: apn_correction_cmds):
         """Configure the apn correction mode on the access gateway
 
         Args:
@@ -1389,7 +1391,7 @@ class MagmadUtil(object):
                 self.enable_service("health")
             print("Health service is enabled")
 
-    def config_ha_service(self, cmd):
+    def config_ha_service(self, cmd: ha_service_cmds) -> int:
         """
         Modify the mme configuration by enabling/disabling use of Ha service
 
@@ -1465,7 +1467,7 @@ class MagmadUtil(object):
             mme_ueip_imsi_map_entries,
         )
 
-    def is_redis_empty(self):
+    def is_redis_empty(self) -> bool:
         """
         Check that the per-IMSI state in Redis data store on AGW is empty
         """
@@ -1477,7 +1479,7 @@ class MagmadUtil(object):
             num_htbl_entries == 0 and \
             s1ap_imsi_map_entries == 0
 
-    def get_redis_state(self):
+    def get_redis_state(self) -> Tuple[List[str], int, int, int]:
         """
         Get the per-IMSI state in Redis data store on AGW
         """
@@ -1521,7 +1523,7 @@ class MagmadUtil(object):
         return keys_to_be_cleaned, mme_ueip_imsi_map_entries, \
             num_htbl_entries, s1ap_imsi_map_entries
 
-    def enable_nat(self, ip_version=4):
+    def enable_nat(self, ip_version: int = 4):
         """Enable Nat"""
         self._set_agw_nat(True)
         self._validate_nated_datapath(ip_version)
@@ -1536,7 +1538,7 @@ class MagmadUtil(object):
                 "sudo ip route add default via 2020::10 dev eth0",
             )
 
-    def disable_nat(self, ip_version=4):
+    def disable_nat(self, ip_version: int = 4):
         """
         Disable Nat
 
@@ -1587,21 +1589,21 @@ class MagmadUtil(object):
 
         self.restart_all_services()
 
-    def _validate_non_nat_datapath(self, ip_version=4):
+    def _validate_non_nat_datapath(self, ip_version: int = 4):
         # validate SGi interface is part of uplink-bridge.
         out1 = self.exec_command_output("sudo ovs-vsctl list-ports uplink_br0")
         iface = "eth2" if ip_version == 4 else "eth3"
         assert iface in str(out1)
         print("NAT is disabled")
 
-    def _validate_nated_datapath(self, ip_version=4):
+    def _validate_nated_datapath(self, ip_version: int = 4):
         # validate SGi interface is not part of uplink-bridge.
         out1 = self.exec_command_output("sudo ovs-vsctl list-ports uplink_br0")
         iface = "eth2" if ip_version == 4 else "eth3"
         assert iface not in str(out1)
         print("NAT is enabled")
 
-    def config_ipv6_iface(self, cmd):
+    def config_ipv6_iface(self, cmd: str):
         """
         Configure eth3 interface for ipv6 data on the access gateway
 

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1231,6 +1231,7 @@ class MagmadUtil(object):
         Returns:
             (str) service name
         """
+
         if self._init_system == InitMode.SYSTEMD:
             if service == "sctpd":
                 return "sctpd"
@@ -2321,7 +2322,7 @@ class HeaderEnrichmentUtils(object):
         print("restarting envoy")
         if self.magma_utils.init_system == InitMode.SYSTEMD:
             self.magma_utils.exec_command_output(
-                "sudo service magma@envoy_controller restart",
+                "sudo systemctl restart magma@envoy_controller",
             )
         elif self.magma_utils.init_system == InitMode.DOCKER:
             self.magma_utils.exec_command_output(
@@ -2329,7 +2330,7 @@ class HeaderEnrichmentUtils(object):
             )
         time.sleep(5)
         self.magma_utils.exec_command_output(
-            "sudo service magma_dp@envoy restart",
+            "sudo systemctl restart magma_dp@envoy",
         )
         time.sleep(20)
         print("restarting envoy done")

--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
@@ -82,6 +82,7 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
         # wait for UE to be idle
         time.sleep(0.1)
         print("*************************  Offloading UE at state ECM-IDLE")
+
         # Send offloading request
         assert self._ha_util.offload_agw(
             "".join(["IMSI"] + [str(i) for i in req.imsi]),

--- a/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
@@ -225,9 +225,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
         end_timer = threading.Timer(test_duration, self.hadle_end_timer)
         end_timer.start()
 
-        while True:
-            if self.test_ended:
-                break
+        while not self.test_ended:
             response = self._s1ap_wrapper.s1_util.get_response()
             self.handle_msg(response)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
@@ -105,21 +105,13 @@ class TestNoIdentityRspWithMmeRestart(unittest.TestCase):
         # part of configuraton file mme.conf.template. If MME restarts after
         # expiry of identity response timer, it will send the re-transmitted
         # identity request message
-        resp_count = 0
-        while True:
+        response = self._s1ap_wrapper.s1_util.get_response()
+        while response.msg_type != s1ap_types.tfwCmd.UE_CTX_REL_IND.value:
             response = self._s1ap_wrapper.s1_util.get_response()
-            if (
-                response.msg_type
-                == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
-            ):
-                resp_count += 1
-                print(
-                    "******************** Ignoring re-transmitted (",
-                    resp_count,
-                    ") Identity request indication",
-                )
-            else:
-                break
+            print(
+                "******************** Ignoring re-transmitted "
+                "Identity request indication",
+            )
 
         # Context release
         assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
@@ -107,11 +107,11 @@ class TestNoIdentityRspWithMmeRestart(unittest.TestCase):
         # identity request message
         response = self._s1ap_wrapper.s1_util.get_response()
         while response.msg_type != s1ap_types.tfwCmd.UE_CTX_REL_IND.value:
-            response = self._s1ap_wrapper.s1_util.get_response()
             print(
                 "******************** Ignoring re-transmitted "
                 "Identity request indication",
             )
+            response = self._s1ap_wrapper.s1_util.get_response()
 
         # Context release
         assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value


### PR DESCRIPTION
## Summary

This is a follow up on #13659. The PR enables running all LTE integration tests versus the containerized AGW. All restart commands are checked for a `systemd` or Docker environment. Restarting the `redis` container does not delete its database, this is done manually. The service / container dependencies are handled manually as well.

Closes #13684.

## Test Plan

`systemd` AGW:

- [x] Precommit
- [x] Extended
- [ ] Non-Sanity

containerized AGW:

- [x] Precommit
    - `test_eps_bearer_context_status_def_bearer_deact` and `test_attach_detach_setsessionrules_tcp_data` are flaky
- [x] Extended
    - `test_attach_detach_flaky_retry_success.py` is flaky, but third time is usually the charm
    - ~`test_attach_detach_with_he_policy.py` and `test_attach_detach_rar_tcp_he.py` are red due to the missing containerized envoy controller. They run green using `sudo service magma@envoy_controller start`.~
    - ~`test_3485_timer_for_dedicated_bearer_with_mme_restart` and `test_3485_timer_for_default_bearer_with_mme_restart` are red~
- [ ] Non-Sanity

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
