### PR TITLE
fix(ci): Build and set up the scripts needed to run services in the bazel LTE integ test workflow

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -79,13 +79,17 @@ jobs:
           export MAGMA_DEV_CPUS=3
           export MAGMA_DEV_MEMORY_MB=9216
           fab bazel_integ_test_pre_build
-      - name: Build all services with bazel
+      - name: Build all services and scripts with bazel
         run: |
           cd lte/gateway
           vagrant ssh -c 'cd ~/magma; bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}";' magma
           vagrant ssh -c 'sudo sed -i "s@#precedence ::ffff:0:0/96  100@precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
           vagrant ssh -c 'cd ~/magma; bazel build --profile=bazel_profile_lte_integ_tests `bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/...)"`;' magma
           vagrant ssh -c 'sudo sed -i "s@precedence ::ffff:0:0/96  100@#precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
+      - name: Linking bazel-built script executables to '/usr/local/bin/'
+        run: |
+          cd lte/gateway
+          vagrant ssh -c 'cd ~/magma; bazel/scripts/link_scripts_for_bazel_integ_tests.sh;' magma
       - name: Run the sudo tests
         id: sudo_tests
         run: |

--- a/bazel/scripts/link_scripts_for_bazel_integ_tests.sh
+++ b/bazel/scripts/link_scripts_for_bazel_integ_tests.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -euo pipefail
+
+###############################################################################
+# FUNCTION DECLARATIONS
+###############################################################################
+
+get_python_scripts() {
+    echo "Collecting script targets..."
+    mapfile -t PYTHON_SCRIPTS < <(bazel query "kind(.*_binary, \
+        //orc8r/gateway/python/scripts/... union \
+        //lte/gateway/python/scripts/... )")
+}
+
+format_targets_to_paths() {
+    for INDEX in "${!PYTHON_SCRIPTS[@]}"
+    do
+        # Strip leading '//'
+        PYTHON_SCRIPTS[INDEX]="${PYTHON_SCRIPTS[INDEX]/\/\//}"
+        # Replace ':' with '/'
+        PYTHON_SCRIPTS[INDEX]="${PYTHON_SCRIPTS[INDEX]/://}"
+    done
+}
+
+create_links() {
+    echo "Linking bazel-built script executables to '/usr/local/bin/'..."
+    for PYTHON_SCRIPT in "${PYTHON_SCRIPTS[@]}"
+    do
+        sudo ln -sf "/home/vagrant/magma/bazel-bin/${PYTHON_SCRIPT}" "/usr/local/bin/$(basename "${PYTHON_SCRIPT}").py"
+    done
+    echo "Linking finished."
+}
+
+mock_virtualenv() {
+    # The virtualenv is not needed with bazel. Until the switchover
+    # to bazel is complete, this creates an empty file that can
+    # be sourced, without failure, in the LTE integration tests.
+    # See https://github.com/magma/magma/issues/13807
+    mkdir -p /home/vagrant/build/python/bin/
+    touch /home/vagrant/build/python/bin/activate
+}
+
+###############################################################################
+# SCRIPT SECTION
+###############################################################################
+
+PYTHON_SCRIPTS=()
+
+get_python_scripts
+format_targets_to_paths
+create_links
+mock_virtualenv


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Fix the broken Bazel LTE integ test workflow by building and setting up the needed scripts used in service definitions.
- In the PR https://github.com/magma/magma/pull/13772 a Make call was removed that also set up a python env.
  - With bazel this is not needed, but the scripts have to be build with bazel instead. 


## Test Plan

- [x] Running selected LTE integ tests locally.
- [x] [LTE integ tests](https://github.com/LKreutzer/magma/runs/8138367565?check_suite_focus=true)
  - Some individual test failures, but overall the issue was fixed (i.e. the services are running.) 
    - `test_ipv6_paging_with_dedicated_bearer`
    - `test_ipv4v6_paging_with_dedicated_bearer`
    - These are failing locally as well.

## Additional Information

- https://github.com/magma/magma/issues/13807

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
