### PR TITLE
fix: ansible is pinned because of ansible-core 2.13.4 breaking change

### DIFF
--- a/lte/gateway/deploy/agw_install_docker.sh
+++ b/lte/gateway/deploy/agw_install_docker.sh
@@ -79,7 +79,8 @@ EOF
   fi
 
   alias python=python3
-  pip3 install ansible
+  # TODO GH13915 pinned for now because of breaking change in ansible-core 2.13.4
+  pip3 install ansible==5.0.1
 
   rm -rf /opt/magma/
   git clone "${GIT_URL}" /opt/magma


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Ansible released a breaking change in ansible-core 2.14.3. The module `apt` used with `only_upgrade: yes` now fails if a package is not already installed.

Especially this fails for the agw docker install script with
```
TASK [magma_deploy : Install runtime dependencies.] ***********************************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"cache_update_time": 1663062238, "cache_updated": false, "changed": false, "msg": "no available installation candidate for graphviz"}
```

Seems unreasonable to try to upgrade packages that are not installed. This should be cleaned up in the magma code (see #13915) but is handled for now via pinning for the 1.8 release.

## Test Plan

* install dockerized agw

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
