### PR TITLE
chore: integ test workflows are reproducible

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -332,8 +332,6 @@ def provision_magma_dev_vm(
     else:
         ansible_setup(gateway_host, "dev", "magma_dev.yml")
 
-    execute(_dist_upgrade)
-
 
 def bazel_integ_test_post_build(
     gateway_host=None, test_host=None, trf_host=None,
@@ -447,7 +445,6 @@ def integ_test(
     # Setup the gateway: use the provided gateway if given, else default to the
     # vagrant machine
     gateway_host, gateway_ip = _setup_gateway(gateway_host, "magma", "dev", "magma_dev.yml", destroy_vm, provision_vm)
-    execute(_dist_upgrade)
     execute(_build_magma)
     execute(_run_sudo_python_unit_tests)
     execute(_start_gateway)
@@ -784,12 +781,6 @@ def _copy_out_c_execs_in_magma_vm():
                 print(exec_path + " does not exist")
                 continue
             run('cp ' + exec_path + ' ' + dest_path)
-
-
-def _dist_upgrade():
-    """ Upgrades OS packages on dev box """
-    run('sudo apt-get update')
-    run('sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade')
 
 
 def _build_magma():


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

**NOTE**: The reasoning for this change might be subjective! If you have a strong opinion to not do this change, then please comment on this issue.

The integ tests workflows (make and bazel) are doing an `apt` `dist-upgrade` on the `magma` dev VM ...
* **inconsistent**: this is only happening on the `magma` vm - not on `magma_test` or `magma_trfserver` (yes, the `magma` vm is here more relevant, but this is still inconsistent)
* **not reproducible**: this can make the tests less reproducible as different versions (packages and kernel) might influence results
* **runtime**: after a fresh pre-burn image is released this step is not doing much - after some time it takes a couple of minutes
  * -> we should aim for more frequent releases of pre-burn images

## Test Plan

Make sure the tests still run without a dist-upgrade - runs on fork:
* lte integ tests: https://github.com/nstng/magma/actions/runs/3196934901
  * -> green
* bazel lte integ tests: https://github.com/nstng/magma/actions/runs/3196931308
  * -> failure of one tests - looks like a flaky test failure not related to this change

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
