### PR TITLE
chore: lte integ tests always publish logs

### DIFF
--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -89,13 +89,13 @@ jobs:
           name: test-results
           path: lte/gateway/test-results/**/*.xml
       - name: Get test logs
-        if: failure()
+        if: always()
         run: |
           cd lte/gateway
           fab get_test_logs:dst_path=./logs.tar.gz
       - name: Upload test logs
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: failure()
+        if: always()
         with:
           name: test-logs
           path: lte/gateway/logs.tar.gz


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>


## Summary

Currently lte integ test logs (syslog from magma dev, etc) are only published if the run failed. For debugging tests it would be helpful to also have these logs for successful runs - for comparison, seeing undetected issues, ...

## Test Plan

* see that workflow file is not damaged

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
