### PR TITLE
fix(agw): fix envoy controller docker image name

### DIFF
--- a/lte/gateway/docker/docker-compose.override.yaml
+++ b/lte/gateway/docker/docker-compose.override.yaml
@@ -16,3 +16,4 @@ services:
     build:
       context: ${BUILD_CONTEXT}
       dockerfile: feg/gateway/docker/go/Dockerfile
+    image: gateway_go


### PR DESCRIPTION
Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>

## Summary

Change the name of the created docker image from `agw_gateway_go` to `gateway_go`, in accordance with the image requested in the `lte/gateway/docker/docker-compose.yaml`.

## Test Plan

Build and start the agw envoy_controller container in the magma dev VM and check that the docker image has the correct name (`gateway_go` instead of `agw_gateway_go`)

## Additional Information

- [ ] This change is backwards-breaking
