### PR TITLE
fix: vagrant box cache location is pointing to correct folder

### DIFF
--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Cache magma-deb-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_deb
+          path: ~/.vagrant.d/boxes/ubuntu-VAGRANTSLASH-focal64
           key: vagrant-box-magma-deb-focal64-20220804.0.0
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Problem:
* the location of the magma_deb base image is not pointing to the correct location - see e.g. https://github.com/magma/magma/actions/runs/3186881346/jobs/5197902730
* `Cache magma-deb-box`
```
Run actions/cache@0865c47f36e68161719c5b124609996bb5c40129
  with:
    path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_deb
    key: vagrant-box-magma-deb-focal64-20220804.0.0
Cache not found for input keys: vagrant-box-magma-deb-focal64-20220804.0.0
```
  * `Post cache magma-deb-box`
```
Post job cleanup.
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

Solution:
* the correct path should be `~/.vagrant.d/boxes/ubuntu-VAGRANTSLASH-focal64` - the name of the base image used

## Test Plan

CI run on fork: https://github.com/nstng/magma/actions/runs/3196079738
* `Post cache magma-deb-box`
```
Cache saved successfully
Cache saved with key: vagrant-box-magma-deb-focal64-20220804.0.0
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
