### PR TITLE
chore(ci): Update FEG integ test job dependency on docker build jobs

### DIFF
--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -80,6 +80,7 @@ jobs:
   federated-integ-test:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
+    needs: [docker-build-orc8r, docker-build-feg]
     env:
       SHA: ${{ github.event.workflow_run.head_commit.id || github.sha }}
       MAGMA_ROOT: "${{ github.workspace }}"


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The FEG integ test job requires the docker images build in the docker build jobs from the same workflow.
  - This dependency is made explicit by adding a `needs:` statement.
  - Drawback: The job is now waiting for the build jobs instead of starting in parallel.
- Resolves [review comment](https://github.com/magma/magma/pull/14227#discussion_r1000606100)  

## Test Plan


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
