### PR TITLE
fix(ci): fix test interdependency in test attach detach rar tcp data

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -40,249 +40,247 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
     def test_attach_detach_rar_tcp_data(self):
         """ Attach/detach + send ReAuth Req to session manager with a
         single UE """
-        num_ues = 1
         detach_type = [
             s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
         ]
         wait_for_s1 = [True, False]
-        self._s1ap_wrapper.configUEDevice(num_ues)
+        self._s1ap_wrapper.configUEDevice(num_ues=1)
         datapath = get_datapath()
         MAX_NUM_RETRIES = 5
 
-        for i in range(num_ues):
-            req = self._s1ap_wrapper.ue_req
-            print(
-                "********************** Running End to End attach for ",
-                "UE id ",
-                req.ue_id,
+        req = self._s1ap_wrapper.ue_req
+        print(
+            "********************** Running End to End attach for ",
+            "UE id ",
+            req.ue_id,
+        )
+        # Now actually complete the attach
+        self._s1ap_wrapper._s1_util.attach(
+            req.ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        # UL Flow description #1
+        ulFlow1 = {
+            "ipv4_dst": "192.168.129.42",  # IPv4 destination address
+            "tcp_dst_port": 5002,  # TCP dest port
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
+        }
+
+        # UL Flow description #2
+        ulFlow2 = {
+            "ipv4_dst": "192.168.129.42",  # IPv4 destination address
+            "tcp_dst_port": 5001,  # TCP dest port
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
+        }
+
+        # UL Flow description #3
+        ulFlow3 = {
+            "ipv4_dst": "192.168.129.64",  # IPv4 destination address
+            "tcp_dst_port": 5003,  # TCP dest port
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
+        }
+
+        # UL Flow description #4
+        ulFlow4 = {
+            "ipv4_dst": "192.168.129.42",  # IPv4 destination address
+            "tcp_dst_port": 5004,  # TCP dest port
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
+        }
+
+        # DL Flow description #1
+        dlFlow1 = {
+            "ipv4_src": "192.168.129.42",  # IPv4 source address
+            "tcp_src_port": 5001,  # TCP source port
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
+        }
+
+        # DL Flow description #2
+        dlFlow2 = {
+            "ipv4_src": "192.168.129.64",  # IPv4 source address
+            "tcp_src_port": 5002,  # TCP source port
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
+        }
+
+        # DL Flow description #3
+        dlFlow3 = {
+            "ipv4_src": "192.168.129.64",  # IPv4 source address
+            "tcp_src_port": 5003,  # TCP source port
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
+        }
+
+        # DL Flow description #4
+        dlFlow4 = {
+            "ipv4_src": "192.168.129.42",  # IPv4 source address
+            "tcp_src_port": 5004,  # TCP source port
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
+        }
+
+        # Flow list to be configured
+        flow_list = [
+            ulFlow1,
+            ulFlow2,
+            ulFlow3,
+            ulFlow4,
+            dlFlow1,
+            dlFlow2,
+            dlFlow3,
+            dlFlow4,
+        ]
+
+        # QoS
+        qos = {
+            "qci": 5,  # qci value [1 to 9]
+            "priority": 0,  # Range [0-255]
+            "max_req_bw_ul": 10000000,  # MAX bw Uplink
+            "max_req_bw_dl": 15000000,  # MAX bw Downlink
+            "gbr_ul": 1000000,  # GBR Uplink
+            "gbr_dl": 2000000,  # GBR Downlink
+            "arp_prio": 15,  # ARP priority
+            "pre_cap": 1,  # pre-emption capability
+            "pre_vul": 1,  # pre-emption vulnerability
+        }
+
+        policy_id = "ims-voice"
+
+        print("Sleeping for 5 seconds")
+        time.sleep(5)
+        print(
+            "********************** Sending RAR for IMSI",
+            "".join([str(i) for i in req.imsi]),
+        )
+        self._sessionManager_util.send_ReAuthRequest(
+            "IMSI" + "".join([str(i) for i in req.imsi]),
+            policy_id,
+            flow_list,
+            qos,
+        )
+
+        # Receive Activate dedicated bearer request
+        response = self._s1ap_wrapper.s1_util.get_response()
+        assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+        act_ded_ber_ctxt_req = response.cast(
+            s1ap_types.UeActDedBearCtxtReq_t,
+        )
+
+        print("Sleeping for 5 seconds")
+        time.sleep(5)
+        # Send Activate dedicated bearer accept
+        self._s1ap_wrapper.sendActDedicatedBearerAccept(
+            req.ue_id, act_ded_ber_ctxt_req.bearerId,
+        )
+        print("Sleeping again for flow to be installed")
+        time.sleep(2)
+
+        # Check if UL and DL OVS flows are created
+        # UPLINK
+        gtp_br_util = GTPBridgeUtils()
+        GTP_PORT = gtp_br_util.get_gtp_port_no()
+
+        print(f"Checking for uplink flow on port {GTP_PORT}")
+        # try at least 5 times before failing as gateway
+        # might take some time to install the flows in ovs
+
+        for i in range(MAX_NUM_RETRIES):
+            print("Get uplink flows: attempt ", i)
+            uplink_flows = get_flows(
+                datapath,
+                {
+                    "table_id": self.SPGW_TABLE,
+                    "match": {"in_port": GTP_PORT},
+                },
             )
-            # Now actually complete the attach
-            self._s1ap_wrapper._s1_util.attach(
-                req.ue_id,
-                s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
-                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t,
-            )
+            if len(uplink_flows) > 1:
+                break
+            time.sleep(5)  # sleep for 5 seconds before retrying
 
-            # Wait on EMM Information from MME
-            self._s1ap_wrapper._s1_util.receive_emm_info()
+        assert len(uplink_flows) > 1, "Uplink flow missing for UE"
+        assert uplink_flows[0]["match"]["tunnel_id"] is not None, \
+            "Uplink flow missing tunnel id match"
 
-            # UL Flow description #1
-            ulFlow1 = {
-                "ipv4_dst": "192.168.129.42",  # IPv4 destination address
-                "tcp_dst_port": 5002,  # TCP dest port
-                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
-                "direction": FlowMatch.UPLINK,  # Direction
-            }
-
-            # UL Flow description #2
-            ulFlow2 = {
-                "ipv4_dst": "192.168.129.42",  # IPv4 destination address
-                "tcp_dst_port": 5001,  # TCP dest port
-                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
-                "direction": FlowMatch.UPLINK,  # Direction
-            }
-
-            # UL Flow description #3
-            ulFlow3 = {
-                "ipv4_dst": "192.168.129.64",  # IPv4 destination address
-                "tcp_dst_port": 5003,  # TCP dest port
-                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
-                "direction": FlowMatch.UPLINK,  # Direction
-            }
-
-            # UL Flow description #4
-            ulFlow4 = {
-                "ipv4_dst": "192.168.129.42",  # IPv4 destination address
-                "tcp_dst_port": 5004,  # TCP dest port
-                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
-                "direction": FlowMatch.UPLINK,  # Direction
-            }
-
-            # DL Flow description #1
-            dlFlow1 = {
-                "ipv4_src": "192.168.129.42",  # IPv4 source address
-                "tcp_src_port": 5001,  # TCP source port
-                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
-                "direction": FlowMatch.DOWNLINK,  # Direction
-            }
-
-            # DL Flow description #2
-            dlFlow2 = {
-                "ipv4_src": "192.168.129.64",  # IPv4 source address
-                "tcp_src_port": 5002,  # TCP source port
-                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
-                "direction": FlowMatch.DOWNLINK,  # Direction
-            }
-
-            # DL Flow description #3
-            dlFlow3 = {
-                "ipv4_src": "192.168.129.64",  # IPv4 source address
-                "tcp_src_port": 5003,  # TCP source port
-                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
-                "direction": FlowMatch.DOWNLINK,  # Direction
-            }
-
-            # DL Flow description #4
-            dlFlow4 = {
-                "ipv4_src": "192.168.129.42",  # IPv4 source address
-                "tcp_src_port": 5004,  # TCP source port
-                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
-                "direction": FlowMatch.DOWNLINK,  # Direction
-            }
-
-            # Flow list to be configured
-            flow_list = [
-                ulFlow1,
-                ulFlow2,
-                ulFlow3,
-                ulFlow4,
-                dlFlow1,
-                dlFlow2,
-                dlFlow3,
-                dlFlow4,
-            ]
-
-            # QoS
-            qos = {
-                "qci": 5,  # qci value [1 to 9]
-                "priority": 0,  # Range [0-255]
-                "max_req_bw_ul": 10000000,  # MAX bw Uplink
-                "max_req_bw_dl": 15000000,  # MAX bw Downlink
-                "gbr_ul": 1000000,  # GBR Uplink
-                "gbr_dl": 2000000,  # GBR Downlink
-                "arp_prio": 15,  # ARP priority
-                "pre_cap": 1,  # pre-emption capability
-                "pre_vul": 1,  # pre-emption vulnerability
-            }
-
-            policy_id = "ims-voice"
-
-            print("Sleeping for 5 seconds")
-            time.sleep(5)
-            print(
-                "********************** Sending RAR for IMSI",
-                "".join([str(i) for i in req.imsi]),
-            )
-            self._sessionManager_util.send_ReAuthRequest(
-                "IMSI" + "".join([str(i) for i in req.imsi]),
-                policy_id,
-                flow_list,
-                qos,
-            )
-
-            # Receive Activate dedicated bearer request
-            response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
-            act_ded_ber_ctxt_req = response.cast(
-                s1ap_types.UeActDedBearCtxtReq_t,
-            )
-
-            print("Sleeping for 5 seconds")
-            time.sleep(5)
-            # Send Activate dedicated bearer accept
-            self._s1ap_wrapper.sendActDedicatedBearerAccept(
-                req.ue_id, act_ded_ber_ctxt_req.bearerId,
-            )
-            print("Sleeping again for flow to be installed")
-            time.sleep(2)
-
-            # Check if UL and DL OVS flows are created
-            # UPLINK
-            gtp_br_util = GTPBridgeUtils()
-            GTP_PORT = gtp_br_util.get_gtp_port_no()
-
-            print(f"Checking for uplink flow on port {GTP_PORT}")
-            # try at least 5 times before failing as gateway
-            # might take some time to install the flows in ovs
-
-            for i in range(MAX_NUM_RETRIES):
-                print("Get uplink flows: attempt ", i)
-                uplink_flows = get_flows(
-                    datapath,
-                    {
-                        "table_id": self.SPGW_TABLE,
-                        "match": {"in_port": GTP_PORT},
+        # DOWNLINK
+        print("Checking for downlink flow")
+        ue_ip = str(self._s1ap_wrapper._s1_util.get_ip(req.ue_id))
+        # try at least 5 times before failing as gateway
+        # might take some time to install the flows in ovs
+        for i in range(MAX_NUM_RETRIES):
+            print("Get downlink flows: attempt ", i)
+            downlink_flows = get_flows(
+                datapath,
+                {
+                    "table_id": self.SPGW_TABLE,
+                    "match": {
+                        "nw_dst": ue_ip,
+                        "eth_type": 2048,
+                        "in_port": self.LOCAL_PORT,
                     },
-                )
-                if len(uplink_flows) > 1:
-                    break
-                time.sleep(5)  # sleep for 5 seconds before retrying
-
-            assert len(uplink_flows) > 1, "Uplink flow missing for UE"
-            assert uplink_flows[0]["match"]["tunnel_id"] is not None, \
-                "Uplink flow missing tunnel id match"
-
-            # DOWNLINK
-            print("Checking for downlink flow")
-            ue_ip = str(self._s1ap_wrapper._s1_util.get_ip(req.ue_id))
-            # try at least 5 times before failing as gateway
-            # might take some time to install the flows in ovs
-            for i in range(MAX_NUM_RETRIES):
-                print("Get downlink flows: attempt ", i)
-                downlink_flows = get_flows(
-                    datapath,
-                    {
-                        "table_id": self.SPGW_TABLE,
-                        "match": {
-                            "nw_dst": ue_ip,
-                            "eth_type": 2048,
-                            "in_port": self.LOCAL_PORT,
-                        },
-                    },
-                )
-                if len(downlink_flows) > 1:
-                    break
-                time.sleep(5)  # sleep for 5 seconds before retrying
-
-            assert len(downlink_flows) > 1, "Downlink flow missing for UE"
-            assert downlink_flows[0]["match"]["ipv4_dst"] == ue_ip, \
-                "UE IP match missing from downlink flow"
-
-            actions = downlink_flows[0]["instructions"][0]["actions"]
-            has_tunnel_action = any(
-                action
-                for action in actions
-                if action["field"] == "tunnel_id"
-                and action["type"] == "SET_FIELD"
+                },
             )
-            assert has_tunnel_action, "Downlink flow missing set tunnel action"
+            if len(downlink_flows) > 1:
+                break
+            time.sleep(5)  # sleep for 5 seconds before retrying
 
-            print("Sleeping for 5 seconds")
-            time.sleep(5)
-            with self._s1ap_wrapper.configUplinkTest(req, duration=1) as test:
-                test.verify()
+        assert len(downlink_flows) > 1, "Downlink flow missing for UE"
+        assert downlink_flows[0]["match"]["ipv4_dst"] == ue_ip, \
+            "UE IP match missing from downlink flow"
 
-            print(
-                "********************** Deleting dedicated bearer for IMSI",
-                "".join([str(i) for i in req.imsi]),
-            )
-            self._spgw_util.delete_bearer(
-                "IMSI" + "".join([str(i) for i in req.imsi]), 5, 6,
-            )
+        actions = downlink_flows[0]["instructions"][0]["actions"]
+        has_tunnel_action = any(
+            action
+            for action in actions
+            if action["field"] == "tunnel_id"
+            and action["type"] == "SET_FIELD"
+        )
+        assert has_tunnel_action, "Downlink flow missing set tunnel action"
 
-            response = self._s1ap_wrapper.s1_util.get_response()
-            assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+        print("Sleeping for 5 seconds")
+        time.sleep(5)
+        with self._s1ap_wrapper.configUplinkTest(req, duration=1) as test:
+            test.verify()
 
-            print("******************* Received deactivate eps bearer context")
+        print(
+            "********************** Deleting dedicated bearer for IMSI",
+            "".join([str(i) for i in req.imsi]),
+        )
+        self._spgw_util.delete_bearer(
+            "IMSI" + "".join([str(i) for i in req.imsi]), 5, 6,
+        )
 
-            deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
-            self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
-                req.ue_id, deactv_bearer_req.bearerId,
-            )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        assert response.msg_type == s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
 
-            print("Sleeping for 5 seconds")
-            time.sleep(5)
+        print("******************* Received deactivate eps bearer context")
 
-            print(
-                "********************** Running UE detach for UE id ",
-                req.ue_id,
-            )
-            # Now detach the UE
-            self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i],
-            )
+        deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
+        self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
+            req.ue_id, deactv_bearer_req.bearerId,
+        )
+
+        print("Sleeping for 5 seconds")
+        time.sleep(5)
+
+        print(
+            "********************** Running UE detach for UE id ",
+            req.ue_id,
+        )
+        # Now detach the UE
+        self._s1ap_wrapper.s1_util.detach(
+            req.ue_id, detach_type[i], wait_for_s1[i],
+        )
 
         # Verify that all UL/DL flows are deleted
         self._s1ap_wrapper.s1_util.verify_flow_rules_deletion()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -49,8 +49,6 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         datapath = get_datapath()
         MAX_NUM_RETRIES = 5
-        gtp_br_util = GTPBridgeUtils()
-        GTP_PORT = gtp_br_util.get_gtp_port_no()
 
         for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
@@ -192,9 +190,13 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
 
             # Check if UL and DL OVS flows are created
             # UPLINK
-            print("Checking for uplink flow")
+            gtp_br_util = GTPBridgeUtils()
+            GTP_PORT = gtp_br_util.get_gtp_port_no()
+
+            print(f"Checking for uplink flow on port {GTP_PORT}")
             # try at least 5 times before failing as gateway
             # might take some time to install the flows in ovs
+
             for i in range(MAX_NUM_RETRIES):
                 print("Get uplink flows: attempt ", i)
                 uplink_flows = get_flows(


### PR DESCRIPTION
## Summary

* Fix for test_attach_detach_rar_tcp_data.
* Removed for loop

You probably want to review each commit in this pr separately.

## Test Plan

- [x] Ran the testcase (test_attach_detach_rar_tcp_data)
- [x] [Ran the integ test suite in ci ](https://github.com/crasu/magma/actions/runs/3289965904)

## Additional Information


Before the change the test was expecting an already existing gtp port g_8d3ca8c0. This port is usally created by other tests and only deleted during cleanup of a failed test. This caused the flaky retry for this test to always fail since after a cleanup the g_8d3ca8c0 would never exists.

As the g_8d3ca8c0 port is setup during flow creation, we now determine the port number after the flows has been created.