### PR TITLE
feat(agw): create new base images of `magma_dev` and `magma_test`

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20220801
+          key: vagrant-box-magma-dev-v1.2.20221012
       - name: Log in to vagrant cloud
         run: |
           if [[ -n "${{ secrets.VAGRANT_TOKEN }}" ]]

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -111,12 +111,12 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20220801
+          key: vagrant-box-magma-dev-v1.2.20221012
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test
+          key: vagrant-box-magma-test-v1.2.20221012
       - name: Cache magma-trfserver-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test
+          key: vagrant-box-magma-test-v1.2.20221012
       - name: Cache magma-trfserver-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20220801
+          key: vagrant-box-magma-dev-v1.2.20221012
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test
+          key: vagrant-box-magma-test-v1.2.20221012
       - name: Cache magma-trfserver-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -30,12 +30,12 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20220801
+          key: vagrant-box-magma-dev-v1.2.20221012
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test
+          key: vagrant-box-magma-test-v1.2.20221012
       - name: Cache magma-trfserver-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test
+          key: vagrant-box-magma-test-v1.2.20221012
       - name: Cache magma-trfserver-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -36,12 +36,12 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20220801
+          key: vagrant-box-magma-dev-v1.2.20221012
       - name: Cache magma-test-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test
+          key: vagrant-box-magma-test-v1.2.20221012
       - name: Cache magma-trfserver-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20220801
+          key: vagrant-box-magma-dev-v1.2.20221012
       - name: Log in to vagrant cloud
         run: |
           if [[ -n "${{ secrets.VAGRANT_TOKEN }}" ]]

--- a/cwf/gateway/deploy/cwag.yml
+++ b/cwf/gateway/deploy/cwag.yml
@@ -20,6 +20,7 @@
       vars:
         distribution: "bionic"
         repo: "cwf-prod"
+        preburn: true
     - role: ovs
       tags:
          - install

--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -35,6 +35,7 @@
       vars:
         distribution: "bionic"
         repo: "cwf-prod"
+        preburn: true
     - role: test_certs
     - role: ovs
     - role: golang

--- a/cwf/gateway/deploy/cwag_dev_centos7.yml
+++ b/cwf/gateway/deploy/cwag_dev_centos7.yml
@@ -28,6 +28,7 @@
       vars:
         distribution: "centos"
         repo: "cwf-prod-redhat"
+        preburn: true
     - role: test_certs
     - role: ovs
     - role: golang

--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -24,6 +24,7 @@
       vars:
         distribution: "bionic"
         repo: "cwf-prod"
+        preburn: true
     - role: ovs
     - role: resolv_conf
       vars:

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define :magma, primary: true do |magma|
     magma.vm.box = "magmacore/magma_dev"
-    magma.vm.box_version = "1.2.20220801"
+    magma.vm.box_version = "1.2.20221012"
     magma.disksize.size = '75GB'
 
      # Enable Dynamic Swap Space to prevent Out of Memory crashes
@@ -116,9 +116,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define :magma_test, autostart: false do |magma_test|
-    # Get our prepackaged box from the atlas cloud
     magma_test.vm.box = "magmacore/magma_test"
-    magma_test.vm.box_version = "1.1.20220608"
+    magma_test.vm.box_version = "1.2.20221012"
     magma_test.vbguest.auto_update = false
 
     # Create a private network, which allows host-only access to the machine

--- a/lte/gateway/deploy/hosts
+++ b/lte/gateway/deploy/hosts
@@ -4,9 +4,6 @@
 [dev]
 magma ansible_ssh_host=192.168.60.142 ansible_ssh_port=22 ansible_user=vagrant
 
-[focal_dev]
-magma ansible_ssh_host=192.168.60.142 ansible_ssh_port=22 ansible_user=vagrant
-
 [deb]
 magma_deb ansible_ssh_host=192.168.60.142 ansible_ssh_port=22 ansible_user=vagrant
 

--- a/lte/gateway/deploy/magma_dev.yml
+++ b/lte/gateway/deploy/magma_dev.yml
@@ -13,7 +13,7 @@
 ################################################################################
 
 - name: Set up Magma dev build environment on a local machine
-  hosts: focal_dev
+  hosts: dev
   become: yes
 
   vars:

--- a/lte/gateway/deploy/magma_test.yml
+++ b/lte/gateway/deploy/magma_test.yml
@@ -23,11 +23,6 @@
 
   roles:
     - role: gai_config
-    - role: apt_cache
-      vars:
-        distribution: "focal"
-        oai_build: "{{ c_build }}/core/oai"
-        repo: "dev"
     - role: pkgrepo
     - role: python_dev
     - role: dev_common

--- a/lte/gateway/deploy/roles/bazel/tasks/main.yml
+++ b/lte/gateway/deploy/roles/bazel/tasks/main.yml
@@ -24,6 +24,7 @@
     path: '/var/cache/bazel-cache'
     state: link
     force: yes
+    follow: false
 
 - name: Symlink bazel disk repository cache configuration into the VM
   file:

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -54,6 +54,7 @@
   become_user: "{{ ansible_user }}"
   command: ansible-galaxy collection install community.general
   ignore_errors: yes
+  when: preburn
 
 - name: Set build environment variables
   lineinfile:
@@ -90,6 +91,7 @@
     line: "{{ item }}"
   with_items:
     - export PATH=$PATH:"/usr/local/go/bin"
+  when: preburn
 
 - name: Create the ccache directory
   file:
@@ -97,7 +99,7 @@
     state: directory
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-  when: full_provision
+  when: preburn
 
 #################################
 # Add common convenience aliases
@@ -108,7 +110,7 @@
     dest: /home/{{ ansible_user }}/.bashrc
     state: present
     line: "alias disable-tcp-checksumming='sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off'"
-  when: full_provision
+  when: preburn
 
 ##############################
 # Install dependency packages
@@ -214,7 +216,7 @@
   file:
     path: /etc/profile.d/env.sh
     state: touch
-  when: full_provision
+  when: preburn
 
 - name: Override the default compiler with cache
   lineinfile:
@@ -235,6 +237,7 @@
     url: "https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64"
     dest: /usr/sbin/bazelisk-linux-amd64
     mode: ugo+x
+  when: preburn
 
 - name: Create a symlink for /usr/sbin/bazel
   # yamllint disable rule:truthy
@@ -244,6 +247,7 @@
     path: /usr/sbin/bazel
     state: link
     force: yes
+  when: preburn
 
 ########################################
 # Install common Magma dev dependencies
@@ -397,6 +401,7 @@
     path: /var/tmp/test_results
     state: directory
     mode: 0777
+  when: preburn
 
 - name: Install multipath-tools
   become: yes

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -181,13 +181,11 @@
     pkg:
       - autogen
       - autoconf
-      - build-essential
       - ccache
       - ninja-build
       - git
       - libtool
       - python3-apt
-      - python3-setuptools
       - python3-requests
       - python3-pip
       - python3-debian

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -424,27 +424,6 @@
     src: magma_resolv.conf
     dest: /etc/systemd/resolved.conf
 
-- name: Wait for APT Lock
-  shell: |
-    while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
-      sleep 1
-    done
-    while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 ; do
-      sleep 1
-    done
-    if [ -f /var/log/unattended-upgrades/unattended-upgrades.log ]; then
-      while sudo fuser /var/log/unattended-upgrades/unattended-upgrades.log >/dev/null 2>&1 ; do
-        sleep 1
-      done
-    fi
-
-- name: Remove unattended upgrades
-  apt:
-    state: absent
-    purge: yes
-    pkg:
-      - unattended-upgrades
-
 - name: Install LLDB debugger
   apt:
     pkg: lldb

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -398,6 +398,15 @@
     state: directory
     mode: 0777
 
+- name: Install multipath-tools
+  become: yes
+  apt:
+    pkg: multipath-tools
+    state: present
+    update_cache: yes
+  retries: 5
+  when: preburn
+
 - name: Patch multipath conf
   when: preburn
   patch:

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -315,7 +315,8 @@
     cd {{ tmp_libprotobuf_mutator_dir }}/build && \
     cmake .. -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON && \
     ninja && \
-    ninja install
+    ninja install && \
+    rm -rf {{ tmp_libprotobuf_mutator_dir }}
   when: preburn
 
 ###############################################

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -264,8 +264,6 @@
     state: present
     update_cache: yes
     pkg:
-      # install prometheus
-      - prometheus-cpp-dev
       # install openvswitch
       - libopenvswitch
       - libopenvswitch-dev
@@ -305,7 +303,6 @@
     state: present
     update_cache: yes
     pkg:
-      - python3-openvswitch
       - nlohmann-json3-dev
       # managing gtp interface
       - ifupdown
@@ -472,7 +469,6 @@
     state: present
     update_cache: yes
     pkg:
-      - bcc-tools
       - linux-headers-5.4.0-74-generic
   when: preburn
 

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -175,11 +175,11 @@
 
 - name: Create the /var/www/local-cdn directory
   file: path=/var/www/local-cdn state=directory
-  when: full_provision
+  when: preburn
 
 - name: Create the /var/www/local-cdn/store directory
   file: path=/var/www/local-cdn/store state=directory
-  when: full_provision
+  when: preburn
 
 - name: Add Magma package directory
   become: no
@@ -229,6 +229,7 @@
       - prometheus-cpp-dev
       - libczmq-dev
       - libczmq-dev
+      - libsqlite3-dev
 
 - name: Install LI Agent dependencies
   retries: 5
@@ -237,6 +238,7 @@
     update_cache: yes
     pkg:
       - uuid-dev
+  when: preburn
 
 - name: Fix vport-gtp kernel module for Ubuntu Focal
   become: yes
@@ -459,14 +461,21 @@
     state: latest
     pkg:
       - magma-libfluid
+  when: preburn
 
 - name: Create eBPF code dir
   command: 'mkdir /var/opt/magma/ebpf/ -p'
-  when: full_provision
+  when: preburn
 
 - name: Prepare AGW for eBPF
-  command: 'apt-get -y install bcc-tools linux-headers-5.4.0-74-generic'
-  when: full_provision
+  apt:
+    state: present
+    update_cache: yes
+    pkg:
+      - bcc-tools
+      - linux-headers-5.4.0-74-generic
+  when: preburn
+
 
 - name: Copy eBPF code
   copy:
@@ -486,15 +495,6 @@
     dest: /var/opt/magma/ebpf/EbpfMap.h
     force: yes
     remote_src: yes
-  when: full_provision
-
-# TODO: preburn this and add it under MME(OAI) dependencies
-- name: Install SQLite3 C++ library
-  retries: 5
-  apt:
-    state: latest
-    pkg:
-      - libsqlite3-dev
   when: full_provision
 
 - name: Extend sda2

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -341,12 +341,9 @@
 - name: Install gmock and gtest for C++ testing
   become: yes
   ignore_errors: yes
-  shell: cmake CMakeLists.txt && make && cp *.a /usr/lib
+  shell: cmake . && cmake --build . --target install
   args:
-    chdir: /usr/src/{{ item }}
-  with_items:
-    - gtest
-    - gmock
+    chdir: /usr/src/googletest
   when: preburn
 
 - name: Download golang tar

--- a/lte/gateway/deploy/roles/magma_test/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_test/tasks/main.yml
@@ -25,14 +25,14 @@
 
 - name: Set up S1AP tester build directory
   file: path={{ s1ap_tester_root }}/bin state=directory recurse=yes
-  when: full_provision
+  when: preburn
 
 - name: Set a convenience function for starting the S1AP tester
   lineinfile: >
     dest=/home/{{ ansible_user }}/.bashrc
     state=present
     line="alias s1aptester='mkdir -p /tmp/fw; cd $S1AP_TESTER_ROOT; venvsudo LD_LIBRARY_PATH=$S1AP_TESTER_ROOT/bin PATH=$PATH:/sbin bin/testCntrlr'"
-  when: full_provision
+  when: preburn
 
 - name: Add integ test scripts to path
   become: yes
@@ -96,11 +96,6 @@
   register: swagger_yml_present
   when: full_provision
 
-#- name: Generate Python bindings for the REST API with swagger-codegen
-#  no_log: True
-#  command: "{{ test_scripts }}/generate_python_bindings.sh"
-#  when: full_provision and (swagger_yml_present.stat.exists == true)
-
 - name: Add the test controller DNS entry
   become: yes
   lineinfile:
@@ -108,4 +103,4 @@
     regexp: '.*controller.magma.test$'
     line: "10.0.2.2 controller.magma.test"
     state: present
-  when: full_provision
+  when: preburn

--- a/lte/gateway/deploy/roles/pyvenv/tasks/main.yml
+++ b/lte/gateway/deploy/roles/pyvenv/tasks/main.yml
@@ -18,6 +18,7 @@
     state: directory
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
+  when: preburn
 
 - name: Install virtualenvwrapper
   apt:
@@ -25,15 +26,18 @@
     update_cache: yes
     pkg:
       - virtualenvwrapper
+  when: preburn
 
 - name: Configure login shell for virtualenv location
   lineinfile:
     path: /home/{{ ansible_user }}/.bashrc
     line: export WORKON_HOME=$HOME/.virtualenvs
     state: present
+  when: preburn
 
 - name: Configure login shell for virtualenv
   lineinfile:
     path: /home/{{ ansible_user }}/.bashrc
     line: source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
     state: present
+  when: preburn

--- a/orc8r/tools/ansible/roles/docker/tasks/install.yml
+++ b/orc8r/tools/ansible/roles/docker/tasks/install.yml
@@ -11,11 +11,11 @@
 # limitations under the License.
 
 - name: Ubuntu install tasks
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution == 'Ubuntu' and preburn
   include_tasks: install_debian.yml
 
 - name: Red Hat install tasks
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' and preburn
   include_tasks: install_redhat.yml
 
 - name: Download the lastest version of Docker Compose
@@ -23,14 +23,17 @@
     url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64"
     dest: /usr/local/bin/docker-compose
     mode: +x
+  when: preburn
 
 - name: Add the user to the docker group
   user:
     name: "{{ user }}"
     groups: docker
     append: yes
+  when: preburn
 
 - name: Install python docker module
   pip:
     executable: /usr/bin/pip3
     name: docker
+  when: preburn

--- a/orc8r/tools/ansible/roles/gateway_dev/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/gateway_dev/tasks/main.yml
@@ -18,7 +18,6 @@
 # Run necessary roles
 #################################
 
-- import_role: name=apt_cache
 - import_role: name=pkgrepo
 - import_role: name=gateway_services
 - import_role: name=python_dev

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -17,19 +17,6 @@
     state: absent
   when: preburn
 
-- name: Ensure ca-certificates is up to date
-  become: yes
-  apt:
-    name: "{{ packages }}"
-    state: latest
-    update_cache: yes
-  register: result
-  until: result is not failed
-  vars:
-    packages:
-      - ca-certificates
-  when: preburn
-
 - name: Copy gpg key from codebase
   copy:
     src: jfrog.pub

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -15,6 +15,7 @@
   ansible.builtin.file:
     path: /etc/apt/sources.list.d/*.list
     state: absent
+  when: preburn
 
 - name: Ensure ca-certificates is up to date
   become: yes
@@ -27,20 +28,25 @@
   vars:
     packages:
       - ca-certificates
+  when: preburn
 
 - name: Copy gpg key from codebase
   copy:
     src: jfrog.pub
     dest: /tmp/jfrog.pub
+  when: preburn
 
 - name: Adding the key to agent
   apt_key:
     file: /tmp/jfrog.pub
     state: present
+  when: preburn
 
 - name: Configuring the registry in sources.list.d
   shell: "echo 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main' > /etc/apt/sources.list.d/magma.list"
+  when: preburn
 
 - name: Update apt
   apt:
     update_cache: yes
+  when: preburn

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -16,27 +16,6 @@
     path: /etc/apt/sources.list.d/*.list
     state: absent
 
-- name: Wait for APT Lock
-  shell: |
-    while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
-      sleep 1
-    done
-    while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 ; do
-      sleep 1
-    done
-    if [ -f /var/log/unattended-upgrades/unattended-upgrades.log ]; then
-      while sudo fuser /var/log/unattended-upgrades/unattended-upgrades.log >/dev/null 2>&1 ; do
-        sleep 1
-      done
-    fi
-
-- name: Remove unattended upgrades
-  apt:
-    state: absent
-    purge: yes
-    pkg:
-      - unattended-upgrades
-
 - name: Ensure ca-certificates is up to date
   become: yes
   apt:

--- a/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
@@ -23,20 +23,20 @@
     - PYTHON_BUILD="{{ python_build }}"
     - PIP_CACHE_HOME="~/.pipcache"
     - PYTHONDONTWRITEBYTECODE="no"
-  when: full_provision
+  when: preburn
 
 - name: Test for path in /etc/environment file
   shell: grep "^PATH=" /etc/environment
   register: test_path
   ignore_errors: true
-  when: full_provision
+  when: preburn
 
 - name: Add PATH line if it doesn't exist
   lineinfile:
     dest: /etc/environment
     state: present
     line: 'PATH=/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  when: full_provision and test_path.rc != 0
+  when: preburn and test_path.rc != 0
 
 - name: Append virtual env python3 bin if path exists
   lineinfile:
@@ -45,7 +45,7 @@
     backrefs: yes
     regexp: 'PATH=(["]*)((?!.*?{{ python_bin }}).*?)(["]*)$'
     line: 'PATH=\1{{ python_bin }}:\2\3'
-  when: full_provision
+  when: preburn
 
 #################################
 # Add common convenience aliases
@@ -56,14 +56,14 @@
     dest: /home/{{ ansible_user }}/.bashrc
     state: present
     line: "alias magtivate='source {{ python_build }}/bin/activate'"
-  when: full_provision
+  when: preburn
 
 - name: Set a convenience function for running things with sudo in the virtualenv
   lineinfile:
     dest: /home/{{ ansible_user }}/.bashrc
     state: present
     line: "alias venvsudo='sudo -E PATH=$PATH PYTHONPATH=$PYTHONPATH env'"
-  when: full_provision
+  when: preburn
 
 ##############################
 # Install dependency packages

--- a/orc8r/tools/packer/magma-dev-virtualbox.json
+++ b/orc8r/tools/packer/magma-dev-virtualbox.json
@@ -93,7 +93,6 @@
         "../../../lte/gateway/deploy/roles/magma",
         "../../../lte/gateway/deploy/roles/pyvenv",
         "../../../lte/gateway/deploy/roles/service_aliases",
-        "../../../orc8r/tools/ansible/roles/apt_cache",
         "../../../orc8r/tools/ansible/roles/docker",
         "../../../orc8r/tools/ansible/roles/fluent_bit",
         "../../../orc8r/tools/ansible/roles/gateway_dev",

--- a/orc8r/tools/packer/magma-dev-virtualbox.json
+++ b/orc8r/tools/packer/magma-dev-virtualbox.json
@@ -72,9 +72,7 @@
     },
     {
       "type": "shell",
-      "inline": [
-        "sudo reboot"
-      ],
+      "inline": "sudo reboot",
       "expect_disconnect": true
     },
     {
@@ -91,8 +89,10 @@
       "role_paths": [
         "../../../lte/gateway/deploy/roles/bazel",
         "../../../lte/gateway/deploy/roles/dev_common",
+        "../../../lte/gateway/deploy/roles/gai_config",
         "../../../lte/gateway/deploy/roles/magma",
         "../../../lte/gateway/deploy/roles/pyvenv",
+        "../../../lte/gateway/deploy/roles/service_aliases",
         "../../../orc8r/tools/ansible/roles/apt_cache",
         "../../../orc8r/tools/ansible/roles/docker",
         "../../../orc8r/tools/ansible/roles/fluent_bit",
@@ -110,6 +110,8 @@
     {
       "type": "shell",
       "scripts": [
+        "scripts/cleanup.sh",
+        "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
         "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",

--- a/orc8r/tools/packer/magma-dev-virtualbox.json
+++ b/orc8r/tools/packer/magma-dev-virtualbox.json
@@ -102,7 +102,7 @@
         "../../../orc8r/tools/ansible/roles/python_dev",
         "../../../orc8r/tools/ansible/roles/test_certs"
       ],
-      "inventory_groups": "focal_dev",
+      "inventory_groups": "dev",
       "extra_arguments": [
         "--extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false}'"
       ]

--- a/orc8r/tools/packer/magma-test-virtualbox.json
+++ b/orc8r/tools/packer/magma-test-virtualbox.json
@@ -1,6 +1,17 @@
 {
   "builders": [
     {
+      "type": "virtualbox-iso",
+      "guest_os_type": "Ubuntu_64",
+      "headless": true,
+      "vm_name": "magma-test",
+      "iso_url": "https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
+      "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "http_directory": "http",
+      "ssh_timeout": "64206s",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -26,21 +37,6 @@
         " -- <wait>",
         "<enter><wait>"
       ],
-      "boot_wait": "5s",
-      "guest_additions_mode": "upload",
-      "guest_os_type": "ubuntu-64",
-      "headless": true,
-      "http_directory": "http",
-      "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
-      "iso_url": "https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
-      "memory": 2048,
-      "name": "magma",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_handshake_attempts": "20",
-      "ssh_password": "vagrant",
-      "ssh_timeout": "64206s",
-      "ssh_username": "vagrant",
-      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -54,45 +50,36 @@
           "--cpus",
           "2"
         ]
-      ]
+      ],
+      "name": "magma",
+      "memory": 2048,
+      "ssh_handshake_attempts": "20",
+      "boot_wait": "5s",
+      "guest_additions_mode": "upload",
+      "virtualbox_version_file": ".vbox_version"
     }
-  ],
-  "post-processors": [
-    [
-      {
-        "output": "builds/magma_test_{{.Provider}}.box",
-        "type": "vagrant"
-      }
-    ]
   ],
   "provisioners": [
     {
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
-      "script": "scripts/ubuntu_setup.sh",
-      "type": "shell"
-    },
-    {
-      "expect_disconnect": true,
-      "inline": [
-        "sudo reboot"
+      "type": "shell",
+      "scripts": [
+        "scripts/ubuntu_setup.sh",
+        "scripts/vagrant_key.sh"
       ],
-      "type": "shell"
+      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}"
     },
     {
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
-      "pause_before": "10s",
-      "script": "scripts/guest_additions.sh",
-      "type": "shell"
+      "type": "shell",
+      "inline": "sudo reboot",
+      "expect_disconnect": true
     },
     {
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
-      "script": "scripts/vagrant_key.sh",
-      "type": "shell"
-    },
-    {
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-      "script": "scripts/ansible.sh",
-      "type": "shell"
+      "type": "shell",
+      "scripts": [
+        "scripts/third_party/chef_bento/update_ubuntu.sh"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true
     },
     {
       "extra_arguments": [
@@ -101,23 +88,33 @@
       "inventory_groups": "test",
       "playbook_file": "../../../lte/gateway/deploy/magma_test.yml",
       "role_paths": [
+        "../../../lte/gateway/deploy/roles/bazel",
         "../../../lte/gateway/deploy/roles/dev_common",
-        "../../../lte/gateway/deploy/roles/magma",
+        "../../../lte/gateway/deploy/roles/gai_config",
         "../../../lte/gateway/deploy/roles/magma_test",
-        "../../../lte/gateway/deploy/roles/trfserver",
         "../../../orc8r/tools/ansible/roles/apt_cache",
-        "../../../orc8r/tools/ansible/roles/distro_snapshot",
-        "../../../orc8r/tools/ansible/roles/docker",
-        "../../../orc8r/tools/ansible/roles/fluent_bit",
-        "../../../orc8r/tools/ansible/roles/gateway_dev",
-        "../../../orc8r/tools/ansible/roles/gateway_services",
-        "../../../orc8r/tools/ansible/roles/golang",
         "../../../orc8r/tools/ansible/roles/pkgrepo",
-        "../../../orc8r/tools/ansible/roles/python_dev",
-        "../../../orc8r/tools/ansible/roles/resolv_conf",
-        "../../../orc8r/tools/ansible/roles/test_certs"
+        "../../../orc8r/tools/ansible/roles/python_dev"
       ],
       "type": "ansible-local"
+    },
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/cleanup.sh",
+        "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
+        "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true
     }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "vagrant",
+        "output": "builds/magma_test_{{.Provider}}.box"
+      }
+    ]
   ]
 }

--- a/orc8r/tools/packer/magma-test-virtualbox.json
+++ b/orc8r/tools/packer/magma-test-virtualbox.json
@@ -92,7 +92,6 @@
         "../../../lte/gateway/deploy/roles/dev_common",
         "../../../lte/gateway/deploy/roles/gai_config",
         "../../../lte/gateway/deploy/roles/magma_test",
-        "../../../orc8r/tools/ansible/roles/apt_cache",
         "../../../orc8r/tools/ansible/roles/pkgrepo",
         "../../../orc8r/tools/ansible/roles/python_dev"
       ],

--- a/orc8r/tools/packer/magma-trfserver-virtualbox.json
+++ b/orc8r/tools/packer/magma-trfserver-virtualbox.json
@@ -1,6 +1,17 @@
 {
   "builders": [
     {
+      "type": "virtualbox-iso",
+      "guest_os_type": "Ubuntu_64",
+      "headless": true,
+      "vm_name": "magma-dev",
+      "iso_url": "https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
+      "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "http_directory": "http",
+      "ssh_timeout": "64206s",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -26,58 +37,35 @@
         " -- <wait>",
         "<enter><wait>"
       ],
+      "name": "magma",
+      "memory": 2048,
+      "ssh_handshake_attempts": "20",
       "boot_wait": "5s",
       "guest_additions_mode": "upload",
-      "guest_os_type": "ubuntu-64",
-      "headless": true,
-      "http_directory": "http",
-      "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
-      "iso_url": "https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
-      "memory": 2048,
-      "name": "magma",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_handshake_attempts": "20",
-      "ssh_password": "vagrant",
-      "ssh_timeout": "64206s",
-      "ssh_username": "vagrant",
-      "type": "virtualbox-iso"
+      "virtualbox_version_file": ".vbox_version"
     }
-  ],
-  "post-processors": [
-    [
-      {
-        "output": "builds/magma_trfserver_{{.Provider}}.box",
-        "type": "vagrant"
-      }
-    ]
   ],
   "provisioners": [
     {
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}",
-      "script": "scripts/ubuntu_setup.sh",
-      "type": "shell"
+      "type": "shell",
+      "scripts": [
+        "scripts/ubuntu_setup.sh",
+        "scripts/vagrant_key.sh"
+      ],
+      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}"
     },
     {
       "type": "shell",
-      "inline": [
-        "sudo reboot"
-      ],
+      "inline": "sudo reboot",
       "expect_disconnect": true
     },
     {
       "type": "shell",
-      "script": "scripts/vagrant_key.sh",
-      "execute_command": "echo 'vagrant' | sudo -S env {{.Vars}} {{.Path}}"
-    },
-    {
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
-      "expect_disconnect": true,
       "scripts": [
-        "scripts/third_party/chef_bento/update_ubuntu.sh",
-        "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
-        "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
+        "scripts/third_party/chef_bento/update_ubuntu.sh"
       ],
-      "type": "shell"
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true
     },
     {
       "type": "ansible-local",
@@ -89,6 +77,23 @@
       "extra_arguments": [
         "--extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false}'"
       ]
+    },
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
+        "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true
     }
+  ],
+  "post-processors": [
+    [
+      {
+        "output": "builds/magma_trfserver_{{.Provider}}.box",
+        "type": "vagrant"
+      }
+    ]
   ]
 }

--- a/orc8r/tools/packer/scripts/cleanup.sh
+++ b/orc8r/tools/packer/scripts/cleanup.sh
@@ -13,19 +13,13 @@
 ################################################################################
 
 # Uninstall Ansible and remove PPA.
-apt -y remove --purge ansible
+apt-get -y remove --purge ansible
 apt-add-repository --remove ppa:ansible/ansible
 
 # Apt cleanup.
-apt autoremove
-apt update
+apt-get -y autoremove
+apt-get -y autoclean
+apt-get update
 
 # Delete unneeded files.
 rm -f /home/vagrant/*.sh
-
-# Zero out the rest of the free space using dd, then delete the written file.
-dd if=/dev/zero of=/EMPTY bs=1M
-rm -f /EMPTY
-
-# Add `sync` so Packer doesn't quit too early, before the large file is deleted.
-sync

--- a/orc8r/tools/packer/scripts/third_party/chef_bento/cleanup_ubuntu.sh
+++ b/orc8r/tools/packer/scripts/third_party/chef_bento/cleanup_ubuntu.sh
@@ -38,7 +38,8 @@ echo "remove X11 libraries"
 apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
 
 echo "remove packages we don't need"
-apt-get -y purge popularity-contest command-not-found friendly-recovery bash-completion laptop-detect usbutils
+# The script in its upstream form removed "bash-completion" as well, which we want to have in the VMs.
+apt-get -y purge popularity-contest command-not-found friendly-recovery laptop-detect usbutils
 
 # Exclude the files we don't need w/o uninstalling linux-firmware
 echo "Setup dpkg excludes for linux-firmware"
@@ -69,8 +70,10 @@ find /var/log -type f -exec truncate --size=0 {} \;
 echo "blank netplan machine-id (DUID) so machines get unique ID generated on boot"
 truncate -s 0 /etc/machine-id
 
-echo "remove the contents of /tmp and /var/tmp"
-rm -rf /tmp/* /var/tmp/*
+echo "remove the contents of /tmp"
+# The script in its upstream form removed "/var/tmp" as well.
+# This step was removed since we use it to store the swagger 
+rm -rf /tmp/*
 
 echo "force a new random seed to be generated"
 rm -f /var/lib/systemd/random-seed

--- a/orc8r/tools/packer/scripts/ubuntu_setup.sh
+++ b/orc8r/tools/packer/scripts/ubuntu_setup.sh
@@ -20,8 +20,10 @@ sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 # Disable daily apt unattended updates.
 echo 'APT::Periodic::Enable "0";' >> /etc/apt/apt.conf.d/10periodic
 
-apt update
-apt install -y ansible
+apt-get install -y software-properties-common
+add-apt-repository -y ppa:ansible/ansible
+apt-get update
+apt-get install -y ansible
 
 # Mount the guest additions iso and run the install script
 mkdir -p /mnt/iso

--- a/orc8r/tools/packer/scripts/ubuntu_setup.sh
+++ b/orc8r/tools/packer/scripts/ubuntu_setup.sh
@@ -25,6 +25,10 @@ add-apt-repository -y ppa:ansible/ansible
 apt-get update
 apt-get install -y ansible
 
+# Mark ca-certificates-java to not have it removed via autoremove;
+# needed for swagger_codegen_jar
+apt-mark manual ca-certificates-java 
+
 # Mount the guest additions iso and run the install script
 mkdir -p /mnt/iso
 mount -t iso9660 -o loop /home/vagrant/VBoxGuestAdditions.iso /mnt/iso


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR aims to improve the current state of these preburn images regarding build time, image size, and general clean up. Since both, the `magma-dev` and the `magma-test` VM share common Ansible roles, we have to create base images for both of them. 
Changes:

- More Ansible steps are moved to preburn.
- Duplicate commands to install packages are removed.
- Address Ansible errors and warnings during the packing / provision process.
- Remove unused magma files from the VM (see #14080).
- Reduce image size by purging more unneeded stuff after the Ubuntu installation.
- Base images are upgraded to Ubuntu 20.04.5.
- Update box cache version in CI
- Update box version in `Vagrantfile`

Closes #13566 and #14080.

## Test Plan
locally:
- [x] Unit tests via `make test`
- [x] Sudo tests via `./bazel/scripts/run_sudo_tests.sh`
- [x] AGW build via `make run`
- [x] LTE integration tests via `make integ_test`
- [x] Federated integration tests
- [x] CWAG integration tests

CI:
- [x] [LTE integration tests](https://github.com/mpfirrmann/magma/actions/runs/3241540175) -> see below
- [x] [Federated integration tests](https://github.com/mpfirrmann/magma/actions/runs/3234543440)
- [x] [CWAG integration tests](https://github.com/mpfirrmann/magma/actions/runs/3235974474/jobs/5301815509) (with unchanged box cache)

The LTE integration tests have a failed `s1aptests/test_attach_detach_rar_tcp_he.py` which was not retried due to an error. The initial error was a connection issue to the traffic server. However, this is not a systematic problem, all the other tests including the traffic server passed. This issue was reported for a different flaky test [here](https://github.com/magma/magma/issues/13956).

## Additional Information


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
