### PR TITLE
feat(ci): make the releasing team default approvers for any backport

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,6 @@
+# releasing team
+*   @m-govind @panyogesh
+
 # approvers-ci
 /ci-scripts/ @magma/approvers-ci
 /.github/workflows/ @magma/approvers-ci
@@ -9,66 +12,7 @@
 /lte/gateway/Vagrantfile @magma/approvers-ci
 /cwf/gateway/Vagrantfile @magma/approvers-ci
 
-# approvers-orc8r
-*/cloud/ @magma/approvers-orc8r
-/.golangci.yml @magma/approvers-orc8r
-/orc8r/ @magma/approvers-orc8r
-
-# approvers-orc8r-infra
-/orc8r/cloud/docker/ @magma/approvers-orc8r-infra
-/orc8r/cloud/deploy/ @magma/approvers-orc8r-infra
-*/cloud/helm/ @magma/approvers-orc8r-infra
-
-# approvers-nms
-/nms/ @magma/approvers-nms
-
-# approvers-feg
-/feg/ @magma/approvers-feg
-
-# approvers-cwf
-/cwf/ @magma/approvers-cwf
-/openwrt/ @magma/approvers-cwf
-
-# approvers-agw
-/lte/gateway @magma/approvers-agw
-/lte/protos @magma/approvers-agw
-/lte/gateway/python @magma/approvers-agw
-/lte/gateway/c @magma/approvers-agw
-/show-tech/ @magma/approvers-agw
-
-# agw code related to orc8r
-/orc8r/gateway/c/ @magma/approvers-agw
-/orc8r/gateway/python @magma/approvers-agw @magma/approvers-orc8r
-/src/go/ @magma/approvers-orc8r
-
-# approvers-agw-<subsection>
-/lte/gateway/c/session_manager @magma/approvers-agw-sessiond
-/lte/gateway/c/core/oai @magma/approvers-agw-mme
-/lte/gateway/c/sctpd @magma/approvers-agw-mme
-/lte/gateway/python/integ_tests @magma/approvers-agw-integtests
-/lte/gateway/docker @magma/approvers-agw-containers @magma/approvers-ci
-
-# approvers-agw-pipelined
-/lte/gateway/python/magma/pipelined @magma/approvers-agw-pipelined
-/third_party/gtp_ovs @magma/approvers-agw-pipelined
-
-# XWF Magma integrations
-/xwf/ @magma/approvers-xwf
-/feg/radius @magma/approvers-xwf @magma/approvers-cwf
-
-/dp/ @magma/approvers-domain-proxy
-
-/docs/ @magma/approvers-docs
 /docs/readmes/proposals @magma/approvers-tsc
-
-# approvers-bazel
-/.bazel-cache/ @magma/approvers-bazel
-/.bazel-cache-repo/ @magma/approvers-bazel
-/.github/workflows/bazel.yml @magma/approvers-bazel
-/bazel/ @magma/approvers-bazel
-/.bazelignore @magma/approvers-bazel
-/.bazelrc @magma/approvers-bazel
-*.bazel @magma/approvers-bazel
 
 /CODEOWNERS @magma/approvers-tsc
 


### PR DESCRIPTION
## Summary

As far as I understand, the current backporting process for a contribution should look as follows:
- A PR is created against `master`.
- The PR against `master` is reviewed by the topic codeowners.
- The PR is merged to `master`.
- A backporting PR is openend against the `v1.X` branch.
- This PR against `v1.X` needs to be approved by the respective release team.
As this PR is content wise the same as the original one, a re-review by the topic codeowners is usually not required, however could be requested by the release team.
- If the release team agrees the PR against the `v1.X` branch can be merged.

If my understanding of the backporting process is correct, the respective branch `v1.8` should have the respective release team (@m-govind , @panyogesh ) as code owners for most parts. An exceptions was made for the infrastructure resources not belonging to the product and for the parts owned by TSC, as those seemed sensible exceptions.

*This PR is seen as basis for discussion, how we could improve the mapping of our process on the Github tooling.*

So the more detailed questions raised with this PR are:
1. Should the release branch be owned by the release team?
1. Can we drop the requirement of a compulsory re-review by topic code-owners and have the release team decide, if this is necessary?
1. Are the exceptions well chosen?