### PR TITLE
chore: cache key of bazel base and image tag are updated

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -28,8 +28,9 @@ concurrency:
 
 env:
   DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:sha-4a878d8"
-  CACHE_KEY: bazel-base-image
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  # see GH14041
+  CACHE_KEY: bazel-base-image-sha-c4de1e5
   REMOTE_DOWNLOAD_OPTIMIZATION: true
 
 jobs:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -23,8 +23,9 @@ on:
       - master
 
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:sha-4a878d8"
-  CACHE_KEY: bazel-base-image
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  # see GH14041
+  CACHE_KEY: bazel-base-image-sha-c4de1e5
   REMOTE_DOWNLOAD_OPTIMIZATION: true
 
 concurrency:

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -26,8 +26,9 @@ on:
       - master
       - 'v1.*'
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:sha-4a878d8"
-  CACHE_KEY: bazel-base-image
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  # see GH14041
+  CACHE_KEY: bazel-base-image-sha-c4de1e5
   REMOTE_DOWNLOAD_OPTIMIZATION: true
 
 concurrency:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Closes #13818.

Last step of aligning folly in the vm and in the bazel base image. See https://github.com/magma/magma/wiki/Bazel-remote-caching#solving-breaking-changes-in-remote-caches for a detailed description.

Note: already filled caches from a local setup for `bazel-base-image-sha-c4de1e5`.

## Test Plan

* read (and correct if necessary) https://github.com/magma/magma/wiki/Bazel-remote-caching#solving-breaking-changes-in-remote-caches
* see bazel jobs succeed in PR checks

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
