### PR TITLE
chore(ci): refactor AGW integration test makefile to handle multiple manual tests correctly

### DIFF
--- a/docs/readmes/feg/s1ap_federated_tests.md
+++ b/docs/readmes/feg/s1ap_federated_tests.md
@@ -201,7 +201,7 @@ vagrant ssh magma_test
 # inside vagrant vm
 cd magma/lte/gateway/python/integ_tests
 ## Individual test(s), e.g.:
-make federated_integ_test TESTS=s1aptests/test_attach_detach.py
+make prepare_federation selected_tests TESTS="<test(s)_to_run_space_separated>"
 
 ## All tests
 make federated_integ_test

--- a/docs/readmes/lte/s1ap_tests.md
+++ b/docs/readmes/lte/s1ap_tests.md
@@ -86,7 +86,7 @@ From `$MAGMA_ROOT/lte/gateway/python/integ_tests` on the *magma_test* VM, run
 either individual tests or the full suite of tests. A safe, non-flaky test to
 run is `s1aptests/test_attach_detach.py`.
 
-- Individual test(s): `make integ_test TESTS=<test(s)_to_run>`
+- Individual test(s): `make selected_tests TESTS="<test(s)_to_run_space_separated>"`
 - All Sanity tests: `make integ_test`
 - All Non-Sanity tests: `make nonsanity`
 - Minimal set of tests to be executed before committing changes to magma repository: `make precommit`
@@ -150,11 +150,11 @@ the redis service with `sudo service magma@redis start` and then try again.
 On test VM:
 
 1. Basic attach/detach test where MME is restarted mid-way:\
-  `make integ_test TESTS=s1aptests/test_attach_detach_with_mme_restart.py`
+  `make selected_tests TESTS=s1aptests/test_attach_detach_with_mme_restart.py`
 
 1. Attach with uplink UDP traffic, where MME is restarted while UDP traffic is
 flowing:\
- `make integ_test TESTS=s1aptests/test_attach_ul_udp_data_with_mme_restart.py`\
+ `make selected_tests TESTS=s1aptests/test_attach_ul_udp_data_with_mme_restart.py`\
  , make sure traffic server VM is running (as described in traffic tests above) and
 TCP checksum is disabled on all VMs.
 
@@ -180,10 +180,10 @@ On test VM:
 1. `cd $MAGMA_ROOT/lte/gateway/python && make`
 1. `cd integ_tests && make`
 1. Basic attach/detach test where Mobilityd is restarted mid-way:\
- `make integ_test TESTS=s1aptests/test_attach_detach_with_mobilityd_restart.py`
+ `make selected_tests TESTS=s1aptests/test_attach_detach_with_mobilityd_restart.py`
 
 1. Test IP blocks are maintained across service restart\
- `make integ_test TESTS=s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py`
+ `make selected_tests TESTS=s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py`
 
 #### Stateless Pipelined
 
@@ -209,7 +209,7 @@ On test VM:
 1. `cd $MAGMA_ROOT/lte/gateway/python && make`
 1. `cd integ_tests && make`
 1. UDP traffic test where Pipelined is restarted mid-way:
- `make integ_test TESTS=s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py`
+ `make selected_tests TESTS=s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py`
 
 ### Testing stateless gateway with all services
 
@@ -221,7 +221,7 @@ listed above
 1. On test VM, you can run any of the test cases for individual service restarts
 listed above. Further, you can test attach with uplink UDP traffic, where
 multiple services are restarted while UDP traffic is flowing:\
- `make integ_test TESTS=s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py`\
+ `make selected_tests TESTS=s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py`\
  , make sure traffic server VM is running (as described in traffic tests above) and
 TCP checksum is disabled on all VMs.
 

--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -44,19 +44,16 @@ prepare_environment: $(PYTHON_BUILD)/setupinteg_env $(BIN)/pytest
 prepare_federation:
 	$(eval export FEDERATED_MODE = True)
 
+.PHONY: selected_tests
+selected_tests: prepare_environment
+	$(foreach test,$(TESTS),$(call execute_test,$(test));)
+
 .PHONY: precommit
 precommit: prepare_environment
-ifdef TESTS
-	$(call execute_test,$(TESTS))
-else
 	$(foreach test,$(PRECOMMIT_TESTS),$(call execute_test,$(test));)
-endif
 
 .PHONY: integ_test
 integ_test: prepare_environment
-ifdef TESTS
-	$(call execute_test,$(TESTS))
-else
 	echo "pass" > $(MAGMA_ROOT)/test_status.txt
 ifndef enable-flaky-retry
 	echo "Flaky test retries are disabled"
@@ -66,13 +63,9 @@ else
 	-$(foreach test,$(EXTENDED_TESTS) $(PRECOMMIT_TESTS),$(call execute_test,$(test));)
 	if [ ! -z `grep -s pass $(MAGMA_ROOT)/test_status.txt` ]; then echo "Final integ_test status: Passed"; else echo "Final integ_test status: Failed"; exit 1; fi
 endif
-endif
 
 .PHONY: federated_integ_test
 federated_integ_test: prepare_environment prepare_federation
-ifdef TESTS
-	$(call execute_test,$(TESTS))
-else
 	echo "pass" > $(MAGMA_ROOT)/test_status.txt
 ifndef enable-flaky-retry
 	echo "Flaky test retries are disabled"
@@ -82,12 +75,7 @@ else
 	-$(foreach test,$(FEDERATED_TESTS),$(call execute_test,$(test));)
 	if [ ! -z `grep -s pass $(MAGMA_ROOT)/test_status.txt` ]; then echo "Final federated_integ_test status: Passed"; else echo "Final federated_integ_test status: Failed"; exit 1; fi
 endif
-endif
 
 .PHONY: nonsanity
 nonsanity: prepare_environment
-ifdef TESTS
-	$(call execute_test,$(TESTS))
-else
 	$(foreach test,$(NON_SANITY_TESTS),$(call execute_test,$(test));)
-endif


### PR DESCRIPTION
## Summary

- allow for multiple tests to be executed manually (space separated)! :rocket: 
  This was previously thought to be possible and also suggested by the naming, but actually not implemented.
- clean up bloat

## Test Plan

- CI
