### PR TITLE
chore: magma debian package meta info is enhanced

### DIFF
--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -41,6 +41,12 @@ MAGMA_FILE_NAME = "{name}_{ver}_{arch}".format(
     ver = VERSION,
 )
 
+### META INFO
+
+URL = "https://github.com/magma/magma/"
+
+MAINTAINER = "The Magma Authors <main@lists.magmacore.org>"
+
 ### SCTPD BUILD
 
 genrule(
@@ -76,7 +82,8 @@ pkg_deb(
     name = "sctpd_deb_pkg",
     data = ":sctpd_content",
     description = "Magma SCTPD",
-    maintainer = "Copyright (c) 2022 The Magma Authors",
+    homepage = URL,
+    maintainer = MAINTAINER,
     package = SCTPD_PKGNAME,
     package_file_name = "{fname}.deb".format(fname = SCTPD_FILE_NAME),
     version = VERSION,
@@ -172,7 +179,8 @@ pkg_deb(
     data = ":magma_content",
     depends = MAGMA_DEPS + OAI_DEPS + OVS_DEPS,
     description = "Magma Access Gateway",
-    maintainer = "Copyright (c) 2022 The Magma Authors",
+    homepage = URL,
+    maintainer = MAINTAINER,
     package = MAGMA_PKGNAME,
     package_file_name = "{fname}.deb".format(fname = MAGMA_FILE_NAME),
     postinst = ":magma-postinst-bazel",

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -324,6 +324,18 @@ echo "${FULL_VERSION}" > "${SCTPD_VERSION_FILE}"
 echo "${SCTPD_MIN_VERSION}" > "${SCTPD_MIN_VERSION_FILE}"
 echo "COMMIT_HASH=\"${COMMIT_HASH_WITH_VERSION}\"" > "${COMMIT_HASH_FILE}"
 
+# meta info
+DESCRIPTION_SCTPD="Magma SCTPD"
+DESCRIPTION_AGW="Magma Access Gateway"
+if [ "${BUILD_TYPE}" != "RelWithDebInfo" ]; then
+    DESCRIPTION_SCTPD="${DESCRIPTION_SCTPD} - dev build"
+    DESCRIPTION_AGW="${DESCRIPTION_AGW} - dev build"
+fi
+URL="https://github.com/magma/magma/"
+VENDOR="magma"
+LICENSE="BSD-3-Clause"
+MAINTAINER="The Magma Authors <main@lists.magmacore.org>"
+
 BUILDCMD="fpm \
 -s dir \
 -t ${PKGFMT} \
@@ -333,7 +345,11 @@ BUILDCMD="fpm \
 --provides ${SCTPD_PKGNAME} \
 --replaces ${SCTPD_PKGNAME} \
 --package ${OUTPUT_DIR}/${SCTPD_PKGNAME}_${FULL_VERSION}_${ARCH}.${PKGFMT} \
---description 'Magma SCTPD' \
+--description '${DESCRIPTION_SCTPD}' \
+--url '${URL}' \
+--vendor '${VENDOR}' \
+--license '${LICENSE}' \
+--maintainer '${MAINTAINER}' \
 --exclude '*/.ignoreme' \
 ${SCTPD_BUILD}/sctpd=/usr/local/sbin/ \
 ${SCTPD_VERSION_FILE}=/usr/local/share/sctpd/version \
@@ -350,7 +366,11 @@ BUILDCMD="fpm \
 --provides ${PKGNAME} \
 --replaces ${PKGNAME} \
 --package ${BUILD_PATH} \
---description 'Magma Access Gateway' \
+--description '${DESCRIPTION_AGW}' \
+--url '${URL}' \
+--vendor '${VENDOR}' \
+--license '${LICENSE}' \
+--maintainer '${MAINTAINER}' \
 --after-install ${POSTINST} \
 --exclude '*/.ignoreme' \
 --config-files /etc/sysctl.d/99-magma.conf \


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

There is no easy way to determine if sctpd or magma debian packages were build with build type `Debug` or `RelWithDebInfo` as these options only influence build flags of the c/c++ services. Also: some meta info properties of the created debian packages are outdated or incomplete.

Change here:
* description: use the original description, but suffix it with "` - dev build`" if the build type `Debug` was used
  * note: this was not changed yet for the bazel build! Bazel needs reproducible outputs, i.e., in this case two different targets need to be created. This will be analyzed separately. It might be more clean to change this after the debian package was created, i.e., outside of the bazel build.
* homepage: "https://github.com/magma/magma/" (was not set before - fpm then uses a dummy value)
* vendor: "magma" (was not set before)
  * note: not supported by the bazel build
* license: "BSD-3-Clause" (was not set before)
  * note: not supported by the bazel build
* maintainer: "The Magma Authors <main@lists.magmacore.org>" (was not set before)

## Test Plan

Build sctpd and magma and check meta info via `dpkg -I <package>`. This can be done more easy by commenting out long running build steps in the make or bazel build.

### make

output is shortened
```
vagrant@magma-dev:~/magma/lte/gateway/release$ ./build-magma.sh 

vagrant@magma-dev:~/magma/lte/gateway/release$ dpkg -I magma_1.8.0-1665737325-_amd64.deb 
 Package: magma
 Version: 1.8.0-1665737325-
 License: BSD-3-Clause
 Vendor: magma
 Maintainer: The Magma Authors <main@lists.magmacore.org>
 Homepage: https://github.com/magma/magma/
 Description: Magma Access Gateway

vagrant@magma-dev:~/magma/lte/gateway/release$ dpkg -I magma-sctpd_1.8.0-1665737325-_amd64.deb 
 Package: magma-sctpd
 Version: 1.8.0-1665737325-
 License: BSD-3-Clause
 Vendor: magma
 Maintainer: The Magma Authors <main@lists.magmacore.org>
 Homepage: https://github.com/magma/magma/
 Description: Magma SCTPD

vagrant@magma-dev:~/magma/lte/gateway/release$ ./build-magma.sh -t Debug

 Description: Magma Access Gateway - dev build

 Description: Magma SCTPD - dev build
```
### bazel

output is shortened

```
vagrant@magma-dev:~/magma/lte/gateway/release$ bazel build //lte/gateway/release:magma_deb_pkg
vagrant@magma-dev:~/magma$ dpkg -I bazel-bin/lte/gateway/release/magma_1.8.0_amd64.deb 
 Package: magma
 Version: 1.8.0
 Maintainer: The Magma Authors <main@lists.magmacore.org>
 Description: Magma Access Gateway
 Homepage: https://github.com/magma/magma/

vagrant@magma-dev:~/magma/lte/gateway/release$ bazel build //lte/gateway/release:sctpd_deb_pkg
vagrant@magma-dev:~/magma$ dpkg -I bazel-bin/lte/gateway/release/sctpd_deb_pkg.deb     
 Package: magma-sctpd
 Version: 1.8.0
 Maintainer: The Magma Authors <main@lists.magmacore.org>
 Description: Magma SCTPD
 Homepage: https://github.com/magma/magma/
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
