### PR TITLE
build(dp): Update curl version in Dockerfiles

### DIFF
--- a/dp/cloud/docker/python/configuration_controller/Dockerfile
+++ b/dp/cloud/docker/python/configuration_controller/Dockerfile
@@ -1,7 +1,7 @@
 ARG ENV=standard
 FROM python:3.9.2-slim-buster as protos-generator
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
+RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u3 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
     -o protoc3.zip
 RUN unzip protoc3.zip -d protoc3 &&\

--- a/dp/cloud/docker/python/radio_controller/Dockerfile
+++ b/dp/cloud/docker/python/radio_controller/Dockerfile
@@ -1,7 +1,7 @@
 ARG ENV=standard
 FROM python:3.9.2-slim-buster as protos-generator
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
+RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u3 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
     -o protoc3.zip
 RUN unzip protoc3.zip -d protoc3 &&\

--- a/dp/cloud/docker/python/test_runner/Dockerfile
+++ b/dp/cloud/docker/python/test_runner/Dockerfile
@@ -1,7 +1,7 @@
 ARG ENV=standard
 FROM python:3.9.2-slim-buster as protos-generator
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
+RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u3 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
     -o protoc3.zip
 RUN unzip protoc3.zip -d protoc3 &&\


### PR DESCRIPTION
Bumped cURL version of apt package from 7.64.0-4+deb10u2 to 7.64.0-4+deb10u3 in Domain Proxy docker images.

Signed-off-by: Artur Dębski <artur.debski@freedomfi.com>

## Summary

Updated ubuntu focal package version of cURL to `7.64.0-4+deb10u3`

## Additional Information

- [ ] This change is backwards-breaking