### PR TITLE
feat(agw): Basic eDRX support

### DIFF
--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h
@@ -704,7 +704,7 @@ typedef enum gprs_mobility_managenent_ie_e {
   GMM_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_IEI = 0x5D, /* 0x5D = 93  */
   GMM_TMSI_STATUS_IEI = 0x90,    /* 0x90 = 144 (shifted by 4)*/
   GMM_IMEISV_REQUEST_IEI = 0xC0, /* 0xC0 = 192 (shifted by 4)*/
-  GMM_EDRX_PARAMETER_IEI = 0x6E,                               /* 0x6E = 110 */
+  GMM_EDRX_PARAMETER_IEI = 0x6E, /* 0x6E = 110 */
 } gprs_mobility_managenent_ie_t;
 
 //------------------------------------------------------------------------------
@@ -977,13 +977,11 @@ typedef struct edrx_parameter_s {
 #ifdef __cplusplus
 extern "C" {
 #endif
-int encode_edrx_parameter_ie(edrx_parameter_t *edrxparameter,
-                             const bool iei_present,
-                             uint8_t *buffer,
+int encode_edrx_parameter_ie(edrx_parameter_t* edrxparameter,
+                             const bool iei_present, uint8_t* buffer,
                              const uint32_t len);
-int decode_edrx_parameter_ie(edrx_parameter_t *edrxparameter,
-                             const bool iei_present,
-                             uint8_t *buffer,
+int decode_edrx_parameter_ie(edrx_parameter_t* edrxparameter,
+                             const bool iei_present, uint8_t* buffer,
                              const uint32_t len);
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008.h
@@ -704,6 +704,7 @@ typedef enum gprs_mobility_managenent_ie_e {
   GMM_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_IEI = 0x5D, /* 0x5D = 93  */
   GMM_TMSI_STATUS_IEI = 0x90,    /* 0x90 = 144 (shifted by 4)*/
   GMM_IMEISV_REQUEST_IEI = 0xC0, /* 0xC0 = 192 (shifted by 4)*/
+  GMM_EDRX_PARAMETER_IEI = 0x6E,                               /* 0x6E = 110 */
 } gprs_mobility_managenent_ie_t;
 
 //------------------------------------------------------------------------------
@@ -956,6 +957,34 @@ int decode_voice_domain_preference_and_ue_usage_setting(
     voice_domain_preference_and_ue_usage_setting_t*
         voicedomainpreferenceandueusagesetting,
     const bool iei_present, uint8_t* buffer, const uint32_t len);
+#ifdef __cplusplus
+}
+#endif
+
+//------------------------------------------------------------------------------
+// 10.5.5.32 Extended DRX parameter
+//------------------------------------------------------------------------------
+#define EDRX_PARAMETER_IE_TYPE 3
+#define EDRX_PARAMETER_IE_MIN_LENGTH 3
+#define EDRX_PARAMETER_IE_MAX_LENGTH 3
+
+typedef struct edrx_parameter_s {
+  uint8_t length;
+  uint8_t pagingtimewindow : 4;
+  uint8_t edrxvalue : 4;
+} edrx_parameter_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+int encode_edrx_parameter_ie(edrx_parameter_t *edrxparameter,
+                             const bool iei_present,
+                             uint8_t *buffer,
+                             const uint32_t len);
+int decode_edrx_parameter_ie(edrx_parameter_t *edrxparameter,
+                             const bool iei_present,
+                             uint8_t *buffer,
+                             const uint32_t len);
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_gmm_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_gmm_ies.c
@@ -501,3 +501,27 @@ int decode_edrx_parameter_ie(edrx_parameter_t* edrxparameter,
   decoded++;
   return decoded;
 }
+
+//------------------------------------------------------------------------------
+int encode_edrx_parameter_ie(edrx_parameter_t* edrxparameter,
+                            const bool iei_present, uint8_t* buffer,
+                            const uint32_t len) {
+  uint32_t encoded = 0;
+
+  if (iei_present) {
+    CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, EDRX_PARAMETER_IE_MAX_LENGTH,
+                                         len);
+    *buffer = GMM_EDRX_PARAMETER_IEI;
+    encoded++;
+  } else {
+    CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
+        buffer, (EDRX_PARAMETER_IE_MAX_LENGTH - 1), len);
+  }
+
+  *(buffer + encoded) = edrxparameter->length;
+  encoded++;
+  *(buffer + encoded) = (edrxparameter->pagingtimewindow << 4) |
+                        edrxparameter->edrxvalue;
+  encoded++;
+  return encoded;
+}

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_gmm_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_gmm_ies.c
@@ -475,3 +475,30 @@ int encode_voice_domain_preference_and_ue_usage_setting(
   *lenPtr = encoded - 1 - ((iei_present) ? 1 : 0);
   return encoded;
 }
+
+//------------------------------------------------------------------------------
+// 10.5.5.32 Extended DRX parameter
+//------------------------------------------------------------------------------
+int decode_edrx_parameter_ie(edrx_parameter_t *edrxparameter,
+                            const bool iei_present, uint8_t *buffer,
+                            const uint32_t len)
+{
+  int decoded = 0;
+
+  if (iei_present) {
+    CHECK_PDU_POINTER_AND_LENGTH_DECODER(
+      buffer, EDRX_PARAMETER_IE_MAX_LENGTH, len);
+    CHECK_IEI_DECODER(GMM_EDRX_PARAMETER_IEI, *buffer);
+    decoded++;
+  } else {
+    CHECK_PDU_POINTER_AND_LENGTH_DECODER(
+      buffer, (EDRX_PARAMETER_IE_MAX_LENGTH - 1), len);
+  }
+
+  edrxparameter->length = *(buffer + decoded);
+  decoded++;
+  edrxparameter->pagingtimewindow = (*(buffer + decoded) >> 4) & 0xF;
+  edrxparameter->edrxvalue = *(buffer + decoded) & 0xF;
+  decoded++;
+  return decoded;
+}

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_gmm_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_gmm_ies.c
@@ -479,20 +479,19 @@ int encode_voice_domain_preference_and_ue_usage_setting(
 //------------------------------------------------------------------------------
 // 10.5.5.32 Extended DRX parameter
 //------------------------------------------------------------------------------
-int decode_edrx_parameter_ie(edrx_parameter_t *edrxparameter,
-                            const bool iei_present, uint8_t *buffer,
-                            const uint32_t len)
-{
+int decode_edrx_parameter_ie(edrx_parameter_t* edrxparameter,
+                             const bool iei_present, uint8_t* buffer,
+                             const uint32_t len) {
   int decoded = 0;
 
   if (iei_present) {
-    CHECK_PDU_POINTER_AND_LENGTH_DECODER(
-      buffer, EDRX_PARAMETER_IE_MAX_LENGTH, len);
+    CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer, EDRX_PARAMETER_IE_MAX_LENGTH,
+                                         len);
     CHECK_IEI_DECODER(GMM_EDRX_PARAMETER_IEI, *buffer);
     decoded++;
   } else {
     CHECK_PDU_POINTER_AND_LENGTH_DECODER(
-      buffer, (EDRX_PARAMETER_IE_MAX_LENGTH - 1), len);
+        buffer, (EDRX_PARAMETER_IE_MAX_LENGTH - 1), len);
   }
 
   edrxparameter->length = *(buffer + decoded);

--- a/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_gmm_ies.c
+++ b/lte/gateway/c/core/oai/lib/3gpp/3gpp_24.008_gmm_ies.c
@@ -504,8 +504,8 @@ int decode_edrx_parameter_ie(edrx_parameter_t* edrxparameter,
 
 //------------------------------------------------------------------------------
 int encode_edrx_parameter_ie(edrx_parameter_t* edrxparameter,
-                            const bool iei_present, uint8_t* buffer,
-                            const uint32_t len) {
+                             const bool iei_present, uint8_t* buffer,
+                             const uint32_t len) {
   uint32_t encoded = 0;
 
   if (iei_present) {
@@ -520,8 +520,8 @@ int encode_edrx_parameter_ie(edrx_parameter_t* edrxparameter,
 
   *(buffer + encoded) = edrxparameter->length;
   encoded++;
-  *(buffer + encoded) = (edrxparameter->pagingtimewindow << 4) |
-                        edrxparameter->edrxvalue;
+  *(buffer + encoded) =
+      (edrxparameter->pagingtimewindow << 4) | edrxparameter->edrxvalue;
   encoded++;
   return encoded;
 }

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.cpp
@@ -338,6 +338,20 @@ int decode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
             ATTACH_REQUEST_NETWORK_RESOURCE_IDENTIFIER_CONTAINER_PRESENT;
         break;
 
+      case ATTACH_REQUEST_EDRX_PARAMETER_IEI:
+        if ((decoded_result = decode_edrx_parameter_ie(
+                 &attach_request->edrxparameter, true, buffer + decoded,
+                 len - decoded)) <= 0) {
+          OAILOG_FUNC_RETURN(LOG_NAS_EMM, decoded_result);
+        }
+
+        decoded += decoded_result;
+        /*
+         * Set corresponding mask to 1 in presencemask
+         */
+        attach_request->presencemask |= ATTACH_REQUEST_EDRX_PARAMETER_PRESENT;
+        break;
+
       case ATTACH_REQUEST_DEVICE_PROPERTIES_IEI:
       case ATTACH_REQUEST_DEVICE_PROPERTIES_LOW_PRIO_IEI:
         // Skip these IEs. We do not support congestion handling.

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.hpp
@@ -77,6 +77,7 @@
 #define ATTACH_REQUEST_MS_NETWORK_FEATURE_SUPPORT_PRESENT (1 << 13)
 #define ATTACH_REQUEST_NETWORK_RESOURCE_IDENTIFIER_CONTAINER_PRESENT (1 << 14)
 #define ATTACH_REQUEST_UE_ADDITIONAL_SECURITY_CAPABILITY_PRESENT (1 << 15)
+#define ATTACH_REQUEST_EDRX_PARAMETER_PRESENT (1 << 16)
 
 typedef enum attach_request_iei_tag {
   ATTACH_REQUEST_OLD_PTMSI_SIGNATURE_IEI = GMM_PTMSI_SIGNATURE_IEI,
@@ -101,6 +102,7 @@ typedef enum attach_request_iei_tag {
   ATTACH_REQUEST_NETWORK_RESOURCE_IDENTIFIER_CONTAINER_IEI = 0x10,
   ATTACH_REQUEST_DEVICE_PROPERTIES_IEI = 0xD0,
   ATTACH_REQUEST_DEVICE_PROPERTIES_LOW_PRIO_IEI = 0xD1,
+  ATTACH_REQUEST_EDRX_PARAMETER_IEI = 0x6e,
   ATTACH_REQUEST_UE_ADDITIONAL_SECURITY_CAPABILITY_IEI = 0x6F
 } attach_request_iei;
 
@@ -139,6 +141,7 @@ typedef struct attach_request_msg_tag {
       voicedomainpreferenceandueusagesetting;
   ms_network_feature_support_t msnetworkfeaturesupport;
   network_resource_identifier_container_t networkresourceidentifiercontainer;
+  edrx_parameter_t edrxparameter;
   ue_additional_security_capability_t ueadditionalsecuritycapability;
 } attach_request_msg;
 


### PR DESCRIPTION
Signed-off-by: Gustavo Junior Alves <gustavo@radtonics.com>

## Summary

Support for eDRX protocol parsing.

Some devices cannot attach to OAI, like CPE Intelbras ICW 4002, because of missing support for eDRX. This patch implements enough features to allow the connection.

## Test Plan

A device using eDRX got the error `EMMAS-SAP - Sending Attach Reject for ue_id = 834, emm_cause = (99)`  and abort. This fix allow the successful connection