### PR TITLE
docs: migrate Documentation Overview from Docusaurus to Contributor Guide

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -14,17 +14,11 @@
       "basics/quick_start_guide": {
         "title": "Quick Start Guide"
       },
-      "contributing/contribute_ci_checks": {
-        "title": "Continuous Integration Checks"
-      },
       "contributing/contribute_codeowners": {
         "title": "Codeowners Workflow"
       },
-      "contributing/contribute_conventions": {
-        "title": "Contributing Conventions"
-      },
-      "contributing/contribute_id_mappings": {
-        "title": "Magma Codeowners"
+      "contributing/contribute_github": {
+        "title": "Community"
       },
       "contributing/contribute_onboarding": {
         "title": "Developer Onboarding"
@@ -34,9 +28,6 @@
       },
       "contributing/contribute_tsc_norms": {
         "title": "TSC Processes"
-      },
-      "contributing/contribute_vscode": {
-        "title": "Develop Magma With VSCode"
       },
       "contributing/contribute_workflow": {
         "title": "Development Workflow"

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -260,26 +260,9 @@
       }
     ],
     "Contribute": [
-      {
-        "type": "subcategory",
-        "label": "Contribute",
-        "ids": [
-          "contributing/contribute_onboarding",
-          "contributing/contribute_workflow",
-          "contributing/contribute_vscode",
-          "contributing/contribute_conventions",
-          "contributing/contribute_id_mappings",
-          "contributing/contribute_ci_checks"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Maintain",
-        "ids": [
-          "contributing/contribute_codeowners",
-          "contributing/contribute_tsc_norms"
-        ]
-      }
+      "contributing/contribute_github",
+      "contributing/contribute_codeowners",
+      "contributing/contribute_tsc_norms"
     ],
     "Technical Reference": [
       {

--- a/docs/readmes/contributing/contribute_ci_checks.md
+++ b/docs/readmes/contributing/contribute_ci_checks.md
@@ -1,9 +1,0 @@
----
-id: contribute_ci_checks
-title: Continuous Integration Checks
-hide_title: true
----
-
-# Continuous Integration Checks
-
-With respect to the [ongoing documentation restructuring](https://github.com/magma/magma/issues/9848) this page was moved to the [Github Wiki](https://github.com/magma/magma/wiki/Contributing-Code).

--- a/docs/readmes/contributing/contribute_conventions.md
+++ b/docs/readmes/contributing/contribute_conventions.md
@@ -1,9 +1,0 @@
----
-id: contribute_conventions
-title: Contributing Conventions
-hide_title: true
----
-
-# Contributing Conventions
-
-With respect to the [ongoing documentation restructuring](https://github.com/magma/magma/issues/9848) this page was moved to the [Github Wiki](https://github.com/magma/magma/wiki/Contributing-Code-Conventions).

--- a/docs/readmes/contributing/contribute_github.md
+++ b/docs/readmes/contributing/contribute_github.md
@@ -1,0 +1,13 @@
+---
+id: contribute_github
+title: Community
+hide_title: true
+---
+
+# Open Source Community
+
+The home of Magma as an open-source project is [on Github](https://github.com/magma/magma).
+
+- [Issues](https://github.com/magma/magma/issues)
+- [Contributions](https://github.com/magma/magma/wiki/Contributor-Guide)
+- [Vulnerabilities](https://github.com/magma/magma/security/policy)

--- a/docs/readmes/contributing/contribute_id_mappings.md
+++ b/docs/readmes/contributing/contribute_id_mappings.md
@@ -1,9 +1,0 @@
----
-id: contribute_id_mappings
-title: Magma Codeowners
-hide_title: true
----
-
-# Magma Codeowners
-
-With respect to the [ongoing documentation restructuring](https://github.com/magma/magma/issues/9848) this page was moved to the [Github Wiki](https://github.com/magma/magma/wiki/Overview-of-the-Community-Structure-and-Governance).

--- a/docs/readmes/contributing/contribute_vscode.md
+++ b/docs/readmes/contributing/contribute_vscode.md
@@ -1,9 +1,0 @@
----
-id: contribute_vscode
-title: Develop Magma With VSCode
-hide_title: true
----
-
-# Devloping Magma with VSCode
-
-With respect to the [ongoing documentation restructuring](https://github.com/magma/magma/issues/9848) this page was moved to the [Github Wiki](https://github.com/magma/magma/wiki/Contributing-Code-with-VSCode).


### PR DESCRIPTION
## Summary

Fixes #13661
Fixes #13662
Closes #12707

1. Point to Contributor Guide in docs/README.md
2. Remove file docs/readmes/docs/docs_overview.md. (Does this break 1.7 and 1.8 versioned docs?)
3. Remove pointer to docs_overview in sidebars.json
4. Redirect pointer in .github/workflows/comment-pr-on-check-failure.yml to CG
5. Remove localized string in docs/docusaurus/i18n/en.json
6. Remove "Contributing" links and replace with a new page linking to the contributor guide.
7. Restructure ["Contributing" nav in sidebar](docs/docusaurus/sidebars.json) to accomodate the many changes in linked files
8. Add "Community" link [pointing to Github](docs/readmes/contributing/contribute_github.md) per conversation at PTG 


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

- [x] Check if changes pass Markdown lints: `cd ${MAGMA_ROOT}/docs && make precommit`
- [x] Automatically fix some of the lints: `cd ${MAGMA_ROOT}/docs && make precommit_fix`
- [x] View local changes: `cd ${MAGMA_ROOT}/docs && make dev`
- [x] Push to draft PR and fix issues identified in CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
