### PR TITLE
fix(agw): the envoy controller is in the feg image

### DIFF
--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -39,7 +39,7 @@ x-agw-c-service: &cservice
 # Generic anchor for go services
 x-agw-go-service: &goservice
   <<: *service
-  image: ${DOCKER_REGISTRY}agw_gateway_go${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
+  image: ${DOCKER_REGISTRY}gateway_go${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
 
 services:
   magmad:

--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -36,11 +36,6 @@ x-agw-c-service: &cservice
   <<: *service
   image: ${DOCKER_REGISTRY}agw_gateway_c${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
 
-# Generic anchor for go services
-x-agw-go-service: &goservice
-  <<: *service
-  image: ${DOCKER_REGISTRY}gateway_go${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
-
 services:
   magmad:
     <<: *pyservice
@@ -309,7 +304,8 @@ services:
     restart: "no"
 
   envoy_controller:
-    <<: *goservice
+    <<: *service
+    image: ${DOCKER_REGISTRY}gateway_go${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
     container_name: envoy_controller
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost", "50081"]


### PR DESCRIPTION
## Summary

- The envoy controller is not in an AGW image, but the the FEG image.
- Follow up for https://github.com/magma/magma/pull/13852.

## Test Plan

- Local `docker pull docker.artifactory.magmacore.org/agw_gateway_go:latest`
- https://github.com/magma/magma/actions/runs/3081229151/jobs/4979531808
