### PR TITLE
fix(orc8r): Handle absent NGC config correctly

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -397,7 +397,9 @@ func (m *GatewayNgcConfigs) FromBackendModels(ctx context.Context, networkID str
 	if err != nil {
 		return err
 	}
-	*m = *gatewayConfig.Ngc
+	if gatewayConfig.Ngc != nil {
+		*m = *gatewayConfig.Ngc
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Return an empty object instead of an internal server error if the NGC config is not set.

Without this change, there is a nil pointer dereference error in the orc8r.
```
orc8r-controller-1  | lte stdout | echo: http: panic serving 127.0.0.1:44296: runtime error: invalid memory address or nil pointer dereference
orc8r-controller-1  | lte stdout | goroutine 1137 [running]:
orc8r-controller-1  | lte stdout | net/http.(*conn).serve.func1()
orc8r-controller-1  | lte stdout |      /usr/local/go/src/net/http/server.go:1825 +0xbf
orc8r-controller-1  | lte stdout | panic({0xf2e300, 0x1b644e0})
orc8r-controller-1  | lte stdout |      /usr/local/go/src/runtime/panic.go:844 +0x258
orc8r-controller-1  | lte stdout | magma/lte/cloud/go/services/lte/obsidian/models.(*GatewayNgcConfigs).FromBackendModels(0xc0000a93e0, {0xc0005ea3c0?, 0x30?}, {0xc0001de5d2?, 0x80?}, {0xc0001de5e0?, 0x41ad05?})
orc8r-controller-1  | lte stdout |      /src/magma/lte/cloud/go/services/lte/obsidian/models/conversion.go:400 +0x88
orc8r-controller-1  | lte stdout | magma/orc8r/cloud/go/services/orchestrator/obsidian/handlers.GetPartialReadGatewayHandler.func1({0x1259438, 0xc0005ea3c0})
orc8r-controller-1  | lte stdout |      /src/magma/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory.go:84 +0x77
orc8r-controller-1  | lte stdout | github.com/labstack/echo/v4.(*Echo).add.func1({0x1259438, 0xc0005ea3c0})
orc8r-controller-1  | lte stdout |      /go/pkg/mod/github.com/labstack/echo/v4@v4.9.0/echo.go:536 +0x51
orc8r-controller-1  | lte stdout | magma/orc8r/cloud/go/service.Logger.func1({0x1259438, 0xc0005ea3c0})
orc8r-controller-1  | lte stdout |      /src/magma/orc8r/cloud/go/service/service.go:218 +0x2e
orc8r-controller-1  | lte stdout | github.com/labstack/echo/v4.(*Echo).ServeHTTP(0xc0003c1440, {0x124cf30?, 0xc000216460}, 0xc000710100)
orc8r-controller-1  | lte stdout |      /go/pkg/mod/github.com/labstack/echo/v4@v4.9.0/echo.go:646 +0x3bc
orc8r-controller-1  | lte stdout | net/http.serverHandler.ServeHTTP({0xc0008b61e0?}, {0x124cf30, 0xc000216460}, 0xc000710100)
orc8r-controller-1  | lte stdout |      /usr/local/go/src/net/http/server.go:2916 +0x43b
orc8r-controller-1  | lte stdout | net/http.(*conn).serve(0xc0003b6b40, {0x124d940, 0xc0001c3140})
orc8r-controller-1  | lte stdout |      /usr/local/go/src/net/http/server.go:1966 +0x5d7
orc8r-controller-1  | lte stdout | created by net/http.(*Server).Serve
orc8r-controller-1  | lte stdout |      /usr/local/go/src/net/http/server.go:3071 +0x4db
```

## Test Plan

- Call the endpoint locally on a gateway without NGC config.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
