### PR TITLE
fix(mobilityd): Set daemon flag for mobilityd timers

### DIFF
--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -93,6 +93,7 @@ class UplinkGatewayInfo:
             self._read_default_gw_interval_seconds,
             self._do_read_default_gw,
         )
+        self._read_default_gw_timer.setDaemon(True)
         self._read_default_gw_timer.start()
         logging.info("GW probe: timer started")
 
@@ -117,6 +118,7 @@ class UplinkGatewayInfo:
             self._read_default_gw_interval_seconds,
             self._do_read_default_gw_v6,
         )
+        self._read_default_gw_timer6.setDaemon(True)
         self._read_default_gw_timer6.start()
         logging.info("GW-v6 probe: timer started")
 


### PR DESCRIPTION
## Summary

This makes sure that mobilityd can be stopped by a `SIGTERM` even if the timers are still running and looking for IP addresses.

Fixes #13826.

## Test Plan

- Make sure that the IPv6 setup is broken on a gateway but an IPv6 block is configured.
  - The timer will be restarted every 20 seconds.
- Kill mobilityd with a `SIGTERM`.
  - Mobilityd can be killed with the changes here, but not without them.

## Additional Information

- [ ] This change is backwards-breaking
