### PR TITLE
fix(nms): bump yarn timeout to avoid preventable build failures

### DIFF
--- a/nms/Dockerfile
+++ b/nms/Dockerfile
@@ -9,7 +9,7 @@ COPY package.json yarn.lock babel.config.js ./
 
 # Install node dependencies
 ENV PUPPETEER_SKIP_DOWNLOAD "true"
-RUN yarn install --mutex network --frozen-lockfile && yarn cache clean
+RUN yarn install --mutex network --frozen-lockfile --network-timeout 90000 && yarn cache clean
 
 # Build our static files
 COPY . .


### PR DESCRIPTION
Signed-off-by: Lucas Gonze <lucas@gonze.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Prevent needless test failures by increasing network timeout. This is an essential change on my machine.

The downside is that tests that are hung rather than simply slow will take longer to die.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
- yarn test
- yarn test:e2e
- Ensure CI tests pass

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
