### PR TITLE
feat(ci): run (nearly all) integration tests against containerized AGW

### DIFF
--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -12,6 +12,8 @@
 name: LTE integ test containerized AGW
 
 on:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
   workflow_dispatch: null
   workflow_run:
     workflows:
@@ -23,7 +25,7 @@ on:
 
 jobs:
   lte-integ-test-containerized:
-    if: (github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'magma') || github.event_name == 'workflow_dispatch'
+    if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
     strategy:
       fail-fast: false

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -25,6 +25,10 @@ jobs:
   lte-integ-test-containerized:
     if: (github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'magma') || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        test_targets: [ "precommit", "extended_tests" ]
     steps:
       - name: Cache magma-dev-box
         uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
@@ -62,16 +66,15 @@ jobs:
           MAGMA_DEV_MEMORY_MB: 9216
         working-directory: lte/gateway
         run: |
-          fab --show=debug --set DOCKER_REGISTRY=${DOCKER_REGISTRY} integ_test_containerized:test_mode="selected_tests",tests="TESTS=s1aptests/test_attach_detach.py"
-
+          fab --show=debug --set DOCKER_REGISTRY=${DOCKER_REGISTRY} integ_test_containerized:test_mode=${{ matrix.test_targets }}
       - name: Get test results
         if: always()
+        working-directory: lte/gateway
         run: |
-          cd lte/gateway
-          fab get_test_summaries:dst_path="test-results,sudo_tests=False"
+          fab get_test_summaries:dst_path="test-results",sudo_tests=False,dev_vm_name="magma_deb"
       - name: Upload test results
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
-          name: test-results
+          name: test-results-${{ matrix.test_targets }}
           path: lte/gateway/test-results/**/*.xml

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -498,6 +498,7 @@ def integ_test_containerized(
     Run the integration tests against the containerized AGW.
     Other than that the same as `integ_test`.
     """
+    start_time = datetime.now()
 
     destroy_vm = bool(strtobool(destroy_vm))
     provision_vm = bool(strtobool(provision_vm))
@@ -505,20 +506,25 @@ def integ_test_containerized(
     # Set up the gateway: use the provided gateway if given, else default to the
     # vagrant machine
     gateway_host, gateway_ip = _setup_gateway(gateway_host, "magma", "dev", "magma_dev.yml", destroy_vm, provision_vm)
+    fastprint(f"########## {datetime.now() - start_time} until finished setup gateway\n")
     # TODO: Remove temporary workaround after resolution of https://github.com/magma/magma/issues/13912
     run('rm -rf /etc/snowflake; sudo touch /etc/snowflake')
     execute(_start_gateway_containerized)
+    fastprint(f"########## {datetime.now() - start_time} until finished start gateway\n")
 
     # Set up the trfserver: use the provided trfserver if given, else default to the
     # vagrant machine
     _setup_vm(trf_host, "magma_trfserver", "trfserver", "magma_trfserver.yml", destroy_vm, provision_vm)
     execute(_start_trfserver)
+    fastprint(f"########## {datetime.now() - start_time} until finished start trf server\n")
 
     # Run the tests: use the provided test machine if given, else default to
     # the vagrant machine
     _setup_vm(test_host, "magma_test", "test", "magma_test.yml", destroy_vm, provision_vm)
+    fastprint(f"########## {datetime.now() - start_time} until finished setup test vm\n")
     execute(_make_integ_tests)
     execute(_run_integ_tests, gateway_ip, test_mode=test_mode, tests=tests)
+    fastprint(f"########## {datetime.now() - start_time} until finished integration tests\n")
 
 
 def _start_gateway_containerized():


### PR DESCRIPTION
## Summary

- needs https://github.com/magma/magma/pull/13766
- run the integration tests against the containerized AGW

## Test Plan

- [CI](https://github.com/magma/magma/actions/workflows/lte-integ-test-containerized.yml?query=branch%3Aci%2Fs1ap-tests-against-containerised-agw-precommit) 

## Additional Information

- `test_ipv6_non_nat_dp_ul_tcp` seems to consistently fail out of the pre-commit tests. IPv6 might be broken on containerized AGW.