### PR TITLE
perf(dp): Configuration Controller performance improvements

### DIFF
--- a/dp/cloud/python/magma/db_service/models.py
+++ b/dp/cloud/python/magma/db_service/models.py
@@ -145,9 +145,8 @@ class DBGrant(Base):
         Return string representation of DB object
         """
         class_name = self.__class__.__name__
-        state_name = self.state.name
+        # state_name = self.state.name
         return f"<{class_name}(id='{self.id}', " \
-            f"state='{state_name}', " \
             f"cbsd_id='{self.cbsd_id}', " \
             f"grant_id='{self.grant_id}', " \
             f"grant_expire_time='{self.grant_expire_time}', " \

--- a/dp/cloud/python/magma/db_service/session_manager.py
+++ b/dp/cloud/python/magma/db_service/session_manager.py
@@ -26,7 +26,7 @@ class SessionManager(object):
     """
 
     def __init__(self, db_engine: Engine):
-        self.session_factory = sessionmaker(bind=db_engine)
+        self.session_factory = sessionmaker(bind=db_engine, autoflush=False)
 
     @contextmanager
     def session_scope(self) -> Session:

--- a/dp/cloud/python/magma/db_service/tests/db_testcase.py
+++ b/dp/cloud/python/magma/db_service/tests/db_testcase.py
@@ -44,7 +44,7 @@ class DBTestCaseBlueprint(unittest.TestCase):
     @classmethod
     def set_up_db_test_case(cls, **kwargs: Optional[Dict]):
         cls.engine = cls.get_test_db_engine(**kwargs)
-        cls.session = Session(bind=cls.engine)
+        cls.session = Session(bind=cls.engine, autoflush=False)
         cls.bind_engine()
 
     @staticmethod

--- a/dp/cloud/python/magma/fluentd_client/client.py
+++ b/dp/cloud/python/magma/fluentd_client/client.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass
+from datetime import datetime
 from typing import List, Optional
 
 import requests
@@ -96,7 +97,5 @@ class FluentdClient(object):
         Raises:
             FluentdClientException: Generic Fluentd Client Exception
         """
-        logger.debug(f"Sending logs batch to Fluentd")
         fluentd_payload = [asdict(log) for log in log_list]
-        resp = self._send_to_fluentd(payload=fluentd_payload)
-        logger.debug(f"Sent logs batch to Fluentd. Response code = {resp.status_code}")
+        self._send_to_fluentd(payload=fluentd_payload)


### PR DESCRIPTION
## Summary

perf(dp): Batch logging in Configuration Controller
    
Instead of sending logs one by one during Configuration Controller's
request/response processing, send all logs related to requests in a
http batch to fluentd, as an array of individual logs.

This change reduces the time footprint it takes for 1 log to be
processed by fluentd, and should greatly improve request processing
performance by not waiting for each log to be sent and processed.

perf(dp): logging in separate thread, session improvements

Sending logs to fluentd in separate threads not to slow down execution of request processing jobs
added autoflush=False to sessionmaker
prepopulating grant_states_map dictionary


## Test Plan
Performance improvements introduced in this PR should be seamless to existing unit and integration tests.
