### PR TITLE
chore(ci): bump `geekyeggo/delete-artifact` version to remove deprecation warning

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -248,7 +248,7 @@ jobs:
       - uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # pin@v2
         with:
           name: sentry-exec
-      - uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # pin@v1
+      - uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # pin@v2.0.0
         with:
           name: sentry-exec
       - run: ls -R

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # pin@v2
         with:
           name: docker-images
-      - uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # pin@v1
+      - uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # pin@v2.0.0
         with:
           name: docker-images
       - name: Copy docker images into /tmp/cwf-images

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           name: docker-build-feg-images
           path: ${{ env.AGW_ROOT }}
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # pin@v2.0.0
         with:
           name: |
             docker-build-orc8r-images |


### PR DESCRIPTION

## Summary
GitHub deprecated [Node 12 in favor of Node 16](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). This PR bumps the version of the third party library `geekyeggo/delete-artifact` from v1 to the latest version v2.0.0 with an adapted Node version.

## Test Plan
- Full text search on repository for 'geekyeggo/delete-artifact'
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
