### PR TITLE
fix(agw): Allow containerized magmad to restart services

### DIFF
--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -40,6 +40,7 @@ containerized AGW by running the following steps inside the VM:
 ```
 cd $MAGMA_ROOT/lte/gateway && make run  # You can skip this if you have built the AGW with make before
 for component in redis nghttpx td-agent-bit; do cp "${MAGMA_ROOT}"/{orc8r,lte}/gateway/configs/templates/${component}.conf.template; done
+sed -i 's/init_system: systemd/init_system: docker/' "${MAGMA_ROOT}"/lte/gateway/configs/magmad.yml
 sudo systemctl stop 'magma@*' 'sctpd' # We don't want the systemd-based AGW to run when we start the containerized AGW
 sudo systemctl start magma_dp@envoy
 cd $MAGMA_ROOT/lte/gateway/docker

--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -20,6 +20,23 @@ x-standard-volumes: &volumes_anchor
   - /var/log:/var/log
   - /etc/openvswitch:/etc/openvswitch
 
+# Magmad volumes mounted
+x-magmad-volumes: &magmad_volumes_anchor
+  - ${CERTS_VOLUME}:/var/opt/magma/certs
+  - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
+  - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+  - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
+  - ${CONFIGS_OVERRIDE_TMP_VOLUME}:/var/opt/magma/tmp
+  - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+  - /etc/snowflake:/etc/snowflake
+  - /var/opt/magma/fluent-bit:/var/opt/magma/fluent-bit
+  - ./:/var/opt/magma/docker
+  - /var/run:/var/run
+  - /tmp:/tmp
+  - /var/log:/var/log
+  - /etc/openvswitch:/etc/openvswitch
+  - /var/run/docker.sock:/var/run/docker.sock
+
 x-generic-service: &service
   volumes: *volumes_anchor
   logging: *logging_anchor
@@ -45,6 +62,7 @@ services:
       interval: "4s"
       timeout: "4s"
       retries: 3
+    volumes: *magmad_volumes_anchor
     environment:
       DOCKER_REGISTRY: ${DOCKER_REGISTRY}
       DOCKER_USERNAME: ${DOCKER_USERNAME}

--- a/lte/gateway/docker/services/python/Dockerfile
+++ b/lte/gateway/docker/services/python/Dockerfile
@@ -89,6 +89,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   ca-certificates \
+  docker.io \
   ethtool \
   inetutils-ping \
   iproute2 \

--- a/orc8r/gateway/python/magma/magmad/config_manager.py
+++ b/orc8r/gateway/python/magma/magmad/config_manager.py
@@ -158,7 +158,6 @@ class ConfigManager(StreamerClient.Callback):
                 ),
             )
 
-        services_to_restart = []
         if SHARED_MCONFIG in mconfig.configs_by_key and did_mconfig_change(SHARED_MCONFIG):
             logging.info("Shared config changed. Restarting all services.")
             services_to_restart = self._services

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -63,6 +63,7 @@ def main():
     # Create service manager
     services = service.config.get('magma_services')
     init_system = service.config.get('init_system', 'systemd')
+    logging.info("Running magmad with init system %s", init_system)
     registered_dynamic_services = service.config.get(
         'registered_dynamic_services', [],
     )


### PR DESCRIPTION
## Summary

Add the docker application and the docker socket to the magmad container setup in the AGW too. (Magmad already has the capability to control other docker services, and this is used in the Federation Gateway.)

Document that init_system needs to be set in the config. Also magmad now logs the init system on startup.

Fixes #13966.

## Test Plan

Start the containerized AGW and connect it to an orc8r. Then change the mconfig to make magmad restart services.

## Additional Information

- [ ] This change is backwards-breaking