### PR TITLE
chore: Clean up boolean arguments in fabfiles

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -12,7 +12,6 @@ limitations under the License.
 """
 
 import sys
-from distutils.util import strtobool
 from time import sleep
 
 from fabric.api import cd, env, execute, local, run, settings, sudo
@@ -24,6 +23,7 @@ import tools.fab.dev_utils as dev_utils
 import tools.fab.pkg as pkg
 from fabric.api import lcd
 from tools.fab.hosts import ansible_setup, split_hoststring, vagrant_setup
+from tools.fab.python_utils import strtobool
 from tools.fab.vagrant import setup_env_vagrant
 
 """
@@ -82,14 +82,14 @@ def release():
 
 
 def package(
-    all_deps="False",
+    all_deps='False',
     cert_file=DEFAULT_CERT, proxy_config=DEFAULT_PROXY,
     destroy_vm='False',
     vm='magma', os="ubuntu",
 ):
     """ Builds the magma package """
-    all_deps = False if all_deps == "False" else True
-    destroy_vm = bool(strtobool(destroy_vm))
+    all_deps = strtobool(all_deps)
+    destroy_vm = strtobool(destroy_vm)
 
     # If a host list isn't specified, default to the magma vagrant vm
     if not env.hosts:
@@ -158,7 +158,7 @@ def package(
 
 
 def openvswitch(destroy_vm='False', destdir='~/magma-packages/'):
-    destroy_vm = bool(strtobool(destroy_vm))
+    destroy_vm = strtobool(destroy_vm)
     # If a host list isn't specified, default to the magma vagrant vm
     if not env.hosts:
         vagrant_setup('magma', destroy_vm=destroy_vm)
@@ -256,11 +256,11 @@ def federated_integ_test(
         build_all='False', clear_orc8r='False', provision_vm='False',
         destroy_vm='False', orc8r_on_vagrant='False',
 ):
-    build_all = bool(strtobool(build_all))
-    clear_orc8r = bool(strtobool(clear_orc8r))
-    provision_vm = bool(strtobool(provision_vm))
-    destroy_vm = bool(strtobool(destroy_vm))
-    orc8r_on_vagrant = bool(strtobool(orc8r_on_vagrant))
+    build_all = strtobool(build_all)
+    clear_orc8r = strtobool(clear_orc8r)
+    provision_vm = strtobool(provision_vm)
+    destroy_vm = strtobool(destroy_vm)
+    orc8r_on_vagrant = strtobool(orc8r_on_vagrant)
 
     if orc8r_on_vagrant:
         # Modify Vagrantfile to allow access to Orc8r running inside Vagrant
@@ -300,7 +300,7 @@ def federated_integ_test(
     )
     execute(_make_integ_tests)
     sleep(20)
-    execute(run_integ_tests, federated_mode=True)
+    execute(run_integ_tests, federated_mode='True')
 
 
 def _modify_for_bazel_services():
@@ -322,8 +322,8 @@ def provision_magma_dev_vm(
         services on. Formatted as "host:port". If not specified, defaults to
         the `magma` vagrant box.
     """
-    destroy_vm = bool(strtobool(destroy_vm))
-    provision_vm = bool(strtobool(provision_vm))
+    destroy_vm = strtobool(destroy_vm)
+    provision_vm = strtobool(provision_vm)
 
     if not gateway_host:
         gateway_host = vagrant_setup(
@@ -356,8 +356,8 @@ def bazel_integ_test_post_build(
         on. Formatted as "host:port". If not specified, defaults to the
         `magma_trfserver` vagrant box.
     """
-    destroy_vm = bool(strtobool(destroy_vm))
-    provision_vm = bool(strtobool(provision_vm))
+    destroy_vm = strtobool(destroy_vm)
+    provision_vm = strtobool(provision_vm)
 
     gateway_ip = '192.168.60.142'
 
@@ -441,8 +441,8 @@ def integ_test(
         `magma_trfserver` vagrant box.
     """
 
-    destroy_vm = bool(strtobool(destroy_vm))
-    provision_vm = bool(strtobool(provision_vm))
+    destroy_vm = strtobool(destroy_vm)
+    provision_vm = strtobool(provision_vm)
 
     # Set up the gateway: use the provided gateway if given, else default to the
     # vagrant machine
@@ -491,8 +491,8 @@ def integ_test_deb_installation(
         `magma_trfserver` vagrant box.
     """
 
-    destroy_vm = bool(strtobool(destroy_vm))
-    provision_vm = bool(strtobool(provision_vm))
+    destroy_vm = strtobool(destroy_vm)
+    provision_vm = strtobool(provision_vm)
 
     # Set up the gateway: use the provided gateway if given, else default to the
     # vagrant machine
@@ -556,7 +556,7 @@ def _start_gateway_containerized():
         run('sleep 60; docker-compose ps')
 
 
-def run_integ_tests(tests=None, federated_mode=False):
+def run_integ_tests(tests=None, federated_mode='False'):
     """
     Function is required to run tests only in pre-configured Jenkins env.
 
@@ -581,28 +581,15 @@ def run_integ_tests(tests=None, federated_mode=False):
     if tests:
         tests = "TESTS=" + tests
 
-    execute(_run_integ_tests, gateway_ip, tests, _to_boolean(federated_mode))
-
-
-def _to_boolean(value):
-    """Fabric function arguments passed by calling fab from external are strings.
-    This is, boolean arguments set to "True" and "False" must be interpreted.
-    """
-    if isinstance(value, bool):
-        return value
-
-    if not isinstance(value, str):
-        raise ValueError('Input can not be parsed to boolean - not a string or a boolean.')
-
-    return bool(strtobool(value))
+    execute(_run_integ_tests, gateway_ip, tests, strtobool(federated_mode))
 
 
 def get_test_summaries(
         gateway_host=None,
         test_host=None,
         dst_path="/tmp",
-        integration_tests=True,
-        sudo_tests=True,
+        integration_tests='True',
+        sudo_tests='True',
         dev_vm_name="magma",
 ):
     local('mkdir -p ' + dst_path)
@@ -612,11 +599,11 @@ def get_test_summaries(
         "magma_deb": "magma_deb.yml",
     }
 
-    if _to_boolean(sudo_tests):
+    if strtobool(sudo_tests):
         _switch_to_vm_no_provision(gateway_host, dev_vm_name, vm_name_to_yaml[dev_vm_name])
         with settings(warn_only=True):
             get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
-    if _to_boolean(integration_tests):
+    if strtobool(integration_tests):
         _switch_to_vm_no_provision(test_host, "magma_test", "magma_test.yml")
         with settings(warn_only=True):
             get(remote_path=TEST_SUMMARY_GLOB, local_path=dst_path)
@@ -716,7 +703,7 @@ def get_test_logs(
     local('rm -rf /tmp/build_logs')
 
 
-def load_test(gateway_host=None, destroy_vm=True):
+def load_test(gateway_host=None, destroy_vm='True'):
     """
     Run the load performance tests. This defaults to running on local vagrant
     machines, but can also be pointed to an arbitrary host (e.g. amazon) by
@@ -735,7 +722,7 @@ def load_test(gateway_host=None, destroy_vm=True):
         ansible_setup(gateway_host, 'dev', 'magma_dev.yml')
         gateway_ip = gateway_host.split('@')[1].split(':')[0]
     else:
-        gateway_host = vagrant_setup('magma', _to_boolean(destroy_vm))
+        gateway_host = vagrant_setup('magma', strtobool(destroy_vm))
         gateway_ip = '192.168.60.142'
 
     execute(_build_magma)
@@ -763,8 +750,8 @@ def build_and_start_magma(gateway_host=None, destroy_vm='False', provision_vm='F
     Returns:
 
     """
-    provision_vm = bool(strtobool(provision_vm))
-    destroy_vm = bool(strtobool(destroy_vm))
+    provision_vm = strtobool(provision_vm)
+    destroy_vm = strtobool(destroy_vm)
     if gateway_host:
         ansible_setup(gateway_host, 'dev', 'magma_dev.yml')
     else:
@@ -775,8 +762,8 @@ def build_and_start_magma(gateway_host=None, destroy_vm='False', provision_vm='F
 
 
 def make_integ_tests(test_host=None, destroy_vm='False', provision_vm='False'):
-    destroy_vm = bool(strtobool(destroy_vm))
-    provision_vm = bool(strtobool(provision_vm))
+    destroy_vm = strtobool(destroy_vm)
+    provision_vm = strtobool(provision_vm)
     if not test_host:
         vagrant_setup('magma_test', destroy_vm, force_provision=provision_vm)
     else:
@@ -785,8 +772,8 @@ def make_integ_tests(test_host=None, destroy_vm='False', provision_vm='False'):
 
 
 def build_and_start_magma_trf(test_host=None, destroy_vm='False', provision_vm='False'):
-    destroy_vm = bool(strtobool(destroy_vm))
-    provision_vm = bool(strtobool(provision_vm))
+    destroy_vm = strtobool(destroy_vm)
+    provision_vm = strtobool(provision_vm)
     if not test_host:
         vagrant_setup('magma_trfserver', destroy_vm, force_provision=provision_vm)
     else:
@@ -795,8 +782,8 @@ def build_and_start_magma_trf(test_host=None, destroy_vm='False', provision_vm='
 
 
 def start_magma(test_host=None, destroy_vm='False', provision_vm='False'):
-    destroy_vm = bool(strtobool(destroy_vm))
-    provision_vm = bool(strtobool(provision_vm))
+    destroy_vm = strtobool(destroy_vm)
+    provision_vm = strtobool(provision_vm)
     if not test_host:
         vagrant_setup('magma', destroy_vm, force_provision=provision_vm)
     else:
@@ -805,6 +792,8 @@ def start_magma(test_host=None, destroy_vm='False', provision_vm='False'):
 
 
 def build_test_vms(provision_vm='False', destroy_vm='False'):
+    destroy_vm = strtobool(destroy_vm)
+    provision_vm = strtobool(provision_vm)
     vagrant_setup(
         'magma_trfserver', destroy_vm, force_provision=provision_vm,
     )

--- a/lte/gateway/python/integ_tests/federated_tests/fabfile.py
+++ b/lte/gateway/python/integ_tests/federated_tests/fabfile.py
@@ -14,13 +14,13 @@ limitations under the License.
 import subprocess
 import sys
 import time
-from distutils.util import strtobool
 
 from fabric.api import cd, run
 
 sys.path.append('../../../../../orc8r')
 import tools.fab.dev_utils as dev_utils
 from tools.fab.hosts import vagrant_setup
+from tools.fab.python_utils import strtobool
 
 magma_path = "../../../../../"
 orc8_docker_path = magma_path + "orc8r/cloud/docker/"
@@ -63,7 +63,7 @@ def build_all(clear_orc8r='False', provision_vm='False', orc8r_on_vagrant='False
     build_feg()
     build_agw(provision_vm=provision_vm)
 
-    if clear_orc8r:
+    if strtobool(clear_orc8r):
         clear_orc8r_db()
 
     # build other VMs
@@ -75,7 +75,7 @@ def build_orc8r(on_vagrant='False'):
     """
     Build orc8r locally on the host VM
     """
-    on_vagrant = bool(strtobool(on_vagrant))
+    on_vagrant = strtobool(on_vagrant)
     command = './build.py -a'
     if not on_vagrant:
         subprocess.check_call(command, shell=True, cwd=orc8_docker_path)
@@ -89,7 +89,7 @@ def start_orc8r(on_vagrant='False'):
     """
     Start orc8r locally on Docker
     """
-    on_vagrant = bool(strtobool(on_vagrant))
+    on_vagrant = strtobool(on_vagrant)
     command = './run.py'
     if not on_vagrant:
         subprocess.check_call(command, shell=True, cwd=orc8_docker_path)
@@ -103,7 +103,7 @@ def stop_orc8r(on_vagrant='False'):
     """
     Start orc8r locally on Docker
     """
-    on_vagrant = bool(strtobool(on_vagrant))
+    on_vagrant = strtobool(on_vagrant)
     command = './run.py --down'
     if not on_vagrant:
         subprocess.check_call(command, shell=True, cwd=orc8_docker_path)
@@ -117,7 +117,7 @@ def configure_orc8r(on_vagrant='False'):
     """
     Configure orc8r with a federated AGW and FEG
     """
-    on_vagrant = bool(strtobool(on_vagrant))
+    on_vagrant = strtobool(on_vagrant)
     print('#### Configuring orc8r ####')
     command_agw = 'fab --fabfile=dev_tools.py register_federated_vm'
     command_feg = 'fab register_feg_gw'
@@ -341,7 +341,6 @@ def build_and_test_all(
         provision_vm: forces the re-provision of the magma VM
         timeout: amount of time the command will retry
     """
-    orc8r_on_vagrant = bool(strtobool(orc8r_on_vagrant))
     build_all(clear_orc8r, provision_vm, orc8r_on_vagrant=orc8r_on_vagrant)
     start_all(orc8r_on_vagrant=orc8r_on_vagrant)
     configure_orc8r()

--- a/orc8r/tools/fab/BUILD.bazel
+++ b/orc8r/tools/fab/BUILD.bazel
@@ -1,0 +1,18 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "python_utils",
+    srcs = ["python_utils.py"],
+    visibility = ["//visibility:public"],
+)

--- a/orc8r/tools/fab/python_utils.py
+++ b/orc8r/tools/fab/python_utils.py
@@ -1,0 +1,35 @@
+"""
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+def strtobool(boolstring: str) -> bool:
+    """
+    Convert a string representation of truth to true (1) or false (0).
+    True values are y, yes, t, true, on and 1;
+    False values are n, no, f, false, off and 0.
+    Raises ValueError if boolstring is anything else.
+
+    This function is a replacement for distutils.util.strtobool,
+    which will be deprecated in Python v3.10. The goal of reimplementing
+    this function is to future proof the code. For more information see:
+    https://peps.python.org/pep-0632/ 
+    """
+    original = boolstring
+    if not isinstance(boolstring, str):
+        raise ValueError("The provided value is not a string.")
+    boolstring = boolstring.lower()
+    if boolstring in ["y", "yes", "t", "true", "on", "1"]:
+        return True
+    if boolstring in ["n", "no", "f", "false", "off", "0"]:
+        return False
+    raise ValueError("Value '{}' could not be converted to bool.".format(original))

--- a/orc8r/tools/fab/tests/BUILD.bazel
+++ b/orc8r/tools/fab/tests/BUILD.bazel
@@ -1,0 +1,19 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:python_test.bzl", "pytest_test")
+
+pytest_test(
+    name = "test_python_utils",
+    size = "small",
+    srcs = ["test_python_utils.py"],
+    deps = ["//orc8r/tools/fab:python_utils"],
+)

--- a/orc8r/tools/fab/tests/test_python_utils.py
+++ b/orc8r/tools/fab/tests/test_python_utils.py
@@ -1,0 +1,82 @@
+from unittest import TestCase
+
+from orc8r.tools.fab.python_utils import strtobool
+
+
+class StrToBoolTestCase(TestCase):
+
+    def test_true_values(self):
+        self.assertTrue(strtobool("y"))
+        self.assertTrue(strtobool("yes"))
+        self.assertTrue(strtobool("t"))
+        self.assertTrue(strtobool("true"))
+        self.assertTrue(strtobool("on"))
+        self.assertTrue(strtobool("1"))
+        self.assertTrue(strtobool("YES"))
+        self.assertTrue(strtobool("TRUE"))
+        self.assertTrue(strtobool("On"))
+        self.assertTrue(strtobool("Y"))
+        self.assertTrue(strtobool("yEs"))
+
+    def test_false_values(self):
+        self.assertFalse(strtobool("n"))
+        self.assertFalse(strtobool("no"))
+        self.assertFalse(strtobool("f"))
+        self.assertFalse(strtobool("false"))
+        self.assertFalse(strtobool("off"))
+        self.assertFalse(strtobool("0"))
+        self.assertFalse(strtobool("NO"))
+        self.assertFalse(strtobool("FALSE"))
+        self.assertFalse(strtobool("Off"))
+        self.assertFalse(strtobool("N"))
+        self.assertFalse(strtobool("FaLsE"))
+
+    def test_not_string_input(self):
+        with self.assertRaises(ValueError) as context:
+            strtobool(1)
+        self.assertTrue("The provided value is not a string." == str(context.exception))
+        with self.assertRaises(ValueError) as context:
+            strtobool(0)
+        self.assertTrue("The provided value is not a string." == str(context.exception))
+        with self.assertRaises(ValueError) as context:
+            strtobool(TestCase())
+        self.assertTrue("The provided value is not a string." == str(context.exception))
+        with self.assertRaises(ValueError) as context:
+            strtobool(object())
+        self.assertTrue("The provided value is not a string." == str(context.exception))
+        with self.assertRaises(ValueError) as context:
+            strtobool(True)
+        self.assertTrue("The provided value is not a string." == str(context.exception))
+        with self.assertRaises(ValueError) as context:
+            strtobool(False)
+        self.assertTrue("The provided value is not a string." == str(context.exception))
+
+    def test_incorrect_string_input(self):
+        wrong_string = "Hello"
+        with self.assertRaises(ValueError) as context:
+            strtobool(wrong_string)
+        self.assertTrue("Value '{}' could not be converted to bool.".format(wrong_string) == str(context.exception))
+        wrong_string = "treu"
+        with self.assertRaises(ValueError) as context:
+            strtobool(wrong_string)
+        self.assertTrue("Value '{}' could not be converted to bool.".format(wrong_string) == str(context.exception))
+        wrong_string = "OFFF"
+        with self.assertRaises(ValueError) as context:
+            strtobool(wrong_string)
+        self.assertTrue("Value '{}' could not be converted to bool.".format(wrong_string) == str(context.exception))
+        wrong_string = "untrue"
+        with self.assertRaises(ValueError) as context:
+            strtobool(wrong_string)
+        self.assertTrue("Value '{}' could not be converted to bool.".format(wrong_string) == str(context.exception))
+        wrong_string = "TrUtH"
+        with self.assertRaises(ValueError) as context:
+            strtobool(wrong_string)
+        self.assertTrue("Value '{}' could not be converted to bool.".format(wrong_string) == str(context.exception))
+        wrong_string = "-1"
+        with self.assertRaises(ValueError) as context:
+            strtobool(wrong_string)
+        self.assertTrue("Value '{}' could not be converted to bool.".format(wrong_string) == str(context.exception))
+        wrong_string = "truefalse"
+        with self.assertRaises(ValueError) as context:
+            strtobool(wrong_string)
+        self.assertTrue("Value '{}' could not be converted to bool.".format(wrong_string) == str(context.exception))


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>



## Summary

In fabfiles the boolean arguments were not standardized. Calling a fabric function from the command line with a boolean argument will pass a string to it. This PR ensures that all of the public functions expect string-boolean values and only use them for conditions if they have been converted to boolean. This closes #14031.

Additionally, the `distutils.util.strtobool` function will be deprecated in Python v3.10, therefore a new converter function was created. For more information see: https://peps.python.org/pep-0632/

## Test Plan

CI.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
