### PR TITLE
chore(ci): Run the sudo tests with bazel

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -86,7 +86,13 @@ jobs:
           vagrant ssh -c 'sudo sed -i "s@#precedence ::ffff:0:0/96  100@precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
           vagrant ssh -c 'cd ~/magma; bazel build --profile=bazel_profile_lte_integ_tests `bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/...)"`;' magma
           vagrant ssh -c 'sudo sed -i "s@precedence ::ffff:0:0/96  100@#precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
+      - name: Run the sudo tests
+        id: sudo_tests
+        run: |
+          cd lte/gateway
+          vagrant ssh -c 'cd ~/magma; bazel/scripts/run_sudo_tests.sh --retry-on-failure --retry-attempts 1;' magma
       - name: Run the integ test
+        if: ${{ success() || steps.sudo_tests.conclusion == 'failure' }}
         run: |
           cd lte/gateway
           export MAGMA_DEV_CPUS=3

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -387,7 +387,6 @@ def bazel_integ_test_post_build(
         ansible_setup(gateway_host, "dev", "magma_dev.yml")
         gateway_ip = gateway_host.split('@')[1].split(':')[0]
 
-    execute(_run_sudo_python_unit_tests)
     execute(_restart_gateway)
 
     # Setup the trfserver: use the provided trfserver if given, else default to the


### PR DESCRIPTION
Co-authored-by: Lars Kreutzer lars.kreutzer@tngtech.com
Co-authored-by: Krisztián Varga krisztian.varga@tngtech.com

Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Run sudo tests with bazel
- Retry failing sudo tests once
- Even if sudo tests fail the integ tests are run ("fail late")
-  :heavy_check_mark: ~Requires https://github.com/magma/magma/pull/13744 to be merged.~
- Resolves #13380

## Test Plan

- See #13380

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
