### PR TITLE
refactor(pipelined): Use netifaces to get mac addresses

### DIFF
--- a/lte/gateway/python/magma/pipelined/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/BUILD.bazel
@@ -34,6 +34,7 @@ py_binary(
     python_version = "PY3",
     tags = TAG_SERVICE,
     deps = [
+        ":ifaces",
         ":pipelined_lib",
         "//lte/gateway/python/magma/pipelined/app:he",
         "//lte/gateway/python/magma/pipelined/app:of_rest_server",
@@ -51,7 +52,6 @@ py_library(
     srcs = [
         "check_quota_server.py",
         "datapath_setup.py",
-        "ifaces.py",
     ],
     deps = [
         ":gtp_stats_collector",
@@ -247,9 +247,19 @@ py_library(
 py_library(
     name = "gw_mac_address",
     srcs = ["gw_mac_address.py"],
+    deps = [":ifaces"],
 )
 
 py_library(
     name = "pg_set_session_msg",
     srcs = ["pg_set_session_msg.py"],
+)
+
+py_library(
+    name = "ifaces",
+    srcs = ["ifaces.py"],
+    deps = [
+        requirement("netifaces"),
+        ":metrics",
+    ],
 )

--- a/lte/gateway/python/magma/pipelined/gw_mac_address.py
+++ b/lte/gateway/python/magma/pipelined/gw_mac_address.py
@@ -15,7 +15,8 @@ import ipaddress
 import logging
 
 from lte.protos.mobilityd_pb2 import IPAddress
-from scapy.arch import get_if_addr, get_if_hwaddr
+from magma.pipelined.ifaces import get_mac_address
+from scapy.arch import get_if_addr
 from scapy.data import ETH_P_ALL, ETHER_BROADCAST
 from scapy.error import Scapy_Exception
 from scapy.layers.inet6 import getmacbyip6
@@ -43,7 +44,7 @@ def _get_gw_mac_address_v4(ip: IPAddress, vlan: str, non_nat_arp_egress_port: st
             "sending arp via egress: %s",
             non_nat_arp_egress_port,
         )
-        eth_mac_src = get_if_hwaddr(non_nat_arp_egress_port)
+        eth_mac_src = get_mac_address(non_nat_arp_egress_port)
         psrc = "0.0.0.0"
         egress_port_ip = get_if_addr(non_nat_arp_egress_port)
         if egress_port_ip:

--- a/lte/gateway/python/magma/pipelined/ifaces.py
+++ b/lte/gateway/python/magma/pipelined/ifaces.py
@@ -29,3 +29,10 @@ def monitor_ifaces(iface_names):
             status = 1 if iface in active else 0
             NETWORK_IFACE_STATUS.labels(iface_name=iface).set(status)
         yield from asyncio.sleep(POLL_INTERVAL_SECONDS)
+
+
+def get_mac_address(interface_name: str) -> str:
+    if_addresses = netifaces.ifaddresses(interface_name)[netifaces.AF_LINK]
+    if not if_addresses or not if_addresses[0].get('addr'):
+        raise ValueError(f"No mac address found for interface {interface_name}")
+    return if_addresses[0]['addr']

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -39,13 +39,12 @@ from magma.pipelined.gtp_stats_collector import (
     MIN_OVSDB_DUMP_POLLING_INTERVAL,
     GTPStatsCollector,
 )
-from magma.pipelined.ifaces import monitor_ifaces
+from magma.pipelined.ifaces import get_mac_address, monitor_ifaces
 from magma.pipelined.rpc_servicer import PipelinedRpcServicer
 from magma.pipelined.service_manager import ServiceManager
 from ryu import cfg
 from ryu.base.app_manager import AppManager
 from ryu.ofproto.ofproto_v1_4 import OFPP_LOCAL
-from scapy.arch import get_if_hwaddr
 
 
 def main():
@@ -121,9 +120,9 @@ def main():
     if 'virtual_mac' not in service.config:
         if service.config['dp_router_enabled']:
             up_iface_name = service.config.get('nat_iface', None)
-            mac_addr = get_if_hwaddr(up_iface_name)
+            mac_addr = get_mac_address(up_iface_name)
         else:
-            mac_addr = get_if_hwaddr(service.config.get('bridge_name'))
+            mac_addr = get_mac_address(service.config.get('bridge_name'))
 
         service.config['virtual_mac'] = mac_addr
 

--- a/lte/gateway/python/magma/pipelined/tests/BUILD.bazel
+++ b/lte/gateway/python/magma/pipelined/tests/BUILD.bazel
@@ -721,6 +721,14 @@ pytest_test(
 )
 
 pytest_test(
+    name = "test_ifaces",
+    size = "small",
+    srcs = ["test_ifaces.py"],
+    imports = [LTE_ROOT],
+    deps = ["//lte/gateway/python/magma/pipelined:ifaces"],
+)
+
+pytest_test(
     name = "test_tunnel_id_mapper",
     size = "small",
     srcs = ["test_tunnel_id_mapper.py"],

--- a/lte/gateway/python/magma/pipelined/tests/test_ifaces.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ifaces.py
@@ -1,0 +1,38 @@
+"""
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Prevent flakiness due to prometheus library import
+sys.modules["magma.pipelined.metrics"] = MagicMock()
+
+from magma.pipelined.ifaces import get_mac_address
+
+
+@patch("magma.pipelined.ifaces.netifaces")
+def test_get_mac_address(netifaces_mock):
+    netifaces_mock.AF_LINK = 13
+    netifaces_mock.ifaddresses.return_value = {netifaces_mock.AF_LINK: [{"addr": "00:11:22:33:44:55"}]}
+
+    assert get_mac_address("eth0") == "00:11:22:33:44:55"
+
+
+@patch("magma.pipelined.ifaces.netifaces")
+def test_get_mac_address_invalid(netifaces_mock):
+    netifaces_mock.AF_LINK = 13
+    netifaces_mock.ifaddresses.return_value = {netifaces_mock.AF_LINK: []}
+    with pytest.raises(ValueError):
+        get_mac_address("eth0")


### PR DESCRIPTION
## Summary

Use the already existing dependency `netifaces` to get mac addresses for interfaces.

Part of #14298.

## Test Plan

* Started pipelined with some additional logging to test that the same mac address is obtained as before.
* New unit test (only for loopback interface, didn't want to add mocks for the library).

## Additional Information

- [ ] This change is backwards-breaking
