### PR TITLE
fix(amf): Fixing session ambr value when policy attached

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -174,6 +174,10 @@ Status AmfServiceImpl::SetSmfSessionContext(
     ul_tft = &itti_msg.qos_flow_list.item[i].qos_flow_req_item.ul_tft;
     memset(ul_tft, 0, sizeof(traffic_flow_template_t));
     auto& qos_rule = req_m5g.qos_policy(i);
+    // Session ambr is policy ambr if policy attached
+    itti_msg.session_ambr.uplink_units = qos_rule.qos().qos().max_req_bw_ul();
+
+    itti_msg.session_ambr.downlink_units = qos_rule.qos().qos().max_req_bw_dl();
     itti_msg.qos_flow_list.item[i].qos_flow_req_item.qos_flow_identifier =
         qos_rule.qos().qos().qci();
 


### PR DESCRIPTION
Signed-off-by: Sathyaj27 <sathya.jayadev@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
fixing #14019 
## Summary

- Session ambr was not populated when policy is attached through nms
-  Fixed by populating session ambr with configures policy ambr when policy is attached.
<img width="835" alt="Session ambr" src="https://user-images.githubusercontent.com/94469973/194313958-43f3b086-5d05-415c-9642-4f95669978c8.PNG">

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Tested on abot and spirent
- 
[Multi_Policy.tgz](https://github.com/magma/magma/files/9724830/Multi_Policy.tgz)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is not backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

Closes #14019 