### PR TITLE
fix(nms): improve sync of orc8r tenants with NMS organizations in NMS scripts 

### DIFF
--- a/nms/scripts/createOrganization.ts
+++ b/nms/scripts/createOrganization.ts
@@ -13,7 +13,6 @@
 
 import Sequelize from 'sequelize';
 
-import axios from 'axios';
 import {Organization} from '../shared/sequelize_models';
 import {OrganizationModel} from '../shared/sequelize_models/models/organization';
 import {
@@ -104,15 +103,7 @@ function main() {
       process.exit();
     })
     .catch(err => {
-      if (axios.isAxiosError(err)) {
-        console.log(
-          `Error: Status: ${
-            err?.response?.status ?? 500
-          }: ${(err as Error).toString()}`,
-        );
-      } else {
-        console.log(err);
-      }
+      console.log(err);
       process.exit(1);
     });
 }

--- a/nms/scripts/createOrganization.ts
+++ b/nms/scripts/createOrganization.ts
@@ -15,10 +15,7 @@ import Sequelize from 'sequelize';
 
 import {Organization} from '../shared/sequelize_models';
 import {OrganizationModel} from '../shared/sequelize_models/models/organization';
-import {
-  syncOrganizationWithOrc8rTenant,
-  syncTenants,
-} from '../server/util/tenantsSync';
+import {syncOrganizationWithOrc8rTenant} from '../server/util/tenantsSync';
 import {union} from 'lodash';
 
 type OrganizationObject = {
@@ -92,18 +89,13 @@ function main() {
     csvCharset: '',
   } as const;
 
-  // sync tenants once on start up
-  syncTenants()
-    .then(() => {
-      console.log('Successfully synced orc8r tenants');
-    })
-    .then(() => createOrUpdateOrganization(organizationObject))
+  createOrUpdateOrganization(organizationObject)
     .then(() => {
       console.log('Success');
       process.exit();
     })
     .catch(err => {
-      console.log(err);
+      console.error(err);
       process.exit(1);
     });
 }

--- a/nms/scripts/createOrganization.ts
+++ b/nms/scripts/createOrganization.ts
@@ -16,7 +16,10 @@ import Sequelize from 'sequelize';
 import axios from 'axios';
 import {Organization} from '../shared/sequelize_models';
 import {OrganizationModel} from '../shared/sequelize_models/models/organization';
-import {syncOrganizationWithOrc8rTenant} from '../server/util/tenantsSync';
+import {
+  syncOrganizationWithOrc8rTenant,
+  syncTenants,
+} from '../server/util/tenantsSync';
 import {union} from 'lodash';
 
 type OrganizationObject = {
@@ -89,7 +92,13 @@ function main() {
     networkIDs,
     csvCharset: '',
   } as const;
-  createOrUpdateOrganization(organizationObject)
+
+  // sync tenants once on start up
+  syncTenants()
+    .then(() => {
+      console.log('Successfully synced orc8r tenants');
+    })
+    .then(() => createOrUpdateOrganization(organizationObject))
     .then(() => {
       console.log('Success');
       process.exit();

--- a/nms/scripts/mockServer.ts
+++ b/nms/scripts/mockServer.ts
@@ -281,6 +281,15 @@ networks.forEach(network => {
       res.status(200).jsonp([]);
     }
   });
+  server.get(`/magma/v1/tenants`, (req, res) => {
+    res.status(200).jsonp([]);
+  });
+  server.post(`/magma/v1/tenants`, (req, res) => {
+    res.status(201).jsonp({});
+  });
+  server.put(`/magma/v1/tenants`, (req, res) => {
+    res.status(204).jsonp({});
+  });
   server.get(
     `/magma/v1/lte/{network}/enodebs/12020000051696P0013/state`,
     (req, res) => {

--- a/nms/scripts/setPassword.ts
+++ b/nms/scripts/setPassword.ts
@@ -112,7 +112,7 @@ function main() {
       process.exit();
     })
     .catch(err => {
-      console.log(err);
+      console.error(err);
       process.exit(1);
     });
 }

--- a/nms/scripts/setPassword.ts
+++ b/nms/scripts/setPassword.ts
@@ -12,7 +12,6 @@
  */
 
 import Sequelize from 'sequelize';
-import axios from 'axios';
 import bcrypt from 'bcryptjs';
 import {AccessRoles} from '../shared/roles';
 import {Organization, User} from '../shared/sequelize_models';
@@ -113,15 +112,7 @@ function main() {
       process.exit();
     })
     .catch(err => {
-      if (axios.isAxiosError(err)) {
-        console.log(
-          `Error: Status: ${
-            err?.response?.status ?? 500
-          }: ${(err as Error).toString()}`,
-        );
-      } else {
-        console.log(err);
-      }
+      console.log(err);
       process.exit(1);
     });
 }

--- a/nms/server/grafana/handlers.ts
+++ b/nms/server/grafana/handlers.ts
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 
+import {isEqual, sortBy} from 'lodash';
+
 import OrchestratorAPI from '../api/OrchestratorAPI';
 import Sequelize from 'sequelize';
 import logging from '../../shared/logging';
@@ -33,13 +35,13 @@ import {
 import {Organization} from '../../shared/sequelize_models';
 import {Request} from 'express';
 import {apiCredentials} from '../../config/config';
-import {organizationsEqual} from '../util/tenantsSync';
 import type {
   CreateDashboardResponse,
   Datasource,
   PostDatasource,
 } from './GrafanaAPIType';
 import type {GrafanaClient, GrafanaResponse} from './GrafanaAPI';
+import type {OrganizationModel} from '../../shared/sequelize_models/models/organization';
 import type {Tenant} from '../../generated';
 import type {UserModel} from '../../shared/sequelize_models/models/user';
 
@@ -606,6 +608,16 @@ function makeDatasourceConfig(params: DatasourceParams): PostDatasource {
 
 function makeAPIUrl(apiHost: string, nmsOrgID: number): string {
   return `https://${apiHost}/magma/v1/tenants/${nmsOrgID}/metrics`;
+}
+
+function organizationsEqual(
+  nmsOrg: OrganizationModel,
+  orc8rTenant: Tenant,
+): boolean {
+  return (
+    nmsOrg.name == orc8rTenant.name &&
+    isEqual(sortBy(nmsOrg.networkIDs), sortBy(orc8rTenant.networks))
+  );
 }
 
 async function hasNetworkOfType(

--- a/nms/server/grafana/handlers.ts
+++ b/nms/server/grafana/handlers.ts
@@ -610,7 +610,7 @@ function makeAPIUrl(apiHost: string, nmsOrgID: number): string {
   return `https://${apiHost}/magma/v1/tenants/${nmsOrgID}/metrics`;
 }
 
-function organizationsEqual(
+export function organizationsEqual(
   nmsOrg: OrganizationModel,
   orc8rTenant: Tenant,
 ): boolean {

--- a/nms/server/grafana/handlers.ts
+++ b/nms/server/grafana/handlers.ts
@@ -11,8 +11,6 @@
  * limitations under the License.
  */
 
-import {isEqual, sortBy} from 'lodash';
-
 import OrchestratorAPI from '../api/OrchestratorAPI';
 import Sequelize from 'sequelize';
 import logging from '../../shared/logging';
@@ -35,13 +33,13 @@ import {
 import {Organization} from '../../shared/sequelize_models';
 import {Request} from 'express';
 import {apiCredentials} from '../../config/config';
+import {organizationsEqual} from '../util/tenantsSync';
 import type {
   CreateDashboardResponse,
   Datasource,
   PostDatasource,
 } from './GrafanaAPIType';
 import type {GrafanaClient, GrafanaResponse} from './GrafanaAPI';
-import type {OrganizationModel} from '../../shared/sequelize_models/models/organization';
 import type {Tenant} from '../../generated';
 import type {UserModel} from '../../shared/sequelize_models/models/user';
 
@@ -608,16 +606,6 @@ function makeDatasourceConfig(params: DatasourceParams): PostDatasource {
 
 function makeAPIUrl(apiHost: string, nmsOrgID: number): string {
   return `https://${apiHost}/magma/v1/tenants/${nmsOrgID}/metrics`;
-}
-
-export function organizationsEqual(
-  nmsOrg: OrganizationModel,
-  orc8rTenant: Tenant,
-): boolean {
-  return (
-    nmsOrg.name == orc8rTenant.name &&
-    isEqual(sortBy(nmsOrg.networkIDs), sortBy(orc8rTenant.networks))
-  );
 }
 
 async function hasNetworkOfType(

--- a/nms/server/host/routes.ts
+++ b/nms/server/host/routes.ts
@@ -14,7 +14,6 @@
 import OrchestratorAPI from '../api/OrchestratorAPI';
 import Sequelize from 'sequelize';
 import asyncHandler from '../util/asyncHandler';
-import axios from 'axios';
 import crypto from 'crypto';
 import featureConfigs, {FeatureConfig} from '../features';
 import logging from '../../shared/logging';
@@ -24,11 +23,14 @@ import {
   sequelize,
 } from '../../shared/sequelize_models';
 import {FeatureFlagModel} from '../../shared/sequelize_models/models/featureflag';
-import {OrganizationModel} from '../../shared/sequelize_models/models/organization';
 import {Request, Router} from 'express';
 import {User} from '../../shared/sequelize_models';
 import {UserRawType} from '../../shared/sequelize_models/models/user';
 import {getPropsToUpdate} from '../auth/util';
+import {
+  rethrowUnlessNotFoundError,
+  syncOrganizationWithOrc8rTenant,
+} from '../util/tenantsSync';
 import type {FeatureID} from '../../shared/types/features';
 
 const logger = logging.getLogger(module);
@@ -292,41 +294,6 @@ router.delete(
   }),
 );
 
-async function syncOrganizationWithOrc8rTenant(
-  organization: OrganizationModel,
-): Promise<void> {
-  let orc8rTenant;
-  try {
-    orc8rTenant = (
-      await OrchestratorAPI.tenants.tenantsTenantIdGet({
-        tenantId: organization.id,
-      })
-    ).data;
-  } catch (error) {
-    // Ignore "not found" since there is no guarantee NMS and Orc8r are in sync
-    rethrowUnlessNotFoundError(error);
-  }
-
-  if (orc8rTenant) {
-    await OrchestratorAPI.tenants.tenantsTenantIdPut({
-      tenant: {
-        id: organization.id,
-        name: organization.name,
-        networks: organization.networkIDs,
-      },
-      tenantId: organization.id,
-    });
-  } else {
-    await OrchestratorAPI.tenants.tenantsPost({
-      tenant: {
-        id: organization.id,
-        name: organization.name,
-        networks: organization.networkIDs,
-      },
-    });
-  }
-}
-
 async function deleteOrc8rTenant(organizationId: number) {
   try {
     await OrchestratorAPI.tenants.tenantsTenantIdDelete({
@@ -335,12 +302,6 @@ async function deleteOrc8rTenant(organizationId: number) {
   } catch (error) {
     // Ignore "not found" since there is no guarantee NMS and Orc8r are in sync
     rethrowUnlessNotFoundError(error);
-  }
-}
-
-function rethrowUnlessNotFoundError(error: unknown) {
-  if (!(axios.isAxiosError(error) && error?.response?.status === 404)) {
-    throw error;
   }
 }
 

--- a/nms/server/util/tenantsSync.ts
+++ b/nms/server/util/tenantsSync.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2022 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import OrchestratorAPI from '../api/OrchestratorAPI';
+import axios from 'axios';
+import {OrganizationModel} from '../../shared/sequelize_models/models/organization';
+
+export async function syncOrganizationWithOrc8rTenant(
+  organization: OrganizationModel,
+): Promise<void> {
+  let orc8rTenant;
+  try {
+    orc8rTenant = (
+      await OrchestratorAPI.tenants.tenantsTenantIdGet({
+        tenantId: organization.id,
+      })
+    ).data;
+  } catch (error) {
+    // Ignore "not found" since there is no guarantee NMS and Orc8r are in sync
+    rethrowUnlessNotFoundError(error);
+  }
+
+  if (orc8rTenant) {
+    await OrchestratorAPI.tenants.tenantsTenantIdPut({
+      tenant: {
+        id: organization.id,
+        name: organization.name,
+        networks: organization.networkIDs,
+      },
+      tenantId: organization.id,
+    });
+  } else {
+    await OrchestratorAPI.tenants.tenantsPost({
+      tenant: {
+        id: organization.id,
+        name: organization.name,
+        networks: organization.networkIDs,
+      },
+    });
+  }
+}
+
+export function rethrowUnlessNotFoundError(error: unknown) {
+  if (!(axios.isAxiosError(error) && error?.response?.status === 404)) {
+    throw error;
+  }
+}

--- a/nms/server/util/tenantsSync.ts
+++ b/nms/server/util/tenantsSync.ts
@@ -16,7 +16,7 @@ import axios from 'axios';
 import {Organization} from '../../shared/sequelize_models';
 import {OrganizationModel} from '../../shared/sequelize_models/models/organization';
 import {Tenant} from '../../generated';
-import {organizationsEqual} from '../grafana/handlers';
+import {isEqual, sortBy} from 'lodash';
 
 export async function syncOrganizationWithOrc8rTenant(
   organization: OrganizationModel,
@@ -57,6 +57,16 @@ export function rethrowUnlessNotFoundError(error: unknown) {
   if (!(axios.isAxiosError(error) && error?.response?.status === 404)) {
     throw error;
   }
+}
+
+export function organizationsEqual(
+  nmsOrg: OrganizationModel,
+  orc8rTenant: Tenant,
+): boolean {
+  return (
+    nmsOrg.name == orc8rTenant.name &&
+    isEqual(sortBy(nmsOrg.networkIDs), sortBy(orc8rTenant.networks))
+  );
 }
 
 export async function syncTenants(): Promise<void> {


### PR DESCRIPTION
## Summary

[merge after #13917 (and rebase before)]

This PR follows up on #13917 and implements corresponding changes in scripts that create or modify organizations.

These scripts are called when `dev_setup.sh` is run after NMS start up.

In `createOrganization.ts` an initial sync is introduced, which updates orc8r tenants to the state of NMS organizations.

## Test Plan

locally test that
- [x] tenants are synced with NMS when `dev_setup.sh` (i.e. createOrganization.ts) is run
- [x] the organizations that are created or updated by `dev_setup.sh` are also created or updated in orc8r "tenants" table

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
