### PR TITLE
feat(nms): implement 5G feature switch for LTE EPC

### DIFF
--- a/nms/app/views/network/NetworkEpc.tsx
+++ b/nms/app/views/network/NetworkEpc.tsx
@@ -48,6 +48,12 @@ export default function NetworkEpc(props: Props) {
   const kpiData: Array<DataRows> = [
     [
       {
+        category: '5G Features',
+        value: props.epcConfigs?.enable5g_features ? 'Enabled' : 'Disabled',
+      },
+    ],
+    [
+      {
         category: 'Policy Enforcement Enabled',
         value: props.epcConfigs?.hss_relay_enabled ? 'Enabled' : 'Disabled',
       },
@@ -101,6 +107,7 @@ export function NetworkEpcEdit(props: EditProps) {
       ? {
           cloud_subscriberdb_enabled: false,
           default_rule_id: 'default_rule_1',
+          enable5g_features: false,
           lte_auth_amf: 'gAA=',
           lte_auth_op: 'EREREREREREREREREREREQ==',
           mcc: '001',
@@ -120,10 +127,15 @@ export function NetworkEpcEdit(props: EditProps) {
       enable_multi_apn_ip_allocation: false,
     },
   );
+
   const handleMobilityChange = <K extends keyof NetworkEpcConfigsMobility>(
     key: K,
     val: NetworkEpcConfigsMobility[K],
   ) => setEpcMobility({...epcMobility, [key]: val});
+  const handleEpcConfigChange = <K extends keyof NetworkEpcConfigs>(
+    key: K,
+    val: NetworkEpcConfigs[K],
+  ) => setEpcConfigs({...epcConfigs, [key]: val});
   const onSave = async () => {
     try {
       await ctx.updateNetworks({
@@ -146,6 +158,17 @@ export function NetworkEpcEdit(props: EditProps) {
           </AltFormField>
         )}
         <List>
+          <AltFormField label={'Enable 5G Features'}>
+            <Switch
+              onChange={() => {
+                handleEpcConfigChange(
+                  'enable5g_features',
+                  !epcConfigs.enable5g_features,
+                );
+              }}
+              checked={epcConfigs.enable5g_features}
+            />
+          </AltFormField>
           <AltFormField label={'IP Allocation Mode'}>
             <Select
               variant={'outlined'}

--- a/nms/app/views/network/__tests__/NetworkTest.tsx
+++ b/nms/app/views/network/__tests__/NetworkTest.tsx
@@ -529,6 +529,7 @@ describe('<NetworkDashboard />', () => {
         config: {
           cloud_subscriberdb_enabled: false,
           default_rule_id: 'default_rule_1',
+          enable5g_features: false,
           lte_auth_amf: 'gAA=',
           lte_auth_op: 'EREREREREREREREREREREQ==',
           mcc: '003',


### PR DESCRIPTION
## Summary

- Closes https://github.com/magma/magma/issues/13500
- Adds a feature switch for 5G with a API call according to [the documentation](https://docs.magmacore.org/docs/next/lte/integrated_5g_sa#enabling--disabling-the-5g-feature-set).

![grafik](https://user-images.githubusercontent.com/13189449/194326286-b16cbaf5-2334-4731-997a-b0a0228355aa.png)

![grafik](https://user-images.githubusercontent.com/13189449/194326461-35fc3e9f-83f4-4b60-b1bb-3597e53a8e8f.png)


## Test Plan

- CI

