### PR TITLE
fix(ci): use correct syntax for push event in sudo python tests

### DIFF
--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -85,7 +85,7 @@ jobs:
           junit_files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
       - name: Publish results to Firebase
-        if: always() && github.event.workflow_run.event == 'push'
+        if: always() && github.event_name == 'push'
         env:
           FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
           REPORT_FILENAME: "sudo_python_tests_${{ github.sha }}.html"


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Amendment to #14227. Using `push` as a workflow trigger now needs a different syntax. This was missed here.

## Test Plan
- [CI runs](https://github.com/magma/magma/actions/workflows/sudo-python-tests.yml) should now publish to Firebase again.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
