### PR TITLE
feat(ci): Add federated integ test for HSS

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -308,7 +308,15 @@ s1aptests/test_attach_emergency.py \
 s1aptests/test_attach_detach_after_ue_context_release.py \
 s1aptests/test_attach_esm_information_wrong_apn.py \
 s1aptests/test_attach_detach_secondary_pdn_invalid_apn.py \
-s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
+s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py \
+s1aptests/test_attach_service_without_mac.py \
+s1aptests/test_attach_mme_restart_detach_multi_ue.py \
+s1aptests/test_attach_detach_with_mme_restart.py \
+s1aptests/test_attach_detach_looped.py \
+s1aptests/test_attach_ipv4v6_pdn_type.py \
+s1aptests/test_standalone_pdn_conn_req.py \
+s1aptests/test_attach_detach_dedicated_multi_ue.py \
+s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_imsi.py
 
 
 CLOUD_TESTS = cloud_tests/checkin_test.py \


### PR DESCRIPTION
Signed-off-by: kharade <rohan.kharade@openairinterface.org>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Merge after https://github.com/magma/magma/pull/13781
<!-- Enumerate changes you made and why you made them -->
This PR adds Federated Integ Test  to validate HSS s6a interface. Here we are reusing existing  [lte-integ-tests](https://github.com/magma/magma/tree/master/lte/gateway/python/integ_tests/s1aptests) in fedrated mode.
#### Following tests are added in this PR which leverages HSS s6a interface over federated gateway -
```bash
test_attach_service_without_mac.py
test_attach_detach_with_mme_restart.py
test_attach_mme_restart_detach_multi_ue.py
test_attach_detach_looped.py
test_attach_ipv4v6_pdn_type.py
test_standalone_pdn_conn_req.py
test_attach_detach_dedicated_multi_ue.py
test_attach_detach_dedicated_bearer_deactivation_invalid_imsi.py
```
## Test Plan

We are reusing some of existing and relevant tests from  lte-integ-tests. The [sheet attached](https://docs.google.com/spreadsheets/d/1oI1FvX1AFaYQDuH85oMJsCu7X20tox248mXsuCFes0c/edit#gid=0) describes the priority and relevancy of tests. Please feel free to update sheet accordingly.

Following tests are already introduced in master 
```bash
test_attach_auth_failure.py
test_no_auth_response.py
test_nas_non_delivery_for_auth.py
test_sctp_abort_after_auth_req.py
test_sctp_shutdown_after_auth_req.py
test_no_auth_resp_with_mme_restart_reattach.py
test_send_error_ind_for_dl_nas_with_auth_req.py
test_attach_auth_mac_failure.py
test_no_auth_response_with_mme_restart.py
test_no_security_mode_complete.py
test_no_attach_complete.py
test_attach_detach_security_algo_eea0_eia0.py
test_attach_detach_security_algo_eea1_eia1.py
test_attach_detach_security_algo_eea2_eia2.py
test_attach_security_mode_reject.py
test_attach_missing_imsi.py
test_duplicate_attach.py
test_attach_emergency.py
test_attach_detach_after_ue_context_release.py
test_attach_esm_information_wrong_apn.py
test_attach_detach_secondary_pdn_invalid_apn.py
test_standalone_pdn_conn_req_with_apn_correction.py
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
