### PR TITLE
fix(ci): MME RHEL8 build from scratch was broken

### DIFF
--- a/ci-scripts/docker/Dockerfile.mme.ci.rhel8
+++ b/ci-scripts/docker/Dockerfile.mme.ci.rhel8
@@ -3,7 +3,7 @@
 ################################################################
 FROM magma-dev-mme:ci-base-image as magma-mme-builder
 
-ARG FEATURES=mme_oai
+ENV FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c

--- a/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
+++ b/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
@@ -3,7 +3,7 @@
 ################################################################
 FROM magma-dev-mme:ci-base-image as magma-mme-builder
 
-ARG FEATURES=mme_oai
+ENV FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -3,7 +3,7 @@
 ################################################################
 FROM registry.access.redhat.com/ubi8/ubi:latest as magma-mme-base
 
-ARG FEATURES=mme_oai
+ENV FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -3,8 +3,7 @@
 ################################################################
 FROM ubuntu:bionic as magma-mme-builder
 
-ARG GIT_PROXY
-ARG FEATURES=mme_oai
+ENV FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
 ENV BUILD_TYPE=RelWithDebInfo
 ENV C_BUILD=/build/c
@@ -50,8 +49,6 @@ RUN echo "Install 3rd party dependencies" && \
     echo "Install libtins" && \
     apt-get install -y libtins-dev && \
     ln -s /usr/bin/python2.7 /usr/local/bin/python
-
-RUN ["/bin/bash", "-c", "if [[ -v GIT_PROXY ]]; then git config --global http.proxy $GIT_PROXY; fi"]
 
 ##### NETTLE
 RUN wget --quiet https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \


### PR DESCRIPTION
## Summary

After merging [the RHEL8 optimization pull request](https://github.com/magma/magma/pull/14070), I verified with manual post-merge check: [It](https://jenkins-oai.eurecom.fr/job/MAGMA-MME-production/19074/) failed.

The reason is simple: the `build-variant` (ie `FEATURES`) was an `argument` and not `environment variables`.

With the new multi-staged build, it was not carried over.

But since these dockerfiles only works for the `mme-oai` build-variant, it is better to use `ENV` anyway.

I did also some clean-up on the build arguments. `GIT_PROXY` is no longer used in Eurecom/OAI environment. It's useless.

## Test Plan

This time, I did build from scratch. Working now.

## Additional Information
