### PR TITLE
fix(agw): Pin version of `grpcio_tool` in `python_dev` ansible role

### DIFF
--- a/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
@@ -117,6 +117,6 @@
 
 - name: Install grpcio-tools
   pip:
-    name: grpcio-tools
+    name: grpcio-tools>=1.46.3,<1.49.0
     executable: pip3
   when: preburn


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

Follow up to #13946.
The `grpcio_tool` version is also pinned in the `python_dev` ansible role.

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
