### PR TITLE
feat(agw): Kill hanging containers immediatly for dockerized agw integ tests

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1080,7 +1080,7 @@ class MagmadUtil(object):
                     or service_name == "pipelined"
                 ):
                     self.exec_command(
-                        "docker restart oai_mme mobilityd sessiond "
+                        "docker restart --time 1 oai_mme mobilityd sessiond "
                         "connectiond pipelined envoy_controller",
                     )
                 elif service_name == "sctpd":
@@ -1095,7 +1095,7 @@ class MagmadUtil(object):
                         "connectiond pipelined envoy_controller",
                     )
                 else:
-                    self.exec_command(f"docker restart {service_name}")
+                    self.exec_command(f"docker restart --time 1 {service_name}")
 
         self.wait_for_restart_to_finish(wait_time)
 
@@ -2325,7 +2325,7 @@ class HeaderEnrichmentUtils(object):
             )
         elif self.magma_utils.init_system == InitMode.DOCKER:
             self.magma_utils.exec_command_output(
-                "docker restart envoy_controller",
+                "docker restart --time 1 envoy_controller",
             )
         time.sleep(5)
         self.magma_utils.exec_command_output(


### PR DESCRIPTION
## Summary

Otherwise hanging containers take up to 20s to restart and tests run into timeouts.

## Tests

Containerized LTE integ test run: https://github.com/crasu/magma/actions/runs/3233773458/jobs/5296052060