### PR TITLE
fix(nms): fix CBSD pagination

### DIFF
--- a/nms/app/views/domain-proxy/__tests__/CbsdsTable.tsx
+++ b/nms/app/views/domain-proxy/__tests__/CbsdsTable.tsx
@@ -85,6 +85,11 @@ const cbsds = [
   },
 ];
 
+const cbsdsResponse = {
+  cbsds,
+  total_count: 2,
+};
+
 const cbsdState = {
   state: {
     isLoading: false,
@@ -94,7 +99,7 @@ const cbsdState = {
     cbsds,
   },
   setPaginationOptions: jest.fn(),
-  refetch: jest.fn(),
+  refetch: () => Promise.resolve(cbsdsResponse),
   create: jest.fn(),
   update: jest.fn(),
   deregister: jest.fn(),


### PR DESCRIPTION
## Summary

Fix CBSD pagination by supplying a proper data function for the Material
Table as per docs:
https://material-table.com/#/docs/features/remote-data

(CBSD pagination wasn't working - it was always showing the 1st page).

Also, remove the `<LoadingFiller>`, because it makes the
`material-table` re-mount on each cbsd page fetch, causing it to request
the first page (it loses state), no matter which page you clicked.

Signed-off-by: Ivan Sergiienko <ivan@freedomfi.com>

## Test Plan

1. Open cbsds list page
2. Click pagination: next/previous, first/last
3. It all works: pages are changed correctly, new data is shown (previously it was stuck on the 1st page always).

![cbsd-pagination](https://user-images.githubusercontent.com/104149278/193320557-d6c40b80-a8e4-4488-84dc-d9bff5ef4f97.gif)

