### PR TITLE
fix(agw): pipelined initialization dependence

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_pipelined.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_pipelined.service
@@ -18,6 +18,8 @@ After=magma@mobilityd.service
 PartOf=openvswitch-switch.service
 After=openvswitch-switch.service
 Wants=openvswitch-switch.service
+Requires=network.target
+After=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
Signed-off-by: Gustavo Junior Alves <gjalves@gjalves.com.br>

## Summary

Proper dependence on pipelined service to network services before initializes

## Test Plan

In machines where the network interface initialization takes much time, pipelined fails to create the MASQUERADE rule, but initializes itself. The behavior in thar case is the customers can connect but cannot navigate on NAT settings.
