### PR TITLE
fix: workflows on 1.8 are pinned to relevant bazel base image and are using own cache key

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -18,8 +18,8 @@ concurrency:
 
 env:
   DEVCONTAINER_IMAGE: "ghcr.io/magma/magma/devcontainer:latest"
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
-  CACHE_KEY: bazel-base-image
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:sha-e533ea8"
+  CACHE_KEY: bazel-base-image-1_8
 
 jobs:
   path_filter:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -17,8 +17,8 @@ on:
     # Run four times a day to build bazel cache
     - cron: '0 0,6,12,18 * * *'
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
-  CACHE_KEY: bazel-base-image
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:sha-e533ea8"
+  CACHE_KEY: bazel-base-image-1_8
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -15,8 +15,8 @@ on:
       - master
       - 'v1.*'
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
-  CACHE_KEY: bazel-base-image
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:sha-e533ea8"
+  CACHE_KEY: bazel-base-image-1_8
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

This change is only relevant for 1.8. - the bazel tests are failing on the 1.8 branch. This is because we are using the latest bazel base image and remote caches that were updated after the 1.8 branch was created. In general it makes sense for a release branch to
* pin the bazel base image to the sha that was latest at branch creation time
* use a dedicated cache key in order to avoid clashes with cache entries that have changes that are not encoded in the cache hash (e.g., links to system libraries are not encoded)  

## Test Plan

CI - bazel workflows

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
