### PR TITLE
feat(ci): prepare integration test CI for special containerized test set

### DIFF
--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -62,7 +62,8 @@ jobs:
           MAGMA_DEV_MEMORY_MB: 9216
         working-directory: lte/gateway
         run: |
-          fab --show=debug --set DOCKER_REGISTRY=${DOCKER_REGISTRY} integ_test_containerized
+          fab --show=debug --set DOCKER_REGISTRY=${DOCKER_REGISTRY} integ_test_containerized:test_mode="selected_tests",tests="TESTS=s1aptests/test_attach_detach.py"
+
       - name: Get test results
         if: always()
         run: |

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -491,6 +491,8 @@ def integ_test_deb_installation(
 def integ_test_containerized(
         gateway_host=None, test_host=None, trf_host=None,
         destroy_vm='True', provision_vm='True',
+        test_mode='integ_test_containerized',
+        tests='',
 ):
     """
     Run the integration tests against the containerized AGW.
@@ -516,7 +518,7 @@ def integ_test_containerized(
     # the vagrant machine
     _setup_vm(test_host, "magma_test", "test", "magma_test.yml", destroy_vm, provision_vm)
     execute(_make_integ_tests)
-    execute(_run_integ_tests, gateway_ip, 'TESTS=s1aptests/test_attach_detach.py')
+    execute(_run_integ_tests, gateway_ip, test_mode=test_mode, tests=tests)
 
 
 def _start_gateway_containerized():


### PR DESCRIPTION
## Summary

- Use the feature implemented in https://github.com/magma/magma/pull/14158 also for containerized tests.
- Needed to make the switch over to a customized test set for containerized AGW.

## Test Plan

- CI
