### PR TITLE
fix(pipelined): added changes for ovs flows of table 13

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement.py
@@ -72,6 +72,7 @@ class EnforcementController(PolicyMixin, RestartMixin, MagmaController):
         self._redirect_manager = None
         self._qos_mgr = kwargs['qos_manager']
         self._clean_restart = kwargs['config']['clean_restart']
+        self.is_stateless = kwargs['config']['redis_enabled']
         self._redirect_manager = RedirectionManager(
             self._bridge_ip_address,
             self.logger,
@@ -357,3 +358,12 @@ class EnforcementController(PolicyMixin, RestartMixin, MagmaController):
         else:
             for rule_id in rule_ids:
                 self._deactivate_flow_for_rule(imsi, ip_addr, rule_id)
+
+    def _skip_extra_flows_removal(self):
+        """
+        Returns redis_enabled flag value
+        Traffic is not getting resumed on service restart in case of stateless.
+        It is due to extra flows - enforcement table entries getting deleted.
+        This will decide to remove extra flows or not.
+        """
+        return self.is_stateless

--- a/lte/gateway/python/magma/pipelined/app/restart_mixin.py
+++ b/lte/gateway/python/magma/pipelined/app/restart_mixin.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 from __future__ import annotations
 
+import logging
 from abc import ABCMeta, abstractmethod
 from asyncio import Future
 from logging import Logger
@@ -126,7 +127,11 @@ class RestartMixin(metaclass=ABCMeta):
                 tbl,
                 [flow.match for flow in startup_flows_map[tbl]],
             )
-        self._remove_extra_flows(startup_flows_map)
+
+        if self._skip_extra_flows_removal():
+            logging.info("skipping removal of enforcement flows since it is in stateless mode")
+        else:
+            self._remove_extra_flows(startup_flows_map)
 
         self.finish_init(requests)
         self.init_finished = True
@@ -151,6 +156,13 @@ class RestartMixin(metaclass=ABCMeta):
         if msg_list:
             chan = self._msg_hub.send(msg_list, self._datapath)
             self._wait_for_responses(chan, len(msg_list))
+
+    def _skip_extra_flows_removal(self):
+        """
+        This method can be overridden by controllers.
+        Skips removal of extra flows in case of stateless mode.
+        """
+        return False
 
     @abstractmethod
     def _get_ue_specific_flow_msgs(self, requests):

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_restart_resilience.RestartResilienceTest.test_with_stateless_enforcement_restart.after_restart.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_restart_resilience.RestartResilienceTest.test_with_stateless_enforcement_restart.after_restart.snapshot
@@ -1,0 +1,3 @@
+ cookie=0x1, table=enforcement(main_table), n_packets=256, n_bytes=8704, priority=65533,ip,reg1=0x1,metadata=0x48c2739fd9c3,nw_src=192.168.128.74,nw_dst=45.10.0.0/24 actions=note:b'sub1_rule_temp',set_field:0x1->reg2,set_field:0x1->reg4,set_field:0->reg11,resubmit(,enforcement_stats(main_table)),resubmit(,egress(main_table))
+ cookie=0xfffffffffffffffe, table=enforcement(main_table), n_packets=3840, n_bytes=130560, priority=0 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0xfffffffffffffffe, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=0 actions=drop

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_restart_resilience.RestartResilienceTest.test_with_stateless_enforcement_restart.before_restart.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_restart_resilience.RestartResilienceTest.test_with_stateless_enforcement_restart.before_restart.snapshot
@@ -1,0 +1,9 @@
+ cookie=0x0, table=mme(main_table), n_packets=4096, n_bytes=139264, priority=65535,ip,nw_src=192.168.128.74 actions=load:0x48c2739fd9c3->OXM_OF_METADATA[],load:0x1->NXM_NX_REG1[],resubmit(,enforcement(main_table))
+ cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ip,nw_dst=192.168.128.74 actions=load:0x48c2739fd9c3->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
+ cookie=0x1, table=enforcement(main_table), n_packets=256, n_bytes=8704, priority=65533,ip,reg1=0x1,metadata=0x48c2739fd9c3,nw_src=192.168.128.74,nw_dst=45.10.0.0/24 actions=note:b'sub1_rule_temp',set_field:0x1->reg2,set_field:0x1->reg4,set_field:0->reg11,resubmit(,enforcement_stats(main_table)),resubmit(,egress(main_table))
+ cookie=0xfffffffffffffffe, table=enforcement(main_table), n_packets=3840, n_bytes=130560, priority=0 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x10,reg2=0x1,reg3=0,reg4=0x1,reg11=0,metadata=0x48c2739fd9c3,nw_dst=192.168.128.74 actions=drop
+ cookie=0x0, table=enforcement_stats(main_table), n_packets=256, n_bytes=8704, priority=10,ip,reg1=0x1,reg2=0x1,reg3=0,reg4=0x1,reg11=0,metadata=0x48c2739fd9c3,nw_src=192.168.128.74 actions=drop
+ cookie=0x0, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=1,ip,reg1=0x10,reg2=0,reg4=0,reg11=0,metadata=0x48c2739fd9c3,nw_dst=192.168.128.74 actions=drop
+ cookie=0x0, table=enforcement_stats(main_table), n_packets=3840, n_bytes=130560, priority=1,ip,reg1=0x1,reg2=0,reg4=0,reg11=0,metadata=0x48c2739fd9c3,nw_src=192.168.128.74 actions=drop
+ cookie=0xfffffffffffffffe, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=0 actions=drop

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_restart_resilience.RestartResilienceTest.test_with_stateless_enforcement_restart.default_flows.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_restart_resilience.RestartResilienceTest.test_with_stateless_enforcement_restart.default_flows.snapshot
@@ -1,0 +1,2 @@
+ cookie=0xfffffffffffffffe, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0xfffffffffffffffe, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=0 actions=drop

--- a/lte/gateway/python/magma/pipelined/tests/test_enforcement.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_enforcement.py
@@ -130,6 +130,7 @@ class EnforcementTableTest(unittest.TestCase):
                 'enable_nat': True,
                 'ovs_gtp_port_number': 10,
                 'setup_type': 'LTE',
+                'redis_enabled': False,
             },
             mconfig=PipelineD(),
             loop=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_enforcement_5g.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_enforcement_5g.py
@@ -83,6 +83,7 @@ class EnforcementTableTest(unittest.TestCase):
                 'enable_nat': True,
                 'ovs_gtp_port_number': 10,
                 'setup_type': 'LTE',
+                'redis_enabled': False,
             },
             mconfig=PipelineD(),
             loop=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_gy.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_gy.py
@@ -118,6 +118,7 @@ class GYTableTest(unittest.TestCase):
                 'qos': {'enable': False},
                 'dpi': {'enable': False},
                 'clean_restart': True,
+                'redis_enabled': False,
             },
             mconfig=PipelineD(
                 ue_ip_block='192.168.128.0/24',

--- a/lte/gateway/python/magma/pipelined/tests/test_he.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_he.py
@@ -520,6 +520,7 @@ class EnforcementTableHeTest(unittest.TestCase):
                 'enable_nat': True,
                 'ovs_gtp_port_number': 10,
                 'setup_type': 'LTE',
+                'redis_enabled': False,
             },
             mconfig=PipelineD(),
             loop=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_redirect.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_redirect.py
@@ -102,6 +102,7 @@ class RedirectTest(unittest.TestCase):
                 'qos': {'enable': False},
                 'clean_restart': True,
                 'setup_type': 'LTE',
+                'redis_enabled': False,
             },
             mconfig=PipelineD(),
             loop=None,


### PR DESCRIPTION
Signed-off-by: aniket021997 <aniket.sonawane@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Traffic is not getting resumed if mme services are restarted in case of stateless mode.
   It is due to in the case of stateless, table 13 - enforcement entries are getting deleted.
- Added check for not to delete table 13 entries in case of stateless mode.

<!-- Enumerate changes you made and why you made them -->

## Test Plan



- Verified flow entries of ovs table 0, 13 and 14 post restarts of magmad services

![after table 0 13 14](https://user-images.githubusercontent.com/95931489/199003565-0cfd3ab6-2ca4-4c0f-8a8f-07d2015373c8.PNG)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
