### PR TITLE
fix(ci): Trigger all bazel workflow jobs by pushing to master

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -63,11 +63,10 @@ jobs:
 
   bazel_build_and_test:
     needs: path_filter
-    # Only run workflow if this is a scheduled run on master branch,
-    # if the workflow has been triggered manually or if it is a pull_request
-    # that skip-duplicate-action wants to run again.
+    # Only run workflow if this is a push to the magma repository,
+    # if the workflow has been triggered manually or if it is a pull_request.
     if: |
-      (github.event_name == 'schedule' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'push' && github.repository_owner == 'magma') ||
       needs.path_filter.outputs.files_changed == 'true' ||
       github.event_name == 'workflow_dispatch'
     strategy:
@@ -163,7 +162,7 @@ jobs:
           echo "Available storage:"
           df -h
       - name: Notify failure to slack
-        if: failure() && (github.event_name == 'push' || github.event_name == 'schedule') && github.repository_owner == 'magma'
+        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
@@ -219,11 +218,10 @@ jobs:
 
   bazel_package:
     needs: path_filter
-    # Only run workflow if this is a scheduled run on master branch,
-    # if the workflow has been triggered manually or if it is a pull_request
-    # that skip-duplicate-action wants to run again.
+    # Only run workflow if this is a push to the magma repository,
+    # if the workflow has been triggered manually or if it is a pull_request.
     if: |
-      (github.event_name == 'schedule' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'push' && github.repository_owner == 'magma') ||
       needs.path_filter.outputs.files_changed == 'true' ||
       github.event_name == 'workflow_dispatch'
     name: Bazel Package Job
@@ -266,7 +264,7 @@ jobs:
           echo "Available storage:"
           df -h
       - name: Notify failure to slack
-        if: failure() && (github.event_name == 'push' || github.event_name == 'schedule') && github.repository_owner == 'magma'
+        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
@@ -288,7 +286,7 @@ jobs:
         run: |
           ./bazel/scripts/check_py_bazel.sh
       - name: Notify failure to slack
-        if: failure() && (github.event_name == 'push' || github.event_name == 'schedule') && github.repository_owner == 'magma'
+        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
@@ -310,7 +308,7 @@ jobs:
         run: |
           ./bazel/scripts/check_c_cpp_bazel.sh
       - name: Notify failure to slack
-        if: failure() && (github.event_name == 'push' || github.event_name == 'schedule') && github.repository_owner == 'magma'
+        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The bazel workflow is currently triggered on master by pushes but the individual jobs still have references to `github.event_name == 'schedule'`, these are replaced by `github.event_name == 'push'`
  - This error was introduced in https://github.com/magma/magma/pull/13751
- Some minor other clean up of the if conditions 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
