### PR TITLE
fix(ci): Mitigate LSAN errors in LTE integ tests

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -70,7 +70,17 @@
     -  XDG_CACHE_HOME="{{magma_root}}/.cache"
     -  SWAGGER_CODEGEN_JAR={{ swagger_codegen_jar }}
     -  CODEGEN_ROOT={{ codegen_root }}
-    -  ASAN_OPTIONS=abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1
+    -  ASAN_OPTIONS=abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:fast_unwind_on_malloc=0
+    -  LSAN_OPTIONS=suppressions=/usr/local/suppressions.txt
+  when: full_provision
+
+- name: Create LSAN suppressions file
+  copy:
+    dest: "/usr/local/suppressions.txt"
+    content: |
+      leak:libczmq.so.4
+      leak:libzmq.so.5
+      leak:fluid_base::BaseOFConnection::OFReadBuffer::read_notify
   when: full_provision
 
 - name: "Go export"


### PR DESCRIPTION
Co-authored-by: Lars Kreutzer <lars.kreutzer@tngtech.com>
Co-authored-by: Nils Semmelrock <nils.semmelrock@tngtech.com>
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- There are frequent memory leaks when MME is restarting. 
  - The leaks likely originate in the context of `intertask_interface.c:214` and `shared_ts_log.c:185`
  - The leaks finally occur in the following libraries:
     - `libczmq.so.4`
     - `libzmq.so.5`
     - `fluid_base::BaseOFConnection::OFReadBuffer::read_notify`
- As a temporary mitigation we suppress the leaks that occur in these locations.
- See also #13941 
- To reproduce the leak start the setup for the extended LTE integ tests and watch the `/var/log/syslog` on the `magma_dev` VM for `ERROR: LeakSanitizer` 
- Additionally the logging for leaks is improved by using the ASAN option `fast_unwind_on_malloc=0` (produces a more detailed stack trace for leaks)
Closes #13941

## Test Plan

- [ ] [LTE integ tests](https://github.com/LKreutzer/magma/actions/runs/3061347633/jobs/4941005229)
- [ ] [LTE integ tests bazel](https://github.com/LKreutzer/magma/actions/runs/3061355045/jobs/4941351095)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
