### PR TITLE
fix(agw): fix incorrect asserts in agw integ tests

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py
@@ -92,7 +92,9 @@ class Test3485TimerForDedicatedBearerWithMmeRestart(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            assert (
+                response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            )
             print(
                 '*******************Received first Activate dedicated bearer '
                 'request',

--- a/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py
@@ -92,9 +92,7 @@ class Test3485TimerForDedicatedBearerWithMmeRestart(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             print(
                 '*******************Received first Activate dedicated bearer '
                 'request',

--- a/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
@@ -128,10 +128,7 @@ class Test3485TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
         )
 
         retransmitted_response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            retransmitted_response.msg_type,
-            s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert retransmitted_response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = retransmitted_response.cast(
             s1ap_types.uePdnConRsp_t,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
@@ -128,7 +128,10 @@ class Test3485TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
         )
 
         retransmitted_response = self._s1ap_wrapper.s1_util.get_response()
-        assert retransmitted_response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+        assert (
+            retransmitted_response.msg_type
+            == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+        )
         act_def_bearer_req = retransmitted_response.cast(
             s1ap_types.uePdnConRsp_t,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_dedicated_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_dedicated_bearer_with_mme_restart.py
@@ -89,9 +89,7 @@ class Test3495TimerForDedicatedBearerWithMmeRestart(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -122,10 +120,7 @@ class Test3495TimerForDedicatedBearerWithMmeRestart(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print("******************* Received deactivate eps bearer context")
             # Do not send deactivate eps bearer context accept
@@ -139,10 +134,7 @@ class Test3495TimerForDedicatedBearerWithMmeRestart(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
             deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
             self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
                 req.ue_id, deactv_bearer_req.bearerId,

--- a/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_default_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3495_timer_for_default_bearer_with_mme_restart.py
@@ -101,9 +101,7 @@ class Test3495TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(req.ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
         sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -138,9 +136,7 @@ class Test3495TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
         )
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
         print(
             "******************* Received deactivate default eps bearer "
@@ -155,9 +151,7 @@ class Test3495TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
         deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
         self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
             req.ue_id, deactv_bearer_req.bearerId,

--- a/lte/gateway/python/integ_tests/s1aptests/test_activate_deactivate_multiple_dedicated.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_activate_deactivate_multiple_dedicated.py
@@ -74,9 +74,7 @@ class TestActivateDeactivateMultipleDedicated(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -113,10 +111,7 @@ class TestActivateDeactivateMultipleDedicated(unittest.TestCase):
         for i in range(num_dedicated_bearers):
             time.sleep(0.1)
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print("******************* Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_activate_deactivate_multiple_dedicated.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_activate_deactivate_multiple_dedicated.py
@@ -74,7 +74,9 @@ class TestActivateDeactivateMultipleDedicated(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            assert (
+                response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            )
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -111,7 +113,10 @@ class TestActivateDeactivateMultipleDedicated(unittest.TestCase):
         for i in range(num_dedicated_bearers):
             time.sleep(0.1)
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            assert (
+                response.msg_type
+                == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            )
 
             print("******************* Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
@@ -69,7 +69,7 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
             "*************************  Offloading UE at state ECM-CONNECTED",
         )
         # Send offloading request
-        self.assertTrue(
+        assert (
             self._ha_util.offload_agw(
                 "".join(["IMSI"] + [str(i) for i in req.imsi]),
                 enb_list[0][0],
@@ -77,14 +77,11 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print("*************************  Offloading UE at state ECM-IDLE")
         # Send offloading request
-        self.assertTrue(
+        assert (
             self._ha_util.offload_agw(
                 "".join(["IMSI"] + [str(i) for i in req.imsi]),
                 enb_list[0][0],
@@ -105,16 +102,10 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
             ser_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # Send service request again:
         # This time auto-release should not happen
@@ -123,10 +114,7 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
             ser_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         print("************************* SLEEPING for 2 sec")
         time.sleep(2)

--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
@@ -92,7 +92,7 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertTrue(response, s1ap_types.tfwCmd.UE_PAGING_IND.value)
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
         # Send service request to reconnect UE
         # Auto-release should happen
         ser_req = s1ap_types.ueserviceReq_t()

--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_mixed_idle_active_multiue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_mixed_idle_active_multiue.py
@@ -83,22 +83,20 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
                 ue_cntxt_rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print("*************************  Send Offload Request to AGW")
         # Send offloading request
-        self.assertTrue(self._ha_util.offload_agw(None, enb_list[0][0]))
+        assert (self._ha_util.offload_agw(None, enb_list[0][0]))
 
         # All UEs should eventually receive Context Release Request
         # The first half should get it immediately
         # The second half should first get paging
         for _ in range(num_ues):
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertIn(
-                response.msg_type,
+            assert (
+                response.msg_type
+                in
                 [
                     s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
                     s1ap_types.tfwCmd.UE_PAGING_IND.value,
@@ -120,16 +118,10 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
                 ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         for i in range(num_ues):
             # Send service request again:
@@ -143,10 +135,7 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
                 ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         # Now detach the UEs normally
         for ue in ue_ids:

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_act_dflt_ber_ctxt_rej.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_act_dflt_ber_ctxt_rej.py
@@ -58,10 +58,7 @@ class TestAttachActDfltBerCtxtRej(unittest.TestCase):
             attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
 
         # Trigger Authentication Response
         auth_res = s1ap_types.ueAuthResp_t()
@@ -74,10 +71,7 @@ class TestAttachActDfltBerCtxtRej(unittest.TestCase):
             auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
@@ -116,16 +110,10 @@ class TestAttachActDfltBerCtxtRej(unittest.TestCase):
         )
         # Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("******** released UE contexts ********")
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_active_tau_with_combined_tala_update_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_active_tau_with_combined_tala_update_reattach.py
@@ -76,10 +76,7 @@ class TestAttachActiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
             req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print(
             "************************* Received UE context release indication",
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
@@ -66,10 +66,7 @@ class TestAttachASR(unittest.TestCase):
 
         # Receive NW initiated detach request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value
         print("**************** Received NW initiated Detach Req")
         print("**************** Sending Detach Accept")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_failure.py
@@ -49,7 +49,7 @@ class TestAttachAuthFailure(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertTrue(response, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value)
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received Authentication Request message ")
 
         auth_failure = s1ap_types.ueAuthFailure_t()
@@ -63,7 +63,7 @@ class TestAttachAuthFailure(unittest.TestCase):
             s1ap_types.tfwCmd.UE_AUTH_FAILURE, auth_failure,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertTrue(response, s1ap_types.tfwCmd.UE_AUTH_REJ_IND.value)
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REJ_IND.value
         print("Received Authentication Reject message")
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_mac_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_mac_failure.py
@@ -49,7 +49,7 @@ class TestAttachAuthMacFailure(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertTrue(response, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value)
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received Authentication Request message ")
 
         auth_failure = s1ap_types.ueAuthFailure_t()
@@ -63,7 +63,7 @@ class TestAttachAuthMacFailure(unittest.TestCase):
             s1ap_types.tfwCmd.UE_AUTH_FAILURE, auth_failure,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertTrue(response, s1ap_types.tfwCmd.UE_AUTH_REJ_IND.value)
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REJ_IND.value
         print("Received Authentication Reject message")
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_complete_after_ics_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_complete_after_ics_timer_expiry.py
@@ -61,10 +61,7 @@ class TestAttachCompleteAfterIcsTimerExpiry(unittest.TestCase):
         )
         print("****** Sent ATTACH_REQUEST")
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("****** Received AUTH_REQ_IND")
         delay_init_ctxt_setup_resp = s1ap_types.UeDelayInitCtxtSetupRsp()
         delay_init_ctxt_setup_resp.ue_Id = req.ue_id
@@ -88,10 +85,7 @@ class TestAttachCompleteAfterIcsTimerExpiry(unittest.TestCase):
         )
         print("****** Sent UE_AUTH_RESP")
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("****** Received UE_SEC_MOD_CMD_IND")
 
         # Trigger Security Mode Complete
@@ -126,10 +120,7 @@ class TestAttachCompleteAfterIcsTimerExpiry(unittest.TestCase):
         print("****** Sent ATTACH_COMPLETE")
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("****** Received UE_CTX_REL_IND")
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ICS_Failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ICS_Failure.py
@@ -51,9 +51,7 @@ class TestAttachDetachICSFailure(unittest.TestCase):
             s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
 
         init_ctxt_setup_fail = s1ap_types.ueInitCtxtSetupFail()
         init_ctxt_setup_fail.ue_Id = req.ue_id
@@ -72,9 +70,7 @@ class TestAttachDetachICSFailure(unittest.TestCase):
             s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         self._s1ap_wrapper._s1_util.issue_cmd(
             s1ap_types.tfwCmd.UE_SET_INIT_CTXT_SETUP_FAIL, init_ctxt_setup_fail,
@@ -88,9 +84,7 @@ class TestAttachDetachICSFailure(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         print("*** Received Initial Context Setup Failure ***")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_after_ue_context_release.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_after_ue_context_release.py
@@ -63,9 +63,7 @@ class TestAttachDetachAfterUeContextRelease(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print(
             "************************* Running UE detach (switch-off) for ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated.py
@@ -78,9 +78,7 @@ class TestAttachDetachDedicated(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -112,10 +110,7 @@ class TestAttachDetachDedicated(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print("******************* Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_activation_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_activation_reject.py
@@ -82,9 +82,7 @@ class TestAttachDetachDedicatedActivationReject(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_ebi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_ebi.py
@@ -83,9 +83,7 @@ class TestAttachDetachDedicatedBearerDeactivationInvalidEbi(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_imsi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_imsi.py
@@ -84,9 +84,7 @@ class TestAttachDetachDedicatedBearerDeactivationInvalidImsi(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_lbi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_lbi.py
@@ -82,7 +82,9 @@ class TestAttachDetachDedicatedBearerDeactivationInvalidLbi(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            assert (
+                response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            )
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_lbi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_bearer_deactivation_invalid_lbi.py
@@ -82,9 +82,7 @@ class TestAttachDetachDedicatedBearerDeactivationInvalidLbi(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_deactivation_timer_expiry.py
@@ -78,9 +78,7 @@ class TestAttachDetachDedicatedDeactivationTimerExpiry(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -115,10 +113,7 @@ class TestAttachDetachDedicatedDeactivationTimerExpiry(unittest.TestCase):
             # TODO:Receive retransmissions once support is added
             # at s1ap tester
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
             deact_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeDeActvBearCtxtReq_t,
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_looped.py
@@ -77,10 +77,7 @@ class TestAttachDetachDedicatedLooped(unittest.TestCase):
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEqual(
-                    response.msg_type,
-                    s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-                )
+                assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
                 act_ded_ber_ctxt_req = response.cast(
                     s1ap_types.UeActDedBearCtxtReq_t,
                 )
@@ -112,10 +109,7 @@ class TestAttachDetachDedicatedLooped(unittest.TestCase):
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEqual(
-                    response.msg_type,
-                    s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-                )
+                assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
                 print("************** Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_multi_ue.py
@@ -78,9 +78,7 @@ class TestAttachDetachDedicatedMultiUe(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             print(
                 "********************** Received activate dedicated EPS"
                 " bearer context request",
@@ -120,10 +118,7 @@ class TestAttachDetachDedicatedMultiUe(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print(
                 "********************** Received deactivate EPS bearer"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_qci_0.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_dedicated_qci_0.py
@@ -80,10 +80,7 @@ class TestAttachDetachDedicatedQci0(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_FW_ERAB_SETUP_REQ_FAILED_FOR_ERABS.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_FW_ERAB_SETUP_REQ_FAILED_FOR_ERABS.value
             erab_setup_failed_for_bearers = response.cast(
                 s1ap_types.FwErabSetupFailedTosetup,
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_disconnect_default_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_disconnect_default_pdn.py
@@ -59,9 +59,7 @@ class TestAttachDetachDisconnectDefaultPdn(unittest.TestCase):
 
         # Receive PDN Disconnect Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REJ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REJ.value
 
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_duplicate_nas_resp_messages.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_duplicate_nas_resp_messages.py
@@ -61,10 +61,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
                 ") ***",
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
             print(
                 "*** Authentication Request Message Received (",
                 str(i + 1),
@@ -97,10 +94,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
                 ") ***",
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
             print(
                 "*** Security Mode Command Message Received (",
                 str(i + 1),
@@ -143,10 +137,7 @@ class TestAttachDetachDuplicateNASRespMessages(unittest.TestCase):
                 ") ***",
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
             print(
                 "*** Attach Accept Message Received in DL NAS transport msg (",
                 str(i + 1),

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_emm_status.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_emm_status.py
@@ -71,9 +71,7 @@ class TestAttachDetachEmmStatus(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print(
             "************************* Running UE detach (switch-off) for ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
@@ -66,10 +66,7 @@ class TestAttachDetachEnbRlfInitialUeMsg(unittest.TestCase):
             attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
 
         # Trigger Authentication Response
         auth_res = s1ap_types.ueAuthResp_t()
@@ -82,10 +79,7 @@ class TestAttachDetachEnbRlfInitialUeMsg(unittest.TestCase):
             auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
@@ -96,9 +96,7 @@ class TestAttachDetachMaxBearersTwoPdns(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_req_oai_apn = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -113,9 +111,7 @@ class TestAttachDetachMaxBearersTwoPdns(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
             # Receive PDN CONN RSP/Activate default EPS bearer context req
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
             sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -151,10 +147,7 @@ class TestAttachDetachMaxBearersTwoPdns(unittest.TestCase):
                     qci_val=idx + 1,
                 )
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEqual(
-                    response.msg_type,
-                    s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-                )
+                assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
                 act_ded_ber_req_ims_apn = response.cast(
                     s1ap_types.UeActDedBearCtxtReq_t,
                 )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_dedicated.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_dedicated.py
@@ -75,9 +75,7 @@ class TestAttachDetachMultipleDedicated(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -116,10 +114,7 @@ class TestAttachDetachMultipleDedicated(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print("******************* Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
@@ -53,7 +53,7 @@ class TestAttachDetachMultipleIpBlocksMobilitydRestart(unittest.TestCase):
         curr_blocks = self._s1ap_wrapper.mobility_util.list_ip_blocks()
         # Check if old_blocks and curr_blocks contain same ip blocks after
         # restart
-        self.assertListEqual(old_blocks, curr_blocks)
+        assert old_blocks == curr_blocks
 
         req = self._s1ap_wrapper.ue_req
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
@@ -192,9 +192,7 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
 
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req1 = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -220,9 +218,7 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
 
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req2 = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -253,8 +249,8 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(uplink_flows) > 2, "Uplink flow missing for UE"
-            self.assertIsNotNone(
-                uplink_flows[0]["match"]["tunnel_id"],
+            assert (
+                uplink_flows[0]["match"]["tunnel_id"] is not None,
                 "Uplink flow missing tunnel id match",
             )
 
@@ -281,9 +277,8 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(downlink_flows) > 2, "Downlink flow missing for UE"
-            self.assertEqual(
-                downlink_flows[0]["match"]["ipv4_dst"],
-                ue_ip,
+            assert (
+                downlink_flows[0]["match"]["ipv4_dst"] == ue_ip,
                 "UE IP match missing from downlink flow",
             )
 
@@ -294,7 +289,7 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
                 if action["field"] == "tunnel_id"
                 and action["type"] == "SET_FIELD"
             )
-            self.assertTrue(
+            assert (
                 has_tunnel_action, "Downlink flow missing set tunnel action",
             )
 
@@ -315,10 +310,7 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print("******************* Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
@@ -192,7 +192,9 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
 
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            assert (
+                response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            )
             act_ded_ber_ctxt_req1 = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -218,7 +220,9 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
 
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            assert (
+                response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            )
             act_ded_ber_ctxt_req2 = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -310,7 +314,10 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            assert (
+                response.msg_type
+                == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            )
 
             print("******************* Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_secondary_pdn.py
@@ -85,9 +85,7 @@ class TestAttachDetachMultipleSecondaryPdn(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn[i])
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
             print(
@@ -118,10 +116,7 @@ class TestAttachDetachMultipleSecondaryPdn(unittest.TestCase):
 
             # Receive UE_DEACTIVATE_BER_REQ
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print(
                 "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_secondary_pdn.py
@@ -85,7 +85,10 @@ class TestAttachDetachMultipleSecondaryPdn(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn[i])
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            assert (
+                response.msg_type
+                == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            )
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
             print(
@@ -116,7 +119,10 @@ class TestAttachDetachMultipleSecondaryPdn(unittest.TestCase):
 
             # Receive UE_DEACTIVATE_BER_REQ
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            assert (
+                response.msg_type
+                == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            )
 
             print(
                 "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_non_nat_dp_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_non_nat_dp_ul_tcp.py
@@ -70,7 +70,7 @@ class TestAttachDetachNonNatDpUlTcp(unittest.TestCase):
             # Validate assigned IP address.
             addr = attach.esmInfo.pAddr.addrInfo
             ue_ipv4 = ipaddress.ip_address(bytes(addr[:4]))
-            self.assertEqual(ue_ipv4, ipaddress.IPv4Address(ue_ips[i]))
+            assert ue_ipv4 == ipaddress.IPv4Address(ue_ips[i])
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_last_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_last_pdn.py
@@ -73,9 +73,7 @@ class TestAttachDetachNwTriggeredDeleteLastPdn(unittest.TestCase):
                 flow_list,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -107,10 +105,7 @@ class TestAttachDetachNwTriggeredDeleteLastPdn(unittest.TestCase):
             )
             # Receive NW initiated detach request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value
             print("**************** Received NW initiated Detach Req")
             print("**************** Sending Detach Accept")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_nw_triggered_delete_secondary_pdn.py
@@ -81,9 +81,7 @@ class TestAttachDetachNwTriggeredDeleteSecondaryPdn(unittest.TestCase):
 
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_sec_pdn = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_sec_pdn.m.pdnInfo.pAddr.addrInfo
         sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -108,9 +106,7 @@ class TestAttachDetachNwTriggeredDeleteSecondaryPdn(unittest.TestCase):
         )
         # Receive Activate dedicated EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_ctxt_req = response.cast(s1ap_types.UeActDedBearCtxtReq_t)
         # Send Activate dedicated EPS bearer context accept
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
@@ -142,9 +138,7 @@ class TestAttachDetachNwTriggeredDeleteSecondaryPdn(unittest.TestCase):
 
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
         deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ps_service_not_available.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ps_service_not_available.py
@@ -68,9 +68,7 @@ class TestAttachDetachPsServiceNotAvailable(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print(
             "************************* Running UE detach (switch-off) for ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_activation_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_activation_reject.py
@@ -97,10 +97,7 @@ class TestAttachDetachRarActivationReject(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_ctxt_req = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -113,10 +110,7 @@ class TestAttachDetachRarActivationReject(unittest.TestCase):
         # Dedicated Bearer Activation Request message.
         # Handling re-transmitted Dedicated Bearer Activation Request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         print(
             "********************** Ignoring re-transmitted Dedicated Bearer "
             "Activation Request",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -176,9 +176,7 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
 
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -211,8 +209,8 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(uplink_flows) > 1, "Uplink flow missing for UE"
-            self.assertIsNotNone(
-                uplink_flows[0]["match"]["tunnel_id"],
+            assert (
+                uplink_flows[0]["match"]["tunnel_id"] is not None,
                 "Uplink flow missing tunnel id match",
             )
 
@@ -239,9 +237,8 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(downlink_flows) > 1, "Downlink flow missing for UE"
-            self.assertEqual(
-                downlink_flows[0]["match"]["ipv4_dst"],
-                ue_ip,
+            assert (
+                downlink_flows[0]["match"]["ipv4_dst"] == ue_ip,
                 "UE IP match missing from downlink flow",
             )
 
@@ -252,7 +249,7 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
                 if action["field"] == "tunnel_id"
                 and action["type"] == "SET_FIELD"
             )
-            self.assertTrue(
+            assert (
                 has_tunnel_action, "Downlink flow missing set tunnel action",
             )
 
@@ -270,10 +267,7 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print("******************* Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
@@ -187,9 +187,7 @@ class TestAttachDetachRarTcpHE(unittest.TestCase):
 
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -220,8 +218,8 @@ class TestAttachDetachRarTcpHE(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(uplink_flows) > 1, "Uplink flow missing for UE"
-            self.assertIsNotNone(
-                uplink_flows[0]["match"]["tunnel_id"],
+            assert (
+                uplink_flows[0]["match"]["tunnel_id"] is not None,
                 "Uplink flow missing tunnel id match",
             )
 
@@ -248,9 +246,8 @@ class TestAttachDetachRarTcpHE(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(downlink_flows) > 1, "Downlink flow missing for UE"
-            self.assertEqual(
-                downlink_flows[0]["match"]["ipv4_dst"],
-                ue_ip,
+            assert (
+                downlink_flows[0]["match"]["ipv4_dst"] == ue_ip,
                 "UE IP match missing from downlink flow",
             )
 
@@ -261,7 +258,7 @@ class TestAttachDetachRarTcpHE(unittest.TestCase):
                 if action["field"] == "tunnel_id"
                 and action["type"] == "SET_FIELD"
             )
-            self.assertTrue(
+            assert (
                 has_tunnel_action, "Downlink flow missing set tunnel action",
             )
 
@@ -280,10 +277,7 @@ class TestAttachDetachRarTcpHE(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print("******************* Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn.py
@@ -79,9 +79,7 @@ class TestAttachDetachSecondaryPdn(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
         sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -118,9 +116,7 @@ class TestAttachDetachSecondaryPdn(unittest.TestCase):
 
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
         print(
             "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_dedicated_bearer.py
@@ -92,7 +92,9 @@ class TestAttachDetachSecondaryPdnDisconnectDedicatedBearer(unittest.TestCase):
                 flow_list1,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            assert (
+                response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            )
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -107,7 +109,10 @@ class TestAttachDetachSecondaryPdnDisconnectDedicatedBearer(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            assert (
+                response.msg_type
+                == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            )
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
             sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -131,7 +136,9 @@ class TestAttachDetachSecondaryPdnDisconnectDedicatedBearer(unittest.TestCase):
                 flow_list2,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            assert (
+                response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            )
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_dedicated_bearer.py
@@ -92,9 +92,7 @@ class TestAttachDetachSecondaryPdnDisconnectDedicatedBearer(unittest.TestCase):
                 flow_list1,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -109,9 +107,7 @@ class TestAttachDetachSecondaryPdnDisconnectDedicatedBearer(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
             sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -135,9 +131,7 @@ class TestAttachDetachSecondaryPdnDisconnectDedicatedBearer(unittest.TestCase):
                 flow_list2,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -173,10 +167,7 @@ class TestAttachDetachSecondaryPdnDisconnectDedicatedBearer(unittest.TestCase):
 
             # Receive PDN Disconnect reject
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REJ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REJ.value
 
             print(
                 "******************** Received PDN Disconnect Reject for "

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_invalid_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_disconnect_invalid_bearer.py
@@ -85,9 +85,7 @@ class TestAttachDetachSecondaryPdnDisconnectInvalidBearer(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
         sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -135,9 +133,7 @@ class TestAttachDetachSecondaryPdnDisconnectInvalidBearer(unittest.TestCase):
 
         # Receive PDN Disconnect reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REJ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REJ.value
 
         print("************************* Received PDN disconnect reject")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_invalid_apn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_invalid_apn.py
@@ -60,15 +60,10 @@ class TestAttachDetachSecondaryPdnInvalidAPN(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN REJ
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         # Verify cause
         pdn_con_rsp = response.cast(s1ap_types.uePdnConRsp_t)
-        self.assertEqual(
-            pdn_con_rsp.m.conRejInfo.cause,
-            s1ap_types.TFW_ESM_CAUSE_MISSING_OR_UNKNOWN_APN,
-        )
+        assert pdn_con_rsp.m.conRejInfo.cause == s1ap_types.TFW_ESM_CAUSE_MISSING_OR_UNKNOWN_APN
 
         print("Sleeping for 5 seconds")
         time.sleep(5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_looped.py
@@ -84,9 +84,7 @@ class TestAttachDetachSecondaryPdnLooped(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
             sec_ip = ipaddress.ip_address(bytes(addr[:4]))

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_multi_ue.py
@@ -89,9 +89,7 @@ class TestAttachDetachSecondaryPdnMultiUe(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
             print(
@@ -133,10 +131,7 @@ class TestAttachDetachSecondaryPdnMultiUe(unittest.TestCase):
 
             # Receive UE_DEACTIVATE_BER_REQ
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print(
                 "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_no_disconnect.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_no_disconnect.py
@@ -79,9 +79,7 @@ class TestAttachDetachSecondaryPdnNoDisconnect(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
 
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer.py
@@ -91,9 +91,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearer(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -108,9 +106,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearer(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
             sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -135,9 +131,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearer(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -171,10 +165,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearer(unittest.TestCase):
 
             # Receive UE_DEACTIVATE_BER_REQ
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print(
                 "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py
@@ -93,9 +93,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerDeactivate(unittest.TestCas
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_req_oai_apn = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -110,9 +108,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerDeactivate(unittest.TestCas
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
             sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -135,9 +131,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerDeactivate(unittest.TestCas
                 flow_list2,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_req_ims_apn = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -176,10 +170,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerDeactivate(unittest.TestCas
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
 
@@ -202,10 +193,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerDeactivate(unittest.TestCas
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
             # Send Deactivate dedicated bearer rsp

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_looped.py
@@ -88,10 +88,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerLooped(unittest.TestCase):
                 self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
                 # Receive PDN CONN RSP/Activate default EPS bearer context req
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEqual(
-                    response.msg_type,
-                    s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-                )
+                assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
                 act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
                 addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
                 sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -115,10 +112,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerLooped(unittest.TestCase):
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEqual(
-                    response.msg_type,
-                    s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-                )
+                assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
                 act_ded_ber_ctxt_req = response.cast(
                     s1ap_types.UeActDedBearCtxtReq_t,
                 )
@@ -153,10 +147,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerLooped(unittest.TestCase):
 
                 # Receive UE_DEACTIVATE_BER_REQ
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEqual(
-                    response.msg_type,
-                    s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-                )
+                assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
                 print(
                     "*************** Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_multi_ue.py
@@ -92,9 +92,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerMultiUe(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
             sec_ips.append(ipaddress.ip_address(bytes(addr[:4])))
@@ -121,9 +119,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerMultiUe(unittest.TestCase):
                 flow_list[i],
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -166,10 +162,7 @@ class TestAttachDetachSecondaryPdnWithDedicatedBearerMultiUe(unittest.TestCase):
 
             # Receive UE_DEACTIVATE_BER_REQ
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print(
                 "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_pcscf_address.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_pcscf_address.py
@@ -104,9 +104,7 @@ class TestAttachDetachSecondaryPdnWithPcscfAddress(unittest.TestCase):
             )
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
             sec_ips.append(ipaddress.ip_address(bytes(addr[:4])))
@@ -153,10 +151,7 @@ class TestAttachDetachSecondaryPdnWithPcscfAddress(unittest.TestCase):
 
             # Receive UE_DEACTIVATE_BER_REQ
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print(
                 "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_service.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_service.py
@@ -69,18 +69,14 @@ class TestAttachDetachService(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
         print(
             "************************* Received Service Reject for UE id ",
             ue_id,
         )
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_setsessionrules_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_setsessionrules_tcp_data.py
@@ -141,9 +141,7 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
 
         # Receive Activate dedicated bearer request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_ctxt_req = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -170,9 +168,7 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
         # Triggers a delete bearer followed by a create bearer request
         # Receive Deactivate dedicated bearer request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
         deactivate_ber_ctxt_req = response.cast(
             s1ap_types.UeDeActvBearCtxtReq_t,
         )
@@ -184,9 +180,7 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
 
         # Receive Activate dedicated bearer request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_ctxt_req = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -219,14 +213,11 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
             time.sleep(5)  # sleep for 5 seconds before retrying
 
         assert len(uplink_flows) == 2, "There should be 2 UL flow rules for UE"
-        self.assertIsNotNone(
-            uplink_flows[0]["match"]["tunnel_id"],
-            "Uplink flow missing tunnel id match",
-        )
-        self.assertIsNotNone(
-            uplink_flows[1]["match"]["tunnel_id"],
-            "Uplink flow missing tunnel id match",
-        )
+        for i in range(len(uplink_flows)):
+            assert (
+                uplink_flows[i]["match"]["tunnel_id"] is not None,
+                "Uplink flow missing tunnel id match",
+            )
 
         # DOWNLINK
         print("Checking for downlink flow")
@@ -251,9 +242,8 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
             time.sleep(5)  # sleep for 5 seconds before retrying
 
         assert len(downlink_flows) == 3, "Downlink flows must have been 3 for UE"
-        self.assertEqual(
-            downlink_flows[0]["match"]["ipv4_dst"],
-            ue_ip,
+        assert (
+            downlink_flows[0]["match"]["ipv4_dst"] == ue_ip,
             "UE IP match missing from downlink flow",
         )
 
@@ -264,7 +254,7 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
             if action["field"] == "tunnel_id"
             and action["type"] == "SET_FIELD"
         )
-        self.assertTrue(
+        assert (
             has_tunnel_action, "Downlink flow missing set tunnel action",
         )
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_static_ip.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_static_ip.py
@@ -56,9 +56,9 @@ class TestAttachDetachStaticIP(unittest.TestCase):
             addr = attach.esmInfo.pAddr.addrInfo
             ue_ipv4 = ipaddress.ip_address(bytes(addr[:4]))
             if i < (num_ues - 1):
-                self.assertEqual(ue_ipv4, ipaddress.IPv4Address(ue_ips[i]))
+                assert ue_ipv4 == ipaddress.IPv4Address(ue_ips[i])
             else:
-                self.assertIn(ue_ipv4, ipaddress.ip_network("192.168.128.0/24"))
+                assert ue_ipv4 in ipaddress.ip_network("192.168.128.0/24")
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_two_pdns_with_tcptraffic.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_two_pdns_with_tcptraffic.py
@@ -83,9 +83,7 @@ class TestAttachDetachTwoPDNsWithTcpTraffic(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         pdn_conn_rsp = response.cast(s1ap_types.uePdnConRsp_t)
         ims_addr = pdn_conn_rsp.m.pdnInfo.pAddr.addrInfo
         ims_ip = ipaddress.ip_address(bytes(ims_addr[:4]))
@@ -144,9 +142,7 @@ class TestAttachDetachTwoPDNsWithTcpTraffic(unittest.TestCase):
 
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
         print(
             "******************* Received deactivate EPS bearer context",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_he_policy.py
@@ -123,9 +123,7 @@ class TestAttachDetachWithHePolicy(unittest.TestCase):
 
             # Receive Activate dedicated bearer request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -161,10 +159,7 @@ class TestAttachDetachWithHePolicy(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
             print("******************* Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ipv6_pcscf_and_dns_addr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ipv6_pcscf_and_dns_addr.py
@@ -83,9 +83,7 @@ class TestAttachDetachWithIpv6PcscfAndDnsAddr(unittest.TestCase):
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -101,9 +99,7 @@ class TestAttachDetachWithIpv6PcscfAndDnsAddr(unittest.TestCase):
 
         # Receive Router Advertisement message
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "************* Received Router Advertisement for APN-%s"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
@@ -41,14 +41,11 @@ class TestAttachDetachWithOVS(unittest.TestCase):
                 if a["field"] == "metadata"
             ), None,
         )
-        self.assertIsNotNone(imsi_action)
+        assert imsi_action is not None
         imsi64 = imsi_action["value"]
         # Convert between compacted uint IMSI and string
         received_imsi = decode_imsi(imsi64)
-        self.assertEqual(
-            sent_imsi, received_imsi,
-            "IMSI set in metadata field does not match sent IMSI",
-        )
+        assert sent_imsi == received_imsi, "IMSI set in metadata field does not match sent IMSI"
 
     def test_attach_detach_with_ovs(self):
         """
@@ -60,10 +57,7 @@ class TestAttachDetachWithOVS(unittest.TestCase):
 
         print("Checking for default table 0 flows")
         flows = get_flows(datapath, {"table_id": self.SPGW_TABLE})
-        self.assertEqual(
-            len(flows), 2,
-            "There should only be 2 default table 0 flows",
-        )
+        assert len(flows) == 2, "There should only be 2 default table 0 flows"
 
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
@@ -96,9 +90,9 @@ class TestAttachDetachWithOVS(unittest.TestCase):
                 break
             time.sleep(5)  # sleep for 5 seconds before retrying
 
-        self.assertEqual(len(uplink_flows), 1, "Uplink flow missing for UE")
-        self.assertIsNotNone(
-            uplink_flows[0]["match"]["tunnel_id"],
+        assert len(uplink_flows) == 1, "Uplink flow missing for UE"
+        assert (
+            uplink_flows[0]["match"]["tunnel_id"] is not None,
             "Uplink flow missing tunnel id match",
         )
         self.check_imsi_metadata(uplink_flows[0], req)
@@ -126,12 +120,9 @@ class TestAttachDetachWithOVS(unittest.TestCase):
                 break
             time.sleep(5)  # sleep for 5 seconds before retrying
 
-        self.assertEqual(
-            len(downlink_flows), 1,
-            "Downlink flow missing for UE",
-        )
-        self.assertEqual(
-            downlink_flows[0]["match"]["ipv4_dst"], ue_ip,
+        assert len(downlink_flows) == 1, "Downlink flow missing for UE"
+        assert (
+            downlink_flows[0]["match"]["ipv4_dst"] == ue_ip,
             "UE IP match missing from downlink flow",
         )
 
@@ -141,7 +132,7 @@ class TestAttachDetachWithOVS(unittest.TestCase):
             if action["field"] == "tunnel_id" and
             action["type"] == "SET_FIELD"
         )
-        self.assertTrue(
+        assert (
             has_tunnel_action,
             "Downlink flow missing set tunnel action",
         )
@@ -155,10 +146,7 @@ class TestAttachDetachWithOVS(unittest.TestCase):
 
         print("Checking that uplink/downlink flows were deleted")
         flows = get_flows(datapath, {"table_id": self.SPGW_TABLE})
-        self.assertEqual(
-            len(flows), 2,
-            "There should only be 2 default table 0 flows",
-        )
+        assert len(flows) == 2, "There should only be 2 default table 0 flows"
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_emergency.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_emergency.py
@@ -41,7 +41,7 @@ class TestAttachEmergency(unittest.TestCase):
         )
 
         # Assert cause
-        self.assertEqual(msg.ueState, expected_ue_state)
+        assert msg.ueState == expected_ue_state
         print(
             "************************* Emergency attach rejection successful",
             "UE id ", req.ue_id,

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_timerexpiration_max_retries.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_timerexpiration_max_retries.py
@@ -63,10 +63,7 @@ class TestAttachEsmInfoTimerExpirationMaxRetries(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ")
 
         auth_res = s1ap_types.ueAuthResp_t()
@@ -81,10 +78,7 @@ class TestAttachEsmInfoTimerExpirationMaxRetries(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
         time.sleep(1)
@@ -99,10 +93,7 @@ class TestAttachEsmInfoTimerExpirationMaxRetries(unittest.TestCase):
         for i in range(max_retries):
             # Esm Information Request indication
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
             print(
                 "Received Esm Information Request (",
                 i + 1,
@@ -167,10 +158,7 @@ class TestAttachEsmInfoTimerExpirationMaxRetries(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_with_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_with_apn_correction.py
@@ -66,10 +66,7 @@ class TestAttachEsmInfoWithApnCorrection(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ")
 
         auth_res = s1ap_types.ueAuthResp_t()
@@ -84,10 +81,7 @@ class TestAttachEsmInfoWithApnCorrection(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
         time.sleep(1)
@@ -105,10 +99,7 @@ class TestAttachEsmInfoWithApnCorrection(unittest.TestCase):
             sec_mode_complete.ue_Id,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
         esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
         # Sending Esm Information Response
         print(
@@ -164,10 +155,7 @@ class TestAttachEsmInfoWithApnCorrection(unittest.TestCase):
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # Disable APN Correction
         self._s1ap_wrapper.magmad_util.config_apn_correction(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information.py
@@ -56,10 +56,7 @@ class TestAttachEsmInformation(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ")
 
         auth_res = s1ap_types.ueAuthResp_t()
@@ -74,10 +71,7 @@ class TestAttachEsmInformation(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
         time.sleep(1)
@@ -95,10 +89,7 @@ class TestAttachEsmInformation(unittest.TestCase):
             sec_mode_complete.ue_Id,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
         esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
 
         # Sending Esm Information Response
@@ -154,10 +145,7 @@ class TestAttachEsmInformation(unittest.TestCase):
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_timerexpiration.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_timerexpiration.py
@@ -91,7 +91,10 @@ class TestAttachEsmInformationTimerExpiration(unittest.TestCase):
                 sec_mode_complete.ue_Id,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
+            assert (
+                response.msg_type
+                == s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
+            )
             esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
 
         # Sending Esm Information Response

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_timerexpiration.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_timerexpiration.py
@@ -57,10 +57,7 @@ class TestAttachEsmInformationTimerExpiration(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ")
 
         auth_res = s1ap_types.ueAuthResp_t()
@@ -75,10 +72,7 @@ class TestAttachEsmInformationTimerExpiration(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
         time.sleep(1)
@@ -97,10 +91,7 @@ class TestAttachEsmInformationTimerExpiration(unittest.TestCase):
                 sec_mode_complete.ue_Id,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
             esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
 
         # Sending Esm Information Response
@@ -156,10 +147,7 @@ class TestAttachEsmInformationTimerExpiration(unittest.TestCase):
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_wrong_apn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information_wrong_apn.py
@@ -51,9 +51,7 @@ class TestAttachEsmInformationWrongApn(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ")
 
         auth_res = s1ap_types.ueAuthResp_t()
@@ -67,9 +65,7 @@ class TestAttachEsmInformationWrongApn(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
         time.sleep(1)
@@ -85,9 +81,7 @@ class TestAttachEsmInformationWrongApn(unittest.TestCase):
             "Received Esm Information Request ue-id", sec_mode_complete.ue_Id,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
         esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
         # Sending Esm Information Response
         print(
@@ -107,9 +101,7 @@ class TestAttachEsmInformationWrongApn(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
 
         print("*** Running UE detach ***")
         # Now detach the UE
@@ -123,9 +115,7 @@ class TestAttachEsmInformationWrongApn(unittest.TestCase):
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_drop_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_drop_with_mme_restart.py
@@ -62,9 +62,7 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("******************** Received Authentiction Request Indication")
 
         # Send Authentication Response
@@ -78,9 +76,7 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("******************** Received Security Mode Command Indication")
 
         print(
@@ -107,9 +103,7 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
         # enbApp sends UE_ICS_DROPD_IND message to tfwApp after dropping
         # ICS request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value
         print(
             "******************** Received Initial Context Setup Dropped "
             "Indication",
@@ -160,10 +154,7 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
                     " with detach type ",
                     nw_init_detach_req.Type,
                 )
-                self.assertEqual(
-                    nw_init_detach_req.Type,
-                    s1ap_types.ueNwInitDetType_t.TFW_RE_ATTACH_REQUIRED.value,
-                )
+                assert nw_init_detach_req.Type == s1ap_types.ueNwInitDetType_t.TFW_RE_ATTACH_REQUIRED.value
 
                 if resp_count == 1:
                     # Send detach accept
@@ -186,9 +177,7 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
             else:
                 break
 
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("******************** Received UE Context Release indication")
 
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_failure_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_failure_with_mme_restart.py
@@ -62,9 +62,7 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("******************** Received Authentiction Request Indication")
 
         # Send Authentication Response
@@ -79,9 +77,7 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("******************** Received Security Mode Command Indication")
 
         print(
@@ -105,9 +101,7 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
         print("******************** Received Initial Context Setup Indication")
 
         print("******************** Restarting MME service on gateway")
@@ -131,9 +125,7 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
 
         # Waiting for UE Context Release indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("******************** Received UE Context Release indication")
 
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_implicit_detach_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_implicit_detach_timer_expiry.py
@@ -78,9 +78,7 @@ class TestAttachImplicitDetachTimerExpiry(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # For implicit detach timer to expire, first ensure that
         # mobile reachability timer is expired or not and then
@@ -110,13 +108,9 @@ class TestAttachImplicitDetachTimerExpiry(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         time.sleep(0.5)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_inactive_tau_with_combined_tala_update_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_inactive_tau_with_combined_tala_update_reattach.py
@@ -75,9 +75,7 @@ class TestAttachInactiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print(
             "************************* Received UE context release indication",
         )
@@ -97,18 +95,14 @@ class TestAttachInactiveTauWithCombinedTalaUpdateReattach(unittest.TestCase):
 
         # Waiting for TAU Accept Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value
         print(
             "************************* Received Tracking Area Update Accept "
             "Indication",
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print(
             "************************* Received UE context release indication",
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ipv4v6_pdn_type.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ipv4v6_pdn_type.py
@@ -36,16 +36,10 @@ class TestAttachIpv4v6PdnType(unittest.TestCase):
         resp_ipv4_ipv6 = self._create_attach_ipv4v6_pdn_type_req(
             pdn_type_value=3,
         )
-        self.assertEqual(
-            resp_ipv4_ipv6.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert resp_ipv4_ipv6.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         # IPv6 is equal to 2
         resp_ipv6 = self._create_attach_ipv4v6_pdn_type_req(pdn_type_value=2)
-        self.assertEqual(
-            resp_ipv6.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert resp_ipv6.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
     def _create_attach_ipv4v6_pdn_type_req(self, pdn_type_value):
         # Ground work.
@@ -77,10 +71,7 @@ class TestAttachIpv4v6PdnType(unittest.TestCase):
             attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
 
         # Trigger Authentication Response
         auth_res = s1ap_types.ueAuthResp_t()
@@ -93,10 +84,7 @@ class TestAttachIpv4v6PdnType(unittest.TestCase):
             auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
@@ -108,10 +96,7 @@ class TestAttachIpv4v6PdnType(unittest.TestCase):
         # Attach Reject will be sent since IPv6 PDN Type is not configured
         if pdn_type_value == 2:
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
             return self._s1ap_wrapper.s1_util.get_response()
 
         # Receive initial context setup and attach accept indication

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_missing_imsi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_missing_imsi.py
@@ -44,9 +44,7 @@ class TestAttachMissingImsi(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         ue_id = 2
         print("************************* Adding IMSI entry for UE id ", ue_id)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_mobile_reachability_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_mobile_reachability_timer_expiry.py
@@ -77,9 +77,7 @@ class TestAttachMobileReachabilityTimerExpiry(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # Delay by 6 minutes to ensure Mobile reachability timer expires.
         # MOBILE REACHABILITY TIMER VALUE = 1 minute (conf file) + delta value
@@ -107,9 +105,7 @@ class TestAttachMobileReachabilityTimerExpiry(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_no_initial_context_resp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_no_initial_context_resp.py
@@ -49,10 +49,7 @@ class TestAttachNoInitialContextResp(unittest.TestCase):
             attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
         sqnrecvd = s1ap_types.ueSqnRcvd_t()
@@ -64,10 +61,7 @@ class TestAttachNoInitialContextResp(unittest.TestCase):
         )
         response = self._s1ap_wrapper.s1_util.get_response()
 
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_fail.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_fail.py
@@ -82,10 +82,7 @@ class TestAttachNwInitiatedDetachFail(unittest.TestCase):
         # Wait for timer 3422 expiry 5 times
         for _ in range(5):
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value
             print("**************** Received NW initiated Detach Req")
 
         time.sleep(6)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_nw_initiated_detach_with_mme_restart.py
@@ -75,10 +75,7 @@ class TestAttachNwInitiatedDetachWithMmeRestart(unittest.TestCase):
         )
         # Receive NW initiated detach request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value
         print("**************** Received NW initiated Detach Req")
         print(
             "************************* Restarting MME service on",
@@ -91,10 +88,7 @@ class TestAttachNwInitiatedDetachWithMmeRestart(unittest.TestCase):
 
         # Receive NW initiated detach request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value
         print("**************** Received second NW initiated Detach Req")
 
         print("**************** Sending Detach Accept")

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_restricted_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_restricted_plmn.py
@@ -79,9 +79,7 @@ class TestAttachRestrictedPlmn(unittest.TestCase):
 
         # Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
 
         attach_rej = response.cast(s1ap_types.ueAttachRejInd_t)
         print(
@@ -90,13 +88,11 @@ class TestAttachRestrictedPlmn(unittest.TestCase):
         )
 
         # Verify cause
-        self.assertEqual(attach_rej.cause, s1ap_types.TFW_EMM_CAUSE_PLMN_NA)
+        assert attach_rej.cause == s1ap_types.TFW_EMM_CAUSE_PLMN_NA
 
         # Context release
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print(
             "************************* Received ue context release cmd for "
             "UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_restricted_plmn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_restricted_plmn.py
@@ -79,7 +79,9 @@ class TestAttachRestrictedPlmn(unittest.TestCase):
 
         # Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+        assert (
+            response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
+        )
 
         attach_rej = response.cast(s1ap_types.ueAttachRejInd_t)
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_security_mode_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_security_mode_reject.py
@@ -50,9 +50,7 @@ class TestAttachSecurityModeReject(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ")
 
         auth_res = s1ap_types.ueAuthResp_t()
@@ -66,9 +64,7 @@ class TestAttachSecurityModeReject(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
         sec_mode_reject = s1ap_types.ueSecModeReject_t()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service.py
@@ -64,9 +64,7 @@ class TestAttachService(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print(
             "************************* Sending Service request for UE id ",
@@ -82,9 +80,7 @@ class TestAttachService(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         print(
             "************************* Running UE detach for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_multi_ue.py
@@ -68,9 +68,7 @@ class TestAttachServiceMultiUe(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         for req in reqs:
             ue_id = req.ue_id
@@ -88,9 +86,7 @@ class TestAttachServiceMultiUe(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         for req in reqs:
             print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_ue_radio_capability.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_ue_radio_capability.py
@@ -65,9 +65,7 @@ class TestAttachServiceUeRadioCapability(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print(
             "************************* Sending Service request for UE id ",
@@ -83,9 +81,7 @@ class TestAttachServiceUeRadioCapability(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         print(
             "************************* Running UE detach for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers.py
@@ -201,9 +201,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_oai_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -218,9 +216,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
         sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -247,9 +243,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -288,9 +282,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print("Sleeping for 5 seconds")
         time.sleep(5)
@@ -313,9 +305,7 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         print("Sleeping for 5 seconds")
         time.sleep(5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_failure.py
@@ -200,9 +200,7 @@ class TestAttachServiceWithMultiPdnsAndBearersFailure(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_oai_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -217,9 +215,7 @@ class TestAttachServiceWithMultiPdnsAndBearersFailure(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
         sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -244,9 +240,7 @@ class TestAttachServiceWithMultiPdnsAndBearersFailure(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -287,9 +281,7 @@ class TestAttachServiceWithMultiPdnsAndBearersFailure(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # Send the bearers to be included in failed to setup list in ICS Rsp
         init_ctxt_setup_failed_erabs = s1ap_types.UeInitCtxtSetupFailedErabs()
@@ -326,9 +318,7 @@ class TestAttachServiceWithMultiPdnsAndBearersFailure(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         print("Sleeping for 5 seconds")
         time.sleep(5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_looped.py
@@ -203,9 +203,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_oai_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -220,9 +218,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
         sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -249,9 +245,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -295,9 +289,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
             # Verify if paging flow rules are created
             ip_list = [default_ip, sec_ip]
@@ -317,9 +309,7 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
             print("Sleeping for 5 seconds")
             time.sleep(5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py
@@ -207,9 +207,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_oai_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -224,9 +222,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
         sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -254,9 +250,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -298,9 +292,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # Verify if paging flow rules are created
         ip_list = [default_ip, sec_ip]
@@ -335,9 +327,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
                 )
                 response = self._s1ap_wrapper.s1_util.get_response()
 
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
             test.verify()
 
         print("Sleeping for 5 seconds")
@@ -359,9 +349,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
 
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
         print(
             "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py
@@ -314,7 +314,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
             req, duration=1, is_udp=True,
         ) as test:
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertTrue(response, s1ap_types.tfwCmd.UE_PAGING_IND.value)
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
             # Send service request to reconnect UE
             print(
                 "************************* Sending Service request for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_multi_ue.py
@@ -207,9 +207,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_req_oai_apn = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -231,9 +229,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
             sec_ips.append(ipaddress.ip_address(bytes(addr[:4])))
@@ -264,9 +260,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_req_ims_apn = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -318,9 +312,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
             # Verify if paging flow rules are created
             ip_list = [default_ips[i], sec_ips[i]]
             self._s1ap_wrapper.s1_util.verify_paging_flow_rules(ip_list)
@@ -346,9 +338,7 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         # Delay of 10 seconds to make sure flows are added
         print("Sleeping for 10 seconds")

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_without_mac.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_without_mac.py
@@ -66,9 +66,7 @@ class TestAttachServiceWithoutMac(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print(
             "************************* Sending Service request for UE id ",
@@ -85,9 +83,7 @@ class TestAttachServiceWithoutMac(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
         print(
             "************************* Received Service Reject for UE id ",
             ue_id,

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej.py
@@ -96,9 +96,7 @@ class TestAttachStandaloneActDfltBerCtxtRej(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(req.ue_id, apn, pdn_type=3)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej_ded_bearer_activation.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_standalone_act_dflt_ber_ctxt_rej_ded_bearer_activation.py
@@ -203,9 +203,7 @@ class TestAttachStandaloneActDfltBerCtxtRejDedBearerActivation(
         self._s1ap_wrapper.sendPdnConnectivityReq(req.ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ue_ctxt_release_cmp_delay.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ue_ctxt_release_cmp_delay.py
@@ -54,10 +54,7 @@ class TestAttachUeCtxtReleaseCmpDelay(unittest.TestCase):
             attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
 
         # Trigger Authentication Response
         auth_res = s1ap_types.ueAuthResp_t()
@@ -70,10 +67,7 @@ class TestAttachUeCtxtReleaseCmpDelay(unittest.TestCase):
             auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
@@ -114,10 +108,7 @@ class TestAttachUeCtxtReleaseCmpDelay(unittest.TestCase):
         )
         time.sleep(0.5)
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_EMM_INFORMATION.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_EMM_INFORMATION.value
 
         time.sleep(0.5)
         # Now detach the UE
@@ -129,10 +120,7 @@ class TestAttachUeCtxtReleaseCmpDelay(unittest.TestCase):
             detach_req,
         )
         response = self._s1ap_wrapper._s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_DETACH_ACCEPT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DETACH_ACCEPT_IND.value
 
         print(
             "*** Sending UE context release request ",
@@ -152,10 +140,7 @@ class TestAttachUeCtxtReleaseCmpDelay(unittest.TestCase):
             uectxtrel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         time.sleep(10)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_with_multiple_mme_restarts.py
@@ -51,10 +51,7 @@ class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("************************* Received UE_AUTH_REQ_IND")
 
         # Try consecutive mme restarts
@@ -76,10 +73,7 @@ class TestAttachWithMultipleMmeRestarts(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("************************* Received UE_SEC_MOD_CMD_IND")
 
         self._s1ap_wrapper.magmad_util.restart_services(['mme'])

--- a/lte/gateway/python/integ_tests/s1aptests/test_concurrent_secondary_pdn_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_concurrent_secondary_pdn_reject.py
@@ -85,15 +85,10 @@ class TestConcurrentSecondaryPdnReject(unittest.TestCase):
 
         # Receive PDN connectivity reject for internet APN
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         # Verify cause
         pdn_con_rsp = response.cast(s1ap_types.uePdnConRsp_t)
-        self.assertEqual(
-            pdn_con_rsp.m.conRejInfo.cause,
-            s1ap_types.TFW_ESM_CAUSE_MISSING_OR_UNKNOWN_APN,
-        )
+        assert pdn_con_rsp.m.conRejInfo.cause == s1ap_types.TFW_ESM_CAUSE_MISSING_OR_UNKNOWN_APN
 
         print(
             "************************* Received PDN Connectivity "
@@ -104,9 +99,7 @@ class TestConcurrentSecondaryPdnReject(unittest.TestCase):
         # Receive PDN CONN RSP/Activate default EPS bearer context
         # request for ims APN
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         print(
             "************************* Received Activate default EPS bearer "
@@ -151,9 +144,7 @@ class TestConcurrentSecondaryPdnReject(unittest.TestCase):
 
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
         deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
         print(
             "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_concurrent_secondary_pdns.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_concurrent_secondary_pdns.py
@@ -91,9 +91,7 @@ class TestConcurrentSecondaryPdns(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req1 = response.cast(s1ap_types.uePdnConRsp_t)
         print(
             "************************* Received Activate default EPS bearer "
@@ -114,9 +112,7 @@ class TestConcurrentSecondaryPdns(unittest.TestCase):
 
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req2 = response.cast(s1ap_types.uePdnConRsp_t)
         addr2 = act_def_bearer_req2.m.pdnInfo.pAddr.addrInfo
         sec_ip2 = ipaddress.ip_address(bytes(addr2[:4]))
@@ -162,9 +158,7 @@ class TestConcurrentSecondaryPdns(unittest.TestCase):
 
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
         deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
         print(
             "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py
@@ -103,7 +103,9 @@ class TestDataFlowAfterServiceRequest(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            assert (
+                response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            )
 
         with test:
             test.verify()

--- a/lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py
@@ -85,9 +85,7 @@ class TestDataFlowAfterServiceRequest(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         for req in reqs:
             ue_id = req.ue_id
@@ -105,9 +103,7 @@ class TestDataFlowAfterServiceRequest(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         with test:
             test.verify()

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode.py
@@ -181,9 +181,7 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # Verify if paging flow rules are created
         ip_list = [default_ip]
@@ -222,9 +220,7 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
 
         print("*********** Received Paging for UE id ", ue_id)
         print("*********** Sending Service request for UE id ", ue_id)
@@ -238,15 +234,11 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         print("*********** Received ICS Request for UE id ", ue_id)
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_oai_apn1 = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -259,9 +251,7 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
             ue_id, act_ded_ber_req_oai_apn1.bearerId,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_oai_apn2 = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_multi_ue.py
@@ -193,9 +193,7 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
             # Verify if paging flow rules are created
             ip_list = [default_ips[i]]
             self._s1ap_wrapper.s1_util.verify_paging_flow_rules(ip_list)
@@ -243,9 +241,7 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
             ue_id = req.ue_id
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
             print("*********** Received Paging for UE id ", ue_id)
 
         self._s1ap_wrapper._ue_idx = 0
@@ -263,15 +259,11 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
             print("*********** Received ICS Request for UE id ", ue_id)
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_req_oai_apn1 = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -284,9 +276,7 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
                 ue_id, act_ded_ber_req_oai_apn1.bearerId,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_req_oai_apn2 = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py
@@ -163,9 +163,7 @@ class TestDedicatedBearerActivationIdleModePagingTimerExpiry(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # Verify if paging flow rules are created
         ip_list = [default_ip]
@@ -189,16 +187,12 @@ class TestDedicatedBearerActivationIdleModePagingTimerExpiry(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
 
         print("*********** Received Paging for UE id ", ue_id)
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PAGING_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
 
         print("*********** Received second Paging for UE id ", ue_id)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_different_enb_s1ap_id_same_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_different_enb_s1ap_id_same_ue.py
@@ -50,10 +50,7 @@ class TestDifferentEnbS1apIdSameUe(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ")
 
         auth_res = s1ap_types.ueAuthResp_t()
@@ -68,10 +65,7 @@ class TestDifferentEnbS1apIdSameUe(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
         attach_req = s1ap_types.ueAttachRequest_t()
@@ -133,10 +127,7 @@ class TestDifferentEnbS1apIdSameUe(unittest.TestCase):
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_duplicate_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_duplicate_attach.py
@@ -54,10 +54,7 @@ class TestDuplicateAttach(unittest.TestCase):
             auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
@@ -90,10 +87,7 @@ class TestDuplicateAttach(unittest.TestCase):
                 )
                 continue
 
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
             print(
                 "************************ Received UE context release indication",
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_complete_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_complete_reset.py
@@ -77,7 +77,7 @@ class TestEnbCompleteReset(unittest.TestCase):
             reset_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
+        assert response.msg_type == s1ap_types.tfwCmd.RESET_ACK.value
 
         # Sleep for 3 seconds to ensure that MME has cleaned up all S1 state
         # before proceeding

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset.py
@@ -82,7 +82,7 @@ class TestEnbPartialReset(unittest.TestCase):
             s1ap_types.tfwCmd.RESET_REQ, reset_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
+        assert response.msg_type == s1ap_types.tfwCmd.RESET_ACK.value
 
         # Sleep for 3 seconds to ensure that MME has cleaned up all S1 state
         # before proceeding

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
@@ -70,10 +70,7 @@ class TestEnbPartialResetConDereg(unittest.TestCase):
                 attach_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
 
             # Trigger Authentication Response
             auth_res = s1ap_types.ueAuthResp_t()
@@ -86,10 +83,7 @@ class TestEnbPartialResetConDereg(unittest.TestCase):
                 auth_res,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
             # Trigger Security Mode Complete
             sec_mode_complete = s1ap_types.ueSecModeComplete_t()
@@ -143,7 +137,7 @@ class TestEnbPartialResetConDereg(unittest.TestCase):
             reset_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
+        assert response.msg_type == s1ap_types.tfwCmd.RESET_ACK.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue.py
@@ -97,7 +97,7 @@ class TestEnbPartialResetMultiUe(unittest.TestCase):
             s1ap_types.tfwCmd.RESET_REQ, reset_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
+        assert response.msg_type == s1ap_types.tfwCmd.RESET_ACK.value
 
         # Sleep for 3 seconds to ensure that MME has cleaned up all S1 state
         # before proceeding

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
@@ -109,7 +109,7 @@ class TestEnbPartialResetMultiUeWithMmeRestart(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
+        assert response.msg_type == s1ap_types.tfwCmd.RESET_ACK.value
 
         # Send service request for all the Reset UE Ids
         for indx in range(reset_req.r.partialRst.numOfConn):
@@ -126,9 +126,7 @@ class TestEnbPartialResetMultiUeWithMmeRestart(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         # Trigger detach request
         for ue in ue_ids:

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_multi_ue_with_mme_restart.py
@@ -126,7 +126,9 @@ class TestEnbPartialResetMultiUeWithMmeRestart(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            assert (
+                response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            )
 
         # Trigger detach request
         for ue in ue_ids:

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_with_unknown_ue_s1ap_ids.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_with_unknown_ue_s1ap_ids.py
@@ -103,7 +103,7 @@ class TestEnbPartialResetWithUnknownUeS1apIds(unittest.TestCase):
             reset_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
+        assert response.msg_type == s1ap_types.tfwCmd.RESET_ACK.value
 
         # Sleep for 3 seconds to ensure that MME has cleaned up all S1 state
         # before proceeding

--- a/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_ded_bearer_deact.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_ded_bearer_deact.py
@@ -104,10 +104,7 @@ class TestEpsBearerContextStatusDedBearerDeact(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn[i])
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
             print(
@@ -136,10 +133,7 @@ class TestEpsBearerContextStatusDedBearerDeact(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -162,10 +156,7 @@ class TestEpsBearerContextStatusDedBearerDeact(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -205,10 +196,7 @@ class TestEpsBearerContextStatusDedBearerDeact(unittest.TestCase):
             cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print(" Sleeping for 2 seconds")
         time.sleep(2)
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_def_bearer_deact.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_def_bearer_deact.py
@@ -100,10 +100,7 @@ class TestEpsBearerContextStatusDefBearerDeact(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn[i])
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
             print(
@@ -132,10 +129,7 @@ class TestEpsBearerContextStatusDefBearerDeact(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -175,10 +169,7 @@ class TestEpsBearerContextStatusDefBearerDeact(unittest.TestCase):
             cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print(
             "************************* Sending Tracking Area Update ",
             "request for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_multiple_ded_bearer_deact.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_eps_bearer_context_status_multiple_ded_bearer_deact.py
@@ -114,10 +114,7 @@ class TestEpsBearerContextStatusMultipleDedBearerDeact(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_ctxt_req = response.cast(s1ap_types.UeActDedBearCtxtReq_t)
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
             ue_id,
@@ -131,10 +128,7 @@ class TestEpsBearerContextStatusMultipleDedBearerDeact(unittest.TestCase):
             self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn[i])
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
             print(
@@ -163,10 +157,7 @@ class TestEpsBearerContextStatusMultipleDedBearerDeact(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -189,10 +180,7 @@ class TestEpsBearerContextStatusMultipleDedBearerDeact(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -232,10 +220,7 @@ class TestEpsBearerContextStatusMultipleDedBearerDeact(unittest.TestCase):
             cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print(" Sleeping for 2 seconds")
         time.sleep(2)
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_gateway_metrics_attach_detach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_gateway_metrics_attach_detach.py
@@ -43,7 +43,7 @@ class TestGatewayMetricsAttachDetach(unittest.TestCase):
             "mme_new_association",
             label_values_success,
         )
-        self.assertGreater(mme_new_association, 0)
+        assert mme_new_association > 0
 
         num_ues = 2
         detach_type = [

--- a/lte/gateway/python/integ_tests/s1aptests/test_gateway_metrics_attach_detach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_gateway_metrics_attach_detach.py
@@ -95,13 +95,13 @@ class TestGatewayMetricsAttachDetach(unittest.TestCase):
                 "ue_attach",
                 label_values_ue_attach_result,
             )
-            assert(val == v_ue_attach + 1)
+            assert (val == v_ue_attach + 1)
 
             val = self._getMetricValueGivenLabel(
                 "spgw_create_session",
                 label_values_success,
             )
-            assert(val == v_spgw_create_session + 1)
+            assert (val == v_spgw_create_session + 1)
 
             val = self._getMetricValueGivenLabel(
                 "ue_detach",

--- a/lte/gateway/python/integ_tests/s1aptests/test_guti_attach_with_zero_mtmsi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_guti_attach_with_zero_mtmsi.py
@@ -71,10 +71,7 @@ class TestGutiAttachWithZeroMtmsi(unittest.TestCase):
             ureq,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         time.sleep(5)
 
@@ -114,10 +111,7 @@ class TestGutiAttachWithZeroMtmsi(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
         id_req = response.cast(s1ap_types.ueIdentityReqInd_t)
         print(
             "********************** Received identity req for UE id",
@@ -137,10 +131,7 @@ class TestGutiAttachWithZeroMtmsi(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         auth_req = response.cast(s1ap_types.ueAuthReqInd_t)
         print(
             "********************** Received auth req for UE id",
@@ -161,10 +152,7 @@ class TestGutiAttachWithZeroMtmsi(unittest.TestCase):
         response = self._s1ap_wrapper.s1_util.get_response()
         sec_mode_cmd = response.cast(s1ap_types.ueSecModeCmdInd_t)
 
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print(
             "********************** Received security mode cmd for UE id",
             sec_mode_cmd.ue_Id,
@@ -221,10 +209,7 @@ class TestGutiAttachWithZeroMtmsi(unittest.TestCase):
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_ue_registered.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_ue_registered.py
@@ -67,9 +67,7 @@ class TestIcsTimerExpiryUeRegistered(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print("*** Sending indication to drop Initial Context Setup Req ***")
         drop_init_ctxt_setup_req = s1ap_types.UeDropInitCtxtSetup()
@@ -100,14 +98,10 @@ class TestIcsTimerExpiryUeRegistered(unittest.TestCase):
         # enbApp sends UE_ICS_DROPD_IND message to tfwApp after dropping
         # ICS request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print(
             "************************* Received UE_CTX_REL_IND for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_ue_unregistered.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_ue_unregistered.py
@@ -52,9 +52,7 @@ class TestIcsTimerExpiryUeUnregistered(unittest.TestCase):
             s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
 
         print("*** Sending indication to drop Initial Context Setup Req ***")
         drop_init_ctxt_setup_req = s1ap_types.UeDropInitCtxtSetup()
@@ -76,9 +74,7 @@ class TestIcsTimerExpiryUeUnregistered(unittest.TestCase):
             s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
@@ -90,14 +86,10 @@ class TestIcsTimerExpiryUeUnregistered(unittest.TestCase):
         # enbApp sends UE_ICS_DROPD_IND message to tfwApp after dropping
         # ICS request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print(
             "************************* Received UE_CTX_REL_IND for UE id ",
             req.ue_id,

--- a/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ics_timer_expiry_with_mme_restart.py
@@ -74,9 +74,7 @@ class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print("*** Sending indication to drop Initial Context Setup Req ***")
         drop_init_ctxt_setup_req = s1ap_types.UeDropInitCtxtSetup()
@@ -105,9 +103,7 @@ class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
         # enbApp sends UE_ICS_DROPD_IND message to tfwApp after dropping
         # ICS request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ICS_DROPD_IND.value
         print("************************* Restarting MME service on gateway")
         wait_for_restart = 30
         self._s1ap_wrapper.magmad_util.restart_services(
@@ -116,9 +112,7 @@ class TestIcsTimerExpiryWithMmeRestart(unittest.TestCase):
 
         print("************************* Waiting for response from MME")
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print(
             "************************* Received UE_CTX_REL_IND for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_identity_timer_3470_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_identity_timer_3470_expiry.py
@@ -55,9 +55,7 @@ class TestIdentityTimer3470Expiry(unittest.TestCase):
                 ") ***",
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
             print(
                 "*** Identity Request Message Received (",
                 str(i + 1),
@@ -65,9 +63,7 @@ class TestIdentityTimer3470Expiry(unittest.TestCase):
             )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("*** Received UE Context Release Indication ***")
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_idle_mode_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_idle_mode_with_mme_restart.py
@@ -75,9 +75,7 @@ class TestIdleModeWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print("************************* Restarting MME service on gateway")
         wait_for_restart = 30
@@ -99,9 +97,7 @@ class TestIdleModeWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         print("************************* Running UE detach for UE id ", ue_id)
         # Now detach the UE

--- a/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_no_imeisv_in_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_no_imeisv_in_smc.py
@@ -84,10 +84,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         auth_req = response.cast(s1ap_types.ueAuthReqInd_t)
         print(
             "********************** Received auth req for UE id",
@@ -107,10 +104,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         print("********************** Sent auth rsp for UE id", ue_ids[0])
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         sec_mod_cmd = response.cast(s1ap_types.ueSecModeCmdInd_t)
         print(
             "********************** Received security mode cmd for UE id",
@@ -132,10 +126,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
         id_req = response.cast(s1ap_types.ueIdentityReqInd_t)
         print(
             "********************** Received identity req for UE id",
@@ -150,7 +141,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         identity_resp.idValPres = True
         imeisv = "9900048235103723"
         # Check if the len of imeisv exceeds 16
-        self.assertLessEqual(len(imeisv), 16)
+        assert len(imeisv) <= 16
         len_imeisv = len(imeisv)
         for i in range(0, len_imeisv):
             identity_resp.idVal[i] = ctypes.c_ubyte(int(imeisv[i]))
@@ -162,10 +153,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
 
         # Receive Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
         attach_rej = response.cast(s1ap_types.ueAttachRejInd_t)
         print(
             "********************** Received attach reject for UE id %d"
@@ -173,17 +161,11 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         )
 
         # Verify cause
-        self.assertEqual(
-            attach_rej.cause,
-            s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED,
-        )
+        assert attach_rej.cause == s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED
 
         # UE Context release
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         ue_context_rel = response.cast(s1ap_types.ueCntxtRelReq_t)
         print(
             "********************** Received UE_CTX_REL_IND for UE id ",
@@ -214,10 +196,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         auth_req = response.cast(s1ap_types.ueAuthReqInd_t)
         print(
             "********************** Received auth req for UE id",
@@ -236,10 +215,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         print("********************** Sent auth rsp for UE id", ue_ids[1])
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         sec_mod_cmd = response.cast(s1ap_types.ueSecModeCmdInd_t)
         print(
             "********************** Received security mode cmd for UE id",
@@ -261,10 +237,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
         id_req = response.cast(s1ap_types.ueIdentityReqInd_t)
         print(
             "********************** Received identity req for UE id",
@@ -303,10 +276,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
             ue_ids[1],
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_EMM_INFORMATION.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_EMM_INFORMATION.value
 
         print("********************** Sleeping for 0.5 seconds ")
         time.sleep(0.5)
@@ -323,10 +293,7 @@ class TestImeiRestrictionNoImeisvInSmc(unittest.TestCase):
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         ue_context_rel = response.cast(s1ap_types.ueCntxtRelReq_t)
         print(
             "********************** Received UE_CTX_REL_IND for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_smc.py
@@ -74,9 +74,7 @@ class TestImeiRestrictionSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         auth_req = response.cast(s1ap_types.ueAuthReqInd_t)
         print(
             "********************** Received auth req for UE id",
@@ -95,9 +93,7 @@ class TestImeiRestrictionSmc(unittest.TestCase):
         print("********************** Sent auth rsp for UE id", ue_ids[0])
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         sec_mod_cmd = response.cast(s1ap_types.ueSecModeCmdInd_t)
         print(
             "********************** Received security mode cmd for UE id",
@@ -110,7 +106,7 @@ class TestImeiRestrictionSmc(unittest.TestCase):
         sec_mode_complete.imeisv_pres = True
         imeisv = "9900048235103723"
         # Check if the len of imeisv exceeds 16
-        self.assertLessEqual(len(imeisv), 16)
+        assert len(imeisv) <= 16
         for i in range(0, len(imeisv)):
             sec_mode_complete.imeisv[i] = ctypes.c_ubyte(int(imeisv[i]))
         self._s1ap_wrapper._s1_util.issue_cmd(
@@ -123,9 +119,7 @@ class TestImeiRestrictionSmc(unittest.TestCase):
 
         # Receive Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
         attach_rej = response.cast(s1ap_types.ueAttachRejInd_t)
         print(
             "********************** Received attach reject for UE id %d"
@@ -133,15 +127,11 @@ class TestImeiRestrictionSmc(unittest.TestCase):
         )
 
         # Verify cause
-        self.assertEqual(
-            attach_rej.cause, s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED,
-        )
+        assert attach_rej.cause == s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED
 
         # UE Context release
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         ue_context_rel = response.cast(s1ap_types.ueCntxtRelReq_t)
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_wildcard_snr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_imei_restriction_wildcard_snr.py
@@ -68,9 +68,7 @@ class TestImeiRestrictionWildcardSnr(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         auth_req = response.cast(s1ap_types.ueAuthReqInd_t)
         print(
             "********************** Received auth req for UE id",
@@ -89,9 +87,7 @@ class TestImeiRestrictionWildcardSnr(unittest.TestCase):
         print("********************** Sent auth rsp for UE id", req.ue_id)
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         sec_mod_cmd = response.cast(s1ap_types.ueSecModeCmdInd_t)
         print(
             "********************** Received security mode cmd for UE id",
@@ -104,7 +100,7 @@ class TestImeiRestrictionWildcardSnr(unittest.TestCase):
         sec_mode_complete.imeisv_pres = True
         imeisv = "9933382135103723"
         # Check if the len of imeisv exceeds 16
-        self.assertLessEqual(len(imeisv), 16)
+        assert len(imeisv) <= 16
         for i in range(0, len(imeisv)):
             sec_mode_complete.imeisv[i] = ctypes.c_ubyte(int(imeisv[i]))
         self._s1ap_wrapper._s1_util.issue_cmd(
@@ -117,9 +113,7 @@ class TestImeiRestrictionWildcardSnr(unittest.TestCase):
 
         # Receive Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
         attach_rej = response.cast(s1ap_types.ueAttachRejInd_t)
         print(
             "********************** Received attach reject for UE id %d"
@@ -127,15 +121,11 @@ class TestImeiRestrictionWildcardSnr(unittest.TestCase):
         )
 
         # Verify cause
-        self.assertEqual(
-            attach_rej.cause, s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED,
-        )
+        assert attach_rej.cause == s1ap_types.TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED
 
         # UE Context release
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         ue_context_rel = response.cast(s1ap_types.ueCntxtRelReq_t)
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
@@ -88,10 +88,7 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
             req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # Delay by 6 minutes to ensure Mobile reachability timer expires.
         # Mobile Reachability Timer value = 1 minute (conf file) + delta value
@@ -141,10 +138,7 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
             req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
         print(
             "************************* Received Service Reject for UE id ",
             ue_id,
@@ -152,10 +146,7 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
 
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
@@ -138,7 +138,9 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
             req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        assert response.msg_type == s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
+        assert (
+            response.msg_type == s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
+        )
         print(
             "************************* Received Service Reject for UE id ",
             ue_id,

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ded_bearer_dl_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ded_bearer_dl_tcp.py
@@ -93,9 +93,7 @@ class TestIpv4v6NonNatDedBearerDlTcp(unittest.TestCase):
         # Receive Router Advertisement message
         apn = "magma"
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "********** Received Router Advertisement for APN-%s"
@@ -136,9 +134,7 @@ class TestIpv4v6NonNatDedBearerDlTcp(unittest.TestCase):
             qos,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ded_bearer_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ded_bearer_ul_tcp.py
@@ -94,9 +94,7 @@ class TestIpv4v6NonNatDedBearerUlTcp(unittest.TestCase):
         # Receive Router Advertisement message
         apn = "magma"
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "********** Received Router Advertisement for APN-%s"
@@ -137,9 +135,7 @@ class TestIpv4v6NonNatDedBearerUlTcp(unittest.TestCase):
             qos,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ul_tcp.py
@@ -91,9 +91,7 @@ class TestIpv4v6NonNatUlTcp(unittest.TestCase):
         # Receive Router Advertisement message
         apn = "magma"
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "********** Received Router Advertisement for APN-%s"

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_paging_with_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_paging_with_dedicated_bearer.py
@@ -77,9 +77,7 @@ class TestIpv4v6PagingWithDedicatedBearer(unittest.TestCase):
         # Receive Router Advertisement message
         apn = "magma"
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "********** Received Router Advertisement for APN-%s"
@@ -120,9 +118,7 @@ class TestIpv4v6PagingWithDedicatedBearer(unittest.TestCase):
             qos,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req = response.cast(s1ap_types.UeActDedBearCtxtReq_t)
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
             req.ue_id, act_ded_ber_req.bearerId,
@@ -160,9 +156,7 @@ class TestIpv4v6PagingWithDedicatedBearer(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("********** UE moved to idle mode")
 
         print("********** Sleeping for 5 seconds")
@@ -190,9 +184,7 @@ class TestIpv4v6PagingWithDedicatedBearer(unittest.TestCase):
         )
         print("********** Sent UE_SERVICE_REQUEST")
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
         print("********** Received INT_CTX_SETUP_IND")
 
         print("********** Sleeping for 5 seconds")

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_paging_with_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_paging_with_dedicated_bearer.py
@@ -177,7 +177,7 @@ class TestIpv4v6PagingWithDedicatedBearer(unittest.TestCase):
         )
         self._s1ap_wrapper.s1_util.run_ipv6_data(default_ipv6)
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertTrue(response, s1ap_types.tfwCmd.UE_PAGING_IND.value)
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
         print("********** Received UE_PAGING_IND")
         # Send service request to reconnect UE
         ser_req = s1ap_types.ueserviceReq_t()

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn.py
@@ -94,9 +94,7 @@ class TestIPv4v6SecondaryPdn(unittest.TestCase):
             )
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
             pdnType = act_def_bearer_req.m.pdnInfo.pAddr.pdnType
@@ -122,9 +120,7 @@ class TestIPv4v6SecondaryPdn(unittest.TestCase):
 
             # Receive Router Advertisement message
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
             routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
             print(
                 "************* Received Router Advertisement for APN-%s"

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_multi_ue.py
@@ -89,9 +89,7 @@ class TestIPv4v6SecondaryPdnMultiUE(unittest.TestCase):
             )
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -109,9 +107,7 @@ class TestIPv4v6SecondaryPdnMultiUE(unittest.TestCase):
 
             # Receive Router Advertisement message
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
             routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
             print(
                 "******************* Received Router Advertisement for APN-%s"

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_rs_retransmit.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_rs_retransmit.py
@@ -89,9 +89,7 @@ class TestIPv4v6SecondaryPdnRSRetransmit(unittest.TestCase):
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_spgw_initiated_ded_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_spgw_initiated_ded_bearer.py
@@ -85,9 +85,7 @@ class TestIPv4v6SecondaryPdnSpgwInitiatedDedBearer(unittest.TestCase):
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         pdn_type = act_def_bearer_req.m.pdnInfo.pAddr.pdnType
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -109,9 +107,7 @@ class TestIPv4v6SecondaryPdnSpgwInitiatedDedBearer(unittest.TestCase):
 
         # Receive Router Advertisement message
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "******************* Received Router Advertisement for APN-%s"
@@ -139,9 +135,7 @@ class TestIPv4v6SecondaryPdnSpgwInitiatedDedBearer(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_ctxt_req = response.cast(s1ap_types.UeActDedBearCtxtReq_t)
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
             req.ue_id, act_ded_ber_ctxt_req.bearerId,
@@ -184,9 +178,7 @@ class TestIPv4v6SecondaryPdnSpgwInitiatedDedBearer(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
         print("******************* Received deactivate eps bearer context")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer.py
@@ -153,9 +153,7 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
         pdnType = act_def_bearer_req.m.pdnInfo.pAddr.pdnType
@@ -182,9 +180,7 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
 
         # Receive Router Advertisement message
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "******************* Received Router Advertisement for APN-%s"
@@ -213,9 +209,7 @@ class TestIPv4v6SecondaryPdnWithDedBearer(unittest.TestCase):
             qos,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_with_ded_bearer_multi_ue.py
@@ -164,9 +164,7 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
             )
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
             act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
             addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
@@ -188,9 +186,7 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
 
             # Receive Router Advertisement message
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
             routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
             print(
                 "******************* Received Router Advertisement for APN-%s"
@@ -219,9 +215,7 @@ class TestIPv4v6SecondaryPdnWithDedBearerMultiUe(unittest.TestCase):
                 qos,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_req_ims_apn = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_ded_bearer_dl_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_ded_bearer_dl_tcp.py
@@ -92,9 +92,7 @@ class TestIpv6NonNatDedBearerDlTcp(unittest.TestCase):
         # Receive Router Advertisement message
         apn = "magma"
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "********** Received Router Advertisement for APN-%s"
@@ -135,9 +133,7 @@ class TestIpv6NonNatDedBearerDlTcp(unittest.TestCase):
             qos,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_ded_bearer_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_ded_bearer_ul_tcp.py
@@ -92,9 +92,7 @@ class TestIpv6NonNatDedBearerUlTcp(unittest.TestCase):
         # Receive Router Advertisement message
         apn = "magma"
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "********** Received Router Advertisement for APN-%s"
@@ -135,9 +133,7 @@ class TestIpv6NonNatDedBearerUlTcp(unittest.TestCase):
             qos,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_dl_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_dl_tcp.py
@@ -87,9 +87,7 @@ class TestIpv6NonNatDpDlTcp(unittest.TestCase):
         # Receive Router Advertisement message
         apn = "magma"
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "********** Received Router Advertisement for APN-%s"

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_dl_udp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_dl_udp.py
@@ -87,9 +87,7 @@ class TestIpv6NonNatDpDlUdp(unittest.TestCase):
         # Receive Router Advertisement message
         apn = "magma"
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "********** Received Router Advertisement for APN-%s"

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_ul_tcp.py
@@ -88,9 +88,7 @@ class TestIpv6NonNatDpUlTcp(unittest.TestCase):
         # Receive Router Advertisement message
         apn = "magma"
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "********** Received Router Advertisement for APN-%s"

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_paging_with_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_paging_with_dedicated_bearer.py
@@ -75,9 +75,7 @@ class TestIpv6PagingWithDedicatedBearer(unittest.TestCase):
         # Receive Router Advertisement message
         apn = "magma"
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         router_adv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "********** Received Router Advertisement for APN-%s"
@@ -118,9 +116,7 @@ class TestIpv6PagingWithDedicatedBearer(unittest.TestCase):
             qos,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req = response.cast(s1ap_types.UeActDedBearCtxtReq_t)
         self._s1ap_wrapper.sendActDedicatedBearerAccept(
             req.ue_id, act_ded_ber_req.bearerId,
@@ -157,9 +153,7 @@ class TestIpv6PagingWithDedicatedBearer(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("********** UE moved to idle mode")
 
         print("********** Sleeping for 5 seconds")
@@ -187,9 +181,7 @@ class TestIpv6PagingWithDedicatedBearer(unittest.TestCase):
         )
         print("********** Sent UE_SERVICE_REQUEST")
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
         print("********** Received INT_CTX_SETUP_IND")
 
         print("********** Sleeping for 5 seconds")

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_paging_with_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_paging_with_dedicated_bearer.py
@@ -174,7 +174,7 @@ class TestIpv6PagingWithDedicatedBearer(unittest.TestCase):
         )
         self._s1ap_wrapper.s1_util.run_ipv6_data(default_ipv6)
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertTrue(response, s1ap_types.tfwCmd.UE_PAGING_IND.value)
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
         print("********** Received UE_PAGING_IND")
         # Send service request to reconnect UE
         ser_req = s1ap_types.ueserviceReq_t()

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_rs_retransmit.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_rs_retransmit.py
@@ -93,9 +93,7 @@ class TestIPv6SecondaryPdnRSRetransmit(unittest.TestCase):
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
         print(
@@ -109,9 +107,7 @@ class TestIPv6SecondaryPdnRSRetransmit(unittest.TestCase):
         )
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
         print(
             "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_with_ded_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_with_ded_bearer.py
@@ -137,9 +137,7 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
 
         print(
@@ -158,9 +156,7 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
 
         # Receive Router Advertisement message
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
         routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
             "******************* Received Router Advertisement for APN-%s"
@@ -189,9 +185,7 @@ class TestIPv6SecondaryPdnWithDedBearer(unittest.TestCase):
             qos,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_tmr_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_tmr_with_mme_restart.py
@@ -87,10 +87,7 @@ class TestMobileReachabilityTmrWithMmeRestart(unittest.TestCase):
             req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print("************************* Restarting MME service on gateway")
         wait_for_restart = 30
@@ -132,10 +129,7 @@ class TestMobileReachabilityTmrWithMmeRestart(unittest.TestCase):
             req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
         print(
             "************************* Received Service Reject for UE id ",
             ue_id,
@@ -143,10 +137,7 @@ class TestMobileReachabilityTmrWithMmeRestart(unittest.TestCase):
 
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_complete_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_complete_reset.py
@@ -103,10 +103,7 @@ class TestMultiEnbCompleteReset(unittest.TestCase):
             reset_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.RESET_ACK.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.RESET_ACK.value
 
         print(
             "Waiting for 3 seconds to ensure that MME has cleaned up all S1 "

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_paging_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_paging_request.py
@@ -107,28 +107,28 @@ class TestMultiEnbPagingRequest(unittest.TestCase):
                 req, duration=1, is_udp=True,
             ) as test:
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertTrue(
-                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value,
+                assert (
+                    response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertTrue(
-                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value,
+                assert (
+                    response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertTrue(
-                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value,
+                assert (
+                    response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertTrue(
-                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value,
+                assert (
+                    response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
                 )
 
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertTrue(
-                    response, s1ap_types.tfwCmd.UE_PAGING_IND.value,
+                assert (
+                    response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
                 )
                 # Send service request to reconnect UE
                 ser_req = s1ap_types.ueserviceReq_t()

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_paging_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_paging_request.py
@@ -95,9 +95,7 @@ class TestMultiEnbPagingRequest(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
             time.sleep(0.5)
             print(
                 "********************* Running UE downlink (UDP) for UE id ",
@@ -140,10 +138,7 @@ class TestMultiEnbPagingRequest(unittest.TestCase):
                     s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
                 )
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEqual(
-                    response.msg_type,
-                    s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-                )
+                assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
                 test.verify()
         time.sleep(0.5)
         # Now detach the UE

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
@@ -114,7 +114,7 @@ class TestMultiEnbPartialReset(unittest.TestCase):
             reset_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(response.msg_type, s1ap_types.tfwCmd.RESET_ACK.value)
+        assert response.msg_type == s1ap_types.tfwCmd.RESET_ACK.value
 
         print(
             "Waiting for 3 seconds to ensure that MME has cleaned up all S1 "

--- a/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_auth.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_auth.py
@@ -67,9 +67,7 @@ class TestNasNonDeliveryForAuth(unittest.TestCase):
 
         """ Waiting for UE Context Release from MME """
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("Received UE_CTX_REL_IND")
         # Reset the nas non delivery flag
         nas_non_del = s1ap_types.UeNasNonDel()

--- a/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_identity_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_identity_req.py
@@ -67,9 +67,7 @@ class TestNasNonDeliveryForIdentityReq(unittest.TestCase):
 
         """ Waiting for UE Context Release command from MME """
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("Received UE_CTX_REL_IND")
         # Reset the nas non delivery flag
         nas_non_del = s1ap_types.UeNasNonDel()

--- a/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_nas_non_delivery_for_smc.py
@@ -50,9 +50,7 @@ class TestNasNonDeliveryForSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ue-Id", req.ue_id)
 
         """ The purpose of UE_SET_NAS_NON_DELIVERY command is to prepare
@@ -86,9 +84,7 @@ class TestNasNonDeliveryForSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("Received UE_CTX_REL_IND")
 
         # Reset the nas non delivery flag

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete.py
@@ -108,10 +108,7 @@ class TestNoAttachComplete(unittest.TestCase):
             attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
         sqn_recvd = s1ap_types.ueSqnRcvd_t()
@@ -124,10 +121,7 @@ class TestNoAttachComplete(unittest.TestCase):
         )
         response = self._s1ap_wrapper.s1_util.get_response()
 
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
@@ -151,18 +145,12 @@ class TestNoAttachComplete(unittest.TestCase):
         # then aborts attach procedure
         for i in range(4):
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
             print("************************* Timeout", i + 1)
 
         print("***************** Attach Aborted and UE Context released")
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_attach_complete_with_mme_restart.py
@@ -67,10 +67,7 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
             attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
         sqn_recvd = s1ap_types.ueSqnRcvd_t()
@@ -83,10 +80,7 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
         )
         response = self._s1ap_wrapper.s1_util.get_response()
 
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
@@ -125,20 +119,14 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
             )
             response = self._s1ap_wrapper.s1_util.get_response()
 
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_NW_INIT_DETACH_REQUEST.value
         nw_init_detach_req = response.cast(s1ap_types.ueNwInitdetachReq_t)
         print(
             "**************** Received NW initiated Detach Req with detach "
             "type set to ",
             nw_init_detach_req.Type,
         )
-        self.assertEqual(
-            nw_init_detach_req.Type,
-            s1ap_types.ueNwInitDetType_t.TFW_RE_ATTACH_REQUIRED.value,
-        )
+        assert nw_init_detach_req.Type == s1ap_types.ueNwInitDetType_t.TFW_RE_ATTACH_REQUIRED.value
 
         print("**************** Sending Detach Accept")
         # Send detach accept
@@ -167,16 +155,10 @@ class TestNoAttachCompleteWithMmeRestart(unittest.TestCase):
                 nw_init_detach_req.Type,
                 "Ignoring...",
             )
-            self.assertEqual(
-                nw_init_detach_req.Type,
-                s1ap_types.ueNwInitDetType_t.TFW_RE_ATTACH_REQUIRED.value,
-            )
+            assert nw_init_detach_req.Type == s1ap_types.ueNwInitDetType_t.TFW_RE_ATTACH_REQUIRED.value
             response = self._s1ap_wrapper.s1_util.get_response()
 
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("****** Received Ue context release command *********")
 
         print("****** Triggering end-end attach after mme restart *********")

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_resp_with_mme_restart_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_resp_with_mme_restart_reattach.py
@@ -58,10 +58,7 @@ class TestNoAuthRespWithMmeRestartReattach(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("************************* Received Auth Req for ue", req.ue_id)
 
         print("************************* Restarting MME service on gateway")
@@ -84,10 +81,7 @@ class TestNoAuthRespWithMmeRestartReattach(unittest.TestCase):
             )
             response = self._s1ap_wrapper.s1_util.get_response()
 
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print(
             "************************* Received UE_CTX_REL_IND for ue",
             req.ue_id,

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response.py
@@ -93,23 +93,17 @@ class TestNoAuthResponse(unittest.TestCase):
         # Wait for timer 3460 expiry 5 times, until context is released
         for i in range(5):
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
             print("************************* Timeout", i + 1)
 
         print("************************* Timeouts complete")
         # Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
 
         # Context release
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("************************* Context released")
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_response_with_mme_restart.py
@@ -56,25 +56,19 @@ class TestNoAuthResponseWithMmeRestart(unittest.TestCase):
         # Wait for timer expiry 5 times, until context is released
         for i in range(5):
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
             print("************************* Timeout", i + 1)
             print("********* Received Auth Req for ue", req.ue_id)
 
         print("************************* Timeouts complete")
         # Attach Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ATTACH_REJECT_IND.value
         print("********* Received Attach Reject for ue", req.ue_id)
 
         # Context release
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("********* Received UE_CTX_REL_IND for ue", req.ue_id)
 
         print("************************* Restarting MME service on", "gateway")
@@ -94,9 +88,7 @@ class TestNoAuthResponseWithMmeRestart(unittest.TestCase):
 
         time.sleep(0.5)
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_EMM_INFORMATION.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_EMM_INFORMATION.value
 
         print(
             "******************* Running UE detach (switch-off) for ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
@@ -57,9 +57,7 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
 
         global response
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received Auth Req for ue-id", ue_id)
 
         auth_res = s1ap_types.ueAuthResp_t()
@@ -73,9 +71,7 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command for ue-id", ue_id)
 
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
@@ -87,9 +83,7 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
 
         # Esm Information Request indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
         print("Received Esm Information Request ue-id", ue_id)
 
         print("************************* Restarting MME service on", "gateway")
@@ -109,9 +103,7 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
             )
             # Wait for UE_CTX_REL_IND
             response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # Perform end-end attach
         self._s1ap_wrapper.s1_util.attach(

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
@@ -65,10 +65,7 @@ class TestNoIdentityRspWithMmeRestart(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
         print(
             "Received Identity req ind ",
             s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
@@ -125,10 +122,7 @@ class TestNoIdentityRspWithMmeRestart(unittest.TestCase):
                 break
 
         # Context release
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("********** UE Context released **********")
 
         time.sleep(5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_security_mode_complete.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_security_mode_complete.py
@@ -91,9 +91,7 @@ class TestNoSecurityModeComplete(unittest.TestCase):
             s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
         sqnRecvd = s1ap_types.ueSqnRcvd_t()
@@ -106,17 +104,13 @@ class TestNoSecurityModeComplete(unittest.TestCase):
         # Wait for timer 3460 expiry 5 times, until context is released
         for i in range(5):
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
             print("************************* Timeout", i + 1)
 
         print("************************* Timeouts complete")
         # Context release
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("************************* Context released")
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_smc_with_mme_restart_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_smc_with_mme_restart_reattach.py
@@ -50,9 +50,7 @@ class TestNoSmcWithMmeRestartReattach(unittest.TestCase):
             s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("************* Received Auth Req for ue", req.ue_id)
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
@@ -66,9 +64,7 @@ class TestNoSmcWithMmeRestartReattach(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         print("************* Received SMC for ue", req.ue_id)
 
@@ -84,9 +80,7 @@ class TestNoSmcWithMmeRestartReattach(unittest.TestCase):
             print("Received SMC retx from previous run... Ignoring")
             response = self._s1ap_wrapper.s1_util.get_response()
 
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print("****** Triggering end-end attach after mme restart *********")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_attach_complete_ICSR.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_attach_complete_ICSR.py
@@ -64,10 +64,7 @@ class TestOutOfOrderAttachCompleteICSR(unittest.TestCase):
             attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
 
         delay_init_ctxt_setup_resp = s1ap_types.UeDelayInitCtxtSetupRsp()
         delay_init_ctxt_setup_resp.ue_Id = req.ue_id
@@ -90,10 +87,7 @@ class TestOutOfOrderAttachCompleteICSR(unittest.TestCase):
             auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
@@ -140,10 +134,7 @@ class TestOutOfOrderAttachCompleteICSR(unittest.TestCase):
         )
         # Wait for UE context release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         time.sleep(1)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_dedicated_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_dedicated_bearer.py
@@ -177,9 +177,7 @@ class TestOutOfOrderErabSetupRspDedicatedBearer(unittest.TestCase):
 
         # Receive Activate dedicated bearer request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_ctxt_req = response.cast(s1ap_types.UeActDedBearCtxtReq_t)
 
         print("Sleeping for 5 seconds")

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_default_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_default_bearer.py
@@ -90,9 +90,7 @@ class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
         sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -130,9 +128,7 @@ class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):
 
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
         print(
             "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_default_bearer.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_outoforder_erab_setup_rsp_default_bearer.py
@@ -128,7 +128,9 @@ class TestOutOfOrderErabSetupRspDefaultBearer(unittest.TestCase):
 
         # Receive UE_DEACTIVATE_BER_REQ
         response = self._s1ap_wrapper.s1_util.get_response()
-        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+        assert (
+            response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+        )
 
         print(
             "******************* Received deactivate eps bearer context"

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_after_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_after_mme_restart.py
@@ -80,9 +80,7 @@ class TestPagingAfterMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         wait_time = 0.3
         time.sleep(wait_time)
         print('************************* Restarting MME service on', 'gateway')
@@ -119,9 +117,7 @@ class TestPagingAfterMmeRestart(unittest.TestCase):
                 )
                 response = self._s1ap_wrapper.s1_util.get_response()
 
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
             test.verify()
 
         time.sleep(0.5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_after_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_after_mme_restart.py
@@ -99,7 +99,7 @@ class TestPagingAfterMmeRestart(unittest.TestCase):
             req, duration=1, is_udp=True,
         ) as test:
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertTrue(response, s1ap_types.tfwCmd.UE_PAGING_IND.value)
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
             print('************************ Received Paging Indication')
 
             # Send service request to reconnect UE

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
@@ -101,7 +101,9 @@ class TestPagingRequest(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            assert (
+                response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            )
             test.verify()
 
         time.sleep(0.5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
@@ -79,9 +79,7 @@ class TestPagingRequest(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, ue_cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         time.sleep(0.3)
         print(
@@ -103,9 +101,7 @@ class TestPagingRequest(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_SERVICE_REQUEST, ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
             test.verify()
 
         time.sleep(0.5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
@@ -92,7 +92,7 @@ class TestPagingRequest(unittest.TestCase):
             req, duration=1, is_udp=True,
         ) as test:
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertTrue(response, s1ap_types.tfwCmd.UE_PAGING_IND.value)
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
             # Send service request to reconnect UE
             ser_req = s1ap_types.ueserviceReq_t()
             ser_req.ue_Id = ue_id

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_with_mme_restart.py
@@ -102,7 +102,7 @@ class TestPagingWithMmeRestart(unittest.TestCase):
             is_udp=True,
         ) as test:
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertTrue(response, s1ap_types.tfwCmd.UE_PAGING_IND.value)
+            assert response.msg_type == s1ap_types.tfwCmd.UE_PAGING_IND.value
             print("************************ Received Paging Indication")
 
             print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_with_mme_restart.py
@@ -86,10 +86,7 @@ class TestPagingWithMmeRestart(unittest.TestCase):
             ue_cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         time.sleep(0.3)
         print(
@@ -145,10 +142,7 @@ class TestPagingWithMmeRestart(unittest.TestCase):
                 else:
                     break
 
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
             test.verify()
 
         time.sleep(0.5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_resync.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_resync.py
@@ -54,10 +54,7 @@ class TestResync(unittest.TestCase):
             attach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         auth_res = s1ap_types.ueAuthResp_t()
         auth_res.ue_Id = req.ue_id
         sqn_recvd = s1ap_types.ueSqnRcvd_t()
@@ -77,10 +74,7 @@ class TestResync(unittest.TestCase):
         response = self._s1ap_wrapper.s1_util.get_response()
 
         # Verify that EPC re-sends Authentication Request
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("************************* Retrying authentication")
         # Use SQN received from EPC as is
         sqn_recvd.pres = False
@@ -90,10 +84,7 @@ class TestResync(unittest.TestCase):
             auth_res,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
 
         # Trigger Security mode complete message
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
@@ -138,10 +129,7 @@ class TestResync(unittest.TestCase):
             detach_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1_handover.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1_handover.py
@@ -120,10 +120,7 @@ class TestS1Handover(unittest.TestCase):
         # Handover Request to Target ENB.
         # Wait for S1 Handover Request Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value
         s1ho_req_ind = response.cast(s1ap_types.FwNbS1HoReqInd_t)
         print(
             "************************* Received S1 Handover Request "
@@ -154,10 +151,7 @@ class TestS1Handover(unittest.TestCase):
         # Handover Command to Source ENB.
         # Wait for S1 Handover Command Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_CMD_IND.value
         s1ho_cmd_ind = response.cast(s1ap_types.FwNbS1HoCmdInd_t)
         print(
             "************************* Received S1 Handover Command "
@@ -188,10 +182,7 @@ class TestS1Handover(unittest.TestCase):
         # Status Transfer to Target ENB.
         # Wait for MME Status Transfer Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_MME_STATUS_TRSFR_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_MME_STATUS_TRSFR_IND.value
         mme_status_trf_ind = response.cast(s1ap_types.FwNbMmeStatusTrnsfrInd_t)
         print(
             "************************* Received MME Status Transfer "
@@ -222,21 +213,10 @@ class TestS1Handover(unittest.TestCase):
         # source ENB for clearing UE context from source ENB
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         ue_ctxt_rel_ind = response.cast(s1ap_types.FwNbUeCtxRelInd_t)
-        self.assertEqual(
-            # causeType = 0 (Radio network)
-            ue_ctxt_rel_ind.relCause.causeType,
-            0,
-        )
-        self.assertEqual(
-            # causeVal = 2 (successful-handover)
-            ue_ctxt_rel_ind.relCause.causeVal,
-            2,
-        )
+        assert ue_ctxt_rel_ind.relCause.causeType == 0  # causeType = 0 (Radio network)
+        assert ue_ctxt_rel_ind.relCause.causeVal == 2  # causeVal = 2 (successful-handover)
         print(
             "************************* Received UE Context Release Command "
             "after successful handover",

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1_handover_cancel.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1_handover_cancel.py
@@ -118,10 +118,7 @@ class TestS1HandoverCancel(unittest.TestCase):
         # Handover Request to Target ENB.
         # Wait for S1 Handover Request Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value
         s1ho_req_ind = response.cast(s1ap_types.FwNbS1HoReqInd_t)
         print(
             "************************* Received S1 Handover Request "
@@ -152,10 +149,7 @@ class TestS1HandoverCancel(unittest.TestCase):
         # Handover Command to Source ENB.
         # Wait for S1 Handover Command Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_CMD_IND.value
         s1ho_cmd_ind = response.cast(s1ap_types.FwNbS1HoCmdInd_t)
         print(
             "************************* Received S1 Handover Command "
@@ -186,10 +180,7 @@ class TestS1HandoverCancel(unittest.TestCase):
         # Handover Cancel Ack to Source ENB.
         # Wait for S1 Handover Cancel Ack Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_CANCEL_ACK_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_CANCEL_ACK_IND.value
         s1ho_cancl_ack_ind = response.cast(s1ap_types.FwNbS1HoCancelAckInd_t)
         print(
             "************************* Received S1 Handover Cancel Ack "

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1_handover_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1_handover_failure.py
@@ -119,10 +119,7 @@ class TestS1HandoverFailure(unittest.TestCase):
         # Handover Request to Target ENB.
         # Wait for S1 Handover Request Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value
         s1ho_req_ind = response.cast(s1ap_types.FwNbS1HoReqInd_t)
         print(
             "************************* Received S1 Handover Request "
@@ -153,10 +150,7 @@ class TestS1HandoverFailure(unittest.TestCase):
         # Handover Preparation Failure to Source ENB.
         # Wait for S1 Handover Preparation Failure Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_PREP_FAIL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_PREP_FAIL_IND.value
         s1ho_prep_fail_ind = response.cast(s1ap_types.FwNbS1HoPrepFailInd_t)
         print(
             "************************* Received S1 Handover Preparation "

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1_handover_ping_pong.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1_handover_ping_pong.py
@@ -121,10 +121,7 @@ class TestS1HandoverPingPong(unittest.TestCase):
         # Handover Request to Target ENB.
         # Wait for S1 Handover Request Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value
         s1ho_req_ind = response.cast(s1ap_types.FwNbS1HoReqInd_t)
         print(
             "************************* Received S1 Handover Request "
@@ -155,10 +152,7 @@ class TestS1HandoverPingPong(unittest.TestCase):
         # Handover Command to Source ENB.
         # Wait for S1 Handover Command Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_CMD_IND.value
         s1ho_cmd_ind = response.cast(s1ap_types.FwNbS1HoCmdInd_t)
         print(
             "************************* Received S1 Handover Command "
@@ -189,10 +183,7 @@ class TestS1HandoverPingPong(unittest.TestCase):
         # Status Transfer to Target ENB.
         # Wait for MME Status Transfer Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_MME_STATUS_TRSFR_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_MME_STATUS_TRSFR_IND.value
         mme_status_trf_ind = response.cast(s1ap_types.FwNbMmeStatusTrnsfrInd_t)
         print(
             "************************* Received MME Status Transfer "
@@ -223,21 +214,10 @@ class TestS1HandoverPingPong(unittest.TestCase):
         # source ENB for clearing UE context from source ENB
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         ue_ctxt_rel_ind = response.cast(s1ap_types.FwNbUeCtxRelInd_t)
-        self.assertEqual(
-            # causeType = 0 (Radio network)
-            ue_ctxt_rel_ind.relCause.causeType,
-            0,
-        )
-        self.assertEqual(
-            # causeVal = 2 (successful-handover)
-            ue_ctxt_rel_ind.relCause.causeVal,
-            2,
-        )
+        assert ue_ctxt_rel_ind.relCause.causeType == 0  # causeType = 0 (Radio network)
+        assert ue_ctxt_rel_ind.relCause.causeVal == 2  # causeVal = 2 (successful-handover)
         print(
             "************************* Received UE Context Release Command "
             "after successful handover",
@@ -282,10 +262,7 @@ class TestS1HandoverPingPong(unittest.TestCase):
         # Handover Request to Target ENB.
         # Wait for S1 Handover Request Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value
         s1ho_req_ind = response.cast(s1ap_types.FwNbS1HoReqInd_t)
         print(
             "************************* Received S1 Handover Request "
@@ -316,10 +293,7 @@ class TestS1HandoverPingPong(unittest.TestCase):
         # Handover Command to Source ENB.
         # Wait for S1 Handover Command Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_CMD_IND.value
         s1ho_cmd_ind = response.cast(s1ap_types.FwNbS1HoCmdInd_t)
         print(
             "************************* Received S1 Handover Command "
@@ -350,10 +324,7 @@ class TestS1HandoverPingPong(unittest.TestCase):
         # Status Transfer to Target ENB.
         # Wait for MME Status Transfer Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_MME_STATUS_TRSFR_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_MME_STATUS_TRSFR_IND.value
         mme_status_trf_ind = response.cast(s1ap_types.FwNbMmeStatusTrnsfrInd_t)
         print(
             "************************* Received MME Status Transfer "
@@ -384,21 +355,10 @@ class TestS1HandoverPingPong(unittest.TestCase):
         # source ENB for clearing UE context from source ENB
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         ue_ctxt_rel_ind = response.cast(s1ap_types.FwNbUeCtxRelInd_t)
-        self.assertEqual(
-            # causeType = 0 (Radio network)
-            ue_ctxt_rel_ind.relCause.causeType,
-            0,
-        )
-        self.assertEqual(
-            # causeVal = 2 (successful-handover)
-            ue_ctxt_rel_ind.relCause.causeVal,
-            2,
-        )
+        assert ue_ctxt_rel_ind.relCause.causeType == 0  # causeType = 0 (Radio network)
+        assert ue_ctxt_rel_ind.relCause.causeVal == 2  # causeVal = 2 (successful-handover)
         print(
             "************************* Received UE Context Release Command "
             "after successful handover",

--- a/lte/gateway/python/integ_tests/s1aptests/test_s1_handover_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_s1_handover_timer_expiry.py
@@ -121,10 +121,7 @@ class TestS1HandoverTimerExpiry(unittest.TestCase):
         # Handover Request to Target ENB.
         # Wait for S1 Handover Request Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_REQ_IND.value
         s1ho_req_ind = response.cast(s1ap_types.FwNbS1HoReqInd_t)
         print(
             "************************* Received S1 Handover Request "
@@ -155,10 +152,7 @@ class TestS1HandoverTimerExpiry(unittest.TestCase):
         # Handover Command to Source ENB.
         # Wait for S1 Handover Command Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_CMD_IND.value
         s1ho_cmd_ind = response.cast(s1ap_types.FwNbS1HoCmdInd_t)
         print(
             "************************* Received S1 Handover Command "
@@ -177,10 +171,7 @@ class TestS1HandoverTimerExpiry(unittest.TestCase):
         # Command Indication to allow the S1 Reloc Timer to Expire
         # Wait for S1 HO Command Drop Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_CMD_DROP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_CMD_DROP_IND.value
         s1ho_cmd_drp_ind = response.cast(s1ap_types.FwNbS1HoCmdDropInd_t)
         print(
             "************************* Received S1 Handover Command Drop "
@@ -200,10 +191,7 @@ class TestS1HandoverTimerExpiry(unittest.TestCase):
         # source ENB
         # Wait for S1 HO Cancel Ack Indication
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.S1_HANDOVER_CANCEL_ACK_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.S1_HANDOVER_CANCEL_ACK_IND.value
         s1ho_cancl_ack_ind = response.cast(s1ap_types.FwNbS1HoCancelAckInd_t)
         print(
             "************************* Received S1 Handover Cancel Ack "

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_auth_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_auth_req.py
@@ -49,9 +49,7 @@ class TestSctpAbortAfterAuthReq(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print(
             "Received auth req ind ", s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_identity_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_identity_req.py
@@ -49,9 +49,7 @@ class TestSctpAbortAfterIdentityReq(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
         print(
             "Received Identity req ind ",
             s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_abort_after_smc.py
@@ -49,9 +49,7 @@ class TestSctpAbortAfterSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ue-id", req.ue_id)
 
         auth_res = s1ap_types.ueAuthResp_t()
@@ -65,9 +63,7 @@ class TestSctpAbortAfterSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command ue-id", req.ue_id)
 
         print("send SCTP ABORT")

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_auth_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_auth_req.py
@@ -49,9 +49,7 @@ class TestSctpShutdownAfterAuthReq(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ue-id", req.ue_id)
 
         print("send SCTP SHUTDOWN")

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_identity_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_identity_req.py
@@ -49,9 +49,7 @@ class TestSctpShutdownAfterIdentityReq(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
         print(
             "Received Identity req ind ",
             s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value,

--- a/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_smc.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_sctp_shutdown_after_smc.py
@@ -50,9 +50,7 @@ class TestSctpShutdownAfterSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ue-id", req.ue_id)
 
         auth_res = s1ap_types.ueAuthResp_t()
@@ -66,9 +64,7 @@ class TestSctpShutdownAfterSmc(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command ue-id", req.ue_id)
 
         print("send SCTP SHUTDOWN")

--- a/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_reject_multiple_sessions_not_allowed_per_apn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_reject_multiple_sessions_not_allowed_per_apn.py
@@ -67,14 +67,9 @@ class TestSecondaryPdnRejectMultipleSessionsNotAllowedPerApn(
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN Connectivity reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         pdn_con_rsp = response.cast(s1ap_types.uePdnConRsp_t)
-        self.assertEqual(
-            pdn_con_rsp.m.conRejInfo.cause,
-            s1ap_types.TFW_ESM_CAUSE_MULTIPLE_PDN_CON_FOR_A_GIVEN_APN_NA,
-        )
+        assert pdn_con_rsp.m.conRejInfo.cause == s1ap_types.TFW_ESM_CAUSE_MULTIPLE_PDN_CON_FOR_A_GIVEN_APN_NA
 
         print("Sleeping for 5 seconds")
         time.sleep(5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_reject_unknown_pdn_type.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_reject_unknown_pdn_type.py
@@ -80,15 +80,10 @@ class TestSecondaryPdnRejectUnknownPdnType(unittest.TestCase):
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn, pdn_type=2)
         # Receive PDN Connectivity reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         # Verify cause
         pdn_con_rsp = response.cast(s1ap_types.uePdnConRsp_t)
-        self.assertEqual(
-            pdn_con_rsp.m.conRejInfo.cause,
-            s1ap_types.TFW_ESM_CAUSE_UNKNOWN_PDN_TYPE,
-        )
+        assert pdn_con_rsp.m.conRejInfo.cause == s1ap_types.TFW_ESM_CAUSE_UNKNOWN_PDN_TYPE
 
         print("Sleeping for 5 seconds")
         time.sleep(5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_secondary_pdn_with_dedicated_bearer_multiple_services_restart.py
@@ -208,9 +208,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_oai_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )
@@ -225,9 +223,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
         self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
         # Receive PDN CONN RSP/Activate default EPS bearer context request
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
         addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
         sec_ip = ipaddress.ip_address(bytes(addr[:4]))
@@ -254,9 +250,7 @@ class TestSecondaryPdnWithDedicatedBearerMultipleServicesRestart(
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
         act_ded_ber_req_ims_apn = response.cast(
             s1ap_types.UeActDedBearCtxtReq_t,
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_send_error_ind_for_dl_nas_with_auth_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_send_error_ind_for_dl_nas_with_auth_req.py
@@ -51,9 +51,7 @@ class TestSendErrorIndForDlNasWithAuthReq(unittest.TestCase):
         )
         print("************************* Sent attach request")
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("************************* Received authentication request")
 
         # Send error indication
@@ -73,9 +71,7 @@ class TestSendErrorIndForDlNasWithAuthReq(unittest.TestCase):
 
         # Context release
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
         print("************************* Received UE_CTX_REL_IND")
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_send_error_ind_for_erab_setup_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_send_error_ind_for_erab_setup_req.py
@@ -83,9 +83,7 @@ class TestSendErrorIndForErabSetupReq(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
             act_ded_ber_ctxt_req = response.cast(
                 s1ap_types.UeActDedBearCtxtReq_t,
             )
@@ -108,9 +106,7 @@ class TestSendErrorIndForErabSetupReq(unittest.TestCase):
                 s1ap_types.tfwCmd.ENB_ERR_IND_MSG, error_ind,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
             print(
                 "************************* Received UE_CTX_REL_IND for UE id ",
                 req.ue_id,

--- a/lte/gateway/python/integ_tests/s1aptests/test_service_info.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_service_info.py
@@ -35,17 +35,16 @@ class TestServiceInfo(unittest.TestCase):
         print("UPTIME ", uptime)
 
         # Sanity checks
-        self.assertGreater(start_time, 0)
-
-        self.assertGreaterEqual(uptime, 0)
+        assert start_time > 0
+        assert uptime >= 0
 
         # Make sure uptime is updating and start time is not
         time.sleep(1)
 
         new_uptime = service_util.get_uptime()
         new_start_time = service_util.get_start_time()
-        self.assertGreater(new_uptime, uptime)
-        self.assertEqual(start_time, new_start_time)
+        assert new_uptime > uptime
+        assert new_start_time == start_time
         print("START TIME ", new_start_time)
         print("UPTIME ", new_uptime)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
@@ -80,9 +80,7 @@ class TestServiceReqUlUdpDataWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print("************************* Restarting MME service on gateway")
         wait_for_restart = 30
@@ -112,9 +110,7 @@ class TestServiceReqUlUdpDataWithMmeRestart(unittest.TestCase):
             )
             response = self._s1ap_wrapper.s1_util.get_response()
 
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
 
         print(
             "************************* Running UE uplink (UDP) for UE id ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req.py
@@ -67,9 +67,7 @@ class TestStandAlonePdnConnReq(unittest.TestCase):
         )
         # Receive PDN Connectivity Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
 
         print("Received PDN CONNECTIVITY REJECT")
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_standalone_pdn_conn_req_with_apn_correction.py
@@ -87,10 +87,7 @@ class TestStandalonePdnConnReqWithApnCorrection(unittest.TestCase):
         )
         # Receive PDN Connectivity Reject
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
 
         print("Received PDN CONNECTIVITY REJECT")
         print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_stateless_multi_ue_mixedstate_mme_restart.py
@@ -57,10 +57,7 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
         print("Received auth req ind ue-id", attach_req.ue_Id)
 
     def exec_auth_resp_step(self, ue_id):
@@ -77,10 +74,7 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         print("Received Security Mode Command ue-id", auth_res.ue_Id)
 
     def exec_sec_mode_complete_step(self, ue_id):
@@ -96,10 +90,7 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
             sec_mode_complete.ue_Id,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
         esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
         return esm_info_req.tId
 
@@ -210,10 +201,7 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
                 ue_cntxt_rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         tid = {}
         # start attach procedures for the remaining UEs
@@ -289,10 +277,7 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
                 ser_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
             self.dl_flow_rules[idle_session_ips[i]] = []
 
         # Verify default bearer rules
@@ -320,10 +305,7 @@ class TestStatelessMultiUeMixedStateMmeRestart(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_mixed_partial_lists.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_mixed_partial_lists.py
@@ -83,9 +83,7 @@ class TestTauMixedPartialLists(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, cntxt_rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
             print(
                 "************************* Sending Tracking Area Update ",
@@ -102,9 +100,7 @@ class TestTauMixedPartialLists(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value
             tau_acc = response.cast(s1ap_types.ueTauAccept_t)
             print(
                 "************************* Received Tracking Area Update ",
@@ -113,9 +109,7 @@ class TestTauMixedPartialLists(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print("************************* Sleeping for 2 seconds")
         time.sleep(2)

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_active.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_active.py
@@ -67,9 +67,7 @@ class TestTauPeriodicActive(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         for _ in range(num_taus):
             timer = threading.Timer(tau_period, lambda: None)
@@ -93,10 +91,7 @@ class TestTauPeriodicActive(unittest.TestCase):
             response = self._s1ap_wrapper.s1_util.get_response()
             if s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value == response.msg_type:
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEqual(
-                    response.msg_type,
-                    s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
-                )
+                assert response.msg_type == s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value
 
                 print(
                     "************************* Sending UE context release ",
@@ -110,15 +105,10 @@ class TestTauPeriodicActive(unittest.TestCase):
                     s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
                 )
                 response = self._s1ap_wrapper.s1_util.get_response()
-                self.assertEqual(
-                    response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-                )
+                assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
             else:
-                self.assertEqual(
-                    response.msg_type,
-                    s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value,
-                )
+                assert response.msg_type == s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value
 
         print(
             "************************* Running UE detach (switch-off) for ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_inactive.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_inactive.py
@@ -65,9 +65,7 @@ class TestTauPeriodicInactive(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         for _ in range(num_taus):
             timer = threading.Timer(tau_period, lambda: None)
@@ -89,14 +87,10 @@ class TestTauPeriodicInactive(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print(
             "************************* Running UE detach (switch-off) for ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating.py
@@ -77,10 +77,7 @@ class TestTauTaUpdating(unittest.TestCase):
                 cntxt_rel_req,
             )
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type,
-                s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # For the 1st UE, send TAU with Eps_Updt_Type
         # TA_UPDATING and active flag set to true
@@ -128,10 +125,7 @@ class TestTauTaUpdating(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value
         tau_acc = response.cast(s1ap_types.ueTauAccept_t)
         print(
             "************************* Received Tracking Area Update ",
@@ -140,10 +134,7 @@ class TestTauTaUpdating(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         for ue in ue_ids:
             print(

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating_connected_mode.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating_connected_mode.py
@@ -77,9 +77,7 @@ class TestTauTaUpdatingConnectedMode(unittest.TestCase):
             )
 
             response = self._s1ap_wrapper.s1_util.get_response()
-            self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value,
-            )
+            assert response.msg_type == s1ap_types.tfwCmd.UE_TAU_ACCEPT_IND.value
             tau_acc = response.cast(s1ap_types.ueTauAccept_t)
             print(
                 "************************* Received Tracking Area Update ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating_reject.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_ta_updating_reject.py
@@ -82,9 +82,7 @@ class TestTauTaUpdatingReject(unittest.TestCase):
             s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, cntxt_rel_req,
         )
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         print(
             "************************* Sending Tracking Area Update ",
@@ -101,9 +99,7 @@ class TestTauTaUpdatingReject(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.UE_TAU_REJECT_IND.value
         tau_rej = response.cast(s1ap_types.ueTauRejInd_t)
         print(
             "************************* Received Tracking Area Update ",

--- a/lte/gateway/python/integ_tests/s1aptests/test_x2_handover.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_x2_handover.py
@@ -81,18 +81,12 @@ class TestX2HandOver(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value
 
         print("************************* Received MME_CONFIGURATION_TRANSFER")
         print("************************* Sending ENB_CONFIGURATION_TRANSFER")
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value
 
         print("************************* Received MME_CONFIGURATION_TRANSFER")
         print("************************* Sending X2_HO_TRIGGER_REQ")
@@ -102,9 +96,7 @@ class TestX2HandOver(unittest.TestCase):
         )
         # Receive Path Switch Request Ack
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value
 
         print("************************* Received Path Switch Request Ack")
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_x2_handover.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_x2_handover.py
@@ -81,12 +81,18 @@ class TestX2HandOver(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        assert response.msg_type == s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value
+        assert (
+            response.msg_type
+            == s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value
+        )
 
         print("************************* Received MME_CONFIGURATION_TRANSFER")
         print("************************* Sending ENB_CONFIGURATION_TRANSFER")
         response = self._s1ap_wrapper.s1_util.get_response()
-        assert response.msg_type == s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value
+        assert (
+            response.msg_type
+            == s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value
+        )
 
         print("************************* Received MME_CONFIGURATION_TRANSFER")
         print("************************* Sending X2_HO_TRIGGER_REQ")

--- a/lte/gateway/python/integ_tests/s1aptests/test_x2_handover_ping_pong.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_x2_handover_ping_pong.py
@@ -82,18 +82,12 @@ class TestX2HandOverPingPong(unittest.TestCase):
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value
 
         print("****************** Received MME_CONFIGURATION_TRANSFER")
         print("****************** Sending ENB_CONFIGURATION_TRANSFER")
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type,
-            s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.MME_CONFIGURATION_TRANSFER.value
 
         print("****************** Received MME_CONFIGURATION_TRANSFER")
         print("****************** Sending X2_HO_TRIGGER_REQ")
@@ -103,9 +97,7 @@ class TestX2HandOverPingPong(unittest.TestCase):
         )
         # Receive Path Switch Request Ack
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value
 
         print("****************** Received Path Switch Request Ack")
 
@@ -115,9 +107,7 @@ class TestX2HandOverPingPong(unittest.TestCase):
         )
         # Receive Path Switch Request Ack
         response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value,
-        )
+        assert response.msg_type == s1ap_types.tfwCmd.PATH_SW_REQ_ACK.value
         print("****************** Received Path Switch Request Ack for 2nd HO")
         print("****************** Running UE detach for UE id ", req.ue_id)
         # Now detach the UE


### PR DESCRIPTION
Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>

## Summary

* Refactor incorrect usage of `assertTrue` to `assert ... == ...` for response message asserts
* Change all `assertEqual` in the touched tests to the new syntax as well

## Test Plan

Run the touched integ tests

## Additional Information

- [ ] This change is backwards-breaking


