### PR TITLE
chore(ci): Consolidate C/C++ coverage generation in new CI workflow

### DIFF
--- a/.github/workflows/agw-coverage.yml
+++ b/.github/workflows/agw-coverage.yml
@@ -1,0 +1,198 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: AGW Generate Coverage
+
+on:
+  push:
+    branches:
+      - master
+      - 'v1.*'
+  pull_request:
+    branches:
+      - master
+      - 'v1.*'
+    types: [ opened, reopened, synchronize ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  # Regarding the CACHE_KEY see https://github.com/magma/magma/pull/14041
+  CACHE_KEY: bazel-base-image-sha-c4de1e5
+  REMOTE_DOWNLOAD_OPTIMIZATION_C_CPP: true
+  REMOTE_DOWNLOAD_OPTIMIZATION_PYTHON: false
+
+jobs:
+  path_filter:
+    runs-on: ubuntu-latest
+    outputs:
+      should_not_skip: ${{ steps.changes.outputs.filesChanged }}
+    steps:
+      # Need to get git on push event
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        if: github.event_name == 'push'
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
+        id: changes
+        with:
+          filters: |
+            filesChanged:
+              - '.github/workflows/agw-coverage.yml'
+              - 'orc8r/**'
+              - 'lte/**'
+              - '.bazelrc'
+              - 'WORKSPACE.bazel'
+              - 'bazel/**'
+
+  c-cpp-codecov:
+    needs: path_filter
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    name: C / C++ code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - name: Maximize build space
+        uses: ./.github/workflows/composite/maximize-build-space
+      - name: Setup Bazel Base Image
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          options: --pull always
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the bazel base image!"
+            bazel # pull down bazel, if bazel download fails we can fail before we do all the lengthy work below
+      - name: Run C/C++ coverage with Bazel
+        if: always()
+        id: bazel-cc-codecoverage
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION_C_CPP }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+            # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178
+            # Coverage in bazel is flaky for remote caches - the flags below are helping. See GH13026 for details.
+            bazel coverage \
+              --profile=Bazel_test_cc_coverage_profile \
+              --experimental_split_coverage_postprocessing --experimental_fetch_all_coverage_outputs --remote_download_outputs=all \
+              //orc8r/gateway/c/...:* //lte/gateway/c/...:*
+            # copy out coverage information into magma so that it's accessible from the CI node
+            cp bazel-out/_coverage/_coverage_report.dat .
+      - name: Upload code coverage
+        if: always()
+        id: c-cpp-codecov-upload
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
+        with:
+          flags: c_cpp
+      - name: Publish bazel profile
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: |
+          always() &&
+          github.repository_owner == 'magma' &&
+          github.ref_name == 'master'
+        with:
+          name: Bazel test C/C++ coverage profile
+          path: Bazel_test_cc_coverage_profile
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h
+      - name: Notify Bazel C/C++ coverage failure to slack
+        if: |
+          failure() &&
+          (steps.bazel-cc-codecoverage.conclusion == 'failure' ||
+          steps.c-cpp-codecov-upload.outcome == 'failure') &&
+          github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "C / C++ code coverage with Bazel"
+          SLACK_USERNAME: "${{ github.workflow }}"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
+
+  python-codecov:
+    needs: path_filter
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    name: Python code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - name: Maximize build space
+        uses: ./.github/workflows/composite/maximize-build-space
+      - name: Setup Bazel Base Image
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          options: --pull always
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the bazel base image!"
+            bazel # pull down bazel, if bazel download fails we can fail before we do all the lengthy work below
+      - name: Run Python coverage with Bazel
+        if: always()
+        id: bazel-python-codecoverage
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION_PYTHON }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+            # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178
+            # Coverage in bazel is flaky for remote caches - the flags below are helping. See GH13026 for details.
+            bazel coverage \
+              --profile=Bazel_test_python_coverage_profile \
+              //orc8r/gateway/python/...:* //lte/gateway/python/...:*
+            # copy out coverage information into magma so that it's accessible from the CI node
+            cp bazel-out/_coverage/_coverage_report.dat .
+      - name: Upload code coverage
+        if: always()
+        id: python-codecov-upload
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
+        with:
+          flags: lte-test
+      - name: Publish bazel profile
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: |
+          always() &&
+          github.repository_owner == 'magma' &&
+          github.ref_name == 'master'
+        with:
+          name: Bazel test python coverage profile
+          path: Bazel_test_python_coverage_profile
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h
+      - name: Notify Bazel Python coverage failure to slack
+        if: |
+          failure() &&
+          (steps.bazel-python-codecoverage.conclusion == 'failure' ||
+          steps.python-codecov-upload.outcome == 'failure') &&
+          github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_TITLE: "Python code coverage with Bazel"
+          SLACK_USERNAME: "${{ github.workflow }}"
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -95,7 +95,6 @@ jobs:
       - name: Install libraries and dependecies
         run: |
           mkdir -p /var/tmp/test_results
-          mkdir -p /var/tmp/codecovs
           sudo -E apt-get update -y
           sudo -E apt-get install -y libsystemd-dev pkg-config curl zip unzip net-tools
           sudo -E apt-get install -y virtualenv python-babel python-dev build-essential autogen autoconf libtool python3-apt python3-requests python3-pip python-protobuf
@@ -123,10 +122,6 @@ jobs:
         with:
           name: Unit Test Results
           path: /var/tmp/test_results
-      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
-        with:
-          files: /var/tmp/codecovs/cover_lte.xml,/var/tmp/codecovs/cover_orc8r.xml
-          flags: lte-test
       - name: Extract commit title
         if: failure() && github.event_name == 'push'
         id: commit
@@ -246,118 +241,6 @@ jobs:
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
-
-  c-cpp-codecov:
-    needs: path_filter
-    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
-    name: C / C++ code coverage
-    runs-on: ubuntu-latest
-    env:
-      MAGMA_ROOT: "${{ github.workspace }}"
-      BRANCH: "${{ github.base_ref }}"
-      REVISION: "${{ github.sha }}"
-    steps:
-      - name: Check Out Repo
-        # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - name: Maximize build space
-        uses: ./.github/workflows/composite/maximize-build-space
-      - name: Setup Devcontainer Image
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
-        with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
-          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
-          run: |
-            echo "Pulled the devontainer image!"
-      - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
-        with:
-          image: ${{ env.BAZEL_BASE_IMAGE }}
-          options: --pull always
-          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
-          run: |
-            echo "Pulled the bazel base image!"
-            bazel # pull down bazel, if bazel download fails we can fail before we do all the lengthy work below
-      - name: Run codecov with CMake (MME)
-        if: always()
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
-        with:
-          image: ${{ env.DEVCONTAINER_IMAGE }}
-          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
-          run: |
-            cd $MAGMA_ROOT/lte/gateway
-            make coverage
-            cp $C_BUILD/coverage.info $MAGMA_ROOT
-      - name: Run coverage with Bazel (COMMON / SESSIOND / SCTPD / LIAGENT / CONNECTIOND)
-        if: always()
-        id: bazel-codecoverage
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
-        with:
-          image: ${{ env.BAZEL_BASE_IMAGE }}
-          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
-          run: |
-            cd $MAGMA_ROOT
-            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
-            # Collecting coverage with Bazel can be slow. We can follow this thread to see if this can be improved: https://github.com/bazelbuild/bazel/issues/8178
-            # Coverage in bazel is flaky for remote caches - the flags below are helping. See GH13026 for details.
-            # TODO: GH11936 Omit OAI coverage until it is tested. We need to determine what the behavior is for doing both CMake and Bazel based coverage at the same time
-            bazel coverage \
-              --profile=Bazel_test_coverage_profile \
-              --experimental_split_coverage_postprocessing --experimental_fetch_all_coverage_outputs --remote_download_outputs=all \
-              -- //orc8r/gateway/c/...:* //lte/gateway/c/...:* -//lte/gateway/c/core/...:*
-            # copy out coverage information into magma so that it's accessible from the CI node
-            cp bazel-out/_coverage/_coverage_report.dat $MAGMA_ROOT
-      - name: Upload code coverage
-        if: always()
-        id: c-cpp-codecov-upload
-        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
-        with:
-          flags: c_cpp
-      - name: Publish bazel profile
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: |
-          always() &&
-          github.repository_owner == 'magma' &&
-          github.ref_name == 'master'
-        with:
-          name: Bazel test coverage profile
-          path: Bazel_test_coverage_profile
-      - name: Extract commit title
-        # yamllint enable
-        if: failure() && github.event_name == 'push'
-        id: commit
-        run: |
-          str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
-          echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to slack
-        if: steps.c-cpp-codecov-upload.outcome=='failure' && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action c-cpp-codecov-upload failed"
-          SLACK_USERNAME: "AGW workflow"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      - name: Build space left after run
-        shell: bash
-        run: |
-          echo "Available storage:"
-          df -h
-      - name: Notify Bazel failure to slack
-        if: failure() && steps.bazel-codecoverage.conclusion == 'failure' && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
-          SLACK_TITLE: "C / C++ code coverage with Bazel"
-          SLACK_USERNAME: "agw-workflow"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
 
   lint-clang-format:
     needs: path_filter

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/orc8r/cloud/docker
           python3 build.py --coverage
-      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
         if: always() && steps.cloud-lint-cov.outcome=='success'
         id: cloud-lint-codecov
         with:

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -124,7 +124,7 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
         with:
           flags: unittests,configuration-controller
           name: codecov-configuration-controller
@@ -200,7 +200,7 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
         with:
           flags: unittests,radio-controller
           name: codecov-radio-controller
@@ -291,7 +291,7 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
         with:
           flags: unittests,db-service
           name: codecov-db-service

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/feg/gateway
           make -C ${MAGMA_ROOT}/feg/gateway cover
-      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
         if: always()
         id: feg-lint-codecov
         with:

--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -216,7 +216,7 @@ jobs:
           cd src/go/
           go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Codecov.io Upload
-        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # pin@v2
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
         with:
           flags: src_go
           verbose: true


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The C/C++ and Python code coverage is now done completely with bazel and in a new workflow.
- The `codecov/codecov-action` is updated everywhere.
- Resolves #13398

## Test Plan

- Coverage for this PR: https://app.codecov.io/gh/magma/magma/pull/14127

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
