### PR TITLE
feat(ci): Move and edit release scripts/workflows

### DIFF
--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -3,22 +3,22 @@ name: docker promote
 on:
   workflow_dispatch:
     inputs:
-      version_to_promote:
-        description: 'Magma version to promote'
+      branch_tag:
+        description: 'Branch version number'
+        required: true
+        default: '1.8'
+      release_tag:
+        description: 'Release version number'
         required: true
         default: '1.8.0'
-      new_tag:
-        description: 'New version to promote to'
-        required: true
-        default: '1.8.1'
 
 
 jobs:
   docker-promote:
     runs-on: ubuntu-latest
     env:
-      MAGMA_TAG: ${{ inputs.version_to_promote }}
-      NEW_MAGMA_TAG: ${{ inputs.new_tag }}
+      BRANCH_TAG: ${{ inputs.branch_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
       MAGMA_ARTIFACTORY: artifactory.magmacore.org
     steps:
       - uses: tspascoal/get-user-teams-membership@533553aa88900a17c59177d65bcf8c5c97ff1a90 # pin@v1.0.3

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -1,15 +1,37 @@
 name: docker promote
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      version_to_promote:
+        description: 'Magma version to promote'
+        required: true
+        default: '1.8.0'
+      new_tag:
+        description: 'New version to promote to'
+        required: true
+        default: '1.8.1'
+
 
 jobs:
   docker-promote:
     runs-on: ubuntu-latest
     env:
-      MAGMA_TAG: 1.8
-      NEW_MAGMA_TAG: 1.8.0
+      MAGMA_TAG: ${{ github.event.inputs.version_to_promote }}
+      NEW_MAGMA_TAG: ${{ github.event.inputs.new_tag }}
       MAGMA_ARTIFACTORY: artifactory.magmacore.org
     steps:
+      - uses: tspascoal/get-user-teams-membership@v533553aa88900a17c59177d65bcf8c5c97ff1a90 # pin@v1.0.3
+        name: Check if user has rights to promote
+        id: checkUserMember
+        with:
+          username: ${{ github.actor }}
+          team: 'approvers-ci'
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        run: |
+          echo "User is not a member of the team"
+          exit 1
       - uses: docker/login-action@v49ed152c8eca782a232dede0303416e8f356c37b # Pin v2.0.0
         name: Login to Artifactory
         with:
@@ -17,7 +39,7 @@ jobs:
           username: ${{ secrets.ARTIFACTORY_USERNAME }}
           password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       - run: |
-          wget https://github.com/magma/magma/raw/master/orc8r/tools/helm/promote.sh
+          wget https://github.com/magma/magma/raw/master/orc8r/tools/docker/promote.sh
           chmod 755 promote.sh
           # Promote Docker images
           ./promote.sh

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -17,8 +17,8 @@ jobs:
   docker-promote:
     runs-on: ubuntu-latest
     env:
-      MAGMA_TAG: ${{ github.event.inputs.version_to_promote }}
-      NEW_MAGMA_TAG: ${{ github.event.inputs.new_tag }}
+      MAGMA_TAG: ${{ inputs.version_to_promote }}
+      NEW_MAGMA_TAG: ${{ inputs.new_tag }}
       MAGMA_ARTIFACTORY: artifactory.magmacore.org
     steps:
       - uses: tspascoal/get-user-teams-membership@533553aa88900a17c59177d65bcf8c5c97ff1a90 # pin@v1.0.3

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -17,12 +17,9 @@ on:
       branch_tag:
         description: 'Branch version number'
         required: true
-        default: '1.8'
       release_tag:
         description: 'Release version number'
         required: true
-        default: '1.8.0'
-
 
 jobs:
   docker-promote:

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo "User is not a member of the team"
           exit 1
-      - uses: docker/login-action@v49ed152c8eca782a232dede0303416e8f356c37b # Pin v2.0.0
+      - uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # Pin v2.0.0
         name: Login to Artifactory
         with:
           registry: docker.${{ env.MAGMA_ARTIFACTORY }}

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -1,0 +1,17 @@
+
+name: docker promote
+
+on: workflow_dispatch
+
+jobs:
+  docker-promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/login-action@v1
+        with:
+          registry: docker.artifactory.magmacore.org
+          username: ${{ secrets.ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+
+      - run: ./promote.sh

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -1,3 +1,14 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: docker promote
 
 on:

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -10,15 +10,14 @@ jobs:
       NEW_MAGMA_TAG: 1.8.0
       MAGMA_ARTIFACTORY: artifactory.magmacore.org
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v49ed152c8eca782a232dede0303416e8f356c37b # Pin v2.0.0
+        name: Login to Artifactory
         with:
-          registry: docker.artifactory.magmacore.org
+          registry: docker.${{ env.MAGMA_ARTIFACTORY }}
           username: ${{ secrets.ARTIFACTORY_USERNAME }}
           password: ${{ secrets.ARTIFACTORY_PASSWORD }}
-
       - run: |
           wget https://github.com/magma/magma/raw/master/orc8r/tools/helm/promote.sh
           chmod 755 promote.sh
-          # Promote Helm charts
-          ./promote.sh ${MAGMA_TAG} ${NEW_MAGMA_TAG}
+          # Promote Docker images
+          ./promote.sh

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -1,4 +1,3 @@
-
 name: docker promote
 
 on: workflow_dispatch
@@ -6,6 +5,10 @@ on: workflow_dispatch
 jobs:
   docker-promote:
     runs-on: ubuntu-latest
+    env:
+      MAGMA_TAG: 1.8
+      NEW_MAGMA_TAG: 1.8.0
+      MAGMA_ARTIFACTORY: artifactory.magmacore.org
     steps:
       - uses: actions/checkout@v3
       - uses: docker/login-action@v1
@@ -14,4 +17,8 @@ jobs:
           username: ${{ secrets.ARTIFACTORY_USERNAME }}
           password: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
-      - run: ./promote.sh
+      - run: |
+          wget https://github.com/magma/magma/raw/master/orc8r/tools/helm/promote.sh
+          chmod 755 promote.sh
+          # Promote Helm charts
+          ./promote.sh ${MAGMA_TAG} ${NEW_MAGMA_TAG}

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -21,7 +21,7 @@ jobs:
       NEW_MAGMA_TAG: ${{ github.event.inputs.new_tag }}
       MAGMA_ARTIFACTORY: artifactory.magmacore.org
     steps:
-      - uses: tspascoal/get-user-teams-membership@v533553aa88900a17c59177d65bcf8c5c97ff1a90 # pin@v1.0.3
+      - uses: tspascoal/get-user-teams-membership@533553aa88900a17c59177d65bcf8c5c97ff1a90 # pin@v1.0.3
         name: Check if user has rights to promote
         id: checkUserMember
         with:

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -1,3 +1,14 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: helm promote
 
 on:

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       magma_version:
-        description: 'Magma version'
+        description: 'Magma version number'
         required: true
         default: '1.8.0'
 

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -17,7 +17,7 @@ jobs:
       HELM_CHART_MUSEUM_TOKEN: ${{ secrets.HELM_CHART_MUSEUM_TOKEN }}
       HELM_CHART_MUSEUM_USERNAME: ${{ secrets.HELM_CHART_MUSEUM_USERNAME }}
     steps:
-      - uses: tspascoal/get-user-teams-membership@v533553aa88900a17c59177d65bcf8c5c97ff1a90 # pin@v1.0.3
+      - uses: tspascoal/get-user-teams-membership@533553aa88900a17c59177d65bcf8c5c97ff1a90 # pin@v1.0.3
         name: Check if user has rights to promote
         id: checkUserMember
         with:

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -17,7 +17,6 @@ on:
       magma_version:
         description: 'Magma version number'
         required: true
-        default: '1.8.0'
 
 jobs:
   helm-promote:

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -12,7 +12,7 @@ jobs:
   helm-promote:
     runs-on: ubuntu-latest
     env:
-      MAGMA_VERSION: ${{ github.event.inputs.magma_version }}
+      MAGMA_VERSION: ${{ inputs.magma_version }}
       MAGMA_ARTIFACTORY: https://artifactory.magmacore.org:443/artifactory
       HELM_CHART_MUSEUM_TOKEN: ${{ secrets.HELM_CHART_MUSEUM_TOKEN }}
       HELM_CHART_MUSEUM_USERNAME: ${{ secrets.HELM_CHART_MUSEUM_USERNAME }}

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -1,16 +1,33 @@
 name: helm promote
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      magma_version:
+        description: 'Magma version'
+        required: true
+        default: '1.8.0'
 
 jobs:
   helm-promote:
     runs-on: ubuntu-latest
     env:
-      MAGMA_VERSION: 1.8.0
+      MAGMA_VERSION: ${{ github.event.inputs.magma_version }}
       MAGMA_ARTIFACTORY: https://artifactory.magmacore.org:443/artifactory
       HELM_CHART_MUSEUM_TOKEN: ${{ secrets.HELM_CHART_MUSEUM_TOKEN }}
       HELM_CHART_MUSEUM_USERNAME: ${{ secrets.HELM_CHART_MUSEUM_USERNAME }}
     steps:
+      - uses: tspascoal/get-user-teams-membership@v533553aa88900a17c59177d65bcf8c5c97ff1a90 # pin@v1.0.3
+        name: Check if user has rights to promote
+        id: checkUserMember
+        with:
+          username: ${{ github.actor }}
+          team: 'approvers-ci'
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        run: |
+          echo "User is not a member of the team"
+          exit 1
       - run: |
           wget https://github.com/magma/magma/raw/master/orc8r/tools/helm/promote.sh
           chmod 755 promote.sh

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -1,0 +1,21 @@
+name: helm promote
+
+on: workflow_dispatch
+
+jobs:
+  helm-promote:
+    runs-on: ubuntu-latest
+    env:
+      MAGMA_VERSION: 1.8.0
+      HELM_CHART_MUSEUM_TOKEN: ${{ secrets.HELM_CHART_MUSEUM_TOKEN }}
+      HELM_CHART_MUSEUM_USERNAME: ${{ secrets.HELM_CHART_MUSEUM_USERNAME }}
+    steps:
+      - run: |
+          wget https://github.com/magma/magma/raw/master/orc8r/tools/helm/promote.sh
+          chmod 755 promote.sh
+          # Promote Helm charts
+          ./promote.sh orc8r-${MAGMA_VERSION}.tgz
+          ./promote.sh cwf-orc8r-${MAGMA_VERSION}.tgz
+          ./promote.sh feg-orc8r-${MAGMA_VERSION}.tgz
+          ./promote.sh lte-orc8r-${MAGMA_VERSION}.tgz
+          ./promote.sh domain-proxy-${MAGMA_VERSION}.tgz

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAGMA_VERSION: 1.8.0
+      MAGMA_ARTIFACTORY: https://artifactory.magmacore.org:443/artifactory
       HELM_CHART_MUSEUM_TOKEN: ${{ secrets.HELM_CHART_MUSEUM_TOKEN }}
       HELM_CHART_MUSEUM_USERNAME: ${{ secrets.HELM_CHART_MUSEUM_USERNAME }}
     steps:

--- a/orc8r/tools/docker/promote.sh
+++ b/orc8r/tools/docker/promote.sh
@@ -6,12 +6,12 @@ if [[ -z $MAGMA_ARTIFACTORY ]]; then
   exitmsg "Environment variable MAGMA_ARTIFACTORY must be set."
 fi
 
-if [[ -z $MAGMA_TAG ]]; then
-  exitmsg "Environment variable MAGMA_TAG must be set."
+if [[ -z $BRANCH_TAG ]]; then
+  exitmsg "Environment variable BRANCH_TAG must be set."
 fi
 
-if [[ -z $NEW_MAGMA_TAG ]]; then
-  exitmsg "Environment variable NEW_MAGMA_TAG must be set."
+if [[ -z $RELEASE_TAG ]]; then
+  exitmsg "Environment variable RELEASE_TAG must be set."
 fi
 
 declare -A repositories=(
@@ -29,19 +29,19 @@ for repo in ${!repositories[@]}; do
     sed -i "s/docker/${repo}-prod/g" ~/.docker/config.json
 
     # Pull docker image from test registry
-    docker pull "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG}"
+    docker pull "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${BRANCH_TAG}"
 
     # Tag docker image with new tag
-    docker tag "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}"
-    docker tag "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest"
+    docker tag "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${BRANCH_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${RELEASE_TAG}"
+    docker tag "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${BRANCH_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest"
 
     # Push docker image to prod registry
-    docker push "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}"
+    docker push "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${RELEASE_TAG}"
     docker push "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest"
 
     # Remove uploaded image
-    docker rmi "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG}"
-    docker rmi "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}"
+    docker rmi "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${BRANCH_TAG}"
+    docker rmi "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${RELEASE_TAG}"
     docker rmi "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest"
 
     # Change docker URL back to docker

--- a/orc8r/tools/docker/promote.sh
+++ b/orc8r/tools/docker/promote.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eou pipefail
 
 if [[ -z $MAGMA_ARTIFACTORY ]]; then

--- a/orc8r/tools/docker/promote.sh
+++ b/orc8r/tools/docker/promote.sh
@@ -13,7 +13,7 @@ declare -A repositories=(
   [cwf]="cwag_go gateway_go gateway_pipelined gateway_python gateway_sessiond operator"
 )
 
-for repo in ${!repositories["$@"]}; do
+for repo in ${!repositories[@]}; do
   for image in ${repositories[${repo}]}; do
 
     # Change docker URL to Artifactory

--- a/orc8r/tools/docker/promote.sh
+++ b/orc8r/tools/docker/promote.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
-set -ex
+set -eou pipefail
 
-MAGMA_TAG=$0
-NEW_MAGMA_TAG=$1
-MAGMA_ARTIFACTORY=$2
+if [[ -z $MAGMA_ARTIFACTORY ]]; then
+  exitmsg "Environment variable MAGMA_ARTIFACTORY must be set."
+fi
+
+if [[ -z $MAGMA_TAG ]]; then
+  exitmsg "Environment variable MAGMA_TAG must be set."
+fi
+
+if [[ -z $NEW_MAGMA_TAG ]]; then
+  exitmsg "Environment variable NEW_MAGMA_TAG must be set."
+fi
 
 declare -A repositories=(
   [orc8r]="controller magmalte nginx active-mode-controller configuration-controller radio-controller db-service"
@@ -13,6 +21,7 @@ declare -A repositories=(
   [cwf]="cwag_go gateway_go gateway_pipelined gateway_python gateway_sessiond operator"
 )
 
+# shellcheck disable=SC2068
 for repo in ${!repositories[@]}; do
   for image in ${repositories[${repo}]}; do
 
@@ -37,6 +46,6 @@ for repo in ${!repositories[@]}; do
 
     # Change docker URL back to docker
     sed -i "s/${repo}-prod/docker/g" ~/.docker/config.json
-
+    echo "Promoted docker image artifact ${image} from test to production registry successfully."
   done
 done

--- a/orc8r/tools/docker/promote.sh
+++ b/orc8r/tools/docker/promote.sh
@@ -46,6 +46,6 @@ for repo in ${!repositories[@]}; do
 
     # Change docker URL back to docker
     sed -i "s/${repo}-prod/docker/g" ~/.docker/config.json
-    echo "Promoted docker image artifact ${image} from test to production registry successfully."
+    echo "Promoted docker image artifact ${image} from ${repo}-test to ${repo}-prod registry successfully."
   done
 done

--- a/orc8r/tools/docker/promote.sh
+++ b/orc8r/tools/docker/promote.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -ex
+
+MAGMA_TAG=$0
+NEW_MAGMA_TAG=$1
+MAGMA_ARTIFACTORY=$2
+
+declare -A repositories=(
+  [orc8r]="controller magmalte nginx active-mode-controller configuration-controller radio-controller db-service"
+  [feg]="gateway_go gateway_python"
+  [agw]="agw_gateway_c agw_gateway_python ghz_gateway_c ghz_gateway_python agw_gateway_c_arm agw_gateway_python_arm"
+  [cwf]="cwag_go gateway_go gateway_pipelined gateway_python gateway_sessiond operator"
+)
+
+for repo in ${!repositories["$@"]}; do
+  for image in ${repositories[${repo}]}; do
+
+    # Change docker URL to Artifactory
+    sed -i "s/docker/${repo}-prod/g" ~/.docker/config.json
+
+    # Pull docker image from test registry
+    docker pull ${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG}
+
+    # Tag docker image with new tag
+    docker tag ${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}
+    docker tag ${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest
+
+    # Push docker image to prod registry
+    docker push ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}
+    docker push ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest
+
+    # Remove uploaded image
+    docker rmi ${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG}
+    docker rmi ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}
+    docker rmi ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest
+
+    # Change docker URL back to docker
+    sed -i "s/${repo}-prod/docker/g" ~/.docker/config.json
+
+  done
+done

--- a/orc8r/tools/docker/promote.sh
+++ b/orc8r/tools/docker/promote.sh
@@ -29,20 +29,20 @@ for repo in ${!repositories[@]}; do
     sed -i "s/docker/${repo}-prod/g" ~/.docker/config.json
 
     # Pull docker image from test registry
-    docker pull ${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG}
+    docker pull "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG}"
 
     # Tag docker image with new tag
-    docker tag ${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}
-    docker tag ${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest
+    docker tag "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}"
+    docker tag "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest"
 
     # Push docker image to prod registry
-    docker push ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}
-    docker push ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest
+    docker push "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}"
+    docker push "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest"
 
     # Remove uploaded image
-    docker rmi ${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG}
-    docker rmi ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}
-    docker rmi ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest
+    docker rmi "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${MAGMA_TAG}"
+    docker rmi "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${NEW_MAGMA_TAG}"
+    docker rmi "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest"
 
     # Change docker URL back to docker
     sed -i "s/${repo}-prod/docker/g" ~/.docker/config.json

--- a/orc8r/tools/helm/promote.sh
+++ b/orc8r/tools/helm/promote.sh
@@ -13,7 +13,7 @@
 
 # promote.sh copies specified artifacts from one repo to another.
 
-set -e -o pipefail
+set -eou pipefail
 
 promote_artifact () {
   ARTIFACT="$1"
@@ -40,18 +40,23 @@ exitmsg() {
 # Check if the required args and env-vars present
 [ $# -eq 0 ] && usage
 
-# Define default values
-HELM_CHART_ARTIFACTORY_URL="${HELM_CHART_ARTIFACTORY_URL:-https://artifactory.magmacore.org:443/artifactory}"
-HELM_CHART_MUSEUM_ORIGIN_REPO="${HELM_CHART_MUSEUM_ORIGIN_REPO:-helm-test}"
-HELM_CHART_MUSEUM_DEST_REPO="${HELM_CHART_MUSEUM_DEST_REPO:-helm-prod}"
+if [[ -z $MAGMA_ARTIFACTORY ]]; then
+  exitmsg "Environment variable MAGMA_ARTIFACTORY must be set."
+fi
 
 if [[ -z $HELM_CHART_MUSEUM_USERNAME ]]; then
-  exitmsg "Environment variable HELM_CHART_MUSEUM_USERNAME must be set"
+  exitmsg "Environment variable HELM_CHART_MUSEUM_USERNAME must be set."
 fi
 
 if [[ -z $HELM_CHART_MUSEUM_TOKEN ]]; then
-  exitmsg "Environment variable HELM_CHART_MUSEUM_TOKEN must be set"
+  exitmsg "Environment variable HELM_CHART_MUSEUM_TOKEN must be set."
 fi
+
+
+# Define default values
+HELM_CHART_ARTIFACTORY_URL="${HELM_CHART_ARTIFACTORY_URL:-${MAGMA_ARTIFACTORY}}"
+HELM_CHART_MUSEUM_ORIGIN_REPO="${HELM_CHART_MUSEUM_ORIGIN_REPO:-helm-test}"
+HELM_CHART_MUSEUM_DEST_REPO="${HELM_CHART_MUSEUM_DEST_REPO:-helm-prod}"
 
 # Trim last backslash if exists
 # shellcheck disable=SC2001


### PR DESCRIPTION
Closes #13883 

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Move release scripts/workflows from:
  - https://github.com/ShubhamTatvamasi/magma-artifactory-docker-promote and
  - https://github.com/nstng/magma-artifactory-helm-promote
- Edit release scripts so they broadly work the same way (e.g. use of environment variables).
- Add magamcore artifactory url variable to make migration to another artifactory easier.
<!-- Enumerate changes you made and why you made them -->
- Configure the workflow so that only the `approvers-ci` codeowners can run it.

## Test Plan

I don't have the necessary permissions for the artifactory to really test it. It would be good to run these scripts in some way to see if they work as expected. However, I do not have the necessary permissions to perform any such tests. I tried to test the workflow team membership checks in my own testing organization. However, I would need a paid tier subscription to use secrets. 

It is also difficult to run `workflow-dispatch` actions if the workflow does not yet exist on master. As far as I can tell, I would have to paste the code temporarily into an existing `workflow-dispatch` workflow. 

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
