### PR TITLE
fix(agw): Do not check for health of "shared_mconfig"

### DIFF
--- a/orc8r/gateway/python/magma/common/health/health_service.py
+++ b/orc8r/gateway/python/magma/common/health/health_service.py
@@ -32,6 +32,7 @@ from magma.common.health.entities import (
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
 from magma.configuration.mconfig_managers import load_service_mconfig_as_json
+from magma.configuration.mconfigs import SHARED_MCONFIG
 from magma.magmad.metrics import UNEXPECTED_SERVICE_RESTARTS
 from magma.magmad.service_poller import ServicePoller
 from orc8r.protos import common_pb2, magmad_pb2
@@ -121,7 +122,10 @@ class GenericHealthChecker:
 
         configs = client.GetConfigs(common_pb2.Void())
 
-        service_names = [str(name) for name in configs.configs_by_key]
+        service_names = [
+            str(name) for name in configs.configs_by_key
+            if name != SHARED_MCONFIG
+        ]
         services_errors = self.get_error_summary(service_names=service_names)
 
         for service_name in service_names:


### PR DESCRIPTION
## Summary

The concept of shared mconfig was added on the top level of the mconfig a while ago to handle configuration that is used in all services. However, the health cli tool is using the top-level entries of mconfig to decide which services to check. The shared mconfig needs to be excluded here.

## Test Plan

Executing `health_cli.py` no longer gives the output:
```
✗ shared_mconfig       inactive   dead            00               INFO          0
```

## Additional Information

- [ ] This change is backwards-breaking