### PR TITLE
fix(agw): Create empty config before running integ tests

### DIFF
--- a/orc8r/tools/fab/vagrant.py
+++ b/orc8r/tools/fab/vagrant.py
@@ -36,8 +36,10 @@ def setup_env_vagrant(machine='magma', apply_to_env=True, force_provision=False)
     Sets the environment to point at the local vagrant machine. Used
     whenever we need to run commands on the vagrant machine.
     """
-
     __ensure_in_vagrant_dir()
+
+    # An empty local ssh config file stops warnings from being printed.
+    local('touch ~/.ssh/config')
 
     # Ensure that VM is running
     isUp = local('vagrant status %s' % machine, capture=True) \


### PR DESCRIPTION
Closes #14053

## Summary

Just create an empty .ssh/config file if it does not already exist. This gets rid off the warnings displayed at the end of the LTE integ tests.

## Test Plan

Run the LTE integ tests and see that there are no .ssh/config warnings at the end. We can accept if the LTE integ tests fail at the moment as long as the warnings do not appear.

LTE integ test workflow: https://github.com/MoritzThomasHuebner/magma/actions/runs/3335258776/jobs/5519043464
LTE integ test magma deb workflow: https://github.com/MoritzThomasHuebner/magma/actions/runs/3341931282/jobs/5533633065

