### PR TITLE
fix(agw): make redis save state after cleaning the db

### DIFF
--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -103,6 +103,7 @@ def clear_redis_state():
     ]:
         for key in redis_client.scan_iter(key_regex):
             redis_client.delete(key)
+        redis_client.save()
 
 
 def flushall_redis():


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The redis state is saved after cleaning the database in order to avoid having persistent data after a restart and tests run more stable.

## Test Plan

Tested with GitHub actions (with one failing test due to trfserver connection problems):
https://github.com/mpfirrmann/magma/actions/runs/3111190925/jobs/5043189710

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
