### PR TITLE
fix(dp): Adjust dp config to deployment names

### DIFF
--- a/dp/cloud/go/services/dp/config.go
+++ b/dp/cloud/go/services/dp/config.go
@@ -32,5 +32,5 @@ type AmcConfig struct {
 	PollingIntervalSec           int    `yaml:"polling_interval"` // TODO add sec to deployment scripts
 	GrpcService                  string `yaml:"grpc_service"`
 	GrpcPort                     int    `yaml:"grpc_port"`
-	CbsdInactivityTimeoutSec     int    `yaml:"cbsd_inactivity_timeout_sec"`
+	CbsdInactivityTimeoutSec     int    `yaml:"cbsd_inactivity_interval_sec"` // TODO temporary fix to make integration tests pass
 }


### PR DESCRIPTION
## Summary

Temporary fix to make dp integration tests pass
Proper solution is to fix typos in deployment scripts

Signed-off-by: Kuba Marciniszyn <kuba@freedomfi.com>