### PR TITLE
fix(nms): Show an error message if the user login fails

### DIFF
--- a/nms/app/login.tsx
+++ b/nms/app/login.tsx
@@ -24,7 +24,11 @@ import {AppContextProvider} from './context/AppContext';
 import {BrowserRouter} from 'react-router-dom';
 import {StyledEngineProvider, ThemeProvider} from '@mui/material/styles';
 
+const LOGIN_ERROR_MESSAGE = 'Invalid email or password';
+
 function LoginWrapper() {
+  const params = new URLSearchParams(window.location.search);
+  const loginInvalid = params.get('invalid');
   return (
     <LoginForm
       action="/user/login"
@@ -32,6 +36,7 @@ function LoginWrapper() {
       ssoAction="/user/login/saml"
       ssoEnabled={window.CONFIG.appData.ssoEnabled}
       csrfToken={window.CONFIG.appData.csrfToken}
+      error={loginInvalid ? LOGIN_ERROR_MESSAGE : undefined}
     />
   );
 }


### PR DESCRIPTION
## Summary

Before this change, the user got no feedback if they typed a wrong password.

NMS already recognized invalid logins via a query parameter, and there was an error property in the login form, the two features were just not put together.

Fixes #13429.

## Test Plan

Started NMS locally and entered a wrong password.

![nmslogin](https://user-images.githubusercontent.com/14236667/189381302-411cd09a-e8b1-4e78-a0f4-562402083846.png)

## Additional Information

- [ ] This change is backwards-breaking
