### PR TITLE
chore: Publish test results for the Bazel integration and sudo tests

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -128,10 +128,11 @@ jobs:
           path: cwf/gateway/tests.xml
       - name: Publish Unit Test Results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@7377632048da85434c30810c38353542d3162dc4 # pin@v1
+        uses: EnricoMi/publish-unit-test-result-action/composite@2a60c5d47eb29cd5cc922f51bbea18e148f56203 # pin@v2
         with:
+          check_name: CWF integration test results
+          junit_files: cwf/gateway/tests.xml
           check_run_annotations: all tests
-          files: cwf/gateway/tests.xml
       - name: Fetch logs
         if: always()
         run: |

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -186,21 +186,22 @@ jobs:
           name: test-results
           path: lte/gateway/test-results/**/*.xml
       - name: Get test logs
-        if: failure()
+        if: always()
         run: |
           cd lte/gateway
           fab get_test_logs:dst_path=./logs.tar.gz
       - name: Upload test logs
         uses: actions/upload-artifact@v2
-        if: failure()
+        if: always()
         with:
           name: test-logs
           path: lte/gateway/logs.tar.gz
       - name: Publish Unit Test Results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@7377632048da85434c30810c38353542d3162dc4 # pin@v1
+        uses: EnricoMi/publish-unit-test-result-action/composite@2a60c5d47eb29cd5cc922f51bbea18e148f56203 # pin@v2
         with:
-          files: lte/gateway/test-results/**/*.xml
+          check_name: FEG integration test results
+          junit_files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
       - name: Publish results to Firebase
         if: always() && github.event.workflow_run.event == 'push'

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -91,6 +91,18 @@ jobs:
           export MAGMA_DEV_CPUS=3
           export MAGMA_DEV_MEMORY_MB=9216
           fab bazel_integ_test_post_build
+      - name: Get test results
+        if: always()
+        run: |
+          cd lte/gateway
+          fab get_test_summaries:dst_path="test-results,sudo_tests=False"
+          ls -R
+      - name: Upload test results
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: test-results
+          path: lte/gateway/test-results/**/*.xml
       - name: Get test logs
         if: always()
         run: |
@@ -102,6 +114,13 @@ jobs:
         with:
           name: test-logs
           path: lte/gateway/logs.tar.gz
+      - name: Publish Unit Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@2a60c5d47eb29cd5cc922f51bbea18e148f56203 # pin@v2
+        with:
+          check_name: LTE Bazel integration test results
+          junit_files: lte/gateway/test-results/**/*.xml
+          check_run_annotations: all tests
       - name: Publish bazel profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -62,3 +62,22 @@ jobs:
         run: |
           cd lte/gateway
           fab integ_test_deb_installation
+      - name: Get test results
+        if: always()
+        run: |
+          cd lte/gateway
+          fab get_test_summaries:dst_path="test-results",sudo_tests=False,dev_vm_name="magma_deb"
+          ls -R
+      - name: Upload test results
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: test-results
+          path: lte/gateway/test-results/**/*.xml
+      - name: Publish Unit Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@2a60c5d47eb29cd5cc922f51bbea18e148f56203 # pin@v2
+        with:
+          check_name: LTE Debian integration test results
+          junit_files: lte/gateway/test-results/**/*.xml
+          check_run_annotations: all tests

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -101,9 +101,10 @@ jobs:
           path: lte/gateway/logs.tar.gz
       - name: Publish Unit Test Results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@7377632048da85434c30810c38353542d3162dc4 # pin@v1
+        uses: EnricoMi/publish-unit-test-result-action/composite@2a60c5d47eb29cd5cc922f51bbea18e148f56203 # pin@v2
         with:
-          files: lte/gateway/test-results/**/*.xml
+          check_name: LTE integration test results
+          junit_files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
       - name: Publish results to Firebase
         if: always() && github.event.workflow_run.event == 'push'

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -69,6 +69,25 @@ jobs:
           cd lte/gateway
           vagrant ssh -c 'cd ~/magma; bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}";' magma
           vagrant ssh -c 'cd ~/magma; bazel/scripts/run_sudo_tests.sh --retry-on-failure --retry-attempts 1;' magma
+      - name: Get test results
+        if: always()
+        run: |
+          cd lte/gateway
+          fab get_test_summaries:dst_path="test-results",integration_tests=False
+          ls -R
+      - name: Upload test results
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: test-results
+          path: lte/gateway/test-results/**/*.xml
+      - name: Publish Unit Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@2a60c5d47eb29cd5cc922f51bbea18e148f56203 # pin@v2
+        with:
+          check_name: Sudo Python test results
+          junit_files: lte/gateway/test-results/**/*.xml
+          check_run_annotations: all tests
       - name: Notify failure to slack
         if: failure() && github.repository_owner == 'magma'
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0

--- a/bazel/scripts/run_integ_tests.sh
+++ b/bazel/scripts/run_integ_tests.sh
@@ -299,10 +299,11 @@ run_test() {
 }
 
 create_xml_report() {
-    rm -f "${MERGED_REPORT_FOLDER}/"*.xml
-    mkdir -p "${MERGED_REPORT_FOLDER}"
-    python3 lte/gateway/python/scripts/runtime_report.py -i "[^\/]+\.xml" -w "${INTEGTEST_REPORT_FOLDER}" -o "${MERGED_REPORT_FOLDER}/integtests_report.xml" 
-    rm -f "${INTEGTEST_REPORT_FOLDER}/"*.xml
+    local MERGED_REPORT_XML="integtests_report.xml"
+    rm -f "${MERGED_REPORT_FOLDER}/${MERGED_REPORT_XML}"
+    mkdir -p "${INTEGTEST_REPORT_FOLDER}"
+    python3 lte/gateway/python/scripts/runtime_report.py -i "[^\/]+\.xml" -w "${INTEGTEST_REPORT_FOLDER}" -o "${MERGED_REPORT_FOLDER}/${MERGED_REPORT_XML}" 
+    sudo rm -f "${INTEGTEST_REPORT_FOLDER}/"*.xml
 }
 
 print_summary() {
@@ -345,8 +346,8 @@ RETRY_ATTEMPTS=2
 RERUN_PREVIOUSLY_FAILED="false"
 FAILED_LIST=()
 FAILED_LIST_FILE="/tmp/last_failed_integration_tests.txt"
-INTEGTEST_REPORT_FOLDER="/var/tmp/test_results"
-MERGED_REPORT_FOLDER="${INTEGTEST_REPORT_FOLDER}/integtest_merged_report"
+MERGED_REPORT_FOLDER="/var/tmp/test_results"
+INTEGTEST_REPORT_FOLDER="${MERGED_REPORT_FOLDER}/integtest_reports"
 
 BOLD='\033[1m'
 RED='\033[0;31m'

--- a/bazel/scripts/run_sudo_tests.sh
+++ b/bazel/scripts/run_sudo_tests.sh
@@ -76,10 +76,11 @@ run_test() {
 }
 
 create_xml_report() {
-    rm -f "${MERGED_REPORT_FOLDER}/"*.xml
-    mkdir -p "${MERGED_REPORT_FOLDER}"
-    python3 lte/gateway/python/scripts/runtime_report.py -i "[^\/]+\.xml" -w "${SUDO_TEST_REPORT_FOLDER}" -o "${MERGED_REPORT_FOLDER}/sudo_tests_report.xml" 
-    rm -f "${SUDO_TEST_REPORT_FOLDER}/"*.xml
+    local MERGED_REPORT_XML="sudotests_report.xml"
+    rm -f "${MERGED_REPORT_FOLDER}/${MERGED_REPORT_XML}"
+    mkdir -p "${SUDO_TEST_REPORT_FOLDER}"
+    python3 lte/gateway/python/scripts/runtime_report.py -i "[^\/]+\.xml" -w "${SUDO_TEST_REPORT_FOLDER}" -o "${MERGED_REPORT_FOLDER}/${MERGED_REPORT_XML}" 
+    sudo rm -f "${SUDO_TEST_REPORT_FOLDER}/"*.xml
 }
 
 print_summary() {
@@ -104,8 +105,8 @@ NUM_SUCCESS=0
 NUM_RUN=1
 RETRY_ON_FAILURE="false"
 RETRY_ATTEMPTS=2
-SUDO_TEST_REPORT_FOLDER="/var/tmp/test_results"
-MERGED_REPORT_FOLDER="${SUDO_TEST_REPORT_FOLDER}/sudo_merged_report"
+MERGED_REPORT_FOLDER="/var/tmp/test_results"
+SUDO_TEST_REPORT_FOLDER="${MERGED_REPORT_FOLDER}/sudotest_reports"
 
 BOLD='\033[1m'
 RED='\033[0;31m'

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -543,16 +543,25 @@ def get_test_summaries(
         gateway_host=None,
         test_host=None,
         dst_path="/tmp",
+        integration_tests=True,
+        sudo_tests=True,
+        dev_vm_name="magma",
 ):
     local('mkdir -p ' + dst_path)
 
-    # TODO we may want to zip up all these files
-    _switch_to_vm_no_provision(gateway_host, "magma", "magma_dev.yml")
-    with settings(warn_only=True):
-        get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
-    _switch_to_vm_no_provision(test_host, "magma_test", "magma_test.yml")
-    with settings(warn_only=True):
-        get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
+    vm_name_to_yaml = {
+        "magma": "magma_dev.yml",
+        "magma_deb": "magma_deb.yml",
+    }
+
+    if sudo_tests:
+        _switch_to_vm_no_provision(gateway_host, dev_vm_name, vm_name_to_yaml[dev_vm_name])
+        with settings(warn_only=True):
+            get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
+    if integration_tests:
+        _switch_to_vm_no_provision(test_host, "magma_test", "magma_test.yml")
+        with settings(warn_only=True):
+            get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
 
 
 def get_test_logs(


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The test results were not published before for `Bazel LTE integ tests`, `LTE integ test magma-deb` and the `Sudo python tests` workflows. These results are published in the `LTE integ tests` workflow and make it a lot easier to see the outcome of the tests.
This PR also includes an update for the publish action, from v1.37 to v2.0. This change affects the `Federated integ tests`, `CWF integ tests` and `LTE integ tests` workflows additionally.

## Test Plan

CI.
Runs on fork: https://github.com/magma/magma/pull/13984#issuecomment-1257775186

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
