### PR TITLE
chore(agw): restart of sctpd is adapted

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -998,7 +998,8 @@ class MagmadUtil(object):
         """Restart all magma services on magma_dev VM"""
         if self._init_system == InitMode.SYSTEMD:
             self.exec_command(
-                "sudo service magma@* stop ; sudo service magma@magmad start",
+                "sudo systemctl stop 'magma@*' 'sctpd' ;"
+                "sudo systemctl start magma@magmad",
             )
         elif self._init_system == InitMode.DOCKER:
             self.exec_command(
@@ -1491,7 +1492,6 @@ class MagmadUtil(object):
         with open(mconfig_conf, "w") as json_file:
             json.dump(data, json_file, sort_keys=True, indent=2)
 
-        self.restart_sctpd(0)
         self.restart_all_services()
 
     def _validate_non_nat_datapath(self, ip_version=4):

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -533,7 +533,7 @@ class TestWrapper(object):
 
         if not is_test_successful:
             print("The test has failed. Restarting Sctpd for cleanup")
-            self.magmad_util.restart_sctpd()
+            self.magmad_util.restart_services(['sctpd'], wait_time=30)
             self.magmad_util.print_redis_state()
             if TestWrapper.TEST_CASE_EXECUTION_COUNT == 3:
                 self.generate_flaky_summary()
@@ -543,7 +543,7 @@ class TestWrapper(object):
 
         if not self.magmad_util.is_redis_empty():
             print("************************* Redis not empty, initiating cleanup")
-            self.magmad_util.restart_sctpd()
+            self.magmad_util.restart_services(['sctpd'], wait_time=30)
             self.magmad_util.print_redis_state()
 
     def multiEnbConfig(self, num_of_enbs, enb_list=None):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
@@ -34,7 +34,9 @@ class TestAttachDetachEnbRlfInitialUeMsg(unittest.TestCase):
             "Restart sctpd service to clear Redis state as test case doesn't"
             " intend to initiate detach procedure",
         )
-        self._s1ap_wrapper.magmad_util.restart_sctpd()
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ['sctpd'], wait_time=30,
+        )
         self._s1ap_wrapper.magmad_util.print_redis_state()
 
     def test_attach_detach_enb_rlf_initial_ue_msg(self):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_sctpd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_sctpd_restart.py
@@ -64,8 +64,9 @@ class TestAttachDetachWithSctpdRestart(unittest.TestCase):
                 "gateway",
             )
 
-            self._s1ap_wrapper.magmad_util.restart_sctpd()
-
+            self._s1ap_wrapper.magmad_util.restart_services(
+                ['sctpd'], wait_time=30,
+            )
             # Re-establish S1 connection between eNB and MME
             self._s1ap_wrapper._s1setup()
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
@@ -37,7 +37,9 @@ class TestContinuousRandomAttach(unittest.TestCase):
             "subsequent test cases",
         )
         self._s1ap_wrapper._s1_util.delete_ovs_flow_rules()
-        self._s1ap_wrapper.magmad_util.restart_sctpd()
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ['sctpd'], wait_time=30,
+        )
         self._s1ap_wrapper.magmad_util.print_redis_state()
 
     def handle_msg(self, msg):

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1setup_failure_incorrect_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1setup_failure_incorrect_plmn.py
@@ -50,7 +50,7 @@ class TestS1SetupFailureIncorrectPlmn(unittest.TestCase):
             print("The test has failed. Restarting Sctpd for cleanup")
             magmad_client = MagmadServiceGrpc()
             magmad_util = MagmadUtil(magmad_client)
-            magmad_util.restart_sctpd()
+            magmad_util.restart_services(['sctpd'], wait_time=30)
             magmad_util.print_redis_state()
             if s1ap_wrapper.TestWrapper.TEST_CASE_EXECUTION_COUNT == 3:
                 s1ap_wrapper.TestWrapper.generate_flaky_summary()

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1setup_failure_incorrect_tac.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1setup_failure_incorrect_tac.py
@@ -49,7 +49,7 @@ class TestS1SetupFailureIncorrectTac(unittest.TestCase):
             print("The test has failed. Restarting Sctpd for cleanup")
             magmad_client = MagmadServiceGrpc()
             magmad_util = MagmadUtil(magmad_client)
-            magmad_util.restart_sctpd()
+            magmad_util.restart_services(['sctpd'], wait_time=30)
             magmad_util.print_redis_state()
             if s1ap_wrapper.TestWrapper.TEST_CASE_EXECUTION_COUNT == 3:
                 s1ap_wrapper.TestWrapper.generate_flaky_summary()

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
@@ -27,7 +27,9 @@ class TestSctpShutdownAfterMultiUeAttach(unittest.TestCase):
             "Restart sctpd service to clear Redis state as test case doesn't"
             " intend to initiate detach procedure",
         )
-        self._s1ap_wrapper.magmad_util.restart_sctpd()
+        self._s1ap_wrapper.magmad_util.restart_services(
+            ['sctpd'], wait_time=30,
+        )
         self._s1ap_wrapper.magmad_util.print_redis_state()
 
     def test_sctp_shutdown_after_multi_ue_attach(self):


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Two small chores concerning the restart of sctpd:

1. Instead of restarting the `sctpd` before restarting all services (which also includes `sctpd`) the service is just stopped together with `magma@*`. This only concerns the `systemd` case.
2. All `restart_sctpd()` calls are redirected to `restart_services()` with its default 30s waiting time.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
