### PR TITLE
fix(ci): Add missing paths to path filter

### DIFF
--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -47,6 +47,7 @@ jobs:
               - "lte/cloud/**"
               - "orc8r/**"
               - "dp/cloud/**"
+              - "dp/protos/**"
       - name: Save should_not_skip output
         if: always()
         run: |


### PR DESCRIPTION
## Summary

In https://github.com/magma/magma/pull/13906#discussion_r971604008 i said that `dp/cloud` and `dp/protos` were already added to the pathfilter on master (by PR #13923). That was wrong as PR #13923 only added `dp_cloud`. Here I am adding the missing `dp/protos`.
