### PR TITLE
fix(ci): Fix broken feg integ tests.

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -894,13 +894,13 @@ class MagmadUtil(object):
             logging.info("systemd is not installed")
 
         if docker_running and systemd_running:
-            raise RuntimeError("Magmad is running with both Docker and systemd")
+            return InitMode.SYSTEMD  # default to systemd if both are running - needed by feg integ tests
         elif docker_running:
             return InitMode.DOCKER
         elif systemd_running:
             return InitMode.SYSTEMD
         else:
-            raise RuntimeError("Magmad is not running with either Docker or systemd")
+            raise RuntimeError("Magmad is not running, you have to start magmad either in Docker or systemd")
 
     def exec_command_output(self, command):
         """Run a command remotely on magma_dev VM.


### PR DESCRIPTION
## Summary

Feg integ tests need both magmad in docker for running the feg and magmad started by systemd for agw. So the detection which magmad to restart fails. We are now defaulting to systemd as it was before and we will probably have some kind of cli parameter for feg tests in the future to restart both magmads.

## Test Plan

Test works on locally machine
Feg test run https://github.com/crasu/magma/actions/runs/2955993651.