### PR TITLE
fix(ci): activate carryforward in CodeCov + apply best practise for flag management

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,29 +1,10 @@
 comment: false
 github_checks:
     annotations: false
-coverage:
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 0%
-      cloud_lint:
-        target: auto
-        threshold: 0%
-        flags:
-          - cloud_lint
-      feg-lint:
-        target: auto
-        threshold: 0%
-        flags:
-          - feg-lint
-      lte-test:
-        target: auto
-        threshold: 0%
-        flags:
-          - lte-test
-      c_cpp:
-        target: auto
-        threshold: 0%
-        flags:
-          - c_cpp
+flag_management:
+    default_rules:
+        carryforward: true
+        statuses:
+            - type: project
+              target: auto
+              threshold: 0%


### PR DESCRIPTION
# Summary

- Activates carryforward flags for all flagged uploads.
- The current setup does not require duplication of defined flags. This is not only manual effort in maintenance, but also discouraged within the documentation. Also see https://docs.codecov.com/docs/flags#step-2-flag-management-in-yaml.
- Resolves #13819 