### PR TITLE
fix(ci): use correct variable offered by dispatch action

### DIFF
--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           MAGMA_DEV_CPUS: 3
           MAGMA_DEV_MEMORY_MB: 9216
-          MAGMA_PACKAGE: ${{ github.event.client_payload.magma_package }}
+          MAGMA_PACKAGE: ${{ github.event.client_payload.artifact }}
         run: |
           cd lte/gateway
           fab integ_test_deb_installation


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary
https://github.com/magma/magma/pull/13983 uses a the wrong environment variable. The result is that the `lte-integ-test-magma-deb` workflow always install the latest magma package version in the magma debian vm.

https://github.com/magma/magma/blob/1bd2b73c646aeeb286601ee90e9f83164786078a/.github/workflows/build_all.yml#L1014

https://github.com/magma/magma/blob/1bd2b73c646aeeb286601ee90e9f83164786078a/.github/workflows/lte-integ-test-magma-deb.yml#L57

The `lte-integ-test-magma-deb` workflow  uses `magma_package`  in line 57  but needs `artifact` which is define in `build-all` in line 1014.

## Test Plan
Can only be seen on the magma master branch after the PR is merged and the` agw-build` job in `build-all` run through.
