### PR TITLE
feat(agw): test-sctp-shutdown-while-mme-is-stopped.py is adapted to c…

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_while_mme_is_stopped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_while_mme_is_stopped.py
@@ -54,10 +54,11 @@ class TestSctpShutdownWhileMmeIsStopped(unittest.TestCase):
         # Wait for EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        print("Stopping MME service")
-        self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service magma@mme stop",
-        )
+        print("Stopping MME, mobilityd, pipelined, and sessiond service")
+        self._s1ap_wrapper.magmad_util.disable_service('mme')
+        self._s1ap_wrapper.magmad_util.disable_service('mobilityd')
+        self._s1ap_wrapper.magmad_util.disable_service('pipelined')
+        self._s1ap_wrapper.magmad_util.disable_service('sessiond')
 
         print("send SCTP SHUTDOWN")
         self._s1ap_wrapper._s1_util.issue_cmd(
@@ -67,19 +68,11 @@ class TestSctpShutdownWhileMmeIsStopped(unittest.TestCase):
         print("Redis state after SCTP shutdown")
         self._s1ap_wrapper.magmad_util.print_redis_state()
 
-        print("Starting MME service and waiting for 30 seconds")
-        self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service magma@mobilityd start",
-        )
-        self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service magma@pipelined start",
-        )
-        self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service magma@sessiond start",
-        )
-        self._s1ap_wrapper.magmad_util.exec_command(
-            "sudo service magma@mme start",
-        )
+        print("Starting the stopped services and waiting for 30 seconds")
+        self._s1ap_wrapper.magmad_util.enable_service('mobilityd')
+        self._s1ap_wrapper.magmad_util.enable_service('pipelined')
+        self._s1ap_wrapper.magmad_util.enable_service('sessiond')
+        self._s1ap_wrapper.magmad_util.enable_service('mme')
         time.sleep(30)
 
         print("Re-establish S1 connection between eNB and MME")


### PR DESCRIPTION
…ontainerized AGW

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR replaces the `systemd` specific stop and start functions for the more general enable/disable_service functions of `s1ap_utils.py` that can handle docker commands as well. With that we avoid starting `systemd` services during the execution of the test suite.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
