### PR TITLE
chore(ci): bump `nick-invision/retry` version to remove deprecation w…

### DIFF
--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry
-        uses: nick-invision/retry@e88a9994b039653512d697de1bce46b00bfe11b5 # pin@v2
+        uses: nick-fields/retry@48bc5d4b1ce856c44a7766114e4da81c980a8a92 # pin@v2.8.2
         with:
           command: cd ${MAGMA_ROOT}/cwf/gateway && go mod download
           timeout_minutes: 10

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry
-        uses: nick-invision/retry@e88a9994b039653512d697de1bce46b00bfe11b5 # pin@v2
+        uses: nick-fields/retry@48bc5d4b1ce856c44a7766114e4da81c980a8a92 # pin@v2.8.2
         with:
           command: cd ${MAGMA_ROOT}/cwf/k8s/cwf_operator && go mod download
           timeout_minutes: 10

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry
-        uses: nick-invision/retry@e88a9994b039653512d697de1bce46b00bfe11b5 # pin@v2
+        uses: nick-fields/retry@48bc5d4b1ce856c44a7766114e4da81c980a8a92 # pin@v2.8.2
         if: always()
         id: feg-lint-init
         with:


### PR DESCRIPTION
…arning

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
GitHub deprecated `save-state` and `save-output` workflow commands with its recent update to `@actions/core` package to v1.10.0. This PR bumps the version of the third party library `nick-invision/retry` from v2.7.0 to the latest version v2.8.2 with adapted commands.

## Test Plan
- Full text search on repository for 'nick-invision/retry`
- CI

## Additional Information

- The author moved this repo from his work account to his private account, hence the renaming.

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
