### PR TITLE
fix(ci): fix test interdependency in test_attach_detach_rar_tcp_he (#…

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_he.py
@@ -54,8 +54,6 @@ class TestAttachDetachRarTcpHE(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         datapath = get_datapath()
         MAX_NUM_RETRIES = 5
-        gtp_br_util = GTPBridgeUtils()
-        GTP_PORT = gtp_br_util.get_gtp_port_no()
         utils = HeaderEnrichmentUtils()
 
         for i in range(num_ues):
@@ -202,6 +200,9 @@ class TestAttachDetachRarTcpHE(unittest.TestCase):
             # Check if UL and DL OVS flows are created
             # UPLINK
             print("Checking for uplink flow")
+            gtp_br_util = GTPBridgeUtils()
+            GTP_PORT = gtp_br_util.get_gtp_port_no()
+
             # try at least 5 times before failing as gateway
             # might take some time to install the flows in ovs
             for i in range(MAX_NUM_RETRIES):


### PR DESCRIPTION
# Summary
Same fix as for test_attach_detach_rar_tcp_data. Before the pr the test was expecting an already existing gtp port g_8d3ca8c0. This is usally created by other tests and only deleted during cleanup of failed test. This caused the flaky retry for this test to always since after a cleanup the g_8d3ca8c0 would never exists.  As the g_8d3ca8c0 port is setup during flow creation, we now rmine the port number after the flows has been created.

# Test plan

* ran test locally about 10 times

# Note

Only fixing this because this failed in this ci run: https://github.com/crasu/magma/actions/runs/3314249640. I checked - this is the last of these tests which needs fixing in this way.
