### PR TITLE
fix(cwg): the ovs python dependency should be 'python3-openvswitch'

### DIFF
--- a/cwf/gateway/deploy/roles/ovs/tasks/debian.yml
+++ b/cwf/gateway/deploy/roles/ovs/tasks/debian.yml
@@ -44,7 +44,7 @@
        - libopenvswitch
        - openvswitch-common
        - openvswitch-switch
-       - python-openvswitch
+       - python3-openvswitch
        - openvswitch-datapath-dkms
 
 - name: Ensure OVS switch will not auto-upgrade


### PR DESCRIPTION
The cwf ansible roles install an outdated debian package `'python-openvswitch'` but instead it should use `'python3-openvswitch'`.

Relevant conversation in slack: https://magmacore.slack.com/archives/C0301NRRL7K/p1662101143133319

Relevant broken build: https://github.com/magma/magma/actions/runs/2974469097