### PR TITLE
chore(ci): bump `peter-evans/find_comment` version to remove deprecat…

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - if: needs.check-semantic-pr.result == 'failure'
         run: echo 'STATUS=:x:' >> $GITHUB_ENV
-      - uses: peter-evans/find-comment@1769778a0c5bd330272d749d12c036d65e70d39d # pin@v2.0.0
+      - uses: peter-evans/find-comment@b657a70ff16d17651703a84bee1cb9ad9d2be2ea # pin@v2.0.1
         id: fc
         with:
           issue-number: ${{ github.event.number }}


### PR DESCRIPTION
…ion warning

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
GitHub deprecated `save-state` and `save-output` workflow commands with its recent update to `@actions/core` package to v1.10.0. This PR bumps the version of the third party library `peter-evans/find_comment` from v2.2.0 to the latest version v2.2.1 with adapted commands.

## Test Plan
- Full text search on repository for 'peter-evans/find_comment`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
