### PR TITLE
fix(pipelined): Handling for GTPU end-marker

### DIFF
--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/0025-fix-ovs-kernel-panic-on-receiving-end-marker.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/0025-fix-ovs-kernel-panic-on-receiving-end-marker.patch
@@ -1,0 +1,68 @@
+From 9f658cf512c4fdac958ee643724d20b5290e1ad2 Mon Sep 17 00:00:00 2001
+From: vagrant <vagrant@magma-dev.magma.com>
+Date: Fri, 23 Sep 2022 09:16:59 +0000
+Subject: [PATCH] fix(ovs): kernel panic on receiving end-marker
+
+Summary:
+  GTP module can panic kernel on receiving end-marker packet.
+  Following PR gracefully handles the packet and pass it to
+  control-plane process.
+
+Test:
+  - Unit testing
+  - End Marker Packet testing
+  - Basic 4G/5G traffic flow
+
+Signed-off-by: vagrant <vagrant@magma-dev.magma.com>
+---
+ datapath/linux/compat/gtp.c | 9 ++++++++-
+ debian/changelog            | 2 +-
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/datapath/linux/compat/gtp.c b/datapath/linux/compat/gtp.c
+index d4d49920d..da7c79914 100644
+--- a/datapath/linux/compat/gtp.c
++++ b/datapath/linux/compat/gtp.c
+@@ -45,6 +45,8 @@
+ #define GTP_EXTENSION_HDR_FLAG 0x04
+ #define GTP_SEQ_FLAG           0x02
+ 
++#define GTP_TYPE_END_MARKER 0xFE
++
+ struct gtpu_ext_hdr {
+ 	__be16 seq_num;
+ 	u8 n_pdu;
+@@ -139,6 +141,11 @@ static int gtp_rx(struct sock *sk, struct gtp_dev *gtp, struct sk_buff *skb,
+                         tun_dst->u.tun_info.key.tun_flags |= TUNNEL_GTPU_OPT;
+                         tun_dst->u.tun_info.options_len = opts_len;
+                         skb->protocol = 0xffff;         // Unknown
++			if (gtp1->type == GTP_TYPE_END_MARKER) {
++				// dont pull the headers
++				hdrlen = sizeof(struct udphdr);
++				netdev_dbg(gtp->dev, "End marker packet len: %d", skb->len);
++			}
+                     }
+ 		}
+ 
+@@ -436,7 +443,7 @@ static inline int gtp1_push_control_header(struct sk_buff *skb, __be32 tid, stru
+ 		return -ENOENT;
+ 	}
+ 
+-	if (opts->type == 0xFE) {
++	if (opts->type == GTP_TYPE_END_MARKER) {
+ 		// for end marker ignore skb data.
+ 		netdev_dbg(dev, "xmit pkt with null data");
+ 		pskb_trim(skb, 0);
+diff --git a/debian/changelog b/debian/changelog
+index 327e5e019..937b5ce7b 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -1,4 +1,4 @@
+-openvswitch (2.15.4-9-magma) unstable; urgency=low
++openvswitch (2.15.4-10-magma) unstable; urgency=low
+    [ Open vSwitch team ]
+    * New upstream version
+ 
+-- 
+2.25.1
+

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/dev.sh
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/dev.sh
@@ -28,12 +28,15 @@ function setup() {
   git clone git://git.osmocom.org/libgtpnl
   cd libgtpnl
   autoreconf -fi && ./configure && make && make install
-  cp ./src/.libs/libgtpnl.so.0.1.1 /lib/libgtpnl.so.0
+  cp ./src/.libs/libgtpnl.so.0.1.2 /lib/libgtpnl.so.0
 }
 
 
 function  build_test() {
   service magma@* stop
+  # sometimes this package is auto removed.
+
+  apt install -y linux-modules-extra-`uname -r`
 
   sleep 1
   ifdown gtp_br0
@@ -64,6 +67,9 @@ function  build_test() {
   modprobe nft_connlimit
   modprobe nft_counter
   modprobe gtp
+  rmmod vport_gtp || true
+  rmmod openvswitch || true
+
   cp datapath/linux/*.ko /lib/modules/`uname -r`/kernel/net/openvswitch/
   cp datapath/linux/*.ko /lib/modules/`uname -r`/updates/dkms/
   sync


### PR DESCRIPTION

 GTP module can panic kernel on receiving end-marker packet.


Signed-off-by: Yogesh Pandey <yogesh@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Handled the case for end marker packet processing. 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Test Plan:
  - OVS Unit testing
  - Magma python modules unit testing
  - End of Marker testing
  - 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
