### PR TITLE
fix(agw): Modified code to fix compilation error on inclusion of proto_map.h file and removed unused file, sgw.h and unused structure

### DIFF
--- a/lte/gateway/c/core/oai/include/sgw_context_manager.hpp
+++ b/lte/gateway/c/core/oai/include/sgw_context_manager.hpp
@@ -23,15 +23,18 @@
  */
 #pragma once
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
-
 #include "lte/gateway/c/core/common/common_defs.h"
-#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.007.h"
+#ifdef __cplusplus
+}
+#endif
+
+#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 
 #define INITIAL_SGW_S8_S1U_TEID 0x7FFFFFFF
 void sgw_display_sgw_eps_bearer_context(
@@ -61,7 +64,3 @@ spgw_ue_context_t* spgw_get_ue_context(imsi64_t imsi64);
 spgw_ue_context_t* spgw_create_or_get_ue_context(imsi64_t imsi64);
 
 status_code_e spgw_update_teid_in_ue_context(imsi64_t imsi64, teid_t teid);
-
-#ifdef __cplusplus
-}
-#endif

--- a/lte/gateway/c/core/oai/include/sgw_s8_state.hpp
+++ b/lte/gateway/c/core/oai/include/sgw_s8_state.hpp
@@ -13,14 +13,18 @@ limitations under the License.
 
 #pragma once
 
+#include <pthread.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <pthread.h>
 #include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
-#include "lte/gateway/c/core/oai/include/spgw_types.hpp"
 #include "lte/gateway/c/core/oai/include/sgw_config.h"
+#ifdef __cplusplus
+}
+#endif
+
+#include "lte/gateway/c/core/oai/include/spgw_types.hpp"
 
 // Initializes SGW state struct when task process starts.
 int sgw_state_init(bool persist_state, const sgw_config_t* config);
@@ -71,7 +75,3 @@ void sgw_free_s11_bearer_context_information(
  * @param spgw_ue_context_t
  */
 void sgw_free_ue_context(spgw_ue_context_t** ue_context_p);
-
-#ifdef __cplusplus
-}
-#endif

--- a/lte/gateway/c/core/oai/include/spgw_state.hpp
+++ b/lte/gateway/c/core/oai/include/spgw_state.hpp
@@ -17,17 +17,19 @@
 
 #pragma once
 
+#include <pthread.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <pthread.h>
-
 #include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
-
 #include "lte/gateway/c/core/oai/include/gtpv1u_types.h"
-#include "lte/gateway/c/core/oai/include/spgw_types.hpp"
 #include "lte/gateway/c/core/oai/include/spgw_config.h"
+#ifdef __cplusplus
+}
+#endif
+
+#include "lte/gateway/c/core/oai/include/spgw_types.hpp"
 
 // Initializes SGW state struct when task process starts.
 int spgw_state_init(bool persist_state, const spgw_config_t* spgw_config_p);
@@ -92,6 +94,3 @@ void pgw_free_pcc_rule(void** rule);
  * @param spgw_ue_context_t
  */
 void sgw_free_ue_context(spgw_ue_context_t** ue_context_p);
-#ifdef __cplusplus
-}
-#endif

--- a/lte/gateway/c/core/oai/include/spgw_types.hpp
+++ b/lte/gateway/c/core/oai/include/spgw_types.hpp
@@ -27,13 +27,20 @@
  * those of the authors and should not be interpreted as representing official
  * policies, either expressed or implied, of the FreeBSD Project.
  */
-#ifndef FILE_SPGW_TYPES_SEEN
-#define FILE_SPGW_TYPES_SEEN
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "lte/gateway/c/core/oai/include/gtpv1u_types.h"
+#ifdef __cplusplus
+}
+#endif
 
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h"
 #include "lte/gateway/c/core/oai/include/ip_forward_messages_types.h"
 #include "lte/gateway/c/core/oai/include/sgw_ie_defs.h"
-#include "lte/gateway/c/core/oai/include/gtpv1u_types.h"
 
 typedef struct s5_create_session_request_s {
   teid_t context_teid;  ///< local SGW S11 Tunnel Endpoint Identifier
@@ -98,7 +105,6 @@ typedef struct sgw_state_s {
 typedef struct spgw_state_s {
   STAILQ_HEAD(ipv4_list_allocated_s, ipv4_list_elm_s) ipv4_list_allocated;
   hash_table_ts_t* deactivated_predefined_pcc_rules;
-  hash_table_ts_t* predefined_pcc_rules;
   gtpv1u_data_t gtpv1u_data;
   uint32_t gtpv1u_teid;
   struct in_addr sgw_ip_address_S1u_S12_S4_up;
@@ -109,9 +115,3 @@ void handle_s5_create_session_response(
     spgw_state_t* state,
     s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
     s5_create_session_response_t session_resp);
-
-status_code_e sgw_handle_sgi_endpoint_created(
-    spgw_state_t* state, itti_sgi_create_end_point_response_t* const resp_p,
-    imsi64_t imsi64);
-
-#endif /* FILE_SPGW_TYPES_SEEN */

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h
@@ -39,8 +39,15 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
 #include "lte/gateway/c/core/oai/lib/hashtable/obj_hashtable.h"
+#ifdef __cplusplus
+}
+#endif
+
 #include "lte/gateway/c/core/oai/common/queue.h"
 
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.003.h"

--- a/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.hpp
+++ b/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.hpp
@@ -26,8 +26,12 @@ extern "C" {
 #include "lte/gateway/c/core/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/common/log.h"
 #include "lte/gateway/c/core/oai/include/ip_forward_messages_types.h"
-#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
+#ifdef __cplusplus
+}
+#endif
+
+#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 
 // Status codes from gRPC
 #define RPC_STATUS_OK 0
@@ -168,9 +172,5 @@ int pgw_handle_allocate_ipv4v6_address(const char* subscriber_id,
                                        const char* apn, const char* pdn_type,
                                        teid_t context_teid,
                                        ebi_t eps_bearer_id);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif  // RPC_CLIENT_H

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.cpp
@@ -15,27 +15,27 @@
  *      contact@openairinterface.org
  */
 
-#include <grpcpp/impl/codegen/status.h>
+#include "lte/gateway/c/core/oai/lib/pcef/pcef_handlers.hpp"
+
 #include <cstring>
 #include <string>
+
+#include <grpcpp/impl/codegen/status.h>
+#include "lte/protos/session_manager.pb.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 #include "lte/gateway/c/core/common/common_defs.h"
 #include "lte/gateway/c/core/oai/common/conversions.h"
 #include "lte/gateway/c/core/oai/common/log.h"
-
+#include "lte/gateway/c/core/oai/lib/itti/itti_types.h"
 #ifdef __cplusplus
 }
 #endif
 
-#include "lte/gateway/c/core/oai/lib/pcef/pcef_handlers.hpp"
 #include "lte/gateway/c/core/oai/lib/pcef/PCEFClient.hpp"
 #include "lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.hpp"
-#include "lte/gateway/c/core/oai/lib/itti/itti_types.h"
-#include "lte/protos/session_manager.pb.h"
 #include "lte/gateway/c/core/oai/include/spgw_types.hpp"
 
 extern task_zmq_ctx_t grpc_service_task_zmq_ctx;

--- a/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.hpp
+++ b/lte/gateway/c/core/oai/lib/pcef/pcef_handlers.hpp
@@ -27,8 +27,11 @@ extern "C" {
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
 #include "lte/gateway/c/core/oai/common/common_types.h"
 #include "lte/gateway/c/core/oai/include/ip_forward_messages_types.h"
-#include "lte/gateway/c/core/oai/include/spgw_types.hpp"
+#ifdef __cplusplus
+}
+#endif
 
+#include "lte/gateway/c/core/oai/include/spgw_types.hpp"
 struct pcef_create_session_data {
   char msisdn[MSISDN_LENGTH + 1];
   char imeisv[IMEISV_DIGITS_MAX + 1];
@@ -104,6 +107,3 @@ int get_imeisv_from_session_req(
 void convert_imeisv_to_string(char* imeisv);
 
 bool pcef_delete_dedicated_bearer(const char* imsi, const ebi_list_t ebi_list);
-#ifdef __cplusplus
-}
-#endif

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u_sgw_defs.h
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u_sgw_defs.h
@@ -17,11 +17,16 @@
 #ifndef FILE_GTPV1U_SGW_DEFS_SEEN
 #define FILE_GTPV1U_SGW_DEFS_SEEN
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "lte/gateway/c/core/oai/include/gtpv1u_types.h"
 #include "lte/gateway/c/core/oai/include/spgw_config.h"
-#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
+#ifdef __cplusplus
+}
+#endif
 
-int gtpv1u_init(spgw_state_t* spgw_state_p, spgw_config_t* spgw_config,
+int gtpv1u_init(gtpv1u_data_t* gtpv1u_data, spgw_config_t* spgw_config,
                 bool persist_state);
 
 void gtpv1u_exit(void);

--- a/lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u_task.c
+++ b/lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u_task.c
@@ -34,8 +34,15 @@
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
 #include "lte/gateway/c/core/oai/tasks/gtpv1-u/gtp_tunnel_upf.h"
 #include "lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u.h"
-#include "lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u_sgw_defs.h"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_ue_ip_address_alloc.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u_sgw_defs.h"
+#ifdef __cplusplus
+}
+#endif
 
 const struct gtp_tunnel_ops* gtp_tunnel_ops;
 static struct in_addr current_ue_net;
@@ -106,7 +113,7 @@ static bool ue_ip_is_in_subnet(struct in_addr _net, int mask,
 }
 
 //------------------------------------------------------------------------------
-int gtpv1u_init(spgw_state_t* spgw_state_p, spgw_config_t* spgw_config,
+int gtpv1u_init(gtpv1u_data_t* gtpv1u_data, spgw_config_t* spgw_config,
                 bool persist_state) {
   int rv = 0;
   struct in_addr netaddr;
@@ -151,8 +158,7 @@ int gtpv1u_init(spgw_state_t* spgw_state_p, spgw_config_t* spgw_config,
 
   // Init GTP device, using the same MTU as SGi.
   gtp_tunnel_ops->init(&netaddr, netmask, spgw_config->pgw_config.ipv4.mtu_SGI,
-                       &spgw_state_p->gtpv1u_data.fd0,
-                       &spgw_state_p->gtpv1u_data.fd1u, persist_state);
+                       &gtpv1u_data->fd0, &gtpv1u_data->fd1u, persist_state);
 
   // END-GTP quick integration only for evaluation purpose
 

--- a/lte/gateway/c/core/oai/tasks/sgw/mobilityd_ue_ip_address_alloc.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/mobilityd_ue_ip_address_alloc.cpp
@@ -17,10 +17,17 @@
 
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_ue_ip_address_alloc.hpp"
 
-#include "lte/gateway/c/core/oai/common/log.h"
 #include "lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.hpp"
 #include "lte/gateway/c/core/oai/include/service303.hpp"
 #include "orc8r/gateway/c/common/service303/MetricsHelpers.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "lte/gateway/c/core/oai/common/log.h"
+#ifdef __cplusplus
+}
+#endif
 
 struct in_addr;
 

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.cpp
@@ -24,6 +24,8 @@
 #define PGW
 #define S5_HANDLERS_C
 
+#include "lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.hpp"
+
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <stdint.h>
@@ -31,21 +33,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-#include "lte/gateway/c/core/oai/common/common_types.h"
-#include "lte/gateway/c/core/oai/common/log.h"
-#include "lte/gateway/c/core/common/assertions.h"
-#include "lte/gateway/c/core/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
-#include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
-#include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
-#include "lte/gateway/c/core/oai/lib/itti/itti_types.h"
-extern void print_bearer_ids_helper(const ebi_t*, uint32_t);
-#ifdef __cplusplus
-}
-#endif
 #include "lte/gateway/c/core/common/common_defs.h"
 #include "lte/gateway/c/core/oai/common/conversions.h"
 #include "lte/gateway/c/core/oai/include/ip_forward_messages_types.h"
@@ -59,14 +47,27 @@ extern void print_bearer_ids_helper(const ebi_t*, uint32_t);
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_29.274.h"
-#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
 #include "lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.hpp"
 #include "lte/gateway/c/core/oai/lib/pcef/pcef_handlers.hpp"
-#include "lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_pco.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.hpp"
-#include "lte/gateway/c/core/oai/tasks/sgw/sgw_defs.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "lte/gateway/c/core/oai/common/common_types.h"
+#include "lte/gateway/c/core/oai/common/log.h"
+#include "lte/gateway/c/core/common/assertions.h"
+#include "lte/gateway/c/core/common/dynamic_memory_check.h"
+#include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
+#include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
+#include "lte/gateway/c/core/oai/lib/itti/itti_types.h"
+#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
+extern void print_bearer_ids_helper(const ebi_t*, uint32_t);
+#ifdef __cplusplus
+}
+#endif
 
 extern task_zmq_ctx_t sgw_s8_task_zmq_ctx;
 extern spgw_config_t spgw_config;

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.hpp
@@ -22,8 +22,8 @@
  * \email: lionel.gauthier@eurecom.fr
  */
 
-#ifndef FILE_PGW_HANDLERS_SEEN
-#define FILE_PGW_HANDLERS_SEEN
+#pragma once
+
 #include "lte/gateway/c/core/common/common_defs.h"
 #include "lte/gateway/c/core/oai/include/gx_messages_types.h"
 #include "lte/gateway/c/core/oai/include/spgw_state.hpp"
@@ -65,5 +65,3 @@ status_code_e spgw_build_and_send_s11_deactivate_bearer_req(
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* FILE_PGW_HANDLERS_SEEN */

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.cpp
@@ -40,6 +40,9 @@ extern "C" {
 #include "lte/gateway/c/core/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/common/assertions.h"
 #include "lte/gateway/c/core/oai/common/async_system.h"
+#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
+#include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
+#include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
 #ifdef __cplusplus
 }
 #endif
@@ -48,9 +51,6 @@ extern "C" {
 #include "lte/gateway/c/core/oai/include/pgw_config.h"
 #include "lte/gateway/c/core/oai/include/pgw_types.h"
 #include "lte/gateway/c/core/oai/include/spgw_config.h"
-#include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
-#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
-#include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
 
 /*
  * Function that adds predefined PCC rules to PGW struct,

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.hpp
@@ -22,8 +22,7 @@
  * \email: lionel.gauthier@eurecom.fr
  */
 
-#ifndef FILE_PGW_PCEF_EMULATION_SEEN
-#define FILE_PGW_PCEF_EMULATION_SEEN
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -47,5 +46,3 @@ status_code_e pgw_pcef_get_sdf_parameters(spgw_state_t* state, sdf_id_t sdf_id,
                                           bearer_qos_t* bearer_qos,
                                           packet_filter_t* packet_filter,
                                           uint8_t* num_pf);
-
-#endif /* FILE_PGW_PCEF_EMULATION_SEEN */

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_pco.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_pco.hpp
@@ -21,8 +21,8 @@
  * \company Eurecom
  * \email: lionel.gauthier@eurecom.fr
  */
-#ifndef FILE_PGW_PCO_SEEN
-#define FILE_PGW_PCO_SEEN
+
+#pragma once
 
 #include <stdint.h>
 
@@ -68,5 +68,3 @@ status_code_e pgw_process_pco_request(
     const protocol_configuration_options_t* const pco_req,
     protocol_configuration_options_t* pco_resp,
     protocol_configuration_options_ids_t* const pco_ids);
-
-#endif

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.cpp
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 
 #include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.hpp
@@ -14,8 +14,8 @@
  * For more information about the OpenAirInterface (OAI) Software Alliance:
  *      contact@openairinterface.org
  */
-#ifndef FILE_PGW_PROCEDURES_SEEN
-#define FILE_PGW_PROCEDURES_SEEN
+
+#pragma once
 
 /*! \file pgw_procedures.hpp
   \brief  Just a workaround waiting for PCEF implementation
@@ -24,8 +24,8 @@
   \email: lionel.gauthier@eurecom.fr
 */
 
-#include "lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/queue.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h"
+#include "lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/queue.h"
 #include "lte/gateway/c/core/oai/common/common_types.h"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.hpp"
 #include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
@@ -70,5 +70,3 @@ pgw_ni_cbr_proc_t* pgw_create_procedure_create_bearer(
     sgw_eps_bearer_context_information_t* const ctx_p);
 void pgw_delete_procedure_create_bearer(
     s_plus_p_gw_eps_bearer_context_information_t* ctx_p);
-
-#endif

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_ue_ip_address_alloc.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_ue_ip_address_alloc.hpp
@@ -22,13 +22,11 @@
  * \email:
  */
 
-#ifndef PGW_UE_IP_ADDRESS_ALLOC_SEEN
-#define PGW_UE_IP_ADDRESS_ALLOC_SEEN
+#pragma once
 
 #include <arpa/inet.h>
 #include <stdint.h>
 
-#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 #include "lte/gateway/c/core/oai/include/ip_forward_messages_types.h"
 
 void release_ue_ipv4_address(const char* imsi, const char* apn,
@@ -43,5 +41,3 @@ int get_ip_block(struct in_addr* netaddr, uint32_t* netmask);
 #endif
 void release_ue_ipv6_address(const char* imsi, const char* apn,
                              struct in6_addr* addr);
-
-#endif /*PGW_UE_IP_ADDRESS_ALLOC_SEEN */

--- a/lte/gateway/c/core/oai/tasks/sgw/s11_causes.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/s11_causes.hpp
@@ -21,8 +21,8 @@
  * \company Eurecom
  * \email: lionel.gauthier@eurecom.fr
  */
-#ifndef FILE_S11_CAUSES_SEEN
-#define FILE_S11_CAUSES_SEEN
+
+#pragma once
 
 #include <stdint.h>
 
@@ -38,5 +38,3 @@ typedef struct SGWCauseMapping_e {
 } SGWCauseMapping_t;
 
 char* sgw_cause_2_string(uint8_t cause_value);
-
-#endif /* FILE_S11_CAUSES_SEEN */

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_defs.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_defs.hpp
@@ -22,8 +22,7 @@
  * \email: lionel.gauthier@eurecom.fr
  */
 
-#ifndef FILE_SGW_DEFS_SEEN
-#define FILE_SGW_DEFS_SEEN
+#pragma once
 
 #include "lte/gateway/c/core/common/common_defs.h"
 #include "lte/gateway/c/core/oai/include/spgw_config.h"
@@ -36,4 +35,3 @@ status_code_e spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state);
 #ifdef __cplusplus
 }
 #endif
-#endif /* FILE_SGW_DEFS_SEEN */

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.cpp
@@ -42,9 +42,11 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u.h"
 #include "lte/gateway/c/core/oai/common/conversions.h"
 #include "lte/gateway/c/core/common/dynamic_memory_check.h"
+#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
 #ifdef __cplusplus
 }
 #endif
+
 #include "lte/gateway/c/core/common/common_defs.h"
 #include "lte/gateway/c/core/oai/common/common_types.h"
 #include "lte/gateway/c/core/oai/include/pgw_config.h"
@@ -61,7 +63,6 @@ extern "C" {
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_29.274.h"
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
 #include "lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/queue.h"
-#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
 #include "lte/gateway/c/core/oai/lib/itti/itti_types.h"
 #include "lte/gateway/c/core/oai/lib/pcef/pcef_handlers.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.hpp"
@@ -69,7 +70,6 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_pco.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_ue_ip_address_alloc.hpp"
-#include "lte/gateway/c/core/oai/tasks/sgw/sgw_defs.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.hpp"
 #include "orc8r/gateway/c/common/service303/MetricsHelpers.hpp"
 

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.hpp
@@ -22,8 +22,7 @@
  * \email: lionel.gauthier@eurecom.fr
  */
 
-#ifndef FILE_SGW_HANDLERS_SEEN
-#define FILE_SGW_HANDLERS_SEEN
+#pragma once
 
 #include "lte/gateway/c/core/common/common_defs.h"
 #include "lte/gateway/c/core/oai/common/common_types.h"
@@ -72,7 +71,11 @@ uint32_t spgw_get_new_s1u_teid(spgw_state_t* state);
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 bool is_enb_ip_address_same(const fteid_t* fte_p, ip_address_t* ip_p);
+status_code_e sgw_handle_sgi_endpoint_created(
+    spgw_state_t* state, itti_sgi_create_end_point_response_t* const resp_p,
+    imsi64_t imsi64);
 status_code_e send_mbr_failure(
     log_proto_t module,
     const itti_s11_modify_bearer_request_t* const modify_bearer_pP,
@@ -132,4 +135,3 @@ void generate_dl_flow(packet_filter_contents_t* packet_filter,
 void sgw_handle_delete_bearer_cmd(
     itti_s11_delete_bearer_command_t* s11_delete_bearer_command,
     imsi64_t imsi64);
-#endif /* FILE_SGW_HANDLERS_SEEN */

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_paging.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_paging.hpp
@@ -14,13 +14,12 @@
  * For more information about the OpenAirInterface (OAI) Software Alliance:
  *      contact@openairinterface.org
  */
-#ifndef FILE_SGW_PAGING_SEEN
-#define FILE_SGW_PAGING_SEEN
+
+#pragma once
+
 #include <netinet/ip.h>
 
 struct in_addr;
 #define ETH_HEADER_LENGTH 14
 void sgw_send_paging_request(const struct in_addr* dest_ip,
                              const struct in6_addr* dest_ipv6);
-
-#endif

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_task.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_task.cpp
@@ -28,11 +28,10 @@
 #include <netinet/in.h>
 #include <sys/types.h>
 
-#include "lte/gateway/c/core/common/common_defs.h"
-#include "lte/gateway/c/core/common/dynamic_memory_check.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
+#include "lte/gateway/c/core/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/common/assertions.h"
 #include "lte/gateway/c/core/oai/common/log.h"
 #include "lte/gateway/c/core/oai/common/itti_free_defined_msg.h"
@@ -40,14 +39,17 @@ extern "C" {
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface_types.h"
 #include "lte/gateway/c/core/oai/include/gtpv1_u_messages_types.h"
 #include "lte/gateway/c/core/oai/tasks/gtpv1-u/gtpv1u_sgw_defs.h"
+#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
 #ifdef __cplusplus
 }
 #endif
+
+#include "lte/gateway/c/core/common/common_defs.h"
 #include "lte/gateway/c/core/oai/include/sgw_config.h"
+#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 #include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
 #include "lte/gateway/c/core/oai/include/spgw_config.h"
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
-#include "lte/gateway/c/core/oai/lib/hashtable/hashtable.h"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_pcef_emulation.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_ue_ip_address_alloc.hpp"
@@ -240,7 +242,8 @@ static void* spgw_app_thread(__attribute__((unused)) void* args) {
 }
 
 //------------------------------------------------------------------------------
-status_code_e spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state) {
+extern "C" status_code_e spgw_app_init(spgw_config_t* spgw_config_pP,
+                                       bool persist_state) {
   OAILOG_DEBUG(LOG_SPGW_APP, "Initializing SPGW-APP  task interface\n");
 
   if (spgw_state_init(persist_state, spgw_config_pP) < 0) {
@@ -254,7 +257,8 @@ status_code_e spgw_app_init(spgw_config_t* spgw_config_pP, bool persist_state) {
   read_spgw_ue_state_db();
 
 #if !MME_UNIT_TEST  // No need to initialize OVS data path for unit tests
-  if (gtpv1u_init(spgw_state_p, spgw_config_pP, persist_state) < 0) {
+  if (gtpv1u_init(&spgw_state_p->gtpv1u_data, spgw_config_pP, persist_state) <
+      0) {
     OAILOG_ALERT(LOG_SPGW_APP, "Initializing GTPv1-U ERROR\n");
     return RETURNerror;
   }

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state.cpp
@@ -18,15 +18,19 @@
 #include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 
 #include <cstdlib>
-#include "lte/gateway/c/core/oai/common/conversions.h"
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 #include "lte/gateway/c/core/common/assertions.h"
 #include "lte/gateway/c/core/common/dynamic_memory_check.h"
-#include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
 #include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
+#ifdef __cplusplus
 }
+#endif
 
+#include "lte/gateway/c/core/oai/common/conversions.h"
+#include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.hpp"
 

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state_converter.cpp
@@ -20,8 +20,9 @@
 extern "C" {
 #include "lte/gateway/c/core/common/dynamic_memory_check.h"
 #include "lte/gateway/c/core/oai/common/conversions.h"
-#include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
 }
+
+#include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
 
 using magma::lte::oai::CreateSessionMessage;
 using magma::lte::oai::GTPV1uData;

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state_manager.cpp
@@ -79,9 +79,6 @@ void SpgwStateManager::create_state() {
   state_cache_p->deactivated_predefined_pcc_rules = hashtable_ts_create(
       MAX_PREDEFINED_PCC_RULES_HT_SIZE, nullptr, pgw_free_pcc_rule, nullptr);
 
-  state_cache_p->predefined_pcc_rules = hashtable_ts_create(
-      MAX_PREDEFINED_PCC_RULES_HT_SIZE, nullptr, pgw_free_pcc_rule, nullptr);
-
   state_cache_p->gtpv1u_teid = 0;
 
   bdestroy_wrapper(&b);
@@ -108,9 +105,6 @@ void SpgwStateManager::free_state() {
     hashtable_ts_destroy(state_cache_p->deactivated_predefined_pcc_rules);
   }
 
-  if (state_cache_p->predefined_pcc_rules) {
-    hashtable_ts_destroy(state_cache_p->predefined_pcc_rules);
-  }
   free_wrapper((void**)&state_cache_p);
 }
 

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_procedures_test_fixture.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_procedures_test_fixture.cpp
@@ -26,6 +26,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h"
 }
 
+#include "lte/gateway/c/core/oai/tasks/sgw/sgw_defs.hpp"
 #include "lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h"
 #include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.hpp"

--- a/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
+++ b/lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h
@@ -18,10 +18,10 @@
 extern "C" {
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
 #include "lte/gateway/c/core/oai/include/sgw_ie_defs.h"
-#include "lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.hpp"
-#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 }
 
+#include "lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.hpp"
+#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 #include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
 
 namespace magma {

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures_dedicated_bearer.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures_dedicated_bearer.cpp
@@ -23,13 +23,13 @@ extern "C" {
 #include "lte/gateway/c/core/oai/include/gx_messages_types.h"
 #include "lte/gateway/c/core/oai/include/ngap_messages_types.h"
 #include "lte/gateway/c/core/oai/include/s11_messages_types.h"
-#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.007.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_29.274.h"
 }
 
+#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 #include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
 #include "lte/gateway/c/core/oai/include/spgw_types.hpp"
 #include "lte/gateway/c/core/oai/test/spgw_task/spgw_test_util.h"

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures_session.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_procedures_session.cpp
@@ -25,6 +25,8 @@
 #include "lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.hpp"
 #include "lte/gateway/c/core/oai/include/sgw_context_manager.hpp"
 #include "lte/gateway/c/core/oai/include/spgw_types.hpp"
+#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
+#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h"
 
 extern "C" {
 #include "lte/gateway/c/core/common/common_defs.h"
@@ -34,8 +36,6 @@ extern "C" {
 #include "lte/gateway/c/core/oai/include/ip_forward_messages_types.h"
 #include "lte/gateway/c/core/oai/include/ngap_messages_types.h"
 #include "lte/gateway/c/core/oai/include/s11_messages_types.h"
-#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
-#include "lte/gateway/c/core/oai/lib/3gpp/3gpp_23.401.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_29.274.h"
 }
 

--- a/lte/gateway/c/core/oai/test/spgw_task/test_spgw_state_converter.cpp
+++ b/lte/gateway/c/core/oai/test/spgw_task/test_spgw_state_converter.cpp
@@ -20,9 +20,9 @@
 #include "lte/gateway/c/core/oai/test/spgw_task/state_creators.hpp"
 #include "lte/gateway/c/core/oai/tasks/sgw/sgw_defs.hpp"
 #include "lte/protos/oai/mme_nas_state.pb.h"
+#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 
 extern "C" {
-#include "lte/gateway/c/core/oai/include/spgw_state.hpp"
 #include "lte/gateway/c/core/oai/lib/message_utils/ie_to_bytes.h"
 }
 


### PR DESCRIPTION
Signed-off-by: Rashmi <rashmi.sarwad@radisys.com>

## Summary

fix(agw): Fixed compilation error on inclusion of proto_map.h file and removed unused file, sgw.h and unused structure, predefined_pcc_rules

## Test Plan
Executed s1ap sanity test suite and unit test cases
