### PR TITLE
fix(agw): Reload magma_deb when provisioning

### DIFF
--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -42,7 +42,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    pyenv install 3.8.10
    pyenv global 3.8.10
    pip3 install ansible fabric3 jsonpickle requests PyYAML
-   vagrant plugin install vagrant-vbguest vagrant-disksize
+   vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
    ```
 
    **Note**: In the case where installation of `fabric3` through pip was unsuccessful,
@@ -150,7 +150,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
 5. Install `vagrant` necessary plugin.
 
    ```bash
-   vagrant plugin install vagrant-vbguest
+   vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
    ```
 
     Make sure `virtualbox` is the default provider for `vagrant` by adding the following line to your `.bashrc` (or equivalent) and restart your shell: `export VAGRANT_DEFAULT_PROVIDER="virtualbox"`.

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -236,6 +236,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                               ["--timeout=30"]
       ansible.verbose = 'v'
     end
+
+    # Reload VM to apply correct network configuration
+    magma_deb.vm.provision :reload
+    
   end
 
 end

--- a/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
@@ -152,7 +152,3 @@
     - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_sessiond.service', dest: 'magma@sessiond.service' }
     - { src: 'orc8r/tools/ansible/roles/fluent_bit/files/magma_td-agent-bit.service', dest: 'magma@td-agent-bit.service' }
     - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_dp_envoy.service', dest: 'magma_dp@envoy.service' }
-
-- name: Reboot the machine (Wait for 180s)
-  ansible.builtin.reboot:
-    reboot_timeout: 180


### PR DESCRIPTION
## Summary

Reloads the magma_deb VM at the end of the provisioning. Without this change, the network interfaces are not configured properly and are only reconfigured after doing `vagrant reload magma_deb` for the first time.  

## Test Plan

1. Without this change, `sudo service magma@mobilityd restart` leads to mobilityd restarting only after 90s, which is the systemd timeout. With this change, it restarts immediately. See https://github.com/magma/magma/issues/13826.

2. Before this change, integration tests would fail in clusters when running them versus magma_deb due to mobilityd not restarting immediately. After this change, running the precommit tests leads to some failures, but no longer in clusters.

```
SUMMARY: 104/117 tests were successful.
```


