### PR TITLE
fix(agw): Downgrade sentry-sdk, grpcio and spyne

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -102,7 +102,7 @@ setup(
         # lxml required by spyne.
         'lxml==4.9.1',
         'ryu>=4.34',
-        'spyne>=2.14.0',
+        'spyne>=2.13,<2.14',
         'scapy==2.4.5',
         'flask==1.1.4',
         'sentry_sdk>=1.5.0,<1.9',
@@ -134,7 +134,7 @@ setup(
     ],
     extras_require={
         'dev': [
-            'grpcio-tools>=1.47.0',
+            'grpcio-tools>=1.46.3',
             'coverage==6.4.2',
             'iperf3>=0.1.11',
             'parameterized==0.8.1',

--- a/lte/gateway/release/magma.lockfile.ubuntu
+++ b/lte/gateway/release/magma.lockfile.ubuntu
@@ -686,7 +686,7 @@
           "root": true,
           "source": "pypi",
           "sysdep": "python3-grpcio",
-          "version": "1.47.0"
+          "version": "1.46.3"
         },
         "h2": {
           "root": true,
@@ -1010,7 +1010,7 @@
           "root": true,
           "source": "pypi",
           "sysdep": "python3-sentry-sdk",
-          "version": "1.9.0"
+          "version": "1.5.4"
         },
         "simplejson": {
           "root": false,
@@ -1038,9 +1038,9 @@
         },
         "spyne": {
           "root": true,
-          "source": "pypi",
+          "source": "apt",
           "sysdep": "python3-spyne",
-          "version": "2.14.0"
+          "version": "2.13.16"
         },
         "strict-rfc3339": {
           "root": true,
@@ -1159,7 +1159,7 @@
           "version": "1.2.1"
         },
         "grpcio": {
-          "version": "1.47.0"
+          "version": "1.46.3"
         },
         "idna": {
           "version": "3.3"
@@ -1246,7 +1246,7 @@
           "version": "2.4.5"
         },
         "sentry-sdk": {
-          "version": "1.9.0"
+          "version": "1.5.4"
         },
         "setuptools": {
           "version": "63.3.0"
@@ -1258,7 +1258,7 @@
           "version": "0.0.3"
         },
         "spyne": {
-          "version": "2.14.0"
+          "version": "2.13.16"
         },
         "strict-rfc3339": {
           "version": "0.7"

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -69,7 +69,7 @@ setup(
         'redis-collections==0.11.0',
         'python-redis-lock>=3.7.0',
         'aiohttp>=3.8.1',
-        'grpcio>=1.47.0',
+        'grpcio>=1.46.3',
         'protobuf==3.20.1',
         'Jinja2==2.11.3',
         'markupsafe==1.1.1',


### PR DESCRIPTION
## Summary

The Python dependency upgrades generated a broken magma Debian package with higher dependencies that could not be fulfilled (see #13787).

Additionally, the new version of spyne breaks the CI due to permission issues.

## Test Plan

- [x] Build magma deb locally and check versions
  - [x] Install the built magma deb
- [x] Running build-all on fork https://github.com/sebathomas/magma/runs/8117658950

## Additional Information

- [ ] This change is backwards-breaking
