### PR TITLE
fix(orc8r): Correctly initialize array to allow removing assocs

### DIFF
--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -1365,6 +1365,25 @@ func TestUpdateSubscriber(t *testing.T) {
 	}
 	assert.Equal(t, expected, actual)
 
+	// Test deleting all active APNs
+	payload.ActiveApns = subscriberModels.ApnList{}
+	payload.StaticIps = subscriberModels.SubscriberStaticIps{}
+	tests.RunUnitTest(t, e, tc)
+	expected = configurator.NetworkEntity{
+		NetworkID:    "n1",
+		Type:         lte.SubscriberEntityType,
+		Key:          "IMSI1234567890",
+		Name:         "Jane Doe",
+		Config:       &subscriberModels.SubscriberConfig{Lte: payload.Lte, StaticIps: nil},
+		GraphID:      "2",
+		Version:      2,
+		Associations: nil,
+	}
+	expected.Config = &subscriberModels.SubscriberConfig{Lte: payload.Lte, StaticIps: nil}
+	actual, err = configurator.LoadEntity(context.Background(), "n1", lte.SubscriberEntityType, "IMSI1234567890", configurator.FullEntityLoadCriteria(), serdes.Entity)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+
 	// No profile matching
 	payload.Lte.SubProfile = &subProfileBar
 	tc = tests.Test{

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
@@ -180,7 +180,7 @@ func (m *MutableSubscriber) FromEnt(ent configurator.NetworkEntity, policyProfil
 }
 
 func (m *MutableSubscriber) GetAssocs() storage.TKs {
-	var assocs storage.TKs
+	assocs := storage.TKs{}
 	assocs = append(assocs, m.ActivePoliciesByApn.ToTKs(string(m.ID))...)
 	assocs = append(assocs, m.ActiveApns.ToTKs()...)
 	assocs = append(assocs, m.ActivePolicies.ToTKs()...)


### PR DESCRIPTION
## Summary

The DB framework will only remove associations if they are set to an empty array, and ignore changes if they are set to nil. This makes it necessary to initialize the array correctly.

Fixes #13507 - removing all active APNs of a subscriber was not possible.

## Test Plan

* Opening a subscriber in local NMS and removing all active APNs is possible.
* Adapted an existing unit test to include this case.

## Additional Information

- [ ] This change is backwards-breaking
