### PR TITLE
chore(ci): remove duplication from fabfile for AGW integration tests

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -295,7 +295,7 @@ def federated_integ_test(
     )
     execute(_make_integ_tests)
     sleep(20)
-    execute(run_integ_tests, federated_mode='True')
+    execute(_run_integ_tests, federated_mode=True)
 
 
 def _modify_for_bazel_services():
@@ -558,34 +558,6 @@ def run_with_retry(command, retries=3):
             fastprint(f"ERROR: Failed on retry {iteration} of \n$ {command}\n")
     else:
         raise Exception(f"ERROR: Failed after {retries} retries of \n$ {command}")
-
-
-def run_integ_tests(tests=None, federated_mode='False'):
-    """
-    Function is required to run tests only in pre-configured Jenkins env.
-
-    In case of no tests specified with command executed like follows:
-    $ fab run_integ_tests
-
-    default tests set will be executed as a result of the execution of following
-    command in test machine:
-    $ make integ_test
-
-    In case of selecting specific test like follows:
-    $ fab run_integ_tests:tests=s1aptests/test_attach_detach.py
-    $ fab run_integ_tests:tests=federated_tests/s1aptests/test_attach_detach.py,federated_mode=True
-
-    The specific test will be executed as a result of the execution of following
-    command in test machine:
-    $ make integ_test TESTS=s1aptests/test_attach_detach.py
-    $ make fed_integ_test TESTS=federated_tests/s1aptests/test_attach_detach.py
-    """
-    vagrant_setup("magma_test", destroy_vm=False)
-    gateway_ip = '192.168.60.142'
-    if tests:
-        tests = "TESTS=" + tests
-
-    execute(_run_integ_tests, gateway_ip, tests, strtobool(federated_mode))
 
 
 def get_test_summaries(


### PR DESCRIPTION
## Summary

- Unbelievable that the same method was implemented twice. And yes, the deleted lines are in the other workflow as well. They might be one level higher or lower though.

## Test Plan

- CI
