### PR TITLE
chore(ci): Add option to store bazel profile data to bazel.yml workflow

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -13,6 +13,12 @@ name: "Bazel Build & Test"
 on:
   # yamllint disable-line rule:truthy
   workflow_dispatch:
+    inputs:
+      publish_bazel_profile:
+        description: 'Publish bazel profile data (default: false)'
+        required: false
+        default: false
+        type: boolean
   pull_request:
     types:
       - opened
@@ -169,13 +175,13 @@ jobs:
           python3 lte/gateway/python/scripts/runtime_report.py -i "[^\/]+\.xml" -w "bazel_unit_test_results" -o "lte/gateway/test_results/merged_unit_test_reports.xml"
       - name: Publish bazel build profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: always()
+        if: ${{ always() && github.event.inputs.publish_bazel_profile == 'true' }}
         with:
           name: Bazel build all profile ${{ matrix.bazel-config }}
           path: Bazel_build_all_profile
       - name: Publish bazel test profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: always()
+        if: ${{ always() && github.event.inputs.publish_bazel_profile == 'true' }}
         with:
           name: Bazel test all profile ${{ matrix.bazel-config }}
           path: Bazel_test_all_profile
@@ -290,7 +296,7 @@ jobs:
               --profile=Bazel_build_package_profile
       - name: Publish bazel profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: always()
+        if: ${{ always() && github.event.inputs.publish_bazel_profile == 'true' }}
         with:
           name: Bazel build package profile
           path: Bazel_build_package_profile


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves #14168
- Bazel profile data is not stored per default
- If data should be stored in manual workflow runs the box needs to be ticked
  ![Screenshot from 2022-10-20 12-12-41](https://user-images.githubusercontent.com/34488763/196921728-88475f19-6b2b-4f94-8bce-b34a70640c22.png)


## Test Plan

- [Workflow run without option ticked](https://github.com/LKreutzer/magma/actions/runs/3288693632)
- See also run on this PR


## Additional Information

- Boolean inputs are strings and not booleans
  - See https://github.com/actions/runner/issues/1483 

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
