### PR TITLE
fix(agw): perform install of magma runtime dependencies

### DIFF
--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -121,7 +121,6 @@
   become: true
   apt:
     name: "{{ packages }}"
-    only_upgrade: yes
   vars:
     packages:
       - graphviz
@@ -130,6 +129,17 @@
       - openssl
       - dkms
       - uuid-runtime
+  tags:
+    - agwc
+    - base
+
+- name: Ensure ca-certificates is up to date
+  become: true
+  apt:
+    name: "{{ packages }}"
+    only_upgrade: yes
+  vars:
+    packages:
       - ca-certificates
   tags:
     - agwc


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The PR https://github.com/magma/magma/pull/9594 introduced a breaking change.
Before the PR, Ansible would install packages that are not present.
After the PR, Ansible tries to update only and fails in case the package was not installed. 

## Test Plan

Checked manually by running the `magma_deploy.yml` Ansible playbook.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
