### PR TITLE
chore(ci): bump `docker/build-push-action` version to remove deprecat…

### DIFF
--- a/.github/workflows/composite/docker-builder/action.yml
+++ b/.github/workflows/composite/docker-builder/action.yml
@@ -55,7 +55,7 @@ runs:
       if: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}
     - name: Build and push Docker image
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # pin@v3.2.0
       with:
         context: .
         file: ${{ inputs.DOCKERFILE }}

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build the python-precommit Docker base image
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # pin@v2
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # pin@v3.2.0
         with:
           context: .
           file: ./lte/gateway/docker/python-precommit/Dockerfile


### PR DESCRIPTION
…ion warning

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
GitHub deprecated `save-state` and `save-output` workflow commands with its recent update to `@actions/core` package to v1.10.0. This PR bumps the version of the third party library `docker/build-push-action` from v2 to the latest version v3.2.0 with adapted commands. The major change from v2.x to v3.x was to use Node 16 as a default.

## Test Plan
- Full text search on repository for 'action/setup-node`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
