### PR TITLE
fix(amf): Handled Registration and Periodic Registration Failure Issues

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_transport.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_transport.cpp
@@ -66,6 +66,9 @@ status_code_e amf_app_handle_nas_dl_req(const amf_ue_ngap_id_t ue_id,
   rc = amf_send_msg_to_task(&amf_app_task_zmq_ctx, TASK_NGAP, message_p);
 
   if (transaction_status != M5G_AS_SUCCESS) {
+    if (M5G_AS_TERMINATED_NAS == transaction_status) {
+      ue_context->ue_context_rel_cause = NGAP_IMPLICIT_CONTEXT_RELEASE;
+    }
     amf_ctx_release_ue_context(ue_context, NGAP_NAS_AUTHENTICATION_FAILURE);
   }
   OAILOG_FUNC_RETURN(LOG_AMF_APP, rc);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -897,7 +897,8 @@ void amf_ctx_release_ue_context(ue_m5gmm_context_s* ue_context_p,
     OAILOG_FUNC_OUT(LOG_AMF_APP);
   }
 
-  amf_app_itti_ue_context_release(ue_context_p, n2_cause);
+  amf_app_itti_ue_context_release(ue_context_p,
+                                  ue_context_p->ue_context_rel_cause);
 
   if (ue_context_p->m5_implicit_deregistration_timer.id !=
       NAS5G_TIMER_INACTIVE_ID) {

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -338,7 +338,9 @@ status_code_e amf_handle_registration_request(
   params->m5gsregistrationtype = m5gsregistrationtype;
 
   // Save the UE Security Capability into AMF's UE Context
-  if (params->m5gsregistrationtype != AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
+  if (msg->ue_sec_capability.length > 0) {
+    OAILOG_DEBUG(LOG_NAS_AMF,
+                 "Updating received Security Capabilities in context\n");
     memcpy(&(ue_context->amf_context.ue_sec_capability),
            &(msg->ue_sec_capability), sizeof(UESecurityCapabilityMsg));
   }

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.hpp
@@ -163,6 +163,7 @@ class M5GSMobileIdentityMsg {
   uint8_t iei;
   uint16_t len;
   uint8_t toi;
+#define M5GSMobileIdentityMsg_NO_IDENTITY 0x00
 #define M5GSMobileIdentityMsg_SUCI_IMSI 0x01
 #define M5GSMobileIdentityMsg_GUTI 0x02
 #define M5GSMobileIdentityMsg_IMEI 0x03

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
@@ -325,8 +325,9 @@ int M5GSMobileIdentityMsg::DecodeM5GSMobileIdentityMsg(
   } else if (type_of_identity == M5GSMobileIdentityMsg_SUCI_IMSI) {
     decoded_rc = DecodeImsiMobileIdentityMsg(
         &mg5smobile_identity->mobile_identity.imsi, buffer + decoded, ielen);
+  } else if (type_of_identity == M5GSMobileIdentityMsg_NO_IDENTITY) {
+    decoded_rc = 1;
   }
-
   if (decoded_rc < 0) {
     OAILOG_ERROR(LOG_NAS5G, "Decode Error");
     return decoded_rc;


### PR DESCRIPTION
Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
  Handled Registration and Periodic Registration Failure Issues
     1. AGW will not send Context Release Command for Registration Failure cases.
     2. addressed Security Capability issues in  Periodic Registration  
## Test Plan
      - verified Registration Failure(Illegal UE)
      - verified Periodic Registration
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
