### PR TITLE
chore: pip performance is improved by ipv4 over ipv6 precedence

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -78,9 +78,7 @@ jobs:
         run: |
           cd lte/gateway
           vagrant ssh -c 'cd ~/magma; bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}";' magma
-          vagrant ssh -c 'sudo sed -i "s@#precedence ::ffff:0:0/96  100@precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
           vagrant ssh -c 'cd ~/magma; bazel build --profile=bazel_profile_lte_integ_tests `bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/...)"`;' magma
-          vagrant ssh -c 'sudo sed -i "s@precedence ::ffff:0:0/96  100@#precedence ::ffff:0:0/96  100@" /etc/gai.conf;' magma
       - name: Linking bazel-built script executables to '/usr/local/bin/'
         run: |
           cd lte/gateway

--- a/lte/gateway/deploy/magma_dev_focal.yml
+++ b/lte/gateway/deploy/magma_dev_focal.yml
@@ -23,6 +23,7 @@
     full_provision: true
 
   roles:
+    - role: gai_config
     - role: gateway_dev
       vars:
         distribution: "focal"

--- a/lte/gateway/deploy/magma_test.yml
+++ b/lte/gateway/deploy/magma_test.yml
@@ -1,4 +1,17 @@
 ---
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 - name: Set up Magma test environment on a local machine
   hosts: test
   become: yes
@@ -9,6 +22,7 @@
     full_provision: true
 
   roles:
+    - role: gai_config
     - role: apt_cache
       vars:
         distribution: "focal"

--- a/lte/gateway/deploy/roles/gai_config/tasks/main.yml
+++ b/lte/gateway/deploy/roles/gai_config/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-################################################################################
 # Copyright 2022 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -10,13 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
-- name: Set up Magma environment based on debian package for integration testing
-  hosts: deb
-  become: yes
-
-  roles:
-    - role: gai_config
-    - role: magma_deb
-    - role: service_aliases
+- name: Prefer ipv4 over ipv6 in getaddrinfo
+  replace:
+    dest: /etc/gai.conf
+    regexp: '^#precedence ::ffff:0:0/96  100'
+    replace: 'precedence ::ffff:0:0/96  100'


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

There is no ipv6 interface defined on the vms that is able to do external communication. Various tools (also pip) use getaddrinfo for communication with a service. This has per default an ipv6 preference. If ipv6 endpoints are not reachable then this can take much longer than needed.
Here: change to an ipv4 over ipv6 preference.

To reproduce:
* run `time pip3 install pip-install-test` with and without this change (can be done without sourcing or restarting)
* without ipv4 preference:
```
vagrant@magma-deb:~$ time pip3 install pip-install-test
Collecting pip-install-test
  Using cached pip_install_test-0.5-py3-none-any.whl (1.7 kB)
Installing collected packages: pip-install-test
Successfully installed pip-install-test-0.5

real	0m13.822s
user	0m1.329s
sys	0m0.132s
```
* with ipv4 preference:
```
vagrant@magma-deb:~$ time pip3 install pip-install-test
Collecting pip-install-test
  Using cached pip_install_test-0.5-py3-none-any.whl (1.7 kB)
Installing collected packages: pip-install-test
Successfully installed pip-install-test-0.5

real	0m1.707s
user	0m1.360s
sys	0m0.163s
```
* -> `real 0m13.822s` vs `real 0m1.707s`

Note: there might be a better way to configure the network interfaces of the VMs - until now I did not find a more clean way.

## Test Plan

Make sure no integration test depends on an ipv6 preference: 
* lte integ tests: https://github.com/nstng/magma/actions/runs/3159729632
  * test_3485_timer_for_default_bearer_with_mme_restart failed -> should not be related to change
* lte integ tests bazel: https://github.com/nstng/magma/actions/runs/3159735914
  * test_attach_detach_with_mobilityd_restart failed -> should not be related to change
* lte integ tests debian: https://github.com/nstng/magma/actions/runs/3159740729
  * currently bug for run on forks
* :heavy_check_mark: cwf integ tests: https://github.com/nstng/magma/actions/runs/3159744715
* :heavy_check_mark: feg integ tests: https://github.com/nstng/magma/actions/runs/3159749260
* :heavy_check_mark: sudo tests: https://github.com/nstng/magma/actions/runs/3159753275

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
