### PR TITLE
chore: Documentation changes after the Bazel switchover

### DIFF
--- a/docs/readmes/lte/dev_notes.md
+++ b/docs/readmes/lte/dev_notes.md
@@ -83,7 +83,6 @@ To connect a physical UE to the gateway VM,
 1. Use a programmable SIM which is provisioned with the LTE auth key that you
 will use in the EPC.
 1. On the gateway VM, add the subscriber using the CLI:
-1. `magtivate`
 1. `subscriber_cli.py add --lte-auth-key <base64 LTE auth key> IMSI<15 digit
 IMSI>`
 
@@ -286,58 +285,30 @@ num_enbs: 1
 
 ## Combining XML Unit test reports
 
-At the moment of writing, running the unit test targets does not generate the aggregated XML report file by default. To get the report of all unit tests, you have two options.
+The script `runtime_report.py` is used by existing scripts (`$MAGMA_ROOT/bazel/scripts/run_integ_tests.sh`, `$MAGMA_ROOT/bazel/scripts/run_sudo_tests.sh`) and should not be executed as a standalone one. This section is only served as a guideline in case, in the future, a developer would like to make some changes to this script or would like to know how to use it.
 
-### Option 1: Running unit test target
+#### Generating XML files
 
-If you prefer a simple method, you can simply do:
-
-```bash
-cd ${MAGMA_ROOT}/lte/gateway/
-make test_oai_runtime
-```
-
-And you will get the combined report at `${MAGMA_ROOT}/report/merged_report/report_all_tests.xml`
-
-### Option 2: Manual method
-
-The script `runtime_report.py` is intended to use as in option 1. This section is only served as a guideline in case, in the future, a developer would like to make some changes to this script or how to use it.
-
-#### Enabling generating the unit test report
-
-Setting the value for the `$GTEST_OUTPUT` as below:
-
-```bash
-export GTEST_OUTPUT=xml:/where/you/want/to/store/the/reports/
-```
-
-#### Running the OAI unit test targets as usual on `magma` VM
-
-```bash
-make test_oai
-```
-
-The report XML files are generated inside your desired folder.
+In order to use the script you need XML files that can be merged together. You can create some from scratch or you can generate some with the above mentioned scripts, you just need to comment out the use of the `create_xml_report` function at the end. The XML files should be in a folder of your choice, lets name it `PATH/TO/FOLDER/XML_FILES_FOLDER`.
 
 #### Combine all the reports into a single report file
 
-Assume that you chose to store all the generated report files at `/where/you/stored/the/reports/` which is called the **working directory** here. You can simply set a regex pattern that matches the **relative** paths of all XML report files from the **working directory** as in the example below.
+Assume that you chose to store all the generated report files at `PATH/TO/FOLDER/XML_FILES_FOLDER` which is called the **working directory** here. You can simply set a regex pattern that matches the **relative** paths of all XML report files from the **working directory** as in the example below.
 
 ```bash
-cd ${MAGMA_ROOT}/lte/gateway/
-## optional: activate your python virtual environment
-python3 python/scripts/runtime_report.py -i [regex_pattern_matches_relative_path_of_report] -w /where/you/stored/the/reports/
+cd ${MAGMA_ROOT}/lte/gateway/python/scripts/
+python3 runtime_report.py -i [regex_pattern_matches_relative_path_of_report] -w PATH/TO/FOLDER/XML_FILES_FOLDER
 ```
 
 For example, when you generated all the `.xml` report files at `${MAGMA_ROOT}/logs/`  and want to combine them, you can run:
 
 ```bash
-python3 python/scripts/runtime_report.py -i .+\\.xml$$ -w ${MAGMA_ROOT}/logs/
+python3 runtime_report.py -i .+\\.xml$$ -w ${MAGMA_ROOT}/logs/
 ```
 
 By default, the XML output file will be generated at `${MAGMA_ROOT}/report/merged_report/report_all_tests.xml`.
 You can overwrite this by using the `-o` option of `runtime_report.py`. Let's reuse the example above:
 
 ```bash
-python3 python/scripts/runtime_report.py -i .+\\.xml$$ -w ${MAGMA_ROOT}/logs/ -o /where/you/want/to/store/this/file.xml
+python3 runtime_report.py -i .+\\.xml$$ -w ${MAGMA_ROOT}/logs/ -o /PATH/TO/DESIRED/FOLDER/FOR/THE/RESULT.xml
 ```

--- a/docs/readmes/lte/dev_unit_testing.md
+++ b/docs/readmes/lte/dev_unit_testing.md
@@ -22,64 +22,20 @@ To SSH into the VM, run
 To run all existing unit tests, run
 
 ```bash
-[VM] cd magma/lte/gateway
-[VM] make test
+[VM] cd magma # or any subdirectory inside magma
+[VM] bazel test //lte/gateway/...
 ```
 
 Note: Running all unit tests can take close to 15 minutes.
 
-### Test Python AGW services
-
-To run only the Python unit tests, run
+In short, to run tests with Bazel you just need to provide the directory that the test targets reside in:
 
 ```bash
-[VM] cd magma/lte/gateway
-[VM] make test_python
-```
-
-The list of services to test are configured in the following files.
-
-- `orc8r/gateway/python/defs.mk`
-- `lte/gateway/python/defs.mk`
-
-To run unit tests for a single Python service, select a name from the list of services and run
-
-```bash
-[VM] cd magma/lte/gateway
-[VM] make test_python_service MAGMA_SERVICE=<service_name>
-```
-
-In the case that unit tests for a single Python service are started multiple times, it is preferable to avoid the upstream installation process of the virtual environment by adding `DONT_BUILD_ENV=1` to the command, run
-
-```bash
-[VM] cd magma/lte/gateway
-[VM] make test_python_service MAGMA_SERVICE=<service_name> DONT_BUILD_ENV=1
-```
-
-To run unit tests of an arbitrary directory, run
-
-```bash
-[VM] cd magma/lte/gateway
-[VM] make test_python_service UT_PATH=<path_of_the_test_folder>
-```
-
-### Test C/C++ AGW services
-
-We have several C/C++ services that live in `lte/gateway/c/`.
-To run tests for those services, run
-
-```bash
-[VM] cd magma/lte/gateway
-[VM] make test_<service_directory_name> # Ex: make test_session_manager
-```
-
-A subset of the AGW C/C++ directories are in the process of being migrated to use Bazel as the default build system. We will list out some of the useful commands here, but please refer to the [Bazel user guide](https://docs.bazel.build/versions/main/guide.html) for a complete overview.
-
-```bash
-[VM] cd magma # or any subdirectory inside magma
-[VM] bazel test //... # to test all targets
-[VM] bazel test //lte/gateway/c/session_manager/...:* # to test all targets under lte/gateway/c/session_manager 
-[VM] bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* # to test all C/C++ targets
+[VM] bazel test //... # to test all targets in magma
+[VM] bazel test //lte/gateway/c/session_manager/... # to test all targets under lte/gateway/c/session_manager 
+[VM] bazel test //orc8r/gateway/c/... //lte/gateway/c/... # to test all C/C++ targets
+[VM] bazel test //lte/gateway/python/magma/enodebd/... # to test all enodebd test targets
+[VM] bazel query "kind(py_test, //lte/gateway/python/magma/... union //orc8r/gateway/python/magma/...) except attr(tags, manual, kind(py_test, //lte/gateway/python/...))" # to list all python service unit tests
 ```
 
 ### Test Go AGW services

--- a/docs/readmes/lte/eventd.md
+++ b/docs/readmes/lte/eventd.md
@@ -80,4 +80,4 @@ An event must be defined before they can be send to `eventd` service.
 - Create a spec under `<plugin_name>/swagger` e.g. `lte/swagger/mock_events.v1.yml`, or add an event to one of the specs
 - Register the `event_type` and the location of the swagger file under `eventd.yml`'s event registry.
 - Make an RPC call to eventd's `log_event` from your service, using the appropriate client API.
-    - (Python-only) Use `make build` under `lte/gateway` to generate swagger models into the `$PYTHON_BUILD` directory. e.g. Use model `ue_added` with the import `<plugin_name>.swagger.models.ue_added`
+    - (Python-only) Use `bazel build $(bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/...)")` under any directory to generate swagger models into the `$PYTHON_BUILD` directory. e.g. Use model `ue_added` with the import `<plugin_name>.swagger.models.ue_added`

--- a/docs/readmes/lte/setup.md
+++ b/docs/readmes/lte/setup.md
@@ -29,8 +29,8 @@ Vagrant will bring up the VM, then Ansible will provision the VM.
 
 ```text
 HOST:magma/lte/gateway USER$ vagrant ssh magma
-AGW:~ USER$ cd magma/lte/gateway
-AGW:~/magma/lte/gateway USER$ make run
+AGW:~ USER$ cd magma
+AGW:~/magma USER$ bazel build $(bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/…)") && sudo service magma@* stop && sudo service magma@magmad start
 ```
 
 Once the Access Gateway VM is running successfully, proceed to attaching the eNodeB.

--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -38,7 +38,6 @@ The magma VM defined in [../Vagrantfile](../Vagrantfile) can be used to run the
 containerized AGW by running the following steps inside the VM:
 
 ```
-cd $MAGMA_ROOT/lte/gateway && make run  # You can skip this if you have built the AGW with make before
 for component in redis nghttpx td-agent-bit; do cp "${MAGMA_ROOT}"/{orc8r,lte}/gateway/configs/templates/${component}.conf.template; done
 sed -i 's/init_system: systemd/init_system: docker/' "${MAGMA_ROOT}"/lte/gateway/configs/magmad.yml
 sudo systemctl stop 'magma@*' 'sctpd' # We don't want the systemd-based AGW to run when we start the containerized AGW


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR is a preparation for the Bazel switchover. Documentation from code comments, Docusaurus and Github Wiki should be prepared, here old commands were changed to new ones in the documentation. 

The local setup for Bazel integration testing needs to be refactored to something more comfortable to use. (#14026)

Additionally to these changes the Github Wiki needs an update on the `Contributing-Code-with-VSCode.md` page.
There is mention of `make test_oai` and `make build_oai`.

## Test Plan

Proof reading.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
