### PR TITLE
fix(orc8r): Updated helm chart version for 1.8.0 release (#13731) [backport to v1.8]

### DIFF
--- a/cwf/cloud/helm/cwf-orc8r/Chart.yaml
+++ b/cwf/cloud/helm/cwf-orc8r/Chart.yaml
@@ -10,10 +10,10 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "1.0"
+appVersion: "1.8.0"
 description: A Helm chart for magma orchestrator's cwf module
 name: cwf-orc8r
-version: 0.2.2
+version: 1.8.0
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/docs/readmes/orc8r/deploy_install.md
+++ b/docs/readmes/orc8r/deploy_install.md
@@ -136,7 +136,7 @@ override the following parameters
 - `orc8r_db_engine_version` on fresh Orc8r installs, target Postgres `12.6`
 
 Make sure that the `source` variables for the module definitions point to
-`github.com/magma/magma//orc8r/cloud/deploy/terraform/MODULE?ref=v1.6`.
+`github.com/magma/magma//orc8r/cloud/deploy/terraform/MODULE?ref=v1.8`.
 Adjust any other parameters as you see fit. Check the READMEs for the
 relevant Terraform modules to see additional variables that can be set.
 You can [override values](./deploy_terraform_options.md#override-terraform-module-values)

--- a/docs/readmes/orc8r/deploy_intro.md
+++ b/docs/readmes/orc8r/deploy_intro.md
@@ -64,6 +64,15 @@ To target a specific release, checkout the Magma repository's relevant release b
 
 Values for recent Orchestrator releases are summarized below
 
+### v1.8.0
+
+Verified with Terraform version `1.0.11`.
+
+- `v1.8` [patch branch](https://github.com/magma/magma/tree/v1.8)
+- `github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.8`
+Terraform module source
+- `1.8.0` Helm chart version
+
 ### v1.6.0
 
 Verified with Terraform version `0.15.0`.

--- a/dp/cloud/helm/dp/charts/domain-proxy/Chart.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/Chart.yaml
@@ -11,8 +11,8 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "0.1.0"
-version: 0.1.0
+appVersion: "1.8.0"
+version: 1.8.0
 description: A Helm chart for magma orchestrator's domain-proxy module.
 name: domain-proxy
 engine: gotpl

--- a/feg/cloud/helm/feg-orc8r/Chart.yaml
+++ b/feg/cloud/helm/feg-orc8r/Chart.yaml
@@ -10,10 +10,10 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "1.0"
+appVersion: "1.8.0"
 description: A Helm chart for magma orchestrator's feg module
 name: feg-orc8r
-version: 0.2.5
+version: 1.8.0
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/lte/cloud/helm/lte-orc8r/Chart.yaml
+++ b/lte/cloud/helm/lte-orc8r/Chart.yaml
@@ -10,10 +10,10 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "1.0"
+appVersion: "1.8.0"
 description: A Helm chart for magma orchestrator's lte module
 name: lte-orc8r
-version: 0.2.6
+version: 1.8.0
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/data/vars.yml
@@ -346,7 +346,7 @@ service:
     Required: false
     ConfigApps:
       - tf
-    Default: 0.2.2
+    Default: 1.8.0
   deploy_nms:
     Description: Flag to deploy NMS.
     Type: bool
@@ -436,7 +436,7 @@ service:
     Required: false
     ConfigApps:
       - tf
-    Default: 0.2.5
+    Default: 1.8.0
   helm_deployment_name:
     Description: Name for the Helm release.
     Type: string
@@ -476,7 +476,7 @@ service:
     Required: false
     ConfigApps:
       - tf
-    Default: 0.2.6
+    Default: 1.8.0
   monitoring_kubernetes_namespace:
     Description: K8s namespace to install Orchestrator monitoring components into.
     Type: string
@@ -489,7 +489,7 @@ service:
     Required: false
     ConfigApps:
       - tf
-    Default: 1.5.28
+    Default: 1.8.0
   orc8r_controller_replicas:
     Description: Replica count for Orchestrator controller pods.
     Type: number
@@ -527,7 +527,7 @@ service:
     ConfigApps:
       - tf
   orc8r_tag:
-    Default: "1.5.0"
+    Default: "1.8.0"
     Description: Image tag for Orchestrator components.
     Type: string
     Required: true
@@ -836,7 +836,7 @@ service:
   dp_orc8r_chart_version:
     Description: Version of the Orchestrator domain proxy module Helm chart to install.
     Type: string
-    Default: 0.1.0
+    Default: 1.8.0
     Required: false
     ConfigApps:
       - tf

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/test_helm_charts_sync.py
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/root/scripts/test_helm_charts_sync.py
@@ -26,6 +26,7 @@ charts_fn_map = {
     'feg-orc8r': 'feg/cloud/helm/feg-orc8r/Chart.yaml',
     'lte-orc8r': 'lte/cloud/helm/lte-orc8r/Chart.yaml',
     'cwf-orc8r': 'cwf/cloud/helm/cwf-orc8r/Chart.yaml',
+    'domain-proxy': 'dp/cloud/helm/dp/charts/domain-proxy/Chart.yaml',
 }
 
 

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -176,25 +176,25 @@ variable "orc8r_deployment_type" {
 variable "orc8r_chart_version" {
   description = "Version of the core orchestrator Helm chart to install."
   type        = string
-  default     = "1.5.28"
+  default     = "1.8.0"
 }
 
 variable "cwf_orc8r_chart_version" {
   description = "Version of the orchestrator cwf module Helm chart to install."
   type        = string
-  default     = "0.2.2"
+  default     = "1.8.0"
 }
 
 variable "feg_orc8r_chart_version" {
   description = "Version of the orchestrator feg module Helm chart to install."
   type        = string
-  default     = "0.2.5"
+  default     = "1.8.0"
 }
 
 variable "lte_orc8r_chart_version" {
   description = "Version of the orchestrator lte module Helm chart to install."
   type        = string
-  default     = "0.2.6"
+  default     = "1.8.0"
 }
 
 variable "wifi_orc8r_chart_version" {
@@ -206,13 +206,13 @@ variable "wifi_orc8r_chart_version" {
 variable "dp_orc8r_chart_version" {
   description = "Version of the orchestrator domain proxy module Helm chart to install."
   type        = string
-  default     = "0.1.0"
+  default     = "1.8.0"
 }
 
 variable "orc8r_tag" {
   description = "Image tag for Orchestrator components."
   type        = string
-  default     = "1.7.0"
+  default     = "1.8.0"
 }
 
 variable "magma_uuid" {

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -10,10 +10,10 @@
 # limitations under the License.
 
 apiVersion: v2
-appVersion: "1.0"
+appVersion: "1.8.0"
 description: Helm chart for the Magma Orchestrator
 name: orc8r
-version: 1.5.28
+version: 1.8.0
 home: https://www.magmacore.org
 sources:
   - https://github.com/magma/magma


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [fix(orc8r): Updated helm chart version for 1.8.0 release (#13731)](https://github.com/magma/magma/pull/13731)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)