### PR TITLE
chore(agw): Create Python environment with bazel

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,6 +60,7 @@ RUN echo "Install general purpose packages" && \
         perl \
         pkg-config \
         python3-pip \
+        python3-venv \
         redis-server \
         ruby \
         rubygems \
@@ -206,75 +207,5 @@ RUN GOBIN="/usr/bin/" go install -v golang.org/x/tools/gopls@v0.8.3 && \
 
 #### Update shared library configuration
 RUN ldconfig -v
-
-
-##### Install Python requirements
-
-### create virtualenv
-ARG PYTHON_VENV=/home/vscode/build/python
-ENV PYTHON_VENV_EXECUTABLE=${PYTHON_VENV}/bin/python${PYTHON_VERSION}
-# PYTHON_VENV must by in sync with "python.defaultInterpreterPath", "python.analysis.extraPaths" and magtivate path in "postCreateCommand" in .devcontainer/devcontainer.json
-
-RUN virtualenv --system-site-packages --python=/usr/bin/python${PYTHON_VERSION} ${PYTHON_VENV}
-RUN ${PYTHON_VENV_EXECUTABLE} -m pip install --quiet --upgrade --no-cache-dir "setuptools==49.6.0"
-
-### install eggs (lte, orc8r)
-COPY /lte/gateway/python/ ${MAGMA_ROOT}/lte/gateway/python/
-WORKDIR ${MAGMA_ROOT}/lte/gateway/python/
-RUN ${PYTHON_VENV_EXECUTABLE} -m pip install --quiet --upgrade --no-build-isolation --no-cache-dir --verbose --editable .[dev] && \
-    rm -rf lte.egg-info
-
-COPY /orc8r/gateway/python/ ${MAGMA_ROOT}/orc8r/gateway/python/
-WORKDIR ${MAGMA_ROOT}/orc8r/gateway/python/
-RUN ${PYTHON_VENV_EXECUTABLE} -m pip install --quiet --upgrade --no-build-isolation --no-cache-dir --verbose --editable .[dev] && \
-    rm -rf orc8r.egg-info
-
-### install formatter autopep8
-RUN ${PYTHON_VENV_EXECUTABLE} -m pip install --no-cache-dir autopep8
-
-#### protos
-ARG GEN_DIR=lib/python${PYTHON_VERSION}/gen
-
-COPY /protos/ ${MAGMA_ROOT}/protos/
-COPY /lte/protos/ ${MAGMA_ROOT}/lte/protos/
-COPY /orc8r/protos/ ${MAGMA_ROOT}/orc8r/protos/
-COPY /feg/protos/ ${MAGMA_ROOT}/feg/protos/
-COPY /dp/protos/ ${MAGMA_ROOT}/dp/protos/
-WORKDIR ${MAGMA_ROOT}
-RUN ${PYTHON_VENV_EXECUTABLE} -m pip install --no-cache-dir "mypy-protobuf==2.4" && \
-    mkdir ${PYTHON_VENV}/${GEN_DIR} && \
-    for PROTO_SRC in orc8r lte feg dp; \
-    do \
-    ${PYTHON_VENV_EXECUTABLE} protos/gen_protos.py ${PROTO_SRC}/protos ${MAGMA_ROOT},orc8r/protos/prometheus ${MAGMA_ROOT} ${PYTHON_VENV}/${GEN_DIR} && \
-    ${PYTHON_VENV_EXECUTABLE} protos/gen_prometheus_proto.py ${MAGMA_ROOT} ${PYTHON_VENV}/${GEN_DIR}; \
-    done && \
-    echo "${PYTHON_VENV}/${GEN_DIR}" > ${PYTHON_VENV}/lib/python${PYTHON_VERSION}/site-packages/magma_gen.pth
-
-### swagger
-ENV SWAGGER_CODEGEN_DIR=/var/tmp/codegen
-ENV SWAGGER_CODEGEN_JAR=${SWAGGER_CODEGEN_DIR}/swagger-codegen-cli.jar
-ARG CODEGEN_VERSION=2.2.3
-
-RUN mkdir -p ${SWAGGER_CODEGEN_DIR}; \
-    wget --no-verbose https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/${CODEGEN_VERSION}/swagger-codegen-cli-${CODEGEN_VERSION}.jar -O ${SWAGGER_CODEGEN_JAR}
-
-# Copy swagger specs over to the build directory,
-# so that eventd can access them at runtime
-COPY lte/swagger/*.yml ${PYTHON_VENV}/${GEN_DIR}/lte/swagger/specs/
-COPY orc8r/swagger/*.yml ${PYTHON_VENV}/${GEN_DIR}/orc8r/swagger/specs/
-RUN for SWAGGER_SRC in lte orc8r; \
-    do \
-    # Generate the files
-    ls ${PYTHON_VENV}/${GEN_DIR}/${SWAGGER_SRC}/swagger/specs/*.yml \
-    | xargs -t -I% /usr/bin/java -jar ${SWAGGER_CODEGEN_JAR} generate \
-    -i % \
-    -o ${PYTHON_VENV}/${GEN_DIR}/${SWAGGER_SRC}/swagger \
-    -l python \
-    -D models && \
-    # Flatten and clean up directory
-    mv ${PYTHON_VENV}/${GEN_DIR}/${SWAGGER_SRC}/swagger/swagger_client/* ${PYTHON_VENV}/${GEN_DIR}/${SWAGGER_SRC}/swagger/ && \
-    rmdir ${PYTHON_VENV}/${GEN_DIR}/${SWAGGER_SRC}/swagger/swagger_client && \
-    rm -r ${PYTHON_VENV}/${GEN_DIR}/${SWAGGER_SRC}/swagger/test; \
-    done
 
 WORKDIR $MAGMA_ROOT

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -82,10 +82,9 @@
 		"python.terminal.activateEnvironment": true,
 		"python.analysis.extraPaths": [
 			"${containerWorkspaceFolder}/orc8r/gateway/python/",
-			"${containerWorkspaceFolder}/lte/gateway/python/",
-			"/home/vscode/build/python/lib/python3.8/site-packages" // has to be in sync with $PYTHON_VENV and $PYTHON_VERSION from .devcontainer/Dockerfile
+			"${containerWorkspaceFolder}/lte/gateway/python/"
 		],
-		"python.defaultInterpreterPath": "/home/vscode/build/python/bin/python3.8", // has to be in sync with $PYTHON_VENV and $PYTHON_VERSION from .devcontainer/Dockerfile
+		"python.defaultInterpreterPath": "/home/vscode/python_ide_env/bin/python3",
 		"python.formatting.provider": "autopep8",
 		"python.formatting.autopep8Args": [
 			// This should be the same set of flags as ones specified in `lte/gateway/precommit.py`

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -18,6 +18,13 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.5.0/rules_python-0.5.0.tar.gz",
 )
 
+http_archive(
+    name = "rules_pyvenv",
+    sha256 = "216dd65adfd78a334e8ecb4f700ffcc3578351bfc89ca55127e5b656626f6916",
+    strip_prefix = "rules_pyvenv-1.0",
+    url = "https://github.com/cedarai/rules_pyvenv/archive/refs/tags/1.0.tar.gz",
+)
+
 ### BUILDIFIER DEPENDENCIES
 # See https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md
 # buildifier is written in Go and hence needs rules_go to be built.

--- a/bazel/external/requirements_README.md
+++ b/bazel/external/requirements_README.md
@@ -10,7 +10,7 @@ Requirements.txt holds all Python dependencies which are required by Python-base
     
        `cd $MAGMA/bazel/external`
 
-       `pip-compile --generate-hashes --output-file=requirements.txt requirements.in`
+       `pip-compile --upgrade-package --generate-hashes --output-file=requirements.txt requirements.in`
 
  The changes are then automatically included in the next Bazel build process.
 

--- a/dev_tools/BUILD.bazel
+++ b/dev_tools/BUILD.bazel
@@ -1,0 +1,140 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_pyvenv//:venv.bzl", "py_venv")
+load("@python_deps//:requirements.bzl", "all_requirements")
+
+lte_protos = [
+    # List generated with bazel query 'kind(py_library, //lte/protos:*) | sed 's/.*/    "&",/'
+    "//lte/protos:abort_session_python_grpc",
+    "//lte/protos:apn_python_proto",
+    "//lte/protos:diam_errors_python_proto",
+    "//lte/protos:enodebd_python_grpc",
+    "//lte/protos:enodebd_python_proto",
+    "//lte/protos:ha_service_python_grpc",
+    "//lte/protos:keyval_python_proto",
+    "//lte/protos:mconfigs_python_proto",
+    "//lte/protos:mobilityd_python_grpc",
+    "//lte/protos:mobilityd_python_proto",
+    "//lte/protos:pipelined_python_grpc",
+    "//lte/protos:pipelined_python_proto",
+    "//lte/protos:policydb_python_grpc",
+    "//lte/protos:policydb_python_proto",
+    "//lte/protos:s1ap_service_python_grpc",
+    "//lte/protos:s6a_service_python_grpc",
+    "//lte/protos:s6a_service_python_proto",
+    "//lte/protos:session_manager_python_grpc",
+    "//lte/protos:session_manager_python_proto",
+    "//lte/protos:sms_orc8r_python_grpc",
+    "//lte/protos:spgw_service_grpc_proto",
+    "//lte/protos:spgw_service_python_grpc",
+    "//lte/protos:subscriberauth_python_grpc",
+    "//lte/protos:subscriberdb_python_grpc",
+    "//lte/protos:subscriberdb_python_proto",
+]
+
+lte_oai_protos = [
+    # List generated with bazel query 'kind(py_library, //lte/protos/oai:*) | sed 's/.*/    "&",/'
+    "//lte/protos/oai:common_types_python_proto",
+    "//lte/protos/oai:mme_nas_state_python_proto",
+    "//lte/protos/oai:nas_state_python_proto",
+    "//lte/protos/oai:s1ap_state_python_proto",
+    "//lte/protos/oai:spgw_state_python_proto",
+    "//lte/protos/oai:std_3gpp_types_python_proto",
+]
+
+orc8r_protos = [
+    # List generated with bazel query 'kind(py_library, //orc8r/protos/...:*) | sed 's/.*/    "&",/'
+    "//orc8r/protos:bootstrapper_python_grpc",
+    "//orc8r/protos:certifier_python_proto",
+    "//orc8r/protos:common_python_proto",
+    "//orc8r/protos:ctraced_python_grpc",
+    "//orc8r/protos:digest_python_proto",
+    "//orc8r/protos:directoryd_python_grpc",
+    "//orc8r/protos:eventd_python_grpc",
+    "//orc8r/protos:identity_python_proto",
+    "//orc8r/protos:magmad_python_grpc",
+    "//orc8r/protos:magmad_python_proto",
+    "//orc8r/protos:mconfig_python_proto",
+    "//orc8r/protos:mconfigs_python_proto",
+    "//orc8r/protos:metrics_python_proto",
+    "//orc8r/protos:metricsd_python_grpc",
+    "//orc8r/protos:metricsd_python_proto",
+    "//orc8r/protos:redis_python_proto",
+    "//orc8r/protos:service303_python_grpc",
+    "//orc8r/protos:service303_python_proto",
+    "//orc8r/protos:service_status_python_proto",
+    "//orc8r/protos:state_python_grpc",
+    "//orc8r/protos:streamer_python_grpc",
+    "//orc8r/protos:sync_rpc_service_python_grpc",
+]
+
+feg_protos = [
+    # List generated with bazel query 'kind(py_library, //feg/protos/...:*)' | sed 's/.*/    "&",/'
+    "//feg/protos:csfb_python_grpc",
+    "//feg/protos:csfb_python_proto",
+    "//feg/protos:envoy_controller_python_grpc",
+    "//feg/protos:hello_python_grpc",
+    "//feg/protos:hss_service_python_grpc",
+    "//feg/protos:hss_service_python_proto",
+    "//feg/protos:mconfigs_python_proto",
+    "//feg/protos:mock_core_python_grpc",
+    "//feg/protos:s6a_proxy_grpc_proto",
+]
+
+dp_protos = [
+    # List generated with bazel query 'kind(py_library, //dp/protos/...:*)' | sed 's/.*/    "&",/'
+    "//dp/protos:cbsd_python_grpc",
+    "//dp/protos:cbsd_python_proto",
+]
+
+all_protos = lte_protos + lte_oai_protos + orc8r_protos + feg_protos + dp_protos
+
+external_python_libs = [
+    "@aioh2_repo//:aioh2",
+    "@ryu_repo//:ryu_patched",
+    "@aioeventlet_repo//:aioeventlet",
+    "@bcc_repo//:bcc",
+]
+
+genrule(
+    name = "external_deps_pth",
+    outs = ["external_deps.pth"],
+    cmd = "\n".join([
+        "echo /tmp/bazel/external/ryu_repo >> $@",
+        "echo /tmp/bazel/external/aioh2_repo >> $@",
+        "echo /tmp/bazel/external/aioeventlet_repo >> $@",
+        "echo /tmp/bazel/external/bcc_repo >> $@",
+    ]),
+)
+
+py_library(
+    # needs to be wrapped in a py_library so that py_venv can consume it
+    name = "external_deps_wrapper",
+    data = [":external_deps_pth"],
+    imports = ["."],
+)
+
+py_venv(
+    # This target creates a script which creates a Python environment.
+    # Usage: `bazel run //dev_tools:python_env <path of your choice>`
+    # Note that this cannot update an existing Python environment, thus for updating you need
+    # to run something like `rm -rf ~/python_env && bazel run //dev_tools:python_env ~/python_env`
+    # NOTE: until https://github.com/cedarai/rules_pyvenv/issues/1 is resolved, the environment does
+    # not cover magma libraries without adaptions.
+    # Our hacky workaround is to include some external dependencies via .pth files
+    # specified in the external_dependencies_wrapper target.
+    # We still also depend directly on the respective py_librarys in order to ensure that
+    # they are built and present at the expected locations.
+    name = "python_env",
+    deps = all_requirements + all_protos + external_python_libs + [":external_deps_wrapper"],
+)

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -195,6 +195,16 @@
   retries: 5
   when: preburn
 
+- name: Install python3-venv for creating dev venvs (used by rules_pyvenv)
+  # TODO: move to preburn
+  tags: dev
+  apt:
+    state: present
+    update_cache: no
+    pkg:
+      - python3-venv
+  retries: 5
+
 - name: Install build requirements for Ubuntu systems
   # python3-aioeventlet manually built with fpm and uploaded to jfrog focal-dev repo
   # due to upstream versioning bug


### PR DESCRIPTION
## Summary

Fixes #14036

Uses [rules_pyvenv](https://github.com/cedarai/rules_pyven) to generate a virtual environment for IDEs. The environment contains PyPI dependencies and compiled Protobuf Python libraries.

## Test Plan

In the VM or devcontainer:
```
sudo apt install python3-venv && cd $MAGMA_ROOT && bazel run //dev_tools:python_env ~/python_ide_env
```
Now configure the IDE to use the Python interpreter `/home/vscode/python_ide_env/bin/python3` (VS Code + Devcontainer) or `sftp://vagrant@localhost:2222/home/vagrant/python_ide_env/bin/python3` (IntelliJ IDEA Ultimate + magma_dev VM). You might have to restart the IDE for the change to be effective.