### PR TITLE
chore(agw): cleanup agw nonsanity tests

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_agw_offload_idle_active_ue.py
@@ -17,6 +17,7 @@ import unittest
 import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import HaUtil
+from lte.protos.ha_service_pb2 import EnbOffloadType
 
 
 class TestAgwOffloadIdleActiveUe(unittest.TestCase):
@@ -72,16 +73,20 @@ class TestAgwOffloadIdleActiveUe(unittest.TestCase):
         assert self._ha_util.offload_agw(
             "".join(["IMSI"] + [str(i) for i in req.imsi]),
             enb_list[0][0],
+            EnbOffloadType.ANY_CONNECTED,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()
         assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
+        # wait for UE to be idle
+        time.sleep(0.1)
         print("*************************  Offloading UE at state ECM-IDLE")
         # Send offloading request
         assert self._ha_util.offload_agw(
             "".join(["IMSI"] + [str(i) for i in req.imsi]),
             enb_list[0][0],
+            EnbOffloadType.ANY_IDLE,
         )
 
         response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_drop_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_drop_with_mme_restart.py
@@ -110,7 +110,8 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
         )
 
         print("******************** Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(["mme"], wait_for_restart)
 
         print(
             "******************** Resetting flag to not drop next Initial "
@@ -122,10 +123,6 @@ class TestAttachIcsDropWithMmeRestart(unittest.TestCase):
         self._s1ap_wrapper._s1_util.issue_cmd(
             s1ap_types.tfwCmd.UE_SET_DROP_ICS, drop_init_ctxt_setup_req,
         )
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
 
         # It has been observed that despite getting the restart command on
         # time, MME sometimes restarts after a delay of 5-6 seconds. If MME

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_failure_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ics_failure_with_mme_restart.py
@@ -105,7 +105,8 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
         print("******************** Received Initial Context Setup Indication")
 
         print("******************** Restarting MME service on gateway")
-        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
+        wait_for_restart = 30
+        self._s1ap_wrapper.magmad_util.restart_services(["mme"], wait_for_restart)
 
         init_ctxt_setup_fail = s1ap_types.ueInitCtxtSetupFail()
         init_ctxt_setup_fail.ue_Id = req.ue_id
@@ -118,10 +119,6 @@ class TestAttachIcsFailureWithMmeRestart(unittest.TestCase):
         self._s1ap_wrapper._s1_util.issue_cmd(
             s1ap_types.tfwCmd.UE_SET_INIT_CTXT_SETUP_FAIL, init_ctxt_setup_fail,
         )
-
-        for j in range(30):
-            print("Waiting for", j, "seconds")
-            time.sleep(1)
 
         # Waiting for UE Context Release indication
         response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
@@ -29,7 +29,6 @@ class TestContinuousRandomAttach(unittest.TestCase):
 
     def tearDown(self):
         """Cleanup after test case execution"""
-        self._s1ap_wrapper.cleanup()
         print(
             "The test case runs for a pre-defined duration and does not "
             "guarantee complete detach of all the UEs. Delete residual flow "
@@ -37,10 +36,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
             "subsequent test cases",
         )
         self._s1ap_wrapper._s1_util.delete_ovs_flow_rules()
-        self._s1ap_wrapper.magmad_util.restart_services(
-            ['sctpd'], wait_time=30,
-        )
-        self._s1ap_wrapper.magmad_util.print_redis_state()
+        self._s1ap_wrapper.cleanup()
 
     def handle_msg(self, msg):
         """Handle messages received from TFW"""

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_auth_resp_with_mme_restart_reattach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_auth_resp_with_mme_restart_reattach.py
@@ -74,7 +74,7 @@ class TestNoAuthRespWithMmeRestartReattach(unittest.TestCase):
         # time, MME sometimes restarts after a delay of around 6 seconds. If
         # MME restarts after T3460 timer expiry of 6 seconds, it will send
         # re-transmitted Authentication Request message
-        if response.msg_type == s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value:
+        while response.msg_type != s1ap_types.tfwCmd.UE_CTX_REL_IND.value:
             print(
                 "******************** Ignoring re-transmitted "
                 "Authentication Request message",

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_esm_information_rsp_with_mme_restart.py
@@ -102,7 +102,8 @@ class TestNoEsmInformationRspWithMmeRestart(unittest.TestCase):
                 ue_id,
             )
             # Wait for UE_CTX_REL_IND
-            response = self._s1ap_wrapper.s1_util.get_response()
+            while response.msg_type != s1ap_types.tfwCmd.UE_CTX_REL_IND.value:
+                response = self._s1ap_wrapper.s1_util.get_response()
         assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value
 
         # Perform end-end attach


### PR DESCRIPTION
## Summary

After #13852 , #13853 , #13918 , and #14004, there are a few minor issues with some nonsanity tests. This PR changes the following:
* `test_continuous_random_attach`: changed the tear_down stage to clean up after the flow rules are deleted (no need to cleanup twice)
* `test_attach_ics_drop_with_mme_restart` and `test_attach_ics_failure_with_mme_restart`: migrate a leftover wait loop to the `restart_services` function
* `test_agw_offload_idle_active_ue`: fix flakyness by waiting 0.1s for the UE to become idle before offloading
* `test_no_esm_information_rsp_with_mme_restart` and `test_no_auth_resp_with_mme_restart_reattach`: changed a single response message check to a while loop, in case mme takes long to restart (multiple messages will be retransmitted in that case, and the message that is looked for will be deeper in the queue)

## Test Plan

Run nonsanity tests against a containerized AGW

## Additional Information

- [ ] This change is backwards-breaking

