### PR TITLE
chore(agw): Create convenient aliases in magma-dev VM for service commands

### DIFF
--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -374,7 +374,7 @@ pipeline {
                     echo "Maybe we could not generate the coverage HTML report"
                   }
                 }
-                sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make stop"')
+                sh('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* stop"')
                 // Retrieving the sys logs and mme log for more debugging.
                 sh('cd lte/gateway && vagrant ssh magma -c "sudo cat /var/log/syslog" > ${WORKSPACE}/archives/magma_dev_syslog.log')
                 sh('cd lte/gateway && vagrant ssh magma -c "sudo cat /var/log/envoy.log" > ${WORKSPACE}/archives/magma_dev_envoy.log')
@@ -503,7 +503,7 @@ pipeline {
       post {
         always {
           script {
-            sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make stop"')
+            sh('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* stop"')
             // Stopping capture
             sh('cd lte/gateway && vagrant ssh magma -c "sudo pkill tcpdump"')
             // Retrieving the sys logs and mme log for more debugging.

--- a/docs/readmes/lte/s1ap_tests.md
+++ b/docs/readmes/lte/s1ap_tests.md
@@ -131,7 +131,7 @@ sctpd.service
 1. Clean up all the state in redis: `redis-cli -p 6380 FLUSHALL`. This might
 throw a "Could not connect" error if magma@redis service is not running. Start
 the redis service with `sudo service magma@redis start` and then try again.
-1. `cd $MAGMA_ROOT/lte/gateway; make restart`
+1. `magma-restart`
 
 On test VM:
 
@@ -159,7 +159,7 @@ service file `/etc/systemd/system/magma@mme.service` (you will need sudo privile
 throw a "Could not connect" error if magma@redis service is not running. Start
 the redis service with `sudo service magma@redis start` and then try again.
 
-1. `cd $MAGMA_ROOT/lte/gateway; make restart`
+1. `magma-restart`
 
 On test VM:
 
@@ -188,7 +188,7 @@ service file `/etc/systemd/system/magma@mme.service` (you will need sudo privile
 throw a "Could not connect" error if magma@redis service is not running. Start
 the redis service with `sudo service magma@redis start` and then try again.
 
-1. `cd $MAGMA_ROOT/lte/gateway; make restart`
+1. `magma-restart`
 
 On test VM:
 

--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -30,18 +30,12 @@ test:
 	gotestsum --junitfile /tmp/test-results/aaa-eap.xml --packages  magma/feg/gateway/services/eap/... magma/feg/gateway/services/aaa/... -- -tags link_local_service,with_builtin_radius
 	go test -tags cli_test magma/feg/gateway/tools/...
 
-buildenv: stop
+buildenv:
+	sudo service magma@* stop
 	PROTO_LIST="orc8r_protos feg_protos lte_protos" $(MAKE) -C $(MAGMA_ROOT)/orc8r/gateway/python $@
 
 run: buildenv build
 	sudo service magma@magmad start
-
-restart:
-	sudo service magma@* stop
-	sudo service magma@magmad start
-
-stop:
-	sudo service magma@* stop
 
 clean:
 	$(MAKE) -C $(MAGMA_ROOT)/lte/gateway/python $@

--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -72,15 +72,9 @@ clean_python: ## Clean Python-only builds
 clean_envoy_controller: ## Clean envoy controller build
 	rm -rf  $(GO_BUILD)/envoy_controller
 
-start: ## Start all services
-	sudo service magma@magmad start
-
-stop: ## Stop all services
+run: build ## Build and run all services
 	sudo service magma@* stop
-
-restart: stop start ## Restart all services
-
-run: build restart ## Build and run all services
+	sudo service magma@magmad start
 
 # run_cmake BUILD_DIRECTORY, FILE_DIRECTORY, FLAGS, ENV
 define run_cmake
@@ -97,7 +91,8 @@ $(call run_cmake, $(1), $(3), $(4) $(TEST_FLAG))
 cd $(2) && ctest --output-on-failure -R $(5)
 endef
 
-build_python: stop ## Build Python environment
+build_python: ## Build Python environment
+	sudo service magma@* stop
 	make -C $(MAGMA_ROOT)/lte/gateway/python buildenv
 
 build_common: ## Build shared libraries
@@ -137,10 +132,12 @@ build_envoy_controller: ## Build envoy controller
 build_%:
 	$(call run_cmake, $(C_BUILD)/$*, $(MAGMA_ROOT)/c/$*, $(COMMON_FLAGS))
 
-test_python: stop ## Run all Python-specific tests
+test_python: ## Run all Python-specific tests
+	sudo service magma@* stop
 	make -C $(MAGMA_ROOT)/lte/gateway/python test_all
 
-test_sudo_python: stop ## Run Python tests that require sudo (datapath, etc.)
+test_sudo_python: ## Run Python tests that require sudo (datapath, etc.)
+	sudo service magma@* stop
 	make -C $(MAGMA_ROOT)/lte/gateway/python test_all SKIP_NON_SUDO_TESTS=1
 
 test_python_service: ## Run all Python-specific tests for a given service

--- a/lte/gateway/deploy/magma_dev_focal.yml
+++ b/lte/gateway/deploy/magma_dev_focal.yml
@@ -43,6 +43,7 @@
     - role: bazel
     - role: fluent_bit
     - role: pyvenv
+    - role: service_aliases
 
   tasks:
     # Only run installation for docker

--- a/lte/gateway/deploy/roles/service_aliases/tasks/main.yml
+++ b/lte/gateway/deploy/roles/service_aliases/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-################################################################################
 # Copyright 2022 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -10,12 +9,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
-- name: Set up Magma environment based on debian package for integration testing
-  hosts: deb
-  become: yes
-
-  roles:
-    - role: magma_deb
-    - role: service_aliases
+- name: Create convenient aliases for magma services
+  lineinfile:
+    dest: /home/{{ ansible_user }}/.bashrc
+    state: present
+    line: "{{ item }}"
+  with_items:
+    - "alias magma-start='sudo service magma@magmad start'"
+    - "alias magma-stop='sudo service magma@* stop && sudo service sctpd stop && sudo service magma_dp@envoy stop'"
+    - "alias magma-restart='magma-stop && magma-start'"
+    - "alias magma-status='sudo service magma* status'"

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -384,7 +384,7 @@ def bazel_integ_test_post_build(
         ansible_setup(gateway_host, "dev", "magma_dev.yml")
         gateway_ip = gateway_host.split('@')[1].split(':')[0]
 
-    execute(_restart_gateway)
+    execute(_start_gateway)
 
     # Setup the trfserver: use the provided trfserver if given, else default to the
     # vagrant machine
@@ -767,16 +767,7 @@ def _run_sudo_python_unit_tests():
 
 def _start_gateway():
     """ Starts the gateway """
-
-    with cd(AGW_ROOT):
-        run('make run')
-
-
-def _restart_gateway():
-    """ Restart the gateway """
-
-    with cd(AGW_ROOT):
-        run('make restart')
+    run('sudo service magma@magmad start')
 
 
 def _set_service_config_var(service, var_name, value):


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Create convenient aliases in magma-dev VM for service commands in order to replace Make commands
  - Create aliases with ansible for magma-dev and magma-deb
  - Remove Make targets for service commands in LTE and FEG
    - Clean up usage by inlineing or replacement with the aliases 
- The `_start_gateway` function in the fabfile now just starts the services. The build that happened in the `make run` is thus removed. This was an unnecessary second build step in LTE integ tests. 
- The `make status` command was removed in https://github.com/magma/magma/pull/13782
  - Since it was actually used by people it was re-added here as an alias 
- Resolves #13811

## Test Plan

- [x] Provision magma-dev or magma-deb VM
  - Run the alias commands (`magma-status` will only return something after `magma-start` has run)
  - Use `make run` to see that the services are still starting 
- [x] [LTE integ tests](https://github.com/LKreutzer/magma/runs/8299451808?check_suite_focus=true)
  - [x] Local LTE integ test run 
- [x] [LTE integ tests bazel (some test failures)](https://github.com/LKreutzer/magma/runs/8306819133?check_suite_focus=true)


## Additional Information

Aliases that replace the removed Make commands:
- `magma-start` starts the services via magmad
- `magma-stop` stops all magma services
- `magma-restart` restarts magma services
- `magma-status` print status of all magma services


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
