### PR TITLE
fix(ci): there was a bit too much deleted in #14050

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -544,7 +544,7 @@ def _start_gateway_containerized():
 
     with cd(AGW_ROOT + "/docker"):
         # The `docker-compose up` times are machine dependent, such that a retry is needed here for resilience.
-        run_with_retry('DOCKER_REGISTRY=%s docker-compose up -d --quiet-pull' % (env.DOCKER_REGISTRY))
+        run_with_retry('DOCKER_REGISTRY=%s docker-compose -f docker-compose.yaml up -d --quiet-pull' % (env.DOCKER_REGISTRY))
 
 
 def run_with_retry(command, retries=3):


### PR DESCRIPTION
## Summary

#14050 only removes the `docker-compose.dev.yaml`. However the file specification for the `docker-compose.yaml` is still required to work as intended.

See also https://github.com/magma/magma/pull/14050/files#diff-a45484bd347cb21aebd4ddc2739cc30aeaa2d3897f81469b7ece4f33a78b1344R547

## Test Plan

- CI
