### PR TITLE
chore(ci): bump `reviewdog/action-golangci-lint` version to remove precation warning

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -100,7 +100,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@1530051a4d9af7e1c94afb2ea38fe7ba13e180ee # pin@v2
+        uses: reviewdog/action-golangci-lint@53f8eabb87b40b1a2c63ec75b0d418bd0f4aa919 # pin@v2.2.2
         with:
           golangci_lint_flags: '--config=../../.golangci.yml'
           reporter: github-pr-review


### PR DESCRIPTION
## Summary
GitHub deprecated `save-state` and `save-output` workflow commands with its recent update to `@actions/core` package to v1.10.0. This PR bumps the version of the third party library `reviewdog/action-golangci-lint` from v2.1.4 to the latest version v2.2.2 with adapted commands.

## Test Plan
- Full text search on repository for 'reviewdog/action-golangci-lint'
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
