### PR TITLE
fix: bazel base uses same folly version as magma vm

### DIFF
--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -19,7 +19,6 @@ RUN echo "Install general purpose packages" && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
         apt-utils \
-        # dependencies of FreeDiameter
         bison \
         build-essential \
         ca-certificates \
@@ -29,39 +28,30 @@ RUN echo "Install general purpose packages" && \
         git \
         gnupg2 \
         g++ \
-        # dependency of mobilityd (tests)
-        iproute2 \
-        # dependency of python services (e.g. magmad)
-        iputils-ping \
+        iproute2 `# dependency of mobilityd (tests)` \
+        iputils-ping `# dependency of python services (e.g. magmad)` \
         flex \
         libconfig-dev \
-        # dependency of @sentry_native//:sentry
-        libcurl4-openssl-dev \
-        # dependencies of oai/mme
+        libcurl4-openssl-dev `# dependency of @sentry_native//:sentry` \
         libczmq-dev \
         libgcrypt-dev \
         libgmp3-dev \
         libidn11-dev \
         libsctp1 \
         libsqlite3-dev \
-        # dependency of sctpd
-        libsctp-dev \
+        libsctp-dev `# dependency of sctpd` \
         libssl-dev \
-        # dependency of pip systemd
-        libsystemd-dev \
+        libsystemd-dev `# dependency of pip systemd` \
         lld \
-        # dependency of python services (e.g. magmad)
-        net-tools \
-        # dependency of python services (e.g. pipelined)
-        netbase \
+        net-tools `# dependency of python services (e.g. magmad)` \
+        netbase `# dependency of python services (e.g. pipelined)` \
         python${PYTHON_VERSION} \
         python-is-python3 \
+        python3-distutils `# dependency of bazel pip_parse rule` \
         software-properties-common \
-        # dependency of python services (e.g. magmad)
-        systemd \
+        systemd `# dependency of python services (e.g. magmad)` \
         unzip \
-        # dependency of liagent
-        uuid-dev \
+        uuid-dev `# dependency of liagent` \
         vim \
         wget \
         zip
@@ -82,38 +72,13 @@ RUN apt-get install -y --no-install-recommends \
         libpcap-dev=1.9.1-3 \
         libmnl-dev=1.0.4-2
 
-## Install Fmt (Folly Dep)
-RUN git clone https://github.com/fmtlib/fmt.git && \
-    cd fmt && \
-    mkdir _build && \
-    cd _build && \
-    cmake -DBUILD_SHARED_LIBS=ON -DFMT_TEST=0 .. && \
-    make -j"$(nproc)" && \
-    make install && \
-    cd / && \
-    rm -rf fmt
-
-# Facebook Folly C++ lib
-# Note: "Because folly does not provide any ABI compatibility guarantees from
-#        commit to commit, we generally recommend building folly as a static library."
-# Here we checkout the hash for v2021.02.22.00 (arbitrary recent version)
-RUN git clone --depth 1 --branch v2021.02.15.00 https://github.com/facebook/folly && \
-    cd /folly && \
-    mkdir _build && \
-    cd _build && \
-    cmake -DBUILD_SHARED_LIBS=ON .. && \
-    make -j"$(nproc)" && \
-    make install && \
-    cd / && \
-    rm -rf folly
-
 # setup magma artifactories and install magma dependencies
 RUN wget -qO - https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public | apt-key add - && \
     add-apt-repository 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main' && \
-    add-apt-repository 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-1.7.0 main' && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
         bcc-tools \
+        libfolly-dev \
         liblfds710 \
         oai-asn1c \
         oai-gnutls \


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

This PR re-applies #13743 (reverted in #13753). This time #13757 was applied before so that bazel workflows still run on the bazel base image before this change.

A follow-up PR will be created where the cache key in bazel workflows will be changed and the latest image is used again. By this, the cache failures that caused the revert should be prevented.

## Test Plan

* see that https://github.com/magma/magma/runs/8231653751?check_suite_focus=true was successful

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
