### PR TITLE
chore(ci): putting the RHEL8 certificates/entitlements in cleaner way

### DIFF
--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -295,12 +295,11 @@ pipeline {
                     } catch (Exception e) {
                       echo 'OK if not present'
                     }
-                    // In case of the full build, we need the host RHEL8 credentials.
-                    if (params.REGRESSION_TEST) {
-                      sh('mkdir -p tmp/ca tmp/entitlement')
-                      sh('cp /etc/pki/entitlement/*pem tmp/entitlement')
-                      sh('sudo cp /etc/rhsm/ca/redhat-uep.pem tmp/ca')
-                    }
+                    // Copying the host RHEL8 credentials all the time
+                    sh('mkdir -p ./etc-pki-entitlement ./rhsm-conf ./rhsm-ca')
+                    sh('cp /etc/pki/entitlement/*pem ./etc-pki-entitlement')
+                    sh('sudo cp /etc/rhsm/rhsm.conf ./rhsm-conf')
+                    sh('sudo cp /etc/rhsm/ca/*.pem ./rhsm-ca')
                     // Create the image to use
                     // Once again, we are not using the full dockerfile from scratch: too long --> when it is a pull request
                     // On the daily master build, we are doing from scratch

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -10,8 +10,10 @@ ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c
 ENV TZ=Europe/Paris
 # Copy RHEL certificates for builder image
-COPY tmp/entitlement/*.pem /etc/pki/entitlement
-COPY tmp/ca/redhat-uep.pem /etc/rhsm/ca
+COPY ./etc-pki-entitlement /etc/pki/entitlement
+# Copy the subscription manager configurations
+COPY ./rhsm-conf /etc/rhsm
+COPY ./rhsm-ca /etc/rhsm/ca
 
 RUN mkdir -p $C_BUILD
 


### PR DESCRIPTION
## Summary

I am preparing a RHEL8 optimization pull request, but I need to this one first.
I will need the host entitlements even during a pull request build and not just during the daily build from scratch.

I also place them in a friendlier way for OpenShift build (the way secrets are stored is not compatible with that `tmp` folder).

## Test Plan

None. It should not affect anything.

## Additional Information

- [ ] This change is backwards-breaking
