### PR TITLE
chore(ci): bump `amannn/action-semantic-pull-request` version to remo…

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -50,7 +50,7 @@ jobs:
     needs: check-reverted-pr
     if: ${{ needs.check-reverted-pr.outputs.is_reverted_pr == 'false' }}
     steps:
-      - uses: amannn/action-semantic-pull-request@db6e259b93f286e3416eef27aaae88935d16cf2e # pin@v3.4.0
+      - uses: amannn/action-semantic-pull-request@01d5fd8a8ebb9aafe902c40c53f0f4744f7381eb # pin@v5.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
…ve deprecation warning

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
GitHub deprecated `save-state` and `save-output` workflow commands with its recent update to `@actions/core` package to v1.10.0. This PR bumps the version of the third party library `amannn/action-semantic-pull-request` from v3.4.0 to the latest version v5.0.2 with adapted commands. The breaking change from v3.x to v4.x was to use Node 16 as a default. The breaking change from v4.x to v5.x was the need for newline-separated enum options [see here](https://github.com/amannn/action-semantic-pull-request/releases/tag/v5.0.0).

## Test Plan
- Full text search on repository for 'amannn/action-semantic-pull-request`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
