### PR TITLE
feat(ci): increase granularity of AGW integration test execution

### DIFF
--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -70,10 +70,31 @@ precommit: prepare_environment
 	-$(foreach test,$(PRECOMMIT_TESTS),$(call execute_test,$(test));)
 	$(call apply_final_status)
 
-.PHONY: integ_test
-integ_test: prepare_environment
-	-$(foreach test,$(EXTENDED_TESTS) $(PRECOMMIT_TESTS),$(call execute_test,$(test));)
+.PHONY: precommit_tests_noncontainer
+precommit_tests_noncontainer: prepare_environment
+	-$(foreach test,$(PRECOMMIT_TESTS_NOT_CONTAINER) $(PRECOMMIT_TESTS_IPV6),$(call execute_test,$(test));)
 	$(call apply_final_status)
+
+.PHONY: extended_tests
+extended_tests: prepare_environment
+	-$(foreach test,$(EXTENDED_TESTS),$(call execute_test,$(test));)
+	$(call apply_final_status)
+
+.PHONY: extended_tests_noncontainer
+extended_tests_noncontainer: prepare_environment
+	-$(foreach test,$(EXTENDED_TESTS_NOT_CONTAINER),$(call execute_test,$(test));)
+	$(call apply_final_status)
+
+.PHONY: extended_tests_long
+extended_tests_long: prepare_environment
+	-$(foreach test,$(EXTENDED_TESTS_LONG),$(call execute_test,$(test));)
+	$(call apply_final_status)
+
+.PHONY: integ_test
+integ_test: precommit precommit_tests_noncontainer extended_tests extended_tests_noncontainer extended_tests_long
+
+.PHONY: integ_test_containerized
+integ_test_containerized: precommit extended_tests
 
 .PHONY: federated_integ_test
 federated_integ_test: prepare_environment prepare_federation

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -112,7 +112,6 @@ s1aptests/test_multi_enb_complete_reset.py \
 s1aptests/test_multi_enb_sctp_shutdown.py \
 s1aptests/test_ipv6_paging_with_dedicated_bearer.py \
 s1aptests/test_ipv4v6_paging_with_dedicated_bearer.py \
-s1aptests/test_attach_ul_udp_data.py \
 s1aptests/test_attach_ul_tcp_data.py \
 s1aptests/test_attach_detach_attach_ul_tcp_data.py \
 s1aptests/test_attach_dl_udp_data.py \
@@ -129,18 +128,21 @@ s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
-s1aptests/test_service_req_ul_udp_data_with_mme_restart.py \
-s1aptests/test_attach_detach_setsessionrules_tcp_data.py \
+s1aptests/test_attach_detach_setsessionrules_tcp_data.py
+
+PRECOMMIT_TESTS_IPV6 = \
 s1aptests/test_enable_ipv6_iface.py \
 s1aptests/test_ipv6_non_nat_dp_ul_tcp.py \
 s1aptests/test_disable_ipv6_iface.py
+
+PRECOMMIT_TESTS_NOT_CONTAINER = \
+s1aptests/test_attach_ul_udp_data.py \
+s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
 
 EXTENDED_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \
 s1aptests/test_attach_detach_flaky_retry_success.py \
 s1aptests/test_attach_detach_multi_ue_looped.py \
 s1aptests/test_attach_detach_ps_service_not_available.py \
-s1aptests/test_attach_detach_with_he_policy.py \
-s1aptests/test_attach_detach_rar_tcp_he.py \
 s1aptests/test_attach_restricted_plmn.py \
 s1aptests/test_imei_restriction_smc.py \
 s1aptests/test_imei_restriction_no_imeisv_in_smc.py \
@@ -164,13 +166,9 @@ s1aptests/test_multi_enb_multi_ue_diff_plmn.py \
 s1aptests/test_x2_handover.py \
 s1aptests/test_x2_handover_ping_pong.py \
 s1aptests/test_s1_handover.py \
-s1aptests/test_attach_detach_rar_tcp_data.py \
 s1aptests/test_attach_detach_with_mme_restart.py \
 s1aptests/test_attach_detach_with_mobilityd_restart.py \
 s1aptests/test_idle_mode_with_mme_restart.py \
-s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py \
-s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py \
-s1aptests/test_paging_after_mme_restart.py \
 s1aptests/test_attach_nw_initiated_detach_fail.py \
 s1aptests/test_tau_ta_updating.py \
 s1aptests/test_tau_ta_updating_reject.py \
@@ -178,6 +176,18 @@ s1aptests/test_tau_mixed_partial_lists.py \
 s1aptests/test_eps_bearer_context_status_multiple_ded_bearer_deact.py \
 s1aptests/test_guti_attach_with_zero_mtmsi.py \
 s1aptests/test_ics_timer_expiry_with_mme_restart.py \
+s1aptests/test_restore_mme_config_after_sanity.py
+
+EXTENDED_TESTS_NOT_CONTAINER = s1aptests/test_modify_mme_config_for_sanity.py \
+s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py \
+s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py \
+s1aptests/test_attach_detach_rar_tcp_data.py \
+s1aptests/test_attach_detach_rar_tcp_he.py \
+s1aptests/test_attach_detach_with_he_policy.py \
+s1aptests/test_paging_after_mme_restart.py \
+s1aptests/test_restore_mme_config_after_sanity.py
+
+EXTENDED_TESTS_LONG = s1aptests/test_modify_mme_config_for_sanity.py \
 s1aptests/test_attach_mobile_reachability_timer_expiry.py \
 s1aptests/test_attach_implicit_detach_timer_expiry.py \
 s1aptests/test_mobile_reachability_tmr_with_mme_restart.py \


### PR DESCRIPTION
... in order to achieve a green integration test run against containerized AGW

:warning: The diff looks ugly. There is _no_ test target deleted! But only were there some new test targets added and the list of tests were divided in those, which run for containerized AGW and those which do not.

## Test Plan

- The CI should be green with that selection. The runs can be found at https://github.com/magma/magma/actions/workflows/lte-integ-test-containerized.yml?query=branch%3Aci%2Fs1ap-tests-against-containerised-agw-precommit.
  - There was a successful run at https://github.com/magma/magma/actions/runs/3267271326, with the selected test set.


## Additional Information

- Some tests are "only" flaky, however, they were still excluded to reach some stable state.