### PR TITLE
feat(ci): s1ap integ tests against dockerized agw

### DIFF
--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v20220722
-
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
         with:
           python-version: '3.8.10'
@@ -50,15 +49,12 @@ jobs:
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML
           vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
-
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/
           echo '* 192.168.0.0/16' | sudo tee /etc/vbox/networks.conf
           echo '* 3001::/64' | sudo tee -a /etc/vbox/networks.conf
-
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
-
       - name: Run the integration test
         env:
           DOCKER_REGISTRY: docker-ci.artifactory.magmacore.org/

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -62,5 +62,4 @@ jobs:
           MAGMA_DEV_MEMORY_MB: 9216
         working-directory: lte/gateway
         run: |
-          fab --version
           fab --show=debug --set DOCKER_REGISTRY=${DOCKER_REGISTRY} integ_test_containerized

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -1,0 +1,70 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: LTE integ test containerized AGW
+
+on:
+  workflow_dispatch: null
+  workflow_run:
+    workflows:
+      - build-all
+    branches:
+      - master
+    types:
+      - completed
+
+jobs:
+  lte-integ-test-containerized:
+    if: github.event.workflow_run.conclusion == 'success' && (github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch')
+    runs-on: macos-12
+    steps:
+      - name: Cache magma-dev-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
+          key: vagrant-box-magma-dev-v1.2.20220801
+      - name: Cache magma-test-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
+          key: vagrant-box-magma-test
+      - name: Cache magma-trfserver-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
+          key: vagrant-box-magma-trfserver-v20220722
+
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
+        with:
+          python-version: '3.8.10'
+      - name: Install pre requisites
+        run: |
+          pip3 install --upgrade pip
+          pip3 install ansible fabric3 jsonpickle requests PyYAML
+          vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
+
+      - name: Open up network interfaces for VM
+        run: |
+          sudo mkdir -p /etc/vbox/
+          echo '* 192.168.0.0/16' | sudo tee /etc/vbox/networks.conf
+          echo '* 3001::/64' | sudo tee -a /etc/vbox/networks.conf
+
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+
+      - name: Run the integration test
+        env:
+          DOCKER_REGISTRY: docker-ci.artifactory.magmacore.org/
+          MAGMA_DEV_CPUS: 3
+          MAGMA_DEV_MEMORY_MB: 9216
+        working-directory: lte/gateway
+        run: |
+          fab --version
+          fab --show=debug --set DOCKER_REGISTRY=${DOCKER_REGISTRY} integ_test_containerized

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -192,7 +192,7 @@ def connect_gateway_to_cloud(
     cert_path=DEFAULT_CERT,
 ):
     """
-    Setup the gateway VM to connects to the cloud
+    Set up the gateway VM to connects to the cloud
     Path to control_proxy.yml and rootCA.pem could be specified to use
     non-default control proxy setting and certificates
     """
@@ -372,7 +372,7 @@ def bazel_integ_test_post_build(
     execute(_modify_for_bazel_services)
     execute(_start_gateway)
 
-    # Setup the trfserver: use the provided trfserver if given, else default to the
+    # Set up the trfserver: use the provided trfserver if given, else default to the
     # vagrant machine
     if not trf_host:
         trf_host = vagrant_setup(
@@ -444,7 +444,7 @@ def integ_test(
     destroy_vm = bool(strtobool(destroy_vm))
     provision_vm = bool(strtobool(provision_vm))
 
-    # Setup the gateway: use the provided gateway if given, else default to the
+    # Set up the gateway: use the provided gateway if given, else default to the
     # vagrant machine
     gateway_host, gateway_ip = _setup_gateway(gateway_host, "magma", "dev", "magma_dev.yml", destroy_vm, provision_vm)
     execute(_dist_upgrade)
@@ -452,7 +452,7 @@ def integ_test(
     execute(_run_sudo_python_unit_tests)
     execute(_start_gateway)
 
-    # Setup the trfserver: use the provided trfserver if given, else default to the
+    # Set up the trfserver: use the provided trfserver if given, else default to the
     # vagrant machine
     _setup_vm(trf_host, "magma_trfserver", "trfserver", "magma_trfserver.yml", destroy_vm, provision_vm)
     execute(_start_trfserver)
@@ -536,14 +536,14 @@ def integ_test_containerized(
     destroy_vm = bool(strtobool(destroy_vm))
     provision_vm = bool(strtobool(provision_vm))
 
-    # Setup the gateway: use the provided gateway if given, else default to the
+    # Set up the gateway: use the provided gateway if given, else default to the
     # vagrant machine
     gateway_host, gateway_ip = _setup_gateway(gateway_host, "magma", "dev", "magma_dev.yml", destroy_vm, provision_vm)
     # TODO: Remove temporary workaround after resolution of https://github.com/magma/magma/issues/13912
     run('rm -rf /etc/snowflake; sudo touch /etc/snowflake')
     execute(_start_gateway_containerized)
 
-    # Setup the trfserver: use the provided trfserver if given, else default to the
+    # Set up the trfserver: use the provided trfserver if given, else default to the
     # vagrant machine
     _setup_vm(trf_host, "magma_trfserver", "trfserver", "magma_trfserver.yml", destroy_vm, provision_vm)
     execute(_start_trfserver)
@@ -742,7 +742,7 @@ def load_test(gateway_host=None, destroy_vm=True):
         destroy_vm: If the vagrant VM should be destroyed and setup
         before running load tests.
     """
-    # Setup the gateway: use the provided gateway if given, else default to the
+    # Set up the gateway: use the provided gateway if given, else default to the
     # vagrant machine
     if gateway_host:
         ansible_setup(gateway_host, 'dev', 'magma_dev.yml')

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -516,21 +516,8 @@ def integ_test_containerized(
         destroy_vm='True', provision_vm='True',
 ):
     """
-    Run the integration tests. This defaults to running on local vagrant
-    machines, but can also be pointed to an arbitrary host (e.g. amazon) by
-    passing "address:port" as arguments
-
-    gateway_host: The ssh address string of the machine to run the gateway
-        services on. Formatted as "host:port". If not specified, defaults to
-        the `magma` vagrant box.
-
-    test_host: The ssh address string of the machine to run the tests on
-        on. Formatted as "host:port". If not specified, defaults to the
-        `magma_test` vagrant box.
-
-    trf_host: The ssh address string of the machine to run the TrafficServer
-        on. Formatted as "host:port". If not specified, defaults to the
-        `magma_trfserver` vagrant box.
+    Run the integration tests against the containerized AGW.
+    Other than that the same as `integ_test`.
     """
 
     destroy_vm = bool(strtobool(destroy_vm))
@@ -556,7 +543,7 @@ def integ_test_containerized(
 
 
 def _start_gateway_containerized():
-    """ Starts the gateway """
+    """ Starts the containerized AGW """
     with cd(AGW_PYTHON_ROOT):
         run('make buildenv')
 


### PR DESCRIPTION
## Summary

- Contributes to https://github.com/magma/magma/issues/13695
- A new workflow is created, which runs some integration tests against a containerized instance of AGW running on the Magma Dev VM.
  - *Only attach-detach test* for this PR. 
- This is the first iteration of testing the containerized AGW in CI.
  - The workflow was designed based on the exiting workflows.
  - It is expected that further optimisation can be made in follow ups later on.
  - Some integration test are flaky in general, such that for this stage, _one_ successful run will be seen as solution.
- The tests are run against the `latest` images of the services available.
  - Especially, it is out of scope to build the containerized AGW within this effort and PR.
  - Using the latest available images should provide sufficient additional information, if there is a sensible trigger to the workflow. In particular, any edge cases or race conditions are acquiesced!

## Test Plan

- See runs: https://github.com/magma/magma/actions/workflows/lte-integ-test-containerized.yml
  -  :heavy_check_mark: Successful at https://github.com/magma/magma/actions/runs/3190270518/jobs/5205143748.

## Additional Information

- As a guide: https://github.com/magma/magma/blob/master/lte/gateway/docker/README.md#running-the-containerized-agw-locally-on-the-magma-vm