### PR TITLE
chore(agw): Fix LTE snowflake issue

### DIFF
--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -11,7 +11,7 @@ x-standard-volumes: &volumes_anchor
   - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
   - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
   - ${CONFIGS_OVERRIDE_TMP_VOLUME}:/var/opt/magma/tmp
-  - /etc/snowflake:/etc/snowflake
+  - ${SNOWFLAKE_PATH}:/etc/snowflake
   - /var/opt/magma/fluent-bit:/var/opt/magma/fluent-bit
   - ./:/var/opt/magma/docker
   - /var/run:/var/run
@@ -26,7 +26,7 @@ x-magmad-volumes: &magmad_volumes_anchor
   - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
   - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
   - ${CONFIGS_OVERRIDE_TMP_VOLUME}:/var/opt/magma/tmp
-  - /etc/snowflake:/etc/snowflake
+  - ${SNOWFLAKE_PATH}:/etc/snowflake
   - /var/opt/magma/fluent-bit:/var/opt/magma/fluent-bit
   - ./:/var/opt/magma/docker
   - /var/run:/var/run

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -505,8 +505,6 @@ def integ_test_containerized(
     # Set up the gateway: use the provided gateway if given, else default to the
     # vagrant machine
     gateway_host, gateway_ip = _setup_gateway(gateway_host, "magma", "dev", "magma_dev.yml", destroy_vm, provision_vm)
-    # TODO: Remove temporary workaround after resolution of https://github.com/magma/magma/issues/13912
-    run('rm -rf /etc/snowflake; sudo touch /etc/snowflake')
     execute(_start_gateway_containerized)
 
     # Set up the trfserver: use the provided trfserver if given, else default to the

--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -11,7 +11,10 @@ define setup_rules
 endef
 _ := $(foreach python_src, $(PYTHON_SRCS), $(eval $(call setup_rules,$(python_src))))
 
-buildenv: setupenv protos swagger $(BUILD_LIST) py_patches
+snowflake:
+	sudo env PATH=${PYTHON_BUILD}/bin:${PATH} snowflake --make-snowflake
+
+buildenv: setupenv protos swagger $(BUILD_LIST) py_patches snowflake
 $(BUILD_LIST): %_build:
 	make -C $* install_egg
 


### PR DESCRIPTION
## Summary

Closes [#13912](https://github.com/magma/magma/issues/13912).

Fix LTE snowflake issue by adding a new `snowflake` target that is included into the python `buildenv` target.

The problem: The gateway VM does not contain an `/etc/snowflake` file after provisioning and `make buildenv` (lte/gateway/python). Installation of snowflake alone does not seem to create the file in this case (as one might expect according to the readme in https://github.com/shaddi/snowflake). Thus, we add a target in the makefile that creates the snowflake manually.

More background: If `make run` (lte/gateway) is executed instead, the snowflake is created. Local testing shows that the difference is the service start up. Once the magmad is started, the snowflake file is created.

In addition:
- make use of `SNOWFLAKE_PATH` which is already defined in the corresponding .env file but not used. 

## Test Plan

- Start containerized agw locally with run.py script, test different flags.
- Test CI workflow (currently running here: https://github.com/alexzurbonsen/magma/actions/runs/3314839743)
    - it seems to work now. Excerpt from the logs of the above integ test run:
```
2022-10-24T17:49:22.5508460Z [vagrant@127.0.0.1:2222] out: sudo env PATH=/home/vagrant/build/python/bin:/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/local/go/bin:/usr/local/bin/go/:/home/vagrant/go/bin/ snowflake --make-snowflake
2022-10-24T17:49:22.6242470Z [vagrant@127.0.0.1:2222] out: 1b9e0d10-a144-4a6c-82fb-a743635671c5
```