### PR TITLE
chore: the bazel vm setup is more comfortable and documented

### DIFF
--- a/docs/readmes/lte/s1ap_tests.md
+++ b/docs/readmes/lte/s1ap_tests.md
@@ -33,19 +33,33 @@ acts as the gateway between *magma_test* and *magma_trfserver*.
 ### Gateway VM setup
 
 There are two options for setting up the gateway VM, with the difference being the magma installation
-method: it can either be installed via `make` or from debian packages, the latter being the
-method by which magma is usually deployed. For everyday development, the `make` installation is
-recommended, while the debian installation is useful for testing packages before release.
+method: it can either be installed by directly compiling the services or from debian packages, the
+latter being the method by which magma is usually deployed. For everyday development, directly
+compiling the services is recommended, while the debian installation is useful for testing packages
+before release.
 
 > **Warning**: These two VMs use the same network configuration, so one must only run one of them
 at a time.
 
-#### Make installation
+#### Directly compiling services
 
-Spin up and provision the gateway VM, then make and start its services:
+Spin up and provision the gateway VM. From `magma/lte/gateway` on the host machine run
+`vagrant up magma && vagrant ssh magma`.
 
-1. From `magma/lte/gateway` on the host machine: `vagrant up magma && vagrant ssh magma`
-1. Now in the gateway VM: `cd $MAGMA_ROOT/lte/gateway && make run`
+Now build the services with either make or bazel.
+
+##### Building with make
+
+In the gateway VM run `cd $MAGMA_ROOT/lte/gateway && make run`.
+
+##### Building with bazel
+
+> :warning: **Bazel based builds are still experimental but can already be used for development**
+
+1. Create links for cli scripts: `cd $MAGMA_ROOT && bazel/scripts/link_scripts_for_bazel_integ_tests.sh`
+2. Use bazel systemd unit files: `sudo cp $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/systemd_bazel/* /etc/systemd/system/ && sudo systemctl daemon-reload`
+3. Build the services: `cd $MAGMA_ROOT && magma-build-agw` (Note: this will take some time for the initial build, but will be fast for follow-up builds.)
+4. Start the access gateway: `magma-restart`
 
 #### Debian installation
 

--- a/lte/gateway/deploy/magma_dev.yml
+++ b/lte/gateway/deploy/magma_dev.yml
@@ -45,6 +45,7 @@
     - role: fluent_bit
     - role: pyvenv
     - role: service_aliases
+    - role: bazel_aliases
 
   tasks:
     # Only run installation for docker

--- a/lte/gateway/deploy/roles/bazel_aliases/tasks/main.yml
+++ b/lte/gateway/deploy/roles/bazel_aliases/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create convenient aliases for bazel builds
+  lineinfile:
+    dest: /home/{{ ansible_user }}/.bashrc
+    state: present
+    line: "{{ item }}"
+  with_items:
+    # build all services and scripts needed to run the lte access gateway
+    - alias magma-build-agw='bazel build `bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/...)"`'


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Here: defining a convenient alias `magma-build-agw` for the clumpy bazel build command to build all lte agw services including cli scripts (`bazel build `bazel query `"kind(.*_binary, //orc8r/... union //lte/... union //feg/...)"`). This is only relevant for the magma dev VM.

Add documentation to integration test setup on how a VM can be setup locally for running bazel build services.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

Follow the documentation and see that services are started. Verify that integration tests can be run locally vs this setup.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
