### PR TITLE
feat(agw): LTE integration tests run on a containerized AGW

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -541,6 +541,11 @@ class TestWrapper(object):
         elif TestWrapper.TEST_CASE_EXECUTION_COUNT > 1:
             self.generate_flaky_summary()
 
+        if not self.magmad_util.is_redis_empty():
+            print("************************* Redis not empty, initiating cleanup")
+            self.magmad_util.restart_sctpd()
+            self.magmad_util.print_redis_state()
+
     def multiEnbConfig(self, num_of_enbs, enb_list=None):
         """Configure multiple eNB in S1APTester"""
         if enb_list is None:

--- a/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py
@@ -101,12 +101,10 @@ class Test3485TimerForDedicatedBearerWithMmeRestart(unittest.TestCase):
             )
 
             print('***** Restarting MME service on gateway')
-            self._s1ap_wrapper.magmad_util.restart_services(['mme'])
-
             wait_for_restart = 20
-            for j in range(wait_for_restart):
-                print('Waiting for', j, 'seconds')
-                time.sleep(1)
+            self._s1ap_wrapper.magmad_util.restart_services(
+                ['mme'], wait_for_restart,
+            )
 
             response = self._s1ap_wrapper.s1_util.get_response()
             act_ded_ber_ctxt_req = response.cast(
@@ -133,12 +131,8 @@ class Test3485TimerForDedicatedBearerWithMmeRestart(unittest.TestCase):
 
             response = self._s1ap_wrapper.s1_util.get_response()
             msg_type = s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
-            while (response.msg_type != msg_type):
+            while response.msg_type != msg_type:
                 response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
             print('******************* Received deactivate eps bearer context')
 
             deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)

--- a/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
@@ -108,12 +108,10 @@ class Test3485TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
         # Receive PDN CONN RSP/Activate default EPS bearer context request
 
         print('************************* Restarting MME service on gateway')
-        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
-
         wait_for_restart = 20
-        for j in range(wait_for_restart):
-            print('Waiting for', j, 'seconds')
-            time.sleep(1)
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ['mme'], wait_for_restart,
+        )
 
         print(
             '*** Sending indication to drop Activate Default EPS bearer Ctxt'
@@ -151,11 +149,8 @@ class Test3485TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
         msg_type = s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
-        while (response.msg_type != msg_type):
+        while response.msg_type != msg_type:
             response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
 
         print(
             '******************* Received deactivate eps bearer context'

--- a/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_dedicated_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_dedicated_bearer_with_mme_restart.py
@@ -133,11 +133,10 @@ class Test3495TimerForDedicatedBearerWithMmeRestart(unittest.TestCase):
                 "************************* Restarting MME service on",
                 "gateway",
             )
-            self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-            for j in range(30):
-                print("Waiting for", j, "seconds")
-                time.sleep(1)
+            wait_for_restart = 30
+            self._s1ap_wrapper.magmad_util.restart_services(
+                ["mme"], wait_for_restart,
+            )
 
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(

--- a/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_default_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_default_bearer_with_mme_restart.py
@@ -149,11 +149,10 @@ class Test3495TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
 
         # Do not send deactivate eps bearer context accept
         print("************************* Restarting MME service on", "gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py
@@ -93,11 +93,10 @@ class TestAttachAndMmeRestartLoopDetachAndMmeRestartLoopMultiUe(
             print(
                 "************************* Restarting MME service on gateway",
             )
-            self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-            for j in range(30):
-                print("Waiting for", j, "seconds")
-                time.sleep(1)
+            wait_for_restart = 30
+            self._s1ap_wrapper.magmad_util.restart_services(
+                ["mme"], wait_for_restart,
+            )
 
         for ue in ue_ids:
             # Now detach the UE
@@ -113,11 +112,10 @@ class TestAttachAndMmeRestartLoopDetachAndMmeRestartLoopMultiUe(
             print(
                 "************************* Restarting MME service on gateway",
             )
-            self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-            for j in range(30):
-                print("Waiting for", j, "seconds")
-                time.sleep(1)
+            wait_for_restart = 30
+            self._s1ap_wrapper.magmad_util.restart_services(
+                ["mme"], wait_for_restart,
+            )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
@@ -45,10 +45,10 @@ class TestAttachDetachMultipleIpBlocksMobilitydRestart(unittest.TestCase):
                                      "mobilityd "
 
         print("************************* Restarting mobilityd")
-        self._s1ap_wrapper.magmad_util.restart_services(["mobilityd"])
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mobilityd"], wait_for_restart,
+        )
 
         curr_blocks = self._s1ap_wrapper.mobility_util.list_ip_blocks()
         # Check if old_blocks and curr_blocks contain same ip blocks after

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_corrupt_stateless_mme.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_corrupt_stateless_mme.py
@@ -66,11 +66,10 @@ class TestAttachDetachWithCorruptStatelessMME(unittest.TestCase):
             )
 
             print("************************* Restarting %s service" % s)
-            self._s1ap_wrapper.magmad_util.restart_services([s])
-
-            for j in range(100):
-                print("Waiting for", j, "seconds")
-                time.sleep(1)
+            wait_for_restart = 100
+            self._s1ap_wrapper.magmad_util.restart_services(
+                [s], wait_for_restart,
+            )
 
             # Re-establish S1 connection between eNB and MME
             self._s1ap_wrapper._s1setup()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mme_restart.py
@@ -62,11 +62,10 @@ class TestAttachDetachWithMmeRestart(unittest.TestCase):
                 "************************* Restarting MME service on",
                 "gateway",
             )
-            self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-            for j in range(30):
-                print("Waiting for", j, "seconds")
-                time.sleep(1)
+            wait_for_restart = 30
+            self._s1ap_wrapper.magmad_util.restart_services(
+                ["mme"], wait_for_restart,
+            )
 
             # Now detach the UE
             print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mobilityd_restart.py
@@ -56,11 +56,10 @@ class TestAttachDetachWithMobilitydRestart(unittest.TestCase):
             self._s1ap_wrapper._s1_util.receive_emm_info()
 
             print('************************* Restarting mobilityd')
-            self._s1ap_wrapper.magmad_util.restart_services(['mobilityd'])
-            # Timeout for mobilityd restart
-            for j in range(30):
-                print("Waiting for", j, "seconds")
-                sleep(1)
+            wait_for_restart = 30
+            self._s1ap_wrapper.magmad_util.restart_services(
+                ["mobilityd"], wait_for_restart,
+            )
 
             print(
                 "************************* Running UE detach for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_with_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_with_apn_correction.py
@@ -39,10 +39,10 @@ class TestAttachEsmInfoWithApnCorrection(unittest.TestCase):
         num_ues = 1
 
         print("************************* restarting mme")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-        for j in range(30):
-            print("Waiting mme restart for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         self._s1ap_wrapper.configUEDevice_ues_same_imsi(num_ues)
         print("************************* sending Attach Request for ue-id : 1")
@@ -173,10 +173,10 @@ class TestAttachEsmInfoWithApnCorrection(unittest.TestCase):
         self._s1ap_wrapper.magmad_util.config_apn_correction(
             MagmadUtil.apn_correction_cmds.DISABLE,
         )
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-        for j in range(30):
-            print("Waiting mme restart for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_mme_restart_detach_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_mme_restart_detach_multi_ue.py
@@ -67,11 +67,10 @@ class TestAttachMmeRestartDetachMultiUe(unittest.TestCase):
             ue_ids.append(req.ue_id)
 
         print("************************* Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         for ue in ue_ids:
             # Now detach the UE

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_with_mme_restart.py
@@ -84,11 +84,10 @@ class TestAttachNwInitiatedDetachWithMmeRestart(unittest.TestCase):
             "************************* Restarting MME service on",
             "gateway",
         )
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         # Receive NW initiated detach request
         response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_mme_restart.py
@@ -57,11 +57,10 @@ class TestAttachUlUdpDataWithMmeRestart(unittest.TestCase):
             test.verify()
 
         print("************************* Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         print(
             "************************* Running UE uplink (UDP) for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py
@@ -63,11 +63,10 @@ class TestAttachUlUdpDataWithMobilitydRestart(unittest.TestCase):
             "************************* Restarting Mobilityd service",
             "on gateway",
         )
-        self._s1ap_wrapper.magmad_util.restart_services(["mobilityd"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mobilityd"], wait_for_restart,
+        )
 
         print(
             "************************* Running UE uplink (UDP) for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py
@@ -63,14 +63,10 @@ class TestAttachUlUdpDataWithMultipleServiceRestart(unittest.TestCase):
             "************************* Restarting Mobilityd, MME and",
             "Pipelined services on gateway",
         )
-        self._s1ap_wrapper.magmad_util.restart_services([
-            "mobilityd", "mme",
-            "pipelined",
-        ])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mobilityd", "mme", "pipelined"], wait_for_restart,
+        )
 
         print(
             "************************* Running UE uplink (UDP) for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py
@@ -63,11 +63,10 @@ class TestAttachUlUdpDataWithPipelinedRestart(unittest.TestCase):
             "************************* Restarting Pipelined service",
             "on gateway",
         )
-        self._s1ap_wrapper.magmad_util.restart_services(["pipelined"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["pipelined"], wait_for_restart,
+        )
 
         print(
             "************************* Running UE uplink (UDP) for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py
@@ -63,11 +63,10 @@ class TestAttachUlUdpDataWithSessiondRestart(unittest.TestCase):
             "************************* Restarting Sessiond service",
             "on gateway",
         )
-        self._s1ap_wrapper.magmad_util.restart_services(["sessiond"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["sessiond"], wait_for_restart,
+        )
 
         print(
             "************************* Running UE uplink (UDP) for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py
@@ -58,8 +58,8 @@ class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
         print("************************* Received UE_AUTH_REQ_IND")
 
         # Try consecutive mme restarts
-        self._s1ap_wrapper.magmad_util.restart_mme_and_wait()
-        self._s1ap_wrapper.magmad_util.restart_mme_and_wait()
+        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
+        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
 
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = 1
@@ -82,7 +82,7 @@ class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
         )
         print("************************* Received UE_SEC_MOD_CMD_IND")
 
-        self._s1ap_wrapper.magmad_util.restart_mme_and_wait()
+        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
 
         print("************************* Sending UE_SEC_MOD_COMPLETE")
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
@@ -103,7 +103,7 @@ class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
             attach_acc.ue_Id,
         )
 
-        self._s1ap_wrapper.magmad_util.restart_mme_and_wait()
+        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
 
         # Trigger Attach Complete
         print("************************* Sending UE_ATTACH_COMPLETE")

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
@@ -103,11 +103,10 @@ class TestEnbPartialResetMultiUeWithMmeRestart(unittest.TestCase):
         )
 
         print("************************* Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)

--- a/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_with_mme_restart.py
@@ -109,11 +109,10 @@ class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
             response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value,
         )
         print("************************* Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         print("************************* Waiting for response from MME")
         response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_idle_mode_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_idle_mode_with_mme_restart.py
@@ -80,11 +80,10 @@ class TestIdleModeWithMmeRestart(unittest.TestCase):
         )
 
         print("************************* Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         print(
             "************************* Sending Service request for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
@@ -107,11 +107,10 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
             print("*********** Slept for", time_slept, "seconds")
 
         print("************************* Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         # Wait for Implicit detach timer to expire, on expiry of which MME deletes
         # UE contexts locally, S1ap tester shall send Service Request expecting

--- a/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_tmr_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_tmr_with_mme_restart.py
@@ -93,11 +93,10 @@ class TestMobileReachabilityTmrWithMmeRestart(unittest.TestCase):
         )
 
         print("************************* Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         # Delay by 11 minutes to ensure Mobile reachability timer and Implicit
         # detach timer expires

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete_with_mme_restart.py
@@ -110,11 +110,10 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
             "************************* Restarting MME service on",
             "gateway",
         )
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(20):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 20
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         # Receive NW initiated detach request
         response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_resp_with_mme_restart_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_resp_with_mme_restart_reattach.py
@@ -65,11 +65,10 @@ class TestNoAuthRespWithMmeRestartReattach(unittest.TestCase):
         print("************************* Received Auth Req for ue", req.ue_id)
 
         print("************************* Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart.py
@@ -78,11 +78,10 @@ class TestNoAuthResponseWithMmeRestart(unittest.TestCase):
         print("********* Received UE_CTX_REL_IND for ue", req.ue_id)
 
         print("************************* Restarting MME service on", "gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         print("****** Triggering attach after mme restart *********")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
@@ -93,11 +93,10 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
         print("Received Esm Information Request ue-id", ue_id)
 
         print("************************* Restarting MME service on", "gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         # Receive UE_ESM_INFORMATION_REQ, as sometimes MME retransmits
         # UE_ESM_INFORMATION_REQ message before it restarts

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
@@ -75,11 +75,10 @@ class TestNoIdentityRspWithMmeRestart(unittest.TestCase):
         )
 
         print("********************** Restarting MME service on gateway ***")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         # Since UE has neither received Attach Reject nor Attach Accept,
         # assuming that both T3410 and T3411 timer expires at UE

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_smc_with_mme_restart_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_smc_with_mme_restart_reattach.py
@@ -73,11 +73,10 @@ class TestNoSmcWithMmeRestartReattach(unittest.TestCase):
         print("************* Received SMC for ue", req.ue_id)
 
         print("************************* Restarting MME service on", "gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_after_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_after_mme_restart.py
@@ -86,12 +86,10 @@ class TestPagingAfterMmeRestart(unittest.TestCase):
         wait_time = 0.3
         time.sleep(wait_time)
         print('************************* Restarting MME service on', 'gateway')
-        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
-
-        wait_time = 20
-        for j in range(wait_time, 0, -1):
-            print('Waiting for', j, 'seconds')
-            time.sleep(1)
+        wait_for_restart = 20
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         print(
             '************************* Running UE downlink (UDP) for UE id ',

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_with_mme_restart.py
@@ -109,11 +109,10 @@ class TestPagingWithMmeRestart(unittest.TestCase):
                 "************************* Restarting MME service on",
                 "gateway",
             )
-            self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-            for j in range(30):
-                print("Waiting for", j, "seconds")
-                time.sleep(1)
+            wait_for_restart = 30
+            self._s1ap_wrapper.magmad_util.restart_services(
+                ["mme"], wait_for_restart,
+            )
 
             # Send service request to reconnect UE
             ser_req = s1ap_types.ueserviceReq_t()

--- a/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
@@ -286,13 +286,10 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
             "************************* Restarting Sessiond, MME and",
             "Pipelined services on gateway",
         )
+        wait_for_restart = 30
         self._s1ap_wrapper.magmad_util.restart_services(
-            ["sessiond", "mme", "pipelined"],
+            ["sessiond", "mme", "pipelined"], wait_for_restart,
         )
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
 
         print("Sleeping for 5 seconds")
         time.sleep(5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
@@ -85,11 +85,10 @@ class TestServiceReqUlUdpDataWithMmeRestart(unittest.TestCase):
         )
 
         print("************************* Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         print(
             "************************* Sending Service request for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
@@ -40,10 +40,10 @@ class TestStandalonePdnConnReqWithApnCorrection(unittest.TestCase):
         num_ues = 1
 
         print("************************* restarting mme")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-        for j in range(30):
-            print("Waiting mme restart for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
         self._s1ap_wrapper.configUEDevice(num_ues)
         req = self._s1ap_wrapper.ue_req
@@ -109,10 +109,10 @@ class TestStandalonePdnConnReqWithApnCorrection(unittest.TestCase):
         self._s1ap_wrapper.magmad_util.config_apn_correction(
             MagmadUtil.apn_correction_cmds.DISABLE,
         )
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
-        for j in range(30):
-            print("Waiting mme restart for", j, "seconds")
-            time.sleep(1)
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ["mme"], wait_for_restart,
+        )
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
@@ -235,7 +235,7 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
                     attach_steps[step](req.ue_id)
 
         # Restart mme
-        self._s1ap_wrapper.magmad_util.restart_mme_and_wait()
+        self._s1ap_wrapper.magmad_util.restart_services(['mme'])
 
         # Post restart, complete the attach procedures that were cut in between
         for i in range(num_ues_attaching):


### PR DESCRIPTION
## Summary

- Linked to #13684 
- Follow-up to #13852 (only to be merged afterwards!)

With the `envoy` controller now dockerized, the util functions for performing the LTE integration tests are adapted to a containerized AGW. 

- The `init_system` check (and subsequent restart behavior) is extended to all relevant functions
- The `sctpd` container restart now also calls `config_stateless_agw.py` and restarts `mme`
- Handling of the `redis` states is improved
- Some syntax adaption in the relevant tests 

## Test Plan

All integration tests (excluding the non-sanity ones) ran green locally with both, a `systemd`-based AGW and a containerized AGW. 

Containerized AGW (For the setup see [here](https://github.com/magma/magma/blob/master/lte/gateway/docker/README.md#running-the-containerized-agw-locally-on-the-magma-vm))
- [x] precommit tests
- [x] extended tests

`systemd`-based AGW
- [x] precommit tests
- [x] extended tests

In GitHub actions: https://github.com/mpfirrmann/magma/runs/8306326461?check_suite_focus=true

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
