### PR TITLE
fix(nms): Improve sync of NMS organizations and orc8r tenants

### DIFF
--- a/nms/app/views/organizations/OrganizationInfoDialog.tsx
+++ b/nms/app/views/organizations/OrganizationInfoDialog.tsx
@@ -32,7 +32,7 @@ import {SSOSelectedType} from '../../../shared/types/auth';
 import {useState} from 'react';
 
 const ENABLE_ALL_NETWORKS_HELPER =
-  'By checking this, the organization will have access to all existing and future networks.';
+  'Checking this gives access to all networks that exist at the moment.';
 
 /**
  * Create Organization Tab
@@ -83,7 +83,7 @@ export default function (props: DialogProps) {
         {!shouldEnableAllNetworks && (
           <AltFormField
             label={'Accessible Networks'}
-            subLabel={'The networks that the organization have access to'}>
+            subLabel={'The networks that the organization has access to'}>
             <Select
               fullWidth={true}
               variant={'outlined'}

--- a/nms/generated/api.ts
+++ b/nms/generated/api.ts
@@ -42062,7 +42062,7 @@ export const TenantsApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Create an tenant
+         * @summary Create a tenant. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
          * @param {Tenant} tenant Tenant to be created
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -42184,7 +42184,7 @@ export const TenantsApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Delete tenant
+         * @summary Delete a tenant. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
          * @param {number} tenantId Tenant ID
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -42260,7 +42260,7 @@ export const TenantsApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Set tenant info
+         * @summary Set tenant info. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
          * @param {number} tenantId Tenant ID
          * @param {Tenant} tenant Tenant to be updated
          * @param {*} [options] Override http request option.
@@ -42324,7 +42324,7 @@ export const TenantsApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Create an tenant
+         * @summary Create a tenant. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
          * @param {Tenant} tenant Tenant to be created
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -42358,7 +42358,7 @@ export const TenantsApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Delete tenant
+         * @summary Delete a tenant. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
          * @param {number} tenantId Tenant ID
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -42380,7 +42380,7 @@ export const TenantsApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Set tenant info
+         * @summary Set tenant info. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
          * @param {number} tenantId Tenant ID
          * @param {Tenant} tenant Tenant to be updated
          * @param {*} [options] Override http request option.
@@ -42411,7 +42411,7 @@ export const TenantsApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Create an tenant
+         * @summary Create a tenant. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
          * @param {Tenant} tenant Tenant to be created
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -42442,7 +42442,7 @@ export const TenantsApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Delete tenant
+         * @summary Delete a tenant. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
          * @param {number} tenantId Tenant ID
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -42462,7 +42462,7 @@ export const TenantsApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Set tenant info
+         * @summary Set tenant info. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
          * @param {number} tenantId Tenant ID
          * @param {Tenant} tenant Tenant to be updated
          * @param {*} [options] Override http request option.
@@ -42592,7 +42592,7 @@ export class TenantsApi extends BaseAPI {
 
     /**
      * 
-     * @summary Create an tenant
+     * @summary Create a tenant. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
      * @param {TenantsApiTenantsPostRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -42628,7 +42628,7 @@ export class TenantsApi extends BaseAPI {
 
     /**
      * 
-     * @summary Delete tenant
+     * @summary Delete a tenant. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
      * @param {TenantsApiTenantsTenantIdDeleteRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -42652,7 +42652,7 @@ export class TenantsApi extends BaseAPI {
 
     /**
      * 
-     * @summary Set tenant info
+     * @summary Set tenant info. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
      * @param {TenantsApiTenantsTenantIdPutRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}

--- a/nms/scripts/setPassword.ts
+++ b/nms/scripts/setPassword.ts
@@ -94,7 +94,7 @@ async function createOrFetchOrganization(
 function main() {
   const args = process.argv.slice(2);
   if (args.length !== 3) {
-    console.log('Usage: setPassword.js <organization> <email> <password>');
+    console.log('Usage: setPassword.ts <organization> <email> <password>');
     process.exit(1);
   }
   const userObject = {

--- a/nms/server/grafana/handlers.ts
+++ b/nms/server/grafana/handlers.ts
@@ -13,7 +13,7 @@
 
 import {isEqual, sortBy} from 'lodash';
 
-import OrchestartorAPI from '../api/OrchestratorAPI';
+import OrchestratorAPI from '../api/OrchestratorAPI';
 import Sequelize from 'sequelize';
 import logging from '../../shared/logging';
 import {AnalyticsDBData} from './dashboards/AnalyticsDashboards';
@@ -392,7 +392,7 @@ export async function syncTenants(): Promise<{
   const completedTasks: Array<Task> = [];
   const tenantMap: Record<string, Tenant> = {};
   try {
-    const orc8rTenants = (await OrchestartorAPI.tenants.tenantsGet()).data;
+    const orc8rTenants = (await OrchestratorAPI.tenants.tenantsGet()).data;
     orc8rTenants.forEach(tenant => {
       tenantMap[tenant.id] = tenant;
     });
@@ -418,7 +418,7 @@ export async function syncTenants(): Promise<{
     try {
       // Update if tenant exists but is not equal to NMS Org
       if (orc8rTenant && !organizationsEqual(org, orc8rTenant)) {
-        await OrchestartorAPI.tenants.tenantsTenantIdPut({
+        await OrchestratorAPI.tenants.tenantsTenantIdPut({
           tenant: {id: org.id, name: org.name, networks: org.networkIDs},
           tenantId: org.id,
         });
@@ -429,7 +429,7 @@ export async function syncTenants(): Promise<{
         });
       } else if (!orc8rTenant) {
         // Create new orc8r tenant if it didn't exist before
-        await OrchestartorAPI.tenants.tenantsPost({
+        await OrchestratorAPI.tenants.tenantsPost({
           tenant: {id: org.id, name: org.name, networks: org.networkIDs},
         });
         completedTasks.push({
@@ -627,7 +627,7 @@ async function hasNetworkOfType(
   for (const networkId of networks) {
     try {
       const networkInfo = (
-        await OrchestartorAPI.networks.networksNetworkIdGet({
+        await OrchestratorAPI.networks.networksNetworkIdGet({
           networkId,
         })
       ).data;

--- a/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
+++ b/orc8r/cloud/go/services/obsidian/swagger/v1/swagger.yml
@@ -5830,7 +5830,8 @@ paths:
           description: Successfully created
         default:
           $ref: '#/responses/UnexpectedError'
-      summary: Create an tenant
+      summary: Create a tenant. This should not be called manually, tenants and organizations
+        are updated in NMS and synced to orc8r.
       tags:
       - Tenants
   /tenants/{tenant_id}:
@@ -5842,7 +5843,8 @@ paths:
           description: Ok
         default:
           $ref: '#/responses/UnexpectedError'
-      summary: Delete tenant
+      summary: Delete a tenant. This should not be called manually, tenants and organizations
+        are updated in NMS and synced to orc8r.
       tags:
       - Tenants
     get:
@@ -5872,7 +5874,8 @@ paths:
           description: Ok
         default:
           $ref: '#/responses/UnexpectedError'
-      summary: Set tenant info
+      summary: Set tenant info. This should not be called manually, tenants and organizations
+        are updated in NMS and synced to orc8r.
       tags:
       - Tenants
   /tenants/{tenant_id}/control_proxy:

--- a/orc8r/cloud/go/services/tenants/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/tenants/obsidian/models/swagger.v1.yml
@@ -35,7 +35,7 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
     post:
-      summary: Create an tenant
+      summary: Create a tenant. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
       tags:
       - Tenants
       parameters:
@@ -66,7 +66,7 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
     put:
-      summary: Set tenant info
+      summary: Set tenant info. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
       tags:
         - Tenants
       parameters:
@@ -83,7 +83,7 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
     delete:
-      summary: Delete tenant
+      summary: Delete a tenant. This should not be called manually, tenants and organizations are updated in NMS and synced to orc8r.
       tags:
         - Tenants
       parameters:


### PR DESCRIPTION
## Summary

- When an NMS endpoint is called that modifies organizations, sync all organization changes to orc8r tenants.
- Add documentation that orc8r tenant API should not be used to modify tenants
![tenantswagger](https://user-images.githubusercontent.com/14236667/189953630-7b9065b6-6bec-452c-8c2f-e3f8ff98c34a.png)

- Fix wrong description in NMS organization edit dialog
![editorg](https://user-images.githubusercontent.com/14236667/189953938-2fa460f7-ee2a-4a9d-917c-2f8deab71d12.png)

## Test Plan

- Adapted unit tests to mock new API calls and added assertions and a new test case.
- Manually tested:
  - POST organization in NMS with and without existing tenant in orc8r
  - PUT organization in NMS with and without existing tenant in orc8r
  - DELETE organization in NMS with and without existing tenant in orc8r

## Additional Information

We originally tried to remove the duplicate information and move the org / tenant config fully to orc8r, and thus avoid synchronization, see #13748. However, this turns out to be infeasible because the organization name is used as a foreign key in NMS, but the orc8r side does not support queries by name (the name is only stored inside a json blob).

A solution avoiding synchronization would require a complete rewrite of the data model on both sides.

- [ ] This change is backwards-breaking
