### PR TITLE
fix: correct action for macos slack notification is used

### DIFF
--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -123,13 +123,11 @@ jobs:
           path: lte/gateway/logs.tar.gz
 
       - name: Notify failure to slack
-        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+        if: failure() && github.repository_owner == 'magma'
+        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
-          SLACK_TITLE: "Bazel Debian Integration Tests"
-          SLACK_USERNAME: "LTE integ test bazel magma-deb"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
+          SLACK_USERNAME: "Bazel Debian Integration Tests"
+          SLACK_AVATAR: ":boom:"
+        with:
+          args: "Bazel Debian LTE integration test failed in run: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>


## Summary

In #14093 a macos based workflow was introduced that sends a slack notification in case of failure. I used an action that only works on ubuntu based workflows. For review: compare with slack action used established macos workflows.

See notification send failure on: https://github.com/magma/magma/actions/runs/3242702815/jobs/5316352859
`Error: Container action is only supported on Linux`.

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
