### PR TITLE
test(cwg): Stabilizing `TestGyCreditExhaustionRedirect`

### DIFF
--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -493,6 +493,10 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 	assert.Eventually(t,
 		tr.WaitForEnforcementStatsForRuleGreaterThan(imsi, "static-pass-all-ocs2", 0.25*MegaBytes), time.Minute, 2*time.Second)
 
+	// Check that no redirect rule is installed when quota grant is not exhausted
+	time.Sleep(15 * time.Second)
+	assert.False(t, tr.WaitForEnforcementStatsForRule(imsi, "redirect")())
+
 	// When we initiate a UE disconnect, we expect a terminate request to go up
 	terminateRequest := fegprotos.NewGyCCRequest(imsi, fegprotos.CCRequestType_TERMINATION)
 	terminateAnswer := fegprotos.NewGyCCAnswer(diam.Success)

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -115,15 +115,15 @@ func provisionRestrictRules(t *testing.T, tr *TestRunner, ruleManager *RuleManag
 	tr.WaitForPoliciesToSync()
 }
 
-// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
-//   respond with a quota grant of 4M.
-//   Generate traffic and assert the CCR-I is received.
-// - Set an expectation for a CCR-U with >80% of data usage to be sent up to
-// 	 OCS, to which it will response with more quota.
-//   Generate traffic and assert the CCR-U is received with final quota grant.
-// - Generate 5M traffic to exceed 100% of the quota and trigger session termination
-// - Assert that UE flows are deleted.
-// - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
+//   - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//     respond with a quota grant of 4M.
+//     Generate traffic and assert the CCR-I is received.
+//   - Set an expectation for a CCR-U with >80% of data usage to be sent up to
+//     OCS, to which it will response with more quota.
+//     Generate traffic and assert the CCR-U is received with final quota grant.
+//   - Generate 5M traffic to exceed 100% of the quota and trigger session termination
+//   - Assert that UE flows are deleted.
+//   - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
 func TestGyCreditExhaustionWithCRRU(t *testing.T) {
 	fmt.Println("\nRunning TestGyCreditExhaustionWithCRRU...")
 	tr, ruleManager, ue := ocsTestSetup(t)
@@ -274,12 +274,12 @@ func TestGyCreditValidityTime(t *testing.T) {
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
-// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
-//   respond with a quota grant of 4M.
-//   Generate traffic and assert the CCR-I is received.
-// - Generate 5M traffic to exceed 100% of the quota and trigger session termination
-// - Assert that UE flows are deleted.
-// - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
+//   - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//     respond with a quota grant of 4M.
+//     Generate traffic and assert the CCR-I is received.
+//   - Generate 5M traffic to exceed 100% of the quota and trigger session termination
+//   - Assert that UE flows are deleted.
+//   - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
 func TestGyCreditExhaustionWithoutCCRU(t *testing.T) {
 	fmt.Println("\nRunning TestGyCreditExhaustionWithoutCCRU...")
 
@@ -342,9 +342,9 @@ func TestGyCreditExhaustionWithoutCCRU(t *testing.T) {
 	tr.AssertAllGyExpectationsMetNoError()
 }
 
-// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
-//   NOT respond with any answer.
-// - Asset that authentication fails and that no rules were installed
+//   - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//     NOT respond with any answer.
+//   - Asset that authentication fails and that no rules were installed
 func TestGyLinksFailureOCStoFEG(t *testing.T) {
 	fmt.Println("\nRunning TestGyLinksFailureOCStoFEG...")
 
@@ -378,22 +378,24 @@ func TestGyLinksFailureOCStoFEG(t *testing.T) {
 	assert.Empty(t, recordsBySubID["IMSI"+ue.Imsi])
 }
 
-// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
-//   respond with a quota grant of 4M and final action set to redirect.
-//   Generate traffic and assert the CCR-I is received.
-// - Generate 5M traffic to exceed 100% of the quota to trigger redirection.
-// - When redirection happens, redirect rule is installed on top of the actual rules
-// 	 Assert that UE flows are NOT deleted and data was passed
-// - Assert redirect rule is installed
-// - Send a Charging ReAuth request to top up quota and assert that the
-//   response is successful
-// - Assert that CCR-U was is generated
-// - Assert the redirect rule is gone
-// - Generate  traffic and assert that UE flows are NOT deleted and data was passed.
-// - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
+//   - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//     respond with a quota grant of 4M and final action set to redirect.
+//     Generate traffic and assert the CCR-I is received.
+//   - Generate 5M traffic to exceed 100% of the quota to trigger redirection.
+//   - When redirection happens, redirect rule is installed on top of the actual rules
+//     Assert that UE flows are NOT deleted and data was passed
+//   - Assert redirect rule is installed
+//   - Send a Charging ReAuth request to top up quota and assert that the
+//     response is successful
+//   - Assert that CCR-U was is generated
+//   - Assert the redirect rule is gone
+//   - Generate  traffic and assert that UE flows are NOT deleted and data was passed.
+//   - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
+//
 // NOTE : the test is only verifying that session was not terminated.
-//        Improvement is needed to validate that ovs rule is well added and
-//        traffic is being redirected.
+//
+//	Improvement is needed to validate that ovs rule is well added and
+//	traffic is being redirected.
 func TestGyCreditExhaustionRedirect(t *testing.T) {
 	fmt.Println("\nRunning TestGyCreditExhaustionRedirect...")
 
@@ -653,16 +655,16 @@ func TestGyAbortSessionRequest(t *testing.T) {
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
-// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
-//   respond with a quota grant of 4M and final action set to redirect.
-//   Generate traffic and assert the CCR-I is received.
-// - Generate 5M traffic to exceed 100% of the quota to trigger service restriction.
-// - Assert that UE flows are NOT deleted and data was passed.
-// - Generate an additional 2M traffic and assert that only Gy flows matched.
-// - Send a Charging ReAuth request to top up quota and assert that the
-//   response is successful
-// - Assert that CCR-U was is generated
-// - Generate 2M traffic and assert that UE flows are NOT deleted and data was passed.
+//   - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//     respond with a quota grant of 4M and final action set to redirect.
+//     Generate traffic and assert the CCR-I is received.
+//   - Generate 5M traffic to exceed 100% of the quota to trigger service restriction.
+//   - Assert that UE flows are NOT deleted and data was passed.
+//   - Generate an additional 2M traffic and assert that only Gy flows matched.
+//   - Send a Charging ReAuth request to top up quota and assert that the
+//     response is successful
+//   - Assert that CCR-U was is generated
+//   - Generate 2M traffic and assert that UE flows are NOT deleted and data was passed.
 func TestGyCreditExhaustionRestrict(t *testing.T) {
 	fmt.Println("\nRunning TestGyCreditExhaustionRestrict...")
 
@@ -778,15 +780,15 @@ func TestGyCreditExhaustionRestrict(t *testing.T) {
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
-// - Send a CCA-I with valid credit for a RG but with 4012 error code (transient)
-// - Assert that UE flows for that RG are deleted
-// - Generate an additional 2M traffic and assert that only Gy flows matched.
-// - Assert that Redirect flows are installed
-// - Send a Charging ReAuth request to top up quota and assert that the
-//   response is successful
-// - Assert that CCR-U was is generated
-// - Generate 2M traffic and assert that UE flows are reinstalled for RG
-//   and traffic goes through them.
+//   - Send a CCA-I with valid credit for a RG but with 4012 error code (transient)
+//   - Assert that UE flows for that RG are deleted
+//   - Generate an additional 2M traffic and assert that only Gy flows matched.
+//   - Assert that Redirect flows are installed
+//   - Send a Charging ReAuth request to top up quota and assert that the
+//     response is successful
+//   - Assert that CCR-U was is generated
+//   - Generate 2M traffic and assert that UE flows are reinstalled for RG
+//     and traffic goes through them.
 func TestGyCreditTransientErrorRestrict(t *testing.T) {
 	fmt.Println("\nRunning TestGyCreditTransientErrorRestrict...")
 
@@ -894,22 +896,22 @@ func TestGyCreditTransientErrorRestrict(t *testing.T) {
 
 	// TODO: uncomment once we fix passing the ip to pipelined for cwf
 	// Check that enforcement stats flow was not removed and data passed
-	//tr.AssertPolicyUsage(imsi, "static-pass-all-ocs1", uint64(math.Round(1.5*MegaBytes)), 3*MegaBytes+Buffer)
-	//assert.Nil(t, policyUsage["IMSI"+imsi]["restrict-pass-user"], fmt.Sprintf("Policy usage restrict-pass-user for imsi: %v was NOT removed", imsi))
+	// tr.AssertPolicyUsage(imsi, "static-pass-all-ocs1", uint64(math.Round(1.5*MegaBytes)), 3*MegaBytes+Buffer)
+	// assert.Nil(t, policyUsage["IMSI"+imsi]["restrict-pass-user"], fmt.Sprintf("Policy usage restrict-pass-user for imsi: %v was NOT removed", imsi))
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
-// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
-//   respond with a quota grant of 4M with two rules.
-// - Generate traffic and assert the CCR-I is received.
-// - Set an expectation for a CCR-U with >80% of data usage to be sent up to
-// 	 OCS, to which it will respond with an ERROR CODE
-// - Send an CCA-U with a 4012 code transient failure which should trigger suspend that credit
-// - Assert that UE flows for one rule are delete.
-// - Assert that UE flows for the other rule are still valid
+//   - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//     respond with a quota grant of 4M with two rules.
+//   - Generate traffic and assert the CCR-I is received.
+//   - Set an expectation for a CCR-U with >80% of data usage to be sent up to
+//     OCS, to which it will respond with an ERROR CODE
+//   - Send an CCA-U with a 4012 code transient failure which should trigger suspend that credit
+//   - Assert that UE flows for one rule are delete.
+//   - Assert that UE flows for the other rule are still valid
 func TestGyWithTransientErrorCode(t *testing.T) {
 	fmt.Println("\nRunning TestGyWithTransientErrorCode...")
 
@@ -997,13 +999,13 @@ func TestGyWithTransientErrorCode(t *testing.T) {
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
-// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
-//   respond with a quota grant of 4M.
-//   Generate traffic and assert the CCR-I is received.
-// - Generate traffic over 80% and under 100% not to trigger termination
-// - Send an CCA-U with a 5xxx code which should trigger termination
-// - Assert that UE flows are deleted.
-// - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
+//   - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//     respond with a quota grant of 4M.
+//     Generate traffic and assert the CCR-I is received.
+//   - Generate traffic over 80% and under 100% not to trigger termination
+//   - Send an CCA-U with a 5xxx code which should trigger termination
+//   - Assert that UE flows are deleted.
+//   - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
 func TestGyWithPermanentErrorCode(t *testing.T) {
 	fmt.Println("\nRunning TestGyWithPermanentErrorCode...")
 

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -409,7 +409,7 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 	quotaGrant := &fegprotos.QuotaGrant{
 		RatingGroup: 1,
 		GrantedServiceUnit: &fegprotos.Octets{
-			TotalOctets: 4 * MegaBytes,
+			TotalOctets: 1 * MegaBytes,
 		},
 		IsFinalCredit: true,
 		FinalUnitIndication: &fegprotos.FinalUnitIndication{
@@ -447,19 +447,17 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 
 	// we need to generate over 100% of the quota to trigger a session redirection
 	req := &cwfprotos.GenTrafficRequest{
-		Imsi:   imsi,
-		Volume: &wrappers.StringValue{Value: "10M"},
-		//Bitrate: &wrappers.StringValue{Value: "100M"},
+		Imsi:    imsi,
+		Volume:  &wrappers.StringValue{Value: "2M"},
 		Timeout: 60,
 	}
 
-	//time.Sleep(500 * time.Microsecond)
 	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
 
 	// Check that enforcement stats flow was not removed and data was passed
 	assert.Eventually(t,
-		tr.WaitForEnforcementStatsForRuleGreaterThan(imsi, "static-pass-all-ocs2", 3*MegaBytes), time.Minute, 2*time.Second)
+		tr.WaitForEnforcementStatsForRuleGreaterThan(imsi, "static-pass-all-ocs2", 1*MegaBytes), time.Minute, 2*time.Second)
 	// Wait for service deactivation
 	assert.Eventually(t,
 		tr.WaitForEnforcementStatsForRule(imsi, "redirect"), time.Minute, 2*time.Second)
@@ -481,7 +479,7 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 	// we need to generate more traffic
 	req = &cwfprotos.GenTrafficRequest{
 		Imsi:    imsi,
-		Volume:  &wrappers.StringValue{Value: "2M"},
+		Volume:  &wrappers.StringValue{Value: "0.5M"},
 		Bitrate: &wrappers.StringValue{Value: "30M"},
 		Timeout: 60,
 	}
@@ -491,7 +489,7 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 
 	// Check that enforcement stats flow was not removed and data was passed
 	assert.Eventually(t,
-		tr.WaitForEnforcementStatsForRuleGreaterThan(imsi, "static-pass-all-ocs2", 1*MegaBytes), time.Minute, 2*time.Second)
+		tr.WaitForEnforcementStatsForRuleGreaterThan(imsi, "static-pass-all-ocs2", 0.25*MegaBytes), time.Minute, 2*time.Second)
 
 	// When we initiate a UE disconnect, we expect a terminate request to go up
 	terminateRequest := fegprotos.NewGyCCRequest(imsi, fegprotos.CCRequestType_TERMINATION)
@@ -587,7 +585,7 @@ func TestGyAbortSessionRequest(t *testing.T) {
 
 	err = setNewOCSConfig(
 		&fegprotos.OCSConfig{
-			MaxUsageOctets: &fegprotos.Octets{TotalOctets: 8 * MegaBytes}, //we generate more then 5Mbyte traffic, if this is set below 7MB this session will terminate before the ASR goes through
+			MaxUsageOctets: &fegprotos.Octets{TotalOctets: 8 * MegaBytes}, // we generate more then 5Mbyte traffic, if this is set below 7MB this session will terminate before the ASR goes through
 			MaxUsageTime:   ReAuthMaxUsageTimeSec,
 			ValidityTime:   ReAuthValidityTime,
 		},

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -257,11 +257,11 @@ func (tr *TestRunner) GenULTraffic(req *cwfprotos.GenTrafficRequest) (*cwfprotos
 // - If we spend more than wait for time, and we haven't reached totalVolume
 //
 // Arguments
-// - req: request to pas to UEsim
-// - ruleID: name of the rule to monitor
-// - totalVolume: total used by that rule. Note that if hte rule was used before, you have to add it's previous usage
-//	 So if the rule already used 1Mb and you want to send 1Mb more, you will have to use 2M as min
-// - waitFor time out the UE will be sending data
+//   - req: request to pas to UEsim
+//   - ruleID: name of the rule to monitor
+//   - totalVolume: total used by that rule. Note that if hte rule was used before, you have to add it's previous usage
+//     So if the rule already used 1Mb and you want to send 1Mb more, you will have to use 2M as min
+//   - waitFor time out the UE will be sending data
 func (tr *TestRunner) GenULTrafficBasedOnPolicyUsage(req *cwfprotos.GenTrafficRequest,
 	ruleID string, totalVolume uint64, waitFor time.Duration) (*cwfprotos.GenTrafficResponse, error) {
 	fmt.Printf("************* Checking rule %s exists before generating traffic for UE\n", ruleID)

--- a/cwf/gateway/services/uesim/servicers/uesim.go
+++ b/cwf/gateway/services/uesim/servicers/uesim.go
@@ -214,10 +214,10 @@ func (srv *UESimServer) Disconnect(ctx context.Context, id *cwfprotos.Disconnect
 // GenTraffic generates traffic using a remote iperf server. The command to be sent is configured using GenTrafficRequest
 // Note that GenTrafficRequest have parameter that configures iperf client itself, and parameters that configure UESim
 // Configuration parameters related to the UESim client itself (not iperf) are:
-// - timeout: if different than 0 stops iperf externally after n seconds. Use it to avoid the test to hang on a unreachable server
-// 	 If the test timesout it will be counted as an error. By default this is 0 (DISABLED)
-// - disableServerReachabilityCheck: enables/disables the function to request the server to send the UE small packets to check if
-//   the server is alive. By default this is ENABLED
+//   - timeout: if different than 0 stops iperf externally after n seconds. Use it to avoid the test to hang on a unreachable server
+//     If the test timesout it will be counted as an error. By default this is 0 (DISABLED)
+//   - disableServerReachabilityCheck: enables/disables the function to request the server to send the UE small packets to check if
+//     the server is alive. By default this is ENABLED
 func (srv *UESimServer) GenTraffic(ctx context.Context, req *cwfprotos.GenTrafficRequest) (*cwfprotos.GenTrafficResponse, error) {
 	if req == nil {
 		return &cwfprotos.GenTrafficResponse{}, fmt.Errorf("Nil GenTrafficRequest provided")


### PR DESCRIPTION
Fixes #13838

Signed-off-by: Moritz Huebner <moritz.huebner@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

I modified the specified quota and requested traffic to make the test less flaky. The requested 10 Megabytes in `TestGyCreditExhaustionRedirect` is larger than any other traffic request in the `cwf` integration tests. It appears that larger traffic requests are more likely to fail for reasons we do not fully understand. The test is run with three reattempts on the CI, so it is sufficient to tune it so that is unlikely to fail four times consecutively.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

Unfortunately, I was not able to reproduce this problem locally. So I used an [upterm Github action](https://github.com/lhotari/action-upterm) to tune this on the Github runner remotely. I executed on the test on the state of `master` ten times and had seven failures. This result implies that we get `(0.7**4) = 24%` failure rate with reattempts on `master`, which is consistent with what is mentioned in #13838. 

I tuned the quotas and ran the test 100 times without reattempts with the state of this branch triggering only 13 failures. This yields a `(0.13**4) = 0.029%` failure rate once reattempts are considered.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

`TestGyCreditExhaustionRedirect` is not the only flaky `cwag` test. I found at least 15 other tests that fail at least occasionally but usually succeed in the reattempts. We could consider increasing the number of reattempts to make the workflow more stable overall.

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
