### PR TITLE
chore(ci): bump `tspascoal/get-user-teams-membership` version to remoprecation warning

### DIFF
--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -29,7 +29,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.release_tag }}
       MAGMA_ARTIFACTORY: artifactory.magmacore.org
     steps:
-      - uses: tspascoal/get-user-teams-membership@533553aa88900a17c59177d65bcf8c5c97ff1a90 # pin@v1.0.3
+      - uses: tspascoal/get-user-teams-membership@39b5264024b7c3bd7480de2f2c8d3076eed49ec5 # pin@v1.0.4
         name: Check if user has rights to promote
         id: checkUserMember
         with:

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -27,7 +27,7 @@ jobs:
       HELM_CHART_MUSEUM_TOKEN: ${{ secrets.HELM_CHART_MUSEUM_TOKEN }}
       HELM_CHART_MUSEUM_USERNAME: ${{ secrets.HELM_CHART_MUSEUM_USERNAME }}
     steps:
-      - uses: tspascoal/get-user-teams-membership@533553aa88900a17c59177d65bcf8c5c97ff1a90 # pin@v1.0.3
+      - uses: tspascoal/get-user-teams-membership@39b5264024b7c3bd7480de2f2c8d3076eed49ec5 # pin@v1.0.4
         name: Check if user has rights to promote
         id: checkUserMember
         with:


### PR DESCRIPTION
## Summary
GitHub deprecated `save-state` and `save-output` workflow commands with its recent update to `@actions/core` package to v1.10.0. This PR bumps the version of the third party library `tspascoal/get-user-teams-membership` from v1.0.3 to the latest version v1.0.4 with adapted commands.

## Test Plan
- Full text search on repository for 'tspascoal/get-user-teams-membership`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
