### PR TITLE
fix(ci): install missing firebase_admin python module

### DIFF
--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install pre requisites
         run: |
           pip3 install --upgrade pip
-          pip3 install ansible fabric3 jsonpickle requests PyYAML
+          pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
           vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
       - name: Open up network interfaces for VM
         run: |


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
The `firebase_admin` python module is needed to push the test results to the firebase database.

## Test Plan
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
