### PR TITLE
refactor(ci): modularize the federated integration test make command

### DIFF
--- a/docs/readmes/feg/s1ap_federated_tests.md
+++ b/docs/readmes/feg/s1ap_federated_tests.md
@@ -201,10 +201,10 @@ vagrant ssh magma_test
 # inside vagrant vm
 cd magma/lte/gateway/python/integ_tests
 ## Individual test(s), e.g.:
-make fed_integ_test TESTS=s1aptests/test_attach_detach.py
+make federated_integ_test TESTS=s1aptests/test_attach_detach.py
 
 ## All tests
-make fed_integ_test
+make federated_integ_test
 
 # once the tests are done, you can exit the vagrant vm
 exit

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -295,7 +295,7 @@ def federated_integ_test(
     )
     execute(_make_integ_tests)
     sleep(20)
-    execute(_run_integ_tests, test_mode="fed_integ_test")
+    execute(_run_integ_tests, test_mode="federated_integ_test")
 
 
 def _modify_for_bazel_services():

--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -40,6 +40,10 @@ endef
 prepare_environment: $(PYTHON_BUILD)/setupinteg_env $(BIN)/pytest
 	. $(PYTHON_BUILD)/bin/activate
 
+.PHONY: prepare_federation
+prepare_federation:
+	$(eval export FEDERATED_MODE = True)
+
 .PHONY: precommit
 precommit: prepare_environment
 ifdef TESTS
@@ -64,9 +68,8 @@ else
 endif
 endif
 
-.PHONY: fed_integ_test
-fed_integ_test: prepare_environment
-	$(eval export FEDERATED_MODE = True)
+.PHONY: federated_integ_test
+federated_integ_test: prepare_environment prepare_federation
 ifdef TESTS
 	$(call execute_test,$(TESTS))
 else
@@ -77,7 +80,7 @@ ifndef enable-flaky-retry
 else
 	echo "Flaky test retries are enabled"
 	-$(foreach test,$(FEDERATED_TESTS),$(call execute_test,$(test));)
-	if [ ! -z `grep -s pass $(MAGMA_ROOT)/test_status.txt` ]; then echo "Final fed_integ_test status: Passed"; else echo "Final fed_integ_test status: Failed"; exit 1; fi
+	if [ ! -z `grep -s pass $(MAGMA_ROOT)/test_status.txt` ]; then echo "Final federated_integ_test status: Passed"; else echo "Final federated_integ_test status: Failed"; exit 1; fi
 endif
 endif
 


### PR DESCRIPTION
## Summary

- Be more explicit about the federation, yet maintain the flexibility of execution and avoid code duplication.
- This is a prerequisite for https://github.com/magma/magma/pull/14150

## Test Plan

- CI

## Additional Information

- Note that the federated integration tests are flaky anyway, due to issues with VM startup.