### PR TITLE
chore(ci): run integ tests again deb installation in ci

### DIFF
--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -1,0 +1,64 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: LTE integ test magma-deb
+
+on:
+  workflow_dispatch: null
+  workflow_run:
+    workflows:
+      - build-all
+    branches:
+      - master
+    types:
+      - completed
+
+jobs:
+  lte-integ-test-magma-deb:
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - name: Cache magma-deb-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_deb
+          key: vagrant-box-magma-deb-focal64-20220804.0.0
+      - name: Cache magma-test-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
+          key: vagrant-box-magma-test
+      - name: Cache magma-trfserver-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
+          key: vagrant-box-magma-trfserver-v20220722
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
+        with:
+          python-version: '3.8.10'
+      - name: Install pre requisites
+        run: |
+          pip3 install --upgrade pip
+          pip3 install ansible fabric3 jsonpickle requests PyYAML
+          vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
+      - name: Open up network interfaces for VM
+        run: |
+          sudo mkdir -p /etc/vbox/
+          echo '* 192.168.0.0/16' | sudo tee /etc/vbox/networks.conf
+          echo '* 3001::/64' | sudo tee -a /etc/vbox/networks.conf
+      - name: Run the integ test
+        env:
+          MAGMA_DEV_CPUS: 3
+          MAGMA_DEV_MEMORY_MB: 9216
+        run: |
+          cd lte/gateway
+          fab integ_test_deb_installation

--- a/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
@@ -90,6 +90,14 @@
     force: yes
 
 - name: Create test certificates directory
+  file: path='/home/vagrant/magma/.cache/test_certs' state=directory
+
+- name: Generate the cloud VM's certs if they are not already generated
+  command: '/home/vagrant/magma/orc8r/tools/ansible/roles/gateway_dev/files/create_rootca /home/vagrant/magma/.cache/test_certs'
+  args:
+    creates: '/home/vagrant/magma/.cache/test_certs/rootCA.pem'
+
+- name: Create test certificates directory
   file:
     path: /var/opt/magma/certs/
     state: directory
@@ -103,7 +111,6 @@
   with_items:
     - .key
     - .pem
-    - .srl
 
 - name: Override pipelined and sessiond production configuration
   file:
@@ -124,9 +131,6 @@
   loop:
     - templates/mme.conf.template
     - gateway.mconfig
-
-- name: Clear existing service files
-  shell: rm -f /etc/systemd/system/magma*
 
 - name: Override production service configurations with test configurations
   copy:

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -414,7 +414,7 @@ def _setup_vm(host, name, ansible_role, ansible_file, destroy_vm, provision_vm):
 
 def _setup_gateway(gateway_host, name, ansible_role, ansible_file, destroy_vm, provision_vm):
     gateway_host, gateway_ip = _setup_vm(gateway_host, name, ansible_role, ansible_file, destroy_vm, provision_vm)
-    if gateway_ip == None:
+    if gateway_ip is None:
         gateway_ip = GATEWAY_IP_ADDRESS
     return gateway_host, gateway_ip
 


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary
This PR adds a new github action workflow to the ci. The workflow executes lte integ tests against the magma_deb vm. It is triggered on master after the build-all step is done. 

## Test Plan
- [x] LTE integ tests run on local machine
- [x] Workflow in CI runs through:
     - https://github.com/voisey/magma/actions/runs/3053667916/jobs/4924582835
     - https://github.com/magma/magma/actions/runs/3060062459

## Additional Information

This change is not backwards-breaking