### PR TITLE
fix(ci): Add debug output to in order to make it easier to  investiga…

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service
@@ -15,7 +15,7 @@ Description=Magma eventd service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
-ExecStartPre=/usr/sbin/ntpdate pool.ntp.org
+ExecStartPre=/usr/sbin/ntpdate -vd pool.ntp.org
 ExecStart=/usr/bin/env python3 -m magma.eventd.main
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py eventd
 StandardOutput=syslog

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@eventd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@eventd.service
@@ -15,7 +15,7 @@ Description=Magma eventd service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
-ExecStartPre=/usr/sbin/ntpdate pool.ntp.org
+ExecStartPre=/usr/sbin/ntpdate -vd pool.ntp.org
 ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/eventd/eventd
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py eventd
 StandardOutput=syslog

--- a/lte/gateway/python/integ_tests/s1aptests/test_services_are_running.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_services_are_running.py
@@ -48,7 +48,7 @@ class TestServicesAreRunning(unittest.TestCase):
         Initialize service status dictionary.
         The dict holds for each service status results that are collected each time the status
         is queried. Also for each service a result list holds reporting about issues with the
-        queried status results. 
+        queried status results.
         """
         service_status = {
             service: {
@@ -69,6 +69,7 @@ class TestServicesAreRunning(unittest.TestCase):
 
         for service, state in failed_services.items():
             print(f'{service} failed with reason(s) "{state[SERVICE_RESULT]}"')
+            print(self.get_failed_service_info(service))
 
         assert not failed_services, "Services are not running correctly. See logging above."
 
@@ -104,6 +105,11 @@ class TestServicesAreRunning(unittest.TestCase):
             print(f'checking {service} ...')
             print(f'  {active_state}')
             print(f'  {start_time}')
+
+    def get_failed_service_info(self, failed_service):
+        return self._s1ap_wrapper.magmad_util.exec_command_capture_output(
+            f'sudo systemctl status {failed_service}',
+        ).stdout.decode("utf-8", errors='ignore')
 
     def _get_failed_services(self, service_status):
         for service, status in service_status.items():


### PR DESCRIPTION
Add debug output to in order to make it easier to investigate services not starting in integ tests

## Summary

There have been several instances when eventd did not startup during agw integ tests during the last days. As this does not happen locally this will enable us to investigate these issues further. Currently I can only reproduce this on master ;-(

Example:
[1](https://storage.googleapis.com/magma-ci.appspot.com/lte_integ_test_67098eeadbaf786f2c4de06eaec3b8fd91fddb5b.html) [2](https://storage.googleapis.com/magma-ci.appspot.com/lte_integ_test_ab2e8655a74cfb7d9ec98942712d923c57a24fc5.html) [3](https://storage.googleapis.com/magma-ci.appspot.com/lte_integ_test_943e63c115fcebda04d2638188d49d83b14024ff.html) [4](https://storage.googleapis.com/magma-ci.appspot.com/lte_integ_test_6861ffa729c3b7c347be9d02308f6111a94a1309.html)

## Integ Run

https://github.com/crasu/magma/actions/runs/3300444273 (green run ;-(
https://github.com/crasu/magma/actions/runs/3320152230 (some flaky test failures)