### PR TITLE
fix(agw): fix always-true-asserts in s1ap integ tests

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -585,9 +585,8 @@ class S1ApUtil(object):
                             time.sleep(
                                 5,
                             )  # sleep for 5 seconds before retrying
-                        assert (
-                            len(downlink_flows) >= num_dl_flows
-                        ), "Downlink flow missing for UE"
+                        assert len(downlink_flows) >= num_dl_flows, \
+                            "Downlink flow missing for UE"
                         assert downlink_flows[0]["match"][ip_dst] == ue_ip_addr
                         actions = downlink_flows[0]["instructions"][0][
                             "actions"
@@ -627,9 +626,8 @@ class S1ApUtil(object):
             if len(uplink_flows) == num_ul_flows:
                 break
             time.sleep(5)  # sleep for 5 seconds before retrying
-        assert (
-            len(uplink_flows) == num_ul_flows
-        ), f"Uplink flow missing for UE: {len(uplink_flows)} != {num_ul_flows}"
+        assert len(uplink_flows) == num_ul_flows, \
+            f"Uplink flow missing for UE: {len(uplink_flows)} != {num_ul_flows}"
 
         assert uplink_flows[0]["match"]["tunnel_id"] is not None
 
@@ -669,9 +667,8 @@ class S1ApUtil(object):
                 if len(paging_flows) == num_paging_flows_to_be_verified:
                     break
                 time.sleep(5)  # sleep for 5 seconds before retrying
-            assert (
-                len(paging_flows) == num_paging_flows_to_be_verified
-            ), "Paging flow missing for UE"
+            assert len(paging_flows) == num_paging_flows_to_be_verified,\
+                "Paging flow missing for UE"
 
             # TODO - Verify that the action is to send to controller
             # controller_port = 4294967293

--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
@@ -69,11 +69,9 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
             "*************************  Offloading UE at state ECM-CONNECTED",
         )
         # Send offloading request
-        assert (
-            self._ha_util.offload_agw(
-                "".join(["IMSI"] + [str(i) for i in req.imsi]),
-                enb_list[0][0],
-            ),
+        assert self._ha_util.offload_agw(
+            "".join(["IMSI"] + [str(i) for i in req.imsi]),
+            enb_list[0][0],
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
@@ -81,11 +79,9 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
 
         print("*************************  Offloading UE at state ECM-IDLE")
         # Send offloading request
-        assert (
-            self._ha_util.offload_agw(
-                "".join(["IMSI"] + [str(i) for i in req.imsi]),
-                enb_list[0][0],
-            ),
+        assert self._ha_util.offload_agw(
+            "".join(["IMSI"] + [str(i) for i in req.imsi]),
+            enb_list[0][0],
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_mixed_idle_active_multiue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_mixed_idle_active_multiue.py
@@ -87,7 +87,7 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
 
         print("*************************  Send Offload Request to AGW")
         # Send offloading request
-        assert (self._ha_util.offload_agw(None, enb_list[0][0]))
+        assert self._ha_util.offload_agw(None, enb_list[0][0])
 
         # All UEs should eventually receive Context Release Request
         # The first half should get it immediately
@@ -100,8 +100,9 @@ class TestAgwOffloadMixedIdleActiveMultiUe(unittest.TestCase):
                 [
                     s1ap_types.tfwCmd.UE_CTX_REL_IND.value,
                     s1ap_types.tfwCmd.UE_PAGING_IND.value,
-                ],
-                "Not a paging or ue context release message",
+                ]
+            ), (
+                "Not a paging or ue context release message"
             )
 
         # Send service request as paging response

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
@@ -253,10 +253,8 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(uplink_flows) > 2, "Uplink flow missing for UE"
-            assert (
-                uplink_flows[0]["match"]["tunnel_id"] is not None,
-                "Uplink flow missing tunnel id match",
-            )
+            assert uplink_flows[0]["match"]["tunnel_id"] is not None, \
+                "Uplink flow missing tunnel id match"
 
             # DOWNLINK
             print("Checking for downlink flow")
@@ -281,10 +279,8 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(downlink_flows) > 2, "Downlink flow missing for UE"
-            assert (
-                downlink_flows[0]["match"]["ipv4_dst"] == ue_ip,
-                "UE IP match missing from downlink flow",
-            )
+            assert downlink_flows[0]["match"]["ipv4_dst"] == ue_ip, \
+                "UE IP match missing from downlink flow"
 
             actions = downlink_flows[0]["instructions"][0]["actions"]
             has_tunnel_action = any(
@@ -293,9 +289,7 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
                 if action["field"] == "tunnel_id"
                 and action["type"] == "SET_FIELD"
             )
-            assert (
-                has_tunnel_action, "Downlink flow missing set tunnel action",
-            )
+            assert has_tunnel_action, "Downlink flow missing set tunnel action"
 
             with self._s1ap_wrapper.configUplinkTest(req, duration=1) as test:
                 test.verify()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -209,10 +209,8 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(uplink_flows) > 1, "Uplink flow missing for UE"
-            assert (
-                uplink_flows[0]["match"]["tunnel_id"] is not None,
-                "Uplink flow missing tunnel id match",
-            )
+            assert uplink_flows[0]["match"]["tunnel_id"] is not None, \
+                "Uplink flow missing tunnel id match"
 
             # DOWNLINK
             print("Checking for downlink flow")
@@ -237,10 +235,8 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(downlink_flows) > 1, "Downlink flow missing for UE"
-            assert (
-                downlink_flows[0]["match"]["ipv4_dst"] == ue_ip,
-                "UE IP match missing from downlink flow",
-            )
+            assert downlink_flows[0]["match"]["ipv4_dst"] == ue_ip, \
+                "UE IP match missing from downlink flow"
 
             actions = downlink_flows[0]["instructions"][0]["actions"]
             has_tunnel_action = any(
@@ -249,9 +245,7 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
                 if action["field"] == "tunnel_id"
                 and action["type"] == "SET_FIELD"
             )
-            assert (
-                has_tunnel_action, "Downlink flow missing set tunnel action",
-            )
+            assert has_tunnel_action, "Downlink flow missing set tunnel action"
 
             print("Sleeping for 5 seconds")
             time.sleep(5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
@@ -218,10 +218,8 @@ class TestAttachDetachRarTcpHE(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(uplink_flows) > 1, "Uplink flow missing for UE"
-            assert (
-                uplink_flows[0]["match"]["tunnel_id"] is not None,
-                "Uplink flow missing tunnel id match",
-            )
+            assert uplink_flows[0]["match"]["tunnel_id"] is not None, \
+                "Uplink flow missing tunnel id match"
 
             # DOWNLINK
             print("Checking for downlink flow")
@@ -246,10 +244,8 @@ class TestAttachDetachRarTcpHE(unittest.TestCase):
                 time.sleep(5)  # sleep for 5 seconds before retrying
 
             assert len(downlink_flows) > 1, "Downlink flow missing for UE"
-            assert (
-                downlink_flows[0]["match"]["ipv4_dst"] == ue_ip,
-                "UE IP match missing from downlink flow",
-            )
+            assert downlink_flows[0]["match"]["ipv4_dst"] == ue_ip, \
+                "UE IP match missing from downlink flow"
 
             actions = downlink_flows[0]["instructions"][0]["actions"]
             has_tunnel_action = any(
@@ -258,9 +254,7 @@ class TestAttachDetachRarTcpHE(unittest.TestCase):
                 if action["field"] == "tunnel_id"
                 and action["type"] == "SET_FIELD"
             )
-            assert (
-                has_tunnel_action, "Downlink flow missing set tunnel action",
-            )
+            assert has_tunnel_action, "Downlink flow missing set tunnel action"
 
             print("Sleeping for 5 seconds")
             time.sleep(5)

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_setsessionrules_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_setsessionrules_tcp_data.py
@@ -214,10 +214,8 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
 
         assert len(uplink_flows) == 2, "There should be 2 UL flow rules for UE"
         for i in range(len(uplink_flows)):
-            assert (
-                uplink_flows[i]["match"]["tunnel_id"] is not None,
-                "Uplink flow missing tunnel id match",
-            )
+            assert uplink_flows[i]["match"]["tunnel_id"] is not None, \
+                "Uplink flow missing tunnel id match"
 
         # DOWNLINK
         print("Checking for downlink flow")
@@ -242,10 +240,8 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
             time.sleep(5)  # sleep for 5 seconds before retrying
 
         assert len(downlink_flows) == 3, "Downlink flows must have been 3 for UE"
-        assert (
-            downlink_flows[0]["match"]["ipv4_dst"] == ue_ip,
-            "UE IP match missing from downlink flow",
-        )
+        assert downlink_flows[0]["match"]["ipv4_dst"] == ue_ip, \
+            "UE IP match missing from downlink flow"
 
         actions = downlink_flows[0]["instructions"][0]["actions"]
         has_tunnel_action = any(
@@ -254,9 +250,7 @@ class TestAttachDetachSetSessionRulesTcpData(unittest.TestCase):
             if action["field"] == "tunnel_id"
             and action["type"] == "SET_FIELD"
         )
-        assert (
-            has_tunnel_action, "Downlink flow missing set tunnel action",
-        )
+        assert has_tunnel_action, "Downlink flow missing set tunnel action"
 
         # Get UL Flow Rule for TCP flows for verifying rate limits enforced
         print("**********************Get uplink TCP flow for UE before UL traffic test:")

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
@@ -45,7 +45,8 @@ class TestAttachDetachWithOVS(unittest.TestCase):
         imsi64 = imsi_action["value"]
         # Convert between compacted uint IMSI and string
         received_imsi = decode_imsi(imsi64)
-        assert sent_imsi == received_imsi, "IMSI set in metadata field does not match sent IMSI"
+        assert sent_imsi == received_imsi, \
+            "IMSI set in metadata field does not match sent IMSI"
 
     def test_attach_detach_with_ovs(self):
         """
@@ -91,10 +92,8 @@ class TestAttachDetachWithOVS(unittest.TestCase):
             time.sleep(5)  # sleep for 5 seconds before retrying
 
         assert len(uplink_flows) == 1, "Uplink flow missing for UE"
-        assert (
-            uplink_flows[0]["match"]["tunnel_id"] is not None,
-            "Uplink flow missing tunnel id match",
-        )
+        assert uplink_flows[0]["match"]["tunnel_id"] is not None,\
+            "Uplink flow missing tunnel id match"
         self.check_imsi_metadata(uplink_flows[0], req)
 
         # DOWNLINK
@@ -121,10 +120,8 @@ class TestAttachDetachWithOVS(unittest.TestCase):
             time.sleep(5)  # sleep for 5 seconds before retrying
 
         assert len(downlink_flows) == 1, "Downlink flow missing for UE"
-        assert (
-            downlink_flows[0]["match"]["ipv4_dst"] == ue_ip,
-            "UE IP match missing from downlink flow",
-        )
+        assert downlink_flows[0]["match"]["ipv4_dst"] == ue_ip, \
+            "UE IP match missing from downlink flow"
 
         actions = downlink_flows[0]["instructions"][0]["actions"]
         has_tunnel_action = any(
@@ -132,10 +129,7 @@ class TestAttachDetachWithOVS(unittest.TestCase):
             if action["field"] == "tunnel_id" and
             action["type"] == "SET_FIELD"
         )
-        assert (
-            has_tunnel_action,
-            "Downlink flow missing set tunnel action",
-        )
+        assert has_tunnel_action, "Downlink flow missing set tunnel action"
         self.check_imsi_metadata(downlink_flows[0], req)
 
         print("Running UE detach for UE id ", req.ue_id)


### PR DESCRIPTION
Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>

## Summary

After #14012 , some asserts were using an incorrect syntax that always yields true: `assert(condition, "description")`. This PR changes these to function as intended: `assert condition, "description"`

Example warning:
![image](https://user-images.githubusercontent.com/104822369/194176176-2feee344-b260-415f-b532-a81ab3a60b41.png)

Affected tests:
* `test_agw_offload_idle_active_ue`
* `test_attach_detach_multiple_rar_tcp_data`
* `test_attach_detach_rar_tcp_data`
* `test_attach_detach_rar_tcp_he`
* `test_attach_detach_setsessionrules_tcp_data`
* `test_attach_detach_with_ovs`

## Test Plan

Run the affected tests and see that the warnings disappear.

## Additional Information

- [ ] This change is backwards-breaking
