### PR TITLE
feat(agw): all AGW containeres have health checks

### DIFF
--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -40,6 +40,11 @@ services:
   magmad:
     <<: *pyservice
     container_name: magmad
+    healthcheck:
+      test: ["CMD", "nc", "-zv", "localhost", "50052"]
+      interval: "4s"
+      timeout: "4s"
+      retries: 3
     environment:
       DOCKER_REGISTRY: ${DOCKER_REGISTRY}
       DOCKER_USERNAME: ${DOCKER_USERNAME}
@@ -54,6 +59,7 @@ services:
     container_name: redis
     healthcheck:
       test: ["CMD", "redis-cli", "-p", "6380", "ping"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: >
@@ -68,6 +74,7 @@ services:
       - redis
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50067"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: /usr/bin/env python3 -m magma.directoryd.main
@@ -77,6 +84,7 @@ services:
     container_name: subscriberdb
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50051"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: /usr/bin/env python3 -m magma.subscriberdb.main
@@ -86,6 +94,7 @@ services:
     container_name: enodebd
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "60055"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     cap_add:
@@ -97,6 +106,7 @@ services:
     container_name: state
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50074"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     depends_on:
@@ -110,6 +120,7 @@ services:
       - redis
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50068"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: /usr/bin/env python3 -m magma.policydb.main
@@ -119,6 +130,7 @@ services:
     container_name: health
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50080"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: /usr/bin/env python3 -m magma.health.main
@@ -128,6 +140,7 @@ services:
     container_name: monitord
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50076"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     cap_add:
@@ -139,6 +152,7 @@ services:
     container_name: redirectd
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50071"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: /usr/bin/env python3 -m magma.redirectd.main
@@ -148,6 +162,7 @@ services:
     container_name: smsd
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50078"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: /usr/bin/env python3 -m magma.smsd.main
@@ -157,6 +172,7 @@ services:
     container_name: control_proxy
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "8443"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: >
@@ -169,6 +185,7 @@ services:
     container_name: ctraced
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50079"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: /usr/bin/env python3 -m magma.ctraced.main
@@ -178,6 +195,11 @@ services:
     container_name: sctpd
     ulimits:
       core: -1
+    healthcheck:
+      test: ["CMD", "test", "-S", "/tmp/sctpd_downstream.sock"]
+      interval: "4s"
+      timeout: "4s"
+      retries: 3
     security_opt:
       - seccomp:unconfined
     environment:
@@ -189,6 +211,7 @@ services:
     container_name: oai_mme
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50073"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     ulimits:
@@ -221,6 +244,7 @@ services:
       - SYS_NICE
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50063"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: >
@@ -244,6 +268,7 @@ services:
       - directoryd
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50065"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     cap_drop:
@@ -255,6 +280,7 @@ services:
     container_name: mobilityd
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "60051"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command:
@@ -265,6 +291,7 @@ services:
     container_name: td-agent-bit
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "5140"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     logging:
@@ -278,6 +305,7 @@ services:
     container_name: eventd
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50075"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: /usr/bin/env python3 -m magma.eventd.main
@@ -287,6 +315,7 @@ services:
     container_name: connectiond
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50082"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     cap_add:
@@ -298,6 +327,7 @@ services:
     container_name: liagentd
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50065"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: /usr/local/bin/liagentd
@@ -309,6 +339,7 @@ services:
     container_name: envoy_controller
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50081"]
+      interval: "4s"
       timeout: "4s"
       retries: 3
     command: /var/opt/magma/bin/envoy_controller


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

This PR is embedded into the larger issue #13684.

- The health checks for the `magmad` and `sctpd` containers are added
- The time between health checks, `interval`, is reduced from its default 30s to 4s.

## Test Plan

Follow the [README](https://github.com/magma/magma/blob/master/lte/gateway/docker/README.md#running-the-containerized-agw-locally-on-the-magma-vm) to build the containers and check their status with `docker ps`.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
