### PR TITLE
feat(nms): Show NGC AMF config for gateways

### DIFF
--- a/nms/app/views/equipment/GatewayDetailConfig.tsx
+++ b/nms/app/views/equipment/GatewayDetailConfig.tsx
@@ -139,6 +139,14 @@ export default function GatewayConfig() {
                   <GatewayDynamicServices gwInfo={gwInfo} />
                 </Grid>
 
+                <Grid item xs={12}>
+                  <CardTitleRow
+                    label="EPC"
+                    filter={() => editFilter({editTable: 'epc'})}
+                  />
+                  <GatewayEPC gwInfo={gwInfo} />
+                </Grid>
+
                 {Object.keys(gwInfo.apn_resources || {}).length > 0 && (
                   <Grid item xs={12}>
                     <CardTitleRow
@@ -154,24 +162,23 @@ export default function GatewayConfig() {
               <Grid container spacing={4} alignItems="center">
                 <Grid item xs={12}>
                   <CardTitleRow
-                    label="EPC"
-                    filter={() => editFilter({editTable: 'epc'})}
-                  />
-                  <GatewayEPC gwInfo={gwInfo} />
-                </Grid>
-                <Grid item xs={12}>
-                  <CardTitleRow
                     label="Ran"
                     filter={() => editFilter({editTable: 'ran'})}
                   />
                   <GatewayRAN gwInfo={gwInfo} />
                 </Grid>
+
                 <Grid item xs={12}>
                   <CardTitleRow
                     label="Header Enrichment"
                     filter={() => editFilter({editTable: 'headerEnrichment'})}
                   />
                   <GatewayHE gwInfo={gwInfo} />
+                </Grid>
+
+                <Grid item xs={12}>
+                  <CardTitleRow label="NGC AMF" />
+                  <GatewayNGC gwInfo={gwInfo} />
                 </Grid>
               </Grid>
             </Grid>
@@ -256,6 +263,43 @@ function GatewayEPC({gwInfo}: {gwInfo: LteGateway}) {
   ];
 
   return <DataGrid data={data} />;
+}
+
+function GatewayNGC({gwInfo}: {gwInfo: LteGateway}) {
+  const data: Array<DataRows> = [
+    [
+      {
+        category: 'Name',
+        value: gwInfo.cellular.ngc?.amf_name ?? '-',
+      },
+    ],
+    [
+      {
+        category: 'Pointer',
+        value: gwInfo.cellular.ngc?.amf_pointer ?? '-',
+      },
+      {
+        category: 'Region ID',
+        value: gwInfo.cellular.ngc?.amf_region_id ?? '-',
+      },
+      {
+        category: 'Set ID',
+        value: gwInfo.cellular.ngc?.amf_set_id ?? '-',
+      },
+    ],
+    [
+      {
+        category: 'Default Slice Service Type',
+        value: gwInfo.cellular.ngc?.amf_default_sst ?? '-',
+      },
+      {
+        category: 'Default Slice Descriptor',
+        value: gwInfo.cellular.ngc?.amf_default_sd ?? '-',
+      },
+    ],
+  ];
+
+  return <DataGrid data={data} testID="ngc-config" />;
 }
 
 function GatewayDynamicServices({gwInfo}: {gwInfo: LteGateway}) {

--- a/nms/app/views/equipment/__tests__/GatewayConfigTest.tsx
+++ b/nms/app/views/equipment/__tests__/GatewayConfigTest.tsx
@@ -22,7 +22,7 @@ import {DynamicServices} from '../../../components/GatewayUtils';
 import {GatewayContextProvider} from '../../../context/GatewayContext';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {StyledEngineProvider, ThemeProvider} from '@mui/material/styles';
-import {fireEvent, render, waitFor} from '@testing-library/react';
+import {fireEvent, render, waitFor, within} from '@testing-library/react';
 import {mockAPI} from '../../../util/TestUtils';
 import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
 import type {Apn, LteGateway, LteNetwork} from '../../../../generated';
@@ -53,6 +53,14 @@ const mockGw0: LteGateway = {
       nat_enabled: false,
       sgi_management_iface_static_ip: '1.1.1.1/24',
       sgi_management_iface_vlan: '100',
+    },
+    ngc: {
+      amf_default_sd: 'AFAF',
+      amf_default_sst: 2,
+      amf_name: 'amf.example.org',
+      amf_pointer: '1F',
+      amf_region_id: 'C1',
+      amf_set_id: '2A1',
     },
     ran: {
       pci: 620,
@@ -766,5 +774,27 @@ describe('<AddEditGatewayButton />', () => {
         networkId: 'test',
       });
     });
+  });
+
+  it('Verify Gateway NGC Config', async () => {
+    const {findByTestId} = render(<DetailWrapper />);
+    const ngcConfig = await findByTestId('ngc-config');
+
+    const nameCell = within(ngcConfig).getByTestId('Name');
+    within(nameCell).getByText('amf.example.org');
+    const pointerCell = within(ngcConfig).getByTestId('Pointer');
+    within(pointerCell).getByText('1F');
+    const regionCell = within(ngcConfig).getByTestId('Region ID');
+    within(regionCell).getByText('C1');
+    const setCell = within(ngcConfig).getByTestId('Set ID');
+    within(setCell).getByText('2A1');
+    const serviceTypeCell = within(ngcConfig).getByTestId(
+      'Default Slice Service Type',
+    );
+    within(serviceTypeCell).getByText('2');
+    const descriptorCell = within(ngcConfig).getByTestId(
+      'Default Slice Descriptor',
+    );
+    within(descriptorCell).getByText('AFAF');
   });
 });


### PR DESCRIPTION
## Summary

Adds a new section to the Gateway Config that shows the NGC AMF configuration. The data is already available in the frontend as part of the gateway data.

Also moves the EPC config to the left column to make room for the new config on the right column.

A new dialog to edit the config will be added in a follow-up PR.

Config with example data:
![ngc_config_data](https://user-images.githubusercontent.com/14236667/197519536-df8e4f49-6b98-41e1-a79c-fc40f4ec66f8.png)

Empty config:
![ngc_config_empty](https://user-images.githubusercontent.com/14236667/197519548-e16c8c2f-83ac-48cb-aa8f-54cb334fee27.png)


## Test Plan

- Added a unit test for the new config.
- Tried it on a local instance.

## Additional Information

- [ ] This change is backwards-breaking