### PR TITLE
fix(agw): copy ryu patch files to agw python container

### DIFF
--- a/lte/gateway/docker/services/python/Dockerfile
+++ b/lte/gateway/docker/services/python/Dockerfile
@@ -88,6 +88,8 @@ COPY ./dp/protos $MAGMA_ROOT/dp/protos
 COPY ./lte/swagger $MAGMA_ROOT/lte/swagger
 COPY ./orc8r/swagger $MAGMA_ROOT/orc8r/swagger
 
+COPY ./lte/gateway/deploy/roles/magma/files/patches $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/patches
+
 WORKDIR /magma/lte/gateway/python
 RUN make buildenv
 


### PR DESCRIPTION
## Summary

After the reduction of the build context for the AGW python containers in #14048 , the ryu patch files were missing. This PR adds them back again.

## Test Plan

Build the AGW python container, and see that the ryu patching works now. Look for the following lines:
```
patch --dry-run -N -s -f /build/lib/python3.8/site-packages/ryu/ofproto/nx_actions.py </magma/lte/gateway/deploy/roles/magma/files/patches/ryu_ipfix_args.patch 2>/dev/null \
&&  (patch -N -s -f /build/lib/python3.8/site-packages/ryu/ofproto/nx_actions.py </magma/lte/gateway/deploy/roles/magma/files/patches/ryu_ipfix_args.patch && echo "ryu was patched" ) \
|| ( true && echo "skipping ryu patch since it was already applied")
ryu was patched
patch --dry-run -N -s -f /build/lib/python3.8/site-packages/ryu/app/ofctl/service.py </magma/lte/gateway/deploy/roles/magma/files/patches/0001-Set-unknown-dpid-ofctl-log-to-debug.patch 2>/dev/null \
&&  (patch -N -s -f /build/lib/python3.8/site-packages/ryu/app/ofctl/service.py </magma/lte/gateway/deploy/roles/magma/files/patches/0001-Set-unknown-dpid-ofctl-log-to-debug.patch && echo "ryu was patched" ) \
|| ( true && echo "skipping ryu patch since it was already applied")
ryu was patched
patch --dry-run -N -s -f /build/lib/python3.8/site-packages/ryu/ofproto/nicira_ext.py </magma/lte/gateway/deploy/roles/magma/files/patches/0002-QFI-value-set-in-Openflow-controller-using-RYU.patch 2>/dev/null \
&&  (patch -N -s -f /build/lib/python3.8/site-packages/ryu/ofproto/nicira_ext.py </magma/lte/gateway/deploy/roles/magma/files/patches/0002-QFI-value-set-in-Openflow-controller-using-RYU.patch && echo "ryu was patched" ) \
|| ( true && echo "skipping ryu patch since it was already applied")
ryu was patched
patch --dry-run -N -s -f /build/lib/python3.8/site-packages/ryu/ofproto/nx_match.py </magma/lte/gateway/deploy/roles/magma/files/patches/0003-QFI-value-set-in-Openflow-controller-using-RYU.patch 2>/dev/null \
        &&  (patch -N -s -f /build/lib/python3.8/site-packages/ryu/ofproto/nx_match.py </magma/lte/gateway/deploy/roles/magma/files/patches/0003-QFI-value-set-in-Openflow-controller-using-RYU.patch && echo "ryu was patched" ) \
|| ( true && echo "skipping ryu patch since it was already applied")
ryu was patched
```

## Additional Information

- [ ] This change is backwards-breaking
