### PR TITLE
chore: Introduce "util_script" and "service" Bazel tags

### DIFF
--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -74,7 +74,9 @@ jobs:
         run: |
           cd lte/gateway
           vagrant ssh -c 'cd ~/magma; bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}";' magma
-          vagrant ssh -c 'cd ~/magma; bazel build --profile=bazel_profile_lte_integ_tests `bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/...)"`;' magma
+          REGEX='"service|util_script"'
+          QUERY="'attr(tags, "${REGEX}", kind(.*_binary, //orc8r/... union //lte/... union //feg/... except //lte/gateway/c/core:mme_oai))'"
+          vagrant ssh -c 'cd ~/magma; bazel build --profile=bazel_profile_lte_integ_tests `bazel query '"${QUERY}"'`;' magma
       - name: Linking bazel-built script executables to '/usr/local/bin/'
         run: |
           cd lte/gateway

--- a/bazel/scripts/link_scripts_for_bazel_integ_tests.sh
+++ b/bazel/scripts/link_scripts_for_bazel_integ_tests.sh
@@ -21,9 +21,9 @@ set -euo pipefail
 
 get_python_scripts() {
     echo "Collecting script targets..."
-    mapfile -t PYTHON_SCRIPTS < <(bazel query "kind(.*_binary, \
+    mapfile -t PYTHON_SCRIPTS < <(bazel query "attr(tags, 'util_script', kind(.*_binary, \
         //orc8r/gateway/python/scripts/... union \
-        //lte/gateway/python/scripts/... )")
+        //lte/gateway/python/scripts/... ))")
 }
 
 format_targets_to_paths() {

--- a/bazel/scripts/test_python_service_imports.sh
+++ b/bazel/scripts/test_python_service_imports.sh
@@ -37,7 +37,7 @@ collect_services() {
         SERVICES=( "${SERVICE_PATH}" )
     else
         echo "Multiple services specified:"
-        mapfile -t SERVICES < <(bazel query "attr(main, main.py, kind(py_binary, //${SERVICE_PATH}...))")
+        mapfile -t SERVICES < <(bazel query "attr(tags, service, kind(py_binary, //${SERVICE_PATH}...))")
     fi
     if [[ "${#SERVICES[@]}" -eq 0 ]];
     then

--- a/bazel/test_constants.bzl
+++ b/bazel/test_constants.bzl
@@ -34,6 +34,9 @@ TAG_MANUAL = ["manual"]
 # Note: for now a sudo test is also tagged as "manual".
 TAG_SUDO_TEST = ["sudo_test"] + TAG_MANUAL
 
+# Used for integration tests. These tests need to be executed manually
+# by a user with sudo privileges. These tags represent test categories,
+# which are used to determine the appropriate environment for them.
 TAG_PRECOMMIT_TEST = ["precommit_test"] + TAG_MANUAL
 TAG_EXTENDED_TEST = ["extended_test"] + TAG_MANUAL
 TAG_EXTENDED_TEST_SETUP = ["extended_setup"] + TAG_MANUAL
@@ -42,3 +45,9 @@ TAG_NON_SANITY_TEST = ["nonsanity_test"] + TAG_MANUAL
 TAG_NON_SANITY_TEST_SETUP = ["nonsanity_setup"] + TAG_MANUAL
 TAG_NON_SANITY_TEST_TEARDOWN = ["nonsanity_teardown"] + TAG_MANUAL
 TAG_TRAFFIC_SERVER_TEST = ["traffic_server_test"]
+
+# Tag for utility scripts that are used in the Magma VM.
+TAG_UTIL_SCRIPT = ["util_script"]
+
+# Tag for Magma services.
+TAG_SERVICE = ["service"]

--- a/feg/gateway/services/envoy_controller/BUILD.bazel
+++ b/feg/gateway/services/envoy_controller/BUILD.bazel
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 go_library(
     name = "envoy_controller_lib",
@@ -29,5 +30,6 @@ go_library(
 go_binary(
     name = "envoy_controller",
     embed = [":envoy_controller_lib"],
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/release:__pkg__"],
 )

--- a/lte/gateway/c/connection_tracker/src/BUILD.bazel
+++ b/lte/gateway/c/connection_tracker/src/BUILD.bazel
@@ -10,10 +10,12 @@
 # limitations under the License.
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 cc_binary(
     name = "connectiond",
     srcs = ["main.cpp"],
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":event_tracker",

--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:asn1c.bzl", "cc_asn1_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
@@ -1187,6 +1188,7 @@ cc_binary(
     srcs = ["oai/oai_mme/oai_mme.c"],
     copts = ["-DEMBEDDED_SGW=1"],
     linkstatic = True,
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/release:__pkg__"],
     deps = [":lib_agw_of"],
 )
@@ -1196,6 +1198,7 @@ cc_binary(
     srcs = ["oai/oai_mme/oai_mme.c"],
     copts = ["-DEMBEDDED_SGW=0"],
     linkstatic = True,
+    tags = TAG_SERVICE,
     deps = [":lib_mme_oai"],
 )
 

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -10,12 +10,14 @@
 # limitations under the License.
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 package(default_visibility = ["//lte/gateway/c/li_agent/src:__subpackages__"])
 
 cc_binary(
     name = "liagentd",
     srcs = ["main.cpp"],
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":interface_monitor",

--- a/lte/gateway/c/sctpd/src/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/BUILD.bazel
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 package(default_visibility = ["//lte/gateway/c/sctpd/src:__subpackages__"])
 
@@ -17,6 +18,7 @@ cc_binary(
     name = "sctpd",
     srcs = ["sctpd.cpp"],
     linkstatic = True,
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":config",

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 package(default_visibility = ["//lte/gateway/c/session_manager/test:__pkg__"])
 
@@ -427,6 +428,7 @@ cc_binary(
     # From bazel doc: this flag makes it so all user libraries are linked statically (if a static version is available),
     #                 but where system libraries (excluding C/C++ runtime libraries) are linked dynamically
     linkstatic = True,
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":operational_states_handler",

--- a/lte/gateway/deploy/roles/bazel_aliases/tasks/main.yml
+++ b/lte/gateway/deploy/roles/bazel_aliases/tasks/main.yml
@@ -17,4 +17,4 @@
     line: "{{ item }}"
   with_items:
     # build all services and scripts needed to run the lte access gateway
-    - alias magma-build-agw='bazel build `bazel query "kind(.*_binary, //orc8r/... union //lte/... union //feg/...)"`'
+    - alias magma-build-agw='bazel build `bazel query "attr(tags, \"service|util_script\", kind(.*_binary, //orc8r/... union //lte/... union //feg/... except //lte/gateway/c/core:mme_oai))"`'

--- a/lte/gateway/python/magma/enodebd/BUILD.bazel
+++ b/lte/gateway/python/magma/enodebd/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -29,6 +30,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//visibility:public"],
     deps = [
         ":enodebd_lib",

--- a/lte/gateway/python/magma/health/BUILD.bazel
+++ b/lte/gateway/python/magma/health/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -29,6 +30,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":health_lib",

--- a/lte/gateway/python/magma/kernsnoopd/BUILD.bazel
+++ b/lte/gateway/python/magma/kernsnoopd/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -29,6 +30,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":kernsnoopd_lib",

--- a/lte/gateway/python/magma/mobilityd/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -29,6 +30,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":mobilityd_lib",

--- a/lte/gateway/python/magma/monitord/BUILD.bazel
+++ b/lte/gateway/python/magma/monitord/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -28,6 +29,7 @@ py_binary(
     # legacy_create_init = False is required to fix issues in module import, see https://github.com/rules-proto-grpc/rules_proto_grpc/issues/145
     legacy_create_init = False,
     main = "main.py",
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":monitord_lib",

--- a/lte/gateway/python/magma/pipelined/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -31,6 +32,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     deps = [
         ":pipelined_lib",
         "//lte/gateway/python/magma/pipelined/app:he",

--- a/lte/gateway/python/magma/policydb/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/BUILD.bazel
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -28,6 +29,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":policydb_lib",

--- a/lte/gateway/python/magma/redirectd/BUILD.bazel
+++ b/lte/gateway/python/magma/redirectd/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -29,6 +30,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":redirect_server",

--- a/lte/gateway/python/magma/smsd/BUILD.bazel
+++ b/lte/gateway/python/magma/smsd/BUILD.bazel
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -28,6 +29,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//lte/gateway/python:__pkg__"],
     deps = [
         ":smsd_lib",

--- a/lte/gateway/python/magma/subscriberdb/BUILD.bazel
+++ b/lte/gateway/python/magma/subscriberdb/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -29,6 +30,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//visibility:public"],
     deps = [
         ":client",

--- a/lte/gateway/python/scripts/BUILD.bazel
+++ b/lte/gateway/python/scripts/BUILD.bazel
@@ -14,6 +14,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_mklink")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel:deb_build.bzl", "PY_DEST")
 load("//bazel:runfiles.bzl", "expand_runfiles")
+load("//bazel:test_constants.bzl", "TAG_UTIL_SCRIPT")
 
 SCRIPTS = [
     "agw_health_cli",
@@ -89,6 +90,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/gateway/python/magma/health:health_service",
         requirement("fire"),
@@ -101,6 +103,7 @@ py_binary(
     srcs = ["config_iface_for_ipv6.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = ["//orc8r/gateway/python/magma/configuration:service_configs"],
 )
 
@@ -112,6 +115,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/protos:mconfigs_python_proto",
         "//orc8r/gateway/python/magma/common/redis:client",
@@ -127,6 +131,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/protos:mobilityd_python_grpc",
         "//orc8r/gateway/python/magma/common:service_registry",
@@ -138,6 +143,7 @@ py_binary(
     name = "create_oai_certs",
     srcs = ["create_oai_certs.py"],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [requirement("envoy")],
 )
 
@@ -149,6 +155,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/protos:mconfigs_python_proto",
         "//orc8r/gateway/python/magma/common:service",
@@ -163,6 +170,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/protos:enodebd_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -177,6 +185,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/gateway/python/magma/pipelined:imsi",
         "//lte/gateway/python/magma/subscriberdb:sid",
@@ -192,6 +201,7 @@ py_binary(
     srcs = ["feg_hello_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//feg/protos:hello_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -206,6 +216,7 @@ py_binary(
         SCRIPTS_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//orc8r/gateway/python/magma/common:misc_utils",
         "//orc8r/gateway/python/scripts:generate_service_config",
@@ -220,6 +231,7 @@ py_binary(
         SCRIPTS_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         ":create_oai_certs",
         "//orc8r/gateway/python/magma/common:misc_utils",
@@ -235,6 +247,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/protos:ha_service_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -247,6 +260,7 @@ py_binary(
     srcs = ["hello_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//feg/protos:hello_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -257,6 +271,7 @@ py_binary(
     name = "icmpv6",
     srcs = ["icmpv6.py"],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [requirement("scapy")],
 )
 
@@ -268,6 +283,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/gateway/python/magma/subscriberdb:sid",
         "//lte/protos:mobilityd_python_grpc",
@@ -283,6 +299,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/gateway/python/magma/mobilityd:dhcp_desc",
         "//lte/gateway/python/magma/mobilityd:mobility_store",
@@ -294,6 +311,7 @@ py_binary(
     srcs = ["ocs_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//feg/protos:mock_core_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -306,6 +324,7 @@ py_binary(
     srcs = ["packet_ryu_cli.py"],
     imports = [LTE_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/gateway/python/integ_tests/s1aptests/ovs:rest_api",
         requirement("scapy"),
@@ -317,6 +336,7 @@ py_binary(
     srcs = ["packet_tracer_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = ["//orc8r/gateway/python/magma/configuration:service_configs"],
 )
 
@@ -325,6 +345,7 @@ py_binary(
     srcs = ["pcrf_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//feg/protos:mock_core_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -340,6 +361,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     visibility = ["//lte/gateway/python/load_tests:__pkg__"],
     deps = [
         "//lte/gateway/python/magma/pipelined:ng_set_session_msg",
@@ -361,6 +383,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/gateway/python/magma/policydb:apn_rule_map_store",
         "//lte/gateway/python/magma/policydb:basename_store",
@@ -380,6 +403,7 @@ py_binary(
     srcs = ["s6a_proxy_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//feg/protos:s6a_proxy_grpc_proto",
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -392,6 +416,7 @@ py_binary(
     srcs = ["s6a_service_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/protos:s6a_service_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -406,6 +431,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//feg/protos:mock_core_python_grpc",
         "//lte/gateway/python/magma/pipelined:policy_converters",
@@ -422,6 +448,7 @@ py_binary(
     srcs = ["sgs_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//feg/protos:csfb_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -434,6 +461,7 @@ py_binary(
     srcs = ["sms_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/protos:sms_orc8r_python_grpc",
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -449,6 +477,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/gateway/python/magma/subscriberdb:sid",
         "//lte/protos:policydb_python_proto",
@@ -465,6 +494,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/gateway/python/magma/mobilityd:serialize_utils",
         "//lte/protos:keyval_python_proto",
@@ -485,6 +515,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/gateway/python/magma/subscriberdb:sid",
         "//lte/protos:subscriberdb_python_grpc",
@@ -496,4 +527,5 @@ py_binary(
     name = "user_trace_cli",
     srcs = ["user_trace_cli.py"],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
 )

--- a/orc8r/gateway/python/magma/ctraced/BUILD.bazel
+++ b/orc8r/gateway/python/magma/ctraced/BUILD.bazel
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -23,6 +24,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//visibility:public"],
     deps = [
         ":ctraced_lib",

--- a/orc8r/gateway/python/magma/directoryd/BUILD.bazel
+++ b/orc8r/gateway/python/magma/directoryd/BUILD.bazel
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -23,6 +24,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//visibility:public"],
     deps = [
         ":rpc_servicer",

--- a/orc8r/gateway/python/magma/eventd/BUILD.bazel
+++ b/orc8r/gateway/python/magma/eventd/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -29,6 +30,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//orc8r/gateway/python:__pkg__"],
     deps = [
         ":eventd_lib",

--- a/orc8r/gateway/python/magma/magmad/BUILD.bazel
+++ b/orc8r/gateway/python/magma/magmad/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -24,6 +25,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//visibility:public"],
     deps = [
         ":magmad_lib",

--- a/orc8r/gateway/python/magma/state/BUILD.bazel
+++ b/orc8r/gateway/python/magma/state/BUILD.bazel
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_SERVICE")
 
 MAGMA_ROOT = "../../../../../"
 
@@ -23,6 +24,7 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     python_version = "PY3",
+    tags = TAG_SERVICE,
     visibility = ["//visibility:public"],
     deps = [
         ":garbage_collector",

--- a/orc8r/gateway/python/scripts/BUILD.bazel
+++ b/orc8r/gateway/python/scripts/BUILD.bazel
@@ -14,6 +14,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_mklink")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel:deb_build.bzl", "PY_DEST")
 load("//bazel:runfiles.bzl", "expand_runfiles")
+load("//bazel:test_constants.bzl", "TAG_UTIL_SCRIPT")
 
 SCRIPTS = [
     "checkin_cli",
@@ -67,6 +68,7 @@ py_binary(
     srcs = ["checkin_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//orc8r/gateway/python/magma/common:cert_utils",
         "//orc8r/gateway/python/magma/common:cert_validity",
@@ -82,6 +84,7 @@ py_binary(
     srcs = ["ctraced_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//orc8r/gateway/python/magma/common:rpc_utils",
         "//orc8r/protos:ctraced_python_grpc",
@@ -93,6 +96,7 @@ py_binary(
     srcs = ["directoryd_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         "//orc8r/gateway/python/magma/common:rpc_utils",
         "//orc8r/protos:directoryd_python_grpc",
@@ -104,6 +108,7 @@ py_binary(
     name = "generate_fluent_bit_config",
     srcs = ["generate_fluent_bit_config.py"],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [":generate_service_config"],
 )
 
@@ -111,6 +116,7 @@ py_binary(
     name = "generate_lighttpd_config",
     srcs = ["generate_lighttpd_config.py"],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         ":generate_service_config",
         "//orc8r/gateway/python/magma/common:misc_utils",
@@ -121,6 +127,7 @@ py_binary(
     name = "generate_nghttpx_config",
     srcs = ["generate_nghttpx_config.py"],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     deps = [
         ":generate_service_config",
         "//orc8r/gateway/python/magma/configuration:environment",
@@ -132,6 +139,7 @@ py_binary(
     srcs = ["generate_service_config.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     visibility = ["//visibility:public"],
     deps = [
         "//orc8r/gateway/python/magma/common:serialization_utils",
@@ -146,6 +154,7 @@ py_binary(
     srcs = ["health_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     visibility = ["//visibility:public"],
     deps = [
         "//orc8r/gateway/python/magma/common/health:docker_health_service",
@@ -158,6 +167,7 @@ py_binary(
     srcs = ["magma_conditional_service.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     visibility = ["//visibility:public"],
     deps = ["//orc8r/gateway/python/magma/configuration:mconfig_managers"],
 )
@@ -166,6 +176,7 @@ py_binary(
     name = "magma_get_config",
     srcs = ["magma_get_config.py"],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     visibility = ["//visibility:public"],
 )
 
@@ -174,6 +185,7 @@ py_binary(
     srcs = ["magmad_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     visibility = ["//visibility:public"],
     deps = [
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -188,6 +200,7 @@ py_binary(
     srcs = ["service303_cli.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     visibility = ["//visibility:public"],
     deps = [
         "//orc8r/gateway/python/magma/common:rpc_utils",
@@ -200,6 +213,7 @@ py_binary(
     srcs = ["service_util.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     visibility = ["//visibility:public"],
     deps = ["//orc8r/gateway/python/magma/common/health:service_state_wrapper"],
 )
@@ -209,6 +223,7 @@ py_binary(
     srcs = ["show_gateway_info.py"],
     imports = [ORC8R_ROOT],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     visibility = ["//visibility:public"],
     deps = [
         "//orc8r/gateway/python/magma/common:cert_utils",
@@ -220,5 +235,6 @@ py_binary(
     name = "traffic_cli",
     srcs = ["traffic_cli.py"],
     legacy_create_init = False,
+    tags = TAG_UTIL_SCRIPT,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

## Summary

Currently we are running bazel queries for `*_binary` that do not distinguish between utility scripts and services. This can lead to unintended consequences.
In the `LTE integ test bazel` workflow building the `mme_oai` target is not necessary, therefore it was removed from the query.

This closes #13808.

## Test Plan

CI.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
