### PR TITLE
fix(dp): Fix typos in dp config

### DIFF
--- a/dp/cloud/configs/dp.yml
+++ b/dp/cloud/configs/dp.yml
@@ -14,14 +14,14 @@
 # time is measured since last get state grpc request to
 # radio controller service in domain proxy
 dp_backend:
-  cbsd_inactivity_interval_sec: 14400
+  cbsd_inactivity_timeout_sec: 14400
   log_consumer_url: "http://domain-proxy-fluentd:9888/dp"
 active_mode_controller:
   dial_timeout_sec: 60
   heartbeat_send_timeout_sec: 10
   request_timeout_sec: 5
   request_processing_interval_sec: 10
-  polling_interval: 10
+  polling_interval_sec: 10
   grpc_service: 'domain-proxy-radio-controller'
   grpc_port: 50053
-  cbsd_inactivity_interval_sec: 14400
+  cbsd_inactivity_timeout_sec: 14400

--- a/dp/cloud/go/services/dp/config.go
+++ b/dp/cloud/go/services/dp/config.go
@@ -20,8 +20,8 @@ type Config struct {
 }
 
 type BackendConfig struct {
-	CbsdInactivityIntervalSec int    `yaml:"cbsd_inactivity_interval_sec"`
-	LogConsumerUrl            string `yaml:"log_consumer_url"`
+	CbsdInactivityTimeoutSec int    `yaml:"cbsd_inactivity_timeout_sec"`
+	LogConsumerUrl           string `yaml:"log_consumer_url"`
 }
 
 type AmcConfig struct {
@@ -29,8 +29,8 @@ type AmcConfig struct {
 	HeartbeatSendTimeoutSec      int    `yaml:"heartbeat_send_timeout_sec"`
 	RequestTimeoutSec            int    `yaml:"request_timeout_sec"`
 	RequestProcessingIntervalSec int    `yaml:"request_processing_interval_sec"`
-	PollingIntervalSec           int    `yaml:"polling_interval"` // TODO add sec to deployment scripts
+	PollingIntervalSec           int    `yaml:"polling_interval_sec"`
 	GrpcService                  string `yaml:"grpc_service"`
 	GrpcPort                     int    `yaml:"grpc_port"`
-	CbsdInactivityTimeoutSec     int    `yaml:"cbsd_inactivity_interval_sec"` // TODO temporary fix to make integration tests pass
+	CbsdInactivityTimeoutSec     int    `yaml:"cbsd_inactivity_timeout_sec"`
 }

--- a/dp/cloud/go/services/dp/dp/main.go
+++ b/dp/cloud/go/services/dp/dp/main.go
@@ -57,10 +57,10 @@ func main() {
 	cbsdStore := dp_storage.NewCbsdManager(db, sqorc.GetSqlBuilder(), sqorc.GetErrorChecker(), sqorc.GetSqlLocker())
 
 	dpCfg := serviceConfig.DpBackend
-	interval := time.Second * time.Duration(dpCfg.CbsdInactivityIntervalSec)
+	timeout := time.Second * time.Duration(dpCfg.CbsdInactivityTimeoutSec)
 	logConsumerUrl := dpCfg.LogConsumerUrl
 
-	protos.RegisterCbsdManagementServer(srv.GrpcServer, servicers.NewCbsdManager(cbsdStore, interval, logConsumerUrl, logs_pusher.PushDPLog))
+	protos.RegisterCbsdManagementServer(srv.GrpcServer, servicers.NewCbsdManager(cbsdStore, timeout, logConsumerUrl, logs_pusher.PushDPLog))
 
 	cancel, errs := startAmc(serviceConfig.ActiveModeController)
 

--- a/dp/cloud/helm/dp/charts/domain-proxy/examples/orc8r_integration_tests.yaml
+++ b/dp/cloud/helm/dp/charts/domain-proxy/examples/orc8r_integration_tests.yaml
@@ -2,9 +2,9 @@
 dp:
   config:
     dp_backend:
-      cbsd_inactivity_interval_sec: 3
+      cbsd_inactivity_timeout_sec: 3
     active_mode_controller:
       heartbeat_send_timeout_sec: 30
       request_processing_interval_sec: 1
-      polling_interval: 1
-      cbsd_inactivity_interval_sec: 3
+      polling_interval_sec: 1
+      cbsd_inactivity_timeout_sec: 3

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -143,7 +143,7 @@ $(TOOLS_LIST): %_tools:
 
 tools_lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-		| sh -s -- -b $$(go env GOPATH)/bin v1.45.0
+		| sh -s -- -b $$(go env GOPATH)/bin v1.46.2
 
 ######################
 ## Swagger/API docs ##

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -348,14 +348,14 @@ dp:
   enabled: false
   config:
     dp_backend:
-      cbsd_inactivity_interval_sec: 14400
+      cbsd_inactivity_timeout_sec: 14400
       log_consumer_url: "http://domain-proxy-fluentd:9888/dp"
     active_mode_controller:
       dial_timeout_sec: 60
       heartbeat_send_timeout_sec: 10
       request_timeout_sec: 5
       request_processing_interval_sec: 10
-      polling_interval: 10
+      polling_interval_sec: 10
       grpc_service: 'domain-proxy-radio-controller'
       grpc_port: 50053
-      cbsd_inactivity_interval_sec: 14400
+      cbsd_inactivity_timeout_sec: 14400


### PR DESCRIPTION
## Summary

Fix 2 typos in dp config:
`cbsd_inactivity_interval_sec` -> `cbsd_inactivity_timeout_sec`
`polling_interval` -> `polling_interval_sec`

Also update golangci-lint from v1.45.0 to v1.46.2 to support generics.

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>