### PR TITLE
fix(nms): statistics not showing for non super users

### DIFF
--- a/nms/app/components/insights/GatewayMetrics.tsx
+++ b/nms/app/components/insights/GatewayMetrics.tsx
@@ -39,7 +39,7 @@ export default function (props: {configs: Array<MetricGraphConfig>}) {
     return <LoadingFiller />;
   }
 
-  const gatewayNames = Object.keys((selectors as any).gateways);
+  const gatewayNames = Object.keys(selectors.gateways);
   const defaultGateway = gatewayNames[0];
 
   const metrics = (

--- a/nms/app/components/insights/GatewayMetrics.tsx
+++ b/nms/app/components/insights/GatewayMetrics.tsx
@@ -39,7 +39,7 @@ export default function (props: {configs: Array<MetricGraphConfig>}) {
     return <LoadingFiller />;
   }
 
-  const gatewayNames = Object.keys(selectors);
+  const gatewayNames = Object.keys((selectors as any).gateways);
   const defaultGateway = gatewayNames[0];
 
   const metrics = (


### PR DESCRIPTION
Signed-off-by: Paulo Henrique Calaes Oliveira <paulo@radtonics.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This pull request solve the issue https://github.com/magma/magma/issues/8847

Closes #8847

## Test Plan

Open metrics page with non super user and check statistics.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
