### PR TITLE
chore(dp): remove idle grants in AMC

### DIFF
--- a/dp/cloud/go/services/dp/active_mode_controller/action_generator/action/action.go
+++ b/dp/cloud/go/services/dp/active_mode_controller/action_generator/action/action.go
@@ -20,22 +20,35 @@ import (
 	"magma/dp/cloud/go/services/dp/storage/db"
 )
 
-type Delete struct {
+type Action interface {
+	Do(sq.BaseRunner, storage.AmcManager) error
+}
+
+type DeleteCbsd struct {
 	Id int64
 }
 
-func (d *Delete) Do(runner sq.BaseRunner, manager storage.AmcManager) error {
+func (d *DeleteCbsd) Do(runner sq.BaseRunner, manager storage.AmcManager) error {
 	cbsd := &storage.DBCbsd{Id: db.MakeInt(d.Id)}
 	return manager.DeleteCbsd(runner, cbsd)
 }
 
-type Update struct {
+type UpdateCbsd struct {
 	Data *storage.DBCbsd
 	Mask db.FieldMask
 }
 
-func (u *Update) Do(runner sq.BaseRunner, manager storage.AmcManager) error {
+func (u *UpdateCbsd) Do(runner sq.BaseRunner, manager storage.AmcManager) error {
 	return manager.UpdateCbsd(runner, u.Data, u.Mask)
+}
+
+type DeleteGrant struct {
+	Id int64
+}
+
+func (d *DeleteGrant) Do(runner sq.BaseRunner, manager storage.AmcManager) error {
+	grant := &storage.DBGrant{Id: db.MakeInt(d.Id)}
+	return manager.DeleteGrant(runner, grant)
 }
 
 type Request struct {

--- a/dp/cloud/go/services/dp/active_mode_controller/action_generator/action/action_test.go
+++ b/dp/cloud/go/services/dp/active_mode_controller/action_generator/action/action_test.go
@@ -44,14 +44,14 @@ func TestRequest(t *testing.T) {
 	assert.Equal(t, m.request, data)
 }
 
-func TestUpdate(t *testing.T) {
+func TestUpdateCbsd(t *testing.T) {
 	m := &stubAmcManager{}
 	data := &storage.DBCbsd{
 		AvailableFrequencies: []uint32{1, 2, 3, 4},
 	}
 	mask := db.NewIncludeMask("available_frequencies")
 
-	a := action.Update{Data: data, Mask: mask}
+	a := action.UpdateCbsd{Data: data, Mask: mask}
 	require.NoError(t, a.Do(nil, m))
 
 	assert.Equal(t, m.action, updateCbsd)
@@ -59,14 +59,24 @@ func TestUpdate(t *testing.T) {
 	assert.Equal(t, m.mask, mask)
 }
 
-func TestDelete(t *testing.T) {
+func TestDeleteCbsd(t *testing.T) {
 	m := &stubAmcManager{}
 
-	a := action.Delete{Id: 123}
+	a := action.DeleteCbsd{Id: 123}
 	require.NoError(t, a.Do(nil, m))
 
 	assert.Equal(t, m.action, deleteCbsd)
 	assert.Equal(t, &storage.DBCbsd{Id: db.MakeInt(123)}, m.cbsd)
+}
+
+func TestDeleteGrant(t *testing.T) {
+	m := &stubAmcManager{}
+
+	a := action.DeleteGrant{Id: 123}
+	require.NoError(t, a.Do(nil, m))
+
+	assert.Equal(t, m.action, deleteGrant)
+	assert.Equal(t, &storage.DBGrant{Id: db.MakeInt(123)}, m.grant)
 }
 
 type actionType uint8
@@ -75,12 +85,14 @@ const (
 	createRequest actionType = iota
 	deleteCbsd
 	updateCbsd
+	deleteGrant
 )
 
 type stubAmcManager struct {
 	action  actionType
 	request *storage.MutableRequest
 	cbsd    *storage.DBCbsd
+	grant   *storage.DBGrant
 	mask    db.FieldMask
 }
 
@@ -97,6 +109,12 @@ func (s *stubAmcManager) CreateRequest(_ squirrel.BaseRunner, request *storage.M
 func (s *stubAmcManager) DeleteCbsd(_ squirrel.BaseRunner, cbsd *storage.DBCbsd) error {
 	s.action = deleteCbsd
 	s.cbsd = cbsd
+	return nil
+}
+
+func (s *stubAmcManager) DeleteGrant(_ squirrel.BaseRunner, grant *storage.DBGrant) error {
+	s.action = deleteGrant
+	s.grant = grant
 	return nil
 }
 

--- a/dp/cloud/go/services/dp/active_mode_controller/action_generator/generators.go
+++ b/dp/cloud/go/services/dp/active_mode_controller/action_generator/generators.go
@@ -1,8 +1,6 @@
 package action_generator
 
 import (
-	sq "github.com/Masterminds/squirrel"
-
 	"magma/dp/cloud/go/services/dp/active_mode_controller/action_generator/action"
 	"magma/dp/cloud/go/services/dp/active_mode_controller/action_generator/sas"
 	"magma/dp/cloud/go/services/dp/active_mode_controller/action_generator/sas/eirp"
@@ -11,17 +9,13 @@ import (
 	"magma/dp/cloud/go/services/dp/storage/db"
 )
 
-type Action interface {
-	Do(sq.BaseRunner, storage.AmcManager) error
-}
-
 type actionGeneratorPerCbsd interface {
-	generateActions(*storage.DetailedCbsd) []Action
+	generateActions(*storage.DetailedCbsd) []action.Action
 }
 
 type nothingGenerator struct{}
 
-func (*nothingGenerator) generateActions(cbsd *storage.DetailedCbsd) []Action {
+func (*nothingGenerator) generateActions(_ *storage.DetailedCbsd) []action.Action {
 	return nil
 }
 
@@ -33,9 +27,9 @@ type sasGenerator interface {
 	GenerateRequests(*storage.DetailedCbsd) []*storage.MutableRequest
 }
 
-func (s *sasRequestGenerator) generateActions(cbsd *storage.DetailedCbsd) []Action {
+func (s *sasRequestGenerator) generateActions(cbsd *storage.DetailedCbsd) []action.Action {
+	actions := grant.RemoveIdleGrants(cbsd)
 	reqs := s.g.GenerateRequests(cbsd)
-	actions := make([]Action, 0, len(reqs))
 	for _, r := range reqs {
 		if r != nil {
 			r.Request.CbsdId = cbsd.Cbsd.Id
@@ -47,38 +41,38 @@ func (s *sasRequestGenerator) generateActions(cbsd *storage.DetailedCbsd) []Acti
 
 type deleteGenerator struct{}
 
-func (*deleteGenerator) generateActions(cbsd *storage.DetailedCbsd) []Action {
-	act := &action.Delete{Id: cbsd.Cbsd.Id.Int64}
-	return []Action{act}
+func (*deleteGenerator) generateActions(cbsd *storage.DetailedCbsd) []action.Action {
+	act := &action.DeleteCbsd{Id: cbsd.Cbsd.Id.Int64}
+	return []action.Action{act}
 }
 
 type acknowledgeDeregisterGenerator struct{}
 
-func (a *acknowledgeDeregisterGenerator) generateActions(cbsd *storage.DetailedCbsd) []Action {
+func (a *acknowledgeDeregisterGenerator) generateActions(cbsd *storage.DetailedCbsd) []action.Action {
 	data := &storage.DBCbsd{
 		Id:               cbsd.Cbsd.Id,
 		ShouldDeregister: db.MakeBool(false),
 	}
 	mask := db.NewIncludeMask("should_deregister")
-	act := &action.Update{Data: data, Mask: mask}
-	return []Action{act}
+	act := &action.UpdateCbsd{Data: data, Mask: mask}
+	return []action.Action{act}
 }
 
 type acknowledgeRelinquishGenerator struct{}
 
-func (a *acknowledgeRelinquishGenerator) generateActions(cbsd *storage.DetailedCbsd) []Action {
+func (a *acknowledgeRelinquishGenerator) generateActions(cbsd *storage.DetailedCbsd) []action.Action {
 	data := &storage.DBCbsd{
 		Id:               cbsd.Cbsd.Id,
 		ShouldRelinquish: db.MakeBool(false),
 	}
 	mask := db.NewIncludeMask("should_relinquish")
-	act := &action.Update{Data: data, Mask: mask}
-	return []Action{act}
+	act := &action.UpdateCbsd{Data: data, Mask: mask}
+	return []action.Action{act}
 }
 
 type storeAvailableFrequenciesGenerator struct{}
 
-func (s *storeAvailableFrequenciesGenerator) generateActions(cbsd *storage.DetailedCbsd) []Action {
+func (s *storeAvailableFrequenciesGenerator) generateActions(cbsd *storage.DetailedCbsd) []action.Action {
 	calc := eirp.NewCalculator(cbsd.Cbsd)
 	frequencies := grant.CalcAvailableFrequencies(cbsd.Cbsd.Channels, calc)
 	data := &storage.DBCbsd{
@@ -86,8 +80,8 @@ func (s *storeAvailableFrequenciesGenerator) generateActions(cbsd *storage.Detai
 		AvailableFrequencies: frequencies,
 	}
 	mask := db.NewIncludeMask("available_frequencies")
-	act := &action.Update{Data: data, Mask: mask}
-	return []Action{act}
+	act := &action.UpdateCbsd{Data: data, Mask: mask}
+	return []action.Action{act}
 }
 
 type grantManager struct {

--- a/dp/cloud/go/services/dp/active_mode_controller/action_generator/message_generator.go
+++ b/dp/cloud/go/services/dp/active_mode_controller/action_generator/message_generator.go
@@ -16,6 +16,7 @@ package action_generator
 import (
 	"time"
 
+	"magma/dp/cloud/go/services/dp/active_mode_controller/action_generator/action"
 	"magma/dp/cloud/go/services/dp/active_mode_controller/action_generator/sas"
 	"magma/dp/cloud/go/services/dp/storage"
 )
@@ -30,8 +31,8 @@ type RNG interface {
 	Int() int
 }
 
-func (a *ActionGenerator) GenerateActions(cbsds []*storage.DetailedCbsd, now time.Time) []Action {
-	actions := make([]Action, 0, len(cbsds))
+func (a *ActionGenerator) GenerateActions(cbsds []*storage.DetailedCbsd, now time.Time) []action.Action {
+	actions := make([]action.Action, 0, len(cbsds))
 	for _, cbsd := range cbsds {
 		g := a.getPerCbsdMessageGenerator(cbsd, now)
 		actions = append(actions, g.generateActions(cbsd)...)

--- a/dp/cloud/go/services/dp/active_mode_controller/action_generator/sas/grant/available_frequencies.go
+++ b/dp/cloud/go/services/dp/active_mode_controller/action_generator/sas/grant/available_frequencies.go
@@ -64,3 +64,22 @@ func makeMaskForRange(begin int64, end int64, band int64) uint32 {
 	}
 	return r<<1 - l
 }
+
+func UnsetGrantFrequency(cbsd *storage.DBCbsd, grant *storage.DBGrant) []uint32 {
+	low := grant.LowFrequencyHz.Int64
+	high := grant.HighFrequencyHz.Int64
+	if cbsd.AvailableFrequencies == nil || low == 0 || high == 0 {
+		return cbsd.AvailableFrequencies
+	}
+
+	frequencies := make([]uint32, len(cbsd.AvailableFrequencies))
+	copy(frequencies, cbsd.AvailableFrequencies)
+
+	bwHz := high - low
+	mid := (low + high) / 2
+	bitToUnset := (mid - int64(3550*1e6)) / int64(5*1e6)
+	bwIndex := bwHz/int64(5*1e6) - 1
+
+	frequencies[bwIndex] = frequencies[bwIndex] & ^(1 << bitToUnset)
+	return frequencies
+}

--- a/dp/cloud/go/services/dp/storage/amc_manager.go
+++ b/dp/cloud/go/services/dp/storage/amc_manager.go
@@ -39,6 +39,7 @@ type AmcManager interface {
 	CreateRequest(sq.BaseRunner, *MutableRequest) error
 	DeleteCbsd(sq.BaseRunner, *DBCbsd) error
 	UpdateCbsd(sq.BaseRunner, *DBCbsd, db.FieldMask) error
+	DeleteGrant(runner sq.BaseRunner, grant *DBGrant) error
 }
 
 type MutableRequest struct {
@@ -128,6 +129,10 @@ func (m *amcManager) UpdateCbsd(tx sq.BaseRunner, cbsd *DBCbsd, mask db.FieldMas
 func (m *amcManager) GetState(tx sq.BaseRunner) ([]*DetailedCbsd, error) {
 	runner := m.getQueryRunner(tx)
 	return runner.getState()
+}
+
+func (m *amcManager) DeleteGrant(tx sq.BaseRunner, grant *DBGrant) error {
+	return nil
 }
 
 func notNull(fields ...string) sq.Sqlizer {


### PR DESCRIPTION
Signed-off-by: Jarosław Jaszczuk <jaroslaw@freedomfi.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
**To be merged after:**
* https://github.com/magma/magma/pull/13950
* https://github.com/magma/magma/pull/13968

## Summary
* add new `DeleteGrant` action
* before generating its own actions `sasRequestGenerator` modifies CBSD available frequencies and removes `idle` grants
<!-- Enumerate changes you made and why you made them -->

## Test Plan
* added unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
