### PR TITLE
fix(nms): Display correct axios errors

### DIFF
--- a/nms/app/util/ErrorUtils.ts
+++ b/nms/app/util/ErrorUtils.ts
@@ -11,17 +11,12 @@
  * limitations under the License.
  */
 
-import {AxiosError, AxiosResponse} from 'axios';
-
-function isAxiosError<T>(error: any): error is AxiosError<T> {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-member-access
-  return 'isAxiosError' in error && error.isAxiosError;
-}
+import axios, {AxiosError, AxiosResponse} from 'axios';
 
 export function isAxiosErrorResponse<T = {message?: string}>(
   error: any,
 ): error is AxiosError<T> & {response: AxiosResponse<T>} {
-  return isAxiosError(error) && !!error.response;
+  return axios.isAxiosError(error) && !!error.response;
 }
 
 export function getErrorMessage(
@@ -29,10 +24,9 @@ export function getErrorMessage(
   fallbackMessage = 'Unknown Error',
 ): string {
   let errorMessage;
-  if (isAxiosError<{message?: string}>(error)) {
+  if (isAxiosErrorResponse(error)) {
     errorMessage = error.response?.data?.message ?? error.message;
-  }
-  if (error instanceof Error) {
+  } else if (error instanceof Error) {
     errorMessage = error.message;
   }
   return errorMessage || fallbackMessage;

--- a/nms/server/auth/express.ts
+++ b/nms/server/auth/express.ts
@@ -226,7 +226,7 @@ function userMiddleware(options: Options) {
       });
       res.status(200).send({users});
     } catch (error) {
-      res.status(400).send({error: (error as Error).toString()});
+      res.status(400).send({message: (error as Error).toString()});
     }
   });
 
@@ -311,7 +311,7 @@ function userMiddleware(options: Options) {
         );
         res.status(201).send({user});
       } catch (error) {
-        res.status(400).send({error: (error as Error).toString()});
+        res.status(400).send({message: (error as Error).toString()});
         await logUserChange(req, req.user, 'CREATE', req.body, 'FAILURE');
       }
     },

--- a/nms/server/auth/expressOnboarding.ts
+++ b/nms/server/auth/expressOnboarding.ts
@@ -79,7 +79,7 @@ export default function () {
 
         res.status(200).send({success: true});
       } catch (error) {
-        res.status(400).send({error: (error as Error).toString()});
+        res.status(400).send({message: (error as Error).toString()});
       }
     },
   );

--- a/nms/server/host/routes.ts
+++ b/nms/server/host/routes.ts
@@ -173,7 +173,7 @@ router.post(
         ),
       });
       if (organization) {
-        return res.status(409).send({error: 'Organization exists already'});
+        return res.status(409).send({message: 'Organization exists already'});
       }
       organization = await Organization.create({
         name: req.body.name,
@@ -200,7 +200,7 @@ router.put(
       ),
     });
     if (!organization) {
-      return res.status(404).send({error: 'Organization does not exist'});
+      return res.status(404).send({message: 'Organization does not exist'});
     }
     const updated = await organization.update(req.body);
     await syncOrganizationWithOrc8rTenant(updated);
@@ -227,7 +227,7 @@ router.post(
         ),
       });
       if (!organization) {
-        return res.status(404).send({error: 'Organization does not exist'});
+        return res.status(404).send({message: 'Organization does not exist'});
       }
 
       try {
@@ -261,7 +261,7 @@ router.post(
         const user = await User.create(props);
         res.status(200).send({user});
       } catch (error) {
-        res.status(400).send({error: (error as Error).toString()});
+        res.status(400).send({message: (error as Error).toString()});
       }
     },
   ),


### PR DESCRIPTION
## Summary

Closes https://github.com/magma/magma/issues/13948.

- Modifies logic in `getErrorMessage` to use `else if` instead of `if` when checking if the error is an instance of `Error`. Otherwise, when an axios error message is encountered, the `errorMessage` always gets overwritten to be the default.
- Replaces the `error` field with `message` throughout `nms/server` so that it corresponds to the field that gets accessed when returning the axios error message.
- Replaces custom `isAxiosError` function with `axios.isAxiosError`.

## Test Plan

- [x] nms-workflow

On master, when trying to create two organizations with the same name on the [host site](https://host.localhost/host), one gets "Request failed with status code 409". With these changes, one gets "Organization exists already".

Similarly, when trying to create two users with the same name, one gets "Request failed with status code 400" on master, but e.g. "Error: admin@magma.test already exists" with this PR.