### PR TITLE
chore(dp): Remove apt packages version pinning in DP Dockerfiles

### DIFF
--- a/dp/cloud/docker/python/configuration_controller/Dockerfile
+++ b/dp/cloud/docker/python/configuration_controller/Dockerfile
@@ -1,7 +1,7 @@
 ARG ENV=standard
 FROM python:3.9.2-slim-buster as protos-generator
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
+RUN apt-get update && apt-get install -y --no-install-recommends curl zip make unzip
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
     -o protoc3.zip
 RUN unzip protoc3.zip -d protoc3 &&\

--- a/dp/cloud/docker/python/radio_controller/Dockerfile
+++ b/dp/cloud/docker/python/radio_controller/Dockerfile
@@ -1,7 +1,7 @@
 ARG ENV=standard
 FROM python:3.9.2-slim-buster as protos-generator
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
+RUN apt-get update && apt-get install -y --no-install-recommends curl zip make unzip
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
     -o protoc3.zip
 RUN unzip protoc3.zip -d protoc3 &&\

--- a/dp/cloud/docker/python/test_runner/Dockerfile
+++ b/dp/cloud/docker/python/test_runner/Dockerfile
@@ -1,7 +1,7 @@
 ARG ENV=standard
 FROM python:3.9.2-slim-buster as protos-generator
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
+RUN apt-get update && apt-get install -y --no-install-recommends curl zip make unzip
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
     -o protoc3.zip
 RUN unzip protoc3.zip -d protoc3 &&\


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
To avoid dependency issues, when the base Docker image is updated, we shouldn't pin apt to a particular package version.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] Check CI
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
