### PR TITLE
docs: Fix a symbolic link 

### DIFF
--- a/lte/gateway/python/integ_tests/federated_tests/README.md
+++ b/lte/gateway/python/integ_tests/federated_tests/README.md
@@ -1,1 +1,1 @@
-../../../../../docs/readmes/feg/s1ap_federated_test.md
+../../../../../docs/readmes/feg/s1ap_federated_tests.md


### PR DESCRIPTION
In pairing with @wolfseb

Signed-off-by: Moritz Huebner <moritz.huebner@tngtech.com>


## Summary

The symbolic link was just missing a character.

## Test Plan

Change the link and see if it works (it does work).
