### PR TITLE
chore(ci): Add upload test results for containerized agw integ tests

### DIFF
--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   lte-integ-test-containerized:
-    if: github.event.workflow_run.conclusion == 'success' && (github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch')
+    if: (github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'magma') || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
     steps:
       - name: Cache magma-dev-box

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -63,3 +63,14 @@ jobs:
         working-directory: lte/gateway
         run: |
           fab --show=debug --set DOCKER_REGISTRY=${DOCKER_REGISTRY} integ_test_containerized
+      - name: Get test results
+        if: always()
+        run: |
+          cd lte/gateway
+          fab get_test_summaries:dst_path="test-results,sudo_tests=False"
+      - name: Upload test results
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: test-results
+          path: lte/gateway/test-results/**/*.xml


### PR DESCRIPTION
## Summary

It is much easier to analyze what tests have failed when the test results xml files are available from a build. At the moment there is no gui for the test results.

## Tests

Integ test run: https://github.com/crasu/magma/actions/runs/3227573232/jobs/5282553991
Currently does not work because the container health check is flaky