### PR TITLE
chore(ci): bump `docker/login-action` version to remove deprecation w…

### DIFF
--- a/.github/workflows/composite/docker-builder/action.yml
+++ b/.github/workflows/composite/docker-builder/action.yml
@@ -47,7 +47,7 @@ runs:
       id: buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to GHCR
-      uses: docker/login-action@v1
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin v2.1.0
       with:
         registry: ${{ inputs.REGISTRY }}
         username: ${{ github.repository_owner }}

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           echo "User is not a member of the team"
           exit 1
-      - uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # Pin v2.0.0
+      - uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin v2.1.0
         name: Login to Artifactory
         with:
           registry: docker.${{ env.MAGMA_ARTIFACTORY }}


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

GitHub deprecated `save-state` and `save-output` workflow commands with its recent update to `@actions/core` package to v1.10.0. This PR bumps the version of the third party library `docker/login-action` to the latest version v2.1.0 with adapted commands.

## Test Plan
- Full text search on repository for 'docker/login-action'
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
