### PR TITLE
chore: delete non-existing directories from dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 *
 !.cache/test_certs
-!fb/config/
 
 !.devcontainer/
 !third_party/
@@ -28,12 +27,6 @@
 !lte/swagger/
 !lte/gateway/deploy
 !lte/gateway/docker/deploy
-
-!devmand/cloud/
-!devmand/gateway/
-!devmand/protos/
-
-!fb/src/dpi/
 
 !orc8r/cloud/configs/
 !orc8r/lib/


### PR DESCRIPTION
## Summary

Tiny clean up in the dockerignore file. It still contained some directories that have been deleted a while ago.

## Test Plan

Check that directories do not exist.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
