### PR TITLE
chore(ci): remove debug-only `hmarr/debug-action`

### DIFF
--- a/.github/workflows/deploy-build-from-pr.yml
+++ b/.github/workflows/deploy-build-from-pr.yml
@@ -26,7 +26,6 @@ jobs:
       WORKFLOW_NAME: "${{ github.event.workflow.name }}"
       WORKFLOW_STATUS: "${{ github.event.workflow_run.conclusion }}"
     steps:
-      - uses: hmarr/debug-action@1201a20fc9d278ddddd5f0f46922d06513892491 # pin@v2
       # Could be improved, only need the tag push docker and helm rotation script here
       - name: checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0


### PR DESCRIPTION
## Summary
`hmarr/debug-action` is a debug-only action and not needed in production code. Removed.

## Test Plan
- Full text search on repository for 'hmarr/debug-action'
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
