### PR TITLE
fix(agw): Fix reinstall logic and error handling in pydep

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -131,11 +131,8 @@ def package(
 
         run('rm -rf ~/magma-packages')
         run('mkdir -p ~/magma-packages')
-        try:
+        with settings(warn_only=True):
             run('cp -f ~/magma-deps/*.deb ~/magma-packages')
-        except Exception:
-            # might be a problem if no deps found, but don't handle here
-            pass
         run('mv *.deb ~/magma-packages')
 
         with cd('release'):
@@ -149,11 +146,7 @@ def package(
                 'cat {}'.format(mirrored_packages_file)
                 + ' | xargs -I% sudo aptitude download -q2 %',
             )
-            try:
-                run('cp *.deb ~/magma-packages')
-            except Exception:
-                # might be a problem if no deps found, but don't handle here
-                pass
+            run('cp *.deb ~/magma-packages')
             run('sudo rm -f *.deb')
 
         if all_deps:

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -149,7 +149,11 @@ def package(
                 'cat {}'.format(mirrored_packages_file)
                 + ' | xargs -I% sudo aptitude download -q2 %',
             )
-            run('cp *.deb ~/magma-packages')
+            try:
+                run('cp *.deb ~/magma-packages')
+            except Exception:
+                # might be a problem if no deps found, but don't handle here
+                pass
             run('sudo rm -f *.deb')
 
         if all_deps:

--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -1086,7 +1086,7 @@ def main(args):
             pip_packages = [req.key for req in repo_installable]
             subprocess.call(shlex.split('sudo pip3 uninstall -y '
                                         + ' '.join(pip_packages)))
-            subprocess.call(shlex.split('sudo apt install -y '
+            subprocess.call(shlex.split('sudo apt reinstall -y '
                                         + ' '.join(repo_pkgs)))
         except Exception:
             log.error('error trying to install repo packages')


### PR DESCRIPTION
Follow up to:
https://github.com/magma/magma/pull/13795

See also:
https://github.com/magma/magma/issues/13787

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Changed the `pydep` script to reinstall all packages with apt since already installed packages might not be registered with python. This solves an issue in the build process where the uninstallation of "idna" breaks some Python scripts.
- Fixed the error handling of fabric (catching exceptions does not work) so the script can run even if no new dependencies are built.

## Test Plan

I made a temporary change to trigger the AGW build workflow.

https://github.com/sebathomas/magma/actions/runs/2971214324

## Additional Information

- [ ] This change is backwards-breaking