### PR TITLE
fix(agw): Fix spyne version in pydep lockfile

### DIFF
--- a/lte/gateway/release/magma.lockfile.ubuntu
+++ b/lte/gateway/release/magma.lockfile.ubuntu
@@ -1040,7 +1040,7 @@
           "root": true,
           "source": "apt",
           "sysdep": "python3-spyne",
-          "version": "2.13.16"
+          "version": "2.13.15"
         },
         "strict-rfc3339": {
           "root": true,
@@ -1258,7 +1258,7 @@
           "version": "0.0.3"
         },
         "spyne": {
-          "version": "2.13.16"
+          "version": "2.13.15"
         },
         "strict-rfc3339": {
           "version": "0.7"


### PR DESCRIPTION
## Summary

The CI still builds a Magma package with a higher spyne dependency than what is available in artifactory. This may be because the local run generating the lockfile in #13795 obtained a higher version than the run in the CI that only worked after other issues were fixed in #13799.

## Test Plan

- [x] Run build-all with these changes and check the spyne version dependency.
  Build at https://github.com/sebathomas/magma/actions/runs/2977149782
  Result depends on "python3-spyne >= 2.13.15"

## Additional Information

- [ ] This change is backwards-breaking