### PR TITLE
feat(agw): add service function to get all magma services

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1215,13 +1215,7 @@ class MagmadUtil(object):
         Returns:
             (bool) True if all services are active, False otherwise
         """
-        magma_services = {
-            "mme", "magmad", "sctpd", "sessiond", "policydb", "state",
-            "directoryd", "connectiond", "td-agent-bit", "redis",
-            "subscriberdb", "eventd", "mobilityd", "pipelined", "monitord",
-            "envoy_controller", "smsd", "enodebd", "redirectd", "ctraced",
-            "control_proxy",
-        }
+        magma_services = self.get_magma_services()
         for service in magma_services:
             if not self.is_service_active(service):
                 print(f"************* {service} is not running")
@@ -1276,8 +1270,12 @@ class MagmadUtil(object):
             (str) service name
         """
         if self._init_system == InitMode.SYSTEMD:
-            if service == "sctpd":
-                return "sctpd"
+            if (
+                service == "sctpd"
+                or service == "openvswitch-switch"
+                or service == "magma_dp@envoy"
+            ):
+                return service
             else:
                 return f"magma@{service}"
         elif self._init_system == InitMode.DOCKER:

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -26,6 +26,7 @@ from typing import List, Optional, Tuple
 
 import grpc
 import s1ap_types
+import yaml
 from integ_tests.common.magmad_client import MagmadServiceGrpc
 from integ_tests.gateway.rpc import get_rpc_channel
 from integ_tests.s1aptests.ovs.rest_api import (
@@ -1099,7 +1100,7 @@ class MagmadUtil(object):
             wait_time: (int) max wait time for restart of the services
         """
         for service in services:
-            service_name = self.get_service_name_from_init_system(service)
+            service_name = self.map_service_to_init_system_service_name(service)
             if self._init_system == InitMode.SYSTEMD:
                 self.exec_command(f"sudo systemctl --no-block restart {service_name}")
             elif self._init_system == InitMode.DOCKER:
@@ -1169,7 +1170,7 @@ class MagmadUtil(object):
             service: (str) service to enable
         """
         for service in services:
-            service_name = self.get_service_name_from_init_system(service)
+            service_name = self.map_service_to_init_system_service_name(service)
             if self._init_system == InitMode.SYSTEMD:
                 self.exec_command(f"sudo systemctl unmask {service_name}")
                 self.exec_command(f"sudo systemctl start {service_name}")
@@ -1184,7 +1185,7 @@ class MagmadUtil(object):
             service: (str) service to disable
         """
         for service in services:
-            service_name = self.get_service_name_from_init_system(service)
+            service_name = self.map_service_to_init_system_service_name(service)
             if self._init_system == InitMode.SYSTEMD:
                 self.exec_command(f"sudo systemctl mask {service_name}")
                 self.exec_command(f"sudo systemctl stop {service_name}")
@@ -1236,7 +1237,7 @@ class MagmadUtil(object):
         Returns:
             service active status
         """
-        service_name = self.get_service_name_from_init_system(service)
+        service_name = self.map_service_to_init_system_service_name(service)
         if self._init_system == InitMode.SYSTEMD:
             is_active_service_cmd = f"systemctl is-active {service_name}"
             return (
@@ -1265,7 +1266,7 @@ class MagmadUtil(object):
             result_str = e.output
         return result_str
 
-    def get_service_name_from_init_system(self, service: str) -> str:
+    def map_service_to_init_system_service_name(self, service):
         """Get the correct service name depending on the init system
 
         Args:
@@ -1287,7 +1288,42 @@ class MagmadUtil(object):
         else:
             return service
 
-    def update_mme_config_for_sanity(self, cmd: config_update_cmds):
+    def get_magma_services(self) -> List[str]:
+        """
+        Returns a list of all services managed by magmad and additionally
+        (depending on the init system) services that are not managed by magmad
+        """
+        non_magmad_services = [
+            'magmad',
+            'sctpd',
+        ]
+
+        systemd_only_magma_services = [
+            'openvswitch-switch',
+            'magma_dp@envoy',
+        ]
+
+        docker_only_magma_services = [
+            'connectiond',
+            'monitord',
+            'redirectd',
+            'td-agent-bit',
+        ]
+
+        raw_magmad_yml = self.exec_command_output('cat /etc/magma/magmad.yml')
+        magmad_yml = yaml.load(raw_magmad_yml, Loader=yaml.loader.SafeLoader)
+        magma_services = magmad_yml['magma_services'] + non_magmad_services
+        magma_services.remove('health')
+
+        if self._init_system == InitMode.SYSTEMD:
+            return magma_services + systemd_only_magma_services
+        elif self._init_system == InitMode.DOCKER:
+            magma_services.remove('dnsd')
+            return magma_services + docker_only_magma_services
+        else:
+            return magma_services
+
+    def update_mme_config_for_sanity(self, cmd):
         """Update MME configuration for all sanity test cases"""
         mme_config_update_script = (
             "/home/vagrant/magma/lte/gateway/deploy/roles/magma/files/"

--- a/lte/gateway/python/integ_tests/s1aptests/test_services_are_running.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_services_are_running.py
@@ -14,10 +14,8 @@ limitations under the License.
 import time
 import unittest
 
-import yaml
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import InitMode, MagmadUtil
-from yaml.loader import SafeLoader
 
 SERVICE_START_TIME = 'start_time'
 SERVICE_ACTIVE = 'active_status'
@@ -42,7 +40,7 @@ class TestServicesAreRunning(unittest.TestCase):
         if self._s1ap_wrapper.magmad_util.init_system.value != InitMode.SYSTEMD.value:
             self.skipTest("Systemd only test.")
 
-        services = self._get_services()
+        services = self._s1ap_wrapper.magmad_util.get_magma_services()
 
         """
         Initialize service status dictionary.
@@ -72,23 +70,6 @@ class TestServicesAreRunning(unittest.TestCase):
             print(self.get_failed_service_info(service))
 
         assert not failed_services, "Services are not running correctly. See logging above."
-
-    def _get_services(self):
-        """
-        Returns a list of all services managed by magmad and additionally magmad itself,
-        openvswitch-switch and sctpd.
-        """
-        non_magmad_services = [
-            'magma@magmad',
-            'openvswitch-switch',
-            'sctpd',
-        ]
-
-        raw_magmad_yml = self._s1ap_wrapper.magmad_util.exec_command_output('cat /etc/magma/magmad.yml')
-        magmad_yml = yaml.load(raw_magmad_yml, Loader=SafeLoader)
-        magmad_services = magmad_yml['magma_services']
-
-        return non_magmad_services + [f'magma@{service}' for service in magmad_services]
 
     def _query_state_of_services(self, service_status):
         for service, status in service_status.items():

--- a/lte/gateway/python/integ_tests/s1aptests/test_services_are_running.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_services_are_running.py
@@ -73,11 +73,16 @@ class TestServicesAreRunning(unittest.TestCase):
 
     def _query_state_of_services(self, service_status):
         for service, status in service_status.items():
-            active_state = self._s1ap_wrapper.magmad_util.check_service_activity(
-                f'systemctl is-active {service}',
-            ).strip()
+            active_state = "not active"
+            if self._s1ap_wrapper.magmad_util.is_service_active(service):
+                active_state = "active"
+            service_name = (
+                self._s1ap_wrapper.magmad_util.
+                map_service_to_init_system_service_name(service)
+            )
             start_time = self._s1ap_wrapper.magmad_util.exec_command_output(
-                f'systemctl show {service} --property=ActiveEnterTimestamp',
+                f'systemctl show {service_name} '
+                f'--property=ActiveEnterTimestamp',
             ).strip()
 
             status[SERVICE_START_TIME].append(start_time)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Follow up PR out of the [review discussion](url) in #14008.
There is now a central function in `s1ap_test.py` to get the names of all magma services (for both AGW init systems). This function is then used in the `test_services_are_running.py` test, enabling this test to run with a containerized AGW as well.

## Test Plan

Test the test for `systemd` and containerized AGW.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
