### PR TITLE
refactor(nms): Migrate Alerts rules detail to new style

### DIFF
--- a/nms/app/views/alarms/components/alertmanager/Receivers/SelectReceiver.tsx
+++ b/nms/app/views/alarms/components/alertmanager/Receivers/SelectReceiver.tsx
@@ -14,9 +14,10 @@
 import * as React from 'react';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
-import Input from '@mui/material/Input';
 import MenuItem from '@mui/material/MenuItem';
 import Select, {SelectChangeEvent} from '@mui/material/Select';
+import {AltFormField} from '../../../../../components/FormField';
+import {FormControl, OutlinedInput} from '@mui/material';
 import {useAlarmContext} from '../../AlarmContext';
 import {useParams} from 'react-router-dom';
 
@@ -51,32 +52,40 @@ export default function SelectReceiver({
   }
 
   return (
-    <Select
-      {...fieldProps}
-      id="select-receiver"
-      data-testid="select-receiver"
-      onChange={handleChange}
-      defaultValue="Select Team"
-      input={<Input inputProps={{'data-testid': 'select-receiver-input'}} />}
-      renderValue={value => (
-        <Chip
-          key={value}
-          label={value}
-          variant="outlined"
-          color="primary"
-          size="small"
-        />
-      )}
-      value={receiver || ''}>
-      <MenuItem value="" key={''}>
-        None
-      </MenuItem>
-      {error && <MenuItem>Error: Could not load receivers</MenuItem>}
-      {(response || []).map(receiver => (
-        <MenuItem value={receiver.name} key={receiver.name}>
-          {receiver.name}
-        </MenuItem>
-      ))}
-    </Select>
+    <AltFormField disableGutters label="Audience">
+      <FormControl fullWidth>
+        <Select
+          {...fieldProps}
+          id="select-receiver"
+          data-testid="select-receiver"
+          onChange={handleChange}
+          defaultValue="Select Team"
+          input={
+            <OutlinedInput
+              inputProps={{'data-testid': 'select-receiver-input'}}
+            />
+          }
+          renderValue={value => (
+            <Chip
+              key={value}
+              label={value}
+              variant="outlined"
+              color="primary"
+              size="small"
+            />
+          )}
+          value={receiver || ''}>
+          <MenuItem value="" key={''}>
+            None
+          </MenuItem>
+          {error && <MenuItem>Error: Could not load receivers</MenuItem>}
+          {(response || []).map(receiver => (
+            <MenuItem value={receiver.name} key={receiver.name}>
+              {receiver.name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </AltFormField>
   );
 }

--- a/nms/app/views/alarms/components/rules/LabelsEditor.tsx
+++ b/nms/app/views/alarms/components/rules/LabelsEditor.tsx
@@ -21,9 +21,9 @@ import CardHeader from '@mui/material/CardHeader';
 import DeleteIcon from '@mui/icons-material/Delete';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
-import InputLabel from '@mui/material/InputLabel';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import {AltFormField} from '../../../../components/FormField';
+import {OutlinedInput} from '@mui/material';
 import type {Labels} from '../AlarmAPIType';
 
 const filteredLabels = new Set(['networkID', 'severity']);
@@ -117,30 +117,28 @@ export default function LabelsEditor({labels, onChange}: Props) {
             labelsState.map(([key, value], index) => (
               <Grid container key={index} item spacing={1}>
                 <Grid item xs={6}>
-                  <InputLabel htmlFor="label-name-input" variant="standard">
-                    Label Name
-                  </InputLabel>
-                  <TextField
-                    variant="standard"
-                    id="label-name-input"
-                    placeholder="Name"
-                    value={key}
-                    fullWidth
-                    onChange={e => handleKeyChange(index, e.target.value)}
-                  />
+                  <AltFormField disableGutters label="Label Name">
+                    <OutlinedInput
+                      fullWidth={true}
+                      name="description"
+                      value={key}
+                      id="label-name-input"
+                      placeholder="Name"
+                      onChange={e => handleKeyChange(index, e.target.value)}
+                    />
+                  </AltFormField>
                 </Grid>
                 <Grid item xs={5}>
-                  <InputLabel htmlFor="label-value-input" variant="standard">
-                    Value
-                  </InputLabel>
-                  <TextField
-                    variant="standard"
-                    id="label-value-input"
-                    placeholder="Value"
-                    value={value}
-                    fullWidth
-                    onChange={e => handleValueChange(index, e.target.value)}
-                  />
+                  <AltFormField disableGutters label="Value">
+                    <OutlinedInput
+                      fullWidth={true}
+                      name="description"
+                      value={value}
+                      id="label-value-input"
+                      placeholder="Value"
+                      onChange={e => handleValueChange(index, e.target.value)}
+                    />
+                  </AltFormField>
                 </Grid>
                 <Grid item xs={1}>
                   <IconButton
@@ -155,6 +153,7 @@ export default function LabelsEditor({labels, onChange}: Props) {
             ))}
           <Grid item>
             <Button
+              variant="outlined"
               color="primary"
               size="small"
               onClick={addNewLabel}

--- a/nms/app/views/alarms/components/rules/PrometheusEditor/PrometheusEditor.tsx
+++ b/nms/app/views/alarms/components/rules/PrometheusEditor/PrometheusEditor.tsx
@@ -275,6 +275,7 @@ function SeverityEditor(props: {
             variant="standard"
             required
             value={props.severity}
+            // @ts-ignore Somehow the whole types are messed up here, as select elements have different types than other elements.
             onChange={props.onChange(value => ({severity: value}))}
             input={<OutlinedInput />}>
             {props.options.map(opt => (
@@ -345,6 +346,7 @@ function TimeUnitEditor(props: {
             variant="standard"
             fullWidth
             value={props.timeUnit}
+            // @ts-ignore Somehow the whole types are messed up here, as select elements have different types than other elements.
             onChange={props.onChange(val => ({timeUnit: val}))}
             input={<OutlinedInput />}>
             {props.timeUnits.map(option => (

--- a/nms/app/views/alarms/components/rules/PrometheusEditor/PrometheusEditor.tsx
+++ b/nms/app/views/alarms/components/rules/PrometheusEditor/PrometheusEditor.tsx
@@ -17,25 +17,23 @@ import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import FormHelperText from '@mui/material/FormHelperText';
 import Grid from '@mui/material/Grid';
-import Input from '@mui/material/Input';
-import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import RuleEditorBase from '../RuleEditorBase';
-import TextField from '@mui/material/TextField';
 import ToggleableExpressionEditor, {
   AdvancedExpressionEditor,
   thresholdToPromQL,
 } from './ToggleableExpressionEditor';
 import useForm from '../../../hooks/useForm';
+import {AltFormField} from '../../../../../components/FormField';
+import {FormControl, OutlinedInput, Select} from '@mui/material';
 import {Labels} from '../../prometheus/PromQL';
 import {Parse} from '../../prometheus/PromQLParser';
 import {SEVERITY} from '../../severity/Severity';
+import {getErrorMessage} from '../../../../../util/ErrorUtils';
 import {makeStyles} from '@mui/styles';
 import {useAlarmContext} from '../../AlarmContext';
 import {useParams} from 'react-router-dom';
 import {useSnackbars} from '../../../../../hooks/useSnackbar';
-
-import {getErrorMessage} from '../../../../../util/ErrorUtils';
 import type {AlertConfig, Labels as LabelsMap} from '../../AlarmAPIType';
 import type {GenericRule, RuleEditorProps} from '../RuleInterface';
 import type {RuleEditorBaseFields} from '../RuleEditorBase';
@@ -49,7 +47,7 @@ type TimeUnit = {value: string; label: string};
 const useStyles = makeStyles<Theme>(theme => ({
   button: {
     marginLeft: -theme.spacing(0.5),
-    margin: theme.spacing(1.5),
+    marginRight: theme.spacing(1.5),
   },
   divider: {
     margin: `${theme.spacing(2)} 0`,
@@ -207,6 +205,7 @@ export default function PrometheusEditor(props: PrometheusEditorProps) {
           />
           <Button
             className={classes.button}
+            variant="outlined"
             color="primary"
             size="small"
             target="_blank"
@@ -215,6 +214,7 @@ export default function PrometheusEditor(props: PrometheusEditorProps) {
           </Button>
           <Button
             className={classes.button}
+            variant="outlined"
             color="primary"
             size="small"
             onClick={toggleMode}>
@@ -258,37 +258,32 @@ const useSeverityMenuItemStyles = makeStyles({
     textTransform: 'capitalize',
   },
 });
-const useSeveritySelectStyles = makeStyles({
-  root: {
-    textTransform: 'capitalize',
-  },
-});
+
 function SeverityEditor(props: {
   onChange: InputChangeFunc;
   severity: string;
   options: Array<MenuItemProps>;
 }) {
-  const severitySelectClasses = useSeveritySelectStyles();
   const severityMenuItemClasses = useSeverityMenuItemStyles();
   return (
     <Grid item xs={3}>
-      <InputLabel htmlFor="severity-input" variant="standard">
-        Severity
-      </InputLabel>
-      <TextField
-        id="severity-input"
-        fullWidth
-        variant="standard"
-        required
-        select
-        value={props.severity}
-        onChange={props.onChange(value => ({severity: value}))}
-        classes={severitySelectClasses}>
-        {props.options.map(opt => (
-          // @ts-ignore somehow TypeScript does understand that ListItemClasses is a valid prop
-          <MenuItem {...opt} ListItemClasses={severityMenuItemClasses} />
-        ))}
-      </TextField>
+      <AltFormField disableGutters label="Severity">
+        <FormControl fullWidth>
+          <Select
+            id="severity-input"
+            fullWidth
+            variant="standard"
+            required
+            value={props.severity}
+            onChange={props.onChange(value => ({severity: value}))}
+            input={<OutlinedInput />}>
+            {props.options.map(opt => (
+              // @ts-ignore somehow TypeScript does understand that ListItemClasses is a valid prop
+              <MenuItem {...opt} ListItemClasses={severityMenuItemClasses} />
+            ))}
+          </Select>
+        </FormControl>
+      </AltFormField>
     </Grid>
   );
 }
@@ -319,14 +314,15 @@ function TimeNumberEditor(props: {
 }) {
   return (
     <Grid item xs={6}>
-      <InputLabel htmlFor="duration-input">Duration</InputLabel>
-      <Input
-        id="duration-input"
-        fullWidth
-        type="number"
-        value={isNaN(props.timeNumber) ? '' : props.timeNumber}
-        onChange={props.onChange(val => ({timeNumber: parseInt(val, 10)}))}
-      />
+      <AltFormField disableGutters label="Duration">
+        <OutlinedInput
+          id="duration-input"
+          fullWidth
+          type="number"
+          value={isNaN(props.timeNumber) ? '' : props.timeNumber}
+          onChange={props.onChange(val => ({timeNumber: parseInt(val, 10)}))}
+        />
+      </AltFormField>
       <FormHelperText>
         Amount of time that conditions are true before an alert is triggered
       </FormHelperText>
@@ -339,30 +335,29 @@ function TimeUnitEditor(props: {
   timeUnit: string;
   timeUnits: Array<TimeUnit>;
 }) {
-  const severitySelectClasses = useSeveritySelectStyles();
   const severityMenuItemClasses = useSeverityMenuItemStyles();
   return (
     <Grid item xs={3}>
-      <InputLabel htmlFor="unit-input" variant="standard">
-        Unit
-      </InputLabel>
-      <TextField
-        id="unit-input"
-        variant="standard"
-        fullWidth
-        select
-        value={props.timeUnit}
-        onChange={props.onChange(val => ({timeUnit: val}))}
-        classes={severitySelectClasses}>
-        {props.timeUnits.map(option => (
-          <MenuItem
-            key={option.value}
-            value={option.value}
-            classes={severityMenuItemClasses}>
-            {option.label}
-          </MenuItem>
-        ))}
-      </TextField>
+      <AltFormField disableGutters label="Unit">
+        <FormControl fullWidth>
+          <Select
+            id="unit-input"
+            variant="standard"
+            fullWidth
+            value={props.timeUnit}
+            onChange={props.onChange(val => ({timeUnit: val}))}
+            input={<OutlinedInput />}>
+            {props.timeUnits.map(option => (
+              <MenuItem
+                key={option.value}
+                value={option.value}
+                classes={severityMenuItemClasses}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </AltFormField>
     </Grid>
   );
 }

--- a/nms/app/views/alarms/components/rules/PrometheusEditor/ToggleableExpressionEditor.tsx
+++ b/nms/app/views/alarms/components/rules/PrometheusEditor/ToggleableExpressionEditor.tsx
@@ -17,28 +17,31 @@ import Autocomplete from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
-import Input from '@mui/material/Input';
-import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import RemoveCircleIcon from '@mui/icons-material/RemoveCircle';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
+import {AltFormField} from '../../../../../components/FormField';
+import {FormControl, OutlinedInput} from '@mui/material';
+import {InputChangeFunc} from './PrometheusEditor';
 import {LABEL_OPERATORS} from '../../prometheus/PromQLTypes';
+import {SelectProps} from '@mui/material/Select/Select';
 import {Theme} from '@mui/material/styles';
+import {getErrorMessage} from '../../../../../util/ErrorUtils';
 import {makeStyles} from '@mui/styles';
 import {useAlarmContext} from '../../AlarmContext';
 import {useNetworkId} from '../../hooks';
 import {useSnackbars} from '../../../../../hooks/useSnackbar';
-
-import {InputChangeFunc} from './PrometheusEditor';
-import {SelectProps} from '@mui/material/Select/Select';
-import {getErrorMessage} from '../../../../../util/ErrorUtils';
 import type {BinaryComparator} from '../../prometheus/PromQLTypes';
 
 const useStyles = makeStyles<Theme>(theme => ({
+  autocompleteInput: {
+    maxHeight: '36px',
+  },
   button: {
     marginLeft: -theme.spacing(0.5),
-    margin: theme.spacing(1.5),
+    marginBottom: theme.spacing(1.5),
+    marginRight: theme.spacing(1.5),
   },
   instructions: {
     marginTop: theme.spacing(1),
@@ -117,18 +120,15 @@ export function AdvancedExpressionEditor(props: {
 }) {
   return (
     <Grid item>
-      <InputLabel htmlFor="metric-advanced-input" variant="standard">
-        Expression
-      </InputLabel>
-      <TextField
-        variant="standard"
-        id="metric-advanced-input"
-        required
-        placeholder="SNR >= 0"
-        value={props.expression}
-        onChange={props.onChange(value => ({expression: value}))}
-        fullWidth
-      />
+      <AltFormField disableGutters label="Expression">
+        <OutlinedInput
+          fullWidth={true}
+          value={props.expression}
+          onChange={props.onChange(value => ({expression: value}))}
+          placeholder="SNR >= 0"
+          id="metric-advanced-input"
+        />
+      </AltFormField>
     </Grid>
   );
 }
@@ -147,31 +147,28 @@ function ConditionSelector(props: {
   ];
   return (
     <Grid>
-      <InputLabel htmlFor="condition-input" variant="standard">
-        Condition
-      </InputLabel>
-      <TextField
-        id="condition-input"
-        variant="standard"
-        fullWidth
-        required
-        select
-        value={props.expression.comparator.op}
-        onChange={({target}) => {
-          props.onChange({
-            ...props.expression,
-            comparator: new PromQL.BinaryComparator(
-              // Cast to element type of conditions as it's item type
-              target.value as typeof conditions[number],
-            ),
-          });
-        }}>
-        {conditions.map(item => (
-          <MenuItem key={item} value={item}>
-            {item}
-          </MenuItem>
-        ))}
-      </TextField>
+      <AltFormField disableGutters label="Conditions">
+        <FormControl fullWidth>
+          <Select
+            value={props.expression.comparator.op}
+            onChange={({target}) => {
+              props.onChange({
+                ...props.expression,
+                comparator: new PromQL.BinaryComparator(
+                  // Cast to element type of conditions as it's item type
+                  target.value as typeof conditions[number],
+                ),
+              });
+            }}
+            input={<OutlinedInput />}>
+            {conditions.map(item => (
+              <MenuItem key={item} value={item}>
+                {item}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </AltFormField>
     </Grid>
   );
 }
@@ -182,22 +179,20 @@ function ValueSelector(props: {
 }) {
   return (
     <Grid item>
-      <InputLabel htmlFor="value-input" variant="standard">
-        Value
-      </InputLabel>
-      <TextField
-        variant="standard"
-        id="value-input"
-        fullWidth
-        value={props.expression.value}
-        type="number"
-        onChange={({target}) => {
-          props.onChange({
-            ...props.expression,
-            value: parseFloat(target.value),
-          });
-        }}
-      />
+      <AltFormField disableGutters label="Value">
+        <OutlinedInput
+          id="value-input"
+          fullWidth
+          value={props.expression.value}
+          type="number"
+          onChange={({target}) => {
+            props.onChange({
+              ...props.expression,
+              value: parseFloat(target.value),
+            });
+          }}
+        />
+      </AltFormField>
     </Grid>
   );
 }
@@ -208,23 +203,29 @@ function MetricSelector(props: {
   metricNames: Array<string>;
 }) {
   const {metricNames} = props;
+  const classes = useStyles();
+
   return (
     <Grid item>
-      <InputLabel htmlFor="metric-input" variant="standard">
-        Metric
-      </InputLabel>
-      <Autocomplete
-        id="metric-input"
-        options={metricNames}
-        groupBy={getMetricNamespace}
-        value={props.expression.metricName}
-        onChange={(_e, value) => {
-          props.onChange({...props.expression, metricName: value!});
-        }}
-        renderInput={params => (
-          <TextField {...params} required variant="standard" />
-        )}
-      />
+      <AltFormField disableGutters label="Metric">
+        <Autocomplete
+          id="metric-input"
+          options={metricNames}
+          groupBy={getMetricNamespace}
+          value={props.expression.metricName}
+          onChange={(_e, value) => {
+            props.onChange({...props.expression, metricName: value!});
+          }}
+          renderInput={params => (
+            <TextField
+              className={classes.autocompleteInput}
+              {...params}
+              required
+              variant="outlined"
+            />
+          )}
+        />
+      </AltFormField>
     </Grid>
   );
 }
@@ -327,6 +328,7 @@ function MetricFilters(props: {
       <Grid item>
         <Button
           className={classes.button}
+          variant="outlined"
           color="primary"
           size="small"
           disabled={!isMetricSelected}
@@ -342,6 +344,7 @@ function MetricFilters(props: {
         </Button>
         <Button
           className={classes.button}
+          variant="outlined"
           color="primary"
           size="small"
           onClick={props.onToggleChange}>
@@ -382,92 +385,90 @@ function LabelFilter(props: {
   selectedLabel: string;
   selectedValue: string;
 }) {
+  const classes = useStyles();
   const currentFilter = props.expression.filters.labels[props.filterIdx];
   const values = Array.from(props.labelValues.get(props.selectedLabel) ?? []);
   return (
     <Grid item container xs={12} spacing={1} alignItems="flex-start">
       <Grid item xs={6}>
-        <InputLabel htmlFor={`metric-input-${props.filterIdx}`}>
-          Label
-        </InputLabel>
-        <FilterSelector
-          id={`metric-input-${props.filterIdx}`}
-          values={props.labelNames}
-          defaultVal=""
-          onChange={({target}) => {
-            const filtersCopy = props.expression.filters.copy();
-            filtersCopy.setIndex(props.filterIdx, target.value, '');
-            props.onChange({...props.expression, filters: filtersCopy});
-          }}
-          selectedValue={props.selectedLabel}
-        />
+        <AltFormField disableGutters label="Label">
+          <FilterSelector
+            id={`metric-input-${props.filterIdx}`}
+            values={props.labelNames}
+            defaultVal=""
+            onChange={({target}) => {
+              const filtersCopy = props.expression.filters.copy();
+              filtersCopy.setIndex(props.filterIdx, target.value, '');
+              props.onChange({...props.expression, filters: filtersCopy});
+            }}
+            selectedValue={props.selectedLabel}
+          />
+        </AltFormField>
       </Grid>
       <Grid item xs={2}>
         <Grid>
-          <InputLabel
-            htmlFor={`condition-input-${props.filterIdx}`}
-            variant="standard">
-            Condition
-          </InputLabel>
-          <TextField
-            variant="standard"
-            id={`condition-input-${props.filterIdx}`}
-            fullWidth
-            required
-            select
-            value={currentFilter.operator}
-            onChange={({target}) => {
-              const filtersCopy = props.expression.filters.copy();
-              const filterOperator = isRegexValue(target.value) ? '=~' : '=';
-              filtersCopy.setIndex(
-                props.filterIdx,
-                currentFilter.name,
-                currentFilter.value,
-                filterOperator,
-              );
-              props.onChange({...props.expression, filters: filtersCopy});
-            }}>
-            {LABEL_OPERATORS.map(item => (
-              <MenuItem key={item} value={item}>
-                {item}
-              </MenuItem>
-            ))}
-          </TextField>
+          <AltFormField disableGutters label="Condition">
+            <FormControl fullWidth>
+              <Select
+                id={`condition-input-${props.filterIdx}`}
+                fullWidth
+                required
+                value={currentFilter.operator}
+                onChange={({target}) => {
+                  const filtersCopy = props.expression.filters.copy();
+                  const filterOperator = isRegexValue(target.value)
+                    ? '=~'
+                    : '=';
+                  filtersCopy.setIndex(
+                    props.filterIdx,
+                    currentFilter.name,
+                    currentFilter.value,
+                    filterOperator,
+                  );
+                  props.onChange({...props.expression, filters: filtersCopy});
+                }}
+                input={<OutlinedInput />}>
+                {LABEL_OPERATORS.map(item => (
+                  <MenuItem key={item} value={item}>
+                    {item}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </AltFormField>
         </Grid>
       </Grid>
       <Grid item xs={3}>
         <Grid item>
-          <InputLabel
-            htmlFor={`value-input-${props.filterIdx}`}
-            variant="standard">
-            Value
-          </InputLabel>
-          <Autocomplete
-            value={currentFilter.value}
-            freeSolo
-            options={values}
-            onChange={(_e, value) => {
-              const filtersCopy = props.expression.filters.copy();
-              filtersCopy.setIndex(
-                props.filterIdx,
-                currentFilter.name,
-                value!,
-                currentFilter.operator,
-              );
-              props.onChange({
-                ...props.expression,
-                filters: filtersCopy,
-              });
-            }}
-            renderInput={params => (
-              <TextField
-                {...params}
-                variant="standard"
-                required
-                id={`value-input-${props.filterIdx}`}
-              />
-            )}
-          />
+          <AltFormField disableGutters label="Metric">
+            <Autocomplete
+              value={currentFilter.value}
+              freeSolo
+              options={values}
+              onChange={(_e, value) => {
+                const filtersCopy = props.expression.filters.copy();
+                filtersCopy.setIndex(
+                  props.filterIdx,
+                  currentFilter.name,
+                  value!,
+                  currentFilter.operator,
+                );
+                props.onChange({
+                  ...props.expression,
+                  filters: filtersCopy,
+                });
+              }}
+              renderInput={params => (
+                <TextField
+                  {...params}
+                  variant="outlined"
+                  required
+                  className={classes.autocompleteInput}
+                  id={`value-input-${props.filterIdx}`}
+                />
+              )}
+            />
+          </AltFormField>
         </Grid>
       </Grid>
       <Grid item xs={1} container alignItems="center" justifyContent="flex-end">
@@ -505,7 +506,7 @@ function FilterSelector(props: {
       displayEmpty
       className={classes.metricFilterItem}
       value={props.selectedValue}
-      input={<Input />}
+      input={<OutlinedInput />}
       onChange={props.onChange as SelectProps['onChange']}>
       <MenuItem disabled value="">
         {props.defaultVal}

--- a/nms/app/views/alarms/components/rules/RuleEditorBase.tsx
+++ b/nms/app/views/alarms/components/rules/RuleEditorBase.tsx
@@ -20,14 +20,14 @@ import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
 import Editor from '../common/Editor';
 import Grid from '@mui/material/Grid';
-import InputLabel from '@mui/material/InputLabel';
 import LabelsEditor from './LabelsEditor';
 import RuleContext from './RuleContext';
 import SelectReceiver from '../alertmanager/Receivers/SelectReceiver';
 import SelectRuleType from './SelectRuleType';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import useForm from '../../hooks/useForm';
+import {AltFormField} from '../../../../components/FormField';
+import {OutlinedInput} from '@mui/material';
 import {useAlarmContext} from '../AlarmContext';
 import {useAlertRuleReceiver} from '../hooks';
 
@@ -92,32 +92,26 @@ export default function RuleEditorBase({
             <Card>
               <CardHeader title="Summary" />
               <CardContent>
-                <Grid item>
-                  <TextField
-                    id="rulename"
-                    variant="standard"
-                    disabled={!isNew}
-                    required
-                    label="Rule Name"
-                    placeholder="Ex: Link down"
-                    fullWidth
+                <AltFormField disableGutters label="Rule Name">
+                  <OutlinedInput
+                    fullWidth={true}
                     value={formState.name}
                     onChange={handleInputChange(val => ({name: val as string}))}
-                  />
-                </Grid>
-                <Grid item>
-                  <TextField
-                    variant="standard"
+                    placeholder="Link down"
                     disabled={!isNew}
-                    label="Description"
-                    placeholder="Ex: The link is down"
-                    fullWidth
+                  />
+                </AltFormField>
+                <AltFormField disableGutters label="Description">
+                  <OutlinedInput
+                    fullWidth={true}
                     value={formState.description}
                     onChange={handleInputChange(val => ({
                       description: val as string,
                     }))}
+                    placeholder="The link is down"
+                    disabled={!isNew}
                   />
-                </Grid>
+                </AltFormField>
               </CardContent>
             </Card>
           </Grid>
@@ -163,7 +157,6 @@ export default function RuleEditorBase({
               <CardContent>
                 <Grid container direction="column" spacing={2}>
                   <Grid item>
-                    <InputLabel variant="standard">Audience</InputLabel>
                     <SelectReceiver
                       fullWidth
                       receiver={receiver}

--- a/nms/app/views/alarms/components/rules/__tests__/LabelsEditor-test.tsx
+++ b/nms/app/views/alarms/components/rules/__tests__/LabelsEditor-test.tsx
@@ -13,6 +13,10 @@
 
 import * as React from 'react';
 import LabelsEditor from '../LabelsEditor';
+import defaultTheme from '../../../../../theme/default';
+
+import {StyledEngineProvider, ThemeProvider} from '@mui/material/styles';
+
 import {act, fireEvent, render} from '@testing-library/react';
 
 const commonProps = {
@@ -20,9 +24,39 @@ const commonProps = {
   onChange: jest.fn(),
 };
 
+const WrapperTwoKeys = () => (
+  <StyledEngineProvider injectFirst>
+    <ThemeProvider theme={defaultTheme}>
+      <LabelsEditor
+        {...commonProps}
+        labels={{
+          testKey1: 'testVal1',
+          testKey2: 'testVal2',
+        }}
+      />
+    </ThemeProvider>
+  </StyledEngineProvider>
+);
+const WrapperOneKey = () => (
+  <StyledEngineProvider injectFirst>
+    <ThemeProvider theme={defaultTheme}>
+      <LabelsEditor
+        {...commonProps}
+        labels={{
+          testKey1: 'testVal1',
+        }}
+      />
+    </ThemeProvider>
+  </StyledEngineProvider>
+);
+
 test('clicking the add button adds new textboxes', () => {
   const {getByTestId, queryAllByPlaceholderText} = render(
-    <LabelsEditor {...commonProps} />,
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={defaultTheme}>
+        <LabelsEditor {...commonProps} />
+      </ThemeProvider>
+    </StyledEngineProvider>,
   );
   expect(queryAllByPlaceholderText(/name/i).length).toBe(0);
   expect(queryAllByPlaceholderText(/value/i).length).toBe(0);
@@ -40,15 +74,7 @@ test('clicking the add button adds new textboxes', () => {
 });
 
 test('typing into a key field edits the key of a label', () => {
-  const {getByDisplayValue} = render(
-    <LabelsEditor
-      {...commonProps}
-      labels={{
-        testKey1: 'testVal1',
-        testKey2: 'testVal2',
-      }}
-    />,
-  );
+  const {getByDisplayValue} = render(<WrapperTwoKeys />);
 
   act(() => {
     fireEvent.change(getByDisplayValue('testKey1'), {
@@ -67,15 +93,7 @@ test('typing into a key field edits the key of a label', () => {
 });
 
 test('spaces in the key field are replaced by underscores', () => {
-  const {getByDisplayValue} = render(
-    <LabelsEditor
-      {...commonProps}
-      labels={{
-        testKey1: 'testVal1',
-        testKey2: 'testVal2',
-      }}
-    />,
-  );
+  const {getByDisplayValue} = render(<WrapperTwoKeys />);
 
   act(() => {
     fireEvent.change(getByDisplayValue('testKey1'), {
@@ -94,15 +112,7 @@ test('spaces in the key field are replaced by underscores', () => {
 });
 
 test('typing into a value field edits the value of a label', () => {
-  const {getByDisplayValue} = render(
-    <LabelsEditor
-      {...commonProps}
-      labels={{
-        testKey1: 'testVal1',
-        testKey2: 'testVal2',
-      }}
-    />,
-  );
+  const {getByDisplayValue} = render(<WrapperTwoKeys />);
 
   act(() => {
     fireEvent.change(getByDisplayValue('testVal1'), {
@@ -120,14 +130,7 @@ test('typing into a value field edits the value of a label', () => {
   });
 });
 test('labels without a key are filtered out', () => {
-  const {getByTestId, queryAllByPlaceholderText} = render(
-    <LabelsEditor
-      {...commonProps}
-      labels={{
-        testKey1: 'testVal1',
-      }}
-    />,
-  );
+  const {getByTestId, queryAllByPlaceholderText} = render(<WrapperOneKey />);
   expect(queryAllByPlaceholderText(/name/i).length).toBe(1);
   act(() => {
     fireEvent.click(getByTestId('add-new-label'));
@@ -144,14 +147,7 @@ test('labels without a key are filtered out', () => {
   });
 });
 test('clicking the remove label button removes a label', () => {
-  const {getByLabelText, queryByLabelText} = render(
-    <LabelsEditor
-      {...commonProps}
-      labels={{
-        testKey1: 'testVal1',
-      }}
-    />,
-  );
+  const {getByLabelText, queryByLabelText} = render(<WrapperOneKey />);
   act(() => {
     fireEvent.click(getByLabelText(/remove label/i));
   });

--- a/nms/app/views/alarms/components/table/TableActionDialog.tsx
+++ b/nms/app/views/alarms/components/table/TableActionDialog.tsx
@@ -68,7 +68,7 @@ export default function TableActionDialog<TRow>(props: Props<TRow>) {
         {additionalContent}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} color="primary">
+        <Button variant="outlined" onClick={onClose} color="primary">
           {showDeleteButton ? 'Cancel' : 'Close'}
         </Button>
         {showCopyButton && (


### PR DESCRIPTION
## Summary

- Use the same input as the rest of NMS for alert rules create/edit
- closes #13491 

Old style: 
<img width="1358" alt="Capture d’écran 2022-08-31 à 17 46 20" src="https://user-images.githubusercontent.com/26038920/187721923-aa50b4ec-815a-423a-9f05-8992601f1fba.png">


New style: 
<img width="1354" alt="Capture d’écran 2022-08-31 à 18 01 29" src="https://user-images.githubusercontent.com/26038920/187725149-a4877690-0775-4c4d-89fb-7973820e5e7c.png">
<img width="1332" alt="Capture d’écran 2022-08-31 à 17 56 00" src="https://user-images.githubusercontent.com/26038920/187725150-22a12829-16e2-4a36-b3f8-35d132eaf363.png">



## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
