### PR TITLE
fix(ci): ntpdate makes eventd startup fail which in turn makes the integ test fail.

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service
@@ -15,7 +15,6 @@ Description=Magma eventd service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
-ExecStartPre=/usr/sbin/ntpdate -vd pool.ntp.org
 ExecStart=/usr/bin/env python3 -m magma.eventd.main
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py eventd
 StandardOutput=syslog

--- a/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@eventd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd_bazel/magma@eventd.service
@@ -15,7 +15,6 @@ Description=Magma eventd service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
-ExecStartPre=/usr/sbin/ntpdate -vd pool.ntp.org
 ExecStart=/home/vagrant/magma/bazel-bin/orc8r/gateway/python/magma/eventd/eventd
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py eventd
 StandardOutput=syslog


### PR DESCRIPTION
## Summary

Remove ntpdate from eventd service, because timesync already handled by systemd-timesyncd (in the dev vm). Eventd startup will fail when no ntp service is reachable. Ntp servers seem to be blocked regularly on github actions/azure due to ddos issues. This makes test_services_are_running.py fail when run on github actions. This does not occur locally. 

## Remarks
If we want to absolutly make sure that time is correct we could add systemd-timesyncd as a deb requirements to magma. Of course this will not work for containerized deployments. Having the time being synced is more like a system setup thing anyway and IMHO should be outside of magmas scope.


## Additional info
Failed integ test run:
https://storage.googleapis.com/magma-ci.appspot.com/lte_integ_test_4e0cae5b2844bd9aa43c3144898ca77e6224706f.html

Excerpt from syslog on github actions:
```
Oct 27 13:55:10 magma-dev eventd[94640]: 27 Oct 13:55:10 ntpdate[94640]: ntpdate 4.2.8p12@1.3728-o (1)
Oct 27 13:55:10 magma-dev eventd[94640]: Looking for host pool.ntp.org and service ntp
Oct 27 13:55:10 magma-dev eventd[94640]: 45.32.207.136 reversed to vps4.drown.org
Oct 27 13:55:10 magma-dev eventd[94640]: host found : vps4.drown.org
Oct 27 13:55:10 magma-dev eventd[94640]: transmit(45.32.207.136)
Oct 27 13:55:10 magma-dev eventd[94640]: transmit(66.220.10.2)
Oct 27 13:55:11 magma-dev eventd[94640]: transmit(138.236.128.36)
Oct 27 13:55:11 magma-dev eventd[94640]: transmit(66.228.58.20)
Oct 27 13:55:11 magma-dev magmad[67428]: ERROR:root:GetServiceInfo Error for eventd! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
Oct 27 13:55:12 magma-dev eventd[94640]: transmit(45.32.207.136)
Oct 27 13:55:12 magma-dev eventd[94640]: transmit(66.220.10.2)
Oct 27 13:55:13 magma-dev eventd[94640]: transmit(138.236.128.36)
Oct 27 13:55:13 magma-dev eventd[94640]: transmit(66.228.58.20)
Oct 27 13:55:14 magma-dev eventd[94640]: transmit(45.32.207.136)
Oct 27 13:55:14 magma-dev eventd[94640]: transmit(66.220.10.2)
Oct 27 13:55:15 magma-dev eventd[94640]: transmit(138.236.128.36)
Oct 27 13:55:15 magma-dev eventd[94640]: transmit(66.228.58.20)
Oct 27 13:55:16 magma-dev eventd[94640]: transmit(45.32.207.136)
Oct 27 13:55:16 magma-dev eventd[94640]: transmit(66.220.10.2)
Oct 27 13:55:17 magma-dev eventd[94640]: transmit(138.236.128.36)
Oct 27 13:55:17 magma-dev eventd[94640]: transmit(66.228.58.20)
Oct 27 13:55:19 magma-dev eventd[94640]: 45.32.207.136: Server dropped: no data
Oct 27 13:55:19 magma-dev eventd[94640]: 66.220.10.2: Server dropped: no data
Oct 27 13:55:19 magma-dev eventd[94640]: 138.236.128.36: Server dropped: no data
Oct 27 13:55:19 magma-dev eventd[94640]: 66.228.58.20: Server dropped: no data
Oct 27 13:55:19 magma-dev eventd[94640]: 27 Oct 13:55:19 ntpdate[94640]: no server suitable for synchronization found
Oct 27 13:55:19 magma-dev systemd[1]: magma@eventd.service: Control process exited, code=exited, status=1/FAILURE
```
As clearly visible from the log ntpdate can resolve the ntp servers via dns but is not able to get a response via ntp.

Basically the same pr as #13979
