### PR TITLE
fix: Do not set HOME in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,6 @@
 ################################################################
 FROM ghcr.io/magma/magma/bazel-base:latest as devcontainer
 
-ARG HOME=/home/vscode
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
@@ -82,7 +81,11 @@ RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://artifactory.magmacore.org/artifactory/generic/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \
  && rm ${GO_TARBALL}
-ENV PATH=${PATH}:/usr/local/go/bin:${HOME}/go/bin
+ENV PATH=${PATH}:/usr/local/go/bin
+
+# /home/vscode/go/bin doesn't exist initially, but for example orc8r/cloud/go/Makefile
+# populates that folder and expects those binaries to be in PATH
+ENV PATH=${PATH}:/home/vscode/go/bin
 
 RUN echo "Install 3rd party dependencies" && \
     apt-get update && \
@@ -207,7 +210,7 @@ RUN ldconfig -v
 ##### Install Python requirements
 
 ### create virtualenv
-ARG PYTHON_VENV=${HOME}/build/python
+ARG PYTHON_VENV=/home/vscode/build/python
 ENV PYTHON_VENV_EXECUTABLE=${PYTHON_VENV}/bin/python${PYTHON_VERSION}
 # PYTHON_VENV must by in sync with "python.defaultInterpreterPath", "python.analysis.extraPaths" and magtivate path in "postCreateCommand" in .devcontainer/devcontainer.json
 


### PR DESCRIPTION
Fixes #14225

## Summary

Do not set HOME in devcontainer Dockerfile to `/home/vscode`

The steps in the Dockerfile are executed as root user, and setting HOME to /home/vscode leads to root-owned files in the /home/vscode folder. Bazel requires $HOME/.cache to be writeable and thus fails if that folder is owned by root.


<!-- Enumerate changes you made and why you made them -->

## Test Plan

* replaced the `image` section of `devcontainer.json` with the following snippet:
```
	"build": {
		"dockerfile": "Dockerfile",
		"context": "../"
	},
```
* closed vscode, removed all vsode docker containers, started vscode
* verified that the container builds and that Bazel can be executed

The HOME arg was introduced in #13494 which is a followup to #13473. The latter has a test step:
```
cd orc8r/cloud && make clean_gen gen swagger tidy
```

I verified that the make step finds the newly downloaded binaries in `/home/vscode/go/bin`.
The make step would later fail because it tries to create `/workspaces/github.com`, but fixing that
is out of scope of this PR.
