### PR TITLE
chore(ci): Unify workflow names

### DIFF
--- a/.github/workflows/agw-docker-load-test.yml
+++ b/.github/workflows/agw-docker-load-test.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: AGW docker load test
+name: AGW Test Load Docker AMI
 
 on:
   workflow_run:

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: agw-workflow
+name: AGW Lint & Test
 
 on:
   push:

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: AutoLabel PR
+name: PR Generate Labels
 on:
   # Use pull_request_target to gain write permissions.
   # Ref: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -11,7 +11,7 @@
 
 # Based on https://github.com/sqren/backport-github-action/blob/main/README.md under MIT license.
 
-name: backport-pull-request
+name: PR Backport
 on:
   pull_request_target:
     types:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Bazel Build & Test"
+name: AGW Build, Format & Test Bazel
 on:
   # yamllint disable-line rule:truthy
   workflow_dispatch:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: build-all
+name: Magma Build & Publish
 
 on:
   workflow_dispatch: null

--- a/.github/workflows/build_magma_dep.yml
+++ b/.github/workflows/build_magma_dep.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Build Nettle and Upload to Artifactory"
+name: Magma Build & Publish Nettle
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/check-rebase.yml
+++ b/.github/workflows/check-rebase.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Check Rebase"
+name: PR Check Rebase
 
 on:
   pull_request:

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: cloud-workflow
+name: Orc8r Lint & Test
 
 on:
   push:

--- a/.github/workflows/codeowners-syntax.yml
+++ b/.github/workflows/codeowners-syntax.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Codeowners Validator"
+name: PR Check Codeowners
 
 on:
   pull_request:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 
-name: "CodeQL"
+name: Magma Analyze With CodeQL
 
 on:
   push:

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -9,13 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Update PR on check failure
+name: PR Generate Comment On Workflow Failure
 on:
   workflow_run:
     workflows:
-      - DCO check
-      - Python Format Check
-      - Markdown lint check
+      - PR Check DCO
+      - AGW Build & Format Python
+      - Docs Lint & Check Generated Files In Sync
     types:
       - completed
 
@@ -101,9 +101,9 @@ jobs:
             fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
       - run: unzip pr.zip
       - name: DCO comment message
-        if: ${{ github.event.workflow.name == 'DCO check' }}
+        if: ${{ github.event.workflow.name == 'PR Check DCO' }}
         run: |
-          echo "Oops! Looks like you failed the \`DCO check\`. Be sure to sign all your commits.
+          echo "Oops! Looks like you failed the \`PR Check DCO\`. Be sure to sign all your commits.
           ### Howto
           - [Magma guidelines on signing commits](https://magma.github.io/magma/docs/next/contributing/contribute_workflow#guidelines)
           - [About the \`signoff\` feature](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)
@@ -111,9 +111,9 @@ jobs:
           - [Howto: sign-off multiple past commits](https://gist.github.com/kwk/d70f20d17b18c4f3296d)
           - $CHECK_GUIDELINE" >> $GITHUB_WORKSPACE/msg
       - name: Python format comment message
-        if: ${{ github.event.workflow.name == 'Python Format Check' }}
+        if: ${{ github.event.workflow.name == 'AGW Build & Format Python' }}
         run: |
-          echo "Oops! Looks like you failed the \`Python Format Check\`.
+          echo "Oops! Looks like you failed the \`AGW Build & Format Python\`.
           ### Howto
           - Instructions on running the formatter and linter locally are provided in the [format AGW doc](https://docs.magmacore.org/docs/next/lte/dev_unit_testing#format-agw)
           - $CHECK_GUIDELINE" >> $GITHUB_WORKSPACE/msg
@@ -126,9 +126,9 @@ jobs:
           - For PRs with only one commit, the commit message must also be semantic. See [Changing a commit message](https://docs.github.com/en/github/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message) for a howto
           - $CHECK_GUIDELINE" >> $GITHUB_WORKSPACE/msg
       - name: Markdown lint comment message
-        if: ${{ github.event.workflow.name == 'Markdown lint check' }}
+        if: ${{ github.event.workflow.name == 'Docs Lint & Check Generated Files In Sync' }}
         run: |
-          echo "Oops! Looks like you failed the \`Markdown lint check\`.
+          echo "Oops! Looks like you failed the \`Docs Lint & Check Generated Files In Sync\`.
           ### Howto
           - [Instructions on formatting your Markdown changes](https://github.com/magma/magma/wiki/Contributing-Documentation#precommit)
           - $CHECK_GUIDELINE" >> $GITHUB_WORKSPACE/msg

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: cwag-workflow
+name: CWAG Format & Test
 
 on:
   push:

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: CWF integ test
+name: CWAG Build & Test Integration
 
 on:
   workflow_dispatch: null

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: cwf-operator
+name: CWAG Lint & Test Operator
 
 on:
   push:

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: DCO check
+name: PR Check DCO
 on:
   pull_request:
     types: [ opened, reopened, synchronize ]

--- a/.github/workflows/deploy-build-from-pr.yml
+++ b/.github/workflows/deploy-build-from-pr.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Deploy PR build
+name: Magma Publish Artifacts
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Build Docker image for Bazel Base and DevContainer"
+name: Magma Build Docker Image Bazel Base & DevContainer
 on:
   push:
     branches:

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Build Docker image for Python Precommit"
+name: AGW Build Docker Image Python Precommit
 on:
   push:
     branches:

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: docker promote
+name: Magma Promote Docker Images
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Markdown lint check
+name: Docs Lint & Check Generated Files In Sync
 
 on:
   push:

--- a/.github/workflows/docusaurus-workflow.yml
+++ b/.github/workflows/docusaurus-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: docusaurus-workflow
+name: Docs Build & Deploy
 
 on:
   push:

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: dp-workflow
+name: DP Lint & Test
 
 on:
   push:

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Federated integ test
+name: Magma Build, Publish & Test Federated Integration
 
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch: null

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: feg-workflow
+name: FeG Lint & Test
 
 on:
   push:

--- a/.github/workflows/fossa-workflow.yml
+++ b/.github/workflows/fossa-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: fossa-workflow
+name: Orc8r Analyze With Fossa
 
 on:
   push:

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -19,7 +19,7 @@
 #   - Option: by improving our build system and enabling faster build-all-targets
 #######
 
-name: "GCC Warnings & Errors"
+name: AGW Generate GCC Warnings & Errors
 on:
   push:
     branches:

--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Golang Build & Test
+name: AGW Build & Test Experimental Go Code
 on:
   push:
     branches:

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Check dependencies of helm charts"
+name: Magma Check Helm Dependencies
 
 on:
   push:

--- a/.github/workflows/helm-deploy-on-demand.yml
+++ b/.github/workflows/helm-deploy-on-demand.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: helm-build-on-demand
+name: Magma Build & Publish Helm Charts
 
 # Temporary on demand Job until we refactor helm build job in build-all
 on:

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: helm promote
+name: Magma Promote Helm Charts
 
 on:
   workflow_dispatch:

--- a/.github/workflows/insync-checkin.yml
+++ b/.github/workflows/insync-checkin.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: insync-check
+name: Orc8r Check Generated Files In Sync
 
 on:
   push:

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: LTE integ test bazel magma-deb
+name: AGW Build & Test LTE Integration With Bazel Debian Build
 
 on:
   workflow_dispatch: null

--- a/.github/workflows/lte-integ-test-bazel.yml
+++ b/.github/workflows/lte-integ-test-bazel.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: LTE integ test bazel
+name: AGW Build & Test LTE Integration With Bazel Dev Build
 
 on:
   workflow_dispatch: null

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: LTE integ test containerized AGW
+name: AGW Test LTE Integration With Make Containerized Build
 
 on:
   workflow_dispatch: null

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: LTE integ test magma-deb
+name: AGW Test LTE Integration With Make Debian Build
 
 on:
   workflow_dispatch: null

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: LTE integ test
+name: AGW Build & Test LTE Integration With Make Dev Build
 
 on:
   workflow_dispatch: null

--- a/.github/workflows/nms-workflow.yml
+++ b/.github/workflows/nms-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: nms-workflow
+name: NMS Lint & Test
 
 on:
   push:

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: PR Hello
+name: PR Generate Hello
 on:
   # Use pull_request_target to gain write permissions.
   # Ref: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
@@ -28,7 +28,7 @@ jobs:
             var msg = `Thanks for opening a PR! :100:
 
             [A couple initial guidelines](https://github.com/magma/magma/wiki/Contributing-Code#commit-and-pull-request-guidelines)
-            - All commits must be signed off. This is [enforced by \`DCO check\`](https://github.com/magma/magma/blob/master/.github/workflows/dco-check.yml).
+            - All commits must be signed off. This is [enforced by \`PR DCO check\`](https://github.com/magma/magma/blob/master/.github/workflows/dco-check.yml).
             - All PR titles must follow the semantic commits format. This is [enforced by \`Semantic PR\`](https://github.com/magma/magma/blob/master/.github/workflows/semantic-pr.yml).
 
             ### Howto

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Python Format Check
+name: AGW Build & Format Python
 on:
   push:
     branches:

--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: reviewdog-workflow
+name: PR Lint Reviewdog
 on:
   pull_request_target:
     types:

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Check for semantic PR title"
+name: PR Check Title Or Commit Message
 
 on:
   # Semantic PR module only works with pull_request_target

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Sudo python tests
+name: AGW Test Sudo Python
 
 on:
   workflow_dispatch: null

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Cloud Unit Test Results
+name: PR Generate Unit Test Results
 on:
   workflow_run:
     workflows:


### PR DESCRIPTION
## Summary

Closes https://github.com/magma/magma/issues/13275.

Unifies the names of the workflows by giving them non-default names (e.g. fossa-workflow -> Orc8r Analyze With Fossa) and by having the names lead with the component they relate to (e.g. insync-check -> Orc8r Check Generated Files In Sync). This PR should make it easier to navigate through the actions and easier to understand what the workflows actually do.

:warning: When merging, we need to propagate these changes to the configuration of the required workflows. CC @maxhbr 
-> Update: It was not necessary to do this because the required jobs are all steps (which are not updated here), not workflows.

## Test Plan

- CI

## Suggestion for formatting which will be added to the Wiki upon merging this:

The convention for naming workflows is as follows:

**{component} {verbs} {additions}**

with

- {component} in AGW, CWAG, Docs, DP, FeG, Magma, NMS, Orc8r, PR
- {verbs} in Analyse, Backport, Build, Check, Deploy, Format, Generate, Lint, Promote, Publish, Test
- {addition} being a short descriptive addition 

Rules and notes:
- All words in the name should be capitalized.
- {component}:
  - Exactly one component should be chosen for every workflow.
  - “Magma” is intended for workflows relating to multiple Magma components.
  - “PR” is intended for workflows that interact with pull requests.
- {verbs}:
  - In the case that multiple verbs are applicable, the last separator should be an ampersand enclosed in one space each side, any other separator should be a comma followed by one space, e.g. `Build & Test`, `Lint, Build & Test`
