### PR TITLE
chore(ci): codecov should not fail the build pipeline

### DIFF
--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -139,7 +139,6 @@ jobs:
         with:
           flags: unittests,configuration-controller
           name: codecov-configuration-controller
-          fail_ci_if_error: false
           verbose: true
 
   active_mode_controller_unit_tests:
@@ -179,7 +178,6 @@ jobs:
         with:
           flags: unittests,active-mode-controller
           name: codecov-active-mode-controller
-          fail_ci_if_error: false
           verbose: true
 
   radio_controller_unit_tests:
@@ -258,7 +256,6 @@ jobs:
         with:
           flags: unittests,radio-controller
           name: codecov-radio-controller
-          fail_ci_if_error: false
           verbose: true
 
   db_migration_check:
@@ -354,7 +351,6 @@ jobs:
         with:
           flags: unittests,db-service
           name: codecov-db-service
-          fail_ci_if_error: false
           verbose: true
 
   integration_tests_orc8r:

--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -219,7 +219,6 @@ jobs:
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
         with:
           flags: src_go
-          fail_ci_if_error: true
           verbose: true
       - name: Extract commit title
         id: commit


### PR DESCRIPTION
This was previously inconsistently used. It should be `false` everywhere consistently. And an explicit statement of `false` is not necessary, as this is the default.

- Contributes to #13819 