### PR TITLE
chore(ci): directory not used at all in federated integration tests

### DIFF
--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -166,7 +166,6 @@ jobs:
             vagrant ssh magma -c 'cat magma/lte/gateway/image.tar | docker load'
             rm image.tar
           done
-          mkdir -p /tmp/fed_integ_test-images
       - name: Run the federated integ test
         run: |
           cd lte/gateway


### PR DESCRIPTION
## Summary

The created directory is not used at all afterwards.

## Test Plan

- Full text search for the directory in the codebase.
- CI

## Additional information

- CI of federated integration tests seems to be overall flaky because often the respective machines do not start properly.