### PR TITLE
chore: the init system check is less chatty

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -916,30 +916,31 @@ class MagmadUtil(object):
 
     def detect_init_system(self) -> InitMode:
         """Detect whether services are running with Docker or systemd."""
+        def _is_installed(cmd):
+            is_installed = self.exec_command(f"type {cmd} >/dev/null 2>&1") == 0
+            if not is_installed:
+                logging.info(f"{cmd} is not installed")
+            return is_installed
 
-        try:
-            docker_running = self.exec_command_output(
+        if _is_installed("docker"):
+            docker_magmad_running = self.exec_command_output(
                 "docker ps --filter 'name=magmad' --format '{{.Names}}'",
             ).strip() == "magmad"
-        except subprocess.CalledProcessError:
-            docker_running = False
-            logging.info("Docker is not installed")
+        else:
+            docker_magmad_running = False
 
-        try:
-            systemd_running = self.exec_command_output(
+        if _is_installed("systemctl"):
+            systemd_magmad_running = self.exec_command_output(
                 "systemctl is-active magma@magmad",
             ).strip() == "active"
-        except subprocess.CalledProcessError:
-            systemd_running = False
-            logging.info("systemd is not installed")
+        else:
+            systemd_magmad_running = False
 
-        if docker_running and systemd_running:
-            # default to systemd if both are running, needed by feg integ tests
+        if systemd_magmad_running:
+            # default to systemd if docker and systemd are running - needed by feg integ tests
             return InitMode.SYSTEMD
-        elif docker_running:
+        elif docker_magmad_running:
             return InitMode.DOCKER
-        elif systemd_running:
-            return InitMode.SYSTEMD
         else:
             raise RuntimeError(
                 "Magmad is not running, you have to start magmad "


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

If integ tests are executed on a system without docker there is for each test a message `bash: docker: command not found`. This PR removes the message.

## Test Plan

execute an integration test locally and see that it is not failing and that the message is not displayed.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
