### PR TITLE
chore: Remove ntpdate from eventd service, because timesync already handled by systemd-timesyncd

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service
@@ -15,7 +15,6 @@ Description=Magma eventd service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
-ExecStartPre=/usr/sbin/ntpdate pool.ntp.org
 ExecStart=/usr/bin/env python3 -m magma.eventd.main
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py eventd
 StandardOutput=syslog

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@eventd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@eventd.service
@@ -15,7 +15,6 @@ Description=Magma eventd service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
-ExecStartPre=/usr/sbin/ntpdate pool.ntp.org
 ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/eventd/eventd
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py eventd
 StandardOutput=syslog


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The ntpd time sync of eventd sometimes fails at the beginning of an integration test run ...
  * `systemd-timesyncd.service` is already configured on the VMs
  * in production environments the respective sysadmin should take care of this
  * -> removed the preStart ntpd sync from eventd

## Test Plan

CI.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
