### PR TITLE
fix(ci): Add systemd notification to all mme related services.

### DIFF
--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -25,7 +25,7 @@ bravado_core
 jsonschema==3.2.0
 psutil
 systemd-python
-# cryptography<38.0.0 because of runtime issues when starting magmad 
+# cryptography<38.0.0 because of runtime issues when starting magmad
 cryptography<38.0.0
 #  h2>=3,<4 is requirement of aioh2 (loaded via bazel)
 h2>=3,<4
@@ -47,6 +47,7 @@ routes==2.5.1
 tinyrpc==1.1.4
 webob==1.8.7
 ovs==2.16.0
+sdnotify>=0.3.2,<1
 
 # scripts requirements
 envoy>=0.0.3

--- a/bazel/external/requirements.txt
+++ b/bazel/external/requirements.txt
@@ -1648,6 +1648,9 @@ yarl==1.8.1 \
     --hash=sha256:f5af52738e225fcc526ae64071b7e5342abe03f42e0e8918227b38c9aa711e28 \
     --hash=sha256:fae37373155f5ef9b403ab48af5136ae9851151f7aacd9926251ab26b953118b
     # via aiohttp
+sdnotify==0.3.2 \
+    --hash=sha256:73977fc746b36cc41184dd43c3fe81323e7b8b06c2bb0826c4f59a20c56bb9f1
+    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==49.6.0 \

--- a/cwf/gateway/docker/c/Dockerfile
+++ b/cwf/gateway/docker/c/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get -y update && apt-get -y install \
   libboost-program-options-dev \
   libboost-filesystem-dev \
   libboost-regex-dev \
+  libsystemd-dev \
   python3-distutils
 
 ENV MAGMA_ROOT /magma

--- a/lte/gateway/c/sctpd/src/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/BUILD.bazel
@@ -29,6 +29,7 @@ cc_binary(
         "//orc8r/gateway/c/common/sentry:sentry_wrapper",
         "//orc8r/gateway/c/common/service_registry",
         "//orc8r/protos:mconfigs_cpp_proto",
+        "@system_libraries//:libsystemd",
     ],
 )
 

--- a/lte/gateway/c/sctpd/src/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/src/CMakeLists.txt
@@ -58,7 +58,7 @@ add_library(SCTPD_LIB
 target_compile_definitions(SCTPD_LIB PUBLIC LOG_WITH_GLOG)
 
 target_link_libraries(SCTPD_LIB MAGMA_LOGGING MAGMA_CONFIG MAGMA_SENTRY
-    sctp pthread grpc++ grpc protobuf glog yaml-cpp
+    sctp pthread grpc++ grpc protobuf glog yaml-cpp systemd
     )
 
 target_include_directories(SCTPD_LIB PUBLIC

--- a/lte/gateway/c/sctpd/src/sctpd.cpp
+++ b/lte/gateway/c/sctpd/src/sctpd.cpp
@@ -13,6 +13,7 @@
 
 #include "lte/gateway/c/sctpd/src/sctpd.hpp"
 
+#include <systemd/sd-daemon.h>
 #include <bits/types/siginfo_t.h>
 #include <glog/logging.h>
 #include <grpcpp/grpcpp.h>
@@ -139,6 +140,8 @@ int main() {
   builder.RegisterService(&service);
 
   std::unique_ptr<Server> sctpd_dl_server = builder.BuildAndStart();
+
+  sd_notify(0, "READY=1");
 
   int end = 0;
   while (end == 0) {

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -439,5 +439,6 @@ cc_binary(
         "//orc8r/gateway/c/common/config:mconfig_loader",
         "//orc8r/gateway/c/common/sentry:sentry_wrapper",
         "//orc8r/protos:mconfigs_cpp_proto",
+        "@system_libraries//:libsystemd",
     ],
 )

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -205,7 +205,7 @@ find_package(MAGMA_SENTRY REQUIRED)
 target_link_libraries(SESSION_MANAGER
   SERVICE303_LIB SERVICE_REGISTRY ASYNC_GRPC MAGMA_CONFIG MAGMA_LOGGING EVENTD MAGMA_SENTRY
   glog gflags folly pthread ${GCOV_LIB} gpr grpc++ grpc yaml-cpp protobuf cpp_redis
-  prometheus-cpp tacopie
+  prometheus-cpp tacopie systemd
   )
 
 if (CLANG_FORMAT)

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -11,6 +11,7 @@
  * limitations under the License.
  */
 
+#include <systemd/sd-daemon.h>
 #include <cpp_redis/core/client.hpp>
 #include <folly/io/async/EventBase.h>
 #include <folly/io/async/EventBaseManager.h>
@@ -525,6 +526,9 @@ int main(int argc, char* argv[]) {
   MLOG(MDEBUG) << "local enforcer Attached EventBase to evb";
   local_enforcer->sync_sessions_on_restart(time(NULL));
   MLOG(MDEBUG) << "Synced session on restart";
+
+  sd_notify(0, "READY=1");
+
   evb->loopForever();
   MLOG(MINFO) << "Stoping.. session manager GRPC server";
 

--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_mobilityd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_mobilityd.service
@@ -19,7 +19,7 @@ After=openvswitch-switch.service
 Wants=openvswitch-switch.service
 
 [Service]
-Type=simple
+Type=notify
 EnvironmentFile=/etc/environment
 ExecStart=/usr/bin/env python3 -m magma.mobilityd.main
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py mobilityd

--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_pipelined.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_pipelined.service
@@ -22,7 +22,7 @@ Requires=network.target
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
 PermissionsStartOnly=true
 LimitNOFILE=65536
 LimitNPROC=65536

--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_sessiond.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_sessiond.service
@@ -15,7 +15,7 @@ PartOf=magma@mme.service
 Before=magma@mme.service
 
 [Service]
-Type=simple
+Type=notify
 EnvironmentFile=/etc/environment
 ExecStart=/usr/local/bin/sessiond
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py sessiond

--- a/lte/gateway/deploy/roles/magma/files/systemd/sctpd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/sctpd.service
@@ -14,7 +14,7 @@ Description=Magma sctpd service
 Before=magma@mme.service
 
 [Service]
-Type=simple
+Type=notify
 EnvironmentFile=/etc/environment
 ExecStartPre=-/bin/cp -f /usr/local/share/sctpd/version /var/run/sctpd.version
 ExecStartPre=/usr/bin/env python3 /usr/local/bin/config_stateless_agw.py sctpd_pre

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mobilityd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@mobilityd.service
@@ -19,7 +19,7 @@ After=openvswitch-switch.service
 Wants=openvswitch-switch.service
 
 [Service]
-Type=simple
+Type=notify
 EnvironmentFile=/etc/environment
 ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/python/magma/mobilityd/mobilityd
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py mobilityd

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@pipelined.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@pipelined.service
@@ -20,7 +20,7 @@ After=openvswitch-switch.service
 Wants=openvswitch-switch.service
 
 [Service]
-Type=simple
+Type=notify
 PermissionsStartOnly=true
 LimitNOFILE=65536
 LimitNPROC=65536

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@sessiond.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@sessiond.service
@@ -15,7 +15,7 @@ PartOf=magma@mme.service
 Before=magma@mme.service
 
 [Service]
-Type=simple
+Type=notify
 EnvironmentFile=/etc/environment
 ExecStart=/home/vagrant/magma/bazel-bin/lte/gateway/c/session_manager/sessiond
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py sessiond

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/sctpd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/sctpd.service
@@ -14,7 +14,7 @@ Description=Magma sctpd service
 Before=magma@mme.service
 
 [Service]
-Type=simple
+Type=notify
 EnvironmentFile=/etc/environment
 ExecStartPre=-/bin/cp -f /usr/local/share/sctpd/version /var/run/sctpd.version
 ExecStartPre=/usr/bin/env python3 /usr/local/bin/config_stateless_agw.py sctpd_pre

--- a/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
@@ -53,6 +53,7 @@ class Test3485TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ue)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
+
         # APN of the secondary PDN
         ims = {
             'apn_name': 'ims',  # APN-name
@@ -125,6 +126,7 @@ class Test3485TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
             s1ap_types.tfwCmd.UE_DROP_ACTV_DEFAULT_EPS_BEARER_CTXT_REQ,
             drop_acctv_dflt_bearer_req,
         )
+
         retransmitted_response = self._s1ap_wrapper.s1_util.get_response()
         assert (
             retransmitted_response.msg_type

--- a/lte/gateway/python/magma/mobilityd/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/BUILD.bazel
@@ -39,6 +39,7 @@ py_binary(
         "//orc8r/gateway/python/magma/common:sentry",
         "//orc8r/gateway/python/magma/common:service",
         "//orc8r/gateway/python/magma/common/redis:client",
+        requirement("sdnotify"),
     ],
 )
 

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -14,6 +14,7 @@ import ipaddress
 import logging
 from typing import Any, Optional
 
+import sdnotify
 from lte.protos.mconfig import mconfigs_pb2
 from lte.protos.mconfig.mconfigs_pb2 import MobilityD
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
@@ -227,6 +228,9 @@ def main():
         ip_address_man, config.get('print_grpc_payload', False),
     )
     mobility_service_servicer.add_to_server(service.rpc_server)
+
+    notifier = sdnotify.SystemdNotifier()
+    notifier.notify("READY=1")
     service.run()
 
     # Cleanup the service

--- a/lte/gateway/python/magma/pipelined/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/BUILD.bazel
@@ -44,6 +44,7 @@ py_binary(
         "//orc8r/gateway/python/magma/common:service",
         "//orc8r/gateway/python/magma/configuration:environment",
         "@aioeventlet_repo//:aioeventlet",
+        requirement("sdnotify"),
     ],
 )
 

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -20,6 +20,7 @@ import logging
 import threading
 
 import aioeventlet
+import sdnotify
 from lte.protos.mconfig import mconfigs_pb2
 from magma.common.misc_utils import get_ip_from_if
 from magma.common.sentry import sentry_init
@@ -221,6 +222,9 @@ def main():
             service.loop,
         )
         collector.start()
+
+    notifier = sdnotify.SystemdNotifier()
+    notifier.notify("READY=1")
 
     # Run the service loop
     service.run()

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -133,6 +133,7 @@ setup(
         'ovs==2.16.0',
         'prometheus-client>=0.3.1',
         'aioeventlet @ git+https://github.com/magma/deb-python-aioeventlet@86130360db113430370ed6c64d42aee3b47cd619',
+        'sdnotify>=0.3.2',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
## Summary

Follow up to #14177. This PR converts all mme related services to systemd notification in order to only mark services as "active" in systemd which have fully started and remove the timeouts in the test.

## Test Plan

Integ run https://github.com/crasu/magma/actions/runs/3314249640 (one flaky test failed due to different reason)
