### PR TITLE
refactor(nms): Migrate Alerts Receivers detail to new style

### DIFF
--- a/nms/app/views/alarms/components/alertmanager/Receivers/AddEditReceiver.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/AddEditReceiver.tsx
@@ -21,7 +21,6 @@ import IconButton from '@mui/material/IconButton';
 import PagerDutyConfigEditor from './PagerDutyConfigEditor';
 import PushoverConfigEditor from './PushoverConfigEditor';
 import SlackConfigEditor from './SlackConfigEditor';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import WebhookConfigEditor from './WebhookConfigEditor';
 import useForm from '../../../hooks/useForm';
@@ -29,6 +28,8 @@ import {useAlarmContext} from '../../AlarmContext';
 import {useParams} from 'react-router-dom';
 import {useSnackbars} from '../../../../../hooks/useSnackbar';
 
+import {AltFormField} from '../../../../../components/FormField';
+import {OutlinedInput} from '@mui/material';
 import {getErrorMessage} from '../../../../../util/ErrorUtils';
 import type {
   AlertReceiver,
@@ -145,17 +146,16 @@ export default function AddEditReceiver(props: Props) {
         <Card>
           <CardContent>
             <Typography paragraph>Details</Typography>
-            <TextField
-              variant="standard"
-              required
-              id="name"
-              label="Name"
-              placeholder="Ex: Support Team"
-              disabled={!isNew}
-              value={formState.name}
-              onChange={handleInputChange((val: string) => ({name: val}))}
-              fullWidth
-            />
+            <AltFormField label="Name">
+              <OutlinedInput
+                data-testid="receiverName"
+                disabled={!isNew}
+                fullWidth={true}
+                value={formState.name}
+                onChange={handleInputChange((val: string) => ({name: val}))}
+                placeholder="Ex: Support Team"
+              />
+            </AltFormField>
           </CardContent>
         </Card>
       </Grid>

--- a/nms/app/views/alarms/components/alertmanager/Receivers/EmailConfigEditor.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/EmailConfigEditor.tsx
@@ -15,99 +15,101 @@ import * as React from 'react';
 import Checkbox from '@mui/material/Checkbox';
 import ConfigEditor from './ConfigEditor';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import Grid from '@mui/material/Grid';
-import TextField from '@mui/material/TextField';
+import Text from '../../../../../theme/design-system/Text';
+import {AltFormField} from '../../../../../components/FormField';
+import {ListItem, OutlinedInput} from '@mui/material';
+import {makeStyles} from '@mui/styles';
+
 import type {EditorProps} from './ConfigEditor';
 import type {ReceiverEmailConfig} from '../../AlarmAPIType';
+
+const useStyles = makeStyles(() => ({
+  input: {
+    padding: '0 16px',
+  },
+}));
 
 export default function EmailConfigEditor({
   config,
   onUpdate,
   ...props
 }: EditorProps<ReceiverEmailConfig>) {
+  const classes = useStyles();
+
   return (
     <ConfigEditor
       {...props}
       RequiredFields={
         <>
-          <Grid item>
-            <TextField
-              variant="standard"
-              required
-              label="Send To"
-              placeholder="Ex: ops@example.com"
+          <AltFormField className={classes.input} dense label="Send To">
+            <OutlinedInput
+              fullWidth={true}
               value={config.to}
               onChange={e => onUpdate({to: e.target.value})}
-              fullWidth
+              placeholder="Ex: ops@example.com"
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
-              required
-              label="From"
-              placeholder="Ex: notifications@example.com"
+          </AltFormField>
+          <AltFormField className={classes.input} dense label="From">
+            <OutlinedInput
+              fullWidth={true}
               value={config.from}
               onChange={e => onUpdate({from: e.target.value})}
-              fullWidth
+              placeholder="Ex: notifications@example.com"
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
-              required
-              label="Host"
-              placeholder="Ex: smtp.example.com"
+          </AltFormField>
+          <AltFormField className={classes.input} label="Host">
+            <OutlinedInput
+              fullWidth={true}
               value={config.smarthost}
               onChange={e => onUpdate({smarthost: e.target.value})}
-              fullWidth
+              placeholder="Ex: smtp.example.com"
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
-              label="Auth Username"
+          </AltFormField>
+          <AltFormField
+            className={classes.input}
+            label="Auth Username"
+            subLabel="SMTP Auth using CRAM-MD5, LOGIN and PLAIN">
+            <OutlinedInput
+              fullWidth={true}
               value={config.auth_username}
               onChange={e => onUpdate({auth_username: e.target.value})}
-              fullWidth
-              helperText="SMTP Auth using CRAM-MD5, LOGIN and PLAIN"
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
-              label="Auth Password"
+          </AltFormField>
+          <AltFormField
+            className={classes.input}
+            label="Auth Password"
+            subLabel="SMTP Auth using LOGIN and PLAIN">
+            <OutlinedInput
+              fullWidth={true}
               value={config.auth_password}
               onChange={e => onUpdate({auth_password: e.target.value})}
-              fullWidth
-              helperText="SMTP Auth using LOGIN and PLAIN"
             />
-          </Grid>
+          </AltFormField>
         </>
       }
       OptionalFields={
         <>
-          <Grid item>
-            <TextField
-              variant="standard"
-              label="Auth Secret"
+          <AltFormField
+            className={classes.input}
+            label="Auth Secret"
+            subLabel="SMTP Auth using CRAM-MD5">
+            <OutlinedInput
+              fullWidth={true}
               value={config.auth_secret}
               onChange={e => onUpdate({auth_secret: e.target.value})}
-              fullWidth
-              helperText="SMTP Auth using CRAM-MD5"
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
-              label="Auth Identity"
+          </AltFormField>
+          <AltFormField
+            className={classes.input}
+            label="Auth Identity"
+            subLabel="SMTP Auth using PLAIN">
+            <OutlinedInput
+              fullWidth={true}
               value={config.auth_identity}
               onChange={e => onUpdate({auth_identity: e.target.value})}
-              fullWidth
-              helperText="SMTP Auth using PLAIN"
             />
-          </Grid>
-          <Grid item>
+          </AltFormField>
+          <ListItem>
             <FormControlLabel
               control={
                 <Checkbox
@@ -118,9 +120,13 @@ export default function EmailConfigEditor({
                   indeterminate={config.require_tls == null}
                 />
               }
-              label="Require TLS"
+              label={
+                <Text weight="medium" variant="subtitle2">
+                  Require TLS
+                </Text>
+              }
             />
-          </Grid>
+          </ListItem>
         </>
       }
       data-testid="email-config-editor"

--- a/nms/app/views/alarms/components/alertmanager/Receivers/PagerDutyConfigEditor.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/PagerDutyConfigEditor.tsx
@@ -13,92 +13,90 @@
 
 import * as React from 'react';
 import ConfigEditor from './ConfigEditor';
-import Grid from '@mui/material/Grid';
-import TextField from '@mui/material/TextField';
+
+import {AltFormField} from '../../../../../components/FormField';
+import {OutlinedInput} from '@mui/material';
+import {makeStyles} from '@mui/styles';
+
 import type {EditorProps} from './ConfigEditor';
 import type {ReceiverPagerDutyConfig} from '../../AlarmAPIType';
+
+const useStyles = makeStyles(() => ({
+  input: {
+    padding: '0 16px',
+  },
+}));
 
 export default function PagerDutyConfigEditor({
   config,
   onUpdate,
   ...props
 }: EditorProps<ReceiverPagerDutyConfig>) {
+  const classes = useStyles();
+
   return (
     <ConfigEditor
       {...props}
       RequiredFields={
         <>
-          <Grid item>
-            <TextField
-              variant="standard"
+          <AltFormField className={classes.input} dense label="Description">
+            <OutlinedInput
+              fullWidth={true}
               required
-              label="Description"
               value={config.description}
               onChange={e => onUpdate({description: e.target.value})}
-              fullWidth
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
+          </AltFormField>
+          <AltFormField className={classes.input} dense label="Severity">
+            <OutlinedInput
+              fullWidth={true}
               required
-              label="Severity"
               value={config.severity}
               onChange={e => onUpdate({severity: e.target.value})}
-              fullWidth
+              placeholder="Ex: notifications@example.com"
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
+          </AltFormField>
+          <AltFormField className={classes.input} dense label="Url">
+            <OutlinedInput
+              fullWidth={true}
               required
-              label="Url"
-              placeholder="Ex: webhook.example.com"
               value={config.url}
               onChange={e => onUpdate({url: e.target.value})}
-              fullWidth
+              placeholder="Ex: webhook.example.com"
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
+          </AltFormField>
+          <AltFormField className={classes.input} dense label="Routing Key">
+            <OutlinedInput
+              fullWidth={true}
               required
-              label="Routing_key"
               value={config.routing_key}
               onChange={e => onUpdate({routing_key: e.target.value})}
-              fullWidth
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
+          </AltFormField>
+          <AltFormField className={classes.input} dense label="Service Key">
+            <OutlinedInput
+              fullWidth={true}
               required
-              label="Service_key"
               value={config.service_key}
               onChange={e => onUpdate({service_key: e.target.value})}
-              fullWidth
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
-              required
-              label="Client"
+          </AltFormField>
+          <AltFormField className={classes.input} dense label="Client">
+            <OutlinedInput
+              fullWidth={true}
               value={config.client}
               onChange={e => onUpdate({client: e.target.value})}
-              fullWidth
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
+          </AltFormField>
+
+          <AltFormField className={classes.input} dense label="Client Url">
+            <OutlinedInput
+              fullWidth={true}
               required
-              label="Client Url"
               value={config.client_url}
               onChange={e => onUpdate({client_url: e.target.value})}
-              fullWidth
             />
-          </Grid>
+          </AltFormField>
         </>
       }
       data-testid="pager-duty-config-editor"

--- a/nms/app/views/alarms/components/alertmanager/Receivers/PushoverConfigEditor.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/PushoverConfigEditor.tsx
@@ -13,85 +13,86 @@
 
 import * as React from 'react';
 import ConfigEditor from './ConfigEditor';
-import Grid from '@mui/material/Grid';
 import MenuItem from '@mui/material/MenuItem';
-import TextField from '@mui/material/TextField';
+import {AltFormField} from '../../../../../components/FormField';
+import {FormControl, OutlinedInput, Select} from '@mui/material';
+import {makeStyles} from '@mui/styles';
+
 import type {EditorProps} from './ConfigEditor';
 import type {ReceiverPushoverConfig} from '../../AlarmAPIType';
+
+const useStyles = makeStyles(() => ({
+  input: {
+    padding: '0 16px',
+  },
+}));
 
 export default function PushoverConfigEditor({
   config,
   onUpdate,
   ...props
 }: EditorProps<ReceiverPushoverConfig>) {
+  const classes = useStyles();
+  const priorityList = [
+    ['-2', 'Lowest'],
+    ['-1', 'Low'],
+    ['0', 'Normal'],
+    ['1', 'High'],
+    ['2', 'Emergency'],
+  ];
   return (
     <ConfigEditor
       {...props}
       RequiredFields={
         <>
-          <Grid item>
-            <TextField
-              variant="standard"
+          <AltFormField className={classes.input} dense label="User Key">
+            <OutlinedInput
+              fullWidth={true}
               required
-              label="User Key"
               value={config.user_key}
               onChange={e => onUpdate({user_key: e.target.value})}
-              fullWidth
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
+          </AltFormField>
+          <AltFormField className={classes.input} dense label="Token">
+            <OutlinedInput
+              fullWidth={true}
               required
-              label="Token"
               value={config.token}
               onChange={e => onUpdate({token: e.target.value})}
-              fullWidth
             />
-          </Grid>
+          </AltFormField>
         </>
       }
       OptionalFields={
         <>
-          <Grid item>
-            <TextField
-              variant="standard"
-              label="Title"
+          <AltFormField className={classes.input} dense label="Title">
+            <OutlinedInput
+              fullWidth={true}
               value={config.title}
               onChange={e => onUpdate({title: e.target.value})}
-              fullWidth
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
-              label="Message"
+          </AltFormField>
+          <AltFormField className={classes.input} dense label="Message">
+            <OutlinedInput
+              fullWidth={true}
               value={config.message}
               onChange={e => onUpdate({message: e.target.value})}
-              fullWidth
             />
-          </Grid>
-          <Grid item>
-            <TextField
-              variant="standard"
-              label="Priority"
-              value={config.priority || '0'}
-              onChange={e => onUpdate({priority: e.target.value})}
-              fullWidth
-              select>
-              {[
-                ['-2', 'Lowest'],
-                ['-1', 'Low'],
-                ['0', 'Normal'],
-                ['1', 'High'],
-                ['2', 'Emergency'],
-              ].map(([priority, label]) => (
-                <MenuItem key={label} value={priority}>
-                  {label}
-                </MenuItem>
-              ))}
-            </TextField>
-          </Grid>
+          </AltFormField>
+          <AltFormField label={'Priority'}>
+            <FormControl fullWidth>
+              <Select
+                value={config.priority || '0'}
+                onChange={e => onUpdate({priority: e.target.value})}
+                input={<OutlinedInput id="deviceClass" />}>
+                {priorityList.map(([priority, label]) => (
+                  <MenuItem key={label} value={priority}>
+                    {label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </AltFormField>
         </>
       }
       data-testid="email-config-editor"

--- a/nms/app/views/alarms/components/alertmanager/Receivers/SlackConfigEditor.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/SlackConfigEditor.tsx
@@ -13,49 +13,54 @@
 
 import * as React from 'react';
 import ConfigEditor from './ConfigEditor';
-import Grid from '@mui/material/Grid';
-import TextField from '@mui/material/TextField';
+import {AltFormField} from '../../../../../components/FormField';
+import {OutlinedInput} from '@mui/material';
+import {makeStyles} from '@mui/styles';
+
 import type {EditorProps} from './ConfigEditor';
 import type {ReceiverSlackConfig} from '../../AlarmAPIType';
+const useStyles = makeStyles(() => ({
+  input: {
+    padding: '0 16px',
+  },
+}));
 
 export default function SlackConfigEditor({
   config,
   onUpdate,
   ...props
 }: EditorProps<ReceiverSlackConfig>) {
+  const classes = useStyles();
+
   return (
     <ConfigEditor
       {...props}
       RequiredFields={
         <>
-          <Grid item>
-            <TextField
-              variant="standard"
+          <AltFormField className={classes.input} dense label="Webhook URL">
+            <OutlinedInput
+              fullWidth={true}
               required
-              data-testid="slack-config-editor"
               id="apiurl"
-              label="Webhook URL"
-              placeholder="Ex: https://hooks.slack.com/services/a/b"
+              data-testid="slack-config-editor"
               value={config.api_url}
               onChange={e => onUpdate({api_url: e.target.value})}
-              fullWidth
+              placeholder="Ex: https://hooks.slack.com/services/a/b"
             />
-          </Grid>
+          </AltFormField>
         </>
       }
       OptionalFields={
         <>
-          <Grid item>
-            <TextField
-              variant="standard"
+          <AltFormField className={classes.input} dense label="Message">
+            <OutlinedInput
+              fullWidth={true}
               id="title"
-              label="Message Title"
-              placeholder="Ex: Urgent"
               value={config.title}
               onChange={e => onUpdate({title: e.target.value})}
-              fullWidth
+              placeholder="Ex: Urgent"
             />
-          </Grid>
+          </AltFormField>
         </>
       }
     />

--- a/nms/app/views/alarms/components/alertmanager/Receivers/WebhookConfigEditor.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/WebhookConfigEditor.tsx
@@ -13,32 +13,39 @@
 
 import * as React from 'react';
 import ConfigEditor from './ConfigEditor';
-import Grid from '@mui/material/Grid';
-import TextField from '@mui/material/TextField';
+import {AltFormField} from '../../../../../components/FormField';
+import {OutlinedInput} from '@mui/material';
+import {makeStyles} from '@mui/styles';
+
 import type {EditorProps} from './ConfigEditor';
 import type {ReceiverWebhookConfig} from '../../AlarmAPIType';
+
+const useStyles = makeStyles(() => ({
+  input: {
+    padding: '0 16px',
+  },
+}));
 
 export default function WebhookConfigEditor({
   config,
   onUpdate,
   ...props
 }: EditorProps<ReceiverWebhookConfig>) {
+  const classes = useStyles();
   return (
     <ConfigEditor
       {...props}
       RequiredFields={
         <>
-          <Grid item>
-            <TextField
-              variant="standard"
+          <AltFormField className={classes.input} dense label="Url">
+            <OutlinedInput
+              fullWidth={true}
               required
-              label="Url"
-              placeholder="Ex: webhook.example.com"
               value={config.url}
               onChange={e => onUpdate({url: e.target.value})}
-              fullWidth
+              placeholder="Ex: webhook.example.com"
             />
-          </Grid>
+          </AltFormField>
         </>
       }
       data-testid="webhook-config-editor"

--- a/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/AddEditReceiver-test.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/__tests__/AddEditReceiver-test.tsx
@@ -53,24 +53,34 @@ test('clicking the add button adds a new config entry', () => {
 });
 
 test('editing a config entry then submitting submits the form state', () => {
-  const {getByLabelText, getByTestId} = render(
+  const {getByTestId} = render(
     <AlarmsWrapper>
       <AddEditReceiver {...commonProps} receiver={{name: ''}} />
     </AlarmsWrapper>,
   );
   act(() => {
-    fireEvent.change(getByLabelText(/Name/i), {
-      target: {value: 'test receiver'},
-    });
-  });
-  act(() => {
     fireEvent.click(getByTestId('add-SlackChannel'));
   });
-  act(() => {
-    fireEvent.change(getByLabelText(/Webhook url/i), {
-      target: {value: 'https://slack.com/hook'},
+  const receiverName = getByTestId('receiverName').firstChild;
+  const webhookUrl = getByTestId('slack-config-editor').firstChild;
+  if (
+    receiverName instanceof HTMLInputElement &&
+    webhookUrl instanceof HTMLInputElement
+  ) {
+    act(() => {
+      fireEvent.change(receiverName, {
+        target: {value: 'test receiver'},
+      });
     });
-  });
+    act(() => {
+      fireEvent.change(webhookUrl, {
+        target: {value: 'https://slack.com/hook'},
+      });
+    });
+  } else {
+    throw 'invalid type';
+  }
+
   act(() => {
     fireEvent.click(getByTestId('editor-submit-button'));
   });


### PR DESCRIPTION
Signed-off-by: HannaFar <hannafarag159@gmail.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Old style: 
<img width="1792" alt="Capture d’écran 2022-08-29 à 17 56 11" src="https://user-images.githubusercontent.com/26038920/187243083-a932eac6-28a0-4993-b663-25cddbc5731c.png">

New style: 
<img width="1792" alt="Capture d’écran 2022-08-29 à 17 55 09" src="https://user-images.githubusercontent.com/26038920/187242964-f45c01f9-a027-4cca-b8eb-0c8e6bf84d8e.png">


<img width="1792" alt="Capture d’écran 2022-08-29 à 17 55 22" src="https://user-images.githubusercontent.com/26038920/187242923-025f91ab-c4fd-45d4-b04e-6873eb626011.png">

 Migrate Alerts Receivers detail to new style

closes #13492 
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
