### PR TITLE
fix: py cryptography is pinned to a version that works with magma

### DIFF
--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -25,7 +25,8 @@ bravado_core
 jsonschema==3.2.0
 psutil
 systemd-python
-cryptography
+# cryptography<38.0.0 because of runtime issues when starting magmad 
+cryptography<38.0.0
 #  h2>=3,<4 is requirement of aioh2 (loaded via bazel)
 h2>=3,<4
 #  priority==1.3.0 is requirement of aioh2 (loaded via bazel)

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -250,33 +250,29 @@ coverage-lcov==0.2.4 \
     --hash=sha256:ceebfc6acec6f0cef457fec60e43ecd582829a5fc79d5f181642b26ed8e30735 \
     --hash=sha256:d65a77e4694c5dab041b2ba9725d819de12d8f26efc93f47bcd3dc25a74f017c
     # via -r requirements.in
-cryptography==38.0.1 \
-    --hash=sha256:0297ffc478bdd237f5ca3a7dc96fc0d315670bfa099c04dc3a4a2172008a405a \
-    --hash=sha256:10d1f29d6292fc95acb597bacefd5b9e812099d75a6469004fd38ba5471a977f \
-    --hash=sha256:16fa61e7481f4b77ef53991075de29fc5bacb582a1244046d2e8b4bb72ef66d0 \
-    --hash=sha256:194044c6b89a2f9f169df475cc167f6157eb9151cc69af8a2a163481d45cc407 \
-    --hash=sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7 \
-    --hash=sha256:3261725c0ef84e7592597606f6583385fed2a5ec3909f43bc475ade9729a41d6 \
-    --hash=sha256:3b72c360427889b40f36dc214630e688c2fe03e16c162ef0aa41da7ab1455153 \
-    --hash=sha256:3e3a2599e640927089f932295a9a247fc40a5bdf69b0484532f530471a382750 \
-    --hash=sha256:3fc26e22840b77326a764ceb5f02ca2d342305fba08f002a8c1f139540cdfaad \
-    --hash=sha256:5067ee7f2bce36b11d0e334abcd1ccf8c541fc0bbdaf57cdd511fdee53e879b6 \
-    --hash=sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b \
-    --hash=sha256:64760ba5331e3f1794d0bcaabc0d0c39e8c60bf67d09c93dc0e54189dfd7cfe5 \
-    --hash=sha256:765fa194a0f3372d83005ab83ab35d7c5526c4e22951e46059b8ac678b44fa5a \
-    --hash=sha256:79473cf8a5cbc471979bd9378c9f425384980fcf2ab6534b18ed7d0d9843987d \
-    --hash=sha256:896dd3a66959d3a5ddcfc140a53391f69ff1e8f25d93f0e2e7830c6de90ceb9d \
-    --hash=sha256:89ed49784ba88c221756ff4d4755dbc03b3c8d2c5103f6d6b4f83a0fb1e85294 \
-    --hash=sha256:ac7e48f7e7261207d750fa7e55eac2d45f720027d5703cd9007e9b37bbb59ac0 \
-    --hash=sha256:ad7353f6ddf285aeadfaf79e5a6829110106ff8189391704c1d8801aa0bae45a \
-    --hash=sha256:b0163a849b6f315bf52815e238bc2b2346604413fa7c1601eea84bcddb5fb9ac \
-    --hash=sha256:b6c9b706316d7b5a137c35e14f4103e2115b088c412140fdbd5f87c73284df61 \
-    --hash=sha256:c2e5856248a416767322c8668ef1845ad46ee62629266f84a8f007a317141013 \
-    --hash=sha256:ca9f6784ea96b55ff41708b92c3f6aeaebde4c560308e5fbbd3173fbc466e94e \
-    --hash=sha256:d1a5bd52d684e49a36582193e0b89ff267704cd4025abefb9e26803adeb3e5fb \
-    --hash=sha256:d3971e2749a723e9084dd507584e2a2761f78ad2c638aa31e80bc7a15c9db4f9 \
-    --hash=sha256:d4ef6cc305394ed669d4d9eebf10d3a101059bdcf2669c366ec1d14e4fb227bd \
-    --hash=sha256:d9e69ae01f99abe6ad646947bba8941e896cb3aa805be2597a0400e0764b5818
+cryptography==37.0.4 \
+    --hash=sha256:190f82f3e87033821828f60787cfa42bff98404483577b591429ed99bed39d59 \
+    --hash=sha256:2be53f9f5505673eeda5f2736bea736c40f051a739bfae2f92d18aed1eb54596 \
+    --hash=sha256:30788e070800fec9bbcf9faa71ea6d8068f5136f60029759fd8c3efec3c9dcb3 \
+    --hash=sha256:3d41b965b3380f10e4611dbae366f6dc3cefc7c9ac4e8842a806b9672ae9add5 \
+    --hash=sha256:4c590ec31550a724ef893c50f9a97a0c14e9c851c85621c5650d699a7b88f7ab \
+    --hash=sha256:549153378611c0cca1042f20fd9c5030d37a72f634c9326e225c9f666d472884 \
+    --hash=sha256:63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82 \
+    --hash=sha256:6bc95ed67b6741b2607298f9ea4932ff157e570ef456ef7ff0ef4884a134cc4b \
+    --hash=sha256:7099a8d55cd49b737ffc99c17de504f2257e3787e02abe6d1a6d136574873441 \
+    --hash=sha256:75976c217f10d48a8b5a8de3d70c454c249e4b91851f6838a4e48b8f41eb71aa \
+    --hash=sha256:7bc997818309f56c0038a33b8da5c0bfbb3f1f067f315f9abd6fc07ad359398d \
+    --hash=sha256:80f49023dd13ba35f7c34072fa17f604d2f19bf0989f292cedf7ab5770b87a0b \
+    --hash=sha256:91ce48d35f4e3d3f1d83e29ef4a9267246e6a3be51864a5b7d2247d5086fa99a \
+    --hash=sha256:a958c52505c8adf0d3822703078580d2c0456dd1d27fabfb6f76fe63d2971cd6 \
+    --hash=sha256:b62439d7cd1222f3da897e9a9fe53bbf5c104fff4d60893ad1355d4c14a24157 \
+    --hash=sha256:b7f8dd0d4c1f21759695c05a5ec8536c12f31611541f8904083f3dc582604280 \
+    --hash=sha256:d204833f3c8a33bbe11eda63a54b1aad7aa7456ed769a982f21ec599ba5fa282 \
+    --hash=sha256:e007f052ed10cc316df59bc90fbb7ff7950d7e2919c9757fd42a2b8ecf8a5f67 \
+    --hash=sha256:f2dcb0b3b63afb6df7fd94ec6fbddac81b5492513f7b0436210d390c14d46ee8 \
+    --hash=sha256:f721d1885ecae9078c3f6bbe8a88bc0786b6e749bf32ccec1ef2b18929a05046 \
+    --hash=sha256:f7a6de3e98771e183645181b3627e2563dcde3ce94a9e42a3f427d2255190327 \
+    --hash=sha256:f8c0a6e9e1dd3eb0414ba320f85da6b0dcbd543126e30fcc546e7372a7fbf3b9
     # via -r requirements.in
 debtcollector==2.5.0 \
     --hash=sha256:1393a527d2c72f143ffa6a629e9c33face6642634eece475b48cab7b04ba61f3 \
@@ -979,7 +975,7 @@ oslo-config==8.8.0 \
     --hash=sha256:96933d3011dae15608a11616bfb00d947e22da3cb09b6ff37ddd7576abd4764c \
     --hash=sha256:b1e2a398450ea35a8e5630d8b23057b8939838c4433cd25a20cc3a36d5df9e3b
     # via -r requirements.in
-oslo-i18n==5.1.0 \
+oslo.i18n==5.1.0 \
     --hash=sha256:6bf111a6357d5449640852de4640eae4159b5562bbba4c90febb0034abc095d0 \
     --hash=sha256:75086cfd898819638ca741159f677e2073a78ca86a9c9be8d38b46800cdf2dc9
     # via oslo-config
@@ -1001,7 +997,7 @@ pbr==5.10.0 \
     --hash=sha256:cfcc4ff8e698256fc17ea3ff796478b050852585aa5bae79ecd05b2ab7b39b9a \
     --hash=sha256:da3e18aac0a3c003e9eea1a81bd23e5a3a75d745670dcf736317b7d966887fdf
     # via
-    #   oslo-i18n
+    #   oslo.i18n
     #   stevedore
 pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
@@ -1011,7 +1007,7 @@ priority==1.3.0 \
     --hash=sha256:6bc1961a6d7fcacbfc337769f1a382c8e746566aaa365e78047abe9f66b2ffbe \
     --hash=sha256:be4fcb94b5e37cdeb40af5533afe6dd603bd665fe9c8b3052610fc1001d5d1eb
     # via -r requirements.in
-prometheus-client==0.3.1 \
+prometheus_client==0.3.1 \
     --hash=sha256:17bc24c09431644f7c65d7bce9f4237252308070b6395d6d8e87767afe867e24
     # via -r requirements.in
 protobuf==3.20.2 \
@@ -1176,32 +1172,32 @@ pyparsing==3.0.9 \
 pyroute2==0.6.13 \
     --hash=sha256:b03d49a581945fec2b1ec7d1d5125c6f40ba04ed11affc90c4caddc019e25792
     # via -r requirements.in
-pyroute2-core==0.6.13 \
+pyroute2.core==0.6.13 \
     --hash=sha256:227dfd9f19888ddd1341966822ffd5880db9e3c89375096418c660ff4d1a11d0
     # via
     #   pyroute2
-    #   pyroute2-ethtool
-    #   pyroute2-ipdb
-    #   pyroute2-ipset
-    #   pyroute2-ndb
-    #   pyroute2-nftables
-    #   pyroute2-nslink
-pyroute2-ethtool==0.6.13 \
+    #   pyroute2.ethtool
+    #   pyroute2.ipdb
+    #   pyroute2.ipset
+    #   pyroute2.ndb
+    #   pyroute2.nftables
+    #   pyroute2.nslink
+pyroute2.ethtool==0.6.13 \
     --hash=sha256:0a687fea0fcd77d9074c7c18ba35d9b9f70e4217ebe68a687e200408473a3bd4
     # via pyroute2
-pyroute2-ipdb==0.6.13 \
+pyroute2.ipdb==0.6.13 \
     --hash=sha256:bbbbb75d13be96e4549cf70eb94fd70b2e1736ea301ac6b683f56aa1acd84d5a
     # via pyroute2
-pyroute2-ipset==0.6.13 \
+pyroute2.ipset==0.6.13 \
     --hash=sha256:28a254f622a18976d0683603d5aefda5ab7c8528fa9e36beb85bce52026f7866
     # via pyroute2
-pyroute2-ndb==0.6.13 \
+pyroute2.ndb==0.6.13 \
     --hash=sha256:09b1f55f26043ce64c933e8224fd08444a498f381e5dc483bc9f428cbaf0901a
     # via pyroute2
-pyroute2-nftables==0.6.13 \
+pyroute2.nftables==0.6.13 \
     --hash=sha256:c94bd740d50b03a1a8d9654f769e77afc77a75e05fc5887dd0551e3970f86592
     # via pyroute2
-pyroute2-nslink==0.6.13 \
+pyroute2.nslink==0.6.13 \
     --hash=sha256:86ed506cadccb154cd27aebb3dbf73ebb723c391104e7f0f3bc2c4a39c62366c
     # via pyroute2
 pyrsistent==0.18.1 \
@@ -1315,7 +1311,7 @@ redis-collections==0.11.0 \
     --hash=sha256:0f6cda00666fdd26e3b8ca47da13a653eaf4cc4e45470a3b09f17d65061fea8a \
     --hash=sha256:d23e8c0f6bf50de10c98a14a3b636ff1bb21119386f884f2641c906832bc4ec9
     # via -r requirements.in
-repoze-lru==0.7 \
+repoze.lru==0.7 \
     --hash=sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77 \
     --hash=sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea
     # via routes


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

cryptography for bazel was upgraded to `38.0.1` (from `37.0.4`) with https://github.com/magma/magma/pull/13946. This was not visible in the PR CI because it causes a runtime issue with magmad that is only seen in the integration tests.
```
bazel run orc8r/gateway/python/magma/magmad
...
Traceback (most recent call last):
  File "/tmp/bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/orc8r/gateway/python/magma/magmad/magmad.runfiles/__main__/orc8r/gateway/python/magma/magmad/main.py", line 20, in <module>
    from magma.common.sentry import sentry_init
  File "/tmp/bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/orc8r/gateway/python/magma/magmad/magmad.runfiles/__main__/orc8r/gateway/python/magma/common/sentry.py", line 19, in <module>
    import sentry_sdk
  File "/tmp/bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/orc8r/gateway/python/magma/magmad/magmad.runfiles/python_deps_pypi__sentry_sdk/sentry_sdk/__init__.py", line 1, in <module>
    from sentry_sdk.hub import Hub, init
  File "/tmp/bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/orc8r/gateway/python/magma/magmad/magmad.runfiles/python_deps_pypi__sentry_sdk/sentry_sdk/hub.py", line 8, in <module>
    from sentry_sdk.scope import Scope
  File "/tmp/bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/orc8r/gateway/python/magma/magmad/magmad.runfiles/python_deps_pypi__sentry_sdk/sentry_sdk/scope.py", line 7, in <module>
    from sentry_sdk.utils import logger, capture_internal_exceptions
  File "/tmp/bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/orc8r/gateway/python/magma/magmad/magmad.runfiles/python_deps_pypi__sentry_sdk/sentry_sdk/utils.py", line 895, in <module>
    HAS_REAL_CONTEXTVARS, ContextVar = _get_contextvars()
  File "/tmp/bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/orc8r/gateway/python/magma/magmad/magmad.runfiles/python_deps_pypi__sentry_sdk/sentry_sdk/utils.py", line 865, in _get_contextvars
    if not _is_contextvars_broken():
  File "/tmp/bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/orc8r/gateway/python/magma/magmad/magmad.runfiles/python_deps_pypi__sentry_sdk/sentry_sdk/utils.py", line 826, in _is_contextvars_broken
    from eventlet.patcher import is_monkey_patched  # type: ignore
  File "/usr/local/lib/python3.8/dist-packages/eventlet/__init__.py", line 17, in <module>
    from eventlet import convenience
  File "/usr/local/lib/python3.8/dist-packages/eventlet/convenience.py", line 7, in <module>
    from eventlet.green import socket
  File "/usr/local/lib/python3.8/dist-packages/eventlet/green/socket.py", line 4, in <module>
    __import__('eventlet.green._socket_nodns')
  File "/usr/local/lib/python3.8/dist-packages/eventlet/green/_socket_nodns.py", line 11, in <module>
    from eventlet import greenio
  File "/usr/local/lib/python3.8/dist-packages/eventlet/greenio/__init__.py", line 3, in <module>
    from eventlet.greenio.base import *  # noqa
  File "/usr/local/lib/python3.8/dist-packages/eventlet/greenio/base.py", line 468, in <module>
    from OpenSSL import SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1553, in <module>
    class X509StoreFlags(object):
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```

## Test Plan

* execute `bazel run orc8r/gateway/python/magma/magmad` and see that error above does not happen

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
