### PR TITLE
feat(agw): AGW container restart check their health status

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1161,6 +1161,26 @@ class MagmadUtil(object):
             result_str = e.output
         return result_str
 
+    def get_service_name_from_init_system(self, service):
+        """Get the correct service name depending on the init system
+
+        Args:
+            service: (str) service name
+
+        Returns:
+            (str) service name
+        """
+        if self._init_system == InitMode.SYSTEMD:
+            if service == "sctpd":
+                return "sctpd"
+            else:
+                return f"magma@{service}"
+        elif self._init_system == InitMode.DOCKER:
+            if service == "mme":
+                return "oai_mme"
+            else:
+                return service
+
     def update_mme_config_for_sanity(self, cmd):
         """Update MME configuration for all sanity test cases"""
         mme_config_update_script = (

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1135,6 +1135,26 @@ class MagmadUtil(object):
         elif self._init_system == InitMode.DOCKER:
             self.exec_command(f"docker stop {service_name}")
 
+    def check_if_magma_services_are_active(self) -> bool:
+        """check if all services in the list are active (only works for docker
+         init_system)
+
+        Returns:
+            (bool) True if all services are active, False otherwise
+        """
+        magma_services = {
+            "mme", "magmad", "sctpd", "sessiond", "policydb", "state",
+            "directoryd", "connectiond", "td-agent-bit", "redis",
+            "subscriberdb", "eventd", "mobilityd", "pipelined", "monitord",
+            "envoy_controller", "smsd", "enodebd", "redirectd", "ctraced",
+            "control_proxy",
+        }
+        for service in magma_services:
+            if not self.is_service_active(service):
+                print(f"************* {service} is not running")
+                return False
+        return True
+
     def is_service_active(self, service) -> bool:
         """Check if a magma service on magma_dev VM is active
 

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1114,11 +1114,12 @@ class MagmadUtil(object):
         Args:
             service: (str) service to enable
         """
+        service_name = self.get_service_name_from_init_system(service)
         if self._init_system == InitMode.SYSTEMD:
-            self.exec_command(f"sudo systemctl unmask magma@{service}")
-            self.exec_command(f"sudo systemctl start magma@{service}")
+            self.exec_command(f"sudo systemctl unmask {service_name}")
+            self.exec_command(f"sudo systemctl start {service_name}")
         elif self._init_system == InitMode.DOCKER:
-            self.exec_command(f"docker start {service}")
+            self.exec_command(f"docker start {service_name}")
 
     def disable_service(self, service):
         """Disables a magma service on magma_dev VM, preventing from

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1144,14 +1144,24 @@ class MagmadUtil(object):
         Returns:
             service active status
         """
+        service_name = self.get_service_name_from_init_system(service)
         if self._init_system == InitMode.SYSTEMD:
-            is_active_service_cmd = "systemctl is-active magma@" + service
-            return self.check_service_activity(is_active_service_cmd).strip() == "active"
+            is_active_service_cmd = f"systemctl is-active {service_name}"
+            return (
+                self.check_service_activity(
+                    is_active_service_cmd,
+                ).strip() == "active"
+            )
         elif self._init_system == InitMode.DOCKER:
             is_active_service_cmd = (
-                f"docker ps --filter 'name={service}' --format '{{.Status}}'"
+                f"docker inspect --format="
+                f"'{{{{.State.Health.Status}}}}' {service_name}"
             )
-            return self.check_service_activity(is_active_service_cmd).strip()[:2] == "up"
+            return (
+                self.check_service_activity(
+                    is_active_service_cmd,
+                ).strip() == "healthy"
+            )
         return False
 
     def check_service_activity(self, is_active_service_cmd):

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1127,11 +1127,12 @@ class MagmadUtil(object):
         Args:
             service: (str) service to disable
         """
+        service_name = self.get_service_name_from_init_system(service)
         if self._init_system == InitMode.SYSTEMD:
-            self.exec_command(f"sudo systemctl mask magma@{service}")
-            self.exec_command(f"sudo systemctl stop magma@{service}")
+            self.exec_command(f"sudo systemctl mask {service_name}")
+            self.exec_command(f"sudo systemctl stop {service_name}")
         elif self._init_system == InitMode.DOCKER:
-            self.exec_command(f"docker stop {service}")
+            self.exec_command(f"docker stop {service_name}")
 
     def is_service_active(self, service) -> bool:
         """Check if a magma service on magma_dev VM is active

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1100,13 +1100,27 @@ class MagmadUtil(object):
             )
         self.wait_for_restart_to_finish(wait_time)
 
-    @staticmethod
-    def wait_for_restart_to_finish(wait_time):
-        for j in range(wait_time):
-            print(
-                f"Waiting for {wait_time - j} seconds for restart to complete",
-            )
-            time.sleep(1)
+    def wait_for_restart_to_finish(self, wait_time):
+        """wait for started services to become active or until timeout
+
+        Args:
+            wait_time: (int) max time to wait for services to become active
+        """
+        print(
+            f"Waiting for a maximum of {wait_time} "
+            f"seconds for restart to finish",
+        )
+        if self._init_system == InitMode.DOCKER:
+            start_time = time.time()
+            all_services_active = False
+            while (
+                not all_services_active
+                and time.time() - start_time < wait_time
+            ):
+                all_services_active = self.check_if_magma_services_are_active()
+                time.sleep(5)
+        elif self._init_system == InitMode.SYSTEMD:
+            time.sleep(wait_time)
 
     def enable_service(self, service):
         """Enable a magma service on magma_dev VM and starts it

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1017,6 +1017,7 @@ class MagmadUtil(object):
                 "cd /home/vagrant/magma/lte/gateway/docker "
                 "&& docker-compose restart",
             )
+            self.wait_for_restart_to_finish(wait_time=30)
 
         self._wait_for_pipelined_to_initialize()
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py
@@ -65,7 +65,7 @@ class TestAttachUlUdpDataWithMultipleServiceRestart(unittest.TestCase):
         )
         wait_for_restart = 30
         self._s1ap_wrapper.magmad_util.restart_services(
-            ["mobilityd", "mme", "pipelined"], wait_for_restart,
+            ["mme"], wait_for_restart,
         )
 
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
@@ -282,7 +282,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
         )
         wait_for_restart = 30
         self._s1ap_wrapper.magmad_util.restart_services(
-            ["sessiond", "mme", "pipelined"], wait_for_restart,
+            ["mme"], wait_for_restart,
         )
 
         print("Sleeping for 5 seconds")


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The LTE integration tests use sleep timer to wait for a magma services to become functional again after restarting them as part of several tests. These sleep timers are based on empirical data for the `systemd`-based AGW and are not necessarily well suited to account for the containerized AGW's docker container to become healty again after a restart.
Instead, we want to check the container health as an indicator to continue with the tests after a restart (and at the same time leave the existing workflow for the `systemd`-based AGW as it is for now).

Some special thoughts to be considered here:
- The container corresponding to the `mme` service is called `oai_mme`.
- The `sctpd` service does not have a `magma@` prefix. Nevertheless, it is started via the `magmad` service.
- We want to avoid a double waiting time resolving these special cases
    
The PR is separated into ten commits:
1. `get_service_name_from_init_system()` is added to handle the special naming cases.
2. `disable_service` uses the correct service name and works with docker and `systemd`.
3. `enable_service` uses the correct service name and works with docker and `systemd`.
4. `is_service_active()` uses the correct name and checks for `systemctl is-active {service_name}` / docker container health status is "healthy".
5. A function to check the health of ALL of magma's AGW docker containers is added (excl. magma's `health` container which is disabled for the tests).
6. The wait for restart function checks if all containers are healthy (docker) or waits the given `wait_time` for a `systemd`-based AGW.
7. All service restarts are handled by `restart_services(["list", "of", "services"], time_wait: int)`.
8. After restarting all services we wait for all docker containers to become healthy.
9. We adapt the `pipelined`/`datapath` check for the containerized AGW.
10. The restarts of AGW containers follows [THIS](https://excalidraw.com/#room=9b3ea34b6f337ccab568,F2DMzJxlW8yjKZtjQ2djtA) scheme.

Closes #12956.

## Test Plan

In its current state, all pre-commit and extended S1AP integration tests pass locally using a containerized and a `systemd`-based AGW.
Tested with GitHub actions (ongoing) to show the tests are still working:
https://github.com/mpfirrmann/magma/actions/runs/3113678195

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
