### PR TITLE
fix(agw): fix bug in latest `magma_dev.yml`

### DIFF
--- a/lte/gateway/deploy/magma_test.yml
+++ b/lte/gateway/deploy/magma_test.yml
@@ -27,6 +27,7 @@
     - role: python_dev
     - role: dev_common
       vars:
+        oai_build: "{{ c_build }}/core/oai"
         c_build: /home/{{ ansible_user }}/build/c
         go_build: /home/{{ ansible_user }}/go/bin/
     - role: magma_test


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>


## Summary

#14096 introduced a bug in `magma_dev.yml` with one environment variable not being set. This fixes it.

## Test Plan

- [x] `vagrant up magma_test` does now work.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
