### PR TITLE
chore(orc8r): Add missing dp enabled parameter to orc8r terraform 

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -231,7 +231,7 @@ logging:
 
 dp:
   create: ${dp_enabled}
-
+  enabled: ${dp_enabled}
   configuration_controller:
     sasEndpointUrl: "${dp_sas_endpoint_url}"
     image:
@@ -245,12 +245,6 @@ dp:
       port: ${orc8r_db_port}
       user: ${orc8r_db_user}
       pass: ${orc8r_db_pass}
-
-  protocol_controller:
-    enabled: false
-    image:
-      repository: "${docker_registry}/protocol-controller"
-      tag: "${docker_tag}"
 
   radio_controller:
     image:


### PR DESCRIPTION
Signed-off-by: Tomasz Gromowski <tomasz@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
As we decided to have dp disabled in orc8r by default.  `dp_enabled` parameter should also control this.
This is related with https://github.com/magma/magma/pull/13445

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] Play with terraform to deploy orc8r with DP enabled, and disabled
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
