### PR TITLE
[v1.8] chore(dp): Remove apt packages version pinning in DP Dockerfiles (#13769)

### DIFF
--- a/dp/cloud/docker/python/configuration_controller/Dockerfile
+++ b/dp/cloud/docker/python/configuration_controller/Dockerfile
@@ -1,7 +1,7 @@
 ARG ENV=standard
 FROM python:3.9.2-slim-buster as protos-generator
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
+RUN apt-get update && apt-get install -y --no-install-recommends curl zip make unzip
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
     -o protoc3.zip
 RUN unzip protoc3.zip -d protoc3 &&\

--- a/dp/cloud/docker/python/radio_controller/Dockerfile
+++ b/dp/cloud/docker/python/radio_controller/Dockerfile
@@ -1,7 +1,7 @@
 ARG ENV=standard
 FROM python:3.9.2-slim-buster as protos-generator
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
+RUN apt-get update && apt-get install -y --no-install-recommends curl zip make unzip
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
     -o protoc3.zip
 RUN unzip protoc3.zip -d protoc3 &&\

--- a/dp/cloud/docker/python/test_runner/Dockerfile
+++ b/dp/cloud/docker/python/test_runner/Dockerfile
@@ -1,7 +1,7 @@
 ARG ENV=standard
 FROM python:3.9.2-slim-buster as protos-generator
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl=7.64.0-4+deb10u2 zip=3.0-11+b1 make=4.2.1-1.2 unzip=6.0-23+deb10u2
+RUN apt-get update && apt-get install -y --no-install-recommends curl zip make unzip
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
     -o protoc3.zip
 RUN unzip protoc3.zip -d protoc3 &&\


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [chore(dp): Remove apt packages version pinning in DP Dockerfiles (#13769)](https://github.com/magma/magma/pull/13769)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)