### PR TITLE
chore(ci): Remove sudo tests from make LTE integ test workflow

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -426,7 +426,6 @@ def integ_test(
     # vagrant machine
     gateway_host, gateway_ip = _setup_gateway(gateway_host, "magma", "dev", "magma_dev.yml", destroy_vm, provision_vm)
     execute(_build_magma)
-    execute(_run_sudo_python_unit_tests)
     execute(_start_gateway)
 
     # Set up the trfserver: use the provided trfserver if given, else default to the
@@ -792,13 +791,6 @@ def _build_magma():
     """
     with cd(AGW_ROOT):
         run('make')
-
-
-def _run_sudo_python_unit_tests():
-    """ Run the magma unit tests """
-    with cd(AGW_ROOT):
-        # Run all unit tests that are not run as pre-commit checks in CI
-        run('make test_sudo_python')
 
 
 def _start_gateway():


### PR DESCRIPTION
## Summary

Closes https://github.com/magma/magma/issues/14161.

:warning: We should wait until https://github.com/magma/magma/issues/14160 has been merged before merging this.

## Test Plan

- [x] [Run workflow on fork](https://github.com/voisey/magma/actions/runs/3290460135). Workflow fails due to flaky tests but runs through without running the sudo tests.