### PR TITLE
chore: a workflow that runs integ tests vs a magma debian package build with bazel

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -250,7 +250,7 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
-            bazel build lte/gateway/release:sctpd_deb_pkg \
+            bazel build lte/gateway/release:sctpd_deb_pkg lte/gateway/release:magma_deb_pkg \
               --config=production \
               --profile=Bazel_build_package_profile
       - name: Publish bazel profile

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -1,0 +1,135 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: LTE integ test bazel magma-deb
+
+on:
+  workflow_dispatch: null
+  push:
+    branches:
+      - master
+      - 'v1.*'
+
+env:
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  # see GH14041
+  CACHE_KEY: bazel-base-image-sha-c4de1e5
+  REMOTE_DOWNLOAD_OPTIMIZATION: true
+
+jobs:
+  lte-integ-test-bazel-magma-deb:
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+
+      - name: Cache magma-deb-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/ubuntu-VAGRANTSLASH-focal64
+          key: vagrant-box-magma-deb-focal64-20220804.0.0
+      - name: Cache magma-test-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
+          key: vagrant-box-magma-test
+      - name: Cache magma-trfserver-box
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
+          key: vagrant-box-magma-trfserver-v20220722
+
+      - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # pin@v2
+        with:
+          python-version: '3.8.10'
+      - name: Install pre requisites
+        run: |
+          pip3 install --upgrade pip
+          pip3 install ansible fabric3 jsonpickle requests PyYAML
+          vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
+      - name: Install docker
+        uses: docker-practice/actions-setup-docker@5d9a5f65f510c01ec5f0bd81d5c95768b1ec032a # pin@v1
+      - name: Open up network interfaces for VM
+        run: |
+          sudo mkdir -p /etc/vbox/
+          echo '* 192.168.0.0/16' | sudo tee /etc/vbox/networks.conf
+          echo '* 3001::/64' | sudo tee -a /etc/vbox/networks.conf
+
+      - name: Build .deb packages
+        run: |
+          docker run \
+            -v ${{ github.workspace }}:/workspaces/magma/ \
+            -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma \
+            -i \
+            ${{ env.BAZEL_BASE_IMAGE }} \
+            bash -c \
+              'cd /workspaces/magma && \
+              bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}" && \
+              bazel build lte/gateway/release:sctpd_deb_pkg lte/gateway/release:magma_deb_pkg \
+                --config=production \
+                --profile=Bazel_build_package_profile && \
+              mv /workspaces/magma/bazel-bin/lte/gateway/release/magma*.deb /workspaces/magma/'
+      - name: Delete all docker containers
+        run: |
+          docker system prune -f -a --volumes
+
+      - name: Run the integ test
+        env:
+          MAGMA_DEV_CPUS: 3
+          MAGMA_DEV_MEMORY_MB: 9216
+          MAGMA_PACKAGE: magma_1.8.0_amd64.deb
+        run: |
+          cd lte/gateway
+          fab integ_test_deb_installation
+
+      - name: Get test results
+        if: always()
+        run: |
+          cd lte/gateway
+          fab get_test_summaries:dst_path="test-results",sudo_tests=False,dev_vm_name="magma_deb"
+          ls -R
+      - name: Upload test results
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: test-results
+          path: lte/gateway/test-results/**/*.xml
+      - name: Publish Unit Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@2a60c5d47eb29cd5cc922f51bbea18e148f56203 # pin@v2
+        with:
+          check_name: LTE Debian integration test results
+          junit_files: lte/gateway/test-results/**/*.xml
+          check_run_annotations: all tests
+
+      - name: Get test logs
+        if: always()
+        run: |
+          cd lte/gateway
+          fab get_test_logs:gateway_host_name=magma_deb,dst_path=./logs.tar.gz
+      - name: Upload test logs
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: test-logs
+          path: lte/gateway/logs.tar.gz
+
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Bazel Debian Integration Tests"
+          SLACK_USERNAME: "LTE integ test bazel magma-deb"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -235,6 +235,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.raw_arguments = ENV.fetch("ANSIBLE_ARGS", "").split(";") +
                               ["--timeout=30"]
       ansible.verbose = 'v'
+      # The magma package to be installed is given by the env variable MAGMA_PACKAGE
+      #   MAGMA_PACKAGE not set or empty: install latest magma from artifactory
+      #   MAGMA_PACKAGE="magma=version": install specific version from artifactory
+      #   MAGMA_PACKAGE="magma.deb": install magma debian file expected at /home/vagrant/magma/magma.deb
       ansible.extra_vars = { MAGMA_PACKAGE: ENV.fetch('MAGMA_PACKAGE', 'magma') }
     end
 

--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -153,14 +153,23 @@
     - agwc
     - base
 
-- name: Installing magma.
+- name: Set magma package variable
+  set_fact:
+    magma_package: "{{ MAGMA_PACKAGE | default('magma', true) }}"
+
+- name: Installing magma from local debian package
   become: true
   apt:
-    name: "{{ packages }}"
+    deb: "/home/vagrant/magma/{{ magma_package }}"
     dpkg_options: 'force-confold,force-confdef,force-overwrite'
-  vars:
-    packages:
-      - "{{ MAGMA_PACKAGE | default('magma', true) }}"
+  when: magma_package is match(".*\.deb")
+
+- name: Installing magma from artifactory
+  become: true
+  apt:
+    name: "{{ magma_package }}"
+    dpkg_options: 'force-confold,force-confdef,force-overwrite'
+  when: magma_package is not match(".*\.deb")
 
 # Install openvswitch in containerized agw only
 - name: Install prebuilt openvswitch packages

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -579,6 +579,7 @@ def get_test_summaries(
 
 def get_test_logs(
     gateway_host=None,
+    gateway_host_name='magma',
     test_host=None,
     trf_host=None,
     dst_path="/tmp/build_logs.tar.gz",
@@ -619,7 +620,7 @@ def get_test_logs(
     # Set up to enter the gateway host
     env.host_string = gateway_host
     if not gateway_host:
-        setup_env_vagrant("magma")
+        setup_env_vagrant(gateway_host_name)
         gateway_host = env.hosts[0]
     (env.user, _, _) = split_hoststring(gateway_host)
 


### PR DESCRIPTION
## Summary

The magma debian package can be build with bazel. The artifact should be tested by running the integration tests vs an environment where it is installed.

We decided for now to build the artifact directly in a new workflow instead of uploading it to an artifactory in another workflow and then installing it. We do not want to build the artifact directly on `magma_deb` (where it will be installed) as required dependencies are missing and should not be installed on `magma_deb` (keep it near to production conditions).
* -> The most lightweight way is to build the artifact on bazel base
* Vagrant is not installed on GH ubuntu base images and `vt-x` is disabled (-> VMs can only run with one CPU) - this makes an ubuntu base unusable for this change
* Docker is not installed on GH macosx base images and needs to be installed separately - this takes some time, but is possible

The commits are separated as follows:
* build the magma debian package also in the bazel.yml workflow - this is not relevant for this change, but is a related improvement.
* extend the `vagrant_deb` mechanics to allow installing a local magma debian file
* allow that logging from `magma_deb` can be fetched in order to publish it to the new workflow
* create the new workflow

## Test Plan

Runs on fork:
* https://github.com/nstng/magma/actions/runs/3196342704
  * this run is green - but there were actually a lot of failed runs because of flakyness
* make sure non bazel magma deb workflow still works https://github.com/nstng/magma/actions/runs/3225931612

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
