### PR TITLE
docs: Fix double stop of magmad in Quick Start Guide

### DIFF
--- a/docs/readmes/basics/quick_start_guide.md
+++ b/docs/readmes/basics/quick_start_guide.md
@@ -198,7 +198,7 @@ then you can verify that things are working:
 HOST [magma/lte/gateway]$ vagrant ssh magma
 
 MAGMA-VM$ sudo service magma@* stop
-MAGMA-VM$ sudo service magma@magmad restart
+MAGMA-VM$ sudo service magma@magmad start
 MAGMA-VM$ sudo tail -f /var/log/syslog
 
 # After a minute or 2 you should see these messages:


### PR DESCRIPTION
## Summary

magmad gets stopped with `sudo service magma@* stop` so this stops it from being stopped a second time via the restart.

## Test Plan

CI
