### PR TITLE
fix(agw): Fix for the issue related to earlier kernels as reported in #13831 

### DIFF
--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0025-IPv6-Kernel-before-ipv6_stub-change.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0025-IPv6-Kernel-before-ipv6_stub-change.patch
@@ -1,0 +1,33 @@
+diff --git a/datapath/linux/compat/gtp.c b/datapath/linux/compat/gtp.c
+index d4d49920d..94b788229 100644
+--- a/datapath/linux/compat/gtp.c
++++ b/datapath/linux/compat/gtp.c
+@@ -506,6 +506,18 @@ static struct dst_entry *gtp_get_v6_rt(struct sk_buff *skb,
+ 	fl6->saddr = info->key.u.ipv6.src;
+ 	fl6->flowlabel = ip6_make_flowinfo(RT_TOS(info->key.tos), info->key.label);
+
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 5) && LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)) || (LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 18) && !defined(ISRHEL82))
++
++	int err;
++	err = ipv6_stub->ipv6_dst_lookup(dev_net(dev), gs6, &ndst, fl6);
++
++	if (unlikely(err < 0)) {
++		netdev_dbg(dev, "no route to %pI6\n", &fl6->daddr);
++		return ERR_PTR(-ENETUNREACH);
++	}
++
++#else
++
+ 	ndst = ipv6_stub->ipv6_dst_lookup_flow(dev_net(dev), gs6,
+ 						   fl6, NULL);
+ 	if (IS_ERR(ndst)) {
+@@ -513,6 +525,8 @@ static struct dst_entry *gtp_get_v6_rt(struct sk_buff *skb,
+ 		return ERR_PTR(-ENETUNREACH);
+ 	}
+
++#endif
++
+ 	if (unlikely(ndst->dev == dev)) {
+ 		netdev_dbg(dev, "circular route to %pI6\n", &fl6->daddr);
+ 		dst_release(ndst);
+


### PR DESCRIPTION
## Summary

Introduced conditional code block in the source of vport_gtp as a patch to OVS to fix issue reported with  #13831. The code block contains implementation of the IPv6 flow lookup that is compliant to earlier kernels. The conditional block is activated only in case of kernels prior 5.4.5 and 5.3.18

## Test Plan

Standard OVS integration tests ware executed.

```
## ------------------------------ ##
## openvswitch 2.15.4 test suite. ##
## ------------------------------ ##

layer3-tunnels

144: layer3 - ping over GTP                          ok
145: layer3 - IPv6 packets over IPv6 GTP             ok
146: layer3 - IPv6 packets over IPv4 GTP             ok
147: layer3 - IPv4 packets over IPv6 GTP             ok
148: layer3 - GTP echo match test                    ok
149: layer3 - IPv6 GTP echo match test               ok
150: layer3 - GTP echo response test                 ok
151: layer3 - IPv6 GTP echo response test            ok
152: layer3 - GTP echo response test multi endpoint  ok
153: layer3 - IPv6 GTP echo response test multi endpoint ok
154: layer3 - GTP end marker test                    ok
155: layer3 - IPv6 GTP end marker test               ok
156: layer3 - Qfi value set for uplink over GTP      ok
157: layer3 - Qfi value set for downlink over GTP    ok

## ------------- ##
## Test results. ##
## ------------- ##

All 14 tests were successful.
```
The patch was verified on devices with earlier kernel by using srsRAN

## Additional Information

Closes #13831