### PR TITLE
chore(ci): Publish unit-test results for the bazel-workflow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -64,6 +64,9 @@ build --test_env=PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin
 build --test_env=MAGMA_ROOT
 build --test_env=S1AP_TESTER_ROOT
 
+# Needed for go tests to generate the test result XML in the correct format  
+test --test_env=GO_TEST_WRAP_TESTV=1
+
 # MME specific compile time defines
 # Compile mme libraries with unit test flag
 test --per_file_copt=^lte/gateway/c/core/.*$@-DMME_UNIT_TEST  # See GH issue #13073

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -124,11 +124,22 @@ jobs:
             printf '\r%s\r' '###############################' 1>&2
             printf '\r%s\r' 'Executing bazel test ${{ matrix.bazel-config }}' 1>&2
             printf '\r%s\r' '###############################' 1>&2
+            TEST_FAILED="false"
             bazel test \
               ${{ matrix.bazel-target }} \
               ${{ matrix.bazel-config }} \
               --test_output=errors \
-              --profile=Bazel_test_all_profile
+              --profile=Bazel_test_all_profile || TEST_FAILED="true"
+            # Create Bazel unit-test results
+            # Can't be a separate step, because the container's '/tmp' folder is not preserved between steps
+            mkdir bazel_unit_test_results/
+            UNIQUE_FILENAME_INDEX=0
+            TEST_REPORT_PATHS=( $(find bazel-testlogs/ -name 'test.xml') )
+            for TEST_REPORT_PATH in "${TEST_REPORT_PATHS[@]}"
+            do
+              cp "${TEST_REPORT_PATH}" "bazel_unit_test_results/test_result_${UNIQUE_FILENAME_INDEX}.xml"
+              UNIQUE_FILENAME_INDEX=$((UNIQUE_FILENAME_INDEX + 1))
+            done
 
             if [ -z "${{ matrix.bazel-config }}" ];
             then
@@ -145,6 +156,17 @@ jobs:
               printf '\r%s\r' '###############################' 1>&2
               bazel/scripts/test_python_service_imports.sh;
             fi
+
+            if [[ "${TEST_FAILED}" == "true" ]];
+            then
+              echo "ERROR: 'bazel test' failed!"
+              exit 1
+            fi
+      - name: Create merged test-result XML file
+        if: always()
+        run: |
+          mkdir -p lte/gateway/test_results/
+          python3 lte/gateway/python/scripts/runtime_report.py -i "[^\/]+\.xml" -w "bazel_unit_test_results" -o "lte/gateway/test_results/merged_unit_test_reports.xml"
       - name: Publish bazel build profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
@@ -157,6 +179,19 @@ jobs:
         with:
           name: Bazel test all profile ${{ matrix.bazel-config }}
           path: Bazel_test_all_profile
+      - name: Upload Bazel unit-test results ${{ matrix.bazel-config }}
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: Bazel unit-test results ${{ matrix.bazel-config }}
+          path: lte/gateway/test_results/merged_unit_test_reports.xml
+      - name: Publish Bazel unit-test results ${{ matrix.bazel-config }}
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@2a60c5d47eb29cd5cc922f51bbea18e148f56203 # pin@v2
+        with:
+          check_name: Bazel unit-test results ${{ matrix.bazel-config }}
+          junit_files: lte/gateway/test_results/**/*.xml
+          check_run_annotations: all tests
       - name: Build space left after run
         shell: bash
         run: |

--- a/lte/gateway/python/scripts/runtime_report.py
+++ b/lte/gateway/python/scripts/runtime_report.py
@@ -46,17 +46,27 @@ def merge_all_report(working_dir, list_xml_report_paths, output_path):
         xml_file_path = working_dir + "/" + xml_file_path
         test_result = ET.parse(xml_file_path)
         test_suites_data = test_result.getroot()
-        # for the integration tests pytest generates the XML files with a slightly different structure
-        integration_tests = test_suites_data.attrib == {}
-        if integration_tests:
+        # for the Python tests, the XML files have a slightly different structure
+        python_tests = test_suites_data.attrib == {}
+        if python_tests:
             test_suites_data.attrib = test_suites_data[0].attrib
         num_all_failures += int(test_suites_data.attrib['failures'])
+        # some Python test-suites might not have a time attribute
+        if test_suites_data.attrib.get('time') is None:
+            test_suites_time = 0
+            for test_suite in test_suites_data:
+                for test_case in test_suite.findall(".//testcase"):
+                    test_suites_time += float(test_case.attrib['time'])
+            test_suites_data.attrib['time'] = str(test_suites_time)
         num_all_tests += int(test_suites_data.attrib['tests'])
         total_time += float(test_suites_data.attrib['time'])
         num_all_errors += int(test_suites_data.attrib['errors'])
-        if not integration_tests:
+        if not python_tests:
             num_all_disabled += int(test_suites_data.attrib['disabled'])
-        init_time = min(init_time, datetime.fromisoformat(test_suites_data.attrib['timestamp']))
+        try:
+            init_time = min(init_time, datetime.fromisoformat(test_suites_data.attrib['timestamp']))
+        except KeyError:
+            pass
 
         for single_test_suite_data in test_suites_data:
             testsuites_node.append(single_test_suite_data)


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The the unit-test results were not published before for the `Bazel build and test` workflow. This PR ensures that the XML files are archived and published for all matrix jobs. This closes #13526.

## Test Plan

CI.

Test run with failing tests: https://github.com/vktng/magma/actions/runs/3235921237
Test run without failing tests: https://github.com/vktng/magma/actions/runs/3236092774

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
