### PR TITLE
chore(lte): Remove Make coverage targets for LTE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,6 @@ fbcinternal
 # Code coverage
 orc8r/cloud/coverage/
 feg/gateway/coverage/
-lte/gateway/c/oai/code_coverage/
 
 # Bazel
 bazel-bin

--- a/.hgignore
+++ b/.hgignore
@@ -2,6 +2,5 @@ syntax: glob
 src/python/**/*.egg-info
 third-party/packages/*.changes
 third-party/packages/*.debian.tar.*
-c/oai/code_coverage/**
 .cache/*
 reports/**

--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -126,18 +126,3 @@ test_oai: ## Run all OAI-specific tests
 # This works with test_dpi and test_session_manager
 test_%: build_common
 	$(call run_ctest, $(C_BUILD)/$*, $(C_BUILD)/$*, $(GATEWAY_C_DIR)/$*, )
-
-coverage_oai: test_oai
-	lcov --capture --directory $(C_BUILD) --output-file /tmp/coverage_oai.info.raw
-	lcov -r /tmp/coverage_oai.info.raw "/*/test/*" "/usr/*" "/build/*protos*" -o /tmp/coverage_oai.info
-	rm -f `find $(C_BUILD) -name *.gcda` # Clean up any prior coverage data
-
-## Generate complete code structural information prior to any test execution
-base_coverage: build_oai
-	lcov --initial --directory $(C_BUILD) -c --output-file /tmp/coverage_initialize.info.raw
-	lcov -r /tmp/coverage_initialize.info.raw "/*/test/*" "/usr/*" "/build/*protos*" -o /tmp/coverage_initialize.info
-	rm -f `find $(C_BUILD) -name *.gcda` # Clean up any prior coverage data
-
-# Combine results of sub-coverages
-coverage: base_coverage coverage_oai
-	lcov -a /tmp/coverage_initialize.info -a /tmp/coverage_oai.info -o $(C_BUILD)/coverage.info

--- a/lte/gateway/c/connection_tracker/src/CMakeLists.txt
+++ b/lte/gateway/c/connection_tracker/src/CMakeLists.txt
@@ -29,12 +29,6 @@ if (NOT BUILD_TESTS)
       "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
   set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
       "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
-else () # BUILD_TESTS
-  message("Adding code coverage build and linker flags for BUILD_TESTS")
-  set(CMAKE_CXX_FLAGS_DEBUG
-      "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
-  set(CMAKE_LINKER_FLAGS_DEBUG
-      "${CMAKE_LINKER_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
 endif ()
 
 add_definitions(-DLOG_WITH_GLOG)

--- a/lte/gateway/c/core/oai/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/CMakeLists.txt
@@ -50,11 +50,6 @@ set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=add
 
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS} -g -DMALLOC_CHECK_=3  -O1")
 
-# Add Gcov flags
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
-# Add gcov linker flags
-set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
 
 # Add LeakSanitizer (lsan) support to the release build of MME so that we can
 # find memory leaks in production.

--- a/lte/gateway/c/li_agent/src/CMakeLists.txt
+++ b/lte/gateway/c/li_agent/src/CMakeLists.txt
@@ -22,13 +22,6 @@ find_package(MAGMA_SENTRY REQUIRED)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 
-if (BUILD_TESTS)
-  message("Adding code coverage build and linker flags for BUILD_TESTS")
-  set(CMAKE_CXX_FLAGS_DEBUG
-      "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
-  set(CMAKE_LINKER_FLAGS_DEBUG
-      "${CMAKE_LINKER_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
-endif ()
 
 # Add AddressSanitizer (asan) support for debug builds of LiAgentD
 set(CMAKE_CXX_FLAGS_DEBUG

--- a/lte/gateway/c/sctpd/src/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/src/CMakeLists.txt
@@ -12,12 +12,6 @@ set(CMAKE_CXX_STANDARD 14)
 
 project(MagmaSctpd)
 
-message("Adding code coverage build and linker flags for BUILD_TESTS")
-set(CMAKE_CXX_FLAGS_DEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
-set(CMAKE_LINKER_FLAGS_DEBUG
-    "${CMAKE_LINKER_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
-
 # generate sctpd protos
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -43,12 +43,6 @@ if (NOT BUILD_TESTS)
 else() # BUILD_TESTS
 endif ()
 
-message("Adding code coverage build and linker flags for BUILD_TESTS")
-set (CMAKE_CXX_FLAGS_DEBUG
-  "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fprofile-arcs -ftest-coverage")
-set(CMAKE_LINKER_FLAGS_DEBUG
-  "${CMAKE_LINKER_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
-
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 set(MAGMA_LIB_DIR $ENV{C_BUILD}/magma_common)

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -332,11 +332,6 @@
   retries: 5
   when: preburn
 
-- name: Install C code coverage analysis dependencies
-  apt: pkg=lcov state=present update_cache=yes
-  retries: 5
-  when: preburn
-
 - name: Install gmock and gtest for C++ testing
   become: yes
   ignore_errors: yes

--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -60,12 +60,6 @@ endif
 	$(if $(strip $(SEL_SUDO_TEST_PATH_LTE)),$(call run_sudo_unit_tests,$(SEL_SUDO_TEST_PATH_LTE), $(MAGMA_ROOT)/lte/gateway/python/))
 	$(if $(strip $(TEST_PATH_ORC8R)), $(call run_unit_tests, $(TEST_PATH_ORC8R), $(MAGMA_ROOT)/orc8r/gateway/python/))
 
-coverage: $(BIN)/coverage
-	$(BIN)/coverage report
-
-$(BIN)/coverage: install_virtualenv
-	$(VIRT_ENV_PIP_INSTALL) coverage==6.4.1
-
 $(BIN)/pytest: install_virtualenv
 	$(VIRT_ENV_PIP_INSTALL) pytest==7.1.2
 
@@ -91,7 +85,7 @@ check: buildenv $(BIN)/pylint $(BIN)/pycodestyle
 	$(CHECK_CMD_PYLINT)
 
 clean: $(CLEAN_LIST)
-	sudo rm -rf $(PYTHON_BUILD)/ .coverage
+	sudo rm -rf $(PYTHON_BUILD)/
 	sudo find . -name '*.pyc' -o -name '__pycache__' -prune -exec rm -rf {} \;
 $(CLEAN_LIST): %_clean:
 	make -C $* remove_egg

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -138,7 +138,6 @@ setup(
         'dev': [
             # Should be kept in sync with the version in python.mk
             'grpcio-tools>=1.46.3,<1.49.0',
-            'coverage==6.4.2',
             'iperf3>=0.1.11',
             'parameterized==0.8.1',
             'pytest==7.1.2',


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
- Clean up dead Make targets for LTE coverage
- Follow up to #14127
- Resolves #13398

## Test Plan

- Codecov for this PR https://app.codecov.io/gh/magma/magma/pull/14264

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
