### PR TITLE
fix(dp): add 103 grantId handling

### DIFF
--- a/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/test_response_processor.py
@@ -124,33 +124,15 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
         )
 
     @parameterized.expand([
-        (
-            GRANT_REQ, ResponseCodes.SUCCESS.value, None, GrantStates.GRANTED.value,
-        ),
-        (
-            GRANT_REQ, ResponseCodes.INTERFERENCE.value, None, None,
-        ),
-        (
-            GRANT_REQ, ResponseCodes.GRANT_CONFLICT.value, ['grant1', 'grant2'], GrantStates.UNSYNC.value,
-        ),
-        (
-            GRANT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, None,
-        ),
-        (
-            HEARTBEAT_REQ, ResponseCodes.SUCCESS.value, None, GrantStates.AUTHORIZED.value,
-        ),
-        (
-            HEARTBEAT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, None,
-        ),
-        (
-            HEARTBEAT_REQ, ResponseCodes.SUSPENDED_GRANT.value, None, GrantStates.GRANTED.value,
-        ),
-        (
-            HEARTBEAT_REQ, ResponseCodes.UNSYNC_OP_PARAM.value, None, GrantStates.UNSYNC.value,
-        ),
-        (
-            RELINQUISHMENT_REQ, ResponseCodes.SUCCESS.value, None, None,
-        ),
+        (GRANT_REQ, ResponseCodes.SUCCESS.value, None, GrantStates.GRANTED.value),
+        (GRANT_REQ, ResponseCodes.INTERFERENCE.value, None, None),
+        (GRANT_REQ, ResponseCodes.GRANT_CONFLICT.value, ['grant1', 'grant2'], GrantStates.UNSYNC.value),
+        (GRANT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, None),
+        (HEARTBEAT_REQ, ResponseCodes.SUCCESS.value, None, GrantStates.AUTHORIZED.value),
+        (HEARTBEAT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, None),
+        (HEARTBEAT_REQ, ResponseCodes.SUSPENDED_GRANT.value, None, GrantStates.GRANTED.value),
+        (HEARTBEAT_REQ, ResponseCodes.UNSYNC_OP_PARAM.value, None, GrantStates.UNSYNC.value),
+        (RELINQUISHMENT_REQ, ResponseCodes.SUCCESS.value, None, None),
     ])
     @responses.activate
     def test_grant_state_after_response(
@@ -180,35 +162,19 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
         )
 
     @parameterized.expand([
-        (
-            GRANT_REQ, ResponseCodes.SUCCESS.value, None, [GrantStates.GRANTED.value],
-        ),
-        (
-            GRANT_REQ, ResponseCodes.INTERFERENCE.value, None, [],
-        ),
+        (GRANT_REQ, ResponseCodes.SUCCESS.value, None, [GrantStates.GRANTED.value]),
+        (GRANT_REQ, ResponseCodes.INTERFERENCE.value, None, []),
         (
             GRANT_REQ, ResponseCodes.GRANT_CONFLICT.value,
             ['test_grant_id_for_1', 'test_grant_id_for_2'],
             [GrantStates.GRANTED.value, GrantStates.UNSYNC.value],
         ),
-        (
-            GRANT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, [],
-        ),
-        (
-            HEARTBEAT_REQ, ResponseCodes.SUCCESS.value, None, [GrantStates.AUTHORIZED.value],
-        ),
-        (
-            HEARTBEAT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, [],
-        ),
-        (
-            HEARTBEAT_REQ, ResponseCodes.SUSPENDED_GRANT.value, None, [GrantStates.GRANTED.value],
-        ),
-        (
-            HEARTBEAT_REQ, ResponseCodes.UNSYNC_OP_PARAM.value, None, [GrantStates.UNSYNC.value],
-        ),
-        (
-            RELINQUISHMENT_REQ, ResponseCodes.SUCCESS.value, None, [],
-        ),
+        (GRANT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, []),
+        (HEARTBEAT_REQ, ResponseCodes.SUCCESS.value, None, [GrantStates.AUTHORIZED.value]),
+        (HEARTBEAT_REQ, ResponseCodes.TERMINATED_GRANT.value, None, []),
+        (HEARTBEAT_REQ, ResponseCodes.SUSPENDED_GRANT.value, None, [GrantStates.GRANTED.value]),
+        (HEARTBEAT_REQ, ResponseCodes.UNSYNC_OP_PARAM.value, None, [GrantStates.UNSYNC.value]),
+        (RELINQUISHMENT_REQ, ResponseCodes.SUCCESS.value, None, []),
     ])
     @responses.activate
     def test_preexisting_grant_state_after_response(
@@ -408,10 +374,15 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
         (HEARTBEAT_REQ, ResponseCodes.INVALID_VALUE.value, [CBSD_ID], CbsdStates.UNREGISTERED.value),
         (RELINQUISHMENT_REQ, ResponseCodes.INVALID_VALUE.value, [CBSD_ID], CbsdStates.UNREGISTERED.value),
         (DEREGISTRATION_REQ, ResponseCodes.INVALID_VALUE.value, [CBSD_ID], CbsdStates.UNREGISTERED.value),
-        (SPECTRUM_INQ_REQ, ResponseCodes.INVALID_VALUE.value, None, CbsdStates.REGISTERED.value),
-        (GRANT_REQ, ResponseCodes.INVALID_VALUE.value, None, CbsdStates.REGISTERED.value),
-        (HEARTBEAT_REQ, ResponseCodes.INVALID_VALUE.value, None, CbsdStates.REGISTERED.value),
-        (RELINQUISHMENT_REQ, ResponseCodes.INVALID_VALUE.value, None, CbsdStates.REGISTERED.value),
+        (SPECTRUM_INQ_REQ, ResponseCodes.INVALID_VALUE.value, [GRANT_ID], CbsdStates.UNREGISTERED.value),
+        (GRANT_REQ, ResponseCodes.INVALID_VALUE.value, [GRANT_ID], CbsdStates.UNREGISTERED.value),
+        (HEARTBEAT_REQ, ResponseCodes.INVALID_VALUE.value, [GRANT_ID], CbsdStates.UNREGISTERED.value),
+        (RELINQUISHMENT_REQ, ResponseCodes.INVALID_VALUE.value, [GRANT_ID], CbsdStates.UNREGISTERED.value),
+        (DEREGISTRATION_REQ, ResponseCodes.INVALID_VALUE.value, [GRANT_ID], CbsdStates.UNREGISTERED.value),
+        (SPECTRUM_INQ_REQ, ResponseCodes.INVALID_VALUE.value, None, CbsdStates.UNREGISTERED.value),
+        (GRANT_REQ, ResponseCodes.INVALID_VALUE.value, None, CbsdStates.UNREGISTERED.value),
+        (HEARTBEAT_REQ, ResponseCodes.INVALID_VALUE.value, None, CbsdStates.UNREGISTERED.value),
+        (RELINQUISHMENT_REQ, ResponseCodes.INVALID_VALUE.value, None, CbsdStates.UNREGISTERED.value),
     ])
     @responses.activate
     def test_cbsd_state_after_unsuccessful_response_code(self, request_type, response_code, response_data, expected_cbsd_sate):
@@ -613,14 +584,18 @@ class DefaultResponseDBProcessorTestCase(LocalDBTestCase):
     def _create_response_payload_from_db_requests(response_type_name, db_requests, sas_response_code=0, sas_response_data=None):
         response_payload = {response_type_name: []}
         for i, db_request in enumerate(db_requests):
-            cbsd_id = db_request.cbsd.cbsd_id or str(i)
             response_json = {
                 "response": {
                     "responseCode": sas_response_code,
-                }, "cbsdId": cbsd_id,
+                },
             }
+
             if sas_response_data:
                 response_json["response"]["responseData"] = sas_response_data
+            else:
+                cbsd_id = db_request.cbsd.cbsd_id or str(i)
+                response_json["cbsdId"] = cbsd_id
+
             if db_request.payload.get(GRANT_ID, ""):
                 response_json[GRANT_ID] = db_request.payload.get(GRANT_ID)
             elif response_type_name == request_response[GRANT_REQ]:


### PR DESCRIPTION
Signed-off-by: Jarosław Jaszczuk <jaroslaw@freedomfi.com>

SAS can respond with `103 cbsdId` but also with `103 grantId` or `103 [any field]`. DP should deregister CBSD on any of these responses, but until now it will only deregister on `103 cbsdId` leading to a deadlock with SAS in other cases.

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
* deregister on any `103` response, not only `103 cbsdId`

<!-- Enumerate changes you made and why you made them -->

## Test Plan
* new test cases
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
