### PR TITLE
fix(agw): fix certificate issue for containerized AGW deployment

### DIFF
--- a/lte/gateway/docker/.env
+++ b/lte/gateway/docker/.env
@@ -18,7 +18,6 @@ OPTIONAL_ARCH_POSTFIX=
 
 BUILD_CONTEXT=../../..
 
-ROOTCA_PATH=../../../.cache/test_certs/rootCA.pem
 CONTROL_PROXY_PATH=../configs/control_proxy.yml
 
 SNOWFLAKE_PATH=/etc/snowflake

--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -42,6 +42,11 @@ cd $MAGMA_ROOT/lte/gateway && make run  # You can skip this if you have built th
 for component in redis nghttpx td-agent-bit; do cp "${MAGMA_ROOT}"/{orc8r,lte}/gateway/configs/templates/${component}.conf.template; done
 sudo systemctl stop 'magma@*' 'sctpd' # We don't want the systemd-based AGW to run when we start the containerized AGW
 sudo systemctl start magma_dp@envoy
+
+# Optional: If you want to connect to an orc8r, copy the `rootCA.pem` from the orc8r
+# to `/var/opt/magma/certs/rootCA.pem`. For example in a typical magma-dev VM:
+cp ${MAGMA_ROOT}/.cache/test_certs/rootCA.pem /var/opt/magma/certs/
+
 cd $MAGMA_ROOT/lte/gateway/docker
 docker-compose build
 docker-compose up

--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -11,7 +11,6 @@ x-standard-volumes: &volumes_anchor
   - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
   - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
   - ${CONFIGS_OVERRIDE_TMP_VOLUME}:/var/opt/magma/tmp
-  - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
   - /etc/snowflake:/etc/snowflake
   - /var/opt/magma/fluent-bit:/var/opt/magma/fluent-bit
   - ./:/var/opt/magma/docker


### PR DESCRIPTION
Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>

## Summary

Resolves issue #13682.
This PR fixes the issue where a containerized deployment on bare metal tries to mount the `rootCA.pem` certificate from the directory`$MAGMA_ROOT/.cache/test_certs/`, which does not exist. Instead, it will be mounted from `/var/opt/magma/certs/`, where it is previously copied to when following the documentation.
This should not affect the containerized AGW setup inside the dev VM, as spinning up the VM creates the certificate in both locations: at `$MAGMA_ROOT/.cache/test_certs/` (mounted from host) and at `/var/opt/magma/certs/` in the VM.

## Test Plan

* test that the containerized AGW deployment in the dev environment (i.e. inside the dev VM) is unaffected by this change
* test the error in the linked issue for a deployment of the AGW containers on bare metal is resolved

## Additional Information

- [ ] This change is backwards-breaking
