### PR TITLE
chore(ci): enable manual execution of the integ test magma_deb in ci

### DIFF
--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -160,7 +160,7 @@
     dpkg_options: 'force-confold,force-confdef,force-overwrite'
   vars:
     packages:
-      - "{{ MAGMA_PACKAGE | default('magma') }}"
+      - "{{ MAGMA_PACKAGE | default('magma', true) }}"
 
 # Install openvswitch in containerized agw only
 - name: Install prebuilt openvswitch packages


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

The PR fixes an issues where the Task `[magma_deb : Install magma]` fails when the lte integ test for magma_deb is triggered by hand in the CI. The reason is that the env variable that holds the debian magma package version is empty.
Now a default is used when the env variable is empty or not defined.


## Test Plan

- [x] build magma_deb locally
- [x] run lte integ test magma_deb workflow in CI
