### PR TITLE
chore: bump node-fetch

### DIFF
--- a/nms/package.json
+++ b/nms/package.json
@@ -178,6 +178,7 @@
   "resolutions": {
     "@babel/runtime": "^7.3.4",
     "node-forge": "^1.0.0",
+    "node-fetch": "^2.6.7",
     "refractor/prismjs": "^1.27.0",
     "jspdf": "^2.3.1",
     "cacache/ssri": "6.0.2",

--- a/nms/yarn.lock
+++ b/nms/yarn.lock
@@ -10304,17 +10304,12 @@ node-environment-flags@^1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@2.6.7, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.8.5, node-forge@^1.0.0:
   version "1.3.1"


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Use a package.json resolution to upgrade node-fetch to 2.6.7 without touching either puppeteer or react-json-view. The earlier approch of modifying react-json-view caused e2e tests to fail. This new approach passes both unit tests and e2e tests, and still clears the stale dependency.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
1. cd nms; yarn run test
2. cd nms; ./e2e_test_setup.sh 
3. CI tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
