### PR TITLE
docs: Fix warning rendering re building the AGW with Bazel

### DIFF
--- a/docs/readmes/lte/s1ap_tests.md
+++ b/docs/readmes/lte/s1ap_tests.md
@@ -54,7 +54,7 @@ In the gateway VM run `cd $MAGMA_ROOT/lte/gateway && make run`.
 
 ##### Building with bazel
 
-> :warning: **Bazel based builds are still experimental but can already be used for development**
+> **Warning**: Bazel based builds are still experimental but can already be used for development.
 
 1. Create links for cli scripts: `cd $MAGMA_ROOT && bazel/scripts/link_scripts_for_bazel_integ_tests.sh`
 2. Use bazel systemd unit files: `sudo cp $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/systemd_bazel/* /etc/systemd/system/ && sudo systemctl daemon-reload`


### PR DESCRIPTION
## Summary

The warning introduced in https://github.com/magma/magma/pull/14166 was not rendering properly, so I've fixed it, making the formatting consistent with the other warning boxes on the page.

## Test Plan

- Tested locally with `cd magma/docs && make dev`
- CI
