### PR TITLE
chore(agw): Add systemd notification to mme so we can detect when the mme has restarted

### DIFF
--- a/bazel/external/system_libraries.BUILD
+++ b/bazel/external/system_libraries.BUILD
@@ -125,4 +125,3 @@ cc_library(
     name = "libsystemd",
     linkopts = ["-lsystemd"],
 )
-

--- a/bazel/external/system_libraries.BUILD
+++ b/bazel/external/system_libraries.BUILD
@@ -120,3 +120,9 @@ cc_library(
     name = "libsqlite3-dev",
     linkopts = ["-lsqlite3"],
 )
+
+cc_library(
+    name = "libsystemd",
+    linkopts = ["-lsystemd"],
+)
+

--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1074,6 +1074,7 @@ MME_DEPS = [
     "@system_libraries//:libgnutls",
     "@system_libraries//:libnettle",
     "@system_libraries//:libsqlite3-dev",
+    "@system_libraries//:libsystemd",
 ]
 
 # EMBEDDED_SGW 1

--- a/lte/gateway/c/core/oai/oai_mme/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/oai_mme/CMakeLists.txt
@@ -55,7 +55,7 @@ target_link_libraries(mme
     -Wl,--end-group
     ${LFDS} pthread m sctp rt crypt ${CRYPTO_LIBRARIES} ${OPENSSL_LIBRARIES}
     ${NETTLE_LIBRARIES} ${CONFIG_LIBRARIES} gnutls
-    prometheus-cpp grpc grpc++ yaml-cpp
+    prometheus-cpp grpc grpc++ yaml-cpp systemd
     )
 
 if (NOT EMBEDDED_SGW)

--- a/lte/gateway/c/core/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/core/oai/oai_mme/oai_mme.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <string.h>
+#include <systemd/sd-daemon.h>
 
 #include "lte/gateway/c/core/oai/include/mme_events.hpp"
 
@@ -168,6 +169,8 @@ int main(int argc, char* argv[]) {
   }
   CHECK_INIT_RETURN(grpc_async_service_init());
   OAILOG_DEBUG(LOG_MME_APP, "MME app initialization complete\n");
+
+  sd_notify(0, "READY=1");
 
 #if EMBEDDED_SGW
   /*

--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_mme.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_mme.service
@@ -21,7 +21,7 @@ Requires=sctpd.service
 After=sctpd.service
 
 [Service]
-Type=simple
+Type=notify
 EnvironmentFile=/etc/environment
 ExecStart=/usr/local/bin/mme -c /var/opt/magma/tmp/mme.conf -s /var/opt/magma/tmp/spgw.conf
 MemoryAccounting=yes

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mme.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mme.service
@@ -21,7 +21,7 @@ Requires=sctpd.service
 After=sctpd.service
 
 [Service]
-Type=simple
+Type=notify
 EnvironmentFile=/etc/environment
 ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/core/agw_of -c /var/opt/magma/tmp/mme.conf -s /var/opt/magma/tmp/spgw.conf
 MemoryAccounting=yes

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -109,6 +109,7 @@ RUN yum install -y \
     valgrind \
     tcpdump \
     openssh-server \
+    systemd-devel \
     tree
 
 RUN yum install -y \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -48,6 +48,8 @@ RUN echo "Install 3rd party dependencies" && \
     apt-get install -y libczmq-dev=4.1.0-2 && \
     echo "Install libtins" && \
     apt-get install -y libtins-dev && \
+    echo "Install libsystemd-dev" && \
+    apt-get install -y libsystemd-dev && \
     ln -s /usr/bin/python2.7 /usr/local/bin/python
 
 ##### NETTLE

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1119,7 +1119,7 @@ class MagmadUtil(object):
                 time.sleep(5)
 
                 if time.time() - start_time > wait_time:
-                    print("Timeout reached while waiting for docker service to restart")
+                    print("Timeout reached while waiting for services to restart")
                     return
 
     def enable_service(self, service):

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1061,7 +1061,7 @@ class MagmadUtil(object):
         for service in services:
             service_name = self.get_service_name_from_init_system(service)
             if self._init_system == InitMode.SYSTEMD:
-                self.exec_command(f"sudo systemctl restart {service_name}")
+                self.exec_command(f"sudo systemctl --no-block restart {service_name}")
             elif self._init_system == InitMode.DOCKER:
                 # TODO GH14055
                 # The docker restart part is ugly due to some technical debt:
@@ -1105,21 +1105,22 @@ class MagmadUtil(object):
         Args:
             wait_time: (int) max time to wait for services to become active
         """
-        print(
-            f"Waiting for a maximum of {wait_time} "
-            f"seconds for restart to finish",
-        )
-        if self._init_system == InitMode.DOCKER:
+        if self._init_system in (InitMode.DOCKER, InitMode.SYSTEMD):
+            print(
+                f"Waiting for a maximum of {wait_time} "
+                f"seconds for restart to finish",
+            )
             start_time = time.time()
             all_services_active = False
             while (
                 not all_services_active
-                and time.time() - start_time < wait_time
             ):
                 all_services_active = self.check_if_magma_services_are_active()
                 time.sleep(5)
-        elif self._init_system == InitMode.SYSTEMD:
-            time.sleep(wait_time)
+
+                if time.time() - start_time > wait_time:
+                    print("Timeout reached while waiting for docker service to restart")
+                    return
 
     def enable_service(self, service):
         """Enable a magma service on magma_dev VM and starts it

--- a/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
@@ -53,7 +53,6 @@ class Test3485TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ue)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-
         # APN of the secondary PDN
         ims = {
             'apn_name': 'ims',  # APN-name
@@ -126,7 +125,6 @@ class Test3485TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_DROP_ACTV_DEFAULT_EPS_BEARER_CTXT_REQ,
             drop_acctv_dflt_bearer_req,
         )
-
         retransmitted_response = self._s1ap_wrapper.s1_util.get_response()
         assert (
             retransmitted_response.msg_type

--- a/lte/gateway/release/deb_dependencies.bzl
+++ b/lte/gateway/release/deb_dependencies.bzl
@@ -65,6 +65,7 @@ OAI_DEPS = [
     "libczmq-dev (>= 4.0.2-7)",
     "libasan5",
     "oai-freediameter (>= 0.0.2)",
+    "libsystemd-dev"
 ]
 
 # OVS runtime dependencies

--- a/lte/gateway/release/deb_dependencies.bzl
+++ b/lte/gateway/release/deb_dependencies.bzl
@@ -65,7 +65,7 @@ OAI_DEPS = [
     "libczmq-dev (>= 4.0.2-7)",
     "libasan5",
     "oai-freediameter (>= 0.0.2)",
-    "libsystemd-dev"
+    "libsystemd-dev",
 ]
 
 # OVS runtime dependencies


### PR DESCRIPTION
## Summary

Currently test_3485_timer_for_default_bearer_with_mme_restart.py is responsible for about 50% of all failed integ test runs. The reason behind this is that mostly on ci the test framework has not fully restarted before the 3485 timer runs out of retries. Fixes #14054

## Test Plan

- Ran the integ tests locally
- Ran integ tests on gh actions 
   - https://github.com/crasu/magma/actions/runs/3256466614 (green run)
   - https://github.com/crasu/magma/actions/runs/3310607918 (tests green/some did not execute)