### PR TITLE
chore(ci): Integ tests magma deb for specific magma package

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -115,6 +115,7 @@ jobs:
     runs-on: macos-12
     outputs:
       artifacts: ${{ steps.publish_packages.outputs.artifacts }}
+      magma_package: ${{ steps.publish_packages.outputs.magma_package }}
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # pin@v2
         with:
@@ -178,6 +179,14 @@ jobs:
             HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
             if [[ "$HTTP_STATUS" != "2"* ]]; then
               PUBLISH_ERROR="true"
+            fi
+            # extract magma debian package version
+            match="magma_[0-9]+\.[0-9]+\.[0-9]+-[0-9]+-[a-z0-9]+_[a-z0-9]+.deb"
+            if [[ $i =~ $match ]]; then
+              magma_package=${i#magma_}
+              magma_package=${magma_package%_[a-z0-9]*.deb}
+              magma_package='magma='${magma_package}
+              echo "::set-output name=magma_package::${magma_package}"
             fi
           done
           # set output
@@ -991,3 +1000,15 @@ jobs:
           SLACK_ICON_EMOJI: ":heavy_check_mark:"
           SLACK_COLOR: "#00FF00"
           SLACK_FOOTER: ' '
+  trigger-debian-integ-test:
+    if: always() && github.event_name == 'push' && github.repository_owner == 'magma' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: agw-build
+    steps:
+      - name: Trigger debian integ test workflow
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: magma/magma
+          event-type: build-all-artifact
+          client-payload: '{ "artifact": "${{ needs.agw-build.outputs.magma_package }}" }'

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -13,13 +13,8 @@ name: LTE integ test magma-deb
 
 on:
   workflow_dispatch: null
-  workflow_run:
-    workflows:
-      - build-all
-    branches:
-      - master
-    types:
-      - completed
+  repository_dispatch:
+    types: [build-all-artifact]
 
 jobs:
   lte-integ-test-magma-deb:
@@ -59,6 +54,7 @@ jobs:
         env:
           MAGMA_DEV_CPUS: 3
           MAGMA_DEV_MEMORY_MB: 9216
+          MAGMA_PACKAGE: ${{ github.event.client_payload.magma_package }}
         run: |
           cd lte/gateway
           fab integ_test_deb_installation

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -235,6 +235,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.raw_arguments = ENV.fetch("ANSIBLE_ARGS", "").split(";") +
                               ["--timeout=30"]
       ansible.verbose = 'v'
+      ansible.extra_vars = { MAGMA_PACKAGE: ENV.fetch('MAGMA_PACKAGE', 'magma') }
     end
 
     # Reload VM to apply correct network configuration

--- a/lte/gateway/deploy/agw_install_ubuntu_vm.sh
+++ b/lte/gateway/deploy/agw_install_ubuntu_vm.sh
@@ -45,7 +45,7 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   127.0.0.1 ansible_connection=local" > $DEPLOY_PATH/agw_hosts
 
   # install magma and its dependencies including OVS.
-  su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='/home/$MAGMA_USER/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts -e \"use_master=True\" $DEPLOY_PATH/magma_deploy.yml"
+  su - $MAGMA_USER -c "ansible-playbook -e \"MAGMA_ROOT='/home/$MAGMA_USER/magma' OUTPUT_DIR='/tmp'\" -i $DEPLOY_PATH/agw_hosts -e \"use_master=True\" $DEPLOY_PATH/magma_deploy.yml --extra-vars \"MAGMA_PACKAGE=\"$MAGMA_PACKAGE\"\""
 
   echo "Cleanup temp files"
   cd /root || exit

--- a/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
@@ -61,7 +61,9 @@
     reboot_timeout: 180
 
 - name: Install magma
-  ansible.builtin.shell: sudo bash /home/vagrant/magma/lte/gateway/deploy/agw_install_ubuntu_vm.sh
+  ansible.builtin.shell: |
+    export MAGMA_PACKAGE="{{ MAGMA_PACKAGE }}"
+    sudo -E bash /home/vagrant/magma/lte/gateway/deploy/agw_install_ubuntu_vm.sh
 
 - name: Copy ssh configuration
   copy:

--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -160,7 +160,7 @@
     dpkg_options: 'force-confold,force-confdef,force-overwrite'
   vars:
     packages:
-      - magma
+      - "{{ MAGMA_PACKAGE | default('magma') }}"
 
 # Install openvswitch in containerized agw only
 - name: Install prebuilt openvswitch packages


### PR DESCRIPTION
Signed-off-by: Alex Jahl [alexander.jahl@tngtech.com](mailto:alexander.jahl@tngtech.com)

## Summary

The PR enables the `lte-integ-test-magma-deb` workflow to install the debian package that is uploaded in the same run by the `build_all/agw-build` job.


## Test Plan
- [x] local magma_deb build (`vagrant up magma_deb`) uses the latest package version
- [x] CI run on https://github.com/ajahl/magma/actions/runs/3097026221

## Additional Information

