### PR TITLE
feat(ci): better startup test for the integration test against containerized AGW

### DIFF
--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -359,3 +359,53 @@ services:
       timeout: "4s"
       retries: 3
     command: /var/opt/magma/bin/envoy_controller
+
+  # for docker compose v1: https://github.com/docker/compose/issues/8351#issuecomment-1085811366
+  # also see https://docs.docker.com/compose/compose-file/#depends_on
+  waitForHealthyPods:
+    image: alpine:latest
+    depends_on:
+      magmad:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      directoryd:
+        condition: service_healthy
+      subscriberdb:
+        condition: service_healthy
+      enodebd:
+        condition: service_healthy
+      state:
+        condition: service_healthy
+      policydb:
+        condition: service_healthy
+      health:
+        condition: service_healthy
+      monitord:
+        condition: service_healthy
+      redirectd:
+        condition: service_healthy
+      smsd:
+        condition: service_healthy
+      control_proxy:
+        condition: service_healthy
+      ctraced:
+        condition: service_healthy
+      sctpd:
+        condition: service_healthy
+      oai_mme:
+        condition: service_healthy
+      pipelined:
+        condition: service_healthy
+      sessiond:
+        condition: service_healthy
+      mobilityd:
+        condition: service_healthy
+      td-agent-bit:
+        condition: service_healthy
+      eventd:
+        condition: service_healthy
+      connectiond:
+        condition: service_healthy
+      envoy_controller:
+        condition: service_healthy

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -17,6 +17,7 @@ from time import sleep
 from fabric.api import cd, env, execute, local, run, settings, sudo
 from fabric.contrib.files import exists
 from fabric.operations import get
+from fabric.utils import fastprint
 
 sys.path.append('../../orc8r')
 import tools.fab.dev_utils as dev_utils
@@ -548,9 +549,21 @@ def _start_gateway_containerized():
         run('for component in redis nghttpx td-agent-bit; do cp "${MAGMA_ROOT}"/{orc8r,lte}/gateway/configs/templates/${component}.conf.template; done')
 
     with cd(AGW_ROOT + "/docker"):
-        run('DOCKER_REGISTRY=%s docker-compose -f docker-compose.yaml -f docker-compose.dev.yaml up -d --quiet-pull' % (env.DOCKER_REGISTRY))
-        # TODO: With docker compose v1 there is no good native way to wait for containers to be reliably up
-        run('sleep 60; docker-compose ps')
+        # The `docker-compose up` times are machine dependent, such that a retry is needed here for resilience.
+        run_with_retry('DOCKER_REGISTRY=%s docker-compose -f docker-compose.yaml -f docker-compose.dev.yaml up -d --quiet-pull' % (env.DOCKER_REGISTRY))
+
+
+def run_with_retry(command, retries=3):
+    iteration = 0
+    while iteration < retries:
+        iteration += 1
+        try:
+            run(command)
+            break
+        except:
+            fastprint(f"ERROR: Failed on retry {iteration} of \n$ {command}\n")
+    else:
+        raise Exception(f"ERROR: Failed after {retries} retries of \n$ {command}")
 
 
 def run_integ_tests(tests=None, federated_mode='False'):


### PR DESCRIPTION
## Summary

- follow up to https://github.com/magma/magma/pull/13884
- implements a startup health check for the docker-compose v1, see also
  - https://github.com/docker/compose/issues/8351#issuecomment-1085811366
  - https://docs.docker.com/compose/compose-file/#depends_on
  - with docker-compose v2 this would reduce to a `--wait`
- turns out that the `oai_mme` health check was a problem because it would sometimes become unhealthy for <~1s leading to a failing deployment
- turns out that Github runners are slow enough, that other containers also shortly fail on startup. This seems to be very machine dependent and flaky. Easiest way to mitigate is a retry mechanism. A retry worked reliably for me.

## Test Plan

- `vagrant@magma-dev:~/magma/lte/gateway/docker$ DOCKER_REGISTRY=docker.artifactory.magmacore.org/ docker-compose -f docker-compose.yaml -f docker-compose.dev.yaml up -d`
- https://github.com/magma/magma/actions/workflows/lte-integ-test-containerized.yml?query=branch%3Aci%2Fs1ap-tests-against-containerised-agw-startup-check+