### PR TITLE
chore(ci): remove flaky integration tests from containerized AGW tests

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -112,20 +112,12 @@ s1aptests/test_multi_enb_complete_reset.py \
 s1aptests/test_multi_enb_sctp_shutdown.py \
 s1aptests/test_ipv6_paging_with_dedicated_bearer.py \
 s1aptests/test_ipv4v6_paging_with_dedicated_bearer.py \
-s1aptests/test_attach_ul_tcp_data.py \
-s1aptests/test_attach_detach_attach_ul_tcp_data.py \
-s1aptests/test_attach_dl_udp_data.py \
-s1aptests/test_attach_dl_tcp_data.py \
-s1aptests/test_attach_detach_attach_dl_tcp_data.py \
 s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
 s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py \
 s1aptests/test_attach_asr.py \
 s1aptests/test_attach_detach_with_sctpd_restart.py \
 s1aptests/test_attach_nw_initiated_detach_with_mme_restart.py \
 s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
-s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
-s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
-s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
 s1aptests/test_attach_detach_setsessionrules_tcp_data.py
@@ -136,7 +128,15 @@ s1aptests/test_ipv6_non_nat_dp_ul_tcp.py \
 s1aptests/test_disable_ipv6_iface.py
 
 PRECOMMIT_TESTS_NOT_CONTAINER = \
+s1aptests/test_attach_detach_attach_dl_tcp_data.py \
+s1aptests/test_attach_detach_attach_ul_tcp_data.py \
+s1aptests/test_attach_dl_udp_data.py \
+s1aptests/test_attach_dl_tcp_data.py \
+s1aptests/test_attach_ul_tcp_data.py \
 s1aptests/test_attach_ul_udp_data.py \
+s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
+s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
+s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
 
 EXTENDED_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \


### PR DESCRIPTION
## Summary

- Failures occured in:
  - https://github.com/magma/magma/actions/runs/3274187308/jobs/5387377117#step:9:12310
  - https://github.com/magma/magma/actions/runs/3274139368/jobs/5387264272#step:9:13207
  - https://github.com/magma/magma/actions/runs/3273103419/jobs/5384908285#step:9:13282
  - https://github.com/magma/magma/actions/runs/3311678851/jobs/5467416493#step:9:12244
  - https://github.com/magma/magma/actions/runs/3311678851/jobs/5467416493#step:9:13373
  - https://github.com/magma/magma/actions/runs/3312741802/jobs/5469789626#step:9:12462
  - https://github.com/magma/magma/actions/runs/3320062614/jobs/5485991703#step:9:12060

## Test Plan

- CI: https://github.com/magma/magma/actions/workflows/lte-integ-test-containerized.yml?query=branch%3Aci%2Fs1ap-tests-against-containerised-agw-remove-flaky-tests
  - :heavy_check_mark: https://github.com/magma/magma/actions/runs/3328238025