### PR TITLE
chore: magma vm is based on focal-1.8.0 dist

### DIFF
--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -59,7 +59,7 @@
 
 - name: Configuring the registry in sources.list.d
   ansible.builtin.shell:
-    cmd: echo 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main' > /etc/apt/sources.list.d/magma.list
+    cmd: echo 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-1.8.0 main' > /etc/apt/sources.list.d/magma.list
 
 - name: Update apt
   apt:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Makes the magma vm based on the 1.8.0 dist on the 1.8 branch.

**Attention**
* this might produce errors in workflows that are using the magma vm
* manually tested for the `build_all` workflow -> produced magma debian package was at least installable

## Test Plan

monitor workflows that uses the magma vm, e.g., lte, cwf, feg integ tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
