### PR TITLE
feat(agw): publish LTE integ test results to firebase

### DIFF
--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -55,13 +55,13 @@ jobs:
           MAGMA_DEV_CPUS: 3
           MAGMA_DEV_MEMORY_MB: 9216
           MAGMA_PACKAGE: ${{ github.event.client_payload.artifact }}
+        working-directory: 'lte/gateway/'
         run: |
-          cd lte/gateway
           fab integ_test_deb_installation
       - name: Get test results
         if: always()
+        working-directory: 'lte/gateway/'
         run: |
-          cd lte/gateway
           fab get_test_summaries:dst_path="test-results",sudo_tests=False,dev_vm_name="magma_deb"
           ls -R
       - name: Upload test results
@@ -77,3 +77,34 @@ jobs:
           check_name: LTE Debian integration test results
           junit_files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
+      - name: Get test logs
+        if: always()
+        working-directory: 'lte/gateway/'
+        run: |
+          fab get_test_logs:gateway_host_name=magma_deb,dst_path=./logs.tar.gz
+      - name: Upload test logs
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: test-logs
+          path: lte/gateway/logs.tar.gz
+      - name: Publish results to Firebase
+        if: always() && github.event.event_type == 'build-all-artifact'
+        env:
+          FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
+          REPORT_FILENAME: "lte_integ_test_magma_deb_${{ github.sha }}.html"
+        run: |
+          npm install -g xunit-viewer
+          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
+          [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
+          [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
+          python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} make_debian_lte_integ_test --url $URL
+      - name: Notify failure to slack
+        if: failure() && github.repository_owner == 'magma'
+        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BAZEL_CI }}
+          SLACK_USERNAME: "LTE Debian integration test"
+          SLACK_AVATAR: ":boom:"
+        with:
+          args: "LTE Debian integration test failed on [${{ github.sha }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ github.sha }}): ${{ steps.commit.outputs.title}}"

--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -21,7 +21,12 @@ from typing import Optional
 from firebase_admin import credentials, db, initialize_app
 
 
-def publish_report(worker_id, build_id, verdict, report):
+def publish_report(
+    worker_id: str,
+    build_id: str,
+    verdict: str,
+    report: str,
+):
     """Publish report to Firebase realtime database"""
     # Read Firebase service account config from envirenment
     firebase_config = os.environ["FIREBASE_SERVICE_CONFIG"]
@@ -45,15 +50,17 @@ def publish_report(worker_id, build_id, verdict, report):
     reports_ref.set(report_dict)
 
 
-def url_to_html_redirect(run_id, url):
+def url_to_html_redirect(run_id: str, url: Optional[str]):
     """Convert URL into a redirecting HTML page"""
     report_url = url
-    if url is None:
-        report_url = 'https://github.com/magma/magma/actions/runs/' + run_id
+    if not url:
+        report_url = f'https://github.com/magma/magma/actions/runs/{run_id}'
 
-    return '<script>'\
-           '  window.location.href = "' + report_url + '";'\
-           '</script>'
+    return (
+        f'<script>',
+        f'  window.location.href = "{report_url}";',
+        f'</script>',
+    )
 
 
 def lte_integ_test(args):

--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -74,6 +74,27 @@ def lte_integ_test(args):
     publish_report('lte_integ_test', args.build_id, verdict, report)
 
 
+def make_debian_lte_integ_test(args):
+    """Prepare and publish LTE Integ Test report"""
+    report = url_to_html_redirect(args.run_id, args.url)
+    # Possible args.verdict values are success, failure, or canceled
+    verdict = 'inconclusive'
+
+    # As per the recent change, CI process runs all integ tests ignoring the
+    # failing test cases, because of which CI report always shows lte integ
+    # test as success. Here we read the CI status from file for more accurate
+    # lte integ test execution status
+    if os.path.exists("test_status.txt"):
+        with open('test_status.txt', 'r') as file:
+            status_file_content = file.read().rstrip()
+            expected_verdict_list = ["pass", "fail"]
+            if status_file_content in expected_verdict_list:
+                verdict = status_file_content
+    publish_report(
+        'make_debian_lte_integ_test', args.build_id, verdict, report,
+    )
+
+
 def feg_integ_test(args):
     """Prepare and publish FEG Integ Test report"""
     report = url_to_html_redirect(args.run_id, args.url)
@@ -146,6 +167,11 @@ parser_cwf.set_defaults(func=cwf_integ_test)
 parser_cwf = subparsers.add_parser('sudo_python_tests')
 parser_cwf.add_argument("--url", default="none", help="Report URL", nargs='?')
 parser_cwf.set_defaults(func=sudo_python_tests)
+
+# Create the parser for the "magma_deb" command
+parser_cwf = subparsers.add_parser('make_debian')
+parser_cwf.add_argument("--url", default="none", help="Report URL", nargs='?')
+parser_cwf.set_defaults(func=make_debian_lte_integ_test)
 
 # Read arguments from the command line
 args = parser.parse_args()

--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -16,6 +16,7 @@ import json
 import os
 import sys
 import time
+from typing import Optional
 
 from firebase_admin import credentials, db, initialize_app
 
@@ -57,80 +58,52 @@ def url_to_html_redirect(run_id, url):
 
 def lte_integ_test(args):
     """Prepare and publish LTE Integ Test report"""
-    report = url_to_html_redirect(args.run_id, args.url)
-    # Possible args.verdict values are success, failure, or canceled
-    verdict = 'inconclusive'
-
-    # As per the recent change, CI process runs all integ tests ignoring the
-    # failing test cases, because of which CI report always shows lte integ
-    # test as success. Here we read the CI status from file for more accurate
-    # lte integ test execution status
-    if os.path.exists("test_status.txt"):
-        with open('test_status.txt', 'r') as file:
-            status_file_content = file.read().rstrip()
-            expected_verdict_list = ["pass", "fail"]
-            if status_file_content in expected_verdict_list:
-                verdict = status_file_content
-    publish_report('lte_integ_test', args.build_id, verdict, report)
+    prepare_and_publish('lte_integ_test', args, 'test_status.txt')
 
 
 def make_debian_lte_integ_test(args):
     """Prepare and publish LTE Integ Test report"""
-    report = url_to_html_redirect(args.run_id, args.url)
-    # Possible args.verdict values are success, failure, or canceled
-    verdict = 'inconclusive'
-
-    # As per the recent change, CI process runs all integ tests ignoring the
-    # failing test cases, because of which CI report always shows lte integ
-    # test as success. Here we read the CI status from file for more accurate
-    # lte integ test execution status
-    if os.path.exists("test_status.txt"):
-        with open('test_status.txt', 'r') as file:
-            status_file_content = file.read().rstrip()
-            expected_verdict_list = ["pass", "fail"]
-            if status_file_content in expected_verdict_list:
-                verdict = status_file_content
-    publish_report(
-        'make_debian_lte_integ_test', args.build_id, verdict, report,
+    prepare_and_publish(
+        'make_debian_lte_integ_test', args, 'test_status.txt',
     )
 
 
 def feg_integ_test(args):
     """Prepare and publish FEG Integ Test report"""
-    report = url_to_html_redirect(args.run_id, args.url)
-    # Possible args.verdict values are success, failure, or canceled
-    verdict = 'inconclusive'
-
-    # As per the recent change, CI process runs all integ tests ignoring the
-    # failing test cases, because of which CI report always shows feg integ
-    # test as success. Here we read the CI status from file for more accurate
-    # feg integ test execution status
-    if os.path.exists("test_status.txt"):
-        with open('test_status.txt', 'r') as file:
-            status_file_content = file.read().rstrip()
-            expected_verdict_list = ["pass", "fail"]
-            if status_file_content in expected_verdict_list:
-                verdict = status_file_content
-    publish_report('feg_integ_test', args.build_id, verdict, report)
+    prepare_and_publish('feg_integ_test', args, 'test_status.txt')
 
 
 def cwf_integ_test(args):
+    """Prepare and publish CWF Integ Test report"""
     prepare_and_publish('cwf_integ_test', args)
 
 
 def sudo_python_tests(args):
+    """Prepare and publish Sudo Python Test report"""
     prepare_and_publish('sudo_python_tests', args)
 
 
-def prepare_and_publish(test_type: str, args):
+def prepare_and_publish(test_type: str, args, path: Optional[str] = None):
     """Prepare and publish test report"""
     report = url_to_html_redirect(args.run_id, args.url)
-    # Possible args.verdict values are success, failure, or canceled
+    # Possible args.verdict values are success, failure, or inconclusive
     verdict = 'inconclusive'
-    if args.verdict.lower() == 'success':
-        verdict = 'pass'
-    elif args.verdict.lower() == 'failure':
-        verdict = 'fail'
+
+    if path and os.path.exists(path):
+        # As per the recent change, CI process runs all integ tests ignoring
+        # the failing test cases, because of which CI report always shows lte
+        # integ test as success. Here we read the CI status from file for more
+        # accurate lte integ test execution status
+        with open(path, 'r') as file:
+            status_file_content = file.read().rstrip()
+            expected_verdict_list = ["pass", "fail"]
+            if status_file_content in expected_verdict_list:
+                verdict = status_file_content
+    else:
+        if args.verdict.lower() == 'success':
+            verdict = 'pass'
+        elif args.verdict.lower() == 'failure':
+            verdict = 'fail'
     publish_report(test_type, args.build_id, verdict, report)
 
 
@@ -140,6 +113,7 @@ parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
 
+
 # Add arguments
 parser.add_argument("--build_id", "-id", required=True, help="build ID")
 parser.add_argument("--verdict", required=True, help="Test verdict")
@@ -148,30 +122,20 @@ parser.add_argument("--run_id", default="none", help="Github Actions Run ID")
 # Add subcommands
 subparsers = parser.add_subparsers(title='subcommands', dest='cmd')
 
-# Create the parser for the "lte" command
-parser_lte = subparsers.add_parser('lte')
-parser_lte.add_argument("--url", default="none", help="Report URL", nargs='?')
-parser_lte.set_defaults(func=lte_integ_test)
+tests = {
+    'lte': lte_integ_test,
+    'feg': feg_integ_test,
+    'cwf': cwf_integ_test,
+    'sudo_python_tests': sudo_python_tests,
+    'make_debian_lte_integ_test': make_debian_lte_integ_test,
+}
 
-# Create the parser for the "feg" command
-parser_feg = subparsers.add_parser('feg')
-parser_feg.add_argument("--url", default="none", help="Report URL", nargs='?')
-parser_feg.set_defaults(func=feg_integ_test)
-
-# Create the parser for the "cwf" command
-parser_cwf = subparsers.add_parser('cwf')
-parser_cwf.add_argument("--url", default="none", help="Report URL", nargs='?')
-parser_cwf.set_defaults(func=cwf_integ_test)
-
-# Create the parser for the "sudo_tests" command
-parser_cwf = subparsers.add_parser('sudo_python_tests')
-parser_cwf.add_argument("--url", default="none", help="Report URL", nargs='?')
-parser_cwf.set_defaults(func=sudo_python_tests)
-
-# Create the parser for the "magma_deb" command
-parser_cwf = subparsers.add_parser('make_debian')
-parser_cwf.add_argument("--url", default="none", help="Report URL", nargs='?')
-parser_cwf.set_defaults(func=make_debian_lte_integ_test)
+for key, value in tests:
+    test_parser = subparsers.add_parser(key)
+    test_parser.add_argument(
+        "--url", default="none", help="Report URL", nargs='?',
+    )
+    test_parser.set_defaults(func=value)
 
 # Read arguments from the command line
 args = parser.parse_args()


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The results are now uploaded to be displayed in the CI dashboard in the future. Code changes analog to the current default `lte-integ-test.yml`.
Closes #14157.

## Test Plan
CI [before](https://github.com/magma/magma/actions/runs/3281968030/jobs/5404719865) and [after](https://github.com/mpfirrmann/magma/actions/runs/3287765106).

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
