### PR TITLE
fix(ci): Containerized AGW integ test

### DIFF
--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -230,6 +230,7 @@ services:
       interval: "4s"
       timeout: "4s"
       retries: 3
+      start_period: "10s"
     ulimits:
       core: -1
     security_opt:


### PR DESCRIPTION
Health check in containerized integ ci job (#13695) fails because the container is not healthy after the first docker compose up command.

## Summary

Without this change the oai_mme container sometimes gets unhealthy as it needs more time than 12s for startup.

## Test Plan

Integ test run: https://github.com/crasu/magma/actions/runs/3233203515/jobs/5294753054