### PR TITLE
feat(ci): Propagate AGW docker images hashes to the integration test job

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -373,104 +373,188 @@ jobs:
           SLACK_ICON_EMOJI: ":heavy_check_mark:"
           SLACK_COLOR: "#00FF00"
           SLACK_FOOTER: ' '
-  agw-container-build:
+
+  agw-container-build-c-ghz:
+    runs-on: ubuntu-latest
     if: github.repository_owner == 'magma'
-    name: agw container build
+    needs: agw-container-build-c
+    env:
+      DOCKER_REGISTRY: agw-ci.artifactory.magmacore.org
+      DOCKER_IMAGE: ghz_gateway_c
+      DOCKERCONTEXT: lte/gateway/docker/ghz
+    outputs:
+      digest: ${{ steps.agw-build-docker.outputs.digest }}
+    steps:
+      - run: echo "DOCKER_REGISTRY=agw-test.artifactory.magmacore.org" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/master'
+
+      - run: echo "Publishing images to ${{ env.DOCKER_REGISTRY }}"
+
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+
+      - uses: ./.github/workflows/composite/docker-builder-agw
+        id: agw-build-docker
+        with:
+          REGISTRY_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+          REGISTRY: ${{ env.DOCKER_REGISTRY }}
+          IMAGE: ${{ env.DOCKER_IMAGE }}
+          DOCKERCONTEXT: ${{ env.DOCKERCONTEXT }}
+
+  agw-container-build-python-ghz:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'magma'
+    needs: agw-container-build-python
+    env:
+      DOCKER_REGISTRY: agw-ci.artifactory.magmacore.org
+      DOCKER_IMAGE: ghz_gateway_python
+      DOCKERCONTEXT: lte/gateway/docker/ghz
+    outputs:
+      digest: ${{ steps.agw-build-docker.outputs.digest }}
+    steps:
+      - run: echo "DOCKER_REGISTRY=agw-test.artifactory.magmacore.org" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/master'
+
+      - run: echo "Publishing images to ${{ env.DOCKER_REGISTRY }}"
+
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+
+      - uses: ./.github/workflows/composite/docker-builder-agw
+        id: agw-build-docker
+        with:
+          REGISTRY_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+          REGISTRY: ${{ env.DOCKER_REGISTRY }}
+          IMAGE: ${{ env.DOCKER_IMAGE }}
+          DOCKERCONTEXT: ${{ env.DOCKERCONTEXT }}
+
+  agw-container-build-c:
+    if: github.repository_owner == 'magma'
     runs-on: ubuntu-latest
     env:
-      MAGMA_ROOT: "${{ github.workspace }}"
-      DOCKER_BUILDKIT: 1
+      DOCKER_REGISTRY: agw-ci.artifactory.magmacore.org
+      DOCKER_IMAGE: agw_gateway_c
+      DOCKER_FILE: lte/gateway/docker/services/c/Dockerfile
+    outputs:
+      digest: ${{ steps.agw-build-docker.outputs.digest }}
     steps:
+      - run: echo "DOCKER_REGISTRY=agw-test.artifactory.magmacore.org" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/master'
+
+      - run: echo "Publishing images to ${{ env.DOCKER_REGISTRY }}"
+
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - name: Run agw docker compose
-        id: agw-docker-compose
-        continue-on-error: true
-        # yamllint disable rule:line-length
-        run: |
-          cd ${MAGMA_ROOT}/lte/gateway/docker
-          docker-compose --file docker-compose.yaml --file docker-compose.override.yaml build --parallel
-      - name: Retry docker agw compose on failure
-        id: retry-agw-docker-compose
-        continue-on-error: true
-        if: steps.agw-docker-compose.outcome=='failure'
-        run: |
-          cd ${MAGMA_ROOT}/lte/gateway/docker
-          docker-compose --file docker-compose.yaml --file docker-compose.override.yaml build --parallel
-      - name: Set the agw docker build status
-        if: always()
-        run: |
-          if ${{ steps.agw-docker-compose.outcome=='success' || steps.retry-agw-docker-compose.outcome=='success' }}; then
-             echo "AGW Docker compose completed successfully"
-          else
-             echo "Docker compose failed"
-             exit 1
-          fi
-      - name: Run ghz docker compose
-        id: ghz-docker-compose
-        continue-on-error: true
-        # yamllint disable rule:line-length
-        run: |
-          cd ${MAGMA_ROOT}/lte/gateway/docker/ghz
-          docker-compose --file docker-compose.yaml --file docker-compose.override.yaml build --parallel
-      - name: Retry ghz docker compose on failure
-        id: retry-ghz-docker-compose
-        continue-on-error: true
-        if: steps.ghz-docker-compose.outcome=='failure'
-        run: |
-          cd ${MAGMA_ROOT}/lte/gateway/docker/ghz
-          docker-compose --file docker-compose.yaml --file docker-compose.override.yaml build --parallel
-      - name: Set the ghz docker build status
-        if: always()
-        run: |
-          if ${{ steps.ghz-docker-compose.outcome=='success' || steps.retry-ghz-docker-compose.outcome=='success' }}; then
-             echo "GHZ Docker compose completed successfully"
-          else
-             echo "Docker compose failed"
-             exit 1
-          fi
-      - name: Export docker images to deploy them on pull_request
-        if: github.event_name == 'pull_request'
-        run: |
-          mkdir images
-          cd images
-          docker save agw_gateway_c | gzip > agw_gateway_c.tar.gz
-          docker save agw_gateway_python | gzip > agw_gateway_python.tar.gz
-          docker save ghz_gateway_c | gzip > ghz_gateway_c.tar.gz
-          docker save ghz_gateway_python | gzip > ghz_gateway_python.tar.gz
-      - name: Upload docker images as artifacts
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: github.event_name == 'pull_request'
+
+      - uses: ./.github/workflows/composite/docker-builder-agw
+        id: agw-build-docker
         with:
-          name: docker-images-agw
-          path: images
-      # Need to save PR number as Github action does not propagate it with workflow_run event
-      # Used as version for PR builds
-      - name: Save PR number
-        run: |
-          mkdir -p ./pr
-          echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+          REGISTRY_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+          REGISTRY: ${{ env.DOCKER_REGISTRY }}
+          IMAGE: ${{ env.DOCKER_IMAGE }}
+          DOCKERFILE: ${{ env.DOCKER_FILE }}
+
+  agw-container-build-python:
+    if: github.repository_owner == 'magma'
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY: agw-ci.artifactory.magmacore.org
+      DOCKER_IMAGE: agw_gateway_python
+      DOCKER_FILE: lte/gateway/docker/services/python/Dockerfile
+    outputs:
+      digest: ${{ steps.agw-build-docker.outputs.digest }}
+    steps:
+      - run: echo "DOCKER_REGISTRY=agw-test.artifactory.magmacore.org" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/master'
+
+      - run: echo "Publishing images to ${{ env.DOCKER_REGISTRY }}"
+
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+
+      - uses: ./.github/workflows/composite/docker-builder-agw
+        id: agw-build-docker
         with:
-          name: pr
-          path: pr/
-      - name: Create release Tag
-        if: github.event_name == 'push'
+          REGISTRY_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+          REGISTRY: ${{ env.DOCKER_REGISTRY }}
+          IMAGE: ${{ env.DOCKER_IMAGE }}
+          DOCKERFILE: ${{ env.DOCKER_FILE }}
+
+  agw-container-build-go:
+    if: github.repository_owner == 'magma'
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY: agw-ci.artifactory.magmacore.org
+      DOCKER_IMAGE: gateway_go
+      DOCKER_FILE: feg/gateway/docker/go/Dockerfile
+    outputs:
+      digest: ${{ steps.agw-build-docker.outputs.digest }}
+    steps:
+      - run: echo "DOCKER_REGISTRY=agw-test.artifactory.magmacore.org" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/master'
+
+      - run: echo "Publishing images to ${{ env.DOCKER_REGISTRY }}"
+
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+
+      - uses: ./.github/workflows/composite/docker-builder-agw
+        id: agw-build-docker
+        with:
+          REGISTRY_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+          REGISTRY: ${{ env.DOCKER_REGISTRY }}
+          IMAGE: ${{ env.DOCKER_IMAGE }}
+          DOCKERFILE: ${{ env.DOCKER_FILE }}
+
+  agw-container-build-is-successful:
+    runs-on: ubuntu-latest
+    if: success()
+    needs:
+      - agw-container-build-c
+      - agw-container-build-python
+      - agw-container-build-go
+    outputs:
+      digest-c: ${{ needs.agw-container-build-c.outputs.digest }}
+      digest-python: ${{ needs.agw-container-build-python.outputs.digest }}
+      digest-go: ${{ needs.agw-container-build-go.outputs.digest }}
+    steps:
+      - run: echo "Successfully built AGW containers."
+
+  agw-container-build:
+    name: agw container build
+    runs-on: ubuntu-latest
+    if: always() && github.repository_owner == 'magma'
+    needs:
+      - agw-container-build-is-successful
+    steps:
+      - name: Check completion of all build steps
         run: |
-          if [ "$GITHUB_REF" = "refs/heads/master" ]; then
-            echo TAG="${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+          if [ "${{ needs.agw-container-build-is-successful.result }}" = "success" ];
+          then
+            exit 0
           else
-            GIT_BRANCH_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-            echo TAG="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
+            echo "Exit status of some previous job(s) was ${{ needs.agw-container-build-is-successful.result }}"
+            exit 1
           fi
-      - name: Tag and push agw containers to Jfrog Registry
-        id: publish_artifacts
-        if: github.event_name == 'push'
-        env:
-          DOCKER_REGISTRY: "agw-test.artifactory.magmacore.org"
-          DOCKER_USERNAME: "${{ secrets.JFROG_USERNAME }}"
-          DOCKER_PASSWORD: "${{ secrets.JFROG_PASSWORD }}"
+
+      - name: Show docker image digests
         run: |
-          ./ci-scripts/tag-push-docker.sh --images 'ghz_gateway_c|ghz_gateway_python|agw_gateway_c|agw_gateway_python' --tag "${TAG}" --tag-latest true
+          echo "digest-c:      ${{ needs.agw-container-build-is-successful.outputs.digest-c }}"
+          echo "digest-python: ${{ needs.agw-container-build-is-successful.outputs.digest-python }}"
+          echo "digest-go:     ${{ needs.agw-container-build-is-successful.outputs.digest-go }}"
+
+      - name: Trigger integration test workflow
+        uses: peter-evans/repository-dispatch@f2696244ec00ed5c659a5cc77f7138ad0302dffb # pin@2.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: magma/magma
+          event-type: agw-build-docker
+          client-payload: '{
+            "digest-c":      "${{ needs.agw-container-build-is-successful.outputs.digest-c }}",
+            "digest-python": "${{ needs.agw-container-build-is-successful.outputs.digest-python }}",
+            "digest-go":     "${{ needs.agw-container-build-is-successful.outputs.digest-go }}"
+            }'
+
   cloud-upload:
     name: cloud upload job
     runs-on: ubuntu-latest

--- a/.github/workflows/composite/docker-builder-agw/action.yml
+++ b/.github/workflows/composite/docker-builder-agw/action.yml
@@ -1,0 +1,76 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build Docker Image For AGW
+description: Build a docker image and push it to a registry
+
+inputs:
+  REGISTRY_USERNAME:
+    description: Registry login username
+    required: true
+  REGISTRY_PASSWORD:
+    description: Registry login password
+    required: true
+  REGISTRY:
+    description: Docker registry
+    required: true
+  IMAGE:
+    description: Docker image stream name
+    required: true
+  TAG:
+    description: Docker image stream tag
+    default: latest
+  DOCKERFILE:
+    description: Docker file
+    required: false
+    default: Dockerfile
+  DOCKERCONTEXT:
+    description: Docker context
+    default: .
+  PUSH:
+    description: Push to registry?
+    default: true
+    type: boolean
+
+outputs:
+  digest:
+    description: Docker image digest
+    value: ${{ steps.build-docker.outputs.digest }}
+
+runs:
+  using: composite
+  steps:
+    - run: echo "Publishing images to ${{ inputs.REGISTRY }}"
+      shell: bash
+
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin@v2.1.0
+      with:
+        registry: ${{ inputs.REGISTRY }}
+        username: ${{ inputs.REGISTRY_USERNAME }}
+        password: ${{ inputs.REGISTRY_PASSWORD }}
+
+    - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # pin@v2.2.1
+
+    - name: Build and push docker image ${{ inputs.IMAGE }}
+      id: build-docker
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # pin@v3.2.0
+      with:
+        # See unresolved bug https://github.com/actions/runner/issues/1483
+        push: ${{ inputs.PUSH == 'true' }}
+        context: ${{ inputs.DOCKERCONTEXT }}
+        file: ${{ inputs.DOCKERCONTEXT }}/${{ inputs.DOCKERFILE }}
+        tags: ${{ inputs.REGISTRY }}/${{ inputs.IMAGE }}:${{ inputs.TAG }}
+
+    - run: echo "Image digest for ${{ inputs.IMAGE }} is ${{ steps.build-docker.outputs.digest }}"
+      shell: bash


### PR DESCRIPTION
## Summary

> **Warning**
> The diff in Github looks really ugly. :crying_cat_face: Best to consider everything in `build-all.yml` new and deleted, and not changed.

- Introduce a **hash based image identifier propagation**. This is part one: the sending side.
- Consolidate image upload
  - Properly build the images and upload images without ugly hacks.
  - Abstract image builds with a composite action.
  - GHZ are not for production. Thus they were separated and are made not required.
  - For GHZ builds a loose coupling was introduced, as they have a dependency on the normal build. However, as they are only for testing, it does not make sense to go for an bigger effort here. The chance of race conditions is small there anyway.

> **Note**
> I introduced some more white-spaces into the yaml files, because this makes them **much** more readable. I am aware that this might not be consistent, however, I believe that this would be such a big improvement, that one should honestly consider this a good change, which could be done throughout the codebase peu-a-peu.


## Test Plan

- CI:
  - https://github.com/magma/magma/actions/workflows/build_all.yml?query=branch%3Aci%2Fdocker-image-propagation-for-agw
  - :heavy_check_mark: https://github.com/magma/magma/actions/runs/3379902371

## Additional Information

- Note that the access to credentials of those jobs has not changed.
- The follow up of the receivers side will be done in https://github.com/magma/magma/pull/14353.