### PR TITLE
chore(ci): bump `docker/setup-qemu-action` version to remove deprecat…

### DIFF
--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install QEMU
-        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # pin@v1
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # pin@v2.1.0
       - name: Setup gotestsum
         uses: autero1/action-gotestsum@2e48af62f5248bd3b014f598cd1aa69a01dd36e3 # pin@v1.0.0
         with:


### PR DESCRIPTION
…ion warning

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
GitHub deprecated `save-state` and `save-output` workflow commands with its recent update to `@actions/core` package to v1.10.0. This PR bumps the version of the third party library `docker/setup-qemu-action` from v1.2.0 to the latest version v2.1.0 with adapted commands. The major change from v1.x to v2.x was to use Node 16 as a default.

## Test Plan
- Full text search on repository for 'docker/setup-qemu-action`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
