### PR TITLE
chore(nms): Improve generic commands functionality

### DIFF
--- a/nms/app/components/GatewayCommandFields.tsx
+++ b/nms/app/components/GatewayCommandFields.tsx
@@ -379,6 +379,15 @@ export function GenericCommandControls(props: ChildProps) {
     <div>
       <Divider className={classes.divider} />
       <Text variant="subtitle1">Generic</Text>
+      <br />
+      <Text variant="body2">
+        Allowed commands are configured in `magmad.yml`. Specify parameters in
+        JSON via "shell_params", i.e. `
+        {`
+        {"shell_params": ["param_1 ... param_n"]}
+        `}
+        `.
+      </Text>
       <FormField label="Command">
         <Input
           className={classes.input}

--- a/nms/app/components/GatewayCommandFields.tsx
+++ b/nms/app/components/GatewayCommandFields.tsx
@@ -339,7 +339,9 @@ export function GenericCommandControls(props: ChildProps) {
   const {networkId} = useParams();
   const enqueueSnackbar = useEnqueueSnackbar();
   const [commandName, setCommandName] = useState('');
-  const [commandParams, setCommandParams] = useState('{\n}');
+  const [commandParams, setCommandParams] = useState(
+    '{\n    "shell_params": [""]\n}',
+  );
   const [genericResponse, setGenericResponse] = useState<string>();
   const [showProgress, setShowProgress] = useState<boolean>();
 

--- a/nms/app/components/GatewayCommandFields.tsx
+++ b/nms/app/components/GatewayCommandFields.tsx
@@ -346,6 +346,13 @@ export function GenericCommandControls(props: ChildProps) {
   const [showProgress, setShowProgress] = useState<boolean>();
 
   const onClick = () => {
+    if (commandName === '') {
+      enqueueSnackbar('Generic command failed: no command provided', {
+        variant: 'error',
+      });
+      return;
+    }
+
     const {gatewayID} = props;
     let params: Record<string, object> = {};
     try {

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_command_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_command_handlers.go
@@ -18,6 +18,8 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	models2 "magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/services/magmad"
@@ -130,7 +132,12 @@ func gatewayGenericCommand(c echo.Context) error {
 
 	response, err := magmad.GatewayGenericCommand(c.Request().Context(), networkID, gatewayID, &genericCommandParams)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		st, _ := status.FromError(err)
+		if st.Code() == codes.NotFound {
+			return echo.NewHTTPError(http.StatusNotFound, st.Message())
+		} else {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
 	}
 
 	resp, err := models2.ProtobufStructToJSONMap(response.Response)

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_command_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_command_handlers.go
@@ -133,7 +133,7 @@ func gatewayGenericCommand(c echo.Context) error {
 	response, err := magmad.GatewayGenericCommand(c.Request().Context(), networkID, gatewayID, &genericCommandParams)
 	if err != nil {
 		st, _ := status.FromError(err)
-		if st.Code() == codes.NotFound {
+		if st.Code() == codes.InvalidArgument {
 			return echo.NewHTTPError(http.StatusNotFound, st.Message())
 		} else {
 			return echo.NewHTTPError(http.StatusInternalServerError, err)

--- a/orc8r/gateway/python/magma/magmad/generic_command/command_executor.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/command_executor.py
@@ -19,6 +19,10 @@ ParamValueT = Union[str, int, float, bool, List[Union[str, int, float, bool]]]
 ExecutorFuncT = Callable[[Dict[str, ParamValueT]], Awaitable[Dict[str, Any]]]
 
 
+class CommandExecutionException(Exception):
+    pass
+
+
 class CommandExecutor(ABC):
     """
     Abstract class for command executors
@@ -40,7 +44,10 @@ class CommandExecutor(ABC):
         """
         Run the command from the dispatch table with params
         """
-        result = await self.get_command_dispatch()[command](params)
+        cmd = self.get_command_dispatch().get(command)
+        if not cmd:
+            raise CommandExecutionException(f"no config for {command}")
+        result = await cmd(params)
         return result
 
     @abstractmethod

--- a/orc8r/gateway/python/magma/magmad/generic_command/command_executor.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/command_executor.py
@@ -13,6 +13,7 @@ limitations under the License.
 import asyncio
 import importlib
 from abc import ABC, abstractmethod
+from functools import partial
 from typing import Any, Awaitable, Callable, Dict, List, Union
 
 ParamValueT = Union[str, int, float, bool, List[Union[str, int, float, bool]]]
@@ -47,6 +48,9 @@ class CommandExecutor(ABC):
         cmd = self.get_command_dispatch().get(command)
         if not cmd:
             raise CommandExecutionException(f"no config for {command}")
+        allow_params = isinstance(cmd, partial) and cmd.args[-1]
+        if allow_params and list(params.keys()) != ["shell_params"]:
+            raise CommandExecutionException("the parameters must be JSON with one key, 'shell_params'")
         result = await cmd(params)
         return result
 

--- a/orc8r/gateway/python/magma/magmad/generic_command/shell_command_executor.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/shell_command_executor.py
@@ -84,7 +84,10 @@ async def _run_subprocess(
     """
     cmd_str = cmd
     if allow_params:
-        cmd_str = cmd.format(*params.get('shell_params', []))
+        if params["shell_params"] == []:
+            cmd_str = cmd.format([''])
+        else:
+            cmd_str = cmd.format(*params.get('shell_params', ['']))
 
     logging.info("Running command: %s", cmd_str)
 

--- a/orc8r/gateway/python/magma/magmad/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/magmad/rpc_servicer.py
@@ -34,7 +34,10 @@ from magma.common.stateless_agw import (
 )
 from magma.configuration.mconfig_managers import MconfigManager
 from magma.magmad.check.network_check import ping, traceroute
-from magma.magmad.generic_command.command_executor import CommandExecutor
+from magma.magmad.generic_command.command_executor import (
+    CommandExecutionException,
+    CommandExecutor,
+)
 from magma.magmad.service_manager import ServiceManager
 from orc8r.protos import magmad_pb2, magmad_pb2_grpc
 
@@ -223,6 +226,17 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
                 context,
                 grpc.StatusCode.DEADLINE_EXCEEDED,
                 'Command timed out',
+            )
+        except CommandExecutionException as e:
+            logging.warning(
+                'Error running command %s! %s: %s',
+                request.command, e.__class__.__name__, e,
+            )
+            future.cancel()
+            set_grpc_err(
+                context,
+                grpc.StatusCode.NOT_FOUND,
+                str(e),
             )
         except Exception as e:  # pylint: disable=broad-except
             logging.error(

--- a/orc8r/gateway/python/magma/magmad/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/magmad/rpc_servicer.py
@@ -235,7 +235,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
             future.cancel()
             set_grpc_err(
                 context,
-                grpc.StatusCode.NOT_FOUND,
+                grpc.StatusCode.INVALID_ARGUMENT,
                 str(e),
             )
         except Exception as e:  # pylint: disable=broad-except


### PR DESCRIPTION
## Summary

Builds on top of https://github.com/magma/magma/pull/13911. Closes https://github.com/magma/magma/issues/13894.

This PR:
- Adds text to NMS to instruct the user how to use the generic command functionality and points the user to magmad.yml for configuration of the commands.
- Adapts the parameters field in NMS so that the field is valid without user modification.
- Gives a more helpful error message when a command is not configured.

This functionality could do with further improvements, so this is seen as a first step to make the current set-up more usable. An issue will be opened with further suggested improvements.

## Test Plan

- Running this locally (see screenshots below)
- NMS workflow in the CI

Command that is configured fails when no parameters specified
![Screenshot from 2022-09-27 11-34-13](https://user-images.githubusercontent.com/32741139/192490929-c09d92b3-20ac-4274-9b74-c7f834d4f67c.png)

New default look
![Screenshot from 2022-09-27 11-35-12](https://user-images.githubusercontent.com/32741139/192491117-6f3a2ea7-72d9-4c56-92f7-50c8ae7f17a4.png)

Command now works without modifying parameters field
![Screenshot from 2022-09-27 11-35-47](https://user-images.githubusercontent.com/32741139/192491282-f95594f0-858a-420c-b675-6166b442d3af.png)

A more helpful error is returned when a non-configured command is used
![Screenshot from 2022-09-27 11-36-42](https://user-images.githubusercontent.com/32741139/192491525-8b542c0b-4797-4fca-a85f-e3aa4ff3fac7.png)