### PR TITLE
fix(ci): format html output correctly

### DIFF
--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -57,9 +57,9 @@ def url_to_html_redirect(run_id: str, url: Optional[str]):
         report_url = f'https://github.com/magma/magma/actions/runs/{run_id}'
 
     return (
-        f'<script>',
-        f'  window.location.href = "{report_url}";',
-        f'</script>',
+        f'<script>'
+        f'  window.location.href = "{report_url}";'
+        f'</script>'
     )
 
 


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fixes a refactoring bug, a tuple was returned instead of a string. `('<script>', '  window.location.href = $URL;', '</script>')`, instead of `<script>  window.location.href = $URL;</script>`, leading to the Firebase dashboard not being able to link the test results.

## Test Plan

- Output the return value locally
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
