### PR TITLE
fix(agw): all `ROOTCA_PATH` variables are deleted

### DIFF
--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -26,7 +26,6 @@ x-magmad-volumes: &magmad_volumes_anchor
   - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
   - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
   - ${CONFIGS_OVERRIDE_TMP_VOLUME}:/var/opt/magma/tmp
-  - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
   - /etc/snowflake:/etc/snowflake
   - /var/opt/magma/fluent-bit:/var/opt/magma/fluent-bit
   - ./:/var/opt/magma/docker


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

With PR #13862, not all mentions of the `ROOTCA_PATH` in the `docker-compose.yaml` were deleted and running the containerized AGW did not work. Here, we remove the latest mention of the variable. This should enable CI workflows for the containerized AGW again, see a failing run i.e. [HERE](https://github.com/magma/magma/actions/runs/3149501215/jobs/5121191496).

## Test Plan

- [x] Set up the containerized AGW (using the [README](https://github.com/magma/magma/blob/master/lte/gateway/docker/README.md#running-the-containerized-agw-locally-on-the-magma-vm)) and 
- [x] connect to an Orchestrator following (the latest version of) the [Quick Start Guide](https://docs.magmacore.org/docs/basics/quick_start_guide).

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
