### PR TITLE
fix(ci): ignore exit status from single test sets

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -871,7 +871,8 @@ def _run_integ_tests(gateway_ip='192.168.60.142', test_mode='integ_test', tests=
         f' sudo ethtool --offload eth2 rx off tx off;'
         f' source ~/build/python/bin/activate;'
         f' export GATEWAY_IP={gateway_ip};'
-        f' make {test_mode} enable-flaky-retry=true {tests}\'',
+        f' make {test_mode} enable-flaky-retry=true {tests};'
+        f' make evaluate_result\'',
     )
 
 

--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -63,32 +63,26 @@ prepare_federation:
 .PHONY: selected_tests
 selected_tests: prepare_environment
 	-$(foreach test,$(TESTS),$(call execute_test,$(test));)
-	$(call apply_final_status)
 
 .PHONY: precommit
 precommit: prepare_environment
 	-$(foreach test,$(PRECOMMIT_TESTS),$(call execute_test,$(test));)
-	$(call apply_final_status)
 
 .PHONY: precommit_tests_noncontainer
 precommit_tests_noncontainer: prepare_environment
 	-$(foreach test,$(PRECOMMIT_TESTS_NOT_CONTAINER) $(PRECOMMIT_TESTS_IPV6),$(call execute_test,$(test));)
-	$(call apply_final_status)
 
 .PHONY: extended_tests
 extended_tests: prepare_environment
 	-$(foreach test,$(EXTENDED_TESTS),$(call execute_test,$(test));)
-	$(call apply_final_status)
 
 .PHONY: extended_tests_noncontainer
 extended_tests_noncontainer: prepare_environment
 	-$(foreach test,$(EXTENDED_TESTS_NOT_CONTAINER),$(call execute_test,$(test));)
-	$(call apply_final_status)
 
 .PHONY: extended_tests_long
 extended_tests_long: prepare_environment
 	-$(foreach test,$(EXTENDED_TESTS_LONG),$(call execute_test,$(test));)
-	$(call apply_final_status)
 
 .PHONY: integ_test
 integ_test: precommit precommit_tests_noncontainer extended_tests extended_tests_noncontainer extended_tests_long
@@ -99,9 +93,11 @@ integ_test_containerized: precommit extended_tests
 .PHONY: federated_integ_test
 federated_integ_test: prepare_environment prepare_federation
 	-$(foreach test,$(FEDERATED_TESTS),$(call execute_test,$(test));)
-	$(call apply_final_status)
 
 .PHONY: nonsanity
 nonsanity: prepare_environment
 	-$(foreach test,$(NON_SANITY_TESTS),$(call execute_test,$(test));)
+
+.PHONY: evaluate_result
+evaluate_result:
 	$(call apply_final_status)

--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -28,8 +28,6 @@ ifdef enable-flaky-retry
 else
 	FLAKY_CMD_ARGS :=
 endif
-# Don't remove the ending comment from function execute_test. Somehow without
-# any ending statement the failing testcases are missing status update
 
 define apply_final_status
 	if [ ! -z `grep -s pass $(MAGMA_ROOT)/test_status.txt` ]; \
@@ -38,6 +36,8 @@ define apply_final_status
 	fi
 endef
 
+# Don't remove the ending comment from function execute_test. Somehow without
+# any ending statement the failing testcases are missing status update
 define execute_test
 	echo "Running test: $(1)"
 	timeout --foreground -k 930s 900s \


### PR DESCRIPTION
## Summary

Allow for multiple test sets to be run, even though, there is an failure in one of them.

## Test Plan

- CI : https://github.com/magma/magma/actions?query=branch%3Aci%2Fignore-errors-on-integration-tests+event%3Apull_request+integ+test

## Additional Information

- Fixing failing integration tests is _out of scope_ for this PR.