### PR TITLE
fix: magma_deb integ tests can use config_iface_for_ipv6.py script

### DIFF
--- a/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
@@ -156,3 +156,10 @@
     - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_sessiond.service', dest: 'magma@sessiond.service' }
     - { src: 'orc8r/tools/ansible/roles/fluent_bit/files/magma_td-agent-bit.service', dest: 'magma@td-agent-bit.service' }
     - { src: 'lte/gateway/deploy/roles/magma/files/systemd/magma_dp_envoy.service', dest: 'magma_dp@envoy.service' }
+
+- name: link python ipv6 config script that is only used for tests and not deployed
+  file:
+    src: /home/vagrant/magma/lte/gateway/python/scripts/config_iface_for_ipv6.py
+    dest: /usr/local/bin/config_iface_for_ipv6.py
+    state: link
+    force: yes


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>


## Summary

This change is only relevant for the new mgma_deb integ tests.
* `test_enable_ipv6_iface` does not fail but does nothing (fyi this is changed in #13978)
  * `Failed to configure`
* this makes the follow-up - `test_ipv6_non_nat_dp_ul_tcp` - test fail

Reason:
* `test_enable_ipv6_iface` uses `lte/gateway/python/scripts/config_iface_for_ipv6.py` and this script is only used for testing, i.e., it is not installed with the magma.deb

Solution here:
* just link the script from the magma repo to the expected folder
* note: this only works because dependencies of the script are installed with magma.deb, i.e., it is a solution that might not work for other scripts!

## Test Plan

see fork run(s) in comments

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
