### PR TITLE
chore(dp): Remove unsetting frequencies from CC

### DIFF
--- a/dp/cloud/go/services/dp/storage/amc_manager.go
+++ b/dp/cloud/go/services/dp/storage/amc_manager.go
@@ -166,7 +166,10 @@ func (r *queryRunner) getState() ([]*DetailedCbsd, error) {
 			Select(db.NewIncludeMask("grant_id", "heartbeat_interval", "last_heartbeat_request_time", "low_frequency", "high_frequency")).
 			Join(db.NewQuery().
 				From(&DBGrantState{}).
-				On(db.On(GrantTable, "state_id", GrantStateTable, "id")).
+				On(sq.And{
+					db.On(GrantTable, "state_id", GrantStateTable, "id"),
+					sq.NotEq{GrantStateTable + ".name": "idle"},
+				}).
 				Select(db.NewIncludeMask("name"))).
 			Nullable()).
 		Nullable().

--- a/dp/cloud/go/services/dp/storage/amc_manager_test.go
+++ b/dp/cloud/go/services/dp/storage/amc_manager_test.go
@@ -304,8 +304,10 @@ func TestWithinTx(t *testing.T) {
 
 func (s *AmcManagerTestSuite) TestGetState() {
 	registeredId := s.enumMaps[storage.CbsdStateTable][registered]
+	unregisteredId := s.enumMaps[storage.CbsdStateTable][unregistered]
 	grantedId := s.enumMaps[storage.GrantStateTable][granted]
 	authorizedId := s.enumMaps[storage.GrantStateTable][authorized]
+	idleId := s.enumMaps[storage.GrantStateTable][idle]
 	grantReqId := s.enumMaps[storage.RequestTypeTable]["grant"]
 	preferences := []uint32{0b10101100, 0b00110, 0b0100000, 0b11010}
 	availableFreqs := []uint32{0b10111100, 0b010110, 0b01001011, 0b11110}
@@ -966,6 +968,41 @@ func (s *AmcManagerTestSuite) TestGetState() {
 					registered).
 				WithAmcGrant(granted, 3600, time.Unix(119, 0).UTC(), someGrantId, 1).
 				WithAmcGrant(authorized, 3600, time.Unix(120, 0).UTC(), someGrantId, 1).
+				Details,
+		},
+	}, {
+		name: "test get state with idle grant",
+		input: []db.Model{
+			b.NewDBCbsdBuilder().
+				WithNetworkId(someNetwork).
+				WithSerialNumber(someSerialNumber).
+				WithId(0).
+				WithCbsdId(someCbsdIdStr).
+				WithStateId(unregisteredId).
+				WithDesiredStateId(unregisteredId).
+				WithAntennaGain(20).
+				Cbsd,
+			b.NewDBGrantBuilder().
+				WithDefaultTestValues().
+				WithCbsdId(2).
+				WithStateId(idleId).
+				Grant,
+		},
+		expected: []*storage.DetailedCbsd{
+			b.NewDetailedDBCbsdBuilder().
+				WithCbsd(
+					b.NewDBCbsdBuilder().
+						WithId(0).
+						WithSerialNumber(someSerialNumber).
+						WithCbsdId(someCbsdIdStr).
+						WithIndoorDeployment(false).
+						WithShouldDeregister(false).
+						WithShouldRelinquish(false).
+						WithIsDeleted(false).
+						WithAntennaGain(20).
+						Cbsd,
+					unregistered,
+					unregistered).
 				Details,
 		},
 	}}

--- a/dp/cloud/python/magma/db_service/migrations/versions/022_cbcd01d5edce_add_idle_grant_state.py
+++ b/dp/cloud/python/magma/db_service/migrations/versions/022_cbcd01d5edce_add_idle_grant_state.py
@@ -1,0 +1,29 @@
+"""add_idle_grant_state
+
+Revision ID: cbcd01d5edce
+Revises: 467ad00fbc83
+Create Date: 2022-09-20 13:19:39.743907
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'cbcd01d5edce'
+down_revision = '467ad00fbc83'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Run upgrade
+    """
+    op.execute("INSERT INTO grant_states (name) VALUES ('idle');")
+
+
+def downgrade():
+    """
+    Run downgrade
+    """
+    op.execute("DELETE FROM grants WHERE state_id = (SELECT id FROM grant_states WHERE name = 'idle');")
+    op.execute("DELETE FROM grant_states WHERE name = 'idle';")

--- a/dp/cloud/python/magma/db_service/tests/unit/test_022_add_idle_grant_state.py
+++ b/dp/cloud/python/magma/db_service/tests/unit/test_022_add_idle_grant_state.py
@@ -1,0 +1,69 @@
+"""
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import sqlalchemy as sa
+from magma.db_service.tests.alembic_testcase import AlembicTestCase
+
+GRANTS_TABLE = 'grants'
+GRANT_STATES_TABLE = 'grant_states'
+IDLE_STATE_NAME = 'idle'
+
+
+class AddIdleGrantStateTestCase(AlembicTestCase):
+    down_revision = '467ad00fbc83'
+    up_revision = 'cbcd01d5edce'
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.upgrade(self.down_revision)
+
+        self._grants_table = self.get_table(GRANTS_TABLE)
+        self._grant_states_table = self.get_table(GRANT_STATES_TABLE)
+
+    def test_upgrade_creates_idle_state(self) -> None:
+        # Given
+        grant_state = self._get_idle_grant_state()
+        self.assertIsNone(grant_state)
+
+        # When
+        self.upgrade()
+
+        # Then
+        grant_state = self._get_idle_grant_state()
+        self.assertEqual(grant_state.name, IDLE_STATE_NAME)
+
+    def test_downgrade_removes_idle_grants_and_state(self) -> None:
+        # Given
+        self.upgrade()
+
+        self.engine.execute(
+            self._grants_table.insert().values(
+                grant_id="some_grant_id",
+                state_id=self._get_idle_grant_state().id,
+                low_frequency=3550_000_000,
+                high_frequency=3570_000_000,
+                max_eirp=20,
+            ),
+        )
+
+        # When
+        self.downgrade()
+
+        # Then
+        grant_state = self._get_idle_grant_state()
+        self.assertIsNone(grant_state)
+
+        grant = self.engine.execute(self._grants_table.select()).first()
+        self.assertIsNone(grant)
+
+    def _get_idle_grant_state(self) -> sa.engine.Row:
+        return self.engine.execute(self._grant_states_table.select()).first()

--- a/dp/cloud/python/magma/db_service/tests/unit/test_db_initialization.py
+++ b/dp/cloud/python/magma/db_service/tests/unit/test_db_initialization.py
@@ -25,7 +25,7 @@ class DBInitializationTestCase(LocalDBTestCase):
 
     @parameterized.expand([
         (DBRequestType, 6),
-        (DBGrantState, 3),
+        (DBGrantState, 4),
         (DBCbsdState, 2),
     ])
     def test_db_is_initialized_with_db_states_and_types(self, model, expected_post_init_count):

--- a/dp/cloud/python/magma/mappings/types.py
+++ b/dp/cloud/python/magma/mappings/types.py
@@ -50,6 +50,7 @@ class GrantStates(enum.Enum):
     """
     Grant SAS state class
     """
+    IDLE = "idle"
     GRANTED = "granted"
     AUTHORIZED = "authorized"
     UNSYNC = "unsync"


### PR DESCRIPTION
Signed-off-by: Jarosław Jaszczuk <jaroslaw@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
**Do not merge until AMC changes are ready. This PR on its own will break DP.**

## Summary
* Migration adds `idle` grant state
* CC does not unset frequencies in CBSDs (AMC will unset frequencies)
* CC does not remove any grants, marks them as `idle` instead (AMC will remove idle grants)

<!-- Enumerate changes you made and why you made them -->

## Test Plan
* Added test cases for code and migrations

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
