### PR TITLE
chore(ci): Reconfigure workflow triggers to push on master instead of waiting for the build-all workflow to complete

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -13,16 +13,10 @@ name: CWF integ test
 
 on:
   workflow_dispatch: null
-  workflow_run:
-    workflows:
-      - build-all
+  push:
     branches:
       - master
       - 'v1.*'
-    types:
-      - completed
-env:
-  SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
 
 jobs:
   docker-build:
@@ -30,8 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-        with:
-          ref: ${{ env.SHA }}
       - name: Run docker compose
         run: |
           cd cwf/gateway/docker
@@ -58,14 +50,14 @@ jobs:
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
       - name: Notify failure to slack
-        if: failure() && github.event.workflow_run.event == 'push'
+        if: failure() && github.event_name == 'push'
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: "CWF integ test"
           SLACK_AVATAR: ":boom:"
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         with:
-          args: 'CWF integration test: docker build step failed on [${{ env.SHA }}](${{github.event.repository.owner.html_url}}/magma/commits/${{ env.SHA }}): ${{ steps.commit.outputs.title}}'
+          args: 'CWF integration test: docker build step failed on [${{ github.sha }}](${{github.event.repository.owner.html_url}}/magma/commits/${{ github.sha }}): ${{ steps.commit.outputs.title}}'
   cwf-integ-test:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
@@ -73,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
-          ref: ${{ env.SHA }}
+          ref: ${{ github.sha }}
       - name: Cache Vagrant Boxes
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
@@ -147,22 +139,22 @@ jobs:
           name: test-logs
           path: cwf/gateway/logs
       - name: Publish results to Firebase
-        if: always() && github.event.workflow_run.event == 'push'
+        if: always() && github.event_name == 'push'
         env:
           FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
-          REPORT_FILENAME: "cwf_integ_test_${{ env.SHA }}.html"
+          REPORT_FILENAME: "cwf_integ_test_${{ github.sha }}.html"
         run: |
           npm install -g xunit-viewer
           [ -f "cwf/gateway/tests.xml" ] && { xunit-viewer -r cwf/gateway/tests.xml -o "$REPORT_FILENAME"; }
           [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
           [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
-          python ci-scripts/firebase_publish_report.py -id ${{ env.SHA }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} cwf --url $URL
+          python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} cwf --url $URL
       - name: Notify failure to slack
-        if: failure() && github.event.workflow_run.event == 'push'
+        if: failure() && github.event_name == 'push'
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: "CWF integ test"
           SLACK_AVATAR: ":boom:"
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         with:
-          args: 'CWF integration test: tests failed on [${{ env.SHA }}](${{github.event.repository.owner.html_url}}/magma/commits/${{ env.SHA }}): ${{ steps.commit.outputs.title}}'
+          args: 'CWF integration test: tests failed on [${{ github.sha }}](${{github.event.repository.owner.html_url}}/magma/commits/${{ github.sha }}): ${{ steps.commit.outputs.title}}'

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -13,14 +13,10 @@ name: Federated integ test
 
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch: null
-  workflow_run:
-    workflows:
-      - build-all
+  push:
     branches:
       - master
       - 'v1.*'
-    types:
-      - completed
 
 jobs:
   # Build images on ubuntu which is faster than MacOs.
@@ -82,13 +78,10 @@ jobs:
     runs-on: macos-12
     needs: [docker-build-orc8r, docker-build-feg]
     env:
-      SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
       MAGMA_ROOT: "${{ github.workspace }}"
       AGW_ROOT: "${{ github.workspace }}/lte/gateway"
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-        with:
-          ref: ${{ env.SHA }}
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
         with:
           python-version: '3.8.5'
@@ -204,22 +197,22 @@ jobs:
           junit_files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
       - name: Publish results to Firebase
-        if: always() && github.event.workflow_run.event == 'push'
+        if: always() && github.event_name == 'push'
         env:
           FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
-          REPORT_FILENAME: "feg_integ_test_${{ env.SHA }}.html"
+          REPORT_FILENAME: "feg_integ_test_${{ github.sha }}.html"
         run: |
           npm install -g xunit-viewer
           [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
           [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
           [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
-          python ci-scripts/firebase_publish_report.py -id ${{ env.SHA }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} feg --url $URL
+          python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} feg --url $URL
       - name: Notify failure to slack
-        if: failure() && github.event.workflow_run.event == 'push'
+        if: failure() && github.event_name == 'push'
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: "FEG integ test"
           SLACK_AVATAR: ":boom:"
         uses: Ilshidur/action-slack@2.1.0
         with:
-          args: "Federated integration test test failed on [${{ env.SHA }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ env.SHA }}): ${{ steps.commit.outputs.title}}"
+          args: "Federated integration test test failed on [${{ github.sha }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ github.sha }}): ${{ steps.commit.outputs.title}}"

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -13,13 +13,9 @@ name: LTE integ test bazel
 
 on:
   workflow_dispatch: null
-  workflow_run:
-    workflows:
-      - build-all
+  push:
     branches:
       - master
-    types:
-      - completed
 
 env:
   CACHE_KEY: magma-dev-vm

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -13,25 +13,17 @@ name: LTE integ test
 
 on:
   workflow_dispatch: null
-  workflow_run:
-    workflows:
-      - build-all
+  push:
     branches:
       - master
       - 'v1.*'
-    types:
-      - completed
 
 jobs:
   lte-integ-test:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
-    env:
-      SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-        with:
-          ref: ${{ env.SHA }}
       - name: Cache magma-dev-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
@@ -107,22 +99,22 @@ jobs:
           junit_files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
       - name: Publish results to Firebase
-        if: always() && github.event.workflow_run.event == 'push'
+        if: always() && github.event_name == 'push'
         env:
           FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
-          REPORT_FILENAME: "lte_integ_test_${{ env.SHA }}.html"
+          REPORT_FILENAME: "lte_integ_test_${{ github.sha }}.html"
         run: |
           npm install -g xunit-viewer
           [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
           [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
           [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
-          python ci-scripts/firebase_publish_report.py -id ${{ env.SHA }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} lte --url $URL
+          python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} lte --url $URL
       - name: Notify failure to slack
-        if: failure() && github.event.workflow_run.event == 'push'
+        if: failure() && github.event_name == 'push'
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: "LTE integ test"
           SLACK_AVATAR: ":boom:"
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         with:
-          args: "LTE integration test test failed on [${{ env.SHA }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ env.SHA }}): ${{ steps.commit.outputs.title}}"
+          args: "LTE integration test test failed on [${{ github.sha }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ github.sha }}): ${{ steps.commit.outputs.title}}"

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -13,13 +13,9 @@ name: Sudo python tests
 
 on:
   workflow_dispatch: null
-  workflow_run:
-    workflows:
-      - build-all
+  push:
     branches:
       - master
-    types:
-      - completed
 
 env:
   CACHE_KEY: magma-dev-vm


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves  #13907
- Instead of waiting for the build-all job to complete the workflows are triggered by pushes/merges to the equivalent branches

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- The deploy-build-from-pr workflow does indeed seem to require the build-all job.


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
