### PR TITLE
docs(agw): start-up procedure for containerized AGW is improved

### DIFF
--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -38,10 +38,9 @@ The magma VM defined in [../Vagrantfile](../Vagrantfile) can be used to run the
 containerized AGW by running the following steps inside the VM:
 
 ```
-cd $MAGMA_ROOT/lte/gateway && make run  # You can skip this if you have built the AGW with make before
+cd $MAGMA_ROOT/lte/gateway && make build  # You can skip this if you have built the AGW with make before
 for component in redis nghttpx td-agent-bit; do cp "${MAGMA_ROOT}"/{orc8r,lte}/gateway/configs/templates/${component}.conf.template; done
 sed -i 's/init_system: systemd/init_system: docker/' "${MAGMA_ROOT}"/lte/gateway/configs/magmad.yml
-sudo systemctl stop 'magma@*' 'sctpd' # We don't want the systemd-based AGW to run when we start the containerized AGW
 sudo systemctl start magma_dp@envoy
 
 # Optional: If you want to connect to an orc8r, copy the `rootCA.pem` from the orc8r


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary

The procedure to run the containerized AGW on the local Magma VM requires as a first step the AGW to be built with make. With this PR, the commands are changed from a `make run` followed by stopping the `magma@*` services to only build the AGW without starting the services in the first place.

## Test Plan

Follow the new procedure.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
