### PR TITLE
fix(lte): Fixed `detect_init_system`

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -875,7 +875,7 @@ class MagmadUtil(object):
         if self._init_system is None:
             self._init_system = self.detect_init_system()
 
-    def exec_command(self, command):
+    def exec_command(self, command: str) -> int:
         """Run a command remotely on magma_dev VM.
 
         Args:
@@ -893,7 +893,7 @@ class MagmadUtil(object):
             stderr=subprocess.DEVNULL,
         )
 
-    def exec_command_output(self, command):
+    def exec_command_output(self, command: str) -> str:
         """Run a command remotely on magma_dev VM.
 
         Args:
@@ -909,15 +909,18 @@ class MagmadUtil(object):
             shell=False,
         ).decode("utf-8")
 
-    def exec_command_capture_output(self, command):
+    def exec_command_capture_output(self, command: str) -> subprocess.CompletedProcess:
         """Run a command remotely on magma_dev VM.
+
+        Unlike `exec_command_output`, this method does not cause an exception
+        if the command returns a non-zero error code.
 
         Args:
             command: command (str) to be executed on remote host
             e.g. 'sed -i \'s/config1/config2/g\' /etc/magma/mme.yml'
 
         Returns:
-            output of command execution
+            Output  of command execution as instance of subprocess.CompletedProcess
         """
         param_list = shlex.split(self._command.format(**self._credentials, command=f'"{command}"'))
         return subprocess.run(
@@ -935,10 +938,10 @@ class MagmadUtil(object):
             "systemctl is-active magma@magmad",
         )
         docker_magmad_running = \
-            self._is_installed("docker") & \
+            self._is_installed("docker") and \
             (res_docker.stdout.decode("utf-8").strip('\n') == 'magmad')
         systemd_magmad_running = \
-            self._is_installed("systemctl") & \
+            self._is_installed("systemctl") and \
             (res_systemd.stdout.decode("utf-8").strip('\n') == 'active')
 
         if systemd_magmad_running:

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -909,51 +909,25 @@ class MagmadUtil(object):
             shell=False,
         ).decode("utf-8")
 
-    def exec_command_capture_output(self, command: str) -> subprocess.CompletedProcess:
-        """Run a command remotely on magma_dev VM.
-
-        Unlike `exec_command_output`, this method does not cause an exception
-        if the command returns a non-zero error code.
-
-        Args:
-            command: command (str) to be executed on remote host
-            e.g. 'sed -i \'s/config1/config2/g\' /etc/magma/mme.yml'
-
-        Returns:
-            Output  of command execution as instance of subprocess.CompletedProcess
-        """
-        param_list = shlex.split(self._command.format(**self._credentials, command=f'"{command}"'))
-        return subprocess.run(
-            param_list,
-            shell=False,
-            capture_output=True,
-        )
-
     def detect_init_system(self) -> InitMode:
         """Detect whether services are running with Docker or systemd."""
-        res_docker = self.exec_command_capture_output(
-            "docker ps --filter 'name=magmad' --format '{{.Names}}'",
+        if self._is_installed("systemctl"):
+            ret = self.exec_command_output(
+                "systemctl is-active magma@magmad",
+            ).strip('\n')
+            if ret == 'active':
+                # default to systemd if docker and systemd are running - needed by feg integ tests
+                return InitMode.SYSTEMD
+        if self._is_installed("docker"):
+            ret = self.exec_command_output(
+                "docker ps --filter 'name=magmad' --format '{{.Names}}'",
+            ).strip('\n')
+            if ret == 'magmad':
+                return InitMode.DOCKER
+        raise RuntimeError(
+            "Magmad is not running, you have to start magmad "
+            "either in Docker or systemd",
         )
-        res_systemd = self.exec_command_capture_output(
-            "systemctl is-active magma@magmad",
-        )
-        docker_magmad_running = \
-            self._is_installed("docker") and \
-            (res_docker.stdout.decode("utf-8").strip('\n') == 'magmad')
-        systemd_magmad_running = \
-            self._is_installed("systemctl") and \
-            (res_systemd.stdout.decode("utf-8").strip('\n') == 'active')
-
-        if systemd_magmad_running:
-            # default to systemd if docker and systemd are running - needed by feg integ tests
-            return InitMode.SYSTEMD
-        elif docker_magmad_running:
-            return InitMode.DOCKER
-        else:
-            raise RuntimeError(
-                "Magmad is not running, you have to start magmad "
-                "either in Docker or systemd",
-            )
 
     def _is_installed(self, cmd):
         """Check if a command is installed on the system."""

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -909,25 +909,51 @@ class MagmadUtil(object):
             shell=False,
         ).decode("utf-8")
 
+    def exec_command_capture_output(self, command: str) -> subprocess.CompletedProcess:
+        """Run a command remotely on magma_dev VM.
+
+        Unlike `exec_command_output`, this method does not raise an exception
+        if the command returns a non-zero error code.
+
+        Args:
+            command: command (str) to be executed on remote host
+            e.g. 'sed -i \'s/config1/config2/g\' /etc/magma/mme.yml'
+
+        Returns:
+            Output  of command execution as instance of subprocess.CompletedProcess
+        """
+        param_list = shlex.split(self._command.format(**self._credentials, command=f'"{command}"'))
+        return subprocess.run(
+            param_list,
+            shell=False,
+            capture_output=True,
+        )
+
     def detect_init_system(self) -> InitMode:
         """Detect whether services are running with Docker or systemd."""
-        if self._is_installed("systemctl"):
-            ret = self.exec_command_output(
-                "systemctl is-active magma@magmad",
-            ).strip('\n')
-            if ret == 'active':
-                # default to systemd if docker and systemd are running - needed by feg integ tests
-                return InitMode.SYSTEMD
-        if self._is_installed("docker"):
-            ret = self.exec_command_output(
-                "docker ps --filter 'name=magmad' --format '{{.Names}}'",
-            ).strip('\n')
-            if ret == 'magmad':
-                return InitMode.DOCKER
-        raise RuntimeError(
-            "Magmad is not running, you have to start magmad "
-            "either in Docker or systemd",
+        res_docker = self.exec_command_capture_output(
+            "docker ps --filter 'name=magmad' --format '{{.Names}}'",
         )
+        res_systemd = self.exec_command_capture_output(
+            "systemctl is-active magma@magmad",
+        )
+        docker_magmad_running = \
+            self._is_installed("docker") and \
+            (res_docker.stdout.decode("utf-8").strip('\n') == 'magmad')
+        systemd_magmad_running = \
+            self._is_installed("systemctl") and \
+            (res_systemd.stdout.decode("utf-8").strip('\n') == 'active')
+
+        if systemd_magmad_running:
+            # default to systemd if docker and systemd are running - needed by feg integ tests
+            return InitMode.SYSTEMD
+        elif docker_magmad_running:
+            return InitMode.DOCKER
+        else:
+            raise RuntimeError(
+                "Magmad is not running, you have to start magmad "
+                "either in Docker or systemd",
+            )
 
     def _is_installed(self, cmd):
         """Check if a command is installed on the system."""


### PR DESCRIPTION
Closes #14033


Signed-off-by: Moritz Huebner <moritz.huebner@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Added `exec_command_capture_output` to allow running commands that return non-zero status codes without raising an exception.
- Moved `_is_installed` function outside `detect_init_system`.
- Simplified docker/systemd_magmad_running logic.
- Renamed `MagmadUtil._data` to `MagmadUtil._credentials` and removed "command" key.
- No longer write "command" to `MagmadUtil._credentials`, as this was not used anyway.


## Test Plan

See if an integration test can be started
- [x] with a dockerized setup
- [x] with a systemd setup 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->