### PR TITLE
feat(agw): dockerize the agw envoy controller

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_dp_envoy.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_dp_envoy.service
@@ -19,7 +19,9 @@ Type=simple
 EnvironmentFile=/etc/environment
 # Add delay to let envoy-controller init
 ExecStartPre=/bin/sleep 40
+ExecStartPre=/bin/bash /usr/local/bin/configure_envoy_namespace.sh setup
 ExecStart=/sbin/ip netns exec envoy_ns1 /usr/bin/envoy -c /var/opt/magma/envoy.yaml --log-path /var/log/envoy.log
+ExecStopPost=/bin/bash /usr/local/bin/configure_envoy_namespace.sh destroy
 MemoryAccounting=yes
 StandardOutput=syslog
 StandardError=syslog

--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_envoy_controller.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_envoy_controller.service
@@ -19,10 +19,8 @@ Before=magma_dp@envoy.service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
-ExecStartPre=/bin/bash /usr/local/bin/configure_envoy_namespace.sh setup
 ExecStart=/usr/local/bin/envoy_controller  --log_dir="/var/log"
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py envoy_controller
-ExecStopPost=/bin/bash /usr/local/bin/configure_envoy_namespace.sh destroy
 MemoryAccounting=yes
 StandardOutput=syslog
 StandardError=syslog

--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -41,6 +41,7 @@ containerized AGW by running the following steps inside the VM:
 cd $MAGMA_ROOT/lte/gateway && make run  # You can skip this if you have built the AGW with make before
 for component in redis nghttpx td-agent-bit; do cp "${MAGMA_ROOT}"/{orc8r,lte}/gateway/configs/templates/${component}.conf.template; done
 sudo systemctl stop 'magma@*' 'sctpd' # We don't want the systemd-based AGW to run when we start the containerized AGW
+sudo systemctl start magma_dp@envoy
 cd $MAGMA_ROOT/lte/gateway/docker
 docker-compose build
 docker-compose up

--- a/lte/gateway/docker/docker-compose.dev.yaml
+++ b/lte/gateway/docker/docker-compose.dev.yaml
@@ -100,3 +100,7 @@ services:
   liagentd:
     environment:
       - MAGMA_DEV_MODE=1
+
+  envoy_controller:
+    environment:
+      - MAGMA_DEV_MODE=1

--- a/lte/gateway/docker/docker-compose.override.yaml
+++ b/lte/gateway/docker/docker-compose.override.yaml
@@ -11,3 +11,8 @@ services:
     build:
       context: ${BUILD_CONTEXT}
       dockerfile: lte/gateway/docker/services/python/Dockerfile
+
+  gateway_go:
+    build:
+      context: ${BUILD_CONTEXT}
+      dockerfile: feg/gateway/docker/go/Dockerfile

--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -36,6 +36,11 @@ x-lte-cservice: &ltecservice
   <<: *service
   image: ${DOCKER_REGISTRY}agw_gateway_c${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
 
+# Generic anchor for go services
+x-goservice: &goservice
+  <<: *service
+  image: ${DOCKER_REGISTRY}agw_gateway_go${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
+
 services:
   magmad:
     <<: *pyservice
@@ -302,3 +307,12 @@ services:
       retries: 3
     command: /usr/local/bin/liagentd
     restart: "no"
+
+  envoy_controller:
+    <<: *goservice
+    container_name: envoy_controller
+    healthcheck:
+      test: ["CMD", "nc", "-zv", "localhost", "50081"]
+      timeout: "4s"
+      retries: 3
+    command: /var/opt/magma/bin/envoy_controller

--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -32,12 +32,12 @@ x-agw-python-service: &pyservice
   image: ${DOCKER_REGISTRY}agw_gateway_python${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
 
 # Generic anchor for lte c services
-x-lte-cservice: &ltecservice
+x-agw-c-service: &cservice
   <<: *service
   image: ${DOCKER_REGISTRY}agw_gateway_c${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
 
 # Generic anchor for go services
-x-goservice: &goservice
+x-agw-go-service: &goservice
   <<: *service
   image: ${DOCKER_REGISTRY}agw_gateway_go${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
 
@@ -179,7 +179,7 @@ services:
     command: /usr/bin/env python3 -m magma.ctraced.main
 
   sctpd:
-    <<: *ltecservice
+    <<: *cservice
     container_name: sctpd
     ulimits:
       core: -1
@@ -190,7 +190,7 @@ services:
     command: /usr/local/bin/sctpd
 
   oai_mme:
-    <<: *ltecservice
+    <<: *cservice
     container_name: oai_mme
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50073"]
@@ -237,7 +237,7 @@ services:
         /usr/bin/env python3 -m magma.pipelined.main"
 
   sessiond:
-    <<: *ltecservice
+    <<: *cservice
     container_name: sessiond
     ulimits:
       core: -1
@@ -288,7 +288,7 @@ services:
     command: /usr/bin/env python3 -m magma.eventd.main
 
   connectiond:
-    <<: *ltecservice
+    <<: *cservice
     container_name: connectiond
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50082"]
@@ -299,7 +299,7 @@ services:
     command: /usr/local/bin/connectiond
 
   liagentd:
-    <<: *ltecservice
+    <<: *cservice
     container_name: liagentd
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50065"]

--- a/lte/gateway/docker/services/envoy_controller/Dockerfile
+++ b/lte/gateway/docker/services/envoy_controller/Dockerfile
@@ -1,5 +1,0 @@
-FROM cbuilder:latest
-
-ENV PATH="/root/go/bin/:$PATH"
-
-ENTRYPOINT envoy_controller

--- a/lte/gateway/docker/services/python/Dockerfile
+++ b/lte/gateway/docker/services/python/Dockerfile
@@ -104,7 +104,8 @@ RUN apt-get update && apt-get install -y \
   ethtool \
   linux-headers-generic \
   iptables \
-  iproute2
+  iproute2 \
+  isc-dhcp-client
 
 RUN python3 -m venv $VIRTUAL_ENV
 


### PR DESCRIPTION
## Summary

Containerizes the `envoy_controller` in the AGW as a first step for #13684 towards running all integration tests against the dockerized AGW.

* Added envoy controller container to the `docker-compose.yaml` using the go container from `/feg/gateway/docker/go/Dockerfile`
* moved the envoy namespace creation from the `envoy_controller` to the `magma_dp@envoy`, since there is no python env inside the container
* additional feature: added the package `isc-dhcp-client` to be installed in the python container for the pipelined container to work and adapted the `README.md`

## Test Plan

* follow the instructions in the `README.md` to build all the containers
* check that `test_attach_detach` is green

## Additional Information

Created in pairing with @mpfirrmann and @crasu 

- [ ] This change is backwards-breaking

