### PR TITLE
fix(ci): Add repository with grpc-dev version 1.43

### DIFF
--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -75,6 +75,7 @@ RUN apt-get install -y --no-install-recommends \
 # setup magma artifactories and install magma dependencies
 RUN wget -qO - https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public | apt-key add - && \
     add-apt-repository 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main' && \
+    add-apt-repository 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-1.7.0 main' && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
         bcc-tools \


### PR DESCRIPTION
Co-authored-by: Jan Heidbrink <jan.heidbrink@tngtech.com>

Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- In the devcontainer there is currently no repository that has the `grpc-dev` version 1.43.
  - As a temporary workaround we add the `focal-1.7.0` repository which has this version.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
