### PR TITLE
fix: ansible is pinned because of ansible-core 2.13.4 breaking change (#13916) [backport to v1.8]

### DIFF
--- a/lte/gateway/deploy/agw_install_docker.sh
+++ b/lte/gateway/deploy/agw_install_docker.sh
@@ -79,7 +79,8 @@ EOF
   fi
 
   alias python=python3
-  pip3 install ansible
+  # TODO GH13915 pinned for now because of breaking change in ansible-core 2.13.4
+  pip3 install ansible==5.0.1
 
   rm -rf /opt/magma/
   git clone "${GIT_URL}" /opt/magma


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [fix: ansible is pinned because of ansible-core 2.13.4 breaking change (#13916)](https://github.com/magma/magma/pull/13916)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)