### PR TITLE
refactor(orc8r): Remove proto.Clone calls

### DIFF
--- a/orc8r/cloud/go/services/configurator/storage/sql_entity_write_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_entity_write_helpers.go
@@ -19,12 +19,11 @@ import (
 	"reflect"
 	"sort"
 
-	sq "github.com/Masterminds/squirrel"
-	"github.com/thoas/go-funk"
-	"google.golang.org/protobuf/proto"
-
 	"magma/orc8r/cloud/go/sqorc"
 	"magma/orc8r/cloud/go/storage"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/thoas/go-funk"
 )
 
 func (store *sqlConfiguratorStorage) doesEntExist(networkID string, tk storage.TK) (bool, error) {
@@ -70,19 +69,18 @@ func (store *sqlConfiguratorStorage) doesPhysicalIDExist(physicalID string) (boo
 }
 
 func (store *sqlConfiguratorStorage) insertIntoEntityTable(networkID string, ent *NetworkEntity) (*NetworkEntity, error) {
-	entCopy := proto.Clone(ent).(*NetworkEntity)
-	entCopy.Pk = store.idGenerator.New()
-	entCopy.GraphID = store.idGenerator.New() // potentially-temporary graph ID
+	ent.Pk = store.idGenerator.New()
+	ent.GraphID = store.idGenerator.New() // potentially-temporary graph ID
 
 	_, err := store.builder.Insert(entityTable).
 		Columns(entPkCol, entNidCol, entTypeCol, entKeyCol, entGidCol, entNameCol, entDescCol, entPidCol, entConfCol).
-		Values(entCopy.Pk, networkID, entCopy.Type, entCopy.Key, entCopy.GraphID, toNullable(entCopy.Name), toNullable(entCopy.Description), toNullable(entCopy.PhysicalID), toNullable(entCopy.Config)).
+		Values(ent.Pk, networkID, ent.Type, ent.Key, ent.GraphID, toNullable(ent.Name), toNullable(ent.Description), toNullable(ent.PhysicalID), toNullable(ent.Config)).
 		RunWith(store.tx).
 		Exec()
 	if err != nil {
-		return &NetworkEntity{}, fmt.Errorf("error creating entity %s: %w", entCopy.GetTK(), err)
+		return &NetworkEntity{}, fmt.Errorf("error creating entity %s: %w", ent.GetTK(), err)
 	}
-	return entCopy, nil
+	return ent, nil
 }
 
 func (store *sqlConfiguratorStorage) createEdges(networkID string, entity *NetworkEntity) (EntitiesByTK, error) {

--- a/orc8r/cloud/go/services/configurator/storage/sql_entity_write_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_entity_write_helpers.go
@@ -19,11 +19,11 @@ import (
 	"reflect"
 	"sort"
 
-	"magma/orc8r/cloud/go/sqorc"
-	"magma/orc8r/cloud/go/storage"
-
 	sq "github.com/Masterminds/squirrel"
 	"github.com/thoas/go-funk"
+
+	"magma/orc8r/cloud/go/sqorc"
+	"magma/orc8r/cloud/go/storage"
 )
 
 func (store *sqlConfiguratorStorage) doesEntExist(networkID string, tk storage.TK) (bool, error) {

--- a/orc8r/cloud/go/services/configurator/storage/sql_integ_test.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_integ_test.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/proto"
-
 	"magma/orc8r/cloud/go/services/configurator/storage"
 	"magma/orc8r/cloud/go/sqorc"
 	orc8r_storage "magma/orc8r/cloud/go/storage"
 	"magma/orc8r/cloud/go/test_utils"
+
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -846,7 +845,7 @@ func TestSqlConfiguratorStorage_Integration(t *testing.T) {
 	// Load paginated entities of the same type
 	store, err = factory.StartTransaction(context.Background(), nil)
 	assert.NoError(t, err)
-	paginatedLoadCriteria := proto.Clone(&storage.FullEntityLoadCriteria).(*storage.EntityLoadCriteria)
+	paginatedLoadCriteria := &storage.FullEntityLoadCriteria
 	paginatedLoadCriteria.PageToken = ""
 	paginatedLoadCriteria.PageSize = 2
 	actualEntityLoad, err = store.LoadEntities("n1", &storage.EntityLoadFilter{TypeFilter: &wrappers.StringValue{Value: "foo"}}, paginatedLoadCriteria)

--- a/orc8r/cloud/go/services/configurator/storage/sql_integ_test.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_integ_test.go
@@ -18,13 +18,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+
 	"magma/orc8r/cloud/go/services/configurator/storage"
 	"magma/orc8r/cloud/go/sqorc"
 	orc8r_storage "magma/orc8r/cloud/go/storage"
 	"magma/orc8r/cloud/go/test_utils"
-
-	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -845,7 +846,7 @@ func TestSqlConfiguratorStorage_Integration(t *testing.T) {
 	// Load paginated entities of the same type
 	store, err = factory.StartTransaction(context.Background(), nil)
 	assert.NoError(t, err)
-	paginatedLoadCriteria := &storage.FullEntityLoadCriteria
+	paginatedLoadCriteria := proto.Clone(&storage.FullEntityLoadCriteria).(*storage.EntityLoadCriteria)
 	paginatedLoadCriteria.PageToken = ""
 	paginatedLoadCriteria.PageSize = 2
 	actualEntityLoad, err = store.LoadEntities("n1", &storage.EntityLoadFilter{TypeFilter: &wrappers.StringValue{Value: "foo"}}, paginatedLoadCriteria)

--- a/orc8r/cloud/go/services/configurator/storage/storage.go
+++ b/orc8r/cloud/go/services/configurator/storage/storage.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"sort"
 
-	"magma/orc8r/cloud/go/storage"
-
 	"github.com/golang/glog"
 	"github.com/thoas/go-funk"
+
+	"magma/orc8r/cloud/go/storage"
 )
 
 // ConfiguratorStorageFactory creates ConfiguratorStorage implementations bound

--- a/orc8r/cloud/go/services/configurator/storage/storage.go
+++ b/orc8r/cloud/go/services/configurator/storage/storage.go
@@ -18,11 +18,10 @@ import (
 	"fmt"
 	"sort"
 
+	"magma/orc8r/cloud/go/storage"
+
 	"github.com/golang/glog"
 	"github.com/thoas/go-funk"
-	"google.golang.org/protobuf/proto"
-
-	"magma/orc8r/cloud/go/storage"
 )
 
 // ConfiguratorStorageFactory creates ConfiguratorStorage implementations bound
@@ -162,12 +161,11 @@ func (m *NetworkEntity) GetTK() storage.TK {
 }
 
 func (m *NetworkEntity) GetGraphEdges() []*GraphEdge {
-	mCopy := proto.Clone(m).(*NetworkEntity)
-	myID := mCopy.GetID()
+	myID := m.GetID()
 	existingAssocs := map[storage.TK]bool{}
 
-	edges := make([]*GraphEdge, 0, len(mCopy.Associations))
-	for _, assoc := range mCopy.Associations {
+	edges := make([]*GraphEdge, 0, len(m.Associations))
+	for _, assoc := range m.Associations {
 		if _, exists := existingAssocs[assoc.ToTK()]; exists {
 			continue
 		}

--- a/orc8r/cloud/go/services/tenants/client_api.go
+++ b/orc8r/cloud/go/services/tenants/client_api.go
@@ -16,15 +16,14 @@ package tenants
 import (
 	"context"
 
-	"github.com/golang/glog"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
-
 	tenant_protos "magma/orc8r/cloud/go/services/tenants/protos"
 	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	srvRegistry "magma/orc8r/lib/go/registry"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // getTenantsClient is a utility function to get a RPC connection to the
@@ -92,12 +91,11 @@ func SetTenant(ctx context.Context, tenantID int64, tenant *tenant_protos.Tenant
 		return err
 	}
 
-	tenantCopy := proto.Clone(tenant).(*tenant_protos.Tenant)
 	_, err = oc.SetTenant(
 		ctx,
 		&tenant_protos.IDAndTenant{
 			Id:     tenantID,
-			Tenant: tenantCopy,
+			Tenant: tenant,
 		},
 	)
 	if err != nil {
@@ -155,8 +153,7 @@ func CreateOrUpdateControlProxy(ctx context.Context, controlProxy *tenant_protos
 		return err
 	}
 
-	controlProxyCopy := proto.Clone(controlProxy).(*tenant_protos.CreateOrUpdateControlProxyRequest)
-	_, err = oc.CreateOrUpdateControlProxy(ctx, controlProxyCopy)
+	_, err = oc.CreateOrUpdateControlProxy(ctx, controlProxy)
 	if err != nil {
 		return mapErr(err)
 	}

--- a/orc8r/cloud/go/services/tenants/client_api.go
+++ b/orc8r/cloud/go/services/tenants/client_api.go
@@ -16,14 +16,14 @@ package tenants
 import (
 	"context"
 
+	"github.com/golang/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	tenant_protos "magma/orc8r/cloud/go/services/tenants/protos"
 	"magma/orc8r/lib/go/merrors"
 	"magma/orc8r/lib/go/protos"
 	srvRegistry "magma/orc8r/lib/go/registry"
-
-	"github.com/golang/glog"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // getTenantsClient is a utility function to get a RPC connection to the


### PR DESCRIPTION
Closes #13698

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Replaced `proto.Clone` calls from the orc8r by passing references.
- Added some missing commas to comments.
- Changed empty slice creation using literals to nil slice declaration.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

Run unit tests.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

The remaining uses of `proto.Clone` in the orc8r are necessary.

I also checked occurrences of `proto.Clone` in the FeG, but these all appear to be required.

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
