### PR TITLE
fix(amf): Added t3512 configuration and registration failure handling

### DIFF
--- a/lte/gateway/c/core/oai/include/amf_config.hpp
+++ b/lte/gateway/c/core/oai/include/amf_config.hpp
@@ -51,6 +51,7 @@
 #define AMF_CONFIG_STRING_AMF_SET_ID "AMF_SET_ID"
 #define AMF_CONFIG_STRING_AMF_POINTER "AMF_POINTER"
 #define AMF_CONFIG_STRING_NAS_ENABLE_IMS_VoPS_3GPP "ENABLE_IMS_VoPS_3GPP"
+#define AMF_CONFIG_STRING_NAS_T3512 "T3512"
 
 typedef struct nas5g_config_s {
   uint8_t preferred_integrity_algorithm[8];

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -897,8 +897,7 @@ void amf_ctx_release_ue_context(ue_m5gmm_context_s* ue_context_p,
     OAILOG_FUNC_OUT(LOG_AMF_APP);
   }
 
-  amf_app_itti_ue_context_release(ue_context_p,
-                                  ue_context_p->ue_context_rel_cause);
+  amf_app_itti_ue_context_release(ue_context_p, n2_cause);
 
   if (ue_context_p->m5_implicit_deregistration_timer.id !=
       NAS5G_TIMER_INACTIVE_ID) {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_as.cpp
@@ -495,9 +495,9 @@ int amf_reg_acceptmsg(const guti_m5_t* guti, const tai_t* tai,
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg.gprs_timer
       .len = 1;
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg.gprs_timer
-      .unit = 0;
+      .unit = static_cast<uint8_t>(M5GGprsTimer3ValueUnit::MULTIPLES_OF_10MIN);
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg.gprs_timer
-      .timervalue = 6;
+      .timervalue = (amf_config.nas_config.t3512_min) / 10;
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg
       .network_feature.iei = NETWORK_FEATURE;
   nas_msg->security_protected.plain.amf.msg.registrationacceptmsg

--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -197,7 +197,7 @@ int amf_config_parse_file(amf_config_t* config_pP,
   const char* default_dns_sec = NULL;
   const char* set_sst = NULL;
   const char* set_sd = NULL;
-
+  int aint = 0;
   config_init(&cfg);
 
   if (config_pP->config_file != NULL) {
@@ -345,6 +345,12 @@ int amf_config_parse_file(amf_config_t* config_pP,
             setting_amf, AMF_CONFIG_STRING_NAS_ENABLE_IMS_VoPS_3GPP,
             &astring))) {
       config_pP->nas_config.enable_IMS_VoPS_3GPP = parse_bool(astring);
+    }
+
+    // t3512
+    if ((config_setting_lookup_int(setting_amf, AMF_CONFIG_STRING_NAS_T3512,
+                                   &aint))) {
+      config_pP->nas_config.t3512_min = (uint32_t)aint;
     }
 
     // guamfi SETTING

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -338,8 +338,10 @@ status_code_e amf_handle_registration_request(
   params->m5gsregistrationtype = m5gsregistrationtype;
 
   // Save the UE Security Capability into AMF's UE Context
-  memcpy(&(ue_context->amf_context.ue_sec_capability),
-         &(msg->ue_sec_capability), sizeof(UESecurityCapabilityMsg));
+  if (params->m5gsregistrationtype != AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
+    memcpy(&(ue_context->amf_context.ue_sec_capability),
+           &(msg->ue_sec_capability), sizeof(UESecurityCapabilityMsg));
+  }
   memcpy(&(ue_context->amf_context.originating_tai),
          (const void*)originating_tai, sizeof(tai_t));
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GNasEnums.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GNasEnums.h
@@ -210,4 +210,15 @@ enum class M5GMessageType : uint8_t {
   FIVEG_SM_STATUS = 0b11010110,
 };
 
+enum class M5GGprsTimer3ValueUnit : uint8_t {
+  MULTIPLES_OF_10MIN = 0b000,
+  MULTIPLES_OF_1HOUR = 0b001,
+  MULTIPLES_OF_10HOUR = 0b010,
+  MULTIPLES_OF_2SEC = 0b011,
+  MULTIPLES_OF_30SEC = 0b100,
+  MULTIPLES_OF_1MIN = 0b101,
+  MULTIPLES_OF_320HOUR = 0b110,
+  DEACTIVATED = 0b111,
+};
+
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_client_servicer.cpp
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_client_servicer.cpp
@@ -60,6 +60,10 @@ status_code_e NGAPClientServicer::send_message_to_amf(
 status_code_e ngap_send_msg_to_task(task_zmq_ctx_t* task_zmq_ctx_p,
                                     task_id_t destination_task_id,
                                     MessageDef* message) {
+  OAILOG_INFO(LOG_NGAP, "Sending msg to :[%s] id: [%d]-[%s]\n",
+              itti_get_task_name(destination_task_id), ITTI_MSG_ID(message),
+              ITTI_MSG_NAME(message));
+
   return (magma5g::NGAPClientServicer::getInstance().send_message_to_amf(
       task_zmq_ctx_p, destination_task_id, message));
 }

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -358,4 +358,5 @@ AMF :
 
     # IMP VoPS FEATURE
     ENABLE_IMS_VoPS_3GPP = "{{ enable_IMS_VoPS_3GPP }}";
+    T3512 = 10
 };


### PR DESCRIPTION
fix(amf): Added t3512 configuration and registration failure handling
## Summary
addressed below issues
1. Clean up NGAP context if Registration failure
2.  Configurable t3512 timer
3. Periodic Registration failure fix

<!-- Enumerate changes you made and why you made them -->

## Test Plan
- Basic Registration and PDU Session
- Periodic registration 
-  verified UT test cases.
![image](https://user-images.githubusercontent.com/83060027/195833081-f3999cda-4586-4213-b138-05599f8446b3.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
