### PR TITLE
fix(ci): test interdependency in test_attach_detach_multiple_rar_tcp_data

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
@@ -52,8 +52,6 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         datapath = get_datapath()
         MAX_NUM_RETRIES = 5
-        gtp_br_util = GTPBridgeUtils()
-        GTP_PORT = gtp_br_util.get_gtp_port_no()
 
         for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
@@ -233,6 +231,9 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
             self._s1ap_wrapper.sendActDedicatedBearerAccept(
                 req.ue_id, act_ded_ber_ctxt_req2.bearerId,
             )
+
+            gtp_br_util = GTPBridgeUtils()
+            GTP_PORT = gtp_br_util.get_gtp_port_no()
 
             # Check if UL and DL OVS flows are created
             # UPLINK


### PR DESCRIPTION
fix(ci): Same fix as for test_attach_detach_rar_tcp_data. 

## Summary

Before the change the test was expecting an already existing gtp port g_8d3ca8c0. This port is usally created by other tests and only deleted during cleanup of a failed test. This caused the flaky retry for this test to always fail since after a cleanup the g_8d3ca8c0 would never exists.

As the g_8d3ca8c0 port is setup during flow creation, we now determine the port number after the flows has been created.

Signed-off-by: Christian Krämer <christian.kraemer@tngtech.com>

## Test Plan

* Integ test run with fix: https://github.com/crasu/magma/actions/runs/3310624453/jobs/5465062088

## Additional Information

Failed ci run without fix: https://github.com/crasu/magma/runs/9065760825
