### PR TITLE
fix(amf): QOS flow descriptors are not updated correctly as configured

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_session_qos.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_session_qos.cpp
@@ -204,9 +204,8 @@ int amf_smf_session_api_fill_qos_ie_info(std::shared_ptr<smf_context_t> smf_ctx,
         flow_des.paramList[flow_des.numOfParams].iei =
             magma5g::M5GQosFlowParam::param_id_mfbr_downlink;
         flow_des.paramList[flow_des.numOfParams].length = 3;
-        flow_des.paramList[flow_des.numOfParams].element =
-            (uint16_t)(qos_flow_desc->mbr_dl / 1000);
-        flow_des.paramList[flow_des.numOfParams].units = 1;
+        M5GQosFlowParam* qosParams = &flow_des.paramList[flow_des.numOfParams];
+        qosParams->mfbr_gbr_convert(qosParams, qos_flow_desc->mbr_dl);
         flow_des.numOfParams++;
       }
 
@@ -215,9 +214,8 @@ int amf_smf_session_api_fill_qos_ie_info(std::shared_ptr<smf_context_t> smf_ctx,
         flow_des.paramList[flow_des.numOfParams].iei =
             magma5g::M5GQosFlowParam::param_id_mfbr_uplink;
         flow_des.paramList[flow_des.numOfParams].length = 3;
-        flow_des.paramList[flow_des.numOfParams].element =
-            (uint16_t)(qos_flow_desc->mbr_ul / 1000);
-        flow_des.paramList[flow_des.numOfParams].units = 1;
+        M5GQosFlowParam* qosParams = &flow_des.paramList[flow_des.numOfParams];
+        qosParams->mfbr_gbr_convert(qosParams, qos_flow_desc->mbr_ul);
         flow_des.numOfParams++;
       }
 
@@ -226,9 +224,8 @@ int amf_smf_session_api_fill_qos_ie_info(std::shared_ptr<smf_context_t> smf_ctx,
         flow_des.paramList[flow_des.numOfParams].iei =
             magma5g::M5GQosFlowParam::param_id_gfbr_downlink;
         flow_des.paramList[flow_des.numOfParams].length = 3;
-        flow_des.paramList[flow_des.numOfParams].element =
-            (uint16_t)(qos_flow_desc->gbr_dl / 1000);
-        flow_des.paramList[flow_des.numOfParams].units = 1;
+        M5GQosFlowParam* qosParams = &flow_des.paramList[flow_des.numOfParams];
+        qosParams->mfbr_gbr_convert(qosParams, qos_flow_desc->gbr_dl);
         flow_des.numOfParams++;
       }
 
@@ -237,9 +234,8 @@ int amf_smf_session_api_fill_qos_ie_info(std::shared_ptr<smf_context_t> smf_ctx,
         flow_des.paramList[flow_des.numOfParams].iei =
             magma5g::M5GQosFlowParam::param_id_gfbr_uplink;
         flow_des.paramList[flow_des.numOfParams].length = 3;
-        flow_des.paramList[flow_des.numOfParams].element =
-            (uint16_t)(qos_flow_desc->gbr_ul / 1000);
-        flow_des.paramList[flow_des.numOfParams].units = 1;
+        M5GQosFlowParam* qosParams = &flow_des.paramList[flow_des.numOfParams];
+        qosParams->mfbr_gbr_convert(qosParams, qos_flow_desc->gbr_ul);
         flow_des.numOfParams++;
       }
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQosFlowParam.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQosFlowParam.hpp
@@ -31,6 +31,12 @@ class M5GQosFlowParam {
 
 #define M5G_QOS_FLOW_PARAM_BIT_RATE_LEN 3
 #define M5G_QOS_FLOW_PARAM_BIT_RATE_UNITS_KBPS 1
+#define M5G_QOS_FLOW_PARAM_BIT_RATE_UNITS_MBPS 6
+#define M5G_QOS_FLOW_PARAM_BIT_RATE_UNITS_GBPS 11
+#define M5G_QOS_FLOW_PARAM_BIT_RATE_UNITS_TBPS 16
+#define M5G_QOS_FLOW_PARAM_BIT_RATE_UNITS_PBPS 21
+#define M5G_QOS_FLOW_PARAM_BIT_RATE_UNITS_COUNT \
+  5  // Considering only 1KBPS,1MBPS,1GBPS,1TBPS,1PBPS as per the specs.
   uint8_t length;
   uint8_t units;
   uint16_t element;
@@ -38,6 +44,8 @@ class M5GQosFlowParam {
   M5GQosFlowParam();
   ~M5GQosFlowParam();
 
+  void mfbr_gbr_convert(magma5g::M5GQosFlowParam* flow_des_paramList,
+                        uint64_t element);
   int EncodeM5GQosFlowParam(M5GQosFlowParam* param, uint8_t* buffer,
                             uint32_t len);
   int DecodeM5GQosFlowParam(M5GQosFlowParam* param, uint8_t* buffer,

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQosFlowParam.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQosFlowParam.cpp
@@ -9,6 +9,7 @@
    limitations under the License.
  */
 #include <sstream>
+#include <cstdint>
 
 #ifdef __cplusplus
 extern "C" {
@@ -249,6 +250,27 @@ int M5GQosFlowParam::DecodeM5GQosFlowParam(M5GQosFlowParam* param,
   }
 
   return decoded;
+}
+
+// Convert mfbr and gfbr values in proper format
+void M5GQosFlowParam::mfbr_gbr_convert(
+    magma5g::M5GQosFlowParam* flow_des_paramList, uint64_t element) {
+  int count = 0;
+  while (element > UINT16_MAX) {
+    element /= 1024;
+    if (count == 0) {
+      count = M5G_QOS_FLOW_PARAM_BIT_RATE_UNITS_KBPS;
+    } else {
+      count += M5G_QOS_FLOW_PARAM_BIT_RATE_UNITS_COUNT;
+    }
+  }
+  if (count == 0) {
+    flow_des_paramList->element = (uint16_t)element / 1024;
+    flow_des_paramList->units = M5G_QOS_FLOW_PARAM_BIT_RATE_UNITS_KBPS;
+  } else {
+    flow_des_paramList->element = (uint16_t)element;
+    flow_des_paramList->units = count;
+  }
 }
 
 }  // namespace magma5g


### PR DESCRIPTION
Signed-off-by: Akshayp77 <akshay.patidar@wavlabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Fix #13604

QOS flow descriptors are not updated correctly as configured due to type mismatch,
Add support to handle higher values of mfbr and gbr because qos flow descriptor element of type uint16_t is not able handle higher values.


## Test Plan
Tested with UT
Tested with Spirent

[logs.tgz](https://github.com/magma/magma/files/9721926/logs.tgz)

## Additional Information
![Screenshot (57)](https://user-images.githubusercontent.com/87304387/194232726-069116fe-0db3-48ef-aac9-aae5ec1479ba.png)
![Screenshot (56)](https://user-images.githubusercontent.com/87304387/194232733-48e1c8b5-75ef-403d-bf6b-824861b1205c.png)


![UT_snapshot](https://user-images.githubusercontent.com/87304387/191431080-dd89946a-e848-4d73-b42b-1e414f283c24.png)
