### PR TITLE
fix(agw): Fix wildcard expansion error in magma aliases

### DIFF
--- a/lte/gateway/deploy/roles/service_aliases/tasks/main.yml
+++ b/lte/gateway/deploy/roles/service_aliases/tasks/main.yml
@@ -16,7 +16,7 @@
     state: present
     line: "{{ item }}"
   with_items:
-    - "alias magma-start='sudo service magma@magmad start'"
-    - "alias magma-stop='sudo service magma@* stop && sudo service sctpd stop && sudo service magma_dp@envoy stop'"
-    - "alias magma-restart='magma-stop && magma-start'"
-    - "alias magma-status='sudo service magma* status'"
+    - alias magma-start='sudo service magma@magmad start'
+    - alias magma-stop='sudo service "magma@*" stop && sudo service sctpd stop && sudo service magma_dp@envoy stop'
+    - alias magma-restart='magma-stop && magma-start'
+    - alias magma-status='sudo service "magma*" status'


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>
Co-authored-by: Jan Heidbrink <jan.heidbrink@tngtech.com>
Co-authored-by: Nils Semmelrock <nils.semmelrock@tngtech.com>
Co-authored-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- If bash cannot expand a wildcard it hands the expression literally to the command if it can expand it it hands over the expanded expression
  - This results in an error for the case of `magma*` e.g.  in the home directory where the magma folder exists as `service` is handed the expanded expression instead of the service.
  - In other directories it is handed `magma*` which service then expands to the services.
  - This can be fixed by adding quotation marks

## Test Plan

- `vagrant up magma`
- `vagrant ssh magma`
- `cd ~ && magma-start && magma-status`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
