### PR TITLE
fix: golangci is upgraded to 1.47.3 in order to support generics

### DIFF
--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -40,7 +40,13 @@ jobs:
         with:
           filters: |
             filesChanged:
-              - [".github/workflows/cloud-workflow.yml", "lte/protos/**", "cwf/cloud/**", "feg/cloud/**", "lte/cloud/**", "orc8r/**"]
+              - ".github/workflows/cloud-workflow.yml"
+              - "lte/protos/**"
+              - "cwf/cloud/**"
+              - "feg/cloud/**"
+              - "lte/cloud/**"
+              - "orc8r/**"
+              - "dp/cloud/**"
       - name: Save should_not_skip output
         if: always()
         run: |

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -143,7 +143,7 @@ $(TOOLS_LIST): %_tools:
 
 tools_lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-		| sh -s -- -b $$(go env GOPATH)/bin v1.45.0
+		| sh -s -- -b $$(go env GOPATH)/bin v1.47.3
 
 ######################
 ## Swagger/API docs ##


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The cloud-workflow is failing when linting go code - see, e.g., https://github.com/magma/magma/actions/runs/3034170464/jobs/4882988391.

The problematic code might have been introduced by https://github.com/magma/magma/pull/13886 - but CI did not run on this PR because dp was missing in the cloud-workflow path filter. The code is actually fine - golanci 1.45.0 has a problem with generics.

Here:
* upgrade golangci to 1.47.3 (includes fix for generics - see 1.47.0 release notes)
* add dp in cloud-workflow path filter

## Test Plan

CI - esp. cloud-workflow

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
