### PR TITLE
[WIP] chore(agw): send integ test name to sentry

### DIFF
--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -33,7 +33,8 @@ endif
 define execute_test
 	echo "Running test: $(1)"
 	sshpass -p vagrant ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR vagrant@192.168.60.142 "echo $(1) > /etc/magma/integ_test_name"
-	timeout --foreground -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(BIN)/pytest $(FLAKY_CMD_ARGS) --capture=tee-sys --junit-xml=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x $(1) || (echo "fail" > $(MAGMA_ROOT)/test_status.txt && exit 1)
+	timeout --foreground -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(BIN)/pytest $(FLAKY_CMD_ARGS) --capture=tee-sys --junit-xml=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x $(1) || echo "fail" > $(MAGMA_ROOT)/test_status.txt
+	sshpass -p vagrant ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR vagrant@192.168.60.142 "echo 'baseline (no test running)' > /etc/magma/integ_test_name"
 	# Testcase $(1) execution completed
 endef
 

--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -32,6 +32,7 @@ endif
 # any ending statement the failing testcases are missing status update
 define execute_test
 	echo "Running test: $(1)"
+	sshpass -p vagrant ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR vagrant@192.168.60.142 "echo $(1) > /etc/magma/integ_test_name"
 	timeout --foreground -k 930s 900s sudo -E PATH=$(PATH) PYTHONPATH=$(PYTHONPATH):$(S1AP_TESTER_PYTHON_PATH) $(BIN)/pytest $(FLAKY_CMD_ARGS) --capture=tee-sys --junit-xml=$(RESULTS_DIR)/$(basename $(notdir $(1))).xml -x $(1) || (echo "fail" > $(MAGMA_ROOT)/test_status.txt && exit 1)
 	# Testcase $(1) execution completed
 endef

--- a/lte/gateway/python/magma/subscriberdb/client.py
+++ b/lte/gateway/python/magma/subscriberdb/client.py
@@ -31,7 +31,10 @@ from lte.protos.subscriberdb_pb2 import (
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.rpc_utils import grpc_async_wrapper
 from magma.common.sdwatchdog import SDWatchdogTask
-from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING, ORC8R_NOT_CONNECTED_KEY
+from magma.common.sentry import (
+    EXCLUDE_FROM_ERROR_MONITORING,
+    ORC8R_NOT_CONNECTED_KEY,
+)
 from magma.common.service_registry import ServiceRegistry
 from magma.subscriberdb.metrics import (
     SUBSCRIBER_SYNC_FAILURE_TOTAL,

--- a/orc8r/gateway/python/magma/common/rpc_utils.py
+++ b/orc8r/gateway/python/magma/common/rpc_utils.py
@@ -14,15 +14,16 @@ limitations under the License.
 
 import asyncio
 import logging
-from typing import Dict
-
 from enum import Enum
+from typing import Dict
 
 import grpc
 from google.protobuf import message as proto_message
 from google.protobuf.json_format import MessageToJson
-
-from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING_KEY, ORC8R_NOT_CONNECTED_KEY
+from magma.common.sentry import (
+    EXCLUDE_FROM_ERROR_MONITORING_KEY,
+    ORC8R_NOT_CONNECTED_KEY,
+)
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos import common_pb2
 
@@ -197,6 +198,7 @@ def get_exclude_conditions(err: Exception) -> Dict[str, bool]:
     if indicates_orc8r_not_connected(err):
         exclude_conditions[ORC8R_NOT_CONNECTED_KEY] = True
     return exclude_conditions
+
 
 def print_grpc(
     message: proto_message.Message, print_grpc_payload: bool,

--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -111,6 +111,7 @@ def _ignore_if_marked(event: Event) -> Optional[Event]:
         return None
     return event
 
+
 def _filter_excluded_messages(event: Event, hint: Hint, patterns_to_exclude: List[str]) -> Optional[Event]:
     explicit_message = event.get('message')
 

--- a/orc8r/gateway/python/magma/common/sentry.py
+++ b/orc8r/gateway/python/magma/common/sentry.py
@@ -93,10 +93,19 @@ def _get_shared_sentry_config(sentry_mconfig: mconfigs_pb2.SharedSentryConfig) -
     return SharedSentryConfig(dsn, sample_rate, exclusion_patterns)
 
 
+def _force_fingerprint_to_integ_test_name(event: Event) -> Event:
+    with open("/etc/magma/integ_test_name", 'r') as f:
+        test_name = f.read()
+        logging.error(f"XXXXXXXXXXX {test_name}")
+        logging.error(f"EEEEEEEE  {event}")
+        event['fingerprint'] = [test_name]
+    return event
+
+
 def _ignore_if_marked(event: Event) -> Optional[Event]:
     if event.get(LOGGING_EXTRA) and event.get(LOGGING_EXTRA).get(EXCLUDE_FROM_ERROR_MONITORING_KEY):
         return None
-    return event
+    return _force_fingerprint_to_integ_test_name(event)
 
 
 def _filter_excluded_messages(event: Event, hint: Hint, patterns_to_exclude: List[str]) -> Optional[Event]:
@@ -110,14 +119,14 @@ def _filter_excluded_messages(event: Event, hint: Hint, patterns_to_exclude: Lis
 
     messages = [msg for msg in (explicit_message, log_message, exception_message) if msg]
     if not messages:
-        return event
+        return _force_fingerprint_to_integ_test_name(event)
 
     for pattern in patterns_to_exclude:
         for message in messages:
             if re.search(pattern, message):
                 return None
 
-    return event
+    return _force_fingerprint_to_integ_test_name(event)
 
 
 def _get_before_send_hook(patterns_to_exclude: List[str]) -> SentryHook:

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -20,7 +20,7 @@ import metrics_pb2
 import prometheus_client.core
 import requests
 import snowflake
-from magma.common.rpc_utils import indicates_connection_error
+from magma.common.rpc_utils import indicates_connection_error, get_exclude_conditions
 from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos import metricsd_pb2
@@ -135,13 +135,14 @@ class MetricsCollector(object):
         """
         err = collect_future.exception()
         if err:
+            exclude_conditions = get_exclude_conditions(err)
             logging.error(
                 "Metrics upload error for service %s (chunk %d)! [%s] %s",
                 service_name,
                 chunk,
                 err.code(),
                 err.details(),
-                extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
+                extra=exclude_conditions if exclude_conditions else None,
             )
         else:
             logging.debug(

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -20,7 +20,10 @@ import metrics_pb2
 import prometheus_client.core
 import requests
 import snowflake
-from magma.common.rpc_utils import indicates_connection_error, get_exclude_conditions
+from magma.common.rpc_utils import (
+    get_exclude_conditions,
+    indicates_connection_error,
+)
 from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos import metricsd_pb2

--- a/orc8r/gateway/python/magma/magmad/state_reporter.py
+++ b/orc8r/gateway/python/magma/magmad/state_reporter.py
@@ -21,8 +21,9 @@ import snowflake
 from magma.common.cert_validity import cert_is_invalid
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.rpc_utils import (
+    get_exclude_conditions,
     grpc_async_wrapper,
-    indicates_connection_error, get_exclude_conditions,
+    indicates_connection_error,
 )
 from magma.common.sdwatchdog import SDWatchdogTask
 from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING

--- a/orc8r/gateway/python/magma/magmad/state_reporter.py
+++ b/orc8r/gateway/python/magma/magmad/state_reporter.py
@@ -22,7 +22,7 @@ from magma.common.cert_validity import cert_is_invalid
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.rpc_utils import (
     grpc_async_wrapper,
-    indicates_connection_error,
+    indicates_connection_error, get_exclude_conditions,
 )
 from magma.common.sdwatchdog import SDWatchdogTask
 from magma.common.sentry import EXCLUDE_FROM_ERROR_MONITORING
@@ -79,11 +79,12 @@ class StateReporterErrorHandler:
         the threshold specified in the config. If it does, it will trigger a
         bootstrap if the certificate is invalid.
         """
+        exclude_conditions = get_exclude_conditions(err)
         logging.error(
             "Checkin Error! Failed to report states. [%s] %s",
             err.code(),
             err.details(),
-            extra=EXCLUDE_FROM_ERROR_MONITORING if indicates_connection_error(err) else None,
+            extra=exclude_conditions if exclude_conditions else None,
         )
         CHECKIN_STATUS.set(0)
         self.num_failed_state_reporting += 1

--- a/orc8r/gateway/python/magma/state/garbage_collector.py
+++ b/orc8r/gateway/python/magma/state/garbage_collector.py
@@ -16,8 +16,9 @@ import grpc
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.redis.containers import RedisFlatDict
 from magma.common.rpc_utils import (
+    get_exclude_conditions,
     grpc_async_wrapper,
-    print_grpc, get_exclude_conditions,
+    print_grpc,
 )
 from magma.common.service import MagmaService
 from magma.state.keys import make_scoped_device_id


### PR DESCRIPTION
## Summary

We are thinking about connecting Sentry to s1ap integ tests. Changes in this PR are needed for the analysis of this idea. Currently, it is just meant to be WIP and serve communication purposes. 

Attach integ test name to events, that are sent to Sentry.

<p>
<img width="1196" alt="Screenshot 2022-10-12 at 15 09 36" src="https://user-images.githubusercontent.com/82914459/195351713-c3410a64-31dd-4be3-a159-26298d5aa10c.png">
<strong>Example. </strong>Event with `integ_test_name` tag.</p>


**Note (potential issues with these changes, if we consider to make them permanent)** 
- (Unidirectional) communication of test name between from test to magma VM currently is enabled by writing and reading a file. If file does not exist, error is raised, no events are sent to Sentry. Better implementation is needed for the filtering option (see next point) to make sense.

- Certain events are filtered out, if grpc error status code is `UNKNOWN` (information is transferred via exclude_conditions dictionary) and `integ_test_name` tag is present in the event. Currently, the tag is always present, since it is created if the file exists. Since the file has to exist, this is more complicated than necessary currently.  

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
